### PR TITLE
[TEP-0089] Modify entrypoint to sign the results.

### DIFF
--- a/cmd/entrypoint/README.md
+++ b/cmd/entrypoint/README.md
@@ -30,6 +30,12 @@ The following flags are available:
   same value as `{{stdout_path}}` so both streams are copied to the same
   file. However, there is no ordering guarantee on data copied from both
   streams.
+- `-enable_spire`: If set will enable signing of the results by SPIRE. Signing
+  results by SPIRE ensures that no process other than the current process can
+  tamper the results and go undetected.
+- `-spire_socket_path`: This flag makes sense only when enable_spire is set. 
+  When enable_spire is set, spire_socket_path is used to point to the
+  SPIRE agent socket for SPIFFE workload API.
 
 Any extra positional arguments are passed to the original entrypoint command.
 

--- a/pkg/entrypoint/entrypointer_test.go
+++ b/pkg/entrypoint/entrypointer_test.go
@@ -24,6 +24,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -31,8 +32,10 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/pkg/spire"
 	"github.com/tektoncd/pipeline/pkg/termination"
 	"github.com/tektoncd/pipeline/test/diff"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/logging"
 )
 
@@ -284,6 +287,7 @@ func TestReadResultsFromDisk(t *testing.T) {
 	},
 	} {
 		t.Run(c.desc, func(t *testing.T) {
+			ctx := context.Background()
 			terminationPath := "termination"
 			if terminationFile, err := ioutil.TempFile("", "termination"); err != nil {
 				t.Fatalf("unexpected error creating temporary termination file: %v", err)
@@ -314,7 +318,7 @@ func TestReadResultsFromDisk(t *testing.T) {
 				Results:         resultsFilePath,
 				TerminationPath: terminationPath,
 			}
-			if err := e.readResultsFromDisk(""); err != nil {
+			if err := e.readResultsFromDisk(ctx, ""); err != nil {
 				t.Fatal(err)
 			}
 			msg, err := ioutil.ReadFile(terminationPath)
@@ -434,6 +438,167 @@ func TestEntrypointer_OnError(t *testing.T) {
 	}
 }
 
+func TestEntrypointerResults(t *testing.T) {
+	for _, c := range []struct {
+		desc, entrypoint, postFile, stepDir, stepDirLink string
+		waitFiles, args                                  []string
+		resultsToWrite                                   map[string]string
+		resultsOverride                                  []string
+		breakpointOnFailure                              bool
+		sign                                             bool
+		signVerify                                       bool
+	}{{
+		desc: "do nothing",
+	}, {
+		desc:       "no results",
+		entrypoint: "echo",
+	}, {
+		desc:       "write single result",
+		entrypoint: "echo",
+		resultsToWrite: map[string]string{
+			"foo": "abc",
+		},
+	}, {
+		desc:       "write multiple result",
+		entrypoint: "echo",
+		resultsToWrite: map[string]string{
+			"foo": "abc",
+			"bar": "def",
+		},
+	}, {
+		// These next two tests show that if not results are defined in the entrypointer, then no signature is produced
+		// indicating that no signature was created. However, it is important to note that results were defined,
+		// but no results were created, that signature is still produced.
+		desc:       "no results signed",
+		entrypoint: "echo",
+		sign:       true,
+		signVerify: false,
+	}, {
+		desc:            "defined results but no results produced signed",
+		entrypoint:      "echo",
+		resultsOverride: []string{"foo"},
+		sign:            true,
+		signVerify:      true,
+	}, {
+		desc:       "write single result",
+		entrypoint: "echo",
+		resultsToWrite: map[string]string{
+			"foo": "abc",
+		},
+		sign:       true,
+		signVerify: true,
+	}, {
+		desc:       "write multiple result",
+		entrypoint: "echo",
+		resultsToWrite: map[string]string{
+			"foo": "abc",
+			"bar": "def",
+		},
+		sign:       true,
+		signVerify: true,
+	}, {
+		desc:       "write n/m results",
+		entrypoint: "echo",
+		resultsToWrite: map[string]string{
+			"foo": "abc",
+		},
+		resultsOverride: []string{"foo", "bar"},
+		sign:            true,
+		signVerify:      true,
+	}} {
+		t.Run(c.desc, func(t *testing.T) {
+			ctx := context.Background()
+			fw, fpw := &fakeWaiter{}, &fakePostWriter{}
+			var fr Runner = &fakeRunner{}
+			timeout := time.Duration(0)
+			terminationPath := "termination"
+			if terminationFile, err := ioutil.TempFile("", "termination"); err != nil {
+				t.Fatalf("unexpected error creating temporary termination file: %v", err)
+			} else {
+				terminationPath = terminationFile.Name()
+				defer os.Remove(terminationFile.Name())
+			}
+
+			resultsDir := createTmpDir(t, "results")
+			var results []string
+			if c.resultsToWrite != nil {
+				tmpResultsToWrite := map[string]string{}
+				for k, v := range c.resultsToWrite {
+					resultFile := path.Join(resultsDir, k)
+					tmpResultsToWrite[resultFile] = v
+					results = append(results, k)
+				}
+
+				fr = &fakeResultsWriter{
+					resultsToWrite: tmpResultsToWrite,
+				}
+			}
+
+			signClient, verifyClient, tr := getMockSpireClient(ctx)
+			if !c.sign {
+				signClient = nil
+			}
+
+			if c.resultsOverride != nil {
+				results = c.resultsOverride
+			}
+
+			err := Entrypointer{
+				Command:             append([]string{c.entrypoint}, c.args...),
+				WaitFiles:           c.waitFiles,
+				PostFile:            c.postFile,
+				Waiter:              fw,
+				Runner:              fr,
+				PostWriter:          fpw,
+				Results:             results,
+				ResultsDirectory:    resultsDir,
+				TerminationPath:     terminationPath,
+				Timeout:             &timeout,
+				BreakpointOnFailure: c.breakpointOnFailure,
+				StepMetadataDir:     c.stepDir,
+				SpireWorkloadAPI:    signClient,
+			}.Go()
+			if err != nil {
+				t.Fatalf("Entrypointer failed: %v", err)
+			}
+
+			fileContents, err := ioutil.ReadFile(terminationPath)
+			if err == nil {
+				resultCheck := map[string]bool{}
+				var entries []v1beta1.PipelineResourceResult
+				if err := json.Unmarshal(fileContents, &entries); err != nil {
+					t.Fatalf("failed to unmarshal results: %v", err)
+				}
+
+				for _, result := range entries {
+					if _, ok := c.resultsToWrite[result.Key]; ok {
+						if c.resultsToWrite[result.Key] == result.Value {
+							resultCheck[result.Key] = true
+						} else {
+							t.Errorf("expected result (%v) to have value %v, got %v", result.Key, result.Value, c.resultsToWrite[result.Key])
+						}
+					}
+				}
+
+				if len(resultCheck) != len(c.resultsToWrite) {
+					t.Error("number of results matching did not add up")
+				}
+
+				// Check signature
+				verified := verifyClient.VerifyTaskRunResults(ctx, entries, tr) == nil
+				if verified != c.signVerify {
+					t.Errorf("expected signature verify result %v, got %v", c.signVerify, verified)
+				}
+			} else if !os.IsNotExist(err) {
+				t.Error("Wanted termination file written, got nil")
+			}
+			if err := os.Remove(terminationPath); err != nil {
+				t.Errorf("Could not remove termination path: %s", err)
+			}
+		})
+	}
+}
+
 type fakeWaiter struct{ waited []string }
 
 func (f *fakeWaiter) Wait(file string, _ bool, _ bool) error {
@@ -502,4 +667,56 @@ type fakeExitErrorRunner struct{ args *[]string }
 func (f *fakeExitErrorRunner) Run(ctx context.Context, args ...string) error {
 	f.args = &args
 	return exec.Command("ls", "/bogus/path").Run()
+}
+
+type fakeResultsWriter struct {
+	args           *[]string
+	resultsToWrite map[string]string
+}
+
+func (f *fakeResultsWriter) Run(ctx context.Context, args ...string) error {
+	f.args = &args
+	for k, v := range f.resultsToWrite {
+		err := ioutil.WriteFile(k, []byte(v), 0666)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func createTmpDir(t *testing.T, name string) string {
+	tmpDir, err := ioutil.TempDir("", name)
+	if err != nil {
+		t.Fatalf("unexpected error creating temporary dir: %v", err)
+	}
+	return tmpDir
+}
+
+func getMockSpireClient(ctx context.Context) (spire.EntrypointerAPIClient, spire.ControllerAPIClient, *v1beta1.TaskRun) {
+	tr := &v1beta1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "taskrun-example",
+			Namespace: "foo",
+		},
+		Spec: v1beta1.TaskRunSpec{
+			TaskRef: &v1beta1.TaskRef{
+				Name:       "taskname",
+				APIVersion: "a1",
+			},
+			ServiceAccountName: "test-sa",
+		},
+	}
+
+	sc := &spire.MockClient{}
+
+	_ = sc.CreateEntries(ctx, tr, nil, 10000)
+
+	// bootstrap with about 20 calls to sign which should be enough for testing
+	id := sc.GetIdentity(tr)
+	for i := 0; i < 20; i++ {
+		sc.SignIdentities = append(sc.SignIdentities, id)
+	}
+
+	return sc, sc, tr
 }


### PR DESCRIPTION
Breaking down PR #4759 originally proposed by @pxp928 to address TEP-0089 according @lumjjb suggestions.
Plan for breaking down PR is
PR 1.1: api
PR 1.2: entrypointer (+cmd line + test/entrypointer) Entrypoint takes results and signs the results (termination message). PR 1.3: reconciler + pod + cmd/controller + integration tests Controller will verify the signed result.
This commit corresponds to 1.2 above.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [X] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [X] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [X] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [X] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [X] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
