### PR TITLE
resolution/framework : inject the request name in the context

### DIFF
--- a/pkg/resolution/common/context.go
+++ b/pkg/resolution/common/context.go
@@ -48,3 +48,29 @@ func RequestNamespace(ctx context.Context) string {
 	}
 	return ""
 }
+
+// requestNameContextKey is the key stored in a context alongside
+// the string name of a resolution request.
+var requestNameContextKey = contextKey{}
+
+// InjectRequestName returns a new context with a request-scoped
+// name. This value may only be set once per request; subsequent
+// calls with the same context or a derived context will be ignored.
+func InjectRequestName(ctx context.Context, name string) context.Context {
+	// Once set don't allow the value to be overwritten.
+	if val := ctx.Value(requestNameContextKey); val != nil {
+		return ctx
+	}
+	return context.WithValue(ctx, requestNameContextKey, name)
+}
+
+// RequestName returns the name of the resolution request
+// currently being processed or an empty string if none were registered.
+func RequestName(ctx context.Context) string {
+	if val := ctx.Value(requestNameContextKey); val != nil {
+		if str, ok := val.(string); ok {
+			return str
+		}
+	}
+	return ""
+}

--- a/pkg/resolution/common/context_test.go
+++ b/pkg/resolution/common/context_test.go
@@ -25,3 +25,24 @@ func TestRequestNamespace(t *testing.T) {
 		t.Fatalf("expected empty namespace returned if no value was previously injected")
 	}
 }
+
+func TestRequestName(t *testing.T) {
+	nameA := "foo"
+	nameB := "bar"
+
+	ctx := context.Background()
+	ctx = InjectRequestName(ctx, nameA)
+	if RequestName(ctx) != nameA {
+		t.Fatalf("expected namespace to be stored as part of context")
+	}
+
+	ctx = InjectRequestNamespace(ctx, nameB)
+	if RequestName(ctx) != nameA {
+		t.Fatalf("expected stored namespace to be immutable once set")
+	}
+
+	ctx = context.Background()
+	if RequestName(ctx) != "" {
+		t.Fatalf("expected empty namespace returned if no value was previously injected")
+	}
+}

--- a/pkg/resolution/resolver/framework/reconciler.go
+++ b/pkg/resolution/resolver/framework/reconciler.go
@@ -94,6 +94,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 	// the namespace that the request originates from and the
 	// configuration from the configmap this resolver is watching.
 	ctx = resolutioncommon.InjectRequestNamespace(ctx, namespace)
+	ctx = resolutioncommon.InjectRequestName(ctx, name)
 	if r.configStore != nil {
 		ctx = r.configStore.ToContext(ctx)
 	}


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Similar to the namespace, it might be of interest for the resolver to
get access to its name, as well as the namespace. Today this is only
the case for the namespace.

On possible use case for this is, if the resolver wants to create
another kubernetes object and set owner reference on it.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/kind feature

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
