### PR TITLE
ref: prompt for specific error fields

### DIFF
--- a/pkg/apis/pipeline/v1beta1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types.go
@@ -290,14 +290,14 @@ func (pt PipelineTask) validateTask(ctx context.Context) (errs *apis.FieldError)
 		if pt.TaskRef.Name != "" {
 			// TaskRef name must be a valid k8s name
 			if errSlice := validation.IsQualifiedName(pt.TaskRef.Name); len(errSlice) != 0 {
-				errs = errs.Also(apis.ErrInvalidValue(strings.Join(errSlice, ","), "name"))
+				errs = errs.Also(apis.ErrInvalidValue(strings.Join(errSlice, ","), "taskRef.name"))
 			}
 		} else if pt.TaskRef.Resolver == "" {
 			errs = errs.Also(apis.ErrInvalidValue("taskRef must specify name", "taskRef.name"))
 		}
 		// fail if bundle is present when EnableTektonOCIBundles feature flag is off (as it won't be allowed nor used)
 		if !cfg.FeatureFlags.EnableTektonOCIBundles && pt.TaskRef.Bundle != "" {
-			errs = errs.Also(apis.ErrDisallowedFields("taskref.bundle"))
+			errs = errs.Also(apis.ErrDisallowedFields("taskRef.bundle"))
 		}
 	}
 	return errs

--- a/pkg/apis/pipeline/v1beta1/pipeline_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types_test.go
@@ -309,7 +309,7 @@ func TestPipelineTask_ValidateRegularTask_Failure(t *testing.T) {
 		},
 		expectedError: apis.FieldError{
 			Message: `invalid value: name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')`,
-			Paths:   []string{"name"},
+			Paths:   []string{"taskRef.name"},
 		},
 	}, {
 		name: "pipeline task - taskRef without name",
@@ -327,7 +327,7 @@ func TestPipelineTask_ValidateRegularTask_Failure(t *testing.T) {
 			Name:    "foo",
 			TaskRef: &TaskRef{Name: "bar", Bundle: "docker.io/foo"},
 		},
-		expectedError: *apis.ErrDisallowedFields("taskref.bundle"),
+		expectedError: *apis.ErrDisallowedFields("taskRef.bundle"),
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -1227,7 +1227,7 @@ func combineTaskRunAndTaskSpecAnnotations(pr *v1beta1.PipelineRun, pipelineTask 
 // addMetadataByPrecedence() adds the elements in addedMetadata to metadata. If the same key is present in both maps, the value from metadata will be used.
 func addMetadataByPrecedence(metadata map[string]string, addedMetadata map[string]string) {
 	for key, value := range addedMetadata {
-		// add new annotations if the key not exists in current ones
+		// add new annotations/labels  if the key not exists in current ones
 		if _, ok := metadata[key]; !ok {
 			metadata[key] = value
 		}

--- a/pkg/reconciler/pipelinerun/resources/pipelineref.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelineref.go
@@ -81,7 +81,7 @@ func GetPipelineFunc(ctx context.Context, k8s kubernetes.Interface, tekton clien
 			return resolvePipeline(ctx, resolver, name)
 		}, nil
 	default:
-		// Even if there is no task ref, we should try to return a local resolver.
+		// Even if there is no pipeline ref, we should try to return a local resolver.
 		local := &LocalPipelineRefResolver{
 			Namespace:    namespace,
 			Tektonclient: tekton,


### PR DESCRIPTION
# Changes

We encountered an error, but the error message does not match.

```
Error from server (BadRequest): error when creating "pipeline_scan.yml": admission webhook "validation.webhook.pipeline.tekton.dev" denied the request: validation failed: invalid value: name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]'): spec.tasks[0].name
```

# Steps to Reproduce the Problem
```
apiVersion: tekton.dev/v1beta1
kind: Pipeline
metadata:
...
  - name: scan
    params:
    - name: git_reponame
      value: $(params.git_reponame)
    runAfter:
    - git-clone
    taskRef:
      kind: ClusterTask
      name: scan-security.  // invalid taskRef.name
    workspaces:
    - name: repo
      workspace: repo
...
```

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```