### PR TITLE
Set ConfigSource in bundleresolver

### DIFF
--- a/docs/bundle-resolver.md
+++ b/docs/bundle-resolver.md
@@ -81,6 +81,73 @@ spec:
     value: "tekton pipelines"
 ```
 
+## `ResolutionRequest` Status
+`ResolutionRequest.Status.Source` field captures the source where the remote resource came from. It includes the 3 subfields: `url`, `digest` and `entrypoint`.
+- `uri`: The image repository URI
+- `digest`: The map of the algorithm portion -> the hex encoded portion of the image digest.
+- `entrypoint`: The resource name in the OCI bundle image.
+
+Example:
+- TaskRun Resolution
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: remote-task-reference
+spec:
+  taskRef:
+    resolver: bundles
+    params:
+    - name: bundle
+      value: gcr.io/tekton-releases/catalog/upstream/git-clone:0.7
+    - name: name
+      value: git-clone
+    - name: kind
+      value: task
+  params:
+    - name: url
+      value: https://github.com/octocat/Hello-World
+  workspaces:
+    - name: output
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 500Mi
+```
+
+- `ResolutionRequest`
+```yaml
+apiVersion: resolution.tekton.dev/v1beta1
+kind: ResolutionRequest
+metadata:
+  ...
+  labels:
+    resolution.tekton.dev/type: bundles
+  name: bundles-21ad80ec13f3e8b73fed5880a64d4611
+  ...
+spec:
+  params:
+  - name: bundle
+    value: gcr.io/tekton-releases/catalog/upstream/git-clone:0.7
+  - name: name
+    value: git-clone
+  - name: kind
+    value: task
+status:
+  annotations: ...
+  ...
+  data: xxx
+  observedGeneration: 1
+  source:
+    digest:
+      sha256: f51ca50f1c065acba8290ef14adec8461915ecc5f70a8eb26190c6e8e0ededaf
+    entryPoint: git-clone
+    uri: gcr.io/tekton-releases/catalog/upstream/git-clone
+```
+
 ---
 
 Except as otherwise noted, the content of this page is licensed under the


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

/kind feature

Related to https://github.com/tektoncd/pipeline/issues/5522

Prior, a field named Source was introduced to `ResolutionRequest` status to record the source where the remote resource came from. And the individual resolvers need to implement the Source function to set the correct source value. But the method in ociresolver returns a nil value.

Now, we return correct source value with the 3 subfields: url, digest and entrypoint
- `url`: The image repository URI
- `digest`: The map of the algorithm portion -> the hex encoded portion of the image digest.
- `entrypoint`: The resource name in the OCI bundle image.

Signed-off-by: Chuang Wang <chuangw@google.com>

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
ociresolver captures correct source information about where remote image came from.
```
