### PR TITLE
Set ConfigSource in clusterresolver

### DIFF
--- a/docs/cluster-resolver.md
+++ b/docs/cluster-resolver.md
@@ -74,6 +74,60 @@ spec:
       value: namespace-containing-pipeline
 ```
 
+## `ResolutionRequest` Status
+`ResolutionRequest.Status.Source` field captures the source where the remote resource came from. It includes the 3 subfields: `url`, `digest` and `entrypoint`.
+- `url`: url is the unique full identifier for the resource in the cluster. It is in the format of `<resource uri>@<uid>`. Resource URI part is the namespace-scoped uri i.e. `/apis/GROUP/VERSION/namespaces/NAMESPACE/RESOURCETYPE/NAME`. See [K8s Resource URIs](https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-uris) for more details.
+- `digest`: hex-encoded sha256 checksum of the content in the in-cluster resource's spec field. The reason why it's the checksum of the spec content rather than the whole object is because the metadata of in-cluster resources might be modified i.e. annotations. Therefore, the checksum of the spec content should be sufficient for source verifiers to verify if things have been changed maliciously even though the metadata is modified with good intentions.
+- `entrypoint`: ***empty*** because the path information is already available in the url field.
+
+Example:
+- TaskRun Resolution
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: cluster-demo
+spec:
+  taskRef:
+    resolver: cluster
+    params:
+    - name: kind
+      value: task
+    - name: name
+      value: a-simple-task
+    - name: namespace
+      value: default
+```
+
+
+- `ResolutionRequest`
+```yaml
+apiVersion: resolution.tekton.dev/v1beta1
+kind: ResolutionRequest
+metadata:
+  labels:
+    resolution.tekton.dev/type: cluster
+  name: cluster-7a04be6baa3eeedd232542036b7f3b2d
+  namespace: default
+  ownerReferences: ...
+spec:
+  params:
+  - name: kind
+    value: task
+  - name: name
+    value: a-simple-task
+  - name: namespace
+    value: default
+status:
+  annotations: ...
+  conditions: ...
+  data: xxx
+  source:
+    digest:
+      sha256: 245b1aa918434cc8195b4d4d026f2e43df09199e2ed31d4dfd9c2cbea1c7ce54
+    uri: /apis/tekton.dev/v1beta1/namespaces/default/task/a-simple-task@3b82d8c4-f89e-47ea-a49d-3be0dca4c038
+```
 ---
 
 Except as otherwise noted, the content of this page is licensed under the


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

/kind feature

Related to https://github.com/tektoncd/pipeline/issues/5522

Prior, a field named Source was introduced to ResolutionRequest status to record the source where the remote resource came from. And the individual resolvers need to implement the Source function to set the correct source value. But the method in clusterresolver returns a nil value.

Now, we return correct source value with the 3 subfields: url, digest and entrypoint
- url: [Kubernetes CRD namespace-scoped resource URI](https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-uris) appended with UID.
Example: /apis/GROUP/VERSION/namespaces/NAMESPACE/RESOURCETYPE/NAME@UID.
- digest: hex-encoded sha256 checksum of the in-cluster resource
- entrypoint: ***empty*** because the path is already available in url field.

Signed-off-by: Chuang Wang <chuangw@google.com>

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Set source value for cluster resource to link back its origin i.e. url and checksum.
```
