### PR TITLE
fix cloud event flaky unit tests by adding waitgroup to fakeclient

### DIFF
--- a/pkg/reconciler/customrun/customrun_test.go
+++ b/pkg/reconciler/customrun/customrun_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/tektoncd/pipeline/pkg/reconciler/events/cloudevent"
 	ttesting "github.com/tektoncd/pipeline/pkg/reconciler/testing"
 	"github.com/tektoncd/pipeline/test"
-	eventstest "github.com/tektoncd/pipeline/test/events"
 	"github.com/tektoncd/pipeline/test/names"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -47,6 +46,7 @@ import (
 
 func initializeCustomRunControllerAssets(t *testing.T, d test.Data) (test.Assets, func()) {
 	ctx, _ := ttesting.SetupFakeContext(t)
+	ctx = ttesting.SetupFakeCloudClientContext(ctx, d.ExpectedCloudEventCount)
 	ctx, cancel := context.WithCancel(ctx)
 	test.EnsureConfigurationConfigMapsExist(&d)
 	c, informers := test.SeedTestData(t, ctx, d)
@@ -158,8 +158,9 @@ func TestReconcile_CloudEvents(t *testing.T) {
 			customRuns := []*v1beta1.CustomRun{&customRun}
 
 			d := test.Data{
-				CustomRuns: customRuns,
-				ConfigMaps: cms,
+				CustomRuns:              customRuns,
+				ConfigMaps:              cms,
+				ExpectedCloudEventCount: len(tc.wantCloudEvents),
 			}
 			testAssets, cancel := getCustomRunController(t, d)
 			defer cancel()
@@ -187,19 +188,13 @@ func TestReconcile_CloudEvents(t *testing.T) {
 			}
 
 			ceClient := clients.CloudEvents.(cloudevent.FakeClient)
-			err = eventstest.CheckEventsUnordered(t, ceClient.Events, tc.name, tc.wantCloudEvents)
-			if err != nil {
-				t.Errorf(err.Error())
-			}
+			ceClient.CheckCloudEventsUnordered(t, tc.name, tc.wantCloudEvents)
 
 			// Try and reconcile again - expect no event
 			if err := c.Reconciler.Reconcile(testAssets.Ctx, getCustomRunName(customRun)); err != nil {
 				t.Fatal("Didn't expect an error, but got one.")
 			}
-			err = eventstest.CheckEventsUnordered(t, ceClient.Events, tc.name, []string{})
-			if err != nil {
-				t.Errorf(err.Error())
-			}
+			ceClient.CheckCloudEventsUnordered(t, tc.name, []string{})
 		})
 	}
 }
@@ -296,10 +291,7 @@ func TestReconcile_CloudEvents_Disabled(t *testing.T) {
 			}
 
 			ceClient := clients.CloudEvents.(cloudevent.FakeClient)
-			err = eventstest.CheckEventsUnordered(t, ceClient.Events, tc.name, []string{})
-			if err != nil {
-				t.Errorf(err.Error())
-			}
+			ceClient.CheckCloudEventsUnordered(t, tc.name, []string{})
 		})
 	}
 }

--- a/pkg/reconciler/events/cloudevent/cloud_event_controller.go
+++ b/pkg/reconciler/events/cloudevent/cloud_event_controller.go
@@ -145,7 +145,10 @@ func SendCloudEventWithRetries(ctx context.Context, object runtime.Object) error
 	_, isCustomRun := object.(*v1beta1.CustomRun)
 
 	wasIn := make(chan error)
+
+	ceClient.addCount()
 	go func() {
+		defer ceClient.decreaseCount()
 		wasIn <- nil
 		logger.Debugf("Sending cloudevent of type %q", event.Type())
 		// In case of Run event, check cache if cloudevent is already sent

--- a/pkg/reconciler/events/cloudevent/cloudevent.go
+++ b/pkg/reconciler/events/cloudevent/cloudevent.go
@@ -88,8 +88,15 @@ func (t TektonEventType) String() string {
 	return string(t)
 }
 
-// CEClient matches the `Client` interface from github.com/cloudevents/sdk-go/v2/cloudevents
-type CEClient cloudevents.Client
+// CEClient wraps the `Client` interface from github.com/cloudevents/sdk-go/v2/cloudevents
+// and has methods to count the cloud events being sent, those methods are for testing purposes.
+type CEClient interface {
+	cloudevents.Client
+	// addCount increments the count of events to be sent
+	addCount()
+	// decreaseCount decrements the count of events to be sent, indicating the event has been sent
+	decreaseCount()
+}
 
 // TektonCloudEventData type is used to marshal and unmarshal the payload of
 // a Tekton cloud event. It can include a TaskRun or a PipelineRun

--- a/pkg/reconciler/events/cloudevent/cloudeventclient.go
+++ b/pkg/reconciler/events/cloudevent/cloudeventclient.go
@@ -21,6 +21,9 @@ import (
 	"net/http"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/cloudevents/sdk-go/v2/client"
+	"github.com/cloudevents/sdk-go/v2/event"
+	"github.com/cloudevents/sdk-go/v2/protocol"
 	"k8s.io/client-go/rest"
 	"knative.dev/pkg/injection"
 	"knative.dev/pkg/logging"
@@ -59,7 +62,38 @@ func withCloudEventClient(ctx context.Context) context.Context {
 		logger.Panicf("Error creating the cloudevents client: %s", err)
 	}
 
-	return context.WithValue(ctx, ceKey{}, cloudEventClient)
+	celient := CloudClient{
+		client: cloudEventClient,
+	}
+	return context.WithValue(ctx, ceKey{}, celient)
+}
+
+// CloudClient is a wrapper of CloudEvents client and implements addCount and decreaseCount
+type CloudClient struct {
+	client client.Client
+}
+
+// AddCount does nothing
+func (c CloudClient) addCount() {
+}
+
+// DecreaseCount does nothing
+func (c CloudClient) decreaseCount() {
+}
+
+// Send invokes call client.Send
+func (c CloudClient) Send(ctx context.Context, event cloudevents.Event) protocol.Result {
+	return c.client.Send(ctx, event)
+}
+
+// Request invokes client.Request
+func (c CloudClient) Request(ctx context.Context, event event.Event) (*cloudevents.Event, protocol.Result) {
+	return c.client.Request(ctx, event)
+}
+
+// StartReceiver invokes client.StartReceiver
+func (c CloudClient) StartReceiver(ctx context.Context, fn interface{}) error {
+	return c.client.StartReceiver(ctx, fn)
 }
 
 // Get extracts the cloudEventClient client from the context.

--- a/pkg/reconciler/events/cloudevent/cloudeventsfakeclient.go
+++ b/pkg/reconciler/events/cloudevent/cloudeventsfakeclient.go
@@ -19,12 +19,13 @@ package cloudevent
 import (
 	"context"
 	"fmt"
+	"regexp"
+	"sync"
+	"testing"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/cloudevents/sdk-go/v2/protocol"
 )
-
-const bufferSize = 100
 
 // FakeClientBehaviour defines how the client will behave
 type FakeClientBehaviour struct {
@@ -37,13 +38,17 @@ type FakeClient struct {
 	behaviour *FakeClientBehaviour
 	// Modelled after k8s.io/client-go fake recorder
 	Events chan string
+	// waitGroup is used to block until all events have been sent
+	waitGroup *sync.WaitGroup
 }
 
 // newFakeClient is a FakeClient factory, it returns a client for the target
-func newFakeClient(behaviour *FakeClientBehaviour) cloudevents.Client {
+func newFakeClient(behaviour *FakeClientBehaviour, expectedEventCount int) CEClient {
 	return FakeClient{
 		behaviour: behaviour,
-		Events:    make(chan string, bufferSize),
+		// set buffersize to length of want events to make sure no extra events are sent
+		Events:    make(chan string, expectedEventCount),
+		waitGroup: &sync.WaitGroup{},
 	}
 }
 
@@ -52,8 +57,12 @@ var _ cloudevents.Client = (*FakeClient)(nil)
 // Send fakes the Send method from cloudevents.Client
 func (c FakeClient) Send(ctx context.Context, event cloudevents.Event) protocol.Result {
 	if c.behaviour.SendSuccessfully {
-		c.Events <- fmt.Sprintf("%s", event.String())
-		return nil
+		// This is to prevent extra events are sent. We don't read events from channel before we call CheckCloudEventsUnordered
+		if len(c.Events) < cap(c.Events) {
+			c.Events <- fmt.Sprintf("%s", event.String())
+			return nil
+		}
+		return fmt.Errorf("Channel is full of size:%v, but extra event wants to be sent:%v", cap(c.Events), event)
 	}
 	return fmt.Errorf("Had to fail. Event ID: %s", event.ID())
 }
@@ -61,8 +70,11 @@ func (c FakeClient) Send(ctx context.Context, event cloudevents.Event) protocol.
 // Request fakes the Request method from cloudevents.Client
 func (c FakeClient) Request(ctx context.Context, event cloudevents.Event) (*cloudevents.Event, protocol.Result) {
 	if c.behaviour.SendSuccessfully {
-		c.Events <- fmt.Sprintf("%v", event.String())
-		return &event, nil
+		if len(c.Events) < cap(c.Events) {
+			c.Events <- fmt.Sprintf("%v", event.String())
+			return &event, nil
+		}
+		return nil, fmt.Errorf("Channel is full of size:%v, but extra event wants to be sent:%v", cap(c.Events), event)
 	}
 	return nil, fmt.Errorf("Had to fail. Event ID: %s", event.ID())
 }
@@ -72,7 +84,56 @@ func (c FakeClient) StartReceiver(ctx context.Context, fn interface{}) error {
 	return nil
 }
 
-// WithClient adds to the context a fake client with the desired behaviour
-func WithClient(ctx context.Context, behaviour *FakeClientBehaviour) context.Context {
-	return context.WithValue(ctx, ceKey{}, newFakeClient(behaviour))
+// addCount can be used to add the count when each event is going to be sent
+func (c FakeClient) addCount() {
+	c.waitGroup.Add(1)
+}
+
+// decreaseCount can be used to the decrease the count when each event is sent
+func (c FakeClient) decreaseCount() {
+	c.waitGroup.Done()
+}
+
+// WithClient adds to the context a fake client with the desired behaviour and expectedEventCount
+func WithClient(ctx context.Context, behaviour *FakeClientBehaviour, expectedEventCount int) context.Context {
+	return context.WithValue(ctx, ceKey{}, newFakeClient(behaviour, expectedEventCount))
+}
+
+// CheckCloudEventsUnordered checks that all events in wantEvents, and no others,
+// were received via the given chan, in any order.
+// Block until all events have been sent.
+func (c *FakeClient) CheckCloudEventsUnordered(t *testing.T, testName string, wantEvents []string) {
+	t.Helper()
+	c.waitGroup.Wait()
+	expected := append([]string{}, wantEvents...)
+	channelEvents := len(c.Events)
+
+	// extra events are prevented in FakeClient's Send function.
+	// fewer events are detected because we collect all events from channel and compare with wantEvents
+	for eventCount := 0; eventCount < channelEvents; eventCount++ {
+		event := <-c.Events
+		if len(expected) == 0 {
+			t.Errorf("extra event received: %q", event)
+		}
+		found := false
+		for wantIdx, want := range expected {
+			matching, err := regexp.MatchString(want, event)
+			if err != nil {
+				t.Errorf("something went wrong matching an event: %s", err)
+			}
+			if matching {
+				found = true
+				// Remove event from list of those we expect to receive
+				expected[wantIdx] = expected[len(expected)-1]
+				expected = expected[:len(expected)-1]
+				break
+			}
+		}
+		if !found {
+			t.Errorf("unexpected event received: %q", event)
+		}
+	}
+	if len(expected) != 0 {
+		t.Errorf("%d events %#v are not received", len(expected), expected)
+	}
 }

--- a/pkg/reconciler/events/cloudevent/cloudeventsfakeclient_test.go
+++ b/pkg/reconciler/events/cloudevent/cloudeventsfakeclient_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2022 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudevent
+
+import (
+	"testing"
+
+	"github.com/cloudevents/sdk-go/v2/event"
+	rtesting "knative.dev/pkg/reconciler/testing"
+)
+
+func TestSend_Success(t *testing.T) {
+	sendEvents := []event.Event{
+		{
+			Context: event.EventContextV1{
+				ID: "test-event",
+			}.AsV1(),
+		}, {
+			Context: event.EventContextV1{
+				ID: "test-event2",
+			}.AsV1(),
+		},
+	}
+
+	wantEvents := []string{"Context Attributes,", "Context Attributes,"}
+
+	// Setup the context and seed test event
+	ctx, _ := rtesting.SetupFakeContext(t)
+	ctx = WithClient(ctx, &FakeClientBehaviour{SendSuccessfully: true}, len(wantEvents))
+	fakeClient := Get(ctx).(FakeClient)
+
+	for _, e := range sendEvents {
+		err := fakeClient.Send(ctx, e)
+		if err != nil {
+			t.Fatalf("got err %v", err)
+		}
+
+	}
+	fakeClient.CheckCloudEventsUnordered(t, "send cloud events", wantEvents)
+}
+
+func TestSend_Error(t *testing.T) {
+	sendEvent := event.Event{
+		Context: event.EventContextV1{
+			ID: "test-event",
+		}.AsV1(),
+	}
+
+	// Setup the context and seed test event
+	ctx, _ := rtesting.SetupFakeContext(t)
+	ctx = WithClient(ctx, &FakeClientBehaviour{SendSuccessfully: true}, 0)
+	fakeClient := Get(ctx).(FakeClient)
+
+	// the channel size is 0 so no more events can be sent
+	err := fakeClient.Send(ctx, sendEvent)
+	if err == nil {
+		t.Fatalf("want err but got nil")
+	}
+
+}

--- a/pkg/reconciler/events/event_test.go
+++ b/pkg/reconciler/events/event_test.go
@@ -143,7 +143,6 @@ func TestSendKubernetesEvents(t *testing.T) {
 		fr := record.NewFakeRecorder(1)
 		tr := &corev1.Pod{}
 		sendKubernetesEvents(fr, ts.before, ts.after, tr)
-
 		err := eventstest.CheckEventsOrdered(t, fr.Events, ts.name, ts.wantEvents)
 		if err != nil {
 			t.Errorf(err.Error())
@@ -170,7 +169,6 @@ func TestEmitError(t *testing.T) {
 		fr := record.NewFakeRecorder(1)
 		tr := &corev1.Pod{}
 		EmitError(fr, ts.err, tr)
-
 		err := eventstest.CheckEventsOrdered(t, fr.Events, ts.name, ts.wantEvents)
 		if err != nil {
 			t.Errorf(err.Error())
@@ -222,7 +220,7 @@ func TestEmit(t *testing.T) {
 	for _, tc := range testcases {
 		// Setup the context and seed test data
 		ctx, _ := rtesting.SetupFakeContext(t)
-		ctx = cloudevent.WithClient(ctx, &cloudevent.FakeClientBehaviour{SendSuccessfully: true})
+		ctx = cloudevent.WithClient(ctx, &cloudevent.FakeClientBehaviour{SendSuccessfully: true}, len(tc.wantCloudEvents))
 		fakeClient := cloudevent.Get(ctx).(cloudevent.FakeClient)
 
 		// Setup the config and add it to the context
@@ -239,9 +237,7 @@ func TestEmit(t *testing.T) {
 		if err := eventstest.CheckEventsOrdered(t, recorder.Events, tc.name, tc.wantEvents); err != nil {
 			t.Fatalf(err.Error())
 		}
-		if err := eventstest.CheckEventsUnordered(t, fakeClient.Events, tc.name, tc.wantCloudEvents); err != nil {
-			t.Fatalf(err.Error())
-		}
+		fakeClient.CheckCloudEventsUnordered(t, tc.name, tc.wantCloudEvents)
 	}
 }
 
@@ -278,7 +274,7 @@ func TestEmitCloudEvents(t *testing.T) {
 	for _, tc := range testcases {
 		// Setup the context and seed test data
 		ctx, _ := rtesting.SetupFakeContext(t)
-		ctx = cloudevent.WithClient(ctx, &cloudevent.FakeClientBehaviour{SendSuccessfully: true})
+		ctx = cloudevent.WithClient(ctx, &cloudevent.FakeClientBehaviour{SendSuccessfully: true}, len(tc.wantCloudEvents))
 		fakeClient := cloudevent.Get(ctx).(cloudevent.FakeClient)
 
 		// Setup the config and add it to the context
@@ -295,8 +291,6 @@ func TestEmitCloudEvents(t *testing.T) {
 		if err := eventstest.CheckEventsOrdered(t, recorder.Events, tc.name, tc.wantEvents); err != nil {
 			t.Fatalf(err.Error())
 		}
-		if err := eventstest.CheckEventsUnordered(t, fakeClient.Events, tc.name, tc.wantCloudEvents); err != nil {
-			t.Fatalf(err.Error())
-		}
+		fakeClient.CheckCloudEventsUnordered(t, tc.name, tc.wantCloudEvents)
 	}
 }

--- a/pkg/reconciler/testing/logger.go
+++ b/pkg/reconciler/testing/logger.go
@@ -24,11 +24,15 @@ import (
 // SetupFakeContext sets up the Context and the fake filtered informers for the tests.
 func SetupFakeContext(t *testing.T) (context.Context, []controller.Informer) {
 	ctx, _, informer := setupFakeContextWithLabelKey(t)
+	return WithLogger(ctx, t), informer
+}
+
+// SetupFakeCloudClientContext sets up the fakeclient to context
+func SetupFakeCloudClientContext(ctx context.Context, expectedEventCount int) context.Context {
 	cloudEventClientBehaviour := cloudevent.FakeClientBehaviour{
 		SendSuccessfully: true,
 	}
-	ctx = cloudevent.WithClient(ctx, &cloudEventClientBehaviour)
-	return WithLogger(ctx, t), informer
+	return cloudevent.WithClient(ctx, &cloudEventClientBehaviour, expectedEventCount)
 }
 
 // SetupDefaultContext sets up the Context and the default filtered informers for the tests.

--- a/test/controller.go
+++ b/test/controller.go
@@ -71,20 +71,21 @@ import (
 // Data represents the desired state of the system (i.e. existing resources) to seed controllers
 // with.
 type Data struct {
-	PipelineRuns       []*v1beta1.PipelineRun
-	Pipelines          []*v1beta1.Pipeline
-	TaskRuns           []*v1beta1.TaskRun
-	Tasks              []*v1beta1.Task
-	ClusterTasks       []*v1beta1.ClusterTask
-	PipelineResources  []*resourcev1alpha1.PipelineResource
-	Runs               []*v1alpha1.Run
-	CustomRuns         []*v1beta1.CustomRun
-	Pods               []*corev1.Pod
-	Namespaces         []*corev1.Namespace
-	ConfigMaps         []*corev1.ConfigMap
-	ServiceAccounts    []*corev1.ServiceAccount
-	LimitRange         []*corev1.LimitRange
-	ResolutionRequests []*resolutionv1alpha1.ResolutionRequest
+	PipelineRuns            []*v1beta1.PipelineRun
+	Pipelines               []*v1beta1.Pipeline
+	TaskRuns                []*v1beta1.TaskRun
+	Tasks                   []*v1beta1.Task
+	ClusterTasks            []*v1beta1.ClusterTask
+	PipelineResources       []*resourcev1alpha1.PipelineResource
+	Runs                    []*v1alpha1.Run
+	CustomRuns              []*v1beta1.CustomRun
+	Pods                    []*corev1.Pod
+	Namespaces              []*corev1.Namespace
+	ConfigMaps              []*corev1.ConfigMap
+	ServiceAccounts         []*corev1.ServiceAccount
+	LimitRange              []*corev1.LimitRange
+	ResolutionRequests      []*resolutionv1alpha1.ResolutionRequest
+	ExpectedCloudEventCount int
 }
 
 // Clients holds references to clients which are useful for reconciler tests.


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This commit adds waitgroup to fakeclient to avoid that some goroutines are not done when we want to collect the events.
The tests are flaky because the cloud events are sent with goroutine
but we don't wait until all goroutines done to check the events. So it
is possible that some events are not collected. The waitGroup will count when each goroutine is created and decrease the count when the goroutine is done.
This change has no impact on current code.

/kind flake

Signed-off-by: Yongxuanzhang yongxuanzhang@google.com

related issues:
https://github.com/tektoncd/pipeline/issues/5160
to reproduce this issue, adding time.Sleep(100 * time.Millisecond) to https://github.com/tektoncd/pipeline/blob/b648a5b2eaebf0ece7199dcf2bd89c65137973d5/pkg/reconciler/events/cloudevent/cloudeventsfakeclient.go#L53  
related PR:
https://github.com/tektoncd/pipeline/pull/5313
Recent failing tests:

- https://prow.tekton.dev/view/gs/tekton-prow/pr-logs/pull/tektoncd_pipeline/5666/pull-tekton-pipeline-unit-tests/1582795530906374144
- https://prow.tekton.dev/view/gs/tekton-prow/pr-logs/pull/tektoncd_pipeline/5662/pull-tekton-pipeline-unit-tests/1583441668340715520
- https://prow.tekton.dev/view/gs/tekton-prow/pr-logs/pull/tektoncd_pipeline/5647/pull-tekton-pipeline-unit-tests/1583130831700889600

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Fix cloud event flacky unit tests by adding EventSender
```
