### PR TITLE
TEP-0114: Remove `retries` field in the initial release.

### DIFF
--- a/pkg/apis/pipeline/v1beta1/customrun_types.go
+++ b/pkg/apis/pipeline/v1beta1/customrun_types.go
@@ -64,10 +64,6 @@ type CustomRunSpec struct {
 	// +optional
 	StatusMessage CustomRunSpecStatusMessage `json:"statusMessage,omitempty"`
 
-	// Used for propagating retries count to custom tasks
-	// +optional
-	Retries int `json:"retries,omitempty"`
-
 	// +optional
 	ServiceAccountName string `json:"serviceAccountName"`
 

--- a/pkg/apis/pipeline/v1beta1/customrun_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/customrun_types_test.go
@@ -198,7 +198,6 @@ kind: CustomRun
 metadata:
   name: run
 spec:
-  retries: 3
   customRef:
     apiVersion: example.dev/v0
     kind: Example
@@ -228,7 +227,6 @@ status:
 			Name: "run",
 		},
 		Spec: v1beta1.CustomRunSpec{
-			Retries: 3,
 			CustomRef: &v1beta1.TaskRef{
 				APIVersion: "example.dev/v0",
 				Kind:       "Example",


### PR DESCRIPTION
# Changes

As per [TEP-0114](https://github.com/tektoncd/community/blob/1b3b77d0042a2a817332c4f09e6f42b93bf7eac8/teps/0114-custom-tasks-beta.md), this commit excludes the `retries` and `retriesStatus` in the initial release.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] ~Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing~
- [x] ~Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed~
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ x Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] ~Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)~
- [x] ~Release notes contains the string "action required" if the change requires additional action from users switching to the new release~

# Release Notes

```release-note
NONE
```
