### PR TITLE
Make the webhook port number configurable

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -222,7 +222,7 @@ func main() {
 	// Set up a signal context with our webhook options
 	ctx = webhook.WithOptions(ctx, webhook.Options{
 		ServiceName: serviceName,
-		Port:        8443,
+		Port:        webhook.PortFromEnv(8443),
 		SecretName:  secretName,
 	})
 

--- a/config/webhook.yaml
+++ b/config/webhook.yaml
@@ -101,6 +101,10 @@ spec:
           value: config-leader-election
         - name: CONFIG_FEATURE_FLAGS_NAME
           value: feature-flags
+        # If you change WEBHOOK_PORT, you will also need to change the
+        # containerPort "https-webhook" to the same value.
+        - name: WEBHOOK_PORT
+          value: "8443"
         - name: WEBHOOK_SERVICE_NAME
           value: tekton-pipelines-webhook
         - name: WEBHOOK_SECRET_NAME
@@ -123,6 +127,7 @@ spec:
           containerPort: 9090
         - name: profiling
           containerPort: 8008
+        # This must match the value of the environment variable WEBHOOK_PORT.
         - name: https-webhook
           containerPort: 8443
         - name: probes
@@ -171,7 +176,7 @@ spec:
     targetPort: 8008
   - name: https-webhook
     port: 443
-    targetPort: 8443
+    targetPort: https-webhook
   - name: probes
     port: 8080
   selector:


### PR DESCRIPTION
# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

Previously the webhook listened on a fixed port, 8443, which is
likely to clash with other services when the webhook is run on the
host network in Kubernetes, which is required when using some CNI
implementations, notably Calico on EKS [1].

Enable configuration of the webhook listen port through the environment
variable WEBHOOK_PORT by using the existing API from the KNative SDK.

[1] https://projectcalico.docs.tigera.io/getting-started/kubernetes/managed-public-cloud/eks#install-eks-with-calico-networking

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
The port on which the webhook server listens may be configured via the WEBHOOK_PORT environment variable.
```
