### PR TITLE
Update README and releases for v0.41.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Tekton Pipelines are **Typed**:
 - Starting from the v0.30.x release of Tekton: **Kubernetes version 1.20 or later**
 - Starting from the v0.33.x release of Tekton: **Kubernetes version 1.21 or later**
 - Starting from the v0.39.x release of Tekton: **Kubernetes version 1.22 or later**
+- Starting from the v0.41.x release of Tekton: **Kubernetes version 1.23 or later**
 
 ### Read the docs
 

--- a/releases.md
+++ b/releases.md
@@ -41,6 +41,13 @@ Further documentation available:
 
 ## Releases
 
+### v0.41
+
+- **Latest Release**: [v0.41.0][v0-41-0] (2022-10-31) ([docs][v0-41-0-docs], [examples][v0-41-0-examples])
+- **Initial Release**: [v0.41.0][v0-41-0] (2022-10-31)
+- **End of Life**: 2023-10-30
+- **Patch Releases**: [v0.40.0][v0-40-0]
+
 ### v0.40
 
 - **Latest Release**: [v0.40.2][v0-40-2] (2022-10-03) ([docs][v0-40-2-docs], [examples][v0-40-2-examples])
@@ -62,17 +69,15 @@ Further documentation available:
 - **End of Life**: 2022-11-24
 - **Patch Releases**: [v0.38.0][v0-38-0], [v0.38.1][v0-38-1], [v0.38.2][v0-38-2], [v0.38.3][v0-38-3], [v0.38.4][v0-38-4]
 
+## End of Life Releases
+
 ### v0.37
 
 - **Latest Release**: [v0.37.5][v0-37-5] (2022-09-25) ([docs][v0-37-5-docs], [examples][v0-37-5-examples])
 - **Initial Release**: [v0.37.0][v0-37-0] (2022-06-21)
 - **End of Life**: 2022-10-20
-- **Patch Releases**: [v0.37.0][v0-37-0], [v0.37.1][v0-37-1], [v0.37.2][v0-37-2], [v0.37.3][v0-37-3], [v0.37.4][v0-37-4]，[v0.37.5][v0-37-5]
-
-## End of Life Releases
 
 Older releases are EOL and available on [GitHub][tekton-pipeline-releases].
-
 
 [release-policy]: https://github.com/tektoncd/community/blob/main/releases.md
 [sigstore]: https://sigstore.dev
@@ -84,6 +89,7 @@ Older releases are EOL and available on [GitHub][tekton-pipeline-releases].
 [release-notes-standards]:
     https://github.com/tektoncd/community/blob/main/standards.md#release-notes
 
+[v0-41-0]: https://github.com/tektoncd/pipeline/releases/tag/v0.41.0
 [v0-40-2]: https://github.com/tektoncd/pipeline/releases/tag/v0.40.2
 [v0-40-1]: https://github.com/tektoncd/pipeline/releases/tag/v0.40.1
 [v0-40-0]: https://github.com/tektoncd/pipeline/releases/tag/v0.40.0
@@ -94,17 +100,15 @@ Older releases are EOL and available on [GitHub][tekton-pipeline-releases].
 [v0-38-1]: https://github.com/tektoncd/pipeline/releases/tag/v0.38.1
 [v0-38-0]: https://github.com/tektoncd/pipeline/releases/tag/v0.38.0
 [v0-37-5]: https://github.com/tektoncd/pipeline/releases/tag/v0.37.5
-[v0-37-4]: https://github.com/tektoncd/pipeline/releases/tag/v0.37.4
-[v0-37-3]: https://github.com/tektoncd/pipeline/releases/tag/v0.37.3
-[v0-37-2]: https://github.com/tektoncd/pipeline/releases/tag/v0.37.2
-[v0-37-1]: https://github.com/tektoncd/pipeline/releases/tag/v0.37.1
 [v0-37-0]: https://github.com/tektoncd/pipeline/releases/tag/v0.37.0
 
+[v0-41-0-docs]: https://github.com/tektoncd/pipeline/tree/v0.41.0/docs#tekton-pipelines
 [v0-40-2-docs]: https://github.com/tektoncd/pipeline/tree/v0.40.2/docs#tekton-pipelines
 [v0-39-0-docs]: https://github.com/tektoncd/pipeline/tree/v0.39.0/docs#tekton-pipelines
 [v0-38-4-docs]: https://github.com/tektoncd/pipeline/tree/v0.38.4/docs#tekton-pipelines
 [v0-37-5-docs]: https://github.com/tektoncd/pipeline/tree/v0.37.5/docs#tekton-pipelines
 
+[v0-41-0-examples]: https://github.com/tektoncd/pipeline/tree/v0.41.0/examples#examples
 [v0-40-2-examples]: https://github.com/tektoncd/pipeline/tree/v0.40.2/examples#examples
 [v0-39-0-examples]: https://github.com/tektoncd/pipeline/tree/v0.39.0/examples#examples
 [v0-38-4-examples]: https://github.com/tektoncd/pipeline/tree/v0.38.4/examples#examples


### PR DESCRIPTION
# Changes

Update the README and releases file for v0.41.0.
Release v0.37.x is EOL, so moving it to the EOL releases.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
/kind documentation