### PR TITLE
Rename v1beta1 clients for test

### DIFF
--- a/pkg/reconciler/pipelinerun/affinity_assistant_test.go
+++ b/pkg/reconciler/pipelinerun/affinity_assistant_test.go
@@ -387,7 +387,7 @@ func TestGetAssistantAffinityMergedWithPodTemplateAffinity(t *testing.T) {
 		},
 	}
 
-	prWithEmptyAffinityPodTemplate := parse.MustParsePipelineRun(t, `
+	prWithEmptyAffinityPodTemplate := parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: pr-with-no-podTemplate
 `)
@@ -399,7 +399,7 @@ metadata:
 		},
 	}
 
-	prWithPodTemplatePodAffinity := parse.MustParsePipelineRun(t, `
+	prWithPodTemplatePodAffinity := parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: pr-with-podTemplate-podAffinity
 spec:
@@ -448,7 +448,7 @@ spec:
 		},
 	}
 
-	prWithPodTemplateNodeAffinity := parse.MustParsePipelineRun(t, `
+	prWithPodTemplateNodeAffinity := parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: pr-with-podTemplate-nodeAffinity
 spec:

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -235,7 +235,7 @@ func runTestReconcileWithEmbeddedStatus(t *testing.T, embeddedStatus string) {
 	// TestReconcile runs "Reconcile" on a PipelineRun with one Task that has not been started yet.
 	// It verifies that the TaskRun is created, it checks the resulting API actions, status and events.
 	names.TestingSeed()
-	prs := []*v1beta1.PipelineRun{parse.MustParsePipelineRun(t, `
+	prs := []*v1beta1.PipelineRun{parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: test-pipeline-run-success
   namespace: foo
@@ -257,7 +257,7 @@ spec:
       type: image
   serviceAccountName: test-sa
 `)}
-	ps := []*v1beta1.Pipeline{parse.MustParsePipeline(t, `
+	ps := []*v1beta1.Pipeline{parse.MustParseV1beta1Pipeline(t, `
 metadata:
   name: test-pipeline
   namespace: foo
@@ -365,7 +365,7 @@ spec:
       name: unit-test-cluster-task
 `)}
 	ts := []*v1beta1.Task{
-		parse.MustParseTask(t, `
+		parse.MustParseV1beta1Task(t, `
 metadata:
   name: unit-test-task
   namespace: foo
@@ -393,7 +393,7 @@ spec:
     - name: workspace
       type: git
 `),
-		parse.MustParseTask(t, `
+		parse.MustParseV1beta1Task(t, `
 metadata:
   name: unit-test-followup-task
   namespace: foo
@@ -598,21 +598,21 @@ spec:
 		embeddedStatus string
 	}{{
 		name:    "simple custom task with taskRef",
-		pr:      parse.MustParsePipelineRun(t, simpleCustomTaskPRYAML),
+		pr:      parse.MustParseV1beta1PipelineRun(t, simpleCustomTaskPRYAML),
 		wantRun: parse.MustParseRun(t, simpleCustomTaskWantRunYAML),
 	}, {
 		name:           "simple custom task with full embedded status",
-		pr:             parse.MustParsePipelineRun(t, simpleCustomTaskPRYAML),
+		pr:             parse.MustParseV1beta1PipelineRun(t, simpleCustomTaskPRYAML),
 		wantRun:        parse.MustParseRun(t, simpleCustomTaskWantRunYAML),
 		embeddedStatus: config.FullEmbeddedStatus,
 	}, {
 		name:           "simple custom task with minimal embedded status",
-		pr:             parse.MustParsePipelineRun(t, simpleCustomTaskPRYAML),
+		pr:             parse.MustParseV1beta1PipelineRun(t, simpleCustomTaskPRYAML),
 		wantRun:        parse.MustParseRun(t, simpleCustomTaskWantRunYAML),
 		embeddedStatus: config.MinimalEmbeddedStatus,
 	}, {
 		name: "simple custom task with taskSpec",
-		pr: parse.MustParsePipelineRun(t, `
+		pr: parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: test-pipelinerun
   namespace: namespace
@@ -653,7 +653,7 @@ spec:
 `),
 	}, {
 		name: "custom task with workspace",
-		pr: parse.MustParsePipelineRun(t, `
+		pr: parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: test-pipelinerun
   namespace: namespace
@@ -773,7 +773,7 @@ func runTestReconcilePipelineSpecTaskSpec(t *testing.T, embeddedStatus string) {
 	names.TestingSeed()
 
 	prs := []*v1beta1.PipelineRun{
-		parse.MustParsePipelineRun(t, `
+		parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: test-pipeline-run-success
   namespace: foo
@@ -783,7 +783,7 @@ spec:
 `),
 	}
 	ps := []*v1beta1.Pipeline{
-		parse.MustParsePipeline(t, `
+		parse.MustParseV1beta1Pipeline(t, `
 metadata:
   name: test-pipeline
   namespace: foo
@@ -813,7 +813,7 @@ spec:
 
 	// Check that the expected TaskRun was created
 	actual := getTaskRunCreations(t, clients.Pipeline.Actions(), 2)[0]
-	expectedTaskRun := parse.MustParseTaskRun(t, fmt.Sprintf(`
+	expectedTaskRun := parse.MustParseV1beta1TaskRun(t, fmt.Sprintf(`
 spec:
   taskSpec:
     steps:
@@ -843,12 +843,12 @@ spec:
 // It verifies that reconcile fails, how it fails and which events are triggered.
 func TestReconcile_InvalidPipelineRuns(t *testing.T) {
 	ts := []*v1beta1.Task{
-		parse.MustParseTask(t, `
+		parse.MustParseV1beta1Task(t, `
 metadata:
   name: a-task-that-exists
   namespace: foo
 `),
-		parse.MustParseTask(t, `
+		parse.MustParseV1beta1Task(t, `
 metadata:
   name: a-task-that-needs-params
   namespace: foo
@@ -856,7 +856,7 @@ spec:
   params:
     - name: some-param
 `),
-		parse.MustParseTask(t, fmt.Sprintf(`
+		parse.MustParseV1beta1Task(t, fmt.Sprintf(`
 metadata:
   name: a-task-that-needs-array-params
   namespace: foo
@@ -865,7 +865,7 @@ spec:
     - name: some-param
       type: %s
 `, v1beta1.ParamTypeArray)),
-		parse.MustParseTask(t, fmt.Sprintf(`
+		parse.MustParseV1beta1Task(t, fmt.Sprintf(`
 metadata:
   name: a-task-that-needs-object-params
   namespace: foo
@@ -877,7 +877,7 @@ spec:
         key1: {}
         key2: {}
 `, v1beta1.ParamTypeObject)),
-		parse.MustParseTask(t, fmt.Sprintf(`
+		parse.MustParseV1beta1Task(t, fmt.Sprintf(`
 metadata:
   name: a-task-that-needs-a-resource
   namespace: foo
@@ -889,7 +889,7 @@ spec:
 `, resourcev1alpha1.PipelineResourceTypeGit)),
 	}
 
-	ps := []*v1beta1.Pipeline{parse.MustParsePipeline(t, `
+	ps := []*v1beta1.Pipeline{parse.MustParseV1beta1Pipeline(t, `
 metadata:
   name: pipeline-missing-tasks
   namespace: foo
@@ -899,7 +899,7 @@ spec:
       taskRef:
         name: sometask
 `),
-		parse.MustParsePipeline(t, `
+		parse.MustParseV1beta1Pipeline(t, `
 metadata:
   name: a-pipeline-without-params
   namespace: foo
@@ -909,7 +909,7 @@ spec:
       taskRef:
         name: a-task-that-needs-params
 `),
-		parse.MustParsePipeline(t, fmt.Sprintf(`
+		parse.MustParseV1beta1Pipeline(t, fmt.Sprintf(`
 metadata:
   name: a-fine-pipeline
   namespace: foo
@@ -926,7 +926,7 @@ spec:
     - name: a-resource
       type: %s
 `, resourcev1alpha1.PipelineResourceTypeGit)),
-		parse.MustParsePipeline(t, `
+		parse.MustParseV1beta1Pipeline(t, `
 metadata:
   name: a-pipeline-that-should-be-caught-by-admission-control
   namespace: foo
@@ -940,7 +940,7 @@ spec:
           - name: needed-resource
             resource: a-resource
 `),
-		parse.MustParsePipeline(t, fmt.Sprintf(`
+		parse.MustParseV1beta1Pipeline(t, fmt.Sprintf(`
 metadata:
   name: a-pipeline-with-array-params
   namespace: foo
@@ -953,7 +953,7 @@ spec:
       taskRef:
         name: a-task-that-needs-array-params
 `, v1beta1.ParamTypeArray)),
-		parse.MustParsePipeline(t, fmt.Sprintf(`
+		parse.MustParseV1beta1Pipeline(t, fmt.Sprintf(`
 metadata:
   name: a-pipeline-with-object-params
   namespace: foo
@@ -980,7 +980,7 @@ spec:
 		wantEvents         []string
 	}{{
 		name: "invalid-pipeline-shd-be-stop-reconciling",
-		pipelineRun: parse.MustParsePipelineRun(t, `
+		pipelineRun: parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: invalid-pipeline
   namespace: foo
@@ -997,7 +997,7 @@ spec:
 		},
 	}, {
 		name: "invalid-pipeline-run-missing-tasks-shd-stop-reconciling",
-		pipelineRun: parse.MustParsePipelineRun(t, `
+		pipelineRun: parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: pipelinerun-missing-tasks
   namespace: foo
@@ -1013,7 +1013,7 @@ spec:
 		},
 	}, {
 		name: "invalid-pipeline-run-params-dont-exist-shd-stop-reconciling",
-		pipelineRun: parse.MustParsePipelineRun(t, `
+		pipelineRun: parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: pipeline-params-dont-exist
   namespace: foo
@@ -1029,7 +1029,7 @@ spec:
 		},
 	}, {
 		name: "invalid-pipeline-run-resources-not-bound-shd-stop-reconciling",
-		pipelineRun: parse.MustParsePipelineRun(t, `
+		pipelineRun: parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: pipeline-resources-not-bound
   namespace: foo
@@ -1045,7 +1045,7 @@ spec:
 		},
 	}, {
 		name: "invalid-pipeline-run-missing-resource-shd-stop-reconciling",
-		pipelineRun: parse.MustParsePipelineRun(t, `
+		pipelineRun: parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: pipeline-resources-dont-exist
   namespace: foo
@@ -1065,7 +1065,7 @@ spec:
 		},
 	}, {
 		name: "invalid-pipeline-missing-declared-resource-shd-stop-reconciling",
-		pipelineRun: parse.MustParsePipelineRun(t, `
+		pipelineRun: parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: pipeline-resources-not-declared
   namespace: foo
@@ -1081,7 +1081,7 @@ spec:
 		},
 	}, {
 		name: "invalid-pipeline-mismatching-parameter-types",
-		pipelineRun: parse.MustParsePipelineRun(t, `
+		pipelineRun: parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: pipeline-mismatching-param-type
   namespace: foo
@@ -1100,7 +1100,7 @@ spec:
 		},
 	}, {
 		name: "invalid-pipeline-missing-object-keys",
-		pipelineRun: parse.MustParsePipelineRun(t, `
+		pipelineRun: parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: pipeline-missing-object-param-keys
   namespace: foo
@@ -1120,7 +1120,7 @@ spec:
 		},
 	}, {
 		name: "invalid-embedded-pipeline-resources-bot-bound-shd-stop-reconciling",
-		pipelineRun: parse.MustParsePipelineRun(t, fmt.Sprintf(`
+		pipelineRun: parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   name: embedded-pipeline-resources-not-bound
   namespace: foo
@@ -1142,7 +1142,7 @@ spec:
 		},
 	}, {
 		name: "invalid-embedded-pipeline-bad-name-shd-stop-reconciling",
-		pipelineRun: parse.MustParsePipelineRun(t, `
+		pipelineRun: parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: embedded-pipeline-invalid
   namespace: foo
@@ -1161,7 +1161,7 @@ spec:
 		},
 	}, {
 		name: "invalid-embedded-pipeline-mismatching-parameter-types",
-		pipelineRun: parse.MustParsePipelineRun(t, fmt.Sprintf(`
+		pipelineRun: parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   name: embedded-pipeline-mismatching-param-type
   namespace: foo
@@ -1186,7 +1186,7 @@ spec:
 		},
 	}, {
 		name: "invalid-pipeline-run-missing-params-shd-stop-reconciling",
-		pipelineRun: parse.MustParsePipelineRun(t, fmt.Sprintf(`
+		pipelineRun: parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   name: pipelinerun-missing-params
   namespace: foo
@@ -1208,7 +1208,7 @@ spec:
 		},
 	}, {
 		name: "invalid-pipeline-with-invalid-dag-graph",
-		pipelineRun: parse.MustParsePipelineRun(t, `
+		pipelineRun: parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: pipeline-invalid-dag-graph
   namespace: foo
@@ -1228,7 +1228,7 @@ spec:
 		},
 	}, {
 		name: "invalid-pipeline-with-invalid-final-tasks-graph",
-		pipelineRun: parse.MustParsePipelineRun(t, `
+		pipelineRun: parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: pipeline-invalid-final-graph
   namespace: foo
@@ -1340,7 +1340,7 @@ func TestReconcileOnCompletedPipelineRun(t *testing.T) {
 	// in the PipelineRun status, that the completion status is not altered, that not error is returned and
 	// a successful event is triggered
 	taskRunName := "test-pipeline-run-completed-hello-world"
-	prs := []*v1beta1.PipelineRun{parse.MustParsePipelineRun(t, `
+	prs := []*v1beta1.PipelineRun{parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: test-pipeline-run-completed
   namespace: foo
@@ -1563,7 +1563,7 @@ func TestReconcileForCustomTaskWithPipelineTaskTimedOut(t *testing.T) {
 	// TestReconcileForCustomTaskWithPipelineTaskTimedOut runs "Reconcile" on a PipelineRun.
 	// It verifies that reconcile is successful, and the individual
 	// custom task which has timed out, is patched as cancelled.
-	ps := []*v1beta1.Pipeline{parse.MustParsePipeline(t, `
+	ps := []*v1beta1.Pipeline{parse.MustParseV1beta1Pipeline(t, `
 metadata:
   name: test-pipeline
   namespace: test
@@ -1575,7 +1575,7 @@ spec:
       kind: Example
 `)}
 	prName := "test-pipeline-run-custom-task-with-timeout"
-	prs := []*v1beta1.PipelineRun{parse.MustParsePipelineRun(t, `
+	prs := []*v1beta1.PipelineRun{parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: test-pipeline-run-custom-task-with-timeout
   namespace: test
@@ -1658,7 +1658,7 @@ func TestReconcileForCustomTaskWithPipelineRunTimedOut(t *testing.T) {
 		timeouts: &v1beta1.TimeoutFields{Pipeline: &metav1.Duration{Duration: 12 * time.Hour}},
 	}} {
 		t.Run(tc.name, func(*testing.T) {
-			ps := []*v1beta1.Pipeline{parse.MustParsePipeline(t, `
+			ps := []*v1beta1.Pipeline{parse.MustParseV1beta1Pipeline(t, `
 metadata:
   name: test-pipeline
   namespace: test
@@ -1671,7 +1671,7 @@ spec:
 `)}
 
 			prName := "test-pipeline-run-custom-task"
-			prs := []*v1beta1.PipelineRun{parse.MustParsePipelineRun(t, `
+			prs := []*v1beta1.PipelineRun{parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: test-pipeline-run-custom-task
   namespace: test
@@ -1885,7 +1885,7 @@ func runTestReconcileOnCancelledRunFinallyPipelineRunWithFinalTask(t *testing.T,
 	// It verifies that reconcile is successful, final tasks run, the pipeline status updated and events generated.
 	prs := []*v1beta1.PipelineRun{createCancelledPipelineRun(t, "test-pipeline-run-cancelled-run-finally", v1beta1.PipelineRunSpecStatusCancelledRunFinally)}
 	ps := []*v1beta1.Pipeline{
-		parse.MustParsePipeline(t, `
+		parse.MustParseV1beta1Pipeline(t, `
 metadata:
   name: test-pipeline
   namespace: foo
@@ -1942,7 +1942,7 @@ spec:
 func TestReconcileOnCancelledRunFinallyPipelineRunWithRunningFinalTask(t *testing.T) {
 	// TestReconcileOnCancelledRunFinallyPipelineRunWithRunningFinalTask runs "Reconcile" on a PipelineRun that has been gracefully cancelled.
 	// It verifies that reconcile is successful and completed tasks and running final tasks are left untouched.
-	prs := []*v1beta1.PipelineRun{parse.MustParsePipelineRun(t, `
+	prs := []*v1beta1.PipelineRun{parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: test-pipeline-run-cancelled-run-finally
   namespace: foo
@@ -1964,7 +1964,7 @@ status:
           status: "True"
           type: Succeeded
 `)}
-	ps := []*v1beta1.Pipeline{parse.MustParsePipeline(t, `
+	ps := []*v1beta1.Pipeline{parse.MustParseV1beta1Pipeline(t, `
 metadata:
   name: test-pipeline
   namespace: foo
@@ -2172,7 +2172,7 @@ func TestReconcileTaskResolutionError(t *testing.T) {
 	ptName := "hello-world-1"
 	prName := "test-pipeline-fails-task-resolution"
 	prs := []*v1beta1.PipelineRun{
-		parse.MustParsePipelineRun(t, fmt.Sprintf(`
+		parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: foo
@@ -2338,7 +2338,7 @@ status:
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			pr := parse.MustParsePipelineRun(t, basePRYAML)
+			pr := parse.MustParseV1beta1PipelineRun(t, basePRYAML)
 			if tc.initialTaskRunStatus != nil {
 				pr.Status.TaskRuns = tc.initialTaskRunStatus
 			}
@@ -2396,7 +2396,7 @@ status:
 func TestReconcileOnPendingPipelineRun(t *testing.T) {
 	// TestReconcileOnPendingPipelineRun runs "Reconcile" on a PipelineRun that is pending.
 	// It verifies that reconcile is successful, the pipeline status updated and events generated.
-	prs := []*v1beta1.PipelineRun{parse.MustParsePipelineRun(t, `
+	prs := []*v1beta1.PipelineRun{parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: test-pipeline-run-pending
   namespace: foo
@@ -2434,7 +2434,7 @@ func TestReconcileWithTimeoutDeprecated(t *testing.T) {
 	// It verifies that reconcile is successful, no TaskRun is created, the PipelineTask is marked as skipped, and the
 	// pipeline status updated and events generated.
 	ps := []*v1beta1.Pipeline{simpleHelloWorldPipeline}
-	prs := []*v1beta1.PipelineRun{parse.MustParsePipelineRun(t, `
+	prs := []*v1beta1.PipelineRun{parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: test-pipeline-run-with-timeout
   namespace: foo
@@ -2482,7 +2482,7 @@ func TestReconcileWithTimeouts_Pipeline(t *testing.T) {
 	// TestReconcileWithTimeouts_Pipeline runs "Reconcile" on a PipelineRun that has timed out.
 	// It verifies that reconcile is successful, no TaskRun is created, the PipelineTask is marked as skipped, and the
 	// pipeline status updated and events generated.
-	ps := []*v1beta1.Pipeline{parse.MustParsePipeline(t, `
+	ps := []*v1beta1.Pipeline{parse.MustParseV1beta1Pipeline(t, `
 metadata:
   name: test-pipeline
   namespace: foo
@@ -2495,7 +2495,7 @@ spec:
     taskRef:
       name: hello-world
 `)}
-	prs := []*v1beta1.PipelineRun{parse.MustParsePipelineRun(t, `
+	prs := []*v1beta1.PipelineRun{parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: test-pipeline-run-with-timeout
   namespace: foo
@@ -2575,7 +2575,7 @@ func TestReconcileWithTimeouts_Tasks(t *testing.T) {
 	// TestReconcileWithTimeouts_Tasks runs "Reconcile" on a PipelineRun with timeouts.tasks configured.
 	// It verifies that reconcile is successful, no TaskRun is created, the PipelineTask is marked as skipped, and the
 	// pipeline status updated and events generated.
-	ps := []*v1beta1.Pipeline{parse.MustParsePipeline(t, `
+	ps := []*v1beta1.Pipeline{parse.MustParseV1beta1Pipeline(t, `
 metadata:
   name: test-pipeline
   namespace: foo
@@ -2588,7 +2588,7 @@ spec:
     taskRef:
       name: hello-world
 `)}
-	prs := []*v1beta1.PipelineRun{parse.MustParsePipelineRun(t, `
+	prs := []*v1beta1.PipelineRun{parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: test-pipeline-run-with-timeout
   namespace: foo
@@ -2673,7 +2673,7 @@ func TestReconcileWithTimeouts_Finally(t *testing.T) {
 	// TestReconcileWithTimeouts_Finally runs "Reconcile" on a PipelineRun with timeouts.finally configured.
 	// It verifies that reconcile is successful, no TaskRun is created, the PipelineTask is marked as skipped, and the
 	// pipeline status updated and events generated.
-	ps := []*v1beta1.Pipeline{parse.MustParsePipeline(t, `
+	ps := []*v1beta1.Pipeline{parse.MustParseV1beta1Pipeline(t, `
 metadata:
   name: test-pipeline-with-finally
   namespace: foo
@@ -2690,7 +2690,7 @@ spec:
     taskRef:
       name: hello-world
 `)}
-	prs := []*v1beta1.PipelineRun{parse.MustParsePipelineRun(t, `
+	prs := []*v1beta1.PipelineRun{parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: test-pipeline-run-with-timeout
   namespace: foo
@@ -2785,7 +2785,7 @@ spec:
 func TestReconcileWithoutPVC(t *testing.T) {
 	// TestReconcileWithoutPVC runs "Reconcile" on a PipelineRun that has two unrelated tasks.
 	// It verifies that reconcile is successful and that no PVC is created
-	ps := []*v1beta1.Pipeline{parse.MustParsePipeline(t, `
+	ps := []*v1beta1.Pipeline{parse.MustParseV1beta1Pipeline(t, `
 metadata:
   name: test-pipeline
   namespace: foo
@@ -2799,7 +2799,7 @@ spec:
       name: hello-world
 `)}
 
-	prs := []*v1beta1.PipelineRun{parse.MustParsePipelineRun(t, `
+	prs := []*v1beta1.PipelineRun{parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: test-pipeline-run
   namespace: foo
@@ -2859,7 +2859,7 @@ func TestReconcileCancelledFailsTaskRunCancellation(t *testing.T) {
 			// The TaskRun cannot be cancelled. Check that the pipelinerun cancel fails, that reconcile fails and
 			// an event is generated
 			names.TestingSeed()
-			prs := []*v1beta1.PipelineRun{parse.MustParsePipelineRun(t, fmt.Sprintf(`
+			prs := []*v1beta1.PipelineRun{parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   name: test-pipeline-fails-to-cancel
   namespace: foo
@@ -2878,7 +2878,7 @@ status:
     test-pipeline-fails-to-cancelhello-world-1:
       pipelineTaskName: hello-world-1
 `, tc.specStatus))}
-			ps := []*v1beta1.Pipeline{parse.MustParsePipeline(t, `
+			ps := []*v1beta1.Pipeline{parse.MustParseV1beta1Pipeline(t, `
 metadata:
   name: test-pipeline
   namespace: foo
@@ -2975,7 +2975,7 @@ func TestReconcileFailsTaskRunTimeOut(t *testing.T) {
 	// The TaskRun cannot be timed out. Check that the pipelinerun timeout fails, that reconcile fails and
 	// an event is generated
 	names.TestingSeed()
-	prs := []*v1beta1.PipelineRun{parse.MustParsePipelineRun(t, `
+	prs := []*v1beta1.PipelineRun{parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: test-pipeline-fails-to-timeout
   namespace: foo
@@ -2994,7 +2994,7 @@ status:
     test-pipeline-fails-to-timeouthello-world-1:
       pipelineTaskName: hello-world-1
 `)}
-	ps := []*v1beta1.Pipeline{parse.MustParsePipeline(t, `
+	ps := []*v1beta1.Pipeline{parse.MustParseV1beta1Pipeline(t, `
 metadata:
   name: test-pipeline
   namespace: foo
@@ -3086,7 +3086,7 @@ func TestReconcilePropagateLabelsAndAnnotations(t *testing.T) {
 	names.TestingSeed()
 
 	ps := []*v1beta1.Pipeline{simpleHelloWorldPipeline}
-	prs := []*v1beta1.PipelineRun{parse.MustParsePipelineRun(t, `
+	prs := []*v1beta1.PipelineRun{parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   annotations:
     PipelineRunAnnotation: PipelineRunValue
@@ -3127,7 +3127,7 @@ spec:
 
 	// Check that the expected TaskRun was created
 	actual := getTaskRunCreations(t, clients.Pipeline.Actions(), 2)[0]
-	// We're ignoring TypeMeta here because parse.MustParseTaskRun populates that, but ktesting does not, so actual does not have it.
+	// We're ignoring TypeMeta here because parse.MustParseV1beta1TaskRun populates that, but ktesting does not, so actual does not have it.
 	if d := cmp.Diff(expected, actual, cmpopts.IgnoreTypes(metav1.TypeMeta{})); d != "" {
 		t.Errorf("expected to see TaskRun %v created. Diff %s", expected, diff.PrintWantGot(d))
 	}
@@ -3152,7 +3152,7 @@ func TestReconcilePropagateLabelsWithSpecStatus(t *testing.T) {
 			names.TestingSeed()
 
 			ps := []*v1beta1.Pipeline{simpleHelloWorldPipeline}
-			prs := []*v1beta1.PipelineRun{parse.MustParsePipelineRun(t, fmt.Sprintf(`
+			prs := []*v1beta1.PipelineRun{parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   annotations:
     PipelineRunAnnotation: PipelineRunValue
@@ -3197,7 +3197,7 @@ spec:
 func TestReconcileWithDifferentServiceAccounts(t *testing.T) {
 	names.TestingSeed()
 
-	ps := []*v1beta1.Pipeline{parse.MustParsePipeline(t, `
+	ps := []*v1beta1.Pipeline{parse.MustParseV1beta1Pipeline(t, `
 metadata:
   name: test-pipeline
   namespace: foo
@@ -3210,7 +3210,7 @@ spec:
     taskRef:
       name: hello-world-task
 `)}
-	prs := []*v1beta1.PipelineRun{parse.MustParsePipelineRun(t, `
+	prs := []*v1beta1.PipelineRun{parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: test-pipeline-run-different-service-accs
   namespace: foo
@@ -3222,7 +3222,7 @@ spec:
   - taskServiceAccountName: test-sa-1
     pipelineTaskName: hello-world-1
 `)}
-	ts := []*v1beta1.Task{parse.MustParseTask(t, `
+	ts := []*v1beta1.Task{parse.MustParseV1beta1Task(t, `
 metadata:
   name: hello-world-task
   namespace: foo
@@ -3279,7 +3279,7 @@ spec:
 func TestReconcileCustomTasksWithDifferentServiceAccounts(t *testing.T) {
 	names.TestingSeed()
 
-	ps := []*v1beta1.Pipeline{parse.MustParsePipeline(t, `
+	ps := []*v1beta1.Pipeline{parse.MustParseV1beta1Pipeline(t, `
 metadata:
   name: test-pipeline
   namespace: foo
@@ -3295,7 +3295,7 @@ spec:
       kind: Example
 `)}
 
-	prs := []*v1beta1.PipelineRun{parse.MustParsePipelineRun(t, `
+	prs := []*v1beta1.PipelineRun{parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: test-pipeline-run-different-service-accs
   namespace: foo
@@ -3360,7 +3360,7 @@ func TestReconcileWithTimeoutAndRetry(t *testing.T) {
 		},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
-			ps := []*v1beta1.Pipeline{parse.MustParsePipeline(t, fmt.Sprintf(`
+			ps := []*v1beta1.Pipeline{parse.MustParseV1beta1Pipeline(t, fmt.Sprintf(`
 metadata:
   name: test-pipeline-retry
   namespace: foo
@@ -3371,7 +3371,7 @@ spec:
     taskRef:
       name: hello-world
 `, tc.retries))}
-			prs := []*v1beta1.PipelineRun{parse.MustParsePipelineRun(t, `
+			prs := []*v1beta1.PipelineRun{parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: test-pipeline-retry-run-with-timeout
   namespace: foo
@@ -3387,7 +3387,7 @@ status:
 			ts := []*v1beta1.Task{
 				simpleHelloWorldTask,
 			}
-			trs := []*v1beta1.TaskRun{parse.MustParseTaskRun(t, `
+			trs := []*v1beta1.TaskRun{parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: hello-world-1
   namespace: foo
@@ -3437,7 +3437,7 @@ func TestReconcileAndPropagateCustomPipelineTaskRunSpec(t *testing.T) {
 	names.TestingSeed()
 	prName := "test-pipeline-run"
 	ps := []*v1beta1.Pipeline{simpleHelloWorldPipeline}
-	prs := []*v1beta1.PipelineRun{parse.MustParsePipelineRun(t, `
+	prs := []*v1beta1.PipelineRun{parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   annotations:
     PipelineRunAnnotation: PipelineRunValue
@@ -3498,7 +3498,7 @@ spec:
 func TestReconcileCustomTasksWithTaskRunSpec(t *testing.T) {
 	names.TestingSeed()
 	prName := "test-pipeline-run"
-	ps := []*v1beta1.Pipeline{parse.MustParsePipeline(t, `
+	ps := []*v1beta1.Pipeline{parse.MustParseV1beta1Pipeline(t, `
 metadata:
   name: test-pipeline
   namespace: foo
@@ -3516,7 +3516,7 @@ spec:
 			"workloadtype": "tekton",
 		},
 	}
-	prs := []*v1beta1.PipelineRun{parse.MustParsePipelineRun(t, `
+	prs := []*v1beta1.PipelineRun{parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: test-pipeline-run
   namespace: foo
@@ -3607,7 +3607,7 @@ func TestReconcileWithWhenExpressionsWithTaskResultsAndParams(t *testing.T) {
 
 func runTestReconcileWithWhenExpressionsWithTaskResultsAndParams(t *testing.T, embeddedStatus string) {
 	names.TestingSeed()
-	ps := []*v1beta1.Pipeline{parse.MustParsePipeline(t, `
+	ps := []*v1beta1.Pipeline{parse.MustParseV1beta1Pipeline(t, `
 metadata:
   name: test-pipeline
   namespace: foo
@@ -3653,7 +3653,7 @@ spec:
     taskRef:
       name: d-task
 `)}
-	prs := []*v1beta1.PipelineRun{parse.MustParsePipelineRun(t, `
+	prs := []*v1beta1.PipelineRun{parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: test-pipeline-run-different-service-accs
   namespace: foo
@@ -3790,7 +3790,7 @@ func TestReconcileWithWhenExpressions(t *testing.T) {
 	//		\
 	//		(e) ———— (f)
 	names.TestingSeed()
-	ps := []*v1beta1.Pipeline{parse.MustParsePipeline(t, `
+	ps := []*v1beta1.Pipeline{parse.MustParseV1beta1Pipeline(t, `
 metadata:
   name: test-pipeline
   namespace: foo
@@ -3847,7 +3847,7 @@ spec:
       name: f-task
 `)}
 	// initialize the pipelinerun with the skipped a-task
-	prs := []*v1beta1.PipelineRun{parse.MustParsePipelineRun(t, `
+	prs := []*v1beta1.PipelineRun{parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: test-pipeline-run-different-service-accs
   namespace: foo
@@ -3866,7 +3866,7 @@ status:
 `)}
 	// initialize the tasks used in the pipeline
 	ts := []*v1beta1.Task{
-		parse.MustParseTask(t, `
+		parse.MustParseV1beta1Task(t, `
 metadata:
   name: a-task
   namespace: foo
@@ -3984,7 +3984,7 @@ spec:
 
 func TestReconcileWithWhenExpressionsWithResultRefs(t *testing.T) {
 	names.TestingSeed()
-	ps := []*v1beta1.Pipeline{parse.MustParsePipeline(t, `
+	ps := []*v1beta1.Pipeline{parse.MustParseV1beta1Pipeline(t, `
 metadata:
   name: test-pipeline
   namespace: foo
@@ -4010,7 +4010,7 @@ spec:
     taskRef:
       name: c-task
 `)}
-	prs := []*v1beta1.PipelineRun{parse.MustParsePipelineRun(t, `
+	prs := []*v1beta1.PipelineRun{parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: test-pipeline-run-different-service-accs
   namespace: foo
@@ -4020,7 +4020,7 @@ spec:
   serviceAccountName: test-sa-0
 `)}
 	ts := []*v1beta1.Task{
-		parse.MustParseTask(t, `
+		parse.MustParseV1beta1Task(t, `
 metadata:
   name: a-task
   namespace: foo
@@ -4118,7 +4118,7 @@ func TestReconcileWithAffinityAssistantStatefulSet(t *testing.T) {
 	workspaceName := "ws1"
 	workspaceName2 := "ws2"
 	pipelineRunName := "test-pipeline-run"
-	ps := []*v1beta1.Pipeline{parse.MustParsePipeline(t, `
+	ps := []*v1beta1.Pipeline{parse.MustParseV1beta1Pipeline(t, `
 metadata:
   name: test-pipeline
   namespace: foo
@@ -4148,7 +4148,7 @@ spec:
   - name: emptyDirWorkspace
 `)}
 
-	prs := []*v1beta1.PipelineRun{parse.MustParsePipelineRun(t, `
+	prs := []*v1beta1.PipelineRun{parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: test-pipeline-run
   namespace: foo
@@ -4250,7 +4250,7 @@ spec:
 // a PVC is created and that the workspace appears as a PersistentVolumeClaim workspace for TaskRuns.
 func TestReconcileWithVolumeClaimTemplateWorkspace(t *testing.T) {
 	pipelineRunName := "test-pipeline-run"
-	ps := []*v1beta1.Pipeline{parse.MustParsePipeline(t, `
+	ps := []*v1beta1.Pipeline{parse.MustParseV1beta1Pipeline(t, `
 metadata:
   name: test-pipeline
   namespace: foo
@@ -4269,7 +4269,7 @@ spec:
   - name: ws1
 `)}
 
-	prs := []*v1beta1.PipelineRun{parse.MustParsePipelineRun(t, `
+	prs := []*v1beta1.PipelineRun{parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: test-pipeline-run
   namespace: foo
@@ -4352,7 +4352,7 @@ func TestReconcileWithVolumeClaimTemplateWorkspaceUsingSubPaths(t *testing.T) {
 	subPath1 := "customdirectory"
 	subPath2 := "otherdirecory"
 	pipelineRunWsSubPath := "mypath"
-	ps := []*v1beta1.Pipeline{parse.MustParsePipeline(t, `
+	ps := []*v1beta1.Pipeline{parse.MustParseV1beta1Pipeline(t, `
 metadata:
   name: test-pipeline
   namespace: foo
@@ -4396,7 +4396,7 @@ spec:
   - name: ws2
 `)}
 
-	prs := []*v1beta1.PipelineRun{parse.MustParsePipelineRun(t, `
+	prs := []*v1beta1.PipelineRun{parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: test-pipeline-run
   namespace: foo
@@ -4498,7 +4498,7 @@ spec:
 
 func TestReconcileWithTaskResults(t *testing.T) {
 	names.TestingSeed()
-	ps := []*v1beta1.Pipeline{parse.MustParsePipeline(t, `
+	ps := []*v1beta1.Pipeline{parse.MustParseV1beta1Pipeline(t, `
 metadata:
   name: test-pipeline
   namespace: foo
@@ -4514,7 +4514,7 @@ spec:
     taskRef:
       name: b-task
 `)}
-	prs := []*v1beta1.PipelineRun{parse.MustParsePipelineRun(t, `
+	prs := []*v1beta1.PipelineRun{parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: test-pipeline-run-different-service-accs
   namespace: foo
@@ -4524,13 +4524,13 @@ spec:
   serviceAccountName: test-sa-0
 `)}
 	ts := []*v1beta1.Task{
-		parse.MustParseTask(t, `
+		parse.MustParseV1beta1Task(t, `
 metadata:
   name: a-task
   namespace: foo
 spec: {}
 `),
-		parse.MustParseTask(t, `
+		parse.MustParseV1beta1Task(t, `
 metadata:
   name: b-task
   namespace: foo
@@ -4606,7 +4606,7 @@ spec:
 
 func TestReconcileWithTaskResultsEmbeddedNoneStarted(t *testing.T) {
 	names.TestingSeed()
-	prs := []*v1beta1.PipelineRun{parse.MustParsePipelineRun(t, `
+	prs := []*v1beta1.PipelineRun{parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: test-pipeline-run-different-service-accs
   namespace: foo
@@ -4631,7 +4631,7 @@ spec:
   serviceAccountName: test-sa-0
 `)}
 	ts := []*v1beta1.Task{
-		parse.MustParseTask(t, `
+		parse.MustParseV1beta1Task(t, `
 metadata:
   name: a-task
   namespace: foo
@@ -4639,7 +4639,7 @@ spec:
   results:
   - name: A_RESULT
 `),
-		parse.MustParseTask(t, `
+		parse.MustParseV1beta1Task(t, `
 metadata:
   name: b-task
   namespace: foo
@@ -4722,7 +4722,7 @@ func TestReconcileWithPipelineResults(t *testing.T) {
 
 func runTestReconcileWithFinallyResults(t *testing.T, embeddedStatus string) {
 	names.TestingSeed()
-	ps := []*v1beta1.Pipeline{parse.MustParsePipeline(t, `
+	ps := []*v1beta1.Pipeline{parse.MustParseV1beta1Pipeline(t, `
 metadata:
   name: test-pipeline
   namespace: foo
@@ -4790,7 +4790,7 @@ status:
   - name: b-Result
     value: bResultValue
 `)}
-	prs := []*v1beta1.PipelineRun{parse.MustParsePipelineRun(t, `
+	prs := []*v1beta1.PipelineRun{parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: test-pipeline-run-finally-results
   namespace: foo
@@ -4804,7 +4804,7 @@ status:
     reason: Succeeded
 `)}
 	ts := []*v1beta1.Task{
-		parse.MustParseTask(t, `
+		parse.MustParseV1beta1Task(t, `
 metadata:
   name: a-task
   namespace: foo
@@ -4812,7 +4812,7 @@ spec:
   results:
   - name: a-Result
 `),
-		parse.MustParseTask(t, `
+		parse.MustParseV1beta1Task(t, `
 metadata:
   name: c-task
   namespace: foo
@@ -4838,7 +4838,7 @@ spec:
 	defer prt.Cancel()
 	reconciledRun, _ := prt.reconcileRun("foo", "test-pipeline-run-finally-results", []string{}, false)
 
-	expectedPrFullStatus := parse.MustParsePipelineRun(t, `
+	expectedPrFullStatus := parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: test-pipeline-run-finally-results
   namespace: foo
@@ -4910,7 +4910,7 @@ status:
           value: bResultValue
 `)
 
-	expectedPrBothStatus := parse.MustParsePipelineRun(t, `
+	expectedPrBothStatus := parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: test-pipeline-run-finally-results
   namespace: foo
@@ -4995,7 +4995,7 @@ status:
           value: bResultValue
 `)
 
-	expectedPrMinimalStatus := parse.MustParsePipelineRun(t, `
+	expectedPrMinimalStatus := parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: test-pipeline-run-finally-results
   namespace: foo
@@ -5075,7 +5075,7 @@ status:
 
 func runTestReconcileWithPipelineResults(t *testing.T, embeddedStatus string) {
 	names.TestingSeed()
-	ps := []*v1beta1.Pipeline{parse.MustParsePipeline(t, `
+	ps := []*v1beta1.Pipeline{parse.MustParseV1beta1Pipeline(t, `
 metadata:
   name: test-pipeline
   namespace: foo
@@ -5129,7 +5129,7 @@ status:
   - name: b-Result
     value: bResultValue
 `)}
-	prs := []*v1beta1.PipelineRun{parse.MustParsePipelineRun(t, `
+	prs := []*v1beta1.PipelineRun{parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: test-pipeline-run-results
   namespace: foo
@@ -5142,7 +5142,7 @@ status:
     type: Succeeded
 `)}
 	ts := []*v1beta1.Task{
-		parse.MustParseTask(t, `
+		parse.MustParseV1beta1Task(t, `
 metadata:
   name: a-task
   namespace: foo
@@ -5165,7 +5165,7 @@ spec:
 	defer prt.Cancel()
 	reconciledRun, _ := prt.reconcileRun("foo", "test-pipeline-run-results", []string{}, false)
 
-	expectedPrFullStatus := parse.MustParsePipelineRun(t, `
+	expectedPrFullStatus := parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: test-pipeline-run-results
   namespace: foo
@@ -5226,7 +5226,7 @@ status:
           value: bResultValue
 `)
 
-	expectedPrBothStatus := parse.MustParsePipelineRun(t, `
+	expectedPrBothStatus := parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: test-pipeline-run-results
   namespace: foo
@@ -5296,7 +5296,7 @@ status:
           value: bResultValue
 `)
 
-	expectedPrMinimalStatus := parse.MustParsePipelineRun(t, `
+	expectedPrMinimalStatus := parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: test-pipeline-run-results
   namespace: foo
@@ -5397,7 +5397,7 @@ func TestReconcileWithPipelineResults_OnFailedPipelineRun(t *testing.T) {
 
 func runTestReconcileWithPipelineResultsOnFailedPipelineRun(t *testing.T, embeddedStatus string) {
 	names.TestingSeed()
-	ps := []*v1beta1.Pipeline{parse.MustParsePipeline(t, `
+	ps := []*v1beta1.Pipeline{parse.MustParseV1beta1Pipeline(t, `
 metadata:
   name: test-pipeline
   namespace: foo
@@ -5452,7 +5452,7 @@ status:
   - name: bResult
     value: bResultValue
 `)}
-	prs := []*v1beta1.PipelineRun{parse.MustParsePipelineRun(t, `
+	prs := []*v1beta1.PipelineRun{parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: test-failed-pr-with-task-results
   namespace: foo
@@ -5472,7 +5472,7 @@ status:
 `)}
 	ts := []*v1beta1.Task{
 		{ObjectMeta: baseObjectMeta("a-task", "foo")},
-		parse.MustParseTask(t, `
+		parse.MustParseV1beta1Task(t, `
 metadata:
   name: b-task
   namespace: foo
@@ -5482,7 +5482,7 @@ spec:
     type: string
 `),
 	}
-	wantPrs := []*v1beta1.PipelineRun{parse.MustParsePipelineRun(t, `
+	wantPrs := []*v1beta1.PipelineRun{parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: test-failed-pr-with-task-results
   namespace: foo
@@ -5524,7 +5524,7 @@ status:
 }
 
 func Test_storePipelineSpec(t *testing.T) {
-	pr := parse.MustParsePipelineRun(t, `
+	pr := parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: test-pipeline-run-success
   labels:
@@ -5626,7 +5626,7 @@ func runTestReconcileOutOfSyncPipelineRun(t *testing.T, embeddedStatus string) {
 	prOutOfSyncName := "test-pipeline-run-out-of-sync"
 	helloWorldTask := simpleHelloWorldTask
 
-	testPipeline := parse.MustParsePipeline(t, `
+	testPipeline := parse.MustParseV1beta1Pipeline(t, `
 metadata:
   name: test-pipeline
   namespace: foo
@@ -5684,7 +5684,7 @@ status:
     type: Succeeded
 `)
 
-	prOutOfSync := parse.MustParsePipelineRun(t, `
+	prOutOfSync := parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: test-pipeline-run-out-of-sync
   namespace: foo
@@ -5903,7 +5903,7 @@ func TestUpdatePipelineRunStatusFromInformer(t *testing.T) {
 func runTestUpdatePipelineRunStatusFromInformer(t *testing.T, embeddedStatus string) {
 	names.TestingSeed()
 
-	pr := parse.MustParsePipelineRun(t, `
+	pr := parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   labels:
     mylabel: myvale
@@ -6471,7 +6471,7 @@ func TestReconcile_CloudEvents(t *testing.T) {
 	names.TestingSeed()
 
 	prs := []*v1beta1.PipelineRun{
-		parse.MustParsePipelineRun(t, `
+		parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: test-pipelinerun
   namespace: foo
@@ -6482,7 +6482,7 @@ spec:
 `),
 	}
 	ps := []*v1beta1.Pipeline{
-		parse.MustParsePipeline(t, `
+		parse.MustParseV1beta1Pipeline(t, `
 metadata:
   name: test-pipeline
   namespace: foo
@@ -6494,7 +6494,7 @@ spec:
 `),
 	}
 	ts := []*v1beta1.Task{
-		parse.MustParseTask(t, `
+		parse.MustParseV1beta1Task(t, `
 metadata:
   name: test-task
   namespace: foo
@@ -6583,7 +6583,7 @@ func runTestReconcilePipelineTaskSpecMetadata(t *testing.T, embeddedStatus strin
 	names.TestingSeed()
 
 	prs := []*v1beta1.PipelineRun{
-		parse.MustParsePipelineRun(t, `
+		parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: test-pipeline-run-success
   namespace: foo
@@ -6594,7 +6594,7 @@ spec:
 	}
 
 	ps := []*v1beta1.Pipeline{
-		parse.MustParsePipeline(t, `
+		parse.MustParseV1beta1Pipeline(t, `
 metadata:
   name: test-pipeline
   namespace: foo
@@ -6680,7 +6680,7 @@ func TestReconciler_ReconcileKind_PipelineTaskContext(t *testing.T) {
 	pipelineName := "p-pipelinetask-status"
 	pipelineRunName := "pr-pipelinetask-status"
 
-	ps := []*v1beta1.Pipeline{parse.MustParsePipeline(t, `
+	ps := []*v1beta1.Pipeline{parse.MustParseV1beta1Pipeline(t, `
 metadata:
   name: p-pipelinetask-status
   namespace: foo
@@ -6698,7 +6698,7 @@ spec:
       name: mytask
 `)}
 
-	prs := []*v1beta1.PipelineRun{parse.MustParsePipelineRun(t, `
+	prs := []*v1beta1.PipelineRun{parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: pr-pipelinetask-status
   namespace: foo
@@ -6710,7 +6710,7 @@ spec:
 
 	ts := []*v1beta1.Task{
 		{ObjectMeta: baseObjectMeta("mytask", "foo")},
-		parse.MustParseTask(t, `
+		parse.MustParseV1beta1Task(t, `
 metadata:
   name: finaltask
   namespace: foo
@@ -6782,7 +6782,7 @@ spec:
 func TestReconcileWithTaskResultsInFinalTasks(t *testing.T) {
 	names.TestingSeed()
 
-	ps := []*v1beta1.Pipeline{parse.MustParsePipeline(t, `
+	ps := []*v1beta1.Pipeline{parse.MustParseV1beta1Pipeline(t, `
 metadata:
   name: test-pipeline
   namespace: foo
@@ -6853,7 +6853,7 @@ spec:
       name: dag-task
 `)}
 
-	prs := []*v1beta1.PipelineRun{parse.MustParsePipelineRun(t, `
+	prs := []*v1beta1.PipelineRun{parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: test-pipeline-run-final-task-results
   namespace: foo
@@ -6864,12 +6864,12 @@ spec:
 `)}
 
 	ts := []*v1beta1.Task{
-		parse.MustParseTask(t, `
+		parse.MustParseV1beta1Task(t, `
 metadata:
   name: dag-task
   namespace: foo
 `),
-		parse.MustParseTask(t, `
+		parse.MustParseV1beta1Task(t, `
 metadata:
   name: final-task
   namespace: foo
@@ -7077,7 +7077,7 @@ func runTestReconcileRemotePipelineRef(t *testing.T, embeddedStatus string) {
 
 	ref := u.Host + "/testreconcile_remotepipelineref"
 
-	prs := []*v1beta1.PipelineRun{parse.MustParsePipelineRun(t, fmt.Sprintf(`
+	prs := []*v1beta1.PipelineRun{parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   name: test-pipeline-run-success
   namespace: foo
@@ -7088,7 +7088,7 @@ spec:
   serviceAccountName: test-sa
   timeout: 1h0m0s
 `, ref))}
-	ps := parse.MustParsePipeline(t, fmt.Sprintf(`
+	ps := parse.MustParseV1beta1Pipeline(t, fmt.Sprintf(`
 metadata:
   name: test-pipeline
   namespace: foo
@@ -7102,7 +7102,7 @@ spec:
 	cms := []*corev1.ConfigMap{withOCIBundles(withEmbeddedStatus(newFeatureFlagsConfigMap(), embeddedStatus))}
 
 	// This task will be uploaded along with the pipeline definition.
-	remoteTask := parse.MustParseTask(t, `
+	remoteTask := parse.MustParseV1beta1Task(t, `
 metadata:
   name: unit-test-task
   namespace: foo
@@ -7197,7 +7197,7 @@ func runTestReconcileOptionalWorkspacesOmitted(t *testing.T, embeddedStatus stri
 	cfg := config.NewStore(logtesting.TestLogger(t))
 	ctx = cfg.ToContext(ctx)
 
-	prs := []*v1beta1.PipelineRun{parse.MustParsePipelineRun(t, `
+	prs := []*v1beta1.PipelineRun{parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: test-pipeline-run-success
   namespace: foo
@@ -7270,7 +7270,7 @@ func TestReconcile_DependencyValidationsImmediatelyFailPipelineRun(t *testing.T)
 	ctx = cfg.ToContext(ctx)
 
 	prs := []*v1beta1.PipelineRun{
-		parse.MustParsePipelineRun(t, `
+		parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: pipelinerun-param-invalid-result-variable
   namespace: foo
@@ -7292,7 +7292,7 @@ spec:
         - image: foo:latest
   serviceAccountName: test-sa
 `),
-		parse.MustParsePipelineRun(t, `
+		parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: pipelinerun-pipeline-result-invalid-result-variable
   namespace: foo
@@ -7312,7 +7312,7 @@ spec:
         - image: foo:latest
   serviceAccountName: test-sa
 `),
-		parse.MustParsePipelineRun(t, `
+		parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: pipelinerun-with-optional-workspace-validation
   namespace: foo
@@ -7377,7 +7377,7 @@ spec:
 // that when the request is successfully resolved the PipelineRun begins running.
 func TestReconcileWithResolver(t *testing.T) {
 	resolverName := "foobar"
-	pr := parse.MustParsePipelineRun(t, `
+	pr := parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: pr
   namespace: default
@@ -7452,7 +7452,7 @@ spec:
 // that when the request fails, the PipelineRun fails.
 func TestReconcileWithFailingResolver(t *testing.T) {
 	resolverName := "does-not-exist"
-	pr := parse.MustParsePipelineRun(t, `
+	pr := parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: pr
   namespace: default
@@ -7508,7 +7508,7 @@ spec:
 // that when the request fails, the PipelineRun fails.
 func TestReconcileWithFailingTaskResolver(t *testing.T) {
 	resolverName := "foobar"
-	pr := parse.MustParsePipelineRun(t, `
+	pr := parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: pr
   namespace: default
@@ -7567,7 +7567,7 @@ spec:
 // that when the request is successfully resolved the PipelineRun begins running.
 func TestReconcileWithTaskResolver(t *testing.T) {
 	resolverName := "foobar"
-	pr := parse.MustParsePipelineRun(t, `
+	pr := parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: pr
   namespace: default
@@ -7741,7 +7741,7 @@ func createHelloWorldTaskRunWithStatusTaskLabel(
 }
 
 func createHelloWorldTaskRun(t *testing.T, trName, ns, prName, pName string) *v1beta1.TaskRun {
-	return parse.MustParseTaskRun(t, fmt.Sprintf(`
+	return parse.MustParseV1beta1TaskRun(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -7756,7 +7756,7 @@ spec:
 }
 
 func createCancelledPipelineRun(t *testing.T, prName string, specStatus v1beta1.PipelineRunSpecStatus) *v1beta1.PipelineRun {
-	return parse.MustParsePipelineRun(t, fmt.Sprintf(`
+	return parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: foo
@@ -7875,7 +7875,7 @@ func filterChildRefsForKind(childRefs []v1beta1.ChildStatusReference, kind strin
 }
 
 func mustParseTaskRunWithObjectMeta(t *testing.T, objectMeta metav1.ObjectMeta, asYAML string) *v1beta1.TaskRun {
-	tr := parse.MustParseTaskRun(t, asYAML)
+	tr := parse.MustParseV1beta1TaskRun(t, asYAML)
 	tr.ObjectMeta = objectMeta
 	return tr
 }
@@ -7887,7 +7887,7 @@ func mustParseRunWithObjectMeta(t *testing.T, objectMeta metav1.ObjectMeta, asYA
 }
 
 func helloWorldPipelineWithRunAfter(t *testing.T) *v1beta1.Pipeline {
-	return parse.MustParsePipeline(t, `
+	return parse.MustParseV1beta1Pipeline(t, `
 metadata:
   name: test-pipeline
   namespace: foo
@@ -7923,7 +7923,7 @@ func TestGetTaskrunWorkspaces_Failure(t *testing.T) {
 		expectedError string
 	}{{
 		name: "failure declaring workspace with different name",
-		pr: parse.MustParsePipelineRun(t, `
+		pr: parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: pipeline
 spec:
@@ -7941,7 +7941,7 @@ spec:
 	},
 		{
 			name: "failure mapping workspace with different name",
-			pr: parse.MustParsePipelineRun(t, `
+			pr: parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: pipeline
 spec:
@@ -7960,7 +7960,7 @@ spec:
 		},
 		{
 			name: "failure propagating workspaces using scripts",
-			pr: parse.MustParsePipelineRun(t, `
+			pr: parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: pipeline
 spec:
@@ -7981,7 +7981,7 @@ spec:
 		},
 		{
 			name: "failure propagating workspaces using args",
-			pr: parse.MustParsePipelineRun(t, `
+			pr: parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: pipeline
 spec:
@@ -8028,7 +8028,7 @@ func TestGetTaskrunWorkspaces_Success(t *testing.T) {
 		rprt *resources.ResolvedPipelineTask
 	}{{
 		name: "valid declaration of workspace names",
-		pr: parse.MustParsePipelineRun(t, `
+		pr: parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: pipeline
 spec:
@@ -8046,7 +8046,7 @@ spec:
 	},
 		{
 			name: "valid mapping with same workspace names",
-			pr: parse.MustParsePipelineRun(t, `
+			pr: parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: pipeline
 spec:
@@ -8064,7 +8064,7 @@ spec:
 		},
 		{
 			name: "propagating workspaces using scripts",
-			pr: parse.MustParsePipelineRun(t, `
+			pr: parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: pipeline
 spec:
@@ -8087,7 +8087,7 @@ spec:
 		},
 		{
 			name: "propagating workspaces using args",
-			pr: parse.MustParsePipelineRun(t, `
+			pr: parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: pipeline
 spec:
@@ -8129,7 +8129,7 @@ func TestReconcile_PropagatePipelineTaskRunSpecMetadata(t *testing.T) {
 	names.TestingSeed()
 	prName := "test-pipeline-run"
 	ps := []*v1beta1.Pipeline{simpleHelloWorldPipeline}
-	prs := []*v1beta1.PipelineRun{parse.MustParsePipelineRun(t, `
+	prs := []*v1beta1.PipelineRun{parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: test-pipeline-run
   namespace: foo
@@ -8178,7 +8178,7 @@ spec:
 func TestReconcile_AddMetadataByPrecedence(t *testing.T) {
 	names.TestingSeed()
 	prName := "test-pipeline-run"
-	ps := []*v1beta1.Pipeline{parse.MustParsePipeline(t, `
+	ps := []*v1beta1.Pipeline{parse.MustParseV1beta1Pipeline(t, `
 metadata:
   name: test-pipeline
   namespace: foo
@@ -8195,7 +8195,7 @@ spec:
           annotations:
             TestPrecedenceAnnotation: PipelineTaskSpecValue
 `)}
-	prs := []*v1beta1.PipelineRun{parse.MustParsePipelineRun(t, `
+	prs := []*v1beta1.PipelineRun{parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: test-pipeline-run
   namespace: foo
@@ -8250,7 +8250,7 @@ spec:
 func TestReconciler_PipelineTaskMatrix(t *testing.T) {
 	names.TestingSeed()
 
-	task := parse.MustParseTask(t, `
+	task := parse.MustParseV1beta1Task(t, `
 metadata:
   name: mytask
   namespace: foo
@@ -8442,7 +8442,7 @@ spec:
 	}{{
 		name:     "p-dag",
 		memberOf: "tasks",
-		p: parse.MustParsePipeline(t, fmt.Sprintf(`
+		p: parse.MustParseV1beta1Pipeline(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: foo
@@ -8467,7 +8467,7 @@ spec:
         - name: version
           value: v0.33.0
 `, "p-dag")),
-		expectedPipelineRun: parse.MustParsePipelineRun(t, `
+		expectedPipelineRun: parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: pr
   namespace: foo
@@ -8548,7 +8548,7 @@ status:
 	}, {
 		name:     "p-finally",
 		memberOf: "finally",
-		p: parse.MustParsePipeline(t, fmt.Sprintf(`
+		p: parse.MustParseV1beta1Pipeline(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: foo
@@ -8608,7 +8608,7 @@ status:
     reason: Succeeded
     message: All Tasks have completed executing
 `),
-		expectedPipelineRun: parse.MustParsePipelineRun(t, `
+		expectedPipelineRun: parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: pr
   namespace: foo
@@ -8705,7 +8705,7 @@ status:
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pr := parse.MustParsePipelineRun(t, fmt.Sprintf(`
+			pr := parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   name: pr
   namespace: foo
@@ -8762,7 +8762,7 @@ spec:
 func TestReconciler_PipelineTaskMatrixWithResults(t *testing.T) {
 	names.TestingSeed()
 
-	task := parse.MustParseTask(t, `
+	task := parse.MustParseV1beta1Task(t, `
 metadata:
   name: mytask
   namespace: foo
@@ -8778,7 +8778,7 @@ spec:
         echo "$(params.platform) and $(params.browser) and $(params.version)"
 `)
 
-	taskwithresults := parse.MustParseTask(t, `
+	taskwithresults := parse.MustParseV1beta1Task(t, `
 metadata:
   name: taskwithresults
   namespace: foo
@@ -8980,7 +8980,7 @@ spec:
 	}{{
 		name:     "p-dag",
 		memberOf: "tasks",
-		p: parse.MustParsePipeline(t, fmt.Sprintf(`
+		p: parse.MustParseV1beta1Pipeline(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: foo
@@ -9049,7 +9049,7 @@ status:
   - name: version
     value: v0.33.0
 `),
-		expectedPipelineRun: parse.MustParsePipelineRun(t, `
+		expectedPipelineRun: parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: pr
   namespace: foo
@@ -9145,7 +9145,7 @@ status:
 	}, {
 		name:     "p-finally",
 		memberOf: "finally",
-		p: parse.MustParsePipeline(t, fmt.Sprintf(`
+		p: parse.MustParseV1beta1Pipeline(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: foo
@@ -9216,7 +9216,7 @@ status:
   - name: version
     value: v0.33.0
 `),
-		expectedPipelineRun: parse.MustParsePipelineRun(t, `
+		expectedPipelineRun: parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: pr
   namespace: foo
@@ -9313,7 +9313,7 @@ status:
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pr := parse.MustParsePipelineRun(t, fmt.Sprintf(`
+			pr := parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   name: pr
   namespace: foo
@@ -9370,7 +9370,7 @@ spec:
 func TestReconciler_PipelineTaskMatrixWithRetries(t *testing.T) {
 	names.TestingSeed()
 
-	task := parse.MustParseTask(t, `
+	task := parse.MustParseV1beta1Task(t, `
 metadata:
   name: mytask
   namespace: foo
@@ -9440,7 +9440,7 @@ status:
 `),
 		},
 		prs: []*v1beta1.PipelineRun{
-			parse.MustParsePipelineRun(t, `
+			parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: pr
   namespace: foo
@@ -9486,7 +9486,7 @@ status:
   runs: {}
 `),
 		},
-		expectedPipelineRun: parse.MustParsePipelineRun(t, `
+		expectedPipelineRun: parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: pr
   namespace: foo
@@ -9622,7 +9622,7 @@ status:
 `),
 		},
 		prs: []*v1beta1.PipelineRun{
-			parse.MustParsePipelineRun(t, `
+			parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: pr
   namespace: foo
@@ -9668,7 +9668,7 @@ status:
   runs: {}
 `),
 		},
-		expectedPipelineRun: parse.MustParsePipelineRun(t, `
+		expectedPipelineRun: parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: pr
   namespace: foo
@@ -9810,7 +9810,7 @@ status:
 func TestReconciler_PipelineTaskMatrixWithCustomTask(t *testing.T) {
 	names.TestingSeed()
 
-	task := parse.MustParseTask(t, `
+	task := parse.MustParseV1beta1Task(t, `
 metadata:
   name: mytask
   namespace: foo
@@ -10022,7 +10022,7 @@ spec:
 	}{{
 		name:     "p-dag",
 		memberOf: "tasks",
-		p: parse.MustParsePipeline(t, fmt.Sprintf(`
+		p: parse.MustParseV1beta1Pipeline(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: foo
@@ -10048,7 +10048,7 @@ spec:
         - name: version
           value: v0.1
 `, "p-dag")),
-		expectedPipelineRun: parse.MustParsePipelineRun(t, `
+		expectedPipelineRun: parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: pr
   namespace: foo
@@ -10129,7 +10129,7 @@ status:
 	}, {
 		name:     "p-finally",
 		memberOf: "finally",
-		p: parse.MustParsePipeline(t, fmt.Sprintf(`
+		p: parse.MustParseV1beta1Pipeline(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: foo
@@ -10190,7 +10190,7 @@ status:
     reason: Succeeded
     message: All Tasks have completed executing
 `),
-		expectedPipelineRun: parse.MustParsePipelineRun(t, `
+		expectedPipelineRun: parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: pr
   namespace: foo
@@ -10287,7 +10287,7 @@ status:
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pr := parse.MustParsePipelineRun(t, fmt.Sprintf(`
+			pr := parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   name: pr
   namespace: foo
@@ -10377,7 +10377,7 @@ func TestReconcile_SetDefaults(t *testing.T) {
 
 func runTestReconcileWithoutDefaults(t *testing.T, embeddedStatus string) {
 	names.TestingSeed()
-	prs := []*v1beta1.PipelineRun{parse.MustParsePipelineRun(t, `
+	prs := []*v1beta1.PipelineRun{parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: test-pipeline-run-success
   namespace: foo
@@ -10389,7 +10389,7 @@ spec:
     name: test-pipeline
   serviceAccountName: test-sa
 `)}
-	ps := []*v1beta1.Pipeline{parse.MustParsePipeline(t, `
+	ps := []*v1beta1.Pipeline{parse.MustParseV1beta1Pipeline(t, `
 metadata:
   name: test-pipeline
   namespace: foo
@@ -10420,7 +10420,7 @@ spec:
       name: unit-test-cluster-task
 `)}
 	ts := []*v1beta1.Task{
-		parse.MustParseTask(t, `
+		parse.MustParseV1beta1Task(t, `
 metadata:
   name: unit-test-task
   namespace: foo
@@ -10491,7 +10491,7 @@ spec:
 }
 
 func TestReconcile_CreateTaskRunWithComputeResources(t *testing.T) {
-	simplePipeline := parse.MustParsePipeline(t, `
+	simplePipeline := parse.MustParseV1beta1Pipeline(t, `
 metadata:
   name: foo-pipeline
   namespace: default
@@ -10518,7 +10518,7 @@ spec:
 	}{{
 		name:     "only with requests",
 		pipeline: simplePipeline,
-		pipelineRun: parse.MustParsePipelineRun(t, `
+		pipelineRun: parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: foo-pipeline-run
   namespace: default
@@ -10537,7 +10537,7 @@ spec:
 	}, {
 		name:     "only with limits",
 		pipeline: simplePipeline,
-		pipelineRun: parse.MustParsePipelineRun(t, `
+		pipelineRun: parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: foo-pipeline-run
   namespace: default
@@ -10556,7 +10556,7 @@ spec:
 	}, {
 		name:     "both with requests and limits",
 		pipeline: simplePipeline,
-		pipelineRun: parse.MustParsePipelineRun(t, `
+		pipelineRun: parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: foo-pipeline-run
   namespace: default
@@ -10578,7 +10578,7 @@ spec:
 	}, {
 		name:     "both with cpu and memory",
 		pipeline: simplePipeline,
-		pipelineRun: parse.MustParsePipelineRun(t, `
+		pipelineRun: parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: foo-pipeline-run
   namespace: default
@@ -10668,7 +10668,7 @@ func TestReconcile_CancelUnscheduled(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			pipelineRunName := "cancel-test-run"
-			prs := []*v1beta1.PipelineRun{parse.MustParsePipelineRun(t, `metadata:
+			prs := []*v1beta1.PipelineRun{parse.MustParseV1beta1PipelineRun(t, `metadata:
   name: cancel-test-run
   namespace: foo
 spec:
@@ -10739,7 +10739,7 @@ func TestReconcile_verifyResolvedPipeline_Success(t *testing.T) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	prs := parse.MustParsePipelineRun(t, `
+	prs := parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: test-pipelinerun
   namespace: foo
@@ -10748,7 +10748,7 @@ spec:
   pipelineRef:
     name: test-pipeline
 `)
-	ps := parse.MustParsePipeline(t, `
+	ps := parse.MustParseV1beta1Pipeline(t, `
 metadata:
   name: test-pipeline
   namespace: foo
@@ -10758,7 +10758,7 @@ spec:
       taskRef:
         name: test-task
 `)
-	ts := parse.MustParseTask(t, `
+	ts := parse.MustParseV1beta1Task(t, `
 metadata:
   name: test-task
   namespace: foo
@@ -10822,7 +10822,7 @@ func TestReconcile_verifyResolvedPipeline_Error(t *testing.T) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	prs := parse.MustParsePipelineRun(t, `
+	prs := parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: test-pipelinerun
   namespace: foo
@@ -10831,7 +10831,7 @@ spec:
   pipelineRef:
     name: test-pipeline
 `)
-	ps := parse.MustParsePipeline(t, `
+	ps := parse.MustParseV1beta1Pipeline(t, `
 metadata:
   name: test-pipeline
   namespace: foo
@@ -10841,7 +10841,7 @@ spec:
       taskRef:
         name: test-task
 `)
-	ts := parse.MustParseTask(t, `
+	ts := parse.MustParseV1beta1Task(t, `
 metadata:
   name: test-task
   namespace: foo

--- a/pkg/reconciler/pipelinerun/pipelinerun_updatestatus_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_updatestatus_test.go
@@ -208,7 +208,7 @@ func TestUpdatePipelineRunStatusFromTaskRuns(t *testing.T) {
 		}, {
 			prName:   "status-nil-taskruns",
 			prStatus: prStatusWithEmptyTaskRuns,
-			trs: []*v1beta1.TaskRun{parse.MustParseTaskRun(t, `
+			trs: []*v1beta1.TaskRun{parse.MustParseV1beta1TaskRun(t, `
 metadata:
   labels:
     tekton.dev/pipelineTask: task-1
@@ -221,7 +221,7 @@ metadata:
 			prName:   "status-missing-taskruns",
 			prStatus: prStatusMissingTaskRun,
 			trs: []*v1beta1.TaskRun{
-				parse.MustParseTaskRun(t, `
+				parse.MustParseV1beta1TaskRun(t, `
 metadata:
   labels:
     tekton.dev/pipelineTask: task-3
@@ -664,7 +664,7 @@ metadata:
 		}, {
 			prName:   "status-nil-taskruns",
 			prStatus: prStatusWithEmptyChildRefs,
-			trs: []*v1beta1.TaskRun{parse.MustParseTaskRun(t, `
+			trs: []*v1beta1.TaskRun{parse.MustParseV1beta1TaskRun(t, `
 metadata:
   labels:
     tekton.dev/pipelineTask: task-1
@@ -682,7 +682,7 @@ metadata:
 			prName:   "status-missing-taskruns",
 			prStatus: prStatusMissingTaskRun,
 			trs: []*v1beta1.TaskRun{
-				parse.MustParseTaskRun(t, `
+				parse.MustParseV1beta1TaskRun(t, `
 metadata:
   labels:
     tekton.dev/pipelineTask: task-3
@@ -724,7 +724,7 @@ metadata:
 			prName:   "matrixed-taskruns-pr",
 			prStatus: prStatusWithEmptyChildRefs,
 			trs: []*v1beta1.TaskRun{
-				parse.MustParseTaskRun(t, `
+				parse.MustParseV1beta1TaskRun(t, `
 metadata:
   labels:
     tekton.dev/pipelineTask: task
@@ -732,7 +732,7 @@ metadata:
   ownerReferences:
   - uid: 11111111-1111-1111-1111-111111111111
 `),
-				parse.MustParseTaskRun(t, `
+				parse.MustParseV1beta1TaskRun(t, `
 metadata:
   labels:
     tekton.dev/pipelineTask: task
@@ -856,7 +856,7 @@ metadata:
 		{
 			prName:   "status-nil-taskruns",
 			prStatus: prStatusWithEmptyEverything,
-			trs: []*v1beta1.TaskRun{parse.MustParseTaskRun(t, `
+			trs: []*v1beta1.TaskRun{parse.MustParseV1beta1TaskRun(t, `
 metadata:
   labels:
     tekton.dev/pipelineTask: task-1
@@ -1191,7 +1191,7 @@ func prStatusFromInputs(embeddedStatus string, status duckv1beta1.Status, taskRu
 
 func getTestTaskRunsAndRuns(t *testing.T) ([]*v1beta1.TaskRun, []*v1beta1.TaskRun, []*v1beta1.TaskRun, []*v1alpha1.Run, []*v1alpha1.Run, []*v1alpha1.Run) {
 	allTaskRuns := []*v1beta1.TaskRun{
-		parse.MustParseTaskRun(t, `
+		parse.MustParseV1beta1TaskRun(t, `
 metadata:
   labels:
     tekton.dev/pipelineTask: task-1
@@ -1199,7 +1199,7 @@ metadata:
   ownerReferences:
   - uid: 11111111-1111-1111-1111-111111111111
 `),
-		parse.MustParseTaskRun(t, `
+		parse.MustParseV1beta1TaskRun(t, `
 metadata:
   labels:
     tekton.dev/pipelineTask: task-3
@@ -1209,7 +1209,7 @@ metadata:
 `),
 	}
 
-	taskRunsFromAnotherPR := []*v1beta1.TaskRun{parse.MustParseTaskRun(t, `
+	taskRunsFromAnotherPR := []*v1beta1.TaskRun{parse.MustParseV1beta1TaskRun(t, `
 metadata:
   labels:
     tekton.dev/pipelineTask: task-1
@@ -1218,7 +1218,7 @@ metadata:
   - uid: 22222222-2222-2222-2222-222222222222
 `)}
 
-	taskRunsWithNoOwner := []*v1beta1.TaskRun{parse.MustParseTaskRun(t, `
+	taskRunsWithNoOwner := []*v1beta1.TaskRun{parse.MustParseV1beta1TaskRun(t, `
 metadata:
   labels:
     tekton.dev/pipelineTask: task-1

--- a/pkg/reconciler/pipelinerun/resources/pipelineref_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelineref_test.go
@@ -268,7 +268,7 @@ func TestGetPipelineFunc_RemoteResolution(t *testing.T) {
 	ctx := context.Background()
 	cfg := config.FromContextOrDefaults(ctx)
 	ctx = config.ToContext(ctx, cfg)
-	pipeline := parse.MustParsePipeline(t, pipelineYAMLString)
+	pipeline := parse.MustParseV1beta1Pipeline(t, pipelineYAMLString)
 	pipelineRef := &v1beta1.PipelineRef{ResolverRef: v1beta1.ResolverRef{Resolver: "git"}}
 	pipelineYAML := strings.Join([]string{
 		"kind: Pipeline",
@@ -302,7 +302,7 @@ func TestGetPipelineFunc_RemoteResolution_ReplacedParams(t *testing.T) {
 	ctx := context.Background()
 	cfg := config.FromContextOrDefaults(ctx)
 	ctx = config.ToContext(ctx, cfg)
-	pipeline := parse.MustParsePipeline(t, pipelineYAMLString)
+	pipeline := parse.MustParseV1beta1Pipeline(t, pipelineYAMLString)
 	pipelineRef := &v1beta1.PipelineRef{
 		ResolverRef: v1beta1.ResolverRef{
 			Resolver: "git",

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
@@ -2564,7 +2564,7 @@ func TestPipelineRunFacts_IsRunning(t *testing.T) {
 // TestUpdateTaskRunsState runs "getTaskRunsStatus" and verifies how it updates a PipelineRun status
 // from a TaskRun associated to the PipelineRun
 func TestUpdateTaskRunsState(t *testing.T) {
-	pr := parse.MustParsePipelineRun(t, `
+	pr := parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: test-pipeline-run
   namespace: foo
@@ -2592,7 +2592,7 @@ spec:
 		TaskRef: &v1beta1.TaskRef{Name: "unit-test-task"},
 	}
 
-	task := parse.MustParseTask(t, fmt.Sprintf(`
+	task := parse.MustParseV1beta1Task(t, fmt.Sprintf(`
 metadata:
   name: unit-test-task
   namespace: foo
@@ -2603,7 +2603,7 @@ spec:
         type: %s
 `, resourcev1alpha1.PipelineResourceTypeGit))
 
-	taskrun := parse.MustParseTaskRun(t, fmt.Sprintf(`
+	taskrun := parse.MustParseV1beta1TaskRun(t, fmt.Sprintf(`
 metadata:
   name: test-pipeline-run-success-unit-test-1
   namespace: foo
@@ -2638,7 +2638,7 @@ status:
 	pr.Status.InitializeConditions(testClock)
 	status := state.GetTaskRunsStatus(pr)
 
-	expectedPipelineRunStatus := parse.MustParsePipelineRun(t, `
+	expectedPipelineRunStatus := parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: pipelinerun
   namespace: foo
@@ -2667,7 +2667,7 @@ status:
 // TestUpdateRunsState runs "getRunsStatus" and verifies how it updates a PipelineRun status
 // from a Run associated to the PipelineRun
 func TestUpdateRunsState(t *testing.T) {
-	pr := parse.MustParsePipelineRun(t, `
+	pr := parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: test-pipeline-run
   namespace: foo
@@ -2726,7 +2726,7 @@ status:
 	pr.Status.InitializeConditions(testClock)
 	status := state.GetRunsStatus(pr)
 
-	expectedPipelineRunStatus := parse.MustParsePipelineRun(t, `
+	expectedPipelineRunStatus := parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: pipelinerun
   namespace: foo

--- a/pkg/reconciler/taskrun/resources/taskref_test.go
+++ b/pkg/reconciler/taskrun/resources/taskref_test.go
@@ -512,7 +512,7 @@ func TestGetTaskFunc_RemoteResolution(t *testing.T) {
 	ctx := context.Background()
 	cfg := config.FromContextOrDefaults(ctx)
 	ctx = config.ToContext(ctx, cfg)
-	task := parse.MustParseTask(t, taskYAMLString)
+	task := parse.MustParseV1beta1Task(t, taskYAMLString)
 	taskRef := &v1beta1.TaskRef{ResolverRef: v1beta1.ResolverRef{Resolver: "git"}}
 	taskYAML := strings.Join([]string{
 		"kind: Task",
@@ -547,7 +547,7 @@ func TestGetTaskFunc_RemoteResolution_ReplacedParams(t *testing.T) {
 	ctx := context.Background()
 	cfg := config.FromContextOrDefaults(ctx)
 	ctx = config.ToContext(ctx, cfg)
-	task := parse.MustParseTask(t, taskYAMLString)
+	task := parse.MustParseV1beta1Task(t, taskYAMLString)
 	taskRef := &v1beta1.TaskRef{
 		ResolverRef: v1beta1.ResolverRef{
 			Resolver: "git",

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -501,7 +501,7 @@ func initializeTaskRunControllerAssets(t *testing.T, d test.Data, opts pipeline.
 }
 
 func TestReconcile_ExplicitDefaultSA(t *testing.T) {
-	taskRunSuccess := parse.MustParseTaskRun(t, `
+	taskRunSuccess := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun-run-success
   namespace: foo
@@ -510,7 +510,7 @@ spec:
     apiVersion: a1
     name: test-task
 `)
-	taskRunWithSaSuccess := parse.MustParseTaskRun(t, `
+	taskRunWithSaSuccess := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun-with-sa-run-success
   namespace: foo
@@ -620,7 +620,7 @@ spec:
 // TestReconcile_CloudEvents runs reconcile with a cloud event sink configured
 // to ensure that events are sent in different cases
 func TestReconcile_CloudEvents(t *testing.T) {
-	task := parse.MustParseTask(t, `
+	task := parse.MustParseV1beta1Task(t, `
 metadata:
   name: test-task
   namespace: foo
@@ -634,7 +634,7 @@ spec:
     image: foo
     name: simple-step
 `)
-	taskRun := parse.MustParseTaskRun(t, `
+	taskRun := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun-not-started
   namespace: foo
@@ -713,7 +713,7 @@ spec:
 }
 
 func TestReconcile(t *testing.T) {
-	taskRunSuccess := parse.MustParseTaskRun(t, `
+	taskRunSuccess := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun-run-success
   namespace: foo
@@ -722,7 +722,7 @@ spec:
     apiVersion: a1
     name: test-task
 `)
-	taskRunWithSaSuccess := parse.MustParseTaskRun(t, `
+	taskRunWithSaSuccess := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun-with-sa-run-success
   namespace: foo
@@ -732,7 +732,7 @@ spec:
     apiVersion: a1
     name: test-with-sa
 `)
-	taskRunSubstitution := parse.MustParseTaskRun(t, `
+	taskRunSubstitution := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun-substitution
   namespace: foo
@@ -757,7 +757,7 @@ spec:
     apiVersion: a1
     name: test-task-with-substitution
 `)
-	taskRunInputOutput := parse.MustParseTaskRun(t, `
+	taskRunInputOutput := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun-input-output
   namespace: foo
@@ -786,7 +786,7 @@ spec:
   taskRef:
     name: test-output-task
 `)
-	taskRunWithTaskSpec := parse.MustParseTaskRun(t, `
+	taskRunWithTaskSpec := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun-with-taskspec
   namespace: foo
@@ -817,7 +817,7 @@ spec:
       name: mycontainer
 `)
 
-	taskRunWithResourceSpecAndTaskSpec := parse.MustParseTaskRun(t, `
+	taskRunWithResourceSpecAndTaskSpec := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun-with-resource-spec
   namespace: foo
@@ -844,7 +844,7 @@ spec:
       name: mystep
 `)
 
-	taskRunWithClusterTask := parse.MustParseTaskRun(t, `
+	taskRunWithClusterTask := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun-with-cluster-task
   namespace: foo
@@ -854,7 +854,7 @@ spec:
     name: test-cluster-task
 `)
 
-	taskRunWithLabels := parse.MustParseTaskRun(t, `
+	taskRunWithLabels := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   labels:
     TaskRunLabel: TaskRunValue
@@ -866,7 +866,7 @@ spec:
     name: test-task
 `)
 
-	taskRunWithAnnotations := parse.MustParseTaskRun(t, `
+	taskRunWithAnnotations := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   annotations:
     TaskRunAnnotation: TaskRunValue
@@ -877,7 +877,7 @@ spec:
     name: test-task
 `)
 
-	taskRunWithPod := parse.MustParseTaskRun(t, `
+	taskRunWithPod := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun-with-pod
   namespace: foo
@@ -888,7 +888,7 @@ status:
   podName: some-pod-abcdethat-no-longer-exists
 `)
 
-	taskRunWithCredentialsVariable := parse.MustParseTaskRun(t, `
+	taskRunWithCredentialsVariable := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun-with-credentials-variable
   namespace: foo
@@ -915,7 +915,7 @@ spec:
 		t.Fatalf("failed to upload image with simple task: %s", err.Error())
 	}
 
-	taskRunBundle := parse.MustParseTaskRun(t, fmt.Sprintf(`
+	taskRunBundle := parse.MustParseV1beta1TaskRun(t, fmt.Sprintf(`
 metadata:
   name: test-taskrun-bundle
   namespace: foo
@@ -1201,7 +1201,7 @@ spec:
 
 func TestAlphaReconcile(t *testing.T) {
 	names.TestingSeed()
-	taskRunWithOutputConfig := parse.MustParseTaskRun(t, `
+	taskRunWithOutputConfig := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun-with-output-config
   namespace: foo
@@ -1216,7 +1216,7 @@ spec:
           path: stdout.txt
 `)
 
-	taskRunWithOutputConfigAndWorkspace := parse.MustParseTaskRun(t, `
+	taskRunWithOutputConfigAndWorkspace := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun-with-output-config-ws
   namespace: foo
@@ -1366,7 +1366,7 @@ func addVolumeMounts(p *corev1.Pod, vms []corev1.VolumeMount) *corev1.Pod {
 // that when the request is successfully resolved the TaskRun begins running.
 func TestReconcileWithResolver(t *testing.T) {
 	resolverName := "foobar"
-	tr := parse.MustParseTaskRun(t, `
+	tr := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: tr
   namespace: default
@@ -1466,7 +1466,7 @@ spec:
 // that when the request fails, the TaskRun fails.
 func TestReconcileWithFailingResolver(t *testing.T) {
 	resolverName := "foobar"
-	tr := parse.MustParseTaskRun(t, `
+	tr := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: tr
   namespace: default
@@ -1544,7 +1544,7 @@ spec:
 }
 
 func TestReconcile_SetsStartTime(t *testing.T) {
-	taskRun := parse.MustParseTaskRun(t, `
+	taskRun := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun
   namespace: foo
@@ -1577,7 +1577,7 @@ spec:
 
 func TestReconcile_DoesntChangeStartTime(t *testing.T) {
 	startTime := time.Date(2000, 1, 1, 1, 1, 1, 1, time.UTC)
-	taskRun := parse.MustParseTaskRun(t, `
+	taskRun := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun
   namespace: foo
@@ -1611,7 +1611,7 @@ status:
 }
 
 func TestReconcileInvalidTaskRuns(t *testing.T) {
-	noTaskRun := parse.MustParseTaskRun(t, `
+	noTaskRun := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: notaskrun
   namespace: foo
@@ -1619,7 +1619,7 @@ spec:
   taskRef:
     name: notask
 `)
-	withWrongRef := parse.MustParseTaskRun(t, `
+	withWrongRef := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: taskrun-with-wrong-ref
   namespace: foo
@@ -1708,7 +1708,7 @@ spec:
 }
 
 func TestReconcileGetTaskError(t *testing.T) {
-	tr := parse.MustParseTaskRun(t, `
+	tr := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun-run-success
   namespace: foo
@@ -1758,7 +1758,7 @@ spec:
 }
 
 func TestReconcileTaskRunWithPermanentError(t *testing.T) {
-	noTaskRun := parse.MustParseTaskRun(t, `
+	noTaskRun := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: notaskrun
   namespace: foo
@@ -1816,7 +1816,7 @@ status:
 }
 
 func TestReconcilePodFetchError(t *testing.T) {
-	taskRun := parse.MustParseTaskRun(t, `
+	taskRun := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun-run-success
   namespace: foo
@@ -1875,7 +1875,7 @@ func makePod(taskRun *v1beta1.TaskRun, task *v1beta1.Task) (*corev1.Pod, error) 
 
 func TestReconcilePodUpdateStatus(t *testing.T) {
 	const taskLabel = "test-task"
-	taskRun := parse.MustParseTaskRun(t, `
+	taskRun := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun-run-success
   namespace: foo
@@ -1970,7 +1970,7 @@ status:
 }
 
 func TestReconcileOnCompletedTaskRun(t *testing.T) {
-	taskRun := parse.MustParseTaskRun(t, `
+	taskRun := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun-run-success
   namespace: foo
@@ -2010,7 +2010,7 @@ status:
 }
 
 func TestReconcileOnCancelledTaskRun(t *testing.T) {
-	taskRun := parse.MustParseTaskRun(t, `
+	taskRun := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun-run-cancelled
   namespace: foo
@@ -2083,7 +2083,7 @@ status:
 }
 
 func TestReconcileOnTimedOutTaskRun(t *testing.T) {
-	taskRun := parse.MustParseTaskRun(t, `
+	taskRun := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun-run-timedout
   namespace: foo
@@ -2156,7 +2156,7 @@ status:
 }
 
 func TestReconcilePodFailuresStepImagePullFailed(t *testing.T) {
-	taskRun := parse.MustParseTaskRun(t, `
+	taskRun := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-imagepull-fail
   namespace: foo
@@ -2213,7 +2213,7 @@ status:
 }
 
 func TestReconcilePodFailuresSidecarImagePullFailed(t *testing.T) {
-	taskRun := parse.MustParseTaskRun(t, `
+	taskRun := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-imagepull-fail
   namespace: foo
@@ -2295,7 +2295,7 @@ func TestReconcileTimeouts(t *testing.T) {
 	testcases := []testCase{
 		{
 			name: "taskrun with timeout",
-			taskRun: parse.MustParseTaskRun(t, `
+			taskRun: parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun-timeout
   namespace: foo
@@ -2321,7 +2321,7 @@ status:
 			},
 		}, {
 			name: "taskrun with default timeout",
-			taskRun: parse.MustParseTaskRun(t, `
+			taskRun: parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun-default-timeout-60-minutes
   namespace: foo
@@ -2345,7 +2345,7 @@ status:
 			},
 		}, {
 			name: "task run with nil timeout uses default",
-			taskRun: parse.MustParseTaskRun(t, `
+			taskRun: parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun-nil-timeout-default-60-minutes
   namespace: foo
@@ -2402,7 +2402,7 @@ status:
 }
 
 func TestPropagatedWorkspaces(t *testing.T) {
-	taskRun := parse.MustParseTaskRun(t, `
+	taskRun := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun-propagating-workspaces
   namespace: foo
@@ -2449,7 +2449,7 @@ func TestExpandMountPath(t *testing.T) {
 	expectedMountPath := "/temppath/replaced"
 	expectedReplacedArgs := fmt.Sprintf("replacedArgs - %s", expectedMountPath)
 	// The task's Workspace has a parameter variable
-	simpleTask := parse.MustParseTask(t, `
+	simpleTask := parse.MustParseV1beta1Task(t, `
 metadata:
   name: test-task
   namespace: foo
@@ -2473,7 +2473,7 @@ spec:
     readOnly: true
 `)
 
-	taskRun := parse.MustParseTaskRun(t, `
+	taskRun := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun-not-started
   namespace: foo
@@ -2548,7 +2548,7 @@ spec:
 func TestExpandMountPath_DuplicatePaths(t *testing.T) {
 	expectedError := "workspace mount path \"/temppath/duplicate\" must be unique: workspaces[1].mountpath"
 	// The task has two workspaces, with different mount path strings.
-	simpleTask := parse.MustParseTask(t, `
+	simpleTask := parse.MustParseV1beta1Task(t, `
 metadata:
   name: test-task
   namespace: foo
@@ -2578,7 +2578,7 @@ spec:
 `)
 
 	// The parameter values will cause the two Workspaces to have duplicate mount path values after the parameters are expanded.
-	taskRun := parse.MustParseTaskRun(t, `
+	taskRun := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun-not-started
   namespace: foo
@@ -2647,7 +2647,7 @@ spec:
 }
 
 func TestHandlePodCreationError(t *testing.T) {
-	taskRun := parse.MustParseTaskRun(t, `
+	taskRun := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun-pod-creation-failed
 spec:
@@ -2736,7 +2736,7 @@ status:
 
 func TestReconcileCloudEvents(t *testing.T) {
 
-	taskRunWithNoCEResources := parse.MustParseTaskRun(t, `
+	taskRunWithNoCEResources := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun-no-ce-resources
   namespace: foo
@@ -2745,7 +2745,7 @@ spec:
     apiVersion: a1
     name: test-task
 `)
-	taskRunWithTwoCEResourcesNoInit := parse.MustParseTaskRun(t, `
+	taskRunWithTwoCEResourcesNoInit := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun-two-ce-resources-no-init
   namespace: foo
@@ -2761,7 +2761,7 @@ spec:
   taskRef:
     name: test-two-output-task
 `)
-	taskRunWithTwoCEResourcesInit := parse.MustParseTaskRun(t, `
+	taskRunWithTwoCEResourcesInit := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun-two-ce-resources-init
   namespace: foo
@@ -2785,7 +2785,7 @@ status:
       condition: Unknown
     target: https://bar
 `)
-	taskRunWithCESucceded := parse.MustParseTaskRun(t, `
+	taskRunWithCESucceded := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun-ce-succeeded
   namespace: foo
@@ -2813,7 +2813,7 @@ status:
   - status: "True"
     type: Succeeded
 `)
-	taskRunWithCEFailed := parse.MustParseTaskRun(t, `
+	taskRunWithCEFailed := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun-ce-failed
   namespace: foo
@@ -2841,7 +2841,7 @@ status:
   - status: "False"
     type: Succeeded
 `)
-	taskRunWithCESuccededOneAttempt := parse.MustParseTaskRun(t, `
+	taskRunWithCESuccededOneAttempt := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun-ce-succeeded-one-attempt
   namespace: foo
@@ -3024,7 +3024,7 @@ status:
 
 func TestReconcile_Single_SidecarState(t *testing.T) {
 	runningState := corev1.ContainerStateRunning{StartedAt: metav1.Time{Time: now}}
-	taskRun := parse.MustParseTaskRun(t, `
+	taskRun := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun-sidecars
 spec:
@@ -3074,7 +3074,7 @@ status:
 func TestReconcile_Multiple_SidecarStates(t *testing.T) {
 	runningState := corev1.ContainerStateRunning{StartedAt: metav1.Time{Time: now}}
 	waitingState := corev1.ContainerStateWaiting{Reason: "PodInitializing"}
-	taskRun := parse.MustParseTaskRun(t, `
+	taskRun := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun-sidecars
 spec:
@@ -3141,7 +3141,7 @@ status:
 // TestReconcileWorkspaceMissing tests a reconcile of a TaskRun that does
 // not include a Workspace that the Task is expecting.
 func TestReconcileWorkspaceMissing(t *testing.T) {
-	taskWithWorkspace := parse.MustParseTask(t, `
+	taskWithWorkspace := parse.MustParseV1beta1Task(t, `
 metadata:
   name: test-task-with-workspace
   namespace: foo
@@ -3151,7 +3151,7 @@ spec:
     name: ws1
     readOnly: true
 `)
-	taskRun := parse.MustParseTaskRun(t, `
+	taskRun := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun-missing-workspace
   namespace: foo
@@ -3197,7 +3197,7 @@ spec:
 // TestReconcileValidDefaultWorkspace tests a reconcile of a TaskRun that does
 // not include a Workspace that the Task is expecting and it uses the default Workspace instead.
 func TestReconcileValidDefaultWorkspace(t *testing.T) {
-	taskWithWorkspace := parse.MustParseTask(t, `
+	taskWithWorkspace := parse.MustParseV1beta1Task(t, `
 metadata:
   name: test-task-with-workspace
   namespace: foo
@@ -3212,7 +3212,7 @@ spec:
     name: ws1
     readOnly: true
 `)
-	taskRun := parse.MustParseTaskRun(t, `
+	taskRun := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun-default-workspace
   namespace: foo
@@ -3262,7 +3262,7 @@ spec:
 // not include a Workspace that the Task is expecting, and gets an error updating
 // the TaskRun with an invalid default workspace.
 func TestReconcileInvalidDefaultWorkspace(t *testing.T) {
-	taskWithWorkspace := parse.MustParseTask(t, `
+	taskWithWorkspace := parse.MustParseV1beta1Task(t, `
 metadata:
   name: test-task-with-workspace
   namespace: foo
@@ -3277,7 +3277,7 @@ spec:
     name: ws1
     readOnly: true
 `)
-	taskRun := parse.MustParseTaskRun(t, `
+	taskRun := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun-default-workspace
   namespace: foo
@@ -3324,7 +3324,7 @@ spec:
 // injected in place of the omitted optional workspace.
 func TestReconcileValidDefaultWorkspaceOmittedOptionalWorkspace(t *testing.T) {
 	optionalWorkspaceMountPath := "/foo/bar/baz"
-	taskWithOptionalWorkspace := parse.MustParseTask(t, `
+	taskWithOptionalWorkspace := parse.MustParseV1beta1Task(t, `
 metadata:
   name: test-task-with-optional-workspace
   namespace: default
@@ -3339,7 +3339,7 @@ spec:
     name: optional-ws
     optional: true
 `)
-	taskRunOmittingWorkspace := parse.MustParseTaskRun(t, `
+	taskRunOmittingWorkspace := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun
   namespace: default
@@ -3404,7 +3404,7 @@ func TestReconcileTaskResourceResolutionAndValidation(t *testing.T) {
 	}{{
 		desc: "Fail ResolveTaskResources",
 		d: test.Data{
-			Tasks: []*v1beta1.Task{parse.MustParseTask(t, `
+			Tasks: []*v1beta1.Task{parse.MustParseV1beta1Task(t, `
 metadata:
   name: test-task-missing-resource
   namespace: foo
@@ -3414,7 +3414,7 @@ spec:
     - name: workspace
       type: git
 `)},
-			TaskRuns: []*v1beta1.TaskRun{parse.MustParseTaskRun(t, `
+			TaskRuns: []*v1beta1.TaskRun{parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun-missing-resource
   namespace: foo
@@ -3440,7 +3440,7 @@ spec:
 	}, {
 		desc: "Fail ValidateResolvedTaskResources",
 		d: test.Data{
-			Tasks: []*v1beta1.Task{parse.MustParseTask(t, `
+			Tasks: []*v1beta1.Task{parse.MustParseV1beta1Task(t, `
 metadata:
   name: test-task-missing-resource
   namespace: foo
@@ -3450,7 +3450,7 @@ spec:
     - name: workspace
       type: git
 `)},
-			TaskRuns: []*v1beta1.TaskRun{parse.MustParseTaskRun(t, `
+			TaskRuns: []*v1beta1.TaskRun{parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun-missing-resource
   namespace: foo
@@ -3471,7 +3471,7 @@ spec:
 	}, {
 		desc: "Fail ValidateTaskSpecRequestResources",
 		d: test.Data{
-			Tasks: []*v1beta1.Task{parse.MustParseTask(t, `
+			Tasks: []*v1beta1.Task{parse.MustParseV1beta1Task(t, `
 metadata:
   name: test-task-invalid-taskspec-resource
   namespace: foo
@@ -3492,7 +3492,7 @@ spec:
     name: ws1
     readOnly: true
 `)},
-			TaskRuns: []*v1beta1.TaskRun{parse.MustParseTaskRun(t, `
+			TaskRuns: []*v1beta1.TaskRun{parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun-invalid-taskspec-resource
   namespace: foo
@@ -3552,7 +3552,7 @@ spec:
 // Affinity Assistant is validated and that the validation fails for a TaskRun that is incompatible with
 // Affinity Assistant; e.g. using more than one PVC-backed workspace.
 func TestReconcileWithWorkspacesIncompatibleWithAffinityAssistant(t *testing.T) {
-	taskWithTwoWorkspaces := parse.MustParseTask(t, `
+	taskWithTwoWorkspaces := parse.MustParseV1beta1Task(t, `
 metadata:
   name: test-task-two-workspaces
   namespace: foo
@@ -3564,7 +3564,7 @@ spec:
   - description: another workspace
     name: ws2
 `)
-	taskRun := parse.MustParseTaskRun(t, `
+	taskRun := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   annotations:
     pipeline.tekton.dev/affinity-assistant: dummy-affinity-assistant
@@ -3620,7 +3620,7 @@ spec:
 // TestReconcileWorkspaceWithVolumeClaimTemplate tests a reconcile of a TaskRun that has
 // a Workspace with VolumeClaimTemplate and check that it is translated to a created PersistentVolumeClaim.
 func TestReconcileWorkspaceWithVolumeClaimTemplate(t *testing.T) {
-	taskWithWorkspace := parse.MustParseTask(t, `
+	taskWithWorkspace := parse.MustParseV1beta1Task(t, `
 metadata:
   name: test-task-with-workspace
   namespace: foo
@@ -3635,7 +3635,7 @@ spec:
     name: ws1
     readOnly: true
 `)
-	taskRun := parse.MustParseTaskRun(t, `
+	taskRun := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun-missing-workspace
   namespace: foo
@@ -3699,7 +3699,7 @@ func TestFailTaskRun(t *testing.T) {
 		expectedStepStates []v1beta1.StepState
 	}{{
 		name: "no-pod-scheduled",
-		taskRun: parse.MustParseTaskRun(t, `
+		taskRun: parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun-run-failed
   namespace: foo
@@ -3723,7 +3723,7 @@ status:
 		},
 	}, {
 		name: "pod-scheduled",
-		taskRun: parse.MustParseTaskRun(t, `
+		taskRun: parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun-run-failed
   namespace: foo
@@ -3751,7 +3751,7 @@ status:
 		},
 	}, {
 		name: "step-status-update-cancel",
-		taskRun: parse.MustParseTaskRun(t, `
+		taskRun: parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun-run-cancel
   namespace: foo
@@ -3793,7 +3793,7 @@ status:
 		},
 	}, {
 		name: "step-status-update-timeout",
-		taskRun: parse.MustParseTaskRun(t, `
+		taskRun: parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun-run-timeout
   namespace: foo
@@ -3834,7 +3834,7 @@ status:
 		},
 	}, {
 		name: "step-status-update-multiple-steps",
-		taskRun: parse.MustParseTaskRun(t, `
+		taskRun: parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun-run-timeout-multiple-steps
   namespace: foo
@@ -3898,7 +3898,7 @@ status:
 		},
 	}, {
 		name: "step-status-update-multiple-steps-waiting-state",
-		taskRun: parse.MustParseTaskRun(t, `
+		taskRun: parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun-run-timeout-multiple-steps-waiting
   namespace: foo
@@ -3959,7 +3959,7 @@ status:
 		},
 	}, {
 		name: "step-status-update-with-multiple-steps-and-some-continue-on-error",
-		taskRun: parse.MustParseTaskRun(t, `
+		taskRun: parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun-run-ignore-step-error
   namespace: foo
@@ -4057,7 +4057,7 @@ status:
 }
 
 func Test_storeTaskSpec(t *testing.T) {
-	tr := parse.MustParseTaskRun(t, `
+	tr := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   annotations:
     io.annotation: value
@@ -4189,7 +4189,7 @@ func TestWillOverwritePodAffinity(t *testing.T) {
 }
 
 func TestPodAdoption(t *testing.T) {
-	tr := parse.MustParseTaskRun(t, `
+	tr := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   labels:
     mylabel: myvalue
@@ -4269,7 +4269,7 @@ spec:
 }
 
 func TestStopSidecars_ClientGetPodForTaskSpecWithSidecars(t *testing.T) {
-	tr := parse.MustParseTaskRun(t, `
+	tr := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun
   namespace: foo
@@ -4326,7 +4326,7 @@ func TestStopSidecars_NoClientGetPodForTaskSpecWithoutRunningSidecars(t *testing
 		tr   *v1beta1.TaskRun
 	}{{
 		desc: "no sidecars",
-		tr: parse.MustParseTaskRun(t, `
+		tr: parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun
   namespace: foo
@@ -4339,7 +4339,7 @@ status:
 `),
 	}, {
 		desc: "sidecars are terminated",
-		tr: parse.MustParseTaskRun(t, `
+		tr: parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun
   namespace: foo
@@ -4745,7 +4745,7 @@ func objectMeta(name, ns string) metav1.ObjectMeta {
 }
 
 func TestReconcile_validateTaskRunResults_valid(t *testing.T) {
-	taskRunResultsTypeMatched := parse.MustParseTaskRun(t, `
+	taskRunResultsTypeMatched := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun-results-type-valid
   namespace: foo
@@ -4759,7 +4759,7 @@ status:
       value: aResultValue
 `)
 
-	taskRunResultsObjectValid := parse.MustParseTaskRun(t, `
+	taskRunResultsObjectValid := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun-results-object-valid
   namespace: foo
@@ -4824,7 +4824,7 @@ status:
 }
 
 func TestReconcile_validateTaskRunResults_invalid(t *testing.T) {
-	taskRunResultsTypeMismatched := parse.MustParseTaskRun(t, `
+	taskRunResultsTypeMismatched := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun-results-type-mismatched
   namespace: foo
@@ -4838,7 +4838,7 @@ status:
       value: aResultValue
 `)
 
-	taskRunResultsObjectMissKey := parse.MustParseTaskRun(t, `
+	taskRunResultsObjectMissKey := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun-results-object-miss-key
   namespace: foo
@@ -4911,7 +4911,7 @@ status:
 }
 
 func TestReconcile_ReplacementsInStatusTaskSpec(t *testing.T) {
-	task := parse.MustParseTask(t, `
+	task := parse.MustParseV1beta1Task(t, `
 metadata:
   name: test-task-with-replacements
   namespace: foo
@@ -4925,7 +4925,7 @@ spec:
     image: myimage
     name: mycontainer
 `)
-	tr := parse.MustParseTaskRun(t, `
+	tr := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun-with-replacements
   namespace: foo
@@ -4986,7 +4986,7 @@ func TestReconcile_verifyResolvedTask_Success(t *testing.T) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	ts := parse.MustParseTask(t, `
+	ts := parse.MustParseV1beta1Task(t, `
 metadata:
   name: test-task
   namespace: foo
@@ -5000,7 +5000,7 @@ spec:
     image: myimage
     name: mycontainer
 `)
-	tr := parse.MustParseTaskRun(t, `
+	tr := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun
   namespace: foo
@@ -5061,7 +5061,7 @@ func TestReconcile_verifyResolvedTask_Error(t *testing.T) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	ts := parse.MustParseTask(t, `
+	ts := parse.MustParseV1beta1Task(t, `
 metadata:
   name: test-task
   namespace: foo
@@ -5075,7 +5075,7 @@ spec:
     image: myimage
     name: mycontainer
 `)
-	tr := parse.MustParseTaskRun(t, `
+	tr := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun
   namespace: foo

--- a/pkg/status/status_test.go
+++ b/pkg/status/status_test.go
@@ -64,7 +64,7 @@ func TestGetTaskRunStatusForPipelineTask(t *testing.T) {
 			},
 		}, {
 			name: "success",
-			taskRun: parse.MustParseTaskRun(t, `
+			taskRun: parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: some-task-run
 spec: {}
@@ -207,7 +207,7 @@ status:
 }
 
 func TestGetFullPipelineTaskStatuses(t *testing.T) {
-	tr1 := parse.MustParseTaskRun(t, `
+	tr1 := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: pr-task-1
 spec: {}
@@ -253,7 +253,7 @@ status:
 		},
 		{
 			name: "minimal embedded",
-			originalPR: parse.MustParsePipelineRun(t, `
+			originalPR: parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: pr
 spec: {}
@@ -302,7 +302,7 @@ pr-run-1:
 			expectedErr: nil,
 		}, {
 			name: "full embedded",
-			originalPR: parse.MustParsePipelineRun(t, `
+			originalPR: parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: pr
 spec: {}
@@ -364,7 +364,7 @@ pr-run-1:
 			expectedErr: nil,
 		}, {
 			name: "both embedded",
-			originalPR: parse.MustParsePipelineRun(t, `
+			originalPR: parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: pr
 spec: {}
@@ -435,7 +435,7 @@ pr-run-1:
 			expectedErr: nil,
 		}, {
 			name: "missing run",
-			originalPR: parse.MustParsePipelineRun(t, `
+			originalPR: parse.MustParseV1beta1PipelineRun(t, `
 metadata:
   name: pr
 spec: {}

--- a/test/artifact_bucket_test.go
+++ b/test/artifact_bucket_test.go
@@ -76,7 +76,7 @@ func TestStorageBucketPipelineRun(t *testing.T) {
 	defer deleteBucketSecret(ctx, c, t, namespace)
 
 	t.Logf("Creating GCS bucket %s", bucketName)
-	createbuckettask := parse.MustParseTask(t, fmt.Sprintf(`
+	createbuckettask := parse.MustParseV1beta1Task(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -99,11 +99,11 @@ spec:
 `, helpers.ObjectNameForTest(t), namespace, bucketName, bucketSecretName, bucketSecretName, bucketSecretKey, bucketSecretName))
 
 	t.Logf("Creating Task %s", createbuckettask.Name)
-	if _, err := c.TaskClient.Create(ctx, createbuckettask, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1TaskClient.Create(ctx, createbuckettask, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Task `%s`: %s", createbuckettask.Name, err)
 	}
 
-	createbuckettaskrun := parse.MustParseTaskRun(t, fmt.Sprintf(`
+	createbuckettaskrun := parse.MustParseV1beta1TaskRun(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -113,7 +113,7 @@ spec:
 `, helpers.ObjectNameForTest(t), namespace, createbuckettask.Name))
 
 	t.Logf("Creating TaskRun %s", createbuckettaskrun.Name)
-	if _, err := c.TaskRunClient.Create(ctx, createbuckettaskrun, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1TaskRunClient.Create(ctx, createbuckettaskrun, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create TaskRun `%s`: %s", createbuckettaskrun.Name, err)
 	}
 
@@ -152,12 +152,12 @@ spec:
 	value: master
   type: git
 `, helloworldResourceName))
-	if _, err := c.PipelineResourceClient.Create(ctx, helloworldResource, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1alpha1PipelineResourceClient.Create(ctx, helloworldResource, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Pipeline Resource `%s`: %s", helloworldResourceName, err)
 	}
 
 	t.Logf("Creating Task %s", addFileTaskName)
-	addFileTask := parse.MustParseTask(t, fmt.Sprintf(`
+	addFileTask := parse.MustParseV1beta1Task(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -179,12 +179,12 @@ spec:
     name: make-executable
     script: chmod +x /workspace/helloworldgit/newfile
 `, addFileTaskName, namespace, helloworldResourceName, helloworldResourceName))
-	if _, err := c.TaskClient.Create(ctx, addFileTask, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1TaskClient.Create(ctx, addFileTask, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Task `%s`: %s", addFileTaskName, err)
 	}
 
 	t.Logf("Creating Task %s", runFileTaskName)
-	readFileTask := parse.MustParseTask(t, fmt.Sprintf(`
+	readFileTask := parse.MustParseV1beta1Task(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -198,12 +198,12 @@ spec:
     image: ubuntu
     name: runfile
 `, runFileTaskName, namespace, helloworldResourceName))
-	if _, err := c.TaskClient.Create(ctx, readFileTask, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1TaskClient.Create(ctx, readFileTask, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Task `%s`: %s", runFileTaskName, err)
 	}
 
 	t.Logf("Creating Pipeline %s", bucketTestPipelineName)
-	bucketTestPipeline := parse.MustParsePipeline(t, fmt.Sprintf(`
+	bucketTestPipeline := parse.MustParseV1beta1Pipeline(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -230,12 +230,12 @@ spec:
     taskRef:
       name: %s
 `, bucketTestPipelineName, namespace, addFileTaskName, runFileTaskName))
-	if _, err := c.PipelineClient.Create(ctx, bucketTestPipeline, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1PipelineClient.Create(ctx, bucketTestPipeline, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Pipeline `%s`: %s", bucketTestPipelineName, err)
 	}
 
 	t.Logf("Creating PipelineRun %s", bucketTestPipelineRunName)
-	bucketTestPipelineRun := parse.MustParsePipelineRun(t, fmt.Sprintf(`
+	bucketTestPipelineRun := parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -247,7 +247,7 @@ spec:
     resourceRef:
       name: %s
 `, bucketTestPipelineRunName, namespace, bucketTestPipelineName, helloworldResourceName))
-	if _, err := c.PipelineRunClient.Create(ctx, bucketTestPipelineRun, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1PipelineRunClient.Create(ctx, bucketTestPipelineRun, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create PipelineRun `%s`: %s", bucketTestPipelineRunName, err)
 	}
 
@@ -308,7 +308,7 @@ func resetConfigMap(ctx context.Context, t *testing.T, c *clients, namespace, co
 }
 
 func runTaskToDeleteBucket(ctx context.Context, c *clients, t *testing.T, namespace, bucketName, bucketSecretName, bucketSecretKey string) {
-	deletelbuckettask := parse.MustParseTask(t, fmt.Sprintf(`
+	deletelbuckettask := parse.MustParseV1beta1Task(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -332,11 +332,11 @@ spec:
 `, helpers.ObjectNameForTest(t), namespace, bucketName, bucketSecretName, bucketSecretKey, bucketSecretName, bucketSecretName))
 
 	t.Logf("Creating Task %s", deletelbuckettask.Name)
-	if _, err := c.TaskClient.Create(ctx, deletelbuckettask, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1TaskClient.Create(ctx, deletelbuckettask, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Task `%s`: %s", deletelbuckettask.Name, err)
 	}
 
-	deletelbuckettaskrun := parse.MustParseTaskRun(t, fmt.Sprintf(`
+	deletelbuckettaskrun := parse.MustParseV1beta1TaskRun(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -346,7 +346,7 @@ spec:
 `, helpers.ObjectNameForTest(t), namespace, deletelbuckettask.Name))
 
 	t.Logf("Creating TaskRun %s", deletelbuckettaskrun.Name)
-	if _, err := c.TaskRunClient.Create(ctx, deletelbuckettaskrun, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1TaskRunClient.Create(ctx, deletelbuckettaskrun, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create TaskRun `%s`: %s", deletelbuckettaskrun.Name, err)
 	}
 

--- a/test/cancel_test.go
+++ b/test/cancel_test.go
@@ -56,7 +56,7 @@ func TestTaskRunPipelineRunCancel(t *testing.T) {
 			knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
 			defer tearDown(ctx, t, c, namespace)
 
-			pipelineRun := parse.MustParsePipelineRun(t, fmt.Sprintf(`
+			pipelineRun := parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -72,7 +72,7 @@ spec:
 `, helpers.ObjectNameForTest(t), namespace, numRetries))
 
 			t.Logf("Creating PipelineRun in namespace %s", namespace)
-			if _, err := c.PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{}); err != nil {
+			if _, err := c.V1beta1PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{}); err != nil {
 				t.Fatalf("Failed to create PipelineRun `%s`: %s", pipelineRun.Name, err)
 			}
 
@@ -81,7 +81,7 @@ spec:
 				t.Fatalf("Error waiting for PipelineRun %s to be running: %s", pipelineRun.Name, err)
 			}
 
-			taskrunList, err := c.TaskRunClient.List(ctx, metav1.ListOptions{LabelSelector: "tekton.dev/pipelineRun=" + pipelineRun.Name})
+			taskrunList, err := c.V1beta1TaskRunClient.List(ctx, metav1.ListOptions{LabelSelector: "tekton.dev/pipelineRun=" + pipelineRun.Name})
 			if err != nil {
 				t.Fatalf("Error listing TaskRuns for PipelineRun %s: %s", pipelineRun.Name, err)
 			}
@@ -100,7 +100,7 @@ spec:
 			}
 			wg.Wait()
 
-			pr, err := c.PipelineRunClient.Get(ctx, pipelineRun.Name, metav1.GetOptions{})
+			pr, err := c.V1beta1PipelineRunClient.Get(ctx, pipelineRun.Name, metav1.GetOptions{})
 			if err != nil {
 				t.Fatalf("Failed to get PipelineRun `%s`: %s", pipelineRun.Name, err)
 			}
@@ -114,7 +114,7 @@ spec:
 			if err != nil {
 				t.Fatalf("failed to marshal patch bytes in order to cancel")
 			}
-			if _, err := c.PipelineRunClient.Patch(ctx, pr.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{}, ""); err != nil {
+			if _, err := c.V1beta1PipelineRunClient.Patch(ctx, pr.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{}, ""); err != nil {
 				t.Fatalf("Failed to patch PipelineRun `%s` with cancellation: %s", pipelineRun.Name, err)
 			}
 
@@ -139,7 +139,7 @@ spec:
 			wg.Wait()
 
 			var trName []string
-			taskrunList, err = c.TaskRunClient.List(ctx, metav1.ListOptions{LabelSelector: "tekton.dev/pipelineRun=" + pipelineRun.Name})
+			taskrunList, err = c.V1beta1TaskRunClient.List(ctx, metav1.ListOptions{LabelSelector: "tekton.dev/pipelineRun=" + pipelineRun.Name})
 			if err != nil {
 				t.Fatalf("Error listing TaskRuns for PipelineRun %s: %s", pipelineRun.Name, err)
 			}

--- a/test/clients.go
+++ b/test/clients.go
@@ -25,7 +25,7 @@ that contains initialized clients for accessing:
 
 For example, to create a Pipeline
 
-	_, err = clients.PipelineClient.Pipelines.Create(test.Pipeline(namespaceName, pipelineName))
+	_, err = clients.V1beta1PipelineClient.Pipelines.Create(test.Pipeline(namespaceName, pipelineName))
 
 And you can use the client to clean up resources created by your test
 
@@ -57,14 +57,14 @@ import (
 type clients struct {
 	KubeClient kubernetes.Interface
 
-	PipelineClient          v1beta1.PipelineInterface
-	ClusterTaskClient       v1beta1.ClusterTaskInterface
-	TaskClient              v1beta1.TaskInterface
-	TaskRunClient           v1beta1.TaskRunInterface
-	PipelineRunClient       v1beta1.PipelineRunInterface
-	PipelineResourceClient  resourcev1alpha1.PipelineResourceInterface
-	RunClient               v1alpha1.RunInterface
-	ResolutionRequestclient resolutionv1alpha1.ResolutionRequestInterface
+	V1beta1PipelineClient           v1beta1.PipelineInterface
+	V1beta1ClusterTaskClient        v1beta1.ClusterTaskInterface
+	V1beta1TaskClient               v1beta1.TaskInterface
+	V1beta1TaskRunClient            v1beta1.TaskRunInterface
+	V1beta1PipelineRunClient        v1beta1.PipelineRunInterface
+	V1alpha1PipelineResourceClient  resourcev1alpha1.PipelineResourceInterface
+	V1alpha1RunClient               v1alpha1.RunInterface
+	V1alpha1ResolutionRequestclient resolutionv1alpha1.ResolutionRequestInterface
 }
 
 // newClients instantiates and returns several clientsets required for making requests to the
@@ -98,13 +98,13 @@ func newClients(t *testing.T, configPath, clusterName, namespace string) *client
 	if err != nil {
 		t.Fatalf("failed to create resolution clientset from config file at %s: %s", configPath, err)
 	}
-	c.PipelineClient = cs.TektonV1beta1().Pipelines(namespace)
-	c.ClusterTaskClient = cs.TektonV1beta1().ClusterTasks()
-	c.TaskClient = cs.TektonV1beta1().Tasks(namespace)
-	c.TaskRunClient = cs.TektonV1beta1().TaskRuns(namespace)
-	c.PipelineRunClient = cs.TektonV1beta1().PipelineRuns(namespace)
-	c.PipelineResourceClient = rcs.TektonV1alpha1().PipelineResources(namespace)
-	c.RunClient = cs.TektonV1alpha1().Runs(namespace)
-	c.ResolutionRequestclient = rrcs.ResolutionV1alpha1().ResolutionRequests(namespace)
+	c.V1beta1PipelineClient = cs.TektonV1beta1().Pipelines(namespace)
+	c.V1beta1ClusterTaskClient = cs.TektonV1beta1().ClusterTasks()
+	c.V1beta1TaskClient = cs.TektonV1beta1().Tasks(namespace)
+	c.V1beta1TaskRunClient = cs.TektonV1beta1().TaskRuns(namespace)
+	c.V1beta1PipelineRunClient = cs.TektonV1beta1().PipelineRuns(namespace)
+	c.V1alpha1PipelineResourceClient = rcs.TektonV1alpha1().PipelineResources(namespace)
+	c.V1alpha1RunClient = cs.TektonV1alpha1().Runs(namespace)
+	c.V1alpha1ResolutionRequestclient = rrcs.ResolutionV1alpha1().ResolutionRequests(namespace)
 	return c
 }

--- a/test/cluster_resource_test.go
+++ b/test/cluster_resource_test.go
@@ -63,17 +63,17 @@ func TestClusterResource(t *testing.T) {
 	}
 
 	t.Logf("Creating cluster PipelineResource %s", resourceName)
-	if _, err := c.PipelineResourceClient.Create(ctx, getClusterResource(t, resourceName, secretName), metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1alpha1PipelineResourceClient.Create(ctx, getClusterResource(t, resourceName, secretName), metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create cluster Pipeline Resource `%s`: %s", resourceName, err)
 	}
 
 	t.Logf("Creating Task %s", taskName)
-	if _, err := c.TaskClient.Create(ctx, getClusterResourceTask(t, namespace, taskName, configName), metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1TaskClient.Create(ctx, getClusterResourceTask(t, namespace, taskName, configName), metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Task `%s`: %s", taskName, err)
 	}
 
 	t.Logf("Creating TaskRun %s", taskRunName)
-	if _, err := c.TaskRunClient.Create(ctx, getClusterResourceTaskRun(t, namespace, taskRunName, taskName, resourceName), metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1TaskRunClient.Create(ctx, getClusterResourceTaskRun(t, namespace, taskRunName, taskName, resourceName), metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Taskrun `%s`: %s", taskRunName, err)
 	}
 
@@ -122,7 +122,7 @@ func getClusterResourceTaskSecret(namespace, name string) *corev1.Secret {
 }
 
 func getClusterResourceTask(t *testing.T, namespace, name, configName string) *v1beta1.Task {
-	return parse.MustParseTask(t, fmt.Sprintf(`
+	return parse.MustParseV1beta1Task(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -158,7 +158,7 @@ spec:
 }
 
 func getClusterResourceTaskRun(t *testing.T, namespace, name, taskName, resName string) *v1beta1.TaskRun {
-	return parse.MustParseTaskRun(t, fmt.Sprintf(`
+	return parse.MustParseV1beta1TaskRun(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s

--- a/test/conformance_test.go
+++ b/test/conformance_test.go
@@ -58,7 +58,7 @@ func TestTaskRun(t *testing.T) {
 		expectedStepState       []v1beta1.StepState
 	}{{
 		name: "successful-task-run",
-		tr: parse.MustParseTaskRun(t, fmt.Sprintf(`
+		tr: parse.MustParseV1beta1TaskRun(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -80,7 +80,7 @@ spec:
 		}},
 	}, {
 		name: "failed-task-run",
-		tr: parse.MustParseTaskRun(t, fmt.Sprintf(`
+		tr: parse.MustParseV1beta1TaskRun(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -124,7 +124,7 @@ spec:
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Logf("Creating TaskRun %s", tc.tr.Name)
-			if _, err := c.TaskRunClient.Create(ctx, tc.tr, metav1.CreateOptions{}); err != nil {
+			if _, err := c.V1beta1TaskRunClient.Create(ctx, tc.tr, metav1.CreateOptions{}); err != nil {
 				t.Fatalf("Failed to create TaskRun `%s`: %s", tc.tr.Name, err)
 			}
 
@@ -132,7 +132,7 @@ spec:
 				t.Errorf("Error waiting for TaskRun to finish: %s", err)
 				return
 			}
-			tr, err := c.TaskRunClient.Get(ctx, tc.tr.Name, metav1.GetOptions{})
+			tr, err := c.V1beta1TaskRunClient.Get(ctx, tc.tr.Name, metav1.GetOptions{})
 			if err != nil {
 				t.Fatalf("Failed to get TaskRun `%s`: %s", tc.tr.Name, err)
 			}

--- a/test/custom_task_test.go
+++ b/test/custom_task_test.go
@@ -82,9 +82,9 @@ func TestCustomTask(t *testing.T) {
 	metadataLabel := map[string]string{"test-label": "test"}
 	// Create a PipelineRun that runs a Custom Task.
 	pipelineRunName := helpers.ObjectNameForTest(t)
-	if _, err := c.PipelineRunClient.Create(
+	if _, err := c.V1beta1PipelineRunClient.Create(
 		ctx,
-		parse.MustParsePipelineRun(t, fmt.Sprintf(`
+		parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   name: %s
 spec:
@@ -134,7 +134,7 @@ spec:
 	}
 
 	// Get the status of the PipelineRun.
-	pr, err := c.PipelineRunClient.Get(ctx, pipelineRunName, metav1.GetOptions{})
+	pr, err := c.V1beta1PipelineRunClient.Get(ctx, pipelineRunName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Failed to get PipelineRun %q: %v", pipelineRunName, err)
 	}
@@ -161,7 +161,7 @@ spec:
 	}
 	for _, runName := range runNames {
 		// Get the Run.
-		r, err := c.RunClient.Get(ctx, runName, metav1.GetOptions{})
+		r, err := c.V1alpha1RunClient.Get(ctx, runName, metav1.GetOptions{})
 		if err != nil {
 			t.Fatalf("Failed to get Run %q: %v", runName, err)
 		}
@@ -185,12 +185,12 @@ spec:
 			},
 		}
 
-		if _, err := c.RunClient.UpdateStatus(ctx, r, metav1.UpdateOptions{}); err != nil {
+		if _, err := c.V1alpha1RunClient.UpdateStatus(ctx, r, metav1.UpdateOptions{}); err != nil {
 			t.Fatalf("Failed to update Run to successful: %v", err)
 		}
 
 		// Get the Run.
-		r, err = c.RunClient.Get(ctx, runName, metav1.GetOptions{})
+		r, err = c.V1alpha1RunClient.Get(ctx, runName, metav1.GetOptions{})
 
 		if strings.Contains(runName, "custom-task-spec") {
 			if d := cmp.Diff(customTaskRawSpec, r.Spec.Spec.Spec.Raw); d != "" {
@@ -213,7 +213,7 @@ spec:
 	}
 
 	// Get the updated status of the PipelineRun.
-	pr, err = c.PipelineRunClient.Get(ctx, pipelineRunName, metav1.GetOptions{})
+	pr, err = c.V1beta1PipelineRunClient.Get(ctx, pipelineRunName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Failed to get PipelineRun %q after it completed: %v", pipelineRunName, err)
 	}
@@ -242,7 +242,7 @@ spec:
 	}
 
 	// Get the TaskRun.
-	taskRun, err := c.TaskRunClient.Get(ctx, taskRunName, metav1.GetOptions{})
+	taskRun, err := c.V1beta1TaskRunClient.Get(ctx, taskRunName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Failed to get TaskRun %q: %v", taskRunName, err)
 	}
@@ -285,7 +285,7 @@ func WaitForRunSpecCancelled(ctx context.Context, c *clients, name string, desc 
 	defer span.End()
 
 	return pollImmediateWithContext(ctx, func() (bool, error) {
-		r, err := c.RunClient.Get(ctx, name, metav1.GetOptions{})
+		r, err := c.V1alpha1RunClient.Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			return true, err
 		}
@@ -306,7 +306,7 @@ func TestPipelineRunCustomTaskTimeout(t *testing.T) {
 
 	embeddedStatusValue := GetEmbeddedStatus(ctx, t, c.KubeClient)
 
-	pipeline := parse.MustParsePipeline(t, fmt.Sprintf(`
+	pipeline := parse.MustParseV1beta1Pipeline(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -317,7 +317,7 @@ spec:
       apiVersion: %s
       kind: %s
 `, helpers.ObjectNameForTest(t), namespace, apiVersion, kind))
-	pipelineRun := parse.MustParsePipelineRun(t, fmt.Sprintf(`
+	pipelineRun := parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -326,10 +326,10 @@ spec:
     name: %s
   timeout: 5s
 `, helpers.ObjectNameForTest(t), namespace, pipeline.Name))
-	if _, err := c.PipelineClient.Create(ctx, pipeline, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1PipelineClient.Create(ctx, pipeline, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Pipeline `%s`: %s", pipeline.Name, err)
 	}
-	if _, err := c.PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create PipelineRun `%s`: %s", pipelineRun.Name, err)
 	}
 
@@ -338,7 +338,7 @@ spec:
 		t.Fatalf("Error waiting for PipelineRun %s to be running: %s", pipelineRun.Name, err)
 	}
 
-	pr, err := c.PipelineRunClient.Get(ctx, pipelineRun.Name, metav1.GetOptions{})
+	pr, err := c.V1beta1PipelineRunClient.Get(ctx, pipelineRun.Name, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Failed to get PipelineRun %q: %v", pipelineRun.Name, err)
 	}
@@ -362,7 +362,7 @@ spec:
 	}
 
 	// Get the Run.
-	r, err := c.RunClient.Get(ctx, runName, metav1.GetOptions{})
+	r, err := c.V1alpha1RunClient.Get(ctx, runName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Failed to get Run %q: %v", runName, err)
 	}
@@ -383,7 +383,7 @@ spec:
 			}},
 		},
 	}
-	if _, err := c.RunClient.UpdateStatus(ctx, r, metav1.UpdateOptions{}); err != nil {
+	if _, err := c.V1alpha1RunClient.UpdateStatus(ctx, r, metav1.UpdateOptions{}); err != nil {
 		t.Fatalf("Failed to update Run to successful: %v", err)
 	}
 
@@ -392,7 +392,7 @@ spec:
 		t.Errorf("Error waiting for PipelineRun %s to finish: %s", pipelineRun.Name, err)
 	}
 
-	runList, err := c.RunClient.List(ctx, metav1.ListOptions{LabelSelector: fmt.Sprintf("tekton.dev/pipelineRun=%s", pipelineRun.Name)})
+	runList, err := c.V1alpha1RunClient.List(ctx, metav1.ListOptions{LabelSelector: fmt.Sprintf("tekton.dev/pipelineRun=%s", pipelineRun.Name)})
 	if err != nil {
 		t.Fatalf("Error listing Runs for PipelineRun %s: %s", pipelineRun.Name, err)
 	}
@@ -411,7 +411,7 @@ spec:
 	}
 	wg.Wait()
 
-	if _, err := c.PipelineRunClient.Get(ctx, pipelineRun.Name, metav1.GetOptions{}); err != nil {
+	if _, err := c.V1beta1PipelineRunClient.Get(ctx, pipelineRun.Name, metav1.GetOptions{}); err != nil {
 		t.Fatalf("Failed to get PipelineRun `%s`: %s", pipelineRun.Name, err)
 	}
 }
@@ -541,7 +541,7 @@ func TestWaitCustomTask_Run(t *testing.T) {
 				},
 			}
 
-			if _, err := c.RunClient.Create(ctx, run, metav1.CreateOptions{}); err != nil {
+			if _, err := c.V1alpha1RunClient.Create(ctx, run, metav1.CreateOptions{}); err != nil {
 				t.Fatalf("Failed to create TaskRun %q: %v", runName, err)
 			}
 
@@ -551,7 +551,7 @@ func TestWaitCustomTask_Run(t *testing.T) {
 			}
 
 			// Get the actual Run
-			gotRun, err := c.RunClient.Get(ctx, runName, metav1.GetOptions{})
+			gotRun, err := c.V1alpha1RunClient.Get(ctx, runName, metav1.GetOptions{})
 			if err != nil {
 				t.Fatalf("%v", err)
 			}
@@ -785,10 +785,10 @@ func TestWaitCustomTask_PipelineRun(t *testing.T) {
 					Timeout: tc.prTimeout,
 				},
 			}
-			if _, err := c.PipelineClient.Create(ctx, pipeline, metav1.CreateOptions{}); err != nil {
+			if _, err := c.V1beta1PipelineClient.Create(ctx, pipeline, metav1.CreateOptions{}); err != nil {
 				t.Fatalf("Failed to create Pipeline %q: %v", pipeline.Name, err)
 			}
-			if _, err := c.PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{}); err != nil {
+			if _, err := c.V1beta1PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{}); err != nil {
 				t.Fatalf("Failed to create PipelineRun %q: %v", pipelineRun.Name, err)
 			}
 
@@ -798,7 +798,7 @@ func TestWaitCustomTask_PipelineRun(t *testing.T) {
 			}
 
 			// Get actual pipelineRun
-			gotPipelineRun, err := c.PipelineRunClient.Get(ctx, pipelineRun.Name, metav1.GetOptions{})
+			gotPipelineRun, err := c.V1beta1PipelineRunClient.Get(ctx, pipelineRun.Name, metav1.GetOptions{})
 			if err != nil {
 				t.Fatalf("Failed to get PipelineRun %q: %v", pipelineRun.Name, err)
 			}
@@ -886,7 +886,7 @@ func TestWaitCustomTask_PipelineRun(t *testing.T) {
 			}
 
 			// Get the Run.
-			_, err = c.RunClient.Get(ctx, wantRunName, metav1.GetOptions{})
+			_, err = c.V1alpha1RunClient.Get(ctx, wantRunName, metav1.GetOptions{})
 			if err != nil {
 				t.Fatalf("Failed to get Run %q: %v", wantRunName, err)
 			}

--- a/test/dag_test.go
+++ b/test/dag_test.go
@@ -40,14 +40,14 @@ const sleepDuration = 15 * time.Second
 
 // TestDAGPipelineRun creates a graph of arbitrary Tasks, then looks at the corresponding
 // TaskRun start times to ensure they were run in the order intended, which is:
-//                               |
-//                        pipeline-task-1
-//                       /               \
-//   pipeline-task-2-parallel-1    pipeline-task-2-parallel-2
-//                       \                /
-//                        pipeline-task-3
-//                               |
-//                        pipeline-task-4
+//                              |
+//                       pipeline-task-1
+//                      /               \
+//  pipeline-task-2-parallel-1    pipeline-task-2-parallel-2
+//                      \                /
+//                       pipeline-task-3
+//                              |
+//                       pipeline-task-4
 func TestDAGPipelineRun(t *testing.T) {
 	ctx := context.Background()
 	ctx, cancel := context.WithCancel(ctx)
@@ -58,7 +58,7 @@ func TestDAGPipelineRun(t *testing.T) {
 	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
 	defer tearDown(ctx, t, c, namespace)
 
-	echoTask := parse.MustParseTask(t, fmt.Sprintf(`
+	echoTask := parse.MustParseV1beta1Task(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -84,7 +84,7 @@ spec:
   - image: busybox
     script: 'ln -s $(resources.inputs.repo.path) $(resources.outputs.repo.path)'
 `, helpers.ObjectNameForTest(t), namespace, int(sleepDuration.Seconds())))
-	if _, err := c.TaskClient.Create(ctx, echoTask, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1TaskClient.Create(ctx, echoTask, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create echo Task: %s", err)
 	}
 
@@ -98,13 +98,13 @@ spec:
   - name: Url
     value: https://github.com/githubtraining/example-basic
 `, helpers.ObjectNameForTest(t)))
-	if _, err := c.PipelineResourceClient.Create(ctx, repoResource, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1alpha1PipelineResourceClient.Create(ctx, repoResource, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create simple repo PipelineResource: %s", err)
 	}
 
 	// Intentionally declaring Tasks in a mixed up order to ensure the order
 	// of execution isn't at all dependent on the order they are declared in
-	pipeline := parse.MustParsePipeline(t, fmt.Sprintf(`
+	pipeline := parse.MustParseV1beta1Pipeline(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -188,10 +188,10 @@ spec:
     taskRef:
       name: %s
 `, helpers.ObjectNameForTest(t), namespace, echoTask.Name, echoTask.Name, echoTask.Name, echoTask.Name, echoTask.Name))
-	if _, err := c.PipelineClient.Create(ctx, pipeline, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1PipelineClient.Create(ctx, pipeline, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create dag-pipeline: %s", err)
 	}
-	pipelineRun := parse.MustParsePipelineRun(t, fmt.Sprintf(`
+	pipelineRun := parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -203,7 +203,7 @@ spec:
     resourceRef:
       name: %s
 `, helpers.ObjectNameForTest(t), namespace, pipeline.Name, repoResource.Name))
-	if _, err := c.PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create dag-pipeline-run PipelineRun: %s", err)
 	}
 	t.Logf("Waiting for DAG pipeline to complete")
@@ -211,7 +211,7 @@ spec:
 		t.Fatalf("Error waiting for PipelineRun to finish: %s", err)
 	}
 
-	verifyExpectedOrder(ctx, t, c.TaskRunClient, pipelineRun.Name)
+	verifyExpectedOrder(ctx, t, c.V1beta1TaskRunClient, pipelineRun.Name)
 }
 
 func verifyExpectedOrder(ctx context.Context, t *testing.T, c clientset.TaskRunInterface, prName string) {

--- a/test/duplicate_test.go
+++ b/test/duplicate_test.go
@@ -53,7 +53,7 @@ func TestDuplicatePodTaskRun(t *testing.T) {
 		taskrunName := helpers.ObjectNameForTest(t)
 		t.Logf("Creating taskrun %q.", taskrunName)
 
-		taskrun := parse.MustParseTaskRun(t, fmt.Sprintf(`
+		taskrun := parse.MustParseV1beta1TaskRun(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -64,7 +64,7 @@ spec:
       command: ['/bin/echo']
       args: ['simple']
 `, taskrunName, namespace))
-		if _, err := c.TaskRunClient.Create(ctx, taskrun, metav1.CreateOptions{}); err != nil {
+		if _, err := c.V1beta1TaskRunClient.Create(ctx, taskrun, metav1.CreateOptions{}); err != nil {
 			t.Fatalf("Error creating taskrun: %v", err)
 		}
 		go func(t *testing.T) {

--- a/test/embed_test.go
+++ b/test/embed_test.go
@@ -54,10 +54,10 @@ func TestTaskRun_EmbeddedResource(t *testing.T) {
 	embedTaskRunName := helpers.ObjectNameForTest(t)
 
 	t.Logf("Creating Task and TaskRun in namespace %s", namespace)
-	if _, err := c.TaskClient.Create(ctx, getEmbeddedTask(t, embedTaskName, namespace, []string{"/bin/sh", "-c", fmt.Sprintf("echo %s", taskOutput)}), metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1TaskClient.Create(ctx, getEmbeddedTask(t, embedTaskName, namespace, []string{"/bin/sh", "-c", fmt.Sprintf("echo %s", taskOutput)}), metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Task `%s`: %s", embedTaskName, err)
 	}
-	if _, err := c.TaskRunClient.Create(ctx, getEmbeddedTaskRun(t, embedTaskRunName, namespace, embedTaskName), metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1TaskRunClient.Create(ctx, getEmbeddedTaskRun(t, embedTaskRunName, namespace, embedTaskName), metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create TaskRun `%s`: %s", embedTaskRunName, err)
 	}
 
@@ -75,7 +75,7 @@ func getEmbeddedTask(t *testing.T, taskName, namespace string, args []string) *v
 	for _, s := range args {
 		argsForYaml = append(argsForYaml, fmt.Sprintf("'%s'", s))
 	}
-	return parse.MustParseTask(t, fmt.Sprintf(`
+	return parse.MustParseV1beta1Task(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -94,7 +94,7 @@ spec:
 }
 
 func getEmbeddedTaskRun(t *testing.T, trName, namespace, taskName string) *v1beta1.TaskRun {
-	return parse.MustParseTaskRun(t, fmt.Sprintf(`
+	return parse.MustParseV1beta1TaskRun(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s

--- a/test/entrypoint_test.go
+++ b/test/entrypoint_test.go
@@ -48,7 +48,7 @@ func TestEntrypointRunningStepsInOrder(t *testing.T) {
 	epTaskRunName := helpers.ObjectNameForTest(t)
 
 	t.Logf("Creating TaskRun in namespace %s", namespace)
-	if _, err := c.TaskRunClient.Create(ctx, parse.MustParseTaskRun(t, fmt.Sprintf(`
+	if _, err := c.V1beta1TaskRunClient.Create(ctx, parse.MustParseV1beta1TaskRun(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s

--- a/test/examples_test.go
+++ b/test/examples_test.go
@@ -100,7 +100,7 @@ func koCreate(input []byte, namespace string) ([]byte, error) {
 // conflicts during test
 func deleteClusterTask(ctx context.Context, t *testing.T, c *clients, name string) {
 	t.Logf("Deleting clustertask %s", name)
-	if err := c.ClusterTaskClient.Delete(ctx, name, metav1.DeleteOptions{}); err != nil {
+	if err := c.V1beta1ClusterTaskClient.Delete(ctx, name, metav1.DeleteOptions{}); err != nil {
 		t.Fatalf("Failed to delete clustertask: %v", err)
 	}
 }

--- a/test/git_checkout_test.go
+++ b/test/git_checkout_test.go
@@ -109,7 +109,7 @@ func TestGitPipelineRun(t *testing.T) {
 
 			t.Logf("Creating Git PipelineResource %s", gitSourceResourceName)
 			// Still using the struct here rather than YAML because we'd have to conditionally determine which fields to set in the YAML.
-			if _, err := c.PipelineResourceClient.Create(ctx, &v1alpha1.PipelineResource{
+			if _, err := c.V1alpha1PipelineResourceClient.Create(ctx, &v1alpha1.PipelineResource{
 				ObjectMeta: metav1.ObjectMeta{Name: gitSourceResourceName},
 				Spec: v1alpha1.PipelineResourceSpec{
 					Type: v1alpha1.PipelineResourceTypeGit,
@@ -125,7 +125,7 @@ func TestGitPipelineRun(t *testing.T) {
 			}
 
 			t.Logf("Creating PipelineRun %s", gitTestPipelineRunName)
-			if _, err := c.PipelineRunClient.Create(ctx, parse.MustParsePipelineRun(t, fmt.Sprintf(`
+			if _, err := c.V1beta1PipelineRunClient.Create(ctx, parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   name: %s
 spec:
@@ -193,7 +193,7 @@ func TestGitPipelineRunFail(t *testing.T) {
 
 			t.Logf("Creating Git PipelineResource %s", gitSourceResourceName)
 			// Still using the struct here rather than YAML because we'd have to conditionally determine which fields to set in the YAML.
-			if _, err := c.PipelineResourceClient.Create(ctx, &v1alpha1.PipelineResource{
+			if _, err := c.V1alpha1PipelineResourceClient.Create(ctx, &v1alpha1.PipelineResource{
 				ObjectMeta: metav1.ObjectMeta{Name: gitSourceResourceName},
 				Spec: v1alpha1.PipelineResourceSpec{
 					Type: v1alpha1.PipelineResourceTypeGit,
@@ -208,7 +208,7 @@ func TestGitPipelineRunFail(t *testing.T) {
 			}
 
 			t.Logf("Creating PipelineRun %s", gitTestPipelineRunName)
-			if _, err := c.PipelineRunClient.Create(ctx, parse.MustParsePipelineRun(t, fmt.Sprintf(`
+			if _, err := c.V1beta1PipelineRunClient.Create(ctx, parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   name: %s
 spec:
@@ -239,7 +239,7 @@ spec:
 			}
 
 			if err := WaitForPipelineRunState(ctx, c, gitTestPipelineRunName, timeout, PipelineRunSucceed(gitTestPipelineRunName), "PipelineRunCompleted"); err != nil {
-				taskruns, err := c.TaskRunClient.List(ctx, metav1.ListOptions{})
+				taskruns, err := c.V1beta1TaskRunClient.List(ctx, metav1.ListOptions{})
 				if err != nil {
 					t.Errorf("Error getting TaskRun list for PipelineRun %s %s", gitTestPipelineRunName, err)
 				}

--- a/test/helm_task_test.go
+++ b/test/helm_task_test.go
@@ -63,37 +63,37 @@ func TestHelmDeployPipelineRun(t *testing.T) {
 	defer tearDown(ctx, t, c, namespace)
 
 	t.Logf("Creating Git PipelineResource %s", sourceResourceName)
-	if _, err := c.PipelineResourceClient.Create(ctx, getGoHelloworldGitResource(t, sourceResourceName), metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1alpha1PipelineResourceClient.Create(ctx, getGoHelloworldGitResource(t, sourceResourceName), metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Pipeline Resource `%s`: %s", sourceResourceName, err)
 	}
 
 	t.Logf("Creating Image PipelineResource %s", sourceImageName)
-	if _, err := c.PipelineResourceClient.Create(ctx, getHelmImageResource(t, repo, sourceImageName), metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1alpha1PipelineResourceClient.Create(ctx, getHelmImageResource(t, repo, sourceImageName), metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Pipeline Resource `%s`: %s", sourceImageName, err)
 	}
 
 	t.Logf("Creating Task %s", createImageTaskName)
-	if _, err := c.TaskClient.Create(ctx, getCreateImageTask(t, namespace, createImageTaskName), metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1TaskClient.Create(ctx, getCreateImageTask(t, namespace, createImageTaskName), metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Task `%s`: %s", createImageTaskName, err)
 	}
 
 	t.Logf("Creating Task %s", helmDeployTaskName)
-	if _, err := c.TaskClient.Create(ctx, getHelmDeployTask(t, namespace, helmDeployTaskName), metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1TaskClient.Create(ctx, getHelmDeployTask(t, namespace, helmDeployTaskName), metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Task `%s`: %s", helmDeployTaskName, err)
 	}
 
 	t.Logf("Creating Task %s", checkServiceTaskName)
-	if _, err := c.TaskClient.Create(ctx, getCheckServiceTask(t, namespace, checkServiceTaskName), metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1TaskClient.Create(ctx, getCheckServiceTask(t, namespace, checkServiceTaskName), metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Task `%s`: %s", checkServiceTaskName, err)
 	}
 
 	t.Logf("Creating Pipeline %s", helmDeployPipelineName)
-	if _, err := c.PipelineClient.Create(ctx, getHelmDeployPipeline(t, namespace, createImageTaskName, helmDeployTaskName, checkServiceTaskName, helmDeployPipelineName), metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1PipelineClient.Create(ctx, getHelmDeployPipeline(t, namespace, createImageTaskName, helmDeployTaskName, checkServiceTaskName, helmDeployPipelineName), metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Pipeline `%s`: %s", helmDeployPipelineName, err)
 	}
 
 	t.Logf("Creating PipelineRun %s", helmDeployPipelineRunName)
-	if _, err := c.PipelineRunClient.Create(ctx, getHelmDeployPipelineRun(t, namespace, sourceResourceName, sourceImageName, helmDeployPipelineRunName, helmDeployPipelineName), metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1PipelineRunClient.Create(ctx, getHelmDeployPipelineRun(t, namespace, sourceResourceName, sourceImageName, helmDeployPipelineRunName, helmDeployPipelineName), metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Pipeline `%s`: %s", helmDeployPipelineRunName, err)
 	}
 
@@ -135,7 +135,7 @@ spec:
 }
 
 func getCreateImageTask(t *testing.T, namespace, createImageTaskName string) *v1beta1.Task {
-	return parse.MustParseTask(t, fmt.Sprintf(`
+	return parse.MustParseV1beta1Task(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -157,7 +157,7 @@ spec:
 }
 
 func getHelmDeployTask(t *testing.T, namespace, helmDeployTaskName string) *v1beta1.Task {
-	return parse.MustParseTask(t, fmt.Sprintf(`
+	return parse.MustParseV1beta1Task(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -199,7 +199,7 @@ spec:
 }
 
 func getCheckServiceTask(t *testing.T, namespace, checkServiceTaskName string) *v1beta1.Task {
-	return parse.MustParseTask(t, fmt.Sprintf(`
+	return parse.MustParseV1beta1Task(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -215,7 +215,7 @@ spec:
 }
 
 func getHelmDeployPipeline(t *testing.T, namespace, createImageTaskName, helmDeployTaskName, checkServiceTaskName, helmDeployPipelineName string) *v1beta1.Pipeline {
-	return parse.MustParsePipeline(t, fmt.Sprintf(`
+	return parse.MustParseV1beta1Pipeline(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -264,7 +264,7 @@ spec:
 }
 
 func getHelmDeployPipelineRun(t *testing.T, namespace, sourceResourceName, sourceImageName, helmDeployPipelineRunName, helmDeployPipelineName string) *v1beta1.PipelineRun {
-	return parse.MustParsePipelineRun(t, fmt.Sprintf(`
+	return parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -324,7 +324,7 @@ func helmCleanup(ctx context.Context, c *clients, t *testing.T, namespace string
 
 func removeAllHelmReleases(ctx context.Context, c *clients, t *testing.T, namespace string) {
 	helmRemoveAllTaskName := "helm-remove-all-task"
-	helmRemoveAllTask := parse.MustParseTask(t, fmt.Sprintf(`
+	helmRemoveAllTask := parse.MustParseV1beta1Task(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -337,7 +337,7 @@ spec:
 `, helmRemoveAllTaskName, namespace, namespace, namespace))
 
 	helmRemoveAllTaskRunName := "helm-remove-all-taskrun"
-	helmRemoveAllTaskRun := parse.MustParseTaskRun(t, fmt.Sprintf(`
+	helmRemoveAllTaskRun := parse.MustParseV1beta1TaskRun(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -347,12 +347,12 @@ spec:
 `, helmRemoveAllTaskRunName, namespace, helmRemoveAllTaskName))
 
 	t.Logf("Creating Task %s", helmRemoveAllTaskName)
-	if _, err := c.TaskClient.Create(ctx, helmRemoveAllTask, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1TaskClient.Create(ctx, helmRemoveAllTask, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Task `%s`: %s", helmRemoveAllTaskName, err)
 	}
 
 	t.Logf("Creating TaskRun %s", helmRemoveAllTaskRunName)
-	if _, err := c.TaskRunClient.Create(ctx, helmRemoveAllTaskRun, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1TaskRunClient.Create(ctx, helmRemoveAllTaskRun, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create TaskRun `%s`: %s", helmRemoveAllTaskRunName, err)
 	}
 

--- a/test/hermetic_taskrun_test.go
+++ b/test/hermetic_taskrun_test.go
@@ -61,7 +61,7 @@ func TestHermeticTaskRun(t *testing.T) {
 			regularTaskRunName := fmt.Sprintf("not-hermetic-%s", test.desc)
 			regularTaskRun := test.getTaskRun(t, regularTaskRunName, namespace, "")
 			t.Logf("Creating TaskRun %s, hermetic=false", regularTaskRunName)
-			if _, err := c.TaskRunClient.Create(ctx, regularTaskRun, metav1.CreateOptions{}); err != nil {
+			if _, err := c.V1beta1TaskRunClient.Create(ctx, regularTaskRun, metav1.CreateOptions{}); err != nil {
 				t.Fatalf("Failed to create TaskRun `%s`: %s", regularTaskRunName, err)
 			}
 			if err := WaitForTaskRunState(ctx, c, regularTaskRunName, Succeed(regularTaskRunName), "TaskRunCompleted"); err != nil {
@@ -73,7 +73,7 @@ func TestHermeticTaskRun(t *testing.T) {
 			hermeticTaskRunName := fmt.Sprintf("hermetic-should-fail-%s", test.desc)
 			hermeticTaskRun := test.getTaskRun(t, hermeticTaskRunName, namespace, "hermetic")
 			t.Logf("Creating TaskRun %s, hermetic=true", hermeticTaskRunName)
-			if _, err := c.TaskRunClient.Create(ctx, hermeticTaskRun, metav1.CreateOptions{}); err != nil {
+			if _, err := c.V1beta1TaskRunClient.Create(ctx, hermeticTaskRun, metav1.CreateOptions{}); err != nil {
 				t.Fatalf("Failed to create TaskRun `%s`: %s", regularTaskRun.Name, err)
 			}
 			if err := WaitForTaskRunState(ctx, c, hermeticTaskRunName, Failed(hermeticTaskRunName), "Failed"); err != nil {
@@ -84,7 +84,7 @@ func TestHermeticTaskRun(t *testing.T) {
 }
 
 func taskRun(t *testing.T, name, namespace, executionMode string) *v1beta1.TaskRun {
-	return parse.MustParseTaskRun(t, fmt.Sprintf(`
+	return parse.MustParseV1beta1TaskRun(t, fmt.Sprintf(`
 metadata:
   annotations:
     experimental.tekton.dev/execution-mode: %s
@@ -107,7 +107,7 @@ spec:
 }
 
 func unpriviligedTaskRun(t *testing.T, name, namespace, executionMode string) *v1beta1.TaskRun {
-	return parse.MustParseTaskRun(t, fmt.Sprintf(`
+	return parse.MustParseV1beta1TaskRun(t, fmt.Sprintf(`
 metadata:
   annotations:
     experimental.tekton.dev/execution-mode: %s

--- a/test/ignore_step_error_test.go
+++ b/test/ignore_step_error_test.go
@@ -40,7 +40,7 @@ func TestMissingResultWhenStepErrorIsIgnored(t *testing.T) {
 	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
 	defer tearDown(ctx, t, c, namespace)
 
-	pipelineRun := parse.MustParsePipelineRun(t, fmt.Sprintf(`
+	pipelineRun := parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   name: %s
 spec:
@@ -72,7 +72,7 @@ spec:
           image: busybox
           script: 'exit 0'`, helpers.ObjectNameForTest(t)))
 
-	if _, err := c.PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create PipelineRun `%s`: %s", pipelineRun.Name, err)
 	}
 
@@ -81,7 +81,7 @@ spec:
 		t.Errorf("Error waiting for PipelineRun to fail: %s", err)
 	}
 
-	taskrunList, err := c.TaskRunClient.List(ctx, metav1.ListOptions{LabelSelector: "tekton.dev/pipelineRun=" + pipelineRun.Name})
+	taskrunList, err := c.V1beta1TaskRunClient.List(ctx, metav1.ListOptions{LabelSelector: "tekton.dev/pipelineRun=" + pipelineRun.Name})
 	if err != nil {
 		t.Fatalf("Error listing TaskRuns for PipelineRun %s: %s", pipelineRun.Name, err)
 	}

--- a/test/init_test.go
+++ b/test/init_test.go
@@ -101,7 +101,7 @@ func tearDown(ctx context.Context, t *testing.T, cs *clients, namespace string) 
 			t.Log(string(bs))
 		}
 		header(t, fmt.Sprintf("Dumping logs from Pods in the %s", namespace))
-		taskruns, err := cs.TaskRunClient.List(ctx, metav1.ListOptions{})
+		taskruns, err := cs.V1beta1TaskRunClient.List(ctx, metav1.ListOptions{})
 		if err != nil {
 			t.Errorf("Error getting TaskRun list %s", err)
 		}
@@ -196,7 +196,7 @@ func getCRDYaml(ctx context.Context, cs *clients, ns string) ([]byte, error) {
 		output = append(output, bs...)
 	}
 
-	ps, err := cs.PipelineClient.List(ctx, metav1.ListOptions{})
+	ps, err := cs.V1beta1PipelineClient.List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("could not get pipeline: %w", err)
 	}
@@ -205,7 +205,7 @@ func getCRDYaml(ctx context.Context, cs *clients, ns string) ([]byte, error) {
 		printOrAdd(i)
 	}
 
-	prs, err := cs.PipelineResourceClient.List(ctx, metav1.ListOptions{})
+	prs, err := cs.V1alpha1PipelineResourceClient.List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("could not get pipelinerun resource: %w", err)
 	}
@@ -214,7 +214,7 @@ func getCRDYaml(ctx context.Context, cs *clients, ns string) ([]byte, error) {
 		printOrAdd(i)
 	}
 
-	prrs, err := cs.PipelineRunClient.List(ctx, metav1.ListOptions{})
+	prrs, err := cs.V1beta1PipelineRunClient.List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("could not get pipelinerun: %w", err)
 	}
@@ -223,7 +223,7 @@ func getCRDYaml(ctx context.Context, cs *clients, ns string) ([]byte, error) {
 		printOrAdd(i)
 	}
 
-	ts, err := cs.TaskClient.List(ctx, metav1.ListOptions{})
+	ts, err := cs.V1beta1TaskClient.List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("could not get tasks: %w", err)
 	}
@@ -232,7 +232,7 @@ func getCRDYaml(ctx context.Context, cs *clients, ns string) ([]byte, error) {
 		printOrAdd(i)
 	}
 
-	cts, err := cs.ClusterTaskClient.List(ctx, metav1.ListOptions{})
+	cts, err := cs.V1beta1ClusterTaskClient.List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("could not get clustertasks: %w", err)
 	}
@@ -241,7 +241,7 @@ func getCRDYaml(ctx context.Context, cs *clients, ns string) ([]byte, error) {
 		printOrAdd(i)
 	}
 
-	trs, err := cs.TaskRunClient.List(ctx, metav1.ListOptions{})
+	trs, err := cs.V1beta1TaskRunClient.List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("could not get taskruns: %w", err)
 	}
@@ -250,7 +250,7 @@ func getCRDYaml(ctx context.Context, cs *clients, ns string) ([]byte, error) {
 		printOrAdd(i)
 	}
 
-	rs, err := cs.RunClient.List(ctx, metav1.ListOptions{})
+	rs, err := cs.V1alpha1RunClient.List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("could not get runs: %v", err)
 	}

--- a/test/kaniko_task_test.go
+++ b/test/kaniko_task_test.go
@@ -60,25 +60,25 @@ func TestKanikoTaskRun(t *testing.T) {
 
 	git := getGitResource(t)
 	t.Logf("Creating Git PipelineResource %s", git.Name)
-	if _, err := c.PipelineResourceClient.Create(ctx, git, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1alpha1PipelineResourceClient.Create(ctx, git, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Pipeline Resource `%s`: %s", git.Name, err)
 	}
 
 	image := getImageResource(t, repo)
 	t.Logf("Creating Image PipelineResource %s", repo)
-	if _, err := c.PipelineResourceClient.Create(ctx, image, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1alpha1PipelineResourceClient.Create(ctx, image, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Pipeline Resource `%s`: %s", git.Name, err)
 	}
 
 	task := getTask(t, repo, namespace)
 	t.Logf("Creating Task %s", task.Name)
-	if _, err := c.TaskClient.Create(ctx, task, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1TaskClient.Create(ctx, task, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Task `%s`: %s", task.Name, err)
 	}
 
 	tr := getTaskRun(t, namespace, task.Name, git.Name, image.Name)
 	t.Logf("Creating TaskRun %s", tr.Name)
-	if _, err := c.TaskRunClient.Create(ctx, tr, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1TaskRunClient.Create(ctx, tr, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create TaskRun `%s`: %s", tr.Name, err)
 	}
 
@@ -88,7 +88,7 @@ func TestKanikoTaskRun(t *testing.T) {
 		t.Errorf("Error waiting for TaskRun %s to finish: %s", tr.Name, err)
 	}
 
-	tr, err := c.TaskRunClient.Get(ctx, tr.Name, metav1.GetOptions{})
+	tr, err := c.V1beta1TaskRunClient.Get(ctx, tr.Name, metav1.GetOptions{})
 	if err != nil {
 		t.Errorf("Error retrieving taskrun: %s", err)
 	}
@@ -160,7 +160,7 @@ spec:
 }
 
 func getTask(t *testing.T, repo, namespace string) *v1beta1.Task {
-	return parse.MustParseTask(t, fmt.Sprintf(`
+	return parse.MustParseV1beta1Task(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -191,7 +191,7 @@ spec:
 }
 
 func getTaskRun(t *testing.T, namespace, task, git, image string) *v1beta1.TaskRun {
-	return parse.MustParseTaskRun(t, fmt.Sprintf(`
+	return parse.MustParseV1beta1TaskRun(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s

--- a/test/parse/yaml.go
+++ b/test/parse/yaml.go
@@ -24,8 +24,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-// MustParseTaskRun takes YAML and parses it into a *v1beta1.TaskRun
-func MustParseTaskRun(t *testing.T, yaml string) *v1beta1.TaskRun {
+// MustParseV1beta1TaskRun takes YAML and parses it into a *v1beta1.TaskRun
+func MustParseV1beta1TaskRun(t *testing.T, yaml string) *v1beta1.TaskRun {
 	var tr v1beta1.TaskRun
 	yaml = `apiVersion: tekton.dev/v1beta1
 kind: TaskRun
@@ -44,8 +44,8 @@ kind: Run
 	return &r
 }
 
-// MustParseTask takes YAML and parses it into a *v1beta1.Task
-func MustParseTask(t *testing.T, yaml string) *v1beta1.Task {
+// MustParseV1beta1Task takes YAML and parses it into a *v1beta1.Task
+func MustParseV1beta1Task(t *testing.T, yaml string) *v1beta1.Task {
 	var task v1beta1.Task
 	yaml = `apiVersion: tekton.dev/v1beta1
 kind: Task
@@ -64,8 +64,8 @@ kind: ClusterTask
 	return &clusterTask
 }
 
-// MustParsePipelineRun takes YAML and parses it into a *v1beta1.PipelineRun
-func MustParsePipelineRun(t *testing.T, yaml string) *v1beta1.PipelineRun {
+// MustParseV1beta1PipelineRun takes YAML and parses it into a *v1beta1.PipelineRun
+func MustParseV1beta1PipelineRun(t *testing.T, yaml string) *v1beta1.PipelineRun {
 	var pr v1beta1.PipelineRun
 	yaml = `apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
@@ -74,8 +74,8 @@ kind: PipelineRun
 	return &pr
 }
 
-// MustParsePipeline takes YAML and parses it into a *v1beta1.Pipeline
-func MustParsePipeline(t *testing.T, yaml string) *v1beta1.Pipeline {
+// MustParseV1beta1Pipeline takes YAML and parses it into a *v1beta1.Pipeline
+func MustParseV1beta1Pipeline(t *testing.T, yaml string) *v1beta1.Pipeline {
 	var pipeline v1beta1.Pipeline
 	yaml = `apiVersion: tekton.dev/v1beta1
 kind: Pipeline

--- a/test/pipelinefinally_test.go
+++ b/test/pipelinefinally_test.go
@@ -55,12 +55,12 @@ func TestPipelineLevelFinally_OneDAGTaskFailed_InvalidTaskResult_Failure(t *test
 	task.Spec.Results = append(task.Spec.Results, v1beta1.TaskResult{
 		Name: "result",
 	})
-	if _, err := c.TaskClient.Create(ctx, task, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1TaskClient.Create(ctx, task, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create dag Task: %s", err)
 	}
 
 	delayedTask := getDelaySuccessTask(t, namespace)
-	if _, err := c.TaskClient.Create(ctx, delayedTask, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1TaskClient.Create(ctx, delayedTask, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create dag Task: %s", err)
 	}
 
@@ -68,12 +68,12 @@ func TestPipelineLevelFinally_OneDAGTaskFailed_InvalidTaskResult_Failure(t *test
 	successTask.Spec.Results = append(successTask.Spec.Results, v1beta1.TaskResult{
 		Name: "result",
 	})
-	if _, err := c.TaskClient.Create(ctx, successTask, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1TaskClient.Create(ctx, successTask, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create final Task: %s", err)
 	}
 
 	finalTaskWithStatus := getTaskVerifyingStatus(t, namespace)
-	if _, err := c.TaskClient.Create(ctx, finalTaskWithStatus, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1TaskClient.Create(ctx, finalTaskWithStatus, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create final Task checking executing status: %s", err)
 	}
 
@@ -81,21 +81,21 @@ func TestPipelineLevelFinally_OneDAGTaskFailed_InvalidTaskResult_Failure(t *test
 	taskProducingResult.Spec.Results = append(taskProducingResult.Spec.Results, v1beta1.TaskResult{
 		Name: "result",
 	})
-	if _, err := c.TaskClient.Create(ctx, taskProducingResult, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1TaskClient.Create(ctx, taskProducingResult, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Task producing task results: %s", err)
 	}
 
 	taskConsumingResultInParam := getSuccessTaskConsumingResults(t, namespace, "dagtask-result")
-	if _, err := c.TaskClient.Create(ctx, taskConsumingResultInParam, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1TaskClient.Create(ctx, taskConsumingResultInParam, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Task consuming task results in param: %s", err)
 	}
 
 	taskConsumingResultInWhenExpression := getSuccessTask(t, namespace)
-	if _, err := c.TaskClient.Create(ctx, taskConsumingResultInWhenExpression, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1TaskClient.Create(ctx, taskConsumingResultInWhenExpression, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Task consuming task results in when expressions: %s", err)
 	}
 
-	pipeline := parse.MustParsePipeline(t, fmt.Sprintf(`
+	pipeline := parse.MustParseV1beta1Pipeline(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -216,12 +216,12 @@ spec:
 		taskConsumingResultInWhenExpression.Name,
 		// Tasks
 		task.Name, delayedTask.Name, successTask.Name, successTask.Name, taskProducingResult.Name))
-	if _, err := c.PipelineClient.Create(ctx, pipeline, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1PipelineClient.Create(ctx, pipeline, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Pipeline: %s", err)
 	}
 
 	pipelineRun := getPipelineRun(t, namespace, pipeline.Name)
-	if _, err := c.PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Pipeline Run `%s`: %s", pipelineRun.Name, err)
 	}
 
@@ -230,12 +230,12 @@ spec:
 	}
 
 	// Get the status of the PipelineRun.
-	pr, err := c.PipelineRunClient.Get(ctx, pipelineRun.Name, metav1.GetOptions{})
+	pr, err := c.V1beta1PipelineRunClient.Get(ctx, pipelineRun.Name, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Failed to get PipelineRun %q: %v", pipelineRun.Name, err)
 	}
 
-	taskrunList, err := c.TaskRunClient.List(ctx, metav1.ListOptions{LabelSelector: "tekton.dev/pipelineRun=" + pipelineRun.Name})
+	taskrunList, err := c.V1beta1TaskRunClient.List(ctx, metav1.ListOptions{LabelSelector: "tekton.dev/pipelineRun=" + pipelineRun.Name})
 	if err != nil {
 		t.Fatalf("Error listing TaskRuns for PipelineRun %s: %s", pipelineRun.Name, err)
 	}
@@ -402,16 +402,16 @@ func TestPipelineLevelFinally_OneFinalTaskFailed_Failure(t *testing.T) {
 	defer tearDown(ctx, t, c, namespace)
 
 	task := getSuccessTask(t, namespace)
-	if _, err := c.TaskClient.Create(ctx, task, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1TaskClient.Create(ctx, task, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create dag Task: %s", err)
 	}
 
 	finalTask := getFailTask(t, namespace)
-	if _, err := c.TaskClient.Create(ctx, finalTask, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1TaskClient.Create(ctx, finalTask, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create final Task: %s", err)
 	}
 
-	pipeline := parse.MustParsePipeline(t, fmt.Sprintf(`
+	pipeline := parse.MustParseV1beta1Pipeline(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -425,12 +425,12 @@ spec:
     taskRef:
       name: %s
 `, helpers.ObjectNameForTest(t), namespace, finalTask.Name, task.Name))
-	if _, err := c.PipelineClient.Create(ctx, pipeline, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1PipelineClient.Create(ctx, pipeline, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Pipeline: %s", err)
 	}
 
 	pipelineRun := getPipelineRun(t, namespace, pipeline.Name)
-	if _, err := c.PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Pipeline Run `%s`: %s", pipelineRun.Name, err)
 	}
 
@@ -439,7 +439,7 @@ spec:
 		t.Fatalf("PipelineRun execution failed")
 	}
 
-	taskrunList, err := c.TaskRunClient.List(ctx, metav1.ListOptions{LabelSelector: "tekton.dev/pipelineRun=" + pipelineRun.Name})
+	taskrunList, err := c.V1beta1TaskRunClient.List(ctx, metav1.ListOptions{LabelSelector: "tekton.dev/pipelineRun=" + pipelineRun.Name})
 	if err != nil {
 		t.Fatalf("Error listing TaskRuns for PipelineRun %s: %s", pipelineRun.Name, err)
 	}
@@ -473,26 +473,26 @@ func TestPipelineLevelFinally_OneFinalTask_CancelledRunFinally(t *testing.T) {
 	task1.Spec.Results = append(task1.Spec.Results, v1beta1.TaskResult{
 		Name: "result",
 	})
-	if _, err := c.TaskClient.Create(ctx, task1, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1TaskClient.Create(ctx, task1, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create dag Task: %s", err)
 	}
 
 	task2 := getSuccessTaskConsumingResults(t, namespace, "dagtask1-result")
-	if _, err := c.TaskClient.Create(ctx, task2, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1TaskClient.Create(ctx, task2, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create dag Task: %s", err)
 	}
 
 	finalTask1 := getSuccessTask(t, namespace)
-	if _, err := c.TaskClient.Create(ctx, finalTask1, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1TaskClient.Create(ctx, finalTask1, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create final Task: %s", err)
 	}
 
 	finalTask2 := getSuccessTaskConsumingResults(t, namespace, "dagtask1-result")
-	if _, err := c.TaskClient.Create(ctx, finalTask2, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1TaskClient.Create(ctx, finalTask2, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create final Task: %s", err)
 	}
 
-	pipeline := parse.MustParsePipeline(t, fmt.Sprintf(`
+	pipeline := parse.MustParseV1beta1Pipeline(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -518,12 +518,12 @@ spec:
     taskRef:
       name: %s
 `, helpers.ObjectNameForTest(t), namespace, finalTask1.Name, finalTask2.Name, task1.Name, task2.Name))
-	if _, err := c.PipelineClient.Create(ctx, pipeline, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1PipelineClient.Create(ctx, pipeline, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Pipeline: %s", err)
 	}
 
 	pipelineRun := getPipelineRun(t, namespace, pipeline.Name)
-	if _, err := c.PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Pipeline Run `%s`: %s", pipelineRun.Name, err)
 	}
 
@@ -541,7 +541,7 @@ spec:
 	if err != nil {
 		t.Fatalf("failed to marshal patch bytes in order to stop")
 	}
-	if _, err := c.PipelineRunClient.Patch(ctx, pipelineRun.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{}, ""); err != nil {
+	if _, err := c.V1beta1PipelineRunClient.Patch(ctx, pipelineRun.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{}, ""); err != nil {
 		t.Fatalf("Failed to patch PipelineRun `%s` with graceful stop: %s", pipelineRun.Name, err)
 	}
 
@@ -550,7 +550,7 @@ spec:
 		t.Fatalf("PipelineRun execution failed")
 	}
 
-	taskrunList, err := c.TaskRunClient.List(ctx, metav1.ListOptions{LabelSelector: "tekton.dev/pipelineRun=" + pipelineRun.Name})
+	taskrunList, err := c.V1beta1TaskRunClient.List(ctx, metav1.ListOptions{LabelSelector: "tekton.dev/pipelineRun=" + pipelineRun.Name})
 	if err != nil {
 		t.Fatalf("Error listing TaskRuns for PipelineRun %s: %s", pipelineRun.Name, err)
 	}
@@ -588,26 +588,26 @@ func TestPipelineLevelFinally_OneFinalTask_StoppedRunFinally(t *testing.T) {
 	task1.Spec.Results = append(task1.Spec.Results, v1beta1.TaskResult{
 		Name: "result",
 	})
-	if _, err := c.TaskClient.Create(ctx, task1, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1TaskClient.Create(ctx, task1, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create dag Task: %s", err)
 	}
 
 	task2 := getSuccessTaskConsumingResults(t, namespace, "dagtask1-result")
-	if _, err := c.TaskClient.Create(ctx, task2, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1TaskClient.Create(ctx, task2, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create dag Task: %s", err)
 	}
 
 	finalTask1 := getSuccessTask(t, namespace)
-	if _, err := c.TaskClient.Create(ctx, finalTask1, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1TaskClient.Create(ctx, finalTask1, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create final Task: %s", err)
 	}
 
 	finalTask2 := getSuccessTaskConsumingResults(t, namespace, "dagtask1-result")
-	if _, err := c.TaskClient.Create(ctx, finalTask2, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1TaskClient.Create(ctx, finalTask2, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create final Task: %s", err)
 	}
 
-	pipeline := parse.MustParsePipeline(t, fmt.Sprintf(`
+	pipeline := parse.MustParseV1beta1Pipeline(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -633,12 +633,12 @@ spec:
     taskRef:
       name: %s
 `, helpers.ObjectNameForTest(t), namespace, finalTask1.Name, finalTask2.Name, task1.Name, task2.Name))
-	if _, err := c.PipelineClient.Create(ctx, pipeline, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1PipelineClient.Create(ctx, pipeline, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Pipeline: %s", err)
 	}
 
 	pipelineRun := getPipelineRun(t, namespace, pipeline.Name)
-	if _, err := c.PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Pipeline Run `%s`: %s", pipelineRun.Name, err)
 	}
 
@@ -656,7 +656,7 @@ spec:
 	if err != nil {
 		t.Fatalf("failed to marshal patch bytes in order to stop")
 	}
-	if _, err := c.PipelineRunClient.Patch(ctx, pipelineRun.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{}, ""); err != nil {
+	if _, err := c.V1beta1PipelineRunClient.Patch(ctx, pipelineRun.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{}, ""); err != nil {
 		t.Fatalf("Failed to patch PipelineRun `%s` with graceful stop: %s", pipelineRun.Name, err)
 	}
 
@@ -665,7 +665,7 @@ spec:
 		t.Fatalf("PipelineRun execution failed")
 	}
 
-	taskrunList, err := c.TaskRunClient.List(ctx, metav1.ListOptions{LabelSelector: "tekton.dev/pipelineRun=" + pipelineRun.Name})
+	taskrunList, err := c.V1beta1TaskRunClient.List(ctx, metav1.ListOptions{LabelSelector: "tekton.dev/pipelineRun=" + pipelineRun.Name})
 	if err != nil {
 		t.Fatalf("Error listing TaskRuns for PipelineRun %s: %s", pipelineRun.Name, err)
 	}
@@ -717,7 +717,7 @@ func isCancelled(t *testing.T, taskRunName string, conds duckv1beta1.Conditions)
 }
 
 func getSuccessTask(t *testing.T, namespace string) *v1beta1.Task {
-	return parse.MustParseTask(t, fmt.Sprintf(`
+	return parse.MustParseV1beta1Task(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -729,7 +729,7 @@ spec:
 }
 
 func getFailTask(t *testing.T, namespace string) *v1beta1.Task {
-	return parse.MustParseTask(t, fmt.Sprintf(`
+	return parse.MustParseV1beta1Task(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -741,7 +741,7 @@ spec:
 }
 
 func getDelaySuccessTask(t *testing.T, namespace string) *v1beta1.Task {
-	return parse.MustParseTask(t, fmt.Sprintf(`
+	return parse.MustParseV1beta1Task(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -753,7 +753,7 @@ spec:
 }
 
 func getTaskVerifyingStatus(t *testing.T, namespace string) *v1beta1.Task {
-	return parse.MustParseTask(t, fmt.Sprintf(`
+	return parse.MustParseV1beta1Task(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -770,7 +770,7 @@ spec:
 }
 
 func getSuccessTaskProducingResults(t *testing.T, namespace string) *v1beta1.Task {
-	return parse.MustParseTask(t, fmt.Sprintf(`
+	return parse.MustParseV1beta1Task(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -784,7 +784,7 @@ spec:
 }
 
 func getDelaySuccessTaskProducingResults(t *testing.T, namespace string) *v1beta1.Task {
-	return parse.MustParseTask(t, fmt.Sprintf(`
+	return parse.MustParseV1beta1Task(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -798,7 +798,7 @@ spec:
 }
 
 func getSuccessTaskConsumingResults(t *testing.T, namespace string, paramName string) *v1beta1.Task {
-	return parse.MustParseTask(t, fmt.Sprintf(`
+	return parse.MustParseV1beta1Task(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -812,7 +812,7 @@ spec:
 }
 
 func getPipelineRun(t *testing.T, namespace, p string) *v1beta1.PipelineRun {
-	return parse.MustParsePipelineRun(t, fmt.Sprintf(`
+	return parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s

--- a/test/pipelinerun_test.go
+++ b/test/pipelinerun_test.go
@@ -63,7 +63,7 @@ func TestPipelineRunStatusSpec(t *testing.T) {
 		name: "pipeline status spec updated",
 		testSetup: func(ctx context.Context, t *testing.T, c *clients, namespace string, _ int) (map[string]*v1alpha1.PipelineResource, *v1beta1.Pipeline) {
 			t.Helper()
-			task := parse.MustParseTask(t, fmt.Sprintf(`
+			task := parse.MustParseV1beta1Task(t, fmt.Sprintf(`
 metadata:
   name: pipeline-status-spec-updated
   namespace: %s
@@ -77,12 +77,12 @@ spec:
       #!/usr/bin/env bash
       echo "$(params.HELLO)"
 `, namespace))
-			if _, err := c.TaskClient.Create(ctx, task, metav1.CreateOptions{}); err != nil {
+			if _, err := c.V1beta1TaskClient.Create(ctx, task, metav1.CreateOptions{}); err != nil {
 				t.Fatalf("Failed to create Task `%s`: %s", task.Name, err)
 			}
 
 			p := getUpdatedStatusSpecPipeline(t, namespace, task.Name)
-			if _, err := c.PipelineClient.Create(ctx, p, metav1.CreateOptions{}); err != nil {
+			if _, err := c.V1beta1PipelineClient.Create(ctx, p, metav1.CreateOptions{}); err != nil {
 				t.Fatalf("Failed to create Pipeline `%s`: %s", p.Name, err)
 			}
 
@@ -112,7 +112,7 @@ spec:
 
 			pipelineRun := td.pipelineRunFunc(t, i, namespace, p.Name, resources)
 			prName := pipelineRun.Name
-			_, err := c.PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{})
+			_, err := c.V1beta1PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{})
 			if err != nil {
 				t.Fatalf("Failed to create PipelineRun `%s`: %s", prName, err)
 			}
@@ -122,7 +122,7 @@ spec:
 				t.Fatalf("Error waiting for PipelineRun %s to finish: %s", prName, err)
 			}
 			t.Logf("Making sure the expected TaskRuns %s were created", td.expectedTaskRuns)
-			actualTaskrunList, err := c.TaskRunClient.List(ctx, metav1.ListOptions{LabelSelector: fmt.Sprintf("tekton.dev/pipelineRun=%s", prName)})
+			actualTaskrunList, err := c.V1beta1TaskRunClient.List(ctx, metav1.ListOptions{LabelSelector: fmt.Sprintf("tekton.dev/pipelineRun=%s", prName)})
 			if err != nil {
 				t.Fatalf("Error listing TaskRuns for PipelineRun %s: %s", prName, err)
 			}
@@ -136,7 +136,7 @@ spec:
 					}
 				}
 				expectedTaskRunNames = append(expectedTaskRunNames, taskRunName)
-				r, err := c.TaskRunClient.Get(ctx, taskRunName, metav1.GetOptions{})
+				r, err := c.V1beta1TaskRunClient.Get(ctx, taskRunName, metav1.GetOptions{})
 				if err != nil {
 					t.Fatalf("Couldn't get expected TaskRun %s: %s", taskRunName, err)
 				}
@@ -162,11 +162,11 @@ spec:
 				t.Fatalf("Expected %d number of successful events from pipelinerun and taskrun but got %d; list of receieved events : %#v", td.expectedNumberOfEvents, len(events), collectedEvents)
 			}
 			t.Log("Checking if parameter replacements have been updated in the spec.")
-			cl, _ := c.PipelineRunClient.Get(ctx, prName, metav1.GetOptions{})
+			cl, _ := c.V1beta1PipelineRunClient.Get(ctx, prName, metav1.GetOptions{})
 			if cl.Status.PipelineSpec.Tasks[0].Params[0].Value.StringVal != "Hello World!" {
 				t.Fatalf(`Expected replaced parameter value %s but found %s`, "Hello World!", cl.Status.PipelineSpec.Tasks[0].Params[0].Value.StringVal)
 			}
-			tl, _ := c.TaskRunClient.Get(ctx, "pipeline-task-update-task1", metav1.GetOptions{})
+			tl, _ := c.V1beta1TaskRunClient.Get(ctx, "pipeline-task-update-task1", metav1.GetOptions{})
 			if !strings.Contains(tl.Status.TaskSpec.Steps[0].Script, "Hello World!") {
 				t.Fatalf(`Expected replaced parameter value : %s in Script: %s But not found`, "Hello World!", tl.Status.TaskSpec.Steps[0].Script)
 			}
@@ -191,20 +191,20 @@ func TestPipelineRun(t *testing.T) {
 			t.Helper()
 			tasks := getFanInFanOutTasks(t, namespace)
 			for _, task := range tasks {
-				if _, err := c.TaskClient.Create(ctx, task, metav1.CreateOptions{}); err != nil {
+				if _, err := c.V1beta1TaskClient.Create(ctx, task, metav1.CreateOptions{}); err != nil {
 					t.Fatalf("Failed to create Task `%s`: %s", task.Name, err)
 				}
 			}
 
 			resources := getFanInFanOutGitResources(t)
 			for _, res := range resources {
-				if _, err := c.PipelineResourceClient.Create(ctx, res, metav1.CreateOptions{}); err != nil {
+				if _, err := c.V1alpha1PipelineResourceClient.Create(ctx, res, metav1.CreateOptions{}); err != nil {
 					t.Fatalf("Failed to create Pipeline Resource `%s`: %s", res.Name, err)
 				}
 			}
 
 			p := getFanInFanOutPipeline(t, namespace, tasks)
-			if _, err := c.PipelineClient.Create(ctx, p, metav1.CreateOptions{}); err != nil {
+			if _, err := c.V1beta1PipelineClient.Create(ctx, p, metav1.CreateOptions{}); err != nil {
 				t.Fatalf("Failed to create Pipeline `%s`: %s", p.Name, err)
 			}
 
@@ -227,7 +227,7 @@ func TestPipelineRun(t *testing.T) {
 				t.Fatalf("Failed to create SA `%s`: %s", getName(saName, index), err)
 			}
 
-			task := parse.MustParseTask(t, fmt.Sprintf(`
+			task := parse.MustParseV1beta1Task(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -243,11 +243,11 @@ spec:
     command: ['skopeo']
     args: ['copy', '$(params["the.path"])', '$(params["the.dest"])']
 `, helpers.ObjectNameForTest(t), namespace))
-			if _, err := c.TaskClient.Create(ctx, task, metav1.CreateOptions{}); err != nil {
+			if _, err := c.V1beta1TaskClient.Create(ctx, task, metav1.CreateOptions{}); err != nil {
 				t.Fatalf("Failed to create Task `%s`: %s", task.Name, err)
 			}
 			p := getHelloWorldPipelineWithSingularTask(t, namespace, task.Name)
-			if _, err := c.PipelineClient.Create(ctx, p, metav1.CreateOptions{}); err != nil {
+			if _, err := c.V1beta1PipelineClient.Create(ctx, p, metav1.CreateOptions{}); err != nil {
 				t.Fatalf("Failed to create Pipeline `%s`: %s", p.Name, err)
 			}
 
@@ -274,7 +274,7 @@ spec:
 				t.Fatalf("Failed to create SA `%s`: %s", getName(saName, index), err)
 			}
 
-			task := parse.MustParseTask(t, fmt.Sprintf(`
+			task := parse.MustParseV1beta1Task(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -290,12 +290,12 @@ spec:
     command: ['skopeo']
     args: ['copy', '$(params["the.path"])', '$(params["the.dest"])']
 `, helpers.ObjectNameForTest(t), namespace))
-			if _, err := c.TaskClient.Create(ctx, task, metav1.CreateOptions{}); err != nil {
+			if _, err := c.V1beta1TaskClient.Create(ctx, task, metav1.CreateOptions{}); err != nil {
 				t.Fatalf("Failed to create Task `%s`: %s", fmt.Sprint("task", index), err)
 			}
 
 			p := getHelloWorldPipelineWithSingularTask(t, namespace, task.Name)
-			if _, err := c.PipelineClient.Create(ctx, p, metav1.CreateOptions{}); err != nil {
+			if _, err := c.V1beta1PipelineClient.Create(ctx, p, metav1.CreateOptions{}); err != nil {
 				t.Fatalf("Failed to create Pipeline `%s`: %s", p.Name, err)
 			}
 
@@ -325,7 +325,7 @@ spec:
 
 			pipelineRun := td.pipelineRunFunc(t, i, namespace, p.Name, resources)
 			prName := pipelineRun.Name
-			_, err := c.PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{})
+			_, err := c.V1beta1PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{})
 			if err != nil {
 				t.Fatalf("Failed to create PipelineRun `%s`: %s", prName, err)
 			}
@@ -335,7 +335,7 @@ spec:
 				t.Fatalf("Error waiting for PipelineRun %s to finish: %s", prName, err)
 			}
 			t.Logf("Making sure the expected TaskRuns %s were created", td.expectedTaskRuns)
-			actualTaskrunList, err := c.TaskRunClient.List(ctx, metav1.ListOptions{LabelSelector: fmt.Sprintf("tekton.dev/pipelineRun=%s", prName)})
+			actualTaskrunList, err := c.V1beta1TaskRunClient.List(ctx, metav1.ListOptions{LabelSelector: fmt.Sprintf("tekton.dev/pipelineRun=%s", prName)})
 			if err != nil {
 				t.Fatalf("Error listing TaskRuns for PipelineRun %s: %s", prName, err)
 			}
@@ -349,7 +349,7 @@ spec:
 					}
 				}
 				expectedTaskRunNames = append(expectedTaskRunNames, taskRunName)
-				r, err := c.TaskRunClient.Get(ctx, taskRunName, metav1.GetOptions{})
+				r, err := c.V1beta1TaskRunClient.Get(ctx, taskRunName, metav1.GetOptions{})
 				if err != nil {
 					t.Fatalf("Couldn't get expected TaskRun %s: %s", taskRunName, err)
 				}
@@ -404,7 +404,7 @@ spec:
 }
 
 func getUpdatedStatusSpecPipeline(t *testing.T, namespace string, taskName string) *v1beta1.Pipeline {
-	return parse.MustParsePipeline(t, fmt.Sprintf(`
+	return parse.MustParseV1beta1Pipeline(t, fmt.Sprintf(`
 metadata:
   name: pipeline-status-spec-updated
   namespace: %s
@@ -423,7 +423,7 @@ spec:
 }
 
 func getHelloWorldPipelineWithSingularTask(t *testing.T, namespace string, taskName string) *v1beta1.Pipeline {
-	return parse.MustParsePipeline(t, fmt.Sprintf(`
+	return parse.MustParseV1beta1Pipeline(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -460,7 +460,7 @@ func TestPipelineRunRefDeleted(t *testing.T) {
 	prName := helpers.ObjectNameForTest(t)
 	t.Logf("Creating Pipeline, and PipelineRun %s in namespace %s", prName, namespace)
 
-	pipeline := parse.MustParsePipeline(t, fmt.Sprintf(`
+	pipeline := parse.MustParseV1beta1Pipeline(t, fmt.Sprintf(`
 metadata:
   name: %s
 spec:
@@ -485,18 +485,18 @@ spec:
           # Sleep for another 10s
           sleep 10
 `, pipelineName))
-	if _, err := c.PipelineClient.Create(ctx, pipeline, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1PipelineClient.Create(ctx, pipeline, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Pipeline `%s`: %s", pipelineName, err)
 	}
 
-	pipelinerun := parse.MustParsePipelineRun(t, fmt.Sprintf(`
+	pipelinerun := parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   name: %s
 spec:
   pipelineRef:
     name: %s
 `, prName, pipelineName))
-	_, err := c.PipelineRunClient.Create(ctx, pipelinerun, metav1.CreateOptions{})
+	_, err := c.V1beta1PipelineRunClient.Create(ctx, pipelinerun, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Failed to create PipelineRun `%s`: %s", prName, err)
 	}
@@ -506,7 +506,7 @@ spec:
 		t.Fatalf("Error waiting for PipelineRun %s to finish: %s", prName, err)
 	}
 
-	if err := c.PipelineClient.Delete(ctx, pipeline.Name, metav1.DeleteOptions{}); err != nil {
+	if err := c.V1beta1PipelineClient.Delete(ctx, pipeline.Name, metav1.DeleteOptions{}); err != nil {
 		t.Fatalf("Failed to delete Pipeline `%s`: %s", pipeline.Name, err)
 	}
 
@@ -536,7 +536,7 @@ func TestPipelineRunPending(t *testing.T) {
 
 	t.Logf("Creating Task, Pipeline, and Pending PipelineRun %s in namespace %s", prName, namespace)
 
-	if _, err := c.TaskClient.Create(ctx, parse.MustParseTask(t, fmt.Sprintf(`
+	if _, err := c.V1beta1TaskClient.Create(ctx, parse.MustParseV1beta1Task(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -549,7 +549,7 @@ spec:
 		t.Fatalf("Failed to create Task `%s`: %s", taskName, err)
 	}
 
-	if _, err := c.PipelineClient.Create(ctx, parse.MustParsePipeline(t, fmt.Sprintf(`
+	if _, err := c.V1beta1PipelineClient.Create(ctx, parse.MustParseV1beta1Pipeline(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -562,7 +562,7 @@ spec:
 		t.Fatalf("Failed to create Pipeline `%s`: %s", pipelineName, err)
 	}
 
-	pipelineRun, err := c.PipelineRunClient.Create(ctx, parse.MustParsePipelineRun(t, fmt.Sprintf(`
+	pipelineRun, err := c.V1beta1PipelineRunClient.Create(ctx, parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -582,7 +582,7 @@ spec:
 
 	t.Logf("Clearing pending status on PipelineRun %s", prName)
 
-	pipelineRun, err = c.PipelineRunClient.Get(ctx, prName, metav1.GetOptions{})
+	pipelineRun, err = c.V1beta1PipelineRunClient.Get(ctx, prName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Error getting PipelineRun %s: %s", prName, err)
 	}
@@ -593,7 +593,7 @@ spec:
 
 	pipelineRun.Spec.Status = ""
 
-	if _, err := c.PipelineRunClient.Update(ctx, pipelineRun, metav1.UpdateOptions{}); err != nil {
+	if _, err := c.V1beta1PipelineRunClient.Update(ctx, pipelineRun, metav1.UpdateOptions{}); err != nil {
 		t.Fatalf("Error clearing pending status on PipelineRun %s: %s", prName, err)
 	}
 
@@ -605,7 +605,7 @@ spec:
 
 func getFanInFanOutTasks(t *testing.T, namespace string) map[string]*v1beta1.Task {
 	return map[string]*v1beta1.Task{
-		"create-file": parse.MustParseTask(t, fmt.Sprintf(`
+		"create-file": parse.MustParseV1beta1Task(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -628,7 +628,7 @@ spec:
     image: ubuntu
     name: write-data-task-0-step-1
 `, helpers.ObjectNameForTest(t), namespace)),
-		"check-create-files-exists": parse.MustParseTask(t, fmt.Sprintf(`
+		"check-create-files-exists": parse.MustParseV1beta1Task(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -650,7 +650,7 @@ spec:
     image: ubuntu
     name: write-data-task-1
 `, helpers.ObjectNameForTest(t), namespace)),
-		"check-create-files-exists-2": parse.MustParseTask(t, fmt.Sprintf(`
+		"check-create-files-exists-2": parse.MustParseV1beta1Task(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -672,7 +672,7 @@ spec:
     image: ubuntu
     name: write-data-task-1
 `, helpers.ObjectNameForTest(t), namespace)),
-		"read-files": parse.MustParseTask(t, fmt.Sprintf(`
+		"read-files": parse.MustParseV1beta1Task(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -696,7 +696,7 @@ spec:
 }
 
 func getFanInFanOutPipeline(t *testing.T, namespace string, tasks map[string]*v1beta1.Task) *v1beta1.Pipeline {
-	return parse.MustParsePipeline(t, fmt.Sprintf(`
+	return parse.MustParseV1beta1Pipeline(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -780,7 +780,7 @@ func getPipelineRunServiceAccount(suffix int, namespace string) *corev1.ServiceA
 	}
 }
 func getFanInFanOutPipelineRun(t *testing.T, _ int, namespace string, pipelineName string, resources map[string]*v1alpha1.PipelineResource) *v1beta1.PipelineRun {
-	return parse.MustParsePipelineRun(t, fmt.Sprintf(`
+	return parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -824,7 +824,7 @@ func getPipelineRunSecret(suffix int, namespace string) *corev1.Secret {
 }
 
 func getUpdatedStatusSpecPipelineRun(t *testing.T, _ int, namespace string, pipelineName string, _ map[string]*v1alpha1.PipelineResource) *v1beta1.PipelineRun {
-	return parse.MustParsePipelineRun(t, fmt.Sprintf(`
+	return parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   name: "pipeline-task-update"
   namespace: %s
@@ -839,7 +839,7 @@ spec:
 }
 
 func getHelloWorldPipelineRun(t *testing.T, suffix int, namespace string, pipelineName string, _ map[string]*v1alpha1.PipelineResource) *v1beta1.PipelineRun {
-	return parse.MustParsePipelineRun(t, fmt.Sprintf(`
+	return parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   labels:
     hello-world-key: hello-world-value
@@ -902,11 +902,11 @@ func checkLabelPropagation(ctx context.Context, t *testing.T, c *clients, namesp
 	labels := make(map[string]string, 4)
 
 	// Check label propagation to PipelineRuns.
-	pr, err := c.PipelineRunClient.Get(ctx, pipelineRunName, metav1.GetOptions{})
+	pr, err := c.V1beta1PipelineRunClient.Get(ctx, pipelineRunName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't get expected PipelineRun for %s: %s", tr.Name, err)
 	}
-	p, err := c.PipelineClient.Get(ctx, pr.Spec.PipelineRef.Name, metav1.GetOptions{})
+	p, err := c.V1beta1PipelineClient.Get(ctx, pr.Spec.PipelineRef.Name, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't get expected Pipeline for %s: %s", pr.Name, err)
 	}
@@ -924,7 +924,7 @@ func checkLabelPropagation(ctx context.Context, t *testing.T, c *clients, namesp
 	// This label is added to every TaskRun by the PipelineRun controller
 	labels[pipeline.PipelineRunLabelKey] = pr.Name
 	if tr.Spec.TaskRef != nil {
-		task, err := c.TaskClient.Get(ctx, tr.Spec.TaskRef.Name, metav1.GetOptions{})
+		task, err := c.V1beta1TaskClient.Get(ctx, tr.Spec.TaskRef.Name, metav1.GetOptions{})
 		if err != nil {
 			t.Fatalf("Couldn't get expected Task for %s: %s", tr.Name, err)
 		}
@@ -953,11 +953,11 @@ func checkAnnotationPropagation(ctx context.Context, t *testing.T, c *clients, n
 	annotations := make(map[string]string)
 
 	// Check annotation propagation to PipelineRuns.
-	pr, err := c.PipelineRunClient.Get(ctx, pipelineRunName, metav1.GetOptions{})
+	pr, err := c.V1beta1PipelineRunClient.Get(ctx, pipelineRunName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't get expected PipelineRun for %s: %s", tr.Name, err)
 	}
-	p, err := c.PipelineClient.Get(ctx, pr.Spec.PipelineRef.Name, metav1.GetOptions{})
+	p, err := c.V1beta1PipelineClient.Get(ctx, pr.Spec.PipelineRef.Name, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't get expected Pipeline for %s: %s", pr.Name, err)
 	}
@@ -971,7 +971,7 @@ func checkAnnotationPropagation(ctx context.Context, t *testing.T, c *clients, n
 		annotations[key] = val
 	}
 	if tr.Spec.TaskRef != nil {
-		task, err := c.TaskClient.Get(ctx, tr.Spec.TaskRef.Name, metav1.GetOptions{})
+		task, err := c.V1beta1TaskClient.Get(ctx, tr.Spec.TaskRef.Name, metav1.GetOptions{})
 		if err != nil {
 			t.Fatalf("Couldn't get expected Task for %s: %s", tr.Name, err)
 		}

--- a/test/propagated_params_test.go
+++ b/test/propagated_params_test.go
@@ -89,7 +89,7 @@ func TestPropagatedParams(t *testing.T) {
 			t.Logf("Setting up test resources for %q test in namespace %s", td.name, namespace)
 			pipelineRun, expectedResolvedPipelineRun, expectedTaskRuns := td.pipelineRunFunc(t, namespace)
 			prName := pipelineRun.Name
-			_, err := c.PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{})
+			_, err := c.V1beta1PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{})
 			if err != nil {
 				t.Fatalf("Failed to create PipelineRun `%s`: %s", prName, err)
 			}
@@ -98,7 +98,7 @@ func TestPropagatedParams(t *testing.T) {
 			if err := WaitForPipelineRunState(ctx, c, prName, timeout, PipelineRunSucceed(prName), "PipelineRunSuccess"); err != nil {
 				t.Fatalf("Error waiting for PipelineRun %s to finish: %s", prName, err)
 			}
-			cl, _ := c.PipelineRunClient.Get(ctx, prName, metav1.GetOptions{})
+			cl, _ := c.V1beta1PipelineRunClient.Get(ctx, prName, metav1.GetOptions{})
 			d := cmp.Diff(expectedResolvedPipelineRun, cl,
 				ignoreTypeMeta,
 				ignoreObjectMeta,
@@ -114,7 +114,7 @@ func TestPropagatedParams(t *testing.T) {
 			}
 			for _, tr := range expectedTaskRuns {
 				t.Logf("Checking Taskrun %s", tr.Name)
-				taskrun, _ := c.TaskRunClient.Get(ctx, tr.Name, metav1.GetOptions{})
+				taskrun, _ := c.V1beta1TaskRunClient.Get(ctx, tr.Name, metav1.GetOptions{})
 				d = cmp.Diff(tr, taskrun,
 					ignoreTypeMeta,
 					ignoreObjectMeta,
@@ -135,7 +135,7 @@ func TestPropagatedParams(t *testing.T) {
 }
 
 func getPropagatedParamPipelineRun(t *testing.T, namespace string) (*v1beta1.PipelineRun, *v1beta1.PipelineRun, []*v1beta1.TaskRun) {
-	pipelineRun := parse.MustParsePipelineRun(t, fmt.Sprintf(`
+	pipelineRun := parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   name: propagated-parameters-fully
   namespace: %s
@@ -159,7 +159,7 @@ spec:
               image: ubuntu
               script: echo $(params.HELLO)
 `, namespace))
-	expectedPipelineRun := parse.MustParsePipelineRun(t, fmt.Sprintf(`
+	expectedPipelineRun := parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   name: propagated-parameters-fully
   namespace: %s
@@ -201,7 +201,7 @@ status:
               image: ubuntu
               script: echo Hello World!
 `, namespace))
-	taskRun := parse.MustParseTaskRun(t, fmt.Sprintf(`
+	taskRun := parse.MustParseV1beta1TaskRun(t, fmt.Sprintf(`
 metadata:
   name: propagated-parameters-fully-echo-hello
   namespace: %s
@@ -225,7 +225,7 @@ status:
          image: ubuntu
          script: echo Hello World!
 `, namespace))
-	finallyTaskRun := parse.MustParseTaskRun(t, fmt.Sprintf(`
+	finallyTaskRun := parse.MustParseV1beta1TaskRun(t, fmt.Sprintf(`
 metadata:
   name: propagated-parameters-fully-echo-hello-finally
   namespace: %s
@@ -252,7 +252,7 @@ status:
 }
 
 func getPropagatedParamTaskLevelPipelineRun(t *testing.T, namespace string) (*v1beta1.PipelineRun, *v1beta1.PipelineRun, []*v1beta1.TaskRun) {
-	pipelineRun := parse.MustParsePipelineRun(t, fmt.Sprintf(`
+	pipelineRun := parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   name: propagated-parameters-task-level
   namespace: %s
@@ -272,7 +272,7 @@ spec:
               image: ubuntu
               script: echo $(params.HELLO)
 `, namespace))
-	expectedPipelineRun := parse.MustParsePipelineRun(t, fmt.Sprintf(`
+	expectedPipelineRun := parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   name: propagated-parameters-task-level
   namespace: %s
@@ -306,7 +306,7 @@ status:
               image: ubuntu
               script: echo Hello World!
 `, namespace))
-	taskRun := parse.MustParseTaskRun(t, fmt.Sprintf(`
+	taskRun := parse.MustParseV1beta1TaskRun(t, fmt.Sprintf(`
 metadata:
   name: propagated-parameters-task-level-echo-hello
   namespace: %s
@@ -336,7 +336,7 @@ status:
 }
 
 func getPropagatedParamTaskLevelDefaultPipelineRun(t *testing.T, namespace string) (*v1beta1.PipelineRun, *v1beta1.PipelineRun, []*v1beta1.TaskRun) {
-	pipelineRun := parse.MustParsePipelineRun(t, fmt.Sprintf(`
+	pipelineRun := parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   name: propagated-parameters-default-task-level
   namespace: %s
@@ -357,7 +357,7 @@ spec:
               image: ubuntu
               script: echo $(params.HELLO)
 `, namespace))
-	expectedPipelineRun := parse.MustParsePipelineRun(t, fmt.Sprintf(`
+	expectedPipelineRun := parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   name: propagated-parameters-default-task-level
   namespace: %s
@@ -393,7 +393,7 @@ status:
               image: ubuntu
               script: echo Hello World!
 `, namespace))
-	taskRun := parse.MustParseTaskRun(t, fmt.Sprintf(`
+	taskRun := parse.MustParseV1beta1TaskRun(t, fmt.Sprintf(`
 metadata:
   name: propagated-parameters-default-task-level-echo-hello
   namespace: %s

--- a/test/remote_test.go
+++ b/test/remote_test.go
@@ -40,7 +40,7 @@ func TestCreateImage(t *testing.T) {
 	defer s.Close()
 	u, _ := url.Parse(s.URL)
 
-	task := parse.MustParseTask(t, `
+	task := parse.MustParseV1beta1Task(t, `
 metadata:
   name: test-create-image
 `)

--- a/test/resolvers_test.go
+++ b/test/resolvers_test.go
@@ -84,7 +84,7 @@ func TestHubResolver(t *testing.T) {
 
 	prName := helpers.ObjectNameForTest(t)
 
-	pipelineRun := parse.MustParsePipelineRun(t, fmt.Sprintf(`
+	pipelineRun := parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -121,7 +121,7 @@ spec:
             value: "true"
 `, prName, namespace))
 
-	_, err := c.PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{})
+	_, err := c.V1beta1PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Failed to create PipelineRun `%s`: %s", prName, err)
 	}
@@ -144,7 +144,7 @@ func TestHubResolver_Failure(t *testing.T) {
 
 	prName := helpers.ObjectNameForTest(t)
 
-	pipelineRun := parse.MustParsePipelineRun(t, fmt.Sprintf(`
+	pipelineRun := parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -181,7 +181,7 @@ spec:
             value: "true"
 `, prName, namespace))
 
-	_, err := c.PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{})
+	_, err := c.V1beta1PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Failed to create PipelineRun `%s`: %s", prName, err)
 	}
@@ -207,7 +207,7 @@ func TestGitResolver_Clone(t *testing.T) {
 
 	prName := helpers.ObjectNameForTest(t)
 
-	pipelineRun := parse.MustParsePipelineRun(t, fmt.Sprintf(`
+	pipelineRun := parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -245,7 +245,7 @@ spec:
             value: "true"
 `, prName, namespace))
 
-	_, err := c.PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{})
+	_, err := c.V1beta1PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Failed to create PipelineRun `%s`: %s", prName, err)
 	}
@@ -309,7 +309,7 @@ func TestGitResolver_Clone_Failure(t *testing.T) {
 
 			prName := helpers.ObjectNameForTest(t)
 
-			pipelineRun := parse.MustParsePipelineRun(t, fmt.Sprintf(`
+			pipelineRun := parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -346,7 +346,7 @@ spec:
             value: "true"
 `, prName, namespace, url, pathInRepo, commit))
 
-			_, err := c.PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{})
+			_, err := c.V1beta1PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{})
 			if err != nil {
 				t.Fatalf("Failed to create PipelineRun `%s`: %s", prName, err)
 			}
@@ -373,7 +373,7 @@ func TestClusterResolver(t *testing.T) {
 	defer tearDown(ctx, t, c, namespace)
 
 	pipelineName := helpers.ObjectNameForTest(t)
-	examplePipeline := parse.MustParsePipeline(t, fmt.Sprintf(`
+	examplePipeline := parse.MustParseV1beta1Pipeline(t, fmt.Sprintf(`
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
@@ -392,14 +392,14 @@ spec:
           sleep 10
 `, pipelineName, namespace))
 
-	_, err := c.PipelineClient.Create(ctx, examplePipeline, metav1.CreateOptions{})
+	_, err := c.V1beta1PipelineClient.Create(ctx, examplePipeline, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Failed to create Pipeline `%s`: %s", pipelineName, err)
 	}
 
 	prName := helpers.ObjectNameForTest(t)
 
-	pipelineRun := parse.MustParsePipelineRun(t, fmt.Sprintf(`
+	pipelineRun := parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -415,7 +415,7 @@ spec:
       value: %s
 `, prName, namespace, pipelineName, namespace))
 
-	_, err = c.PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{})
+	_, err = c.V1beta1PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Failed to create PipelineRun `%s`: %s", prName, err)
 	}
@@ -437,7 +437,7 @@ func TestClusterResolver_Failure(t *testing.T) {
 
 	prName := helpers.ObjectNameForTest(t)
 
-	pipelineRun := parse.MustParsePipelineRun(t, fmt.Sprintf(`
+	pipelineRun := parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -453,7 +453,7 @@ spec:
       value: %s
 `, prName, namespace, namespace))
 
-	_, err := c.PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{})
+	_, err := c.V1beta1PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Failed to create PipelineRun `%s`: %s", prName, err)
 	}
@@ -501,7 +501,7 @@ func TestGitResolver_API(t *testing.T) {
 	defer resetConfigMap(ctx, t, c, resovlerNS, git.ConfigMapName, originalConfigMapData)
 
 	trName := helpers.ObjectNameForTest(t)
-	tr := parse.MustParseTaskRun(t, fmt.Sprintf(`
+	tr := parse.MustParseV1beta1TaskRun(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -519,7 +519,7 @@ spec:
       value: %s
 `, trName, namespace, scmRemoteBranch, scmRemoteTaskPath, scmRemoteOrg, scmRemoteRepo))
 
-	_, err = c.TaskRunClient.Create(ctx, tr, metav1.CreateOptions{})
+	_, err = c.V1beta1TaskRunClient.Create(ctx, tr, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Failed to create TaskRun: %v", err)
 	}
@@ -575,7 +575,7 @@ func setupGitea(ctx context.Context, t *testing.T, c *clients, namespace string)
 	giteaUserJSON := fmt.Sprintf(`{"admin":true,"email":"%s@example.com","full_name":"%s","login_name":"%s","must_change_password":false,"password":"%s","send_notify":false,"source_id":0,"username":"%s"}`, scmRemoteUser, scmRemoteUser, scmRemoteUser, scmRemoteUserPassword, scmRemoteUser)
 
 	trName := helpers.AppendRandomString("git-resolver-setup-gitea-user")
-	giteaConfigTaskRun := parse.MustParseTaskRun(t, fmt.Sprintf(`
+	giteaConfigTaskRun := parse.MustParseV1beta1TaskRun(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -599,7 +599,7 @@ spec:
 		scmGiteaAdminPassword, giteaInternalHostname, giteaUserJSON,
 		scmRemoteUser, scmRemoteUserPassword, giteaInternalHostname))
 
-	if _, err := c.TaskRunClient.Create(ctx, giteaConfigTaskRun, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1TaskRunClient.Create(ctx, giteaConfigTaskRun, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create gitea user setup TaskRun: %s", err)
 	}
 
@@ -608,7 +608,7 @@ spec:
 		t.Fatalf("Error waiting for gitea user setup TaskRun to finish: %s", err)
 	}
 
-	tr, err := c.TaskRunClient.Get(ctx, trName, metav1.GetOptions{})
+	tr, err := c.V1beta1TaskRunClient.Get(ctx, trName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't get expected gitea user setup TaskRun %s: %s", trName, err)
 	}

--- a/test/retry_test.go
+++ b/test/retry_test.go
@@ -53,7 +53,7 @@ func TestTaskRunRetry(t *testing.T) {
 	// configured to retry 5 times.
 	pipelineRunName := helpers.ObjectNameForTest(t)
 	numRetries := 5
-	if _, err := c.PipelineRunClient.Create(ctx, parse.MustParsePipelineRun(t, fmt.Sprintf(`
+	if _, err := c.V1beta1PipelineRunClient.Create(ctx, parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   name: %s
 spec:
@@ -75,7 +75,7 @@ spec:
 	}
 
 	// Get the status of the PipelineRun.
-	pr, err := c.PipelineRunClient.Get(ctx, pipelineRunName, metav1.GetOptions{})
+	pr, err := c.V1beta1PipelineRunClient.Get(ctx, pipelineRunName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Failed to get PipelineRun %q: %v", pipelineRunName, err)
 	}
@@ -101,7 +101,7 @@ spec:
 		}
 		taskRunName := pr.Status.ChildReferences[0].Name
 
-		tr, err := c.TaskRunClient.Get(ctx, taskRunName, metav1.GetOptions{})
+		tr, err := c.V1beta1TaskRunClient.Get(ctx, taskRunName, metav1.GetOptions{})
 		if err != nil {
 			t.Fatalf("Failed to get TaskRun %q: %v", taskRunName, err)
 		}
@@ -111,7 +111,7 @@ spec:
 	}
 
 	// There should only be one TaskRun created.
-	trs, err := c.TaskRunClient.List(ctx, metav1.ListOptions{})
+	trs, err := c.V1beta1TaskRunClient.List(ctx, metav1.ListOptions{})
 	if err != nil {
 		t.Fatalf("Failed to list TaskRuns: %v", err)
 	} else if len(trs.Items) != 1 {

--- a/test/serviceaccount_test.go
+++ b/test/serviceaccount_test.go
@@ -115,7 +115,7 @@ func TestPipelineRunWithServiceAccounts(t *testing.T) {
 	}
 
 	// Create a Pipeline with multiple tasks
-	pipeline := parse.MustParsePipeline(t, fmt.Sprintf(`
+	pipeline := parse.MustParseV1beta1Pipeline(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -137,12 +137,12 @@ spec:
       - image: ubuntu
         script: echo task3
 `, helpers.ObjectNameForTest(t), namespace))
-	if _, err := c.PipelineClient.Create(ctx, pipeline, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1PipelineClient.Create(ctx, pipeline, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Pipeline `%s`: %s", pipeline.Name, err)
 	}
 
 	// Create a PipelineRun that uses those ServiceAccount
-	pipelineRun := parse.MustParsePipelineRun(t, fmt.Sprintf(`
+	pipelineRun := parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -157,7 +157,7 @@ spec:
     taskServiceAccountName: sa3
 `, helpers.ObjectNameForTest(t), namespace, pipeline.Name))
 
-	_, err := c.PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{})
+	_, err := c.V1beta1PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Failed to create PipelineRun `%s`: %s", pipelineRun.Name, err)
 	}
@@ -168,7 +168,7 @@ spec:
 	}
 
 	// Verify it used those serviceAccount
-	taskRuns, err := c.TaskRunClient.List(ctx, metav1.ListOptions{LabelSelector: fmt.Sprintf("tekton.dev/pipelineRun=%s", pipelineRun.Name)})
+	taskRuns, err := c.V1beta1TaskRunClient.List(ctx, metav1.ListOptions{LabelSelector: fmt.Sprintf("tekton.dev/pipelineRun=%s", pipelineRun.Name)})
 	if err != nil {
 		t.Fatalf("Error listing TaskRuns for PipelineRun %s: %s", pipelineRun.Name, err)
 	}
@@ -232,7 +232,7 @@ func TestPipelineRunWithServiceAccountNameAndTaskRunSpec(t *testing.T) {
 	}
 
 	// Create a Pipeline with multiple tasks
-	pipeline := parse.MustParsePipeline(t, fmt.Sprintf(`
+	pipeline := parse.MustParseV1beta1Pipeline(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -245,13 +245,13 @@ spec:
       - image: ubuntu
         script: echo task1
 `, helpers.ObjectNameForTest(t), namespace))
-	if _, err := c.PipelineClient.Create(ctx, pipeline, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1PipelineClient.Create(ctx, pipeline, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Pipeline `%s`: %s", pipeline.Name, err)
 	}
 
 	dnsPolicy := corev1.DNSClusterFirst
 	// Create a PipelineRun that uses those ServiceAccount
-	pipelineRun := parse.MustParsePipelineRun(t, fmt.Sprintf(`
+	pipelineRun := parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -265,7 +265,7 @@ spec:
       dnsPolicy: %s
 `, helpers.ObjectNameForTest(t), namespace, pipeline.Name, dnsPolicy))
 
-	if _, err := c.PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create PipelineRun `%s`: %s", pipelineRun.Name, err)
 	}
 
@@ -275,7 +275,7 @@ spec:
 	}
 
 	// Verify it used those serviceAccount
-	taskRuns, err := c.TaskRunClient.List(ctx, metav1.ListOptions{LabelSelector: fmt.Sprintf("tekton.dev/pipelineRun=%s", pipelineRun.Name)})
+	taskRuns, err := c.V1beta1TaskRunClient.List(ctx, metav1.ListOptions{LabelSelector: fmt.Sprintf("tekton.dev/pipelineRun=%s", pipelineRun.Name)})
 	if err != nil {
 		t.Fatalf("Error listing TaskRuns for PipelineRun %s: %s", pipelineRun.Name, err)
 	}

--- a/test/sidecar_test.go
+++ b/test/sidecar_test.go
@@ -74,7 +74,7 @@ func TestSidecarTaskSupport(t *testing.T) {
 
 			sidecarTaskName := helpers.ObjectNameForTest(t)
 			sidecarTaskRunName := helpers.ObjectNameForTest(t)
-			task := parse.MustParseTask(t, fmt.Sprintf(`
+			task := parse.MustParseV1beta1Task(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -89,7 +89,7 @@ spec:
     command: [%s]
 `, sidecarTaskName, namespace, primaryContainerName, stringSliceToYAMLArray(test.stepCommand), sidecarContainerName, stringSliceToYAMLArray(test.sidecarCommand)))
 
-			taskRun := parse.MustParseTaskRun(t, fmt.Sprintf(`
+			taskRun := parse.MustParseV1beta1TaskRun(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -100,12 +100,12 @@ spec:
 `, sidecarTaskRunName, namespace, sidecarTaskName))
 
 			t.Logf("Creating Task %q", sidecarTaskName)
-			if _, err := clients.TaskClient.Create(ctx, task, metav1.CreateOptions{}); err != nil {
+			if _, err := clients.V1beta1TaskClient.Create(ctx, task, metav1.CreateOptions{}); err != nil {
 				t.Fatalf("Failed to create Task %q: %v", sidecarTaskName, err)
 			}
 
 			t.Logf("Creating TaskRun %q", sidecarTaskRunName)
-			if _, err := clients.TaskRunClient.Create(ctx, taskRun, metav1.CreateOptions{}); err != nil {
+			if _, err := clients.V1beta1TaskRunClient.Create(ctx, taskRun, metav1.CreateOptions{}); err != nil {
 				t.Fatalf("Failed to create TaskRun %q: %v", sidecarTaskRunName, err)
 			}
 
@@ -113,7 +113,7 @@ spec:
 				t.Fatalf("Error waiting for TaskRun %q to finish: %v", sidecarTaskRunName, err)
 			}
 
-			tr, err := clients.TaskRunClient.Get(ctx, sidecarTaskRunName, metav1.GetOptions{})
+			tr, err := clients.V1beta1TaskRunClient.Get(ctx, sidecarTaskRunName, metav1.GetOptions{})
 			if err != nil {
 				t.Fatalf("Error getting Taskrun: %v", err)
 			}
@@ -160,7 +160,7 @@ spec:
 				t.Errorf("Either the primary or sidecar containers did not terminate")
 			}
 
-			trCheckSidecarStatus, err := clients.TaskRunClient.Get(ctx, sidecarTaskRunName, metav1.GetOptions{})
+			trCheckSidecarStatus, err := clients.V1beta1TaskRunClient.Get(ctx, sidecarTaskRunName, metav1.GetOptions{})
 			if err != nil {
 				t.Fatalf("Error getting TaskRun: %v", err)
 			}

--- a/test/start_time_test.go
+++ b/test/start_time_test.go
@@ -6,7 +6,9 @@ Copyright 2019 The Tekton Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -48,7 +50,7 @@ func TestStartTime(t *testing.T) {
 	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
 	defer tearDown(ctx, t, c, namespace)
 	t.Logf("Creating TaskRun in namespace %q", namespace)
-	tr, err := c.TaskRunClient.Create(ctx, parse.MustParseTaskRun(t, fmt.Sprintf(`
+	tr, err := c.V1beta1TaskRunClient.Create(ctx, parse.MustParseV1beta1TaskRun(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -74,7 +76,7 @@ spec:
 	if err := WaitForTaskRunState(ctx, c, tr.Name, TaskRunSucceed(tr.Name), "TaskRunSuccess"); err != nil {
 		t.Errorf("Error waiting for TaskRun to succeed: %v", err)
 	}
-	tr, err = c.TaskRunClient.Get(ctx, tr.Name, metav1.GetOptions{})
+	tr, err = c.V1beta1TaskRunClient.Get(ctx, tr.Name, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Error getting TaskRun: %v", err)
 	}

--- a/test/status_test.go
+++ b/test/status_test.go
@@ -45,7 +45,7 @@ func TestTaskRunPipelineRunStatus(t *testing.T) {
 	defer tearDown(ctx, t, c, namespace)
 
 	t.Logf("Creating Task and TaskRun in namespace %s", namespace)
-	task := parse.MustParseTask(t, fmt.Sprintf(`
+	task := parse.MustParseV1beta1Task(t, fmt.Sprintf(`
 metadata:
   name: %s
 spec:
@@ -53,17 +53,17 @@ spec:
   - name: foo
     image: busybox
     command: ['ls', '-la']`, helpers.ObjectNameForTest(t)))
-	if _, err := c.TaskClient.Create(ctx, task, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1TaskClient.Create(ctx, task, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Task: %s", err)
 	}
-	taskRun := parse.MustParseTaskRun(t, fmt.Sprintf(`
+	taskRun := parse.MustParseV1beta1TaskRun(t, fmt.Sprintf(`
 metadata:
   name: %s
 spec:
   taskRef:
     name: %s
   serviceAccountName: inexistent`, helpers.ObjectNameForTest(t), task.Name))
-	if _, err := c.TaskRunClient.Create(ctx, taskRun, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1TaskRunClient.Create(ctx, taskRun, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create TaskRun: %s", err)
 	}
 
@@ -72,7 +72,7 @@ spec:
 		t.Errorf("Error waiting for TaskRun to finish: %s", err)
 	}
 
-	pipeline := parse.MustParsePipeline(t, fmt.Sprintf(`
+	pipeline := parse.MustParseV1beta1Pipeline(t, fmt.Sprintf(`
 metadata:
   name: %s
 spec:
@@ -80,17 +80,17 @@ spec:
   - name: foo
     taskRef:
       name: %s`, helpers.ObjectNameForTest(t), task.Name))
-	if _, err := c.PipelineClient.Create(ctx, pipeline, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1PipelineClient.Create(ctx, pipeline, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Pipeline `%s`: %s", pipeline.Name, err)
 	}
-	pipelineRun := parse.MustParsePipelineRun(t, fmt.Sprintf(`
+	pipelineRun := parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   name: %s
 spec:
   pipelineRef:
     name: %s
   serviceAccountName: inexistent`, helpers.ObjectNameForTest(t), pipeline.Name))
-	if _, err := c.PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create PipelineRun `%s`: %s", pipelineRun.Name, err)
 	}
 

--- a/test/step_output_test.go
+++ b/test/step_output_test.go
@@ -83,7 +83,7 @@ func TestStepOutput(t *testing.T) {
 	}
 
 	t.Logf("Creating TaskRun %q in namespace %q", taskRun.Name, taskRun.Namespace)
-	if _, err := clients.TaskRunClient.Create(ctx, taskRun, metav1.CreateOptions{}); err != nil {
+	if _, err := clients.V1beta1TaskRunClient.Create(ctx, taskRun, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create TaskRun %q: %s", taskRun.Name, err)
 	}
 
@@ -92,7 +92,7 @@ func TestStepOutput(t *testing.T) {
 		t.Errorf("Error waiting for TaskRun %q to finish: %v", taskRun.Name, err)
 	}
 
-	tr, err := clients.TaskRunClient.Get(ctx, taskRun.Name, metav1.GetOptions{})
+	tr, err := clients.V1beta1TaskRunClient.Get(ctx, taskRun.Name, metav1.GetOptions{})
 	if err != nil {
 		t.Errorf("Error getting Taskrun %q: %v", taskRun.Name, err)
 	}
@@ -157,7 +157,7 @@ func TestStepOutputWithWorkspace(t *testing.T) {
 	}
 
 	t.Logf("Creating TaskRun %q in namespace %q", taskRun.Name, taskRun.Namespace)
-	if _, err := clients.TaskRunClient.Create(ctx, taskRun, metav1.CreateOptions{}); err != nil {
+	if _, err := clients.V1beta1TaskRunClient.Create(ctx, taskRun, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create TaskRun %q: %s", taskRun.Name, err)
 	}
 
@@ -166,7 +166,7 @@ func TestStepOutputWithWorkspace(t *testing.T) {
 		t.Errorf("Error waiting for TaskRun %q to finish: %v", taskRun.Name, err)
 	}
 
-	tr, err := clients.TaskRunClient.Get(ctx, taskRun.Name, metav1.GetOptions{})
+	tr, err := clients.V1beta1TaskRunClient.Get(ctx, taskRun.Name, metav1.GetOptions{})
 	if err != nil {
 		t.Errorf("Error getting Taskrun %q: %v", taskRun.Name, err)
 	}

--- a/test/taskrun_test.go
+++ b/test/taskrun_test.go
@@ -52,7 +52,7 @@ func TestTaskRunFailure(t *testing.T) {
 	taskRunName := helpers.ObjectNameForTest(t)
 
 	t.Logf("Creating Task and TaskRun in namespace %s", namespace)
-	task := parse.MustParseTask(t, fmt.Sprintf(`
+	task := parse.MustParseV1beta1Task(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -68,10 +68,10 @@ spec:
     command: ['/bin/sh']
     args: ['-c', 'sleep 30s']
 `, helpers.ObjectNameForTest(t), namespace))
-	if _, err := c.TaskClient.Create(ctx, task, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1TaskClient.Create(ctx, task, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Task: %s", err)
 	}
-	taskRun := parse.MustParseTaskRun(t, fmt.Sprintf(`
+	taskRun := parse.MustParseV1beta1TaskRun(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -79,7 +79,7 @@ spec:
   taskRef:
     name: %s
 `, taskRunName, namespace, task.Name))
-	if _, err := c.TaskRunClient.Create(ctx, taskRun, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1TaskRunClient.Create(ctx, taskRun, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create TaskRun: %s", err)
 	}
 
@@ -88,7 +88,7 @@ spec:
 		t.Errorf("Error waiting for TaskRun to finish: %s", err)
 	}
 
-	taskrun, err := c.TaskRunClient.Get(ctx, taskRunName, metav1.GetOptions{})
+	taskrun, err := c.V1beta1TaskRunClient.Get(ctx, taskRunName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't get expected TaskRun %s: %s", taskRunName, err)
 	}
@@ -150,7 +150,7 @@ func TestTaskRunStatus(t *testing.T) {
 	fqImageName := getTestImage(busyboxImage)
 
 	t.Logf("Creating Task and TaskRun in namespace %s", namespace)
-	task := parse.MustParseTask(t, fmt.Sprintf(`
+	task := parse.MustParseV1beta1Task(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -160,10 +160,10 @@ spec:
     command: ['/bin/sh']
     args: ['-c', 'echo hello']
 `, helpers.ObjectNameForTest(t), namespace, fqImageName))
-	if _, err := c.TaskClient.Create(ctx, task, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1TaskClient.Create(ctx, task, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Task: %s", err)
 	}
-	taskRun := parse.MustParseTaskRun(t, fmt.Sprintf(`
+	taskRun := parse.MustParseV1beta1TaskRun(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -171,7 +171,7 @@ spec:
   taskRef:
     name: %s
 `, taskRunName, namespace, task.Name))
-	if _, err := c.TaskRunClient.Create(ctx, taskRun, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1TaskRunClient.Create(ctx, taskRun, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create TaskRun: %s", err)
 	}
 
@@ -180,7 +180,7 @@ spec:
 		t.Errorf("Error waiting for TaskRun to finish: %s", err)
 	}
 
-	taskrun, err := c.TaskRunClient.Get(ctx, taskRunName, metav1.GetOptions{})
+	taskrun, err := c.V1beta1TaskRunClient.Get(ctx, taskRunName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't get expected TaskRun %s: %s", taskRunName, err)
 	}

--- a/test/tektonbundles_test.go
+++ b/test/tektonbundles_test.go
@@ -79,7 +79,7 @@ func TestTektonBundlesSimpleWorkingExample(t *testing.T) {
 		t.Fatalf("Failed to parse %s as an OCI reference: %s", repo, err)
 	}
 
-	task := parse.MustParseTask(t, fmt.Sprintf(`
+	task := parse.MustParseV1beta1Task(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -90,7 +90,7 @@ spec:
     script: 'echo Hello'
 `, taskName, namespace))
 
-	pipeline := parse.MustParsePipeline(t, fmt.Sprintf(`
+	pipeline := parse.MustParseV1beta1Pipeline(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -145,7 +145,7 @@ spec:
 	publishImg(ctx, t, c, namespace, img, ref)
 
 	// Now generate a PipelineRun to invoke this pipeline and task.
-	pr := parse.MustParsePipelineRun(t, fmt.Sprintf(`
+	pr := parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   name: %s
 spec:
@@ -153,7 +153,7 @@ spec:
     name: %s
     bundle: %s
 `, pipelineRunName, pipelineName, repo))
-	if _, err := c.PipelineRunClient.Create(ctx, pr, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1PipelineRunClient.Create(ctx, pr, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create PipelineRun: %s", err)
 	}
 
@@ -162,7 +162,7 @@ spec:
 		t.Errorf("Error waiting for PipelineRun to finish with error: %s", err)
 	}
 
-	trs, err := c.TaskRunClient.List(ctx, metav1.ListOptions{})
+	trs, err := c.V1beta1TaskRunClient.List(ctx, metav1.ListOptions{})
 	if err != nil {
 		t.Errorf("Error retrieving taskrun: %s", err)
 	}
@@ -217,7 +217,7 @@ func TestTektonBundlesResolver(t *testing.T) {
 		t.Fatalf("Failed to parse %s as an OCI reference: %s", repo, err)
 	}
 
-	task := parse.MustParseTask(t, fmt.Sprintf(`
+	task := parse.MustParseV1beta1Task(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -228,7 +228,7 @@ spec:
     script: 'echo Hello'
 `, taskName, namespace))
 
-	pipeline := parse.MustParsePipeline(t, fmt.Sprintf(`
+	pipeline := parse.MustParseV1beta1Pipeline(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -287,7 +287,7 @@ spec:
 	publishImg(ctx, t, c, namespace, img, ref)
 
 	// Now generate a PipelineRun to invoke this pipeline and task.
-	pr := parse.MustParsePipelineRun(t, fmt.Sprintf(`
+	pr := parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   name: %s
 spec:
@@ -301,7 +301,7 @@ spec:
     - name: kind
       value: pipeline
 `, pipelineRunName, repo, pipelineName))
-	if _, err := c.PipelineRunClient.Create(ctx, pr, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1PipelineRunClient.Create(ctx, pr, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create PipelineRun: %s", err)
 	}
 
@@ -310,7 +310,7 @@ spec:
 		t.Errorf("Error waiting for PipelineRun to finish with error: %s", err)
 	}
 
-	trs, err := c.TaskRunClient.List(ctx, metav1.ListOptions{})
+	trs, err := c.V1beta1TaskRunClient.List(ctx, metav1.ListOptions{})
 	if err != nil {
 		t.Errorf("Error retrieving taskrun: %s", err)
 	}
@@ -365,7 +365,7 @@ func TestTektonBundlesUsingRegularImage(t *testing.T) {
 		t.Fatalf("Failed to parse %s as an OCI reference: %s", repo, err)
 	}
 
-	pipeline := parse.MustParsePipeline(t, fmt.Sprintf(`
+	pipeline := parse.MustParseV1beta1Pipeline(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -405,7 +405,7 @@ spec:
 	publishImg(ctx, t, c, namespace, img, ref)
 
 	// Now generate a PipelineRun to invoke this pipeline and task.
-	pr := parse.MustParsePipelineRun(t, fmt.Sprintf(`
+	pr := parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   name: %s
 spec:
@@ -413,7 +413,7 @@ spec:
     name: %s
     bundle: %s
 `, pipelineRunName, pipelineName, repo))
-	if _, err := c.PipelineRunClient.Create(ctx, pr, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1PipelineRunClient.Create(ctx, pr, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create PipelineRun: %s", err)
 	}
 
@@ -448,7 +448,7 @@ func TestTektonBundlesUsingImproperFormat(t *testing.T) {
 		t.Fatalf("Failed to parse %s as an OCI reference: %s", repo, err)
 	}
 
-	task := parse.MustParseTask(t, fmt.Sprintf(`
+	task := parse.MustParseV1beta1Task(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -459,7 +459,7 @@ spec:
     script: 'echo Hello'
 `, taskName, namespace))
 
-	pipeline := parse.MustParsePipeline(t, fmt.Sprintf(`
+	pipeline := parse.MustParseV1beta1Pipeline(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -516,7 +516,7 @@ spec:
 	publishImg(ctx, t, c, namespace, img, ref)
 
 	// Now generate a PipelineRun to invoke this pipeline and task.
-	pr := parse.MustParsePipelineRun(t, fmt.Sprintf(`
+	pr := parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   name: %s
 spec:
@@ -524,7 +524,7 @@ spec:
     name: %s
     bundle: %s
 `, pipelineRunName, pipelineName, repo))
-	if _, err := c.PipelineRunClient.Create(ctx, pr, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1PipelineRunClient.Create(ctx, pr, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create PipelineRun: %s", err)
 	}
 

--- a/test/trusted_resources_test.go
+++ b/test/trusted_resources_test.go
@@ -67,7 +67,7 @@ func TestTrustedResourcesVerify_Success(t *testing.T) {
 
 	// create pipelines
 	fqImageName := getTestImage(busyboxImage)
-	task := parse.MustParseTask(t, fmt.Sprintf(`
+	task := parse.MustParseV1beta1Task(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -82,11 +82,11 @@ spec:
 	if err != nil {
 		t.Errorf("error getting signed task: %v", err)
 	}
-	if _, err := c.TaskClient.Create(ctx, signedTask, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1TaskClient.Create(ctx, signedTask, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Task: %s", err)
 	}
 
-	pipeline := parse.MustParsePipeline(t, fmt.Sprintf(`
+	pipeline := parse.MustParseV1beta1Pipeline(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -103,11 +103,11 @@ spec:
 		t.Errorf("error getting signed pipeline: %v", err)
 	}
 
-	if _, err := c.PipelineClient.Create(ctx, signedPipeline, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1PipelineClient.Create(ctx, signedPipeline, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Pipeline: %s", err)
 	}
 
-	pr := parse.MustParsePipelineRun(t, fmt.Sprintf(`
+	pr := parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -117,7 +117,7 @@ spec:
 `, helpers.ObjectNameForTest(t), namespace, signedPipeline.Name))
 
 	t.Logf("Creating PipelineRun %s", pr.Name)
-	if _, err := c.PipelineRunClient.Create(ctx, pr, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1PipelineRunClient.Create(ctx, pr, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create PipelineRun `%s`: %s", pr.Name, err)
 	}
 
@@ -126,7 +126,7 @@ spec:
 		t.Errorf("Error waiting for PipelineRun to finish: %s", err)
 	}
 
-	pr, err = c.PipelineRunClient.Get(ctx, pr.Name, metav1.GetOptions{})
+	pr, err = c.V1beta1PipelineRunClient.Get(ctx, pr.Name, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't get expected PipelineRun %s: %s", pr.Name, err)
 	}
@@ -148,7 +148,7 @@ func TestTrustedResourcesVerify_Error(t *testing.T) {
 
 	// create pipelines
 	fqImageName := getTestImage(busyboxImage)
-	task := parse.MustParseTask(t, fmt.Sprintf(`
+	task := parse.MustParseV1beta1Task(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -165,11 +165,11 @@ spec:
 	}
 	// modify the task to fail the verification
 	signedTask.Annotations["foo"] = "bar"
-	if _, err := c.TaskClient.Create(ctx, signedTask, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1TaskClient.Create(ctx, signedTask, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Task: %s", err)
 	}
 
-	pipeline := parse.MustParsePipeline(t, fmt.Sprintf(`
+	pipeline := parse.MustParseV1beta1Pipeline(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -186,11 +186,11 @@ spec:
 		t.Errorf("error getting signed pipeline: %v", err)
 	}
 
-	if _, err := c.PipelineClient.Create(ctx, signedPipeline, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1PipelineClient.Create(ctx, signedPipeline, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Pipeline: %s", err)
 	}
 
-	pr := parse.MustParsePipelineRun(t, fmt.Sprintf(`
+	pr := parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -200,7 +200,7 @@ spec:
 `, helpers.ObjectNameForTest(t), namespace, signedPipeline.Name))
 
 	t.Logf("Creating PipelineRun %s", pr.Name)
-	if _, err := c.PipelineRunClient.Create(ctx, pr, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1PipelineRunClient.Create(ctx, pr, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create PipelineRun `%s`: %s", pr.Name, err)
 	}
 
@@ -209,7 +209,7 @@ spec:
 		t.Errorf("Error waiting for PipelineRun to finish: %s", err)
 	}
 
-	pr, err = c.PipelineRunClient.Get(ctx, pr.Name, metav1.GetOptions{})
+	pr, err = c.V1beta1PipelineRunClient.Get(ctx, pr.Name, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't get expected PipelineRun %s: %s", pr.Name, err)
 	}

--- a/test/wait.go
+++ b/test/wait.go
@@ -88,7 +88,7 @@ func WaitForTaskRunState(ctx context.Context, c *clients, name string, inState C
 	defer span.End()
 
 	return pollImmediateWithContext(ctx, func() (bool, error) {
-		r, err := c.TaskRunClient.Get(ctx, name, metav1.GetOptions{})
+		r, err := c.V1beta1TaskRunClient.Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			return true, err
 		}
@@ -108,7 +108,7 @@ func WaitForRunState(ctx context.Context, c *clients, name string, polltimeout t
 	ctx, cancel := context.WithTimeout(ctx, polltimeout)
 	defer cancel()
 	return pollImmediateWithContext(ctx, func() (bool, error) {
-		r, err := c.RunClient.Get(ctx, name, metav1.GetOptions{})
+		r, err := c.V1alpha1RunClient.Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			return true, err
 		}
@@ -164,7 +164,7 @@ func WaitForPipelineRunState(ctx context.Context, c *clients, name string, pollt
 	ctx, cancel := context.WithTimeout(ctx, polltimeout)
 	defer cancel()
 	return pollImmediateWithContext(ctx, func() (bool, error) {
-		r, err := c.PipelineRunClient.Get(ctx, name, metav1.GetOptions{})
+		r, err := c.V1beta1PipelineRunClient.Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			return true, err
 		}

--- a/test/windows_script_test.go
+++ b/test/windows_script_test.go
@@ -45,7 +45,7 @@ func TestWindowsScript(t *testing.T) {
 	taskRunName := helpers.ObjectNameForTest(t)
 	t.Logf("Creating TaskRun in namespace %s", namespace)
 
-	taskRun := parse.MustParseTaskRun(t, fmt.Sprintf(`
+	taskRun := parse.MustParseV1beta1TaskRun(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -64,7 +64,7 @@ spec:
         #!win
         echo Hello
 `, taskRunName, namespace))
-	if _, err := c.TaskRunClient.Create(ctx, taskRun, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1TaskRunClient.Create(ctx, taskRun, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create TaskRun: %s", err)
 	}
 
@@ -73,7 +73,7 @@ spec:
 		t.Errorf("Error waiting for TaskRun to finish: %s", err)
 	}
 
-	taskrun, err := c.TaskRunClient.Get(ctx, taskRunName, metav1.GetOptions{})
+	taskrun, err := c.V1beta1TaskRunClient.Get(ctx, taskRunName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't get expected TaskRun %s: %s", taskRunName, err)
 	}
@@ -116,7 +116,7 @@ func TestWindowsScriptFailure(t *testing.T) {
 	taskRunName := helpers.ObjectNameForTest(t)
 	t.Logf("Creating TaskRun in namespace %s", namespace)
 
-	taskRun := parse.MustParseTaskRun(t, fmt.Sprintf(`
+	taskRun := parse.MustParseV1beta1TaskRun(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -139,7 +139,7 @@ spec:
         #!win pwsh.exe -File
         echo Hello
 `, taskRunName, namespace))
-	if _, err := c.TaskRunClient.Create(ctx, taskRun, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1TaskRunClient.Create(ctx, taskRun, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create TaskRun: %s", err)
 	}
 
@@ -148,7 +148,7 @@ spec:
 		t.Errorf("Error waiting for TaskRun to finish: %s", err)
 	}
 
-	taskrun, err := c.TaskRunClient.Get(ctx, taskRunName, metav1.GetOptions{})
+	taskrun, err := c.V1beta1TaskRunClient.Get(ctx, taskRunName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't get expected TaskRun %s: %s", taskRunName, err)
 	}

--- a/test/windows_test.go
+++ b/test/windows_test.go
@@ -54,7 +54,7 @@ func TestWindows(t *testing.T) {
 	taskRunName := helpers.ObjectNameForTest(t)
 	t.Logf("Creating TaskRun in namespace %s", namespace)
 
-	taskRun := parse.MustParseTaskRun(t, fmt.Sprintf(`
+	taskRun := parse.MustParseV1beta1TaskRun(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -68,7 +68,7 @@ spec:
       command: ['cmd.exe']
       image: mcr.microsoft.com/windows/nanoserver:1809
 `, taskRunName, namespace))
-	if _, err := c.TaskRunClient.Create(ctx, taskRun, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1TaskRunClient.Create(ctx, taskRun, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create TaskRun: %s", err)
 	}
 
@@ -77,7 +77,7 @@ spec:
 		t.Errorf("Error waiting for TaskRun to finish: %s", err)
 	}
 
-	taskrun, err := c.TaskRunClient.Get(ctx, taskRunName, metav1.GetOptions{})
+	taskrun, err := c.V1beta1TaskRunClient.Get(ctx, taskRunName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't get expected TaskRun %s: %s", taskRunName, err)
 	}
@@ -111,7 +111,7 @@ func TestWindowsFailure(t *testing.T) {
 	taskRunName := helpers.ObjectNameForTest(t)
 	t.Logf("Creating TaskRun in namespace %s", namespace)
 
-	taskRun := parse.MustParseTaskRun(t, fmt.Sprintf(`
+	taskRun := parse.MustParseV1beta1TaskRun(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -131,7 +131,7 @@ spec:
       command: ['cmd.exe']
       image: mcr.microsoft.com/windows/nanoserver:1809
 `, taskRunName, namespace))
-	if _, err := c.TaskRunClient.Create(ctx, taskRun, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1TaskRunClient.Create(ctx, taskRun, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create TaskRun: %s", err)
 	}
 
@@ -140,7 +140,7 @@ spec:
 		t.Errorf("Error waiting for TaskRun to finish: %s", err)
 	}
 
-	taskrun, err := c.TaskRunClient.Get(ctx, taskRunName, metav1.GetOptions{})
+	taskrun, err := c.V1beta1TaskRunClient.Get(ctx, taskRunName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't get expected TaskRun %s: %s", taskRunName, err)
 	}

--- a/test/workingdir_test.go
+++ b/test/workingdir_test.go
@@ -46,7 +46,7 @@ func TestWorkingDirCreated(t *testing.T) {
 	wdTaskName := helpers.ObjectNameForTest(t)
 	wdTaskRunName := helpers.ObjectNameForTest(t)
 
-	task := parse.MustParseTask(t, fmt.Sprintf(`
+	task := parse.MustParseV1beta1Task(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -56,12 +56,12 @@ spec:
     workingDir: /workspace/HELLOMOTO
     args: ['-c', 'echo YES']
 `, wdTaskName, namespace))
-	if _, err := c.TaskClient.Create(ctx, task, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1TaskClient.Create(ctx, task, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Task: %s", err)
 	}
 
 	t.Logf("Creating TaskRun  namespace %s", namespace)
-	taskRun := parse.MustParseTaskRun(t, fmt.Sprintf(`
+	taskRun := parse.MustParseV1beta1TaskRun(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -70,7 +70,7 @@ spec:
     name: %s
   serviceAccountName: default
 `, wdTaskRunName, namespace, wdTaskName))
-	if _, err := c.TaskRunClient.Create(ctx, taskRun, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1TaskRunClient.Create(ctx, taskRun, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create TaskRun: %s", err)
 	}
 
@@ -79,7 +79,7 @@ spec:
 		t.Errorf("Error waiting for TaskRun to finish successfully: %s", err)
 	}
 
-	tr, err := c.TaskRunClient.Get(ctx, wdTaskRunName, metav1.GetOptions{})
+	tr, err := c.V1beta1TaskRunClient.Get(ctx, wdTaskRunName, metav1.GetOptions{})
 	if err != nil {
 		t.Errorf("Error retrieving taskrun: %s", err)
 	}
@@ -119,7 +119,7 @@ func TestWorkingDirIgnoredNonSlashWorkspace(t *testing.T) {
 	wdTaskName := helpers.ObjectNameForTest(t)
 	wdTaskRunName := helpers.ObjectNameForTest(t)
 
-	task := parse.MustParseTask(t, fmt.Sprintf(`
+	task := parse.MustParseV1beta1Task(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -129,12 +129,12 @@ spec:
     workingDir: /HELLOMOTO
     args: ['-c', 'echo YES']
 `, wdTaskName, namespace))
-	if _, err := c.TaskClient.Create(ctx, task, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1TaskClient.Create(ctx, task, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Task: %s", err)
 	}
 
 	t.Logf("Creating TaskRun  namespace %s", namespace)
-	taskRun := parse.MustParseTaskRun(t, fmt.Sprintf(`
+	taskRun := parse.MustParseV1beta1TaskRun(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -143,7 +143,7 @@ spec:
     name: %s
   serviceAccountName: default
 `, wdTaskRunName, namespace, wdTaskName))
-	if _, err := c.TaskRunClient.Create(ctx, taskRun, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1TaskRunClient.Create(ctx, taskRun, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create TaskRun: %s", err)
 	}
 
@@ -152,7 +152,7 @@ spec:
 		t.Errorf("Error waiting for TaskRun to finish successfully: %s", err)
 	}
 
-	tr, err := c.TaskRunClient.Get(ctx, wdTaskRunName, metav1.GetOptions{})
+	tr, err := c.V1beta1TaskRunClient.Get(ctx, wdTaskRunName, metav1.GetOptions{})
 	if err != nil {
 		t.Errorf("Error retrieving taskrun: %s", err)
 	}

--- a/test/workspace_test.go
+++ b/test/workspace_test.go
@@ -46,7 +46,7 @@ func TestWorkspaceReadOnlyDisallowsWrite(t *testing.T) {
 	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
 	defer tearDown(ctx, t, c, namespace)
 
-	task := parse.MustParseTask(t, fmt.Sprintf(`
+	task := parse.MustParseV1beta1Task(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -60,11 +60,11 @@ spec:
     mountPath: /workspace/test
     readOnly: true
 `, taskName, namespace))
-	if _, err := c.TaskClient.Create(ctx, task, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1TaskClient.Create(ctx, task, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Task: %s", err)
 	}
 
-	taskRun := parse.MustParseTaskRun(t, fmt.Sprintf(`
+	taskRun := parse.MustParseV1beta1TaskRun(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -76,7 +76,7 @@ spec:
   - name: test
     emptyDir: {}
 `, taskRunName, namespace, taskName))
-	if _, err := c.TaskRunClient.Create(ctx, taskRun, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1TaskRunClient.Create(ctx, taskRun, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create TaskRun: %s", err)
 	}
 
@@ -85,7 +85,7 @@ spec:
 		t.Errorf("Error waiting for TaskRun to finish with error: %s", err)
 	}
 
-	tr, err := c.TaskRunClient.Get(ctx, taskRunName, metav1.GetOptions{})
+	tr, err := c.V1beta1TaskRunClient.Get(ctx, taskRunName, metav1.GetOptions{})
 	if err != nil {
 		t.Errorf("Error retrieving taskrun: %s", err)
 	}
@@ -124,7 +124,7 @@ func TestWorkspacePipelineRunDuplicateWorkspaceEntriesInvalid(t *testing.T) {
 	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
 	defer tearDown(ctx, t, c, namespace)
 
-	task := parse.MustParseTask(t, fmt.Sprintf(`
+	task := parse.MustParseV1beta1Task(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -138,11 +138,11 @@ spec:
     mountPath: /workspace/test
     readOnly: true
 `, taskName, namespace))
-	if _, err := c.TaskClient.Create(ctx, task, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1TaskClient.Create(ctx, task, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Task: %s", err)
 	}
 
-	pipeline := parse.MustParsePipeline(t, fmt.Sprintf(`
+	pipeline := parse.MustParseV1beta1Pipeline(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -157,11 +157,11 @@ spec:
     - name: test
       workspace: foo
 `, pipelineName, namespace, taskName))
-	if _, err := c.PipelineClient.Create(ctx, pipeline, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1PipelineClient.Create(ctx, pipeline, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Pipeline: %s", err)
 	}
 
-	pipelineRun := parse.MustParsePipelineRun(t, fmt.Sprintf(`
+	pipelineRun := parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -174,7 +174,7 @@ spec:
   - name: foo
     emptyDir: {}
 `, pipelineRunName, namespace, pipelineName))
-	_, err := c.PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{})
+	_, err := c.V1beta1PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{})
 
 	if err == nil || !strings.Contains(err.Error(), "provided by pipelinerun more than once") {
 		t.Fatalf("Expected error when creating pipelinerun with duplicate workspace entries but received: %v", err)
@@ -194,7 +194,7 @@ func TestWorkspacePipelineRunMissingWorkspaceInvalid(t *testing.T) {
 	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
 	defer tearDown(ctx, t, c, namespace)
 
-	task := parse.MustParseTask(t, fmt.Sprintf(`
+	task := parse.MustParseV1beta1Task(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -208,11 +208,11 @@ spec:
     mountPath: /workspace/test
     readOnly: true
 `, taskName, namespace))
-	if _, err := c.TaskClient.Create(ctx, task, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1TaskClient.Create(ctx, task, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Task: %s", err)
 	}
 
-	pipeline := parse.MustParsePipeline(t, fmt.Sprintf(`
+	pipeline := parse.MustParseV1beta1Pipeline(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -227,11 +227,11 @@ spec:
     - name: test
       workspace: foo
 `, pipelineName, namespace, taskName))
-	if _, err := c.PipelineClient.Create(ctx, pipeline, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1PipelineClient.Create(ctx, pipeline, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Pipeline: %s", err)
 	}
 
-	pipelineRun := parse.MustParsePipelineRun(t, fmt.Sprintf(`
+	pipelineRun := parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -239,7 +239,7 @@ spec:
   pipelineRef:
     name: %s
 `, pipelineRunName, namespace, pipelineName))
-	if _, err := c.PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create PipelineRun: %s", err)
 	}
 
@@ -263,7 +263,7 @@ func TestWorkspaceVolumeNameMatchesVolumeVariableReplacement(t *testing.T) {
 	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
 	defer tearDown(ctx, t, c, namespace)
 
-	task := parse.MustParseTask(t, fmt.Sprintf(`
+	task := parse.MustParseV1beta1Task(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -279,11 +279,11 @@ spec:
     mountPath: /workspace/test/file
     readOnly: true
 `, taskName, namespace))
-	if _, err := c.TaskClient.Create(ctx, task, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1TaskClient.Create(ctx, task, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Task: %s", err)
 	}
 
-	taskRun := parse.MustParseTaskRun(t, fmt.Sprintf(`
+	taskRun := parse.MustParseV1beta1TaskRun(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -295,7 +295,7 @@ spec:
   - name: test
     emptyDir: {}
 `, taskRunName, namespace, taskName))
-	if _, err := c.TaskRunClient.Create(ctx, taskRun, metav1.CreateOptions{}); err != nil {
+	if _, err := c.V1beta1TaskRunClient.Create(ctx, taskRun, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create TaskRun: %s", err)
 	}
 
@@ -304,7 +304,7 @@ spec:
 		t.Errorf("Error waiting for TaskRun to finish with error: %s", err)
 	}
 
-	tr, err := c.TaskRunClient.Get(ctx, taskRunName, metav1.GetOptions{})
+	tr, err := c.V1beta1TaskRunClient.Get(ctx, taskRunName, metav1.GetOptions{})
 	if err != nil {
 		t.Errorf("Error retrieving taskrun: %s", err)
 	}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
This commit renames the v1beta1 apiVersion of clients and adds the apiVersion to `./parse/yaml.go` for test.

/kind misc
cc @lbernick @XinruZhang
# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [n/a] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [n/a] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
