### PR TITLE
Fix TaskRef and PipelineRef name with Resolver Conversion

### DIFF
--- a/pkg/apis/pipeline/v1beta1/pipelineref_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/pipelineref_conversion.go
@@ -7,7 +7,9 @@ import (
 )
 
 func (pr PipelineRef) convertTo(ctx context.Context, sink *v1.PipelineRef) {
-	sink.Name = pr.Name
+	if pr.Bundle == "" {
+		sink.Name = pr.Name
+	}
 	sink.APIVersion = pr.APIVersion
 	new := v1.ResolverRef{}
 	pr.ResolverRef.convertTo(ctx, &new)

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_conversion_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_conversion_test.go
@@ -252,7 +252,6 @@ func TestPipelineRunConversionFromDeprecated(t *testing.T) {
 			},
 			Spec: v1beta1.PipelineRunSpec{
 				PipelineRef: &v1beta1.PipelineRef{
-					Name: "test-bundle-name",
 					ResolverRef: v1beta1.ResolverRef{
 						Resolver: "bundles",
 						Params: []v1beta1.Param{

--- a/pkg/apis/pipeline/v1beta1/taskref_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/taskref_conversion.go
@@ -7,7 +7,9 @@ import (
 )
 
 func (tr TaskRef) convertTo(ctx context.Context, sink *v1.TaskRef) {
-	sink.Name = tr.Name
+	if tr.Bundle == "" {
+		sink.Name = tr.Name
+	}
 	sink.Kind = v1.TaskKind(tr.Kind)
 	sink.APIVersion = tr.APIVersion
 	new := v1.ResolverRef{}

--- a/pkg/apis/pipeline/v1beta1/taskrun_conversion_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_conversion_test.go
@@ -301,7 +301,6 @@ func TestTaskRunConversionFromDeprecated(t *testing.T) {
 			},
 			Spec: v1beta1.TaskRunSpec{
 				TaskRef: &v1beta1.TaskRef{
-					Name: "test-bundle-name",
 					ResolverRef: v1beta1.ResolverRef{
 						Resolver: "bundles",
 						Params: []v1beta1.Param{


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This commit fixes the conversion where there is `bundle`, the pipelineRef and taskRef `name` should not be converted into v1 with the existence of the resolvers.

/kind bug
cc @abayer @lbernick 
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [n/a] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [n/a] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
