### PR TITLE
Use SchemeGroupVersion for tekton objects in cluster resolver

### DIFF
--- a/pkg/resolution/resolver/cluster/resolver.go
+++ b/pkg/resolution/resolver/cluster/resolver.go
@@ -101,6 +101,7 @@ func (r *Resolver) Resolve(ctx context.Context, origParams []pipelinev1beta1.Par
 	}
 
 	var data []byte
+	groupVersion := pipelinev1beta1.SchemeGroupVersion.String()
 
 	switch params[KindParam] {
 	case "task":
@@ -110,7 +111,7 @@ func (r *Resolver) Resolve(ctx context.Context, origParams []pipelinev1beta1.Par
 			return nil, err
 		}
 		task.Kind = "Task"
-		task.APIVersion = "tekton.dev/v1beta1"
+		task.APIVersion = groupVersion
 		data, err = yaml.Marshal(task)
 		if err != nil {
 			logger.Infof("failed to marshal task %s from namespace %s: %v", params[NameParam], params[NamespaceParam], err)
@@ -123,7 +124,7 @@ func (r *Resolver) Resolve(ctx context.Context, origParams []pipelinev1beta1.Par
 			return nil, err
 		}
 		pipeline.Kind = "Pipeline"
-		pipeline.APIVersion = "tekton.dev/v1beta1"
+		pipeline.APIVersion = groupVersion
 		data, err = yaml.Marshal(pipeline)
 		if err != nil {
 			logger.Infof("failed to marshal pipeline %s from namespace %s: %v", params[NameParam], params[NamespaceParam], err)


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

/kind cleanup

Prior, the cluster resolver sets the APIVersion of the retrieved tekton object to be a fixed string "tekton.dev/v1beta1".

Now, we changed this to `v1beta1.SchemeGroupVersion.String()` for easier transition to v1 once v1 is released.

Signed-off-by: Chuang Wang <chuangw@google.com>

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Use v1beta1.SchemeGroupVersion.String() for the APIVersion field in the tekton object retrieved by cluster resolver.
```
