### PR TITLE
Stop using copy-paste of old git-clone catalog task in examples/tests

### DIFF
--- a/examples/v1beta1/pipelineruns/pipelinerun-with-final-tasks.yaml
+++ b/examples/v1beta1/pipelineruns/pipelinerun-with-final-tasks.yaml
@@ -1,111 +1,3 @@
-# Copied from https://github.com/tektoncd/catalog/blob/v1beta1/git/git-clone.yaml :(
-# This can be deleted after we add support to refer to the remote Task in a registry (Issue #1839) or
-# add support for referencing task in git directly (issue #2298)
-apiVersion: tekton.dev/v1beta1
-kind: Task
-metadata:
-  name: git-clone-from-catalog
-spec:
-  workspaces:
-    - name: output
-      description: The git repo will be cloned onto the volume backing this workspace
-  params:
-    - name: url
-      description: git url to clone
-      type: string
-    - name: revision
-      description: git revision to checkout (branch, tag, sha, ref…)
-      type: string
-      default: main
-    - name: refspec
-      description: (optional) git refspec to fetch before checking out revision
-      default: ""
-    - name: submodules
-      description: defines if the resource should initialize and fetch the submodules
-      type: string
-      default: "true"
-    - name: depth
-      description: performs a shallow clone where only the most recent commit(s) will be fetched
-      type: string
-      default: "1"
-    - name: sslVerify
-      description: defines if http.sslVerify should be set to true or false in the global git config
-      type: string
-      default: "true"
-    - name: subdirectory
-      description: subdirectory inside the "output" workspace to clone the git repo into
-      type: string
-      default: ""
-    - name: deleteExisting
-      description: clean out the contents of the repo's destination directory (if it already exists) before trying to clone the repo there
-      type: string
-      default: "false"
-    - name: httpProxy
-      description: git HTTP proxy server for non-SSL requests
-      type: string
-      default: ""
-    - name: httpsProxy
-      description: git HTTPS proxy server for SSL requests
-      type: string
-      default: ""
-    - name: noProxy
-      description: git no proxy - opt out of proxying HTTP/HTTPS requests
-      type: string
-      default: ""
-  results:
-    - name: commit
-      description: The precise commit SHA that was fetched by this Task
-  steps:
-    - name: clone
-      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:latest
-      securityContext:
-        runAsUser: 0 # This needs root, and git-init is nonroot by default
-      script: |
-        CHECKOUT_DIR="$(workspaces.output.path)/$(params.subdirectory)"
-
-        cleandir() {
-          # Delete any existing contents of the repo directory if it exists.
-          #
-          # We don't just "rm -rf $CHECKOUT_DIR" because $CHECKOUT_DIR might be "/"
-          # or the root of a mounted volume.
-          if [[ -d "$CHECKOUT_DIR" ]] ; then
-            # Delete non-hidden files and directories
-            rm -rf "$CHECKOUT_DIR"/*
-            # Delete files and directories starting with . but excluding ..
-            rm -rf "$CHECKOUT_DIR"/.[!.]*
-            # Delete files and directories starting with .. plus any other character
-            rm -rf "$CHECKOUT_DIR"/..?*
-          fi
-        }
-
-        if [[ "$(params.deleteExisting)" == "true" ]] ; then
-          cleandir
-        fi
-
-        test -z "$(params.httpProxy)" || export HTTP_PROXY=$(params.httpProxy)
-        test -z "$(params.httpsProxy)" || export HTTPS_PROXY=$(params.httpsProxy)
-        test -z "$(params.noProxy)" || export NO_PROXY=$(params.noProxy)
-
-        /ko-app/git-init \
-          -url "$(params.url)" \
-          -revision "$(params.revision)" \
-          -refspec "$(params.refspec)" \
-          -path "$CHECKOUT_DIR" \
-          -sslVerify="$(params.sslVerify)" \
-          -submodules="$(params.submodules)" \
-          -depth "$(params.depth)"
-        cd "$CHECKOUT_DIR"
-        RESULT_SHA="$(git rev-parse HEAD | tr -d '\n')"
-        EXIT_CODE="$?"
-        if [ "$EXIT_CODE" != 0 ]
-        then
-          exit $EXIT_CODE
-        fi
-        # Make sure we don't add a trailing newline to the result!
-        echo -n "$RESULT_SHA" > $(results.commit.path)
-
----
-
 # Task to cleanup shared workspace
 apiVersion: tekton.dev/v1beta1
 kind: Task
@@ -149,7 +41,14 @@ spec:
     # Clone app repo to workspace
     - name: clone-app-repo
       taskRef:
-        name: git-clone-from-catalog
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/tektoncd/catalog.git
+          - name: pathInRepo
+            value: /task/git-clone/0.9/git-clone.yaml
+          - name: revision
+            value: main
       params:
         - name: url
           value: https://github.com/tektoncd/community.git

--- a/examples/v1beta1/pipelineruns/pipelinerun.yaml
+++ b/examples/v1beta1/pipelineruns/pipelinerun.yaml
@@ -36,92 +36,8 @@ spec:
       # we are now pinning the version of Skaffold we pull) or use Tekton Pipelines unit tests.
       echo "pass"
 ---
-# Copied from https://github.com/tektoncd/catalog/blob/v1beta1/git/git-clone.yaml
-# With a few fixes being ported over in https://github.com/tektoncd/catalog/pull/290
-# Post #1839 we can refer to the remote Task in a registry or post #2298 in git directly
-apiVersion: tekton.dev/v1beta1
-kind: Task
-metadata:
-  name: git-clone
-spec:
-  workspaces:
-  - name: output
-    description: The git repo will be cloned onto the volume backing this workspace
-  params:
-  - name: url
-    description: git url to clone
-    type: string
-  - name: revision
-    description: git revision to checkout (branch, tag, sha, ref…)
-    type: string
-    default: master
-  - name: submodules
-    description: defines if the resource should initialize and fetch the submodules
-    type: string
-    default: "true"
-  - name: depth
-    description: performs a shallow clone where only the most recent commit(s) will be fetched
-    type: string
-    default: "1"
-  - name: sslVerify
-    description: defines if http.sslVerify should be set to true or false in the global git config
-    type: string
-    default: "true"
-  - name: subdirectory
-    description: subdirectory inside the "output" workspace to clone the git repo into
-    type: string
-    default: ""
-  - name: deleteExisting
-    description: clean out the contents of the repo's destination directory (if it already exists) before trying to clone the repo there
-    type: string
-    default: "false"
-  results:
-  - name: commit
-    description: The precise commit SHA that was fetched by this Task
-  steps:
-  - name: clone
-    image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:latest
-    securityContext:
-      runAsUser: 0 # This needs root, and git-init is nonroot by default
-    script: |
-      CHECKOUT_DIR="$(workspaces.output.path)/$(params.subdirectory)"
-      cleandir() {
-        # Delete any existing contents of the repo directory if it exists.
-        #
-        # We don't just "rm -rf $CHECKOUT_DIR" because $CHECKOUT_DIR might be "/"
-        # or the root of a mounted volume.
-        if [[ -d "$CHECKOUT_DIR" ]] ; then
-          # Delete non-hidden files and directories
-          rm -rf "$CHECKOUT_DIR"/*
-          # Delete files and directories starting with . but excluding ..
-          rm -rf "$CHECKOUT_DIR"/.[!.]*
-          # Delete files and directories starting with .. plus any other character
-          rm -rf "$CHECKOUT_DIR"/..?*
-        fi
-      }
-      if [[ "$(params.deleteExisting)" == "true" ]] ; then
-        cleandir
-      fi
-      /ko-app/git-init \
-        -url "$(params.url)" \
-        -revision "$(params.revision)" \
-        -path "$CHECKOUT_DIR" \
-        -sslVerify="$(params.sslVerify)" \
-        -submodules="$(params.submodules)" \
-        -depth="$(params.depth)"
-      cd "$CHECKOUT_DIR"
-      RESULT_SHA="$(git rev-parse HEAD | tr -d '\n')"
-      EXIT_CODE="$?"
-      if [ "$EXIT_CODE" != 0 ]
-      then
-        exit $EXIT_CODE
-      fi
-      # Make sure we don't add a trailing newline to the result!
-      echo -n "$RESULT_SHA" > $(results.commit.path)
----
 # Copied from https://github.com/tektoncd/catalog/blob/v1beta1/kaniko/kaniko.yaml
-# with a few fixes that will be port over in https://github.com/tektoncd/catalog/pull/291
-# Post #1839 we can refer to the remote Task in a registry or post #2298 in git directly
+# Using the catalog fails for unknown reasons, so we're keeping this here.
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
@@ -239,7 +155,14 @@ spec:
   tasks:
   - name: fetch-from-git
     taskRef:
-      name: git-clone
+      resolver: git
+      params:
+      - name: url
+        value: https://github.com/tektoncd/catalog.git
+      - name: pathInRepo
+        value: /task/git-clone/0.9/git-clone.yaml
+      - name: revision
+        value: main
     params:
     - name: url
       value: https://github.com/GoogleContainerTools/skaffold

--- a/test/yamls/v1beta1/pipelineruns/pipelinerun-with-final-tasks.yaml
+++ b/test/yamls/v1beta1/pipelineruns/pipelinerun-with-final-tasks.yaml
@@ -1,111 +1,3 @@
-# Copied from https://github.com/tektoncd/catalog/blob/v1beta1/git/git-clone.yaml :(
-# This can be deleted after we add support to refer to the remote Task in a registry (Issue #1839) or
-# add support for referencing task in git directly (issue #2298)
-apiVersion: tekton.dev/v1beta1
-kind: Task
-metadata:
-  name: git-clone-from-catalog
-spec:
-  workspaces:
-    - name: output
-      description: The git repo will be cloned onto the volume backing this workspace
-  params:
-    - name: url
-      description: git url to clone
-      type: string
-    - name: revision
-      description: git revision to checkout (branch, tag, sha, ref…)
-      type: string
-      default: main
-    - name: refspec
-      description: (optional) git refspec to fetch before checking out revision
-      default: ""
-    - name: submodules
-      description: defines if the resource should initialize and fetch the submodules
-      type: string
-      default: "true"
-    - name: depth
-      description: performs a shallow clone where only the most recent commit(s) will be fetched
-      type: string
-      default: "1"
-    - name: sslVerify
-      description: defines if http.sslVerify should be set to true or false in the global git config
-      type: string
-      default: "true"
-    - name: subdirectory
-      description: subdirectory inside the "output" workspace to clone the git repo into
-      type: string
-      default: ""
-    - name: deleteExisting
-      description: clean out the contents of the repo's destination directory (if it already exists) before trying to clone the repo there
-      type: string
-      default: "false"
-    - name: httpProxy
-      description: git HTTP proxy server for non-SSL requests
-      type: string
-      default: ""
-    - name: httpsProxy
-      description: git HTTPS proxy server for SSL requests
-      type: string
-      default: ""
-    - name: noProxy
-      description: git no proxy - opt out of proxying HTTP/HTTPS requests
-      type: string
-      default: ""
-  results:
-    - name: commit
-      description: The precise commit SHA that was fetched by this Task
-  steps:
-    - name: clone
-      image: ko://github.com/tektoncd/pipeline/cmd/git-init
-      securityContext:
-        runAsUser: 0 # This needs root, and git-init is nonroot by default
-      script: |
-        CHECKOUT_DIR="$(workspaces.output.path)/$(params.subdirectory)"
-
-        cleandir() {
-          # Delete any existing contents of the repo directory if it exists.
-          #
-          # We don't just "rm -rf $CHECKOUT_DIR" because $CHECKOUT_DIR might be "/"
-          # or the root of a mounted volume.
-          if [[ -d "$CHECKOUT_DIR" ]] ; then
-            # Delete non-hidden files and directories
-            rm -rf "$CHECKOUT_DIR"/*
-            # Delete files and directories starting with . but excluding ..
-            rm -rf "$CHECKOUT_DIR"/.[!.]*
-            # Delete files and directories starting with .. plus any other character
-            rm -rf "$CHECKOUT_DIR"/..?*
-          fi
-        }
-
-        if [[ "$(params.deleteExisting)" == "true" ]] ; then
-          cleandir
-        fi
-
-        test -z "$(params.httpProxy)" || export HTTP_PROXY=$(params.httpProxy)
-        test -z "$(params.httpsProxy)" || export HTTPS_PROXY=$(params.httpsProxy)
-        test -z "$(params.noProxy)" || export NO_PROXY=$(params.noProxy)
-
-        /ko-app/git-init \
-          -url "$(params.url)" \
-          -revision "$(params.revision)" \
-          -refspec "$(params.refspec)" \
-          -path "$CHECKOUT_DIR" \
-          -sslVerify="$(params.sslVerify)" \
-          -submodules="$(params.submodules)" \
-          -depth "$(params.depth)"
-        cd "$CHECKOUT_DIR"
-        RESULT_SHA="$(git rev-parse HEAD | tr -d '\n')"
-        EXIT_CODE="$?"
-        if [ "$EXIT_CODE" != 0 ]
-        then
-          exit $EXIT_CODE
-        fi
-        # Make sure we don't add a trailing newline to the result!
-        echo -n "$RESULT_SHA" > $(results.commit.path)
-
----
-
 # Task to cleanup shared workspace
 apiVersion: tekton.dev/v1beta1
 kind: Task
@@ -149,7 +41,14 @@ spec:
     # Clone app repo to workspace
     - name: clone-app-repo
       taskRef:
-        name: git-clone-from-catalog
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/tektoncd/catalog.git
+          - name: pathInRepo
+            value: /task/git-clone/0.9/git-clone.yaml
+          - name: revision
+            value: main
       params:
         - name: url
           value: https://github.com/tektoncd/community.git

--- a/test/yamls/v1beta1/pipelineruns/pipelinerun.yaml
+++ b/test/yamls/v1beta1/pipelineruns/pipelinerun.yaml
@@ -36,89 +36,6 @@ spec:
       # we are now pinning the version of Skaffold we pull) or use Tekton Pipelines unit tests.
       echo "pass"
 ---
-# Copied from https://github.com/tektoncd/catalog/blob/v1beta1/git/git-clone.yaml
-# With a few fixes being ported over in https://github.com/tektoncd/catalog/pull/290
-# Post #1839 we can refer to the remote Task in a registry or post #2298 in git directly
-apiVersion: tekton.dev/v1beta1
-kind: Task
-metadata:
-  name: git-clone
-spec:
-  workspaces:
-  - name: output
-    description: The git repo will be cloned onto the volume backing this workspace
-  params:
-  - name: url
-    description: git url to clone
-    type: string
-  - name: revision
-    description: git revision to checkout (branch, tag, sha, ref…)
-    type: string
-    default: master
-  - name: submodules
-    description: defines if the resource should initialize and fetch the submodules
-    type: string
-    default: "true"
-  - name: depth
-    description: performs a shallow clone where only the most recent commit(s) will be fetched
-    type: string
-    default: "1"
-  - name: sslVerify
-    description: defines if http.sslVerify should be set to true or false in the global git config
-    type: string
-    default: "true"
-  - name: subdirectory
-    description: subdirectory inside the "output" workspace to clone the git repo into
-    type: string
-    default: ""
-  - name: deleteExisting
-    description: clean out the contents of the repo's destination directory (if it already exists) before trying to clone the repo there
-    type: string
-    default: "false"
-  results:
-  - name: commit
-    description: The precise commit SHA that was fetched by this Task
-  steps:
-  - name: clone
-    image: ko://github.com/tektoncd/pipeline/cmd/git-init
-    securityContext:
-      runAsUser: 0 # This needs root, and git-init is nonroot by default
-    script: |
-      CHECKOUT_DIR="$(workspaces.output.path)/$(params.subdirectory)"
-      cleandir() {
-        # Delete any existing contents of the repo directory if it exists.
-        #
-        # We don't just "rm -rf $CHECKOUT_DIR" because $CHECKOUT_DIR might be "/"
-        # or the root of a mounted volume.
-        if [[ -d "$CHECKOUT_DIR" ]] ; then
-          # Delete non-hidden files and directories
-          rm -rf "$CHECKOUT_DIR"/*
-          # Delete files and directories starting with . but excluding ..
-          rm -rf "$CHECKOUT_DIR"/.[!.]*
-          # Delete files and directories starting with .. plus any other character
-          rm -rf "$CHECKOUT_DIR"/..?*
-        fi
-      }
-      if [[ "$(params.deleteExisting)" == "true" ]] ; then
-        cleandir
-      fi
-      /ko-app/git-init \
-        -url "$(params.url)" \
-        -revision "$(params.revision)" \
-        -path "$CHECKOUT_DIR" \
-        -sslVerify="$(params.sslVerify)" \
-        -submodules="$(params.submodules)" \
-        -depth="$(params.depth)"
-      cd "$CHECKOUT_DIR"
-      RESULT_SHA="$(git rev-parse HEAD | tr -d '\n')"
-      EXIT_CODE="$?"
-      if [ "$EXIT_CODE" != 0 ]
-      then
-        exit $EXIT_CODE
-      fi
-      # Make sure we don't add a trailing newline to the result!
-      echo -n "$RESULT_SHA" > $(results.commit.path)
----
 # Copied from https://github.com/tektoncd/catalog/blob/v1beta1/kaniko/kaniko.yaml
 # with a few fixes that will be port over in https://github.com/tektoncd/catalog/pull/291
 # Post #1839 we can refer to the remote Task in a registry or post #2298 in git directly
@@ -241,7 +158,14 @@ spec:
   tasks:
   - name: fetch-from-git
     taskRef:
-      name: git-clone
+      resolver: git
+      params:
+      - name: url
+        value: https://github.com/tektoncd/catalog.git
+      - name: pathInRepo
+        value: /task/git-clone/0.9/git-clone.yaml
+      - name: revision
+        value: main
     params:
     - name: url
       value: https://github.com/GoogleContainerTools/skaffold


### PR DESCRIPTION
# Changes

Since the git resolver is now built-in, let's switch to using it where we had previously used a copy-paste of an old version of the `git-clone` task from the catalog.

Note that the `kaniko` task is still copy-pasted in, because the catalog `kaniko` task fails for mysterious reasons in CI.

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
