### PR TITLE
Skip TestGitResolver_API on other archs

### DIFF
--- a/test/multiarch_utils.go
+++ b/test/multiarch_utils.go
@@ -137,6 +137,8 @@ func initExcludedTests() sets.String {
 	switch getTestArch() {
 	case "s390x":
 		return sets.NewString(
+			// Git resolver test using local Gitea instance
+			"TestGitResolver_API",
 			// examples
 			"TestExamples/v1alpha1/taskruns/gcs-resource",
 			"TestExamples/v1beta1/taskruns/gcs-resource",
@@ -144,6 +146,8 @@ func initExcludedTests() sets.String {
 		)
 	case "ppc64le":
 		return sets.NewString(
+			// Git resolver test using local Gitea instance
+			"TestGitResolver_API",
 			// examples
 			"TestExamples/v1alpha1/taskruns/gcs-resource",
 			"TestExamples/v1beta1/taskruns/gcs-resource",


### PR DESCRIPTION
# Changes

Fixes #5703

Gitea doesn't support other architectures, so let's skip the test using it on s390x and ppc64e. The actual functionality being tested isn't at all arch-specific, so I don't think anything is lost by skipping it.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
