### PR TITLE
Add RunReason and CustomRunReason

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/run_types.go
+++ b/pkg/apis/pipeline/v1alpha1/run_types.go
@@ -117,18 +117,33 @@ func (rs RunSpec) GetParam(name string) *v1beta1.Param {
 	return nil
 }
 
+// RunReason is an enum used to store all Run reason for the Succeeded condition that are controlled by the Run itself.
+type RunReason string
+
 const (
+	// RunReasonStarted is the reason set when the Run has just started.
+	RunReasonStarted RunReason = "Started"
+	// RunReasonRunning is the reason set when the Run is running.
+	RunReasonRunning RunReason = "Running"
+	// RunReasonSuccessful is the reason set when the Run completed successfully.
+	RunReasonSuccessful RunReason = "Succeeded"
+	// RunReasonFailed is the reason set when the Run completed with a failure.
+	RunReasonFailed RunReason = "Failed"
 	// RunReasonCancelled must be used in the Condition Reason to indicate that a Run was cancelled.
-	RunReasonCancelled = "RunCancelled"
+	RunReasonCancelled RunReason = "RunCancelled"
 	// RunReasonTimedOut must be used in the Condition Reason to indicate that a Run was timed out.
-	RunReasonTimedOut = "RunTimedOut"
+	RunReasonTimedOut RunReason = "RunTimedOut"
 	// RunReasonWorkspaceNotSupported can be used in the Condition Reason to indicate that the
 	// Run contains a workspace which is not supported by this custom task.
-	RunReasonWorkspaceNotSupported = "RunWorkspaceNotSupported"
+	RunReasonWorkspaceNotSupported RunReason = "RunWorkspaceNotSupported"
 	// RunReasonPodTemplateNotSupported can be used in the Condition Reason to indicate that the
 	// Run contains a pod template which is not supported by this custom task.
-	RunReasonPodTemplateNotSupported = "RunPodTemplateNotSupported"
+	RunReasonPodTemplateNotSupported RunReason = "RunPodTemplateNotSupported"
 )
+
+func (t RunReason) String() string {
+	return string(t)
+}
 
 // RunStatus defines the observed state of Run.
 type RunStatus = runv1alpha1.RunStatus

--- a/pkg/apis/pipeline/v1beta1/customrun_types.go
+++ b/pkg/apis/pipeline/v1beta1/customrun_types.go
@@ -109,15 +109,30 @@ func (rs CustomRunSpec) GetParam(name string) *Param {
 	return nil
 }
 
+// CustomRunReason is an enum used to store all Run reason for the Succeeded condition that are controlled by the CustomRun itself.
+type CustomRunReason string
+
 const (
+	// CustomRunReasonStarted is the reason set when the CustomRun has just started.
+	CustomRunReasonStarted CustomRunReason = "Started"
+	// CustomRunReasonRunning is the reason set when the CustomRun is running.
+	CustomRunReasonRunning CustomRunReason = "Running"
+	// CustomRunReasonSuccessful is the reason set when the CustomRun completed successfully.
+	CustomRunReasonSuccessful CustomRunReason = "Succeeded"
+	// CustomRunReasonFailed is the reason set when the CustomRun completed with a failure.
+	CustomRunReasonFailed CustomRunReason = "Failed"
 	// CustomRunReasonCancelled must be used in the Condition Reason to indicate that a CustomRun was cancelled.
-	CustomRunReasonCancelled = "CustomRunCancelled"
+	CustomRunReasonCancelled CustomRunReason = "CustomRunCancelled"
 	// CustomRunReasonTimedOut must be used in the Condition Reason to indicate that a CustomRun was timed out.
-	CustomRunReasonTimedOut = "CustomRunTimedOut"
+	CustomRunReasonTimedOut CustomRunReason = "CustomRunTimedOut"
 	// CustomRunReasonWorkspaceNotSupported can be used in the Condition Reason to indicate that the
 	// CustomRun contains a workspace which is not supported by this custom task.
-	CustomRunReasonWorkspaceNotSupported = "CustomRunWorkspaceNotSupported"
+	CustomRunReasonWorkspaceNotSupported CustomRunReason = "CustomRunWorkspaceNotSupported"
 )
+
+func (t CustomRunReason) String() string {
+	return string(t)
+}
 
 // CustomRunStatus defines the observed state of CustomRun.
 type CustomRunStatus = runv1beta1.CustomRunStatus

--- a/pkg/reconciler/customrun/customrun_test.go
+++ b/pkg/reconciler/customrun/customrun_test.go
@@ -113,7 +113,7 @@ func TestReconcile_CloudEvents(t *testing.T) {
 		condition: &apis.Condition{
 			Type:   apis.ConditionSucceeded,
 			Status: corev1.ConditionUnknown,
-			Reason: v1beta1.TaskRunReasonRunning.String(),
+			Reason: v1beta1.CustomRunReasonRunning.String(),
 		},
 		wantCloudEvents: []string{`(?s)dev.tekton.event.customrun.running.v1.*test-customRun`},
 	}, {
@@ -121,7 +121,7 @@ func TestReconcile_CloudEvents(t *testing.T) {
 		condition: &apis.Condition{
 			Type:   apis.ConditionSucceeded,
 			Status: corev1.ConditionTrue,
-			Reason: v1beta1.PipelineRunReasonSuccessful.String(),
+			Reason: v1beta1.CustomRunReasonSuccessful.String(),
 		},
 		wantCloudEvents: []string{`(?s)dev.tekton.event.customrun.successful.v1.*test-customRun`},
 	}, {
@@ -129,7 +129,7 @@ func TestReconcile_CloudEvents(t *testing.T) {
 		condition: &apis.Condition{
 			Type:   apis.ConditionSucceeded,
 			Status: corev1.ConditionFalse,
-			Reason: v1beta1.PipelineRunReasonCancelled.String(),
+			Reason: v1beta1.CustomRunReasonCancelled.String(),
 		},
 		wantCloudEvents: []string{`(?s)dev.tekton.event.customrun.failed.v1.*test-customRun`},
 	}}
@@ -252,7 +252,7 @@ func TestReconcile_CloudEvents_Disabled(t *testing.T) {
 					{
 						Type:   apis.ConditionSucceeded,
 						Status: corev1.ConditionFalse,
-						Reason: v1beta1.PipelineRunReasonCancelled.String(),
+						Reason: v1beta1.CustomRunReasonCancelled.String(),
 					},
 				},
 			}

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -256,7 +256,7 @@ func (t ResolvedPipelineTask) isCancelledForTimeOut() bool {
 			isDone = isDone && run.IsDone()
 			c := run.Status.GetCondition(apis.ConditionSucceeded)
 			runCancelled := c.IsFalse() &&
-				c.Reason == v1alpha1.RunReasonCancelled &&
+				c.Reason == v1alpha1.RunReasonCancelled.String() &&
 				run.Spec.StatusMessage == v1alpha1.RunCancelledByPipelineTimeoutMsg
 			atLeastOneCancelled = atLeastOneCancelled || runCancelled
 		}
@@ -267,7 +267,7 @@ func (t ResolvedPipelineTask) isCancelledForTimeOut() bool {
 		}
 		c := t.Run.Status.GetCondition(apis.ConditionSucceeded)
 		return c != nil && c.IsFalse() &&
-			c.Reason == v1alpha1.RunReasonCancelled &&
+			c.Reason == v1alpha1.RunReasonCancelled.String() &&
 			t.Run.Spec.StatusMessage == v1alpha1.RunCancelledByPipelineTimeoutMsg
 	case t.IsMatrixed():
 		if len(t.TaskRuns) == 0 {
@@ -308,7 +308,7 @@ func (t ResolvedPipelineTask) isCancelled() bool {
 		for _, run := range t.Runs {
 			isDone = isDone && run.IsDone()
 			c := run.Status.GetCondition(apis.ConditionSucceeded)
-			runCancelled := c.IsFalse() && c.Reason == v1alpha1.RunReasonCancelled
+			runCancelled := c.IsFalse() && c.Reason == v1alpha1.RunReasonCancelled.String()
 			atLeastOneCancelled = atLeastOneCancelled || runCancelled
 		}
 		return atLeastOneCancelled && isDone
@@ -317,7 +317,7 @@ func (t ResolvedPipelineTask) isCancelled() bool {
 			return false
 		}
 		c := t.Run.Status.GetCondition(apis.ConditionSucceeded)
-		return c != nil && c.IsFalse() && c.Reason == v1alpha1.RunReasonCancelled
+		return c != nil && c.IsFalse() && c.Reason == v1alpha1.RunReasonCancelled.String()
 	case t.IsMatrixed():
 		if len(t.TaskRuns) == 0 {
 			return false

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
@@ -301,13 +301,13 @@ func withCancelledForTimeout(tr *v1beta1.TaskRun) *v1beta1.TaskRun {
 }
 
 func withRunCancelled(run *v1alpha1.Run) *v1alpha1.Run {
-	run.Status.Conditions[0].Reason = v1alpha1.RunReasonCancelled
+	run.Status.Conditions[0].Reason = v1alpha1.RunReasonCancelled.String()
 	return run
 }
 
 func withRunCancelledForTimeout(run *v1alpha1.Run) *v1alpha1.Run {
 	run.Spec.StatusMessage = v1alpha1.RunCancelledByPipelineTimeoutMsg
-	run.Status.Conditions[0].Reason = v1alpha1.RunReasonCancelled
+	run.Status.Conditions[0].Reason = v1alpha1.RunReasonCancelled.String()
 	return run
 }
 

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
@@ -1710,7 +1710,7 @@ func TestGetPipelineConditionStatus(t *testing.T) {
 				Status: duckv1.Status{Conditions: []apis.Condition{{
 					Type:   apis.ConditionSucceeded,
 					Status: corev1.ConditionFalse,
-					Reason: v1alpha1.RunReasonCancelled,
+					Reason: v1alpha1.RunReasonCancelled.String(),
 				}}},
 			},
 		},
@@ -1728,7 +1728,7 @@ func TestGetPipelineConditionStatus(t *testing.T) {
 				Status: duckv1.Status{Conditions: []apis.Condition{{
 					Type:   apis.ConditionSucceeded,
 					Status: corev1.ConditionFalse,
-					Reason: v1alpha1.RunReasonCancelled,
+					Reason: v1alpha1.RunReasonCancelled.String(),
 				}}},
 			},
 		},

--- a/pkg/reconciler/run/run_test.go
+++ b/pkg/reconciler/run/run_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/reconciler/events/cloudevent"
 	ttesting "github.com/tektoncd/pipeline/pkg/reconciler/testing"
 	"github.com/tektoncd/pipeline/test"
@@ -116,7 +115,7 @@ func TestReconcile_CloudEvents(t *testing.T) {
 		condition: &apis.Condition{
 			Type:   apis.ConditionSucceeded,
 			Status: corev1.ConditionUnknown,
-			Reason: v1beta1.TaskRunReasonRunning.String(),
+			Reason: v1alpha1.RunReasonRunning.String(),
 		},
 		wantCloudEvents: []string{`(?s)dev.tekton.event.run.running.v1.*test-run`},
 	}, {
@@ -124,7 +123,7 @@ func TestReconcile_CloudEvents(t *testing.T) {
 		condition: &apis.Condition{
 			Type:   apis.ConditionSucceeded,
 			Status: corev1.ConditionTrue,
-			Reason: v1beta1.PipelineRunReasonSuccessful.String(),
+			Reason: v1alpha1.RunReasonSuccessful.String(),
 		},
 		wantCloudEvents: []string{`(?s)dev.tekton.event.run.successful.v1.*test-run`},
 	}, {
@@ -132,7 +131,7 @@ func TestReconcile_CloudEvents(t *testing.T) {
 		condition: &apis.Condition{
 			Type:   apis.ConditionSucceeded,
 			Status: corev1.ConditionFalse,
-			Reason: v1beta1.PipelineRunReasonCancelled.String(),
+			Reason: v1alpha1.RunReasonCancelled.String(),
 		},
 		wantCloudEvents: []string{`(?s)dev.tekton.event.run.failed.v1.*test-run`},
 	}}
@@ -255,7 +254,7 @@ func TestReconcile_CloudEvents_Disabled(t *testing.T) {
 					{
 						Type:   apis.ConditionSucceeded,
 						Status: corev1.ConditionFalse,
-						Reason: v1beta1.PipelineRunReasonCancelled.String(),
+						Reason: v1alpha1.RunReasonCancelled.String(),
 					},
 				},
 			}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

Prior to this change, we did not have `RunReason` and `CustomRunReason`. As a result, there were instances where we reused `TaskRunReason` and `PipelineRunReason`. This worked because the underlying strings are the same, but it is confusing when reading the code (and reviewing changes).

In this change, we:
- introduce `RunReason` and `CustomRunReason`
- clean up existing reasons to use the enum
- add three common reasons - started, running, successful and failed

/kind cleanup

Follow up to my comments in https://github.com/tektoncd/pipeline/pull/5662#discussion_r999899221 and https://github.com/tektoncd/pipeline/pull/5662#discussion_r999800781 (cc @abayer)

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [n/a] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [n/a] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [n/a] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
