### PR TITLE
Remove `retriesStatus` from `CustomRunStatus`

### DIFF
--- a/docs/pipeline-api.md
+++ b/docs/pipeline-api.md
@@ -13893,20 +13893,6 @@ tasks in a pipeline.</p>
 </tr>
 <tr>
 <td>
-<code>retriesStatus</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.CustomRunStatus">
-[]CustomRunStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>RetriesStatus contains the history of CustomRunStatus, in case of a retry.</p>
-</td>
-</tr>
-<tr>
-<td>
 <code>extraFields</code><br/>
 <em>
 k8s.io/apimachinery/pkg/runtime.RawExtension

--- a/pkg/apis/run/v1beta1/customrunstatus_types.go
+++ b/pkg/apis/run/v1beta1/customrunstatus_types.go
@@ -57,10 +57,6 @@ type CustomRunStatusFields struct {
 	// +optional
 	Results []CustomRunResult `json:"results,omitempty"`
 
-	// RetriesStatus contains the history of CustomRunStatus, in case of a retry.
-	// +optional
-	RetriesStatus []CustomRunStatus `json:"retriesStatus,omitempty"`
-
 	// ExtraFields holds arbitrary fields provided by the custom task
 	// controller.
 	ExtraFields runtime.RawExtension `json:"extraFields,omitempty"`

--- a/pkg/apis/run/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/run/v1beta1/zz_generated.deepcopy.go
@@ -55,13 +55,6 @@ func (in *CustomRunStatusFields) DeepCopyInto(out *CustomRunStatusFields) {
 		*out = make([]CustomRunResult, len(*in))
 		copy(*out, *in)
 	}
-	if in.RetriesStatus != nil {
-		in, out := &in.RetriesStatus, &out.RetriesStatus
-		*out = make([]CustomRunStatus, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
-	}
 	in.ExtraFields.DeepCopyInto(&out.ExtraFields)
 	return
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

As discussed in [TEP-0114][tep-0114], `retries` and `retriesStatus` will not be included in the initial release of `CustomRuns`.

In https://github.com/tektoncd/pipeline/pull/5662, we removed the `retries` field from the spec. This is a follow up change removing `retriesStatus` field from the status. Shout out to @lbernick for catching this in https://github.com/tektoncd/pipeline/pull/5662#issuecomment-1302580628 👏🏾 

[tep-0114]: https://github.com/tektoncd/community/blob/main/teps/0114-custom-tasks-beta.md#exclude-retries-and-retriesstatus

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [n/a] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [n/a] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
