### PR TITLE
fix: the pipelinerun never done due to repeated workspace

### DIFF
--- a/pkg/apis/pipeline/v1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1/pipeline_types.go
@@ -420,7 +420,13 @@ func validateExecutionStatusVariablesExpressions(expressions []string, ptNames s
 }
 
 func (pt *PipelineTask) validateWorkspaces(workspaceNames sets.String) (errs *apis.FieldError) {
+	workspaceBindingNames := sets.NewString()
 	for i, ws := range pt.Workspaces {
+		if workspaceBindingNames.Has(ws.Name) {
+			errs = errs.Also(apis.ErrGeneric(
+				fmt.Sprintf("workspace name %q must be unique", ws.Name), "").ViaFieldIndex("workspaces", i))
+		}
+
 		if ws.Workspace == "" {
 			if !workspaceNames.Has(ws.Name) {
 				errs = errs.Also(apis.ErrInvalidValue(
@@ -434,6 +440,8 @@ func (pt *PipelineTask) validateWorkspaces(workspaceNames sets.String) (errs *ap
 				"",
 			).ViaFieldIndex("workspaces", i))
 		}
+
+		workspaceBindingNames.Insert(ws.Name)
 	}
 	return errs
 }

--- a/pkg/apis/pipeline/v1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1/pipeline_validation_test.go
@@ -1923,6 +1923,29 @@ func TestValidatePipelineWorkspacesUsage_Failure(t *testing.T) {
 			Message: `invalid value: pipeline task "foo" expects workspace with name "taskWorkspaceName" but none exists in pipeline spec`,
 			Paths:   []string{"tasks[0].workspaces[0]"},
 		},
+	}, {
+		name: "invalid pipeline task use duplicate workspace binding name",
+		workspaces: []PipelineWorkspaceDeclaration{{
+			Name: "foo",
+		}},
+		tasks: []PipelineTask{{
+			Name:    "foo",
+			TaskRef: &TaskRef{Name: "foo"},
+			Workspaces: []WorkspacePipelineTaskBinding{
+				{
+					Name:      "repo",
+					Workspace: "foo",
+				},
+				{
+					Name:      "repo",
+					Workspace: "foo",
+				},
+			},
+		}},
+		expectedError: apis.FieldError{
+			Message: `workspace name "repo" must be unique`,
+			Paths:   []string{"tasks[0].workspaces[1]"},
+		},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/apis/pipeline/v1beta1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types.go
@@ -450,7 +450,13 @@ func validateExecutionStatusVariablesExpressions(expressions []string, ptNames s
 }
 
 func (pt *PipelineTask) validateWorkspaces(workspaceNames sets.String) (errs *apis.FieldError) {
+	workspaceBindingNames := sets.NewString()
 	for i, ws := range pt.Workspaces {
+		if workspaceBindingNames.Has(ws.Name) {
+			errs = errs.Also(apis.ErrGeneric(
+				fmt.Sprintf("workspace name %q must be unique", ws.Name), "").ViaFieldIndex("workspaces", i))
+		}
+
 		if ws.Workspace == "" {
 			if !workspaceNames.Has(ws.Name) {
 				errs = errs.Also(apis.ErrInvalidValue(
@@ -464,6 +470,8 @@ func (pt *PipelineTask) validateWorkspaces(workspaceNames sets.String) (errs *ap
 				"",
 			).ViaFieldIndex("workspaces", i))
 		}
+
+		workspaceBindingNames.Insert(ws.Name)
 	}
 	return errs
 }

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
@@ -2314,6 +2314,29 @@ func TestValidatePipelineWorkspacesUsage_Failure(t *testing.T) {
 			Message: `invalid value: pipeline task "foo" expects workspace with name "taskWorkspaceName" but none exists in pipeline spec`,
 			Paths:   []string{"tasks[0].workspaces[0]"},
 		},
+	}, {
+		name: "invalid pipeline task use duplicate workspace binding name",
+		workspaces: []PipelineWorkspaceDeclaration{{
+			Name: "foo",
+		}},
+		tasks: []PipelineTask{{
+			Name:    "foo",
+			TaskRef: &TaskRef{Name: "foo"},
+			Workspaces: []WorkspacePipelineTaskBinding{
+				{
+					Name:      "repo",
+					Workspace: "foo",
+				},
+				{
+					Name:      "repo",
+					Workspace: "foo",
+				},
+			},
+		}},
+		expectedError: apis.FieldError{
+			Message: `workspace name "repo" must be unique`,
+			Paths:   []string{"tasks[0].workspaces[1]"},
+		},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The Pipeline creation should be inhibited when there are duplicate workspaces.

Fixs: #5723 

/kind bug

# Submitter Checklist

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Check for duplicate workspaces of pipeline task.
```
