### PR TITLE
Fixes default value for enabling resolvers

### DIFF
--- a/pkg/apis/config/resolver/feature_flags.go
+++ b/pkg/apis/config/resolver/feature_flags.go
@@ -26,13 +26,13 @@ import (
 
 const (
 	// DefaultEnableGitResolver is the default value for "enable-git-resolver".
-	DefaultEnableGitResolver = false
+	DefaultEnableGitResolver = true
 	// DefaultEnableHubResolver is the default value for "enable-hub-resolver".
-	DefaultEnableHubResolver = false
+	DefaultEnableHubResolver = true
 	// DefaultEnableBundlesResolver is the default value for "enable-bundles-resolver".
-	DefaultEnableBundlesResolver = false
+	DefaultEnableBundlesResolver = true
 	// DefaultEnableClusterResolver is the default value for "enable-cluster-resolver".
-	DefaultEnableClusterResolver = false
+	DefaultEnableClusterResolver = true
 
 	// EnableGitResolver is the flag used to enable the git remote resolver
 	EnableGitResolver = "enable-git-resolver"

--- a/pkg/apis/config/resolver/feature_flags_test.go
+++ b/pkg/apis/config/resolver/feature_flags_test.go
@@ -34,19 +34,19 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 	testCases := []testCase{
 		{
 			expectedConfig: &resolver.FeatureFlags{
-				EnableGitResolver:     false,
-				EnableHubResolver:     false,
-				EnableBundleResolver:  false,
-				EnableClusterResolver: false,
+				EnableGitResolver:     true,
+				EnableHubResolver:     true,
+				EnableBundleResolver:  true,
+				EnableClusterResolver: true,
 			},
 			fileName: "feature-flags-empty",
 		},
 		{
 			expectedConfig: &resolver.FeatureFlags{
-				EnableGitResolver:     true,
-				EnableHubResolver:     true,
-				EnableBundleResolver:  true,
-				EnableClusterResolver: true,
+				EnableGitResolver:     false,
+				EnableHubResolver:     false,
+				EnableBundleResolver:  false,
+				EnableClusterResolver: false,
 			},
 			fileName: "feature-flags-all-flags-set",
 		},
@@ -64,9 +64,10 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 func TestNewFeatureFlagsFromEmptyConfigMap(t *testing.T) {
 	FeatureFlagsConfigEmptyName := "feature-flags-empty"
 	expectedConfig := &resolver.FeatureFlags{
-		EnableGitResolver:    resolver.DefaultEnableGitResolver,
-		EnableHubResolver:    resolver.DefaultEnableHubResolver,
-		EnableBundleResolver: resolver.DefaultEnableBundlesResolver,
+		EnableGitResolver:     resolver.DefaultEnableGitResolver,
+		EnableHubResolver:     resolver.DefaultEnableHubResolver,
+		EnableBundleResolver:  resolver.DefaultEnableBundlesResolver,
+		EnableClusterResolver: resolver.DefaultEnableClusterResolver,
 	}
 	verifyConfigFileWithExpectedFeatureFlagsConfig(t, FeatureFlagsConfigEmptyName, expectedConfig)
 }

--- a/pkg/apis/config/resolver/testdata/feature-flags-all-flags-set.yaml
+++ b/pkg/apis/config/resolver/testdata/feature-flags-all-flags-set.yaml
@@ -18,7 +18,7 @@ metadata:
   name: resolvers-feature-flags
   namespace: tekton-pipelines-resolvers
 data:
-  enable-git-resolver: "true"
-  enable-hub-resolver: "true"
-  enable-bundles-resolver: "true"
-  enable-cluster-resolver: "true"
+  enable-git-resolver: "false"
+  enable-hub-resolver: "false"
+  enable-bundles-resolver: "false"
+  enable-cluster-resolver: "false"

--- a/pkg/resolution/resolver/bundle/resolver_test.go
+++ b/pkg/resolution/resolver/bundle/resolver_test.go
@@ -72,7 +72,7 @@ func TestValidateParams(t *testing.T) {
 		Value: *pipelinev1beta1.NewStructuredValues("baz"),
 	}}
 
-	if err := resolver.ValidateParams(resolverContext(), paramsWithTask); err != nil {
+	if err := resolver.ValidateParams(context.Background(), paramsWithTask); err != nil {
 		t.Fatalf("unexpected error validating params: %v", err)
 	}
 
@@ -89,7 +89,7 @@ func TestValidateParams(t *testing.T) {
 		Name:  ParamServiceAccount,
 		Value: *pipelinev1beta1.NewStructuredValues("baz"),
 	}}
-	if err := resolver.ValidateParams(resolverContext(), paramsWithPipeline); err != nil {
+	if err := resolver.ValidateParams(context.Background(), paramsWithPipeline); err != nil {
 		t.Fatalf("unexpected error validating params: %v", err)
 	}
 }
@@ -112,7 +112,7 @@ func TestValidateParamsDisabled(t *testing.T) {
 		Name:  ParamServiceAccount,
 		Value: *pipelinev1beta1.NewStructuredValues("baz"),
 	}}
-	err = resolver.ValidateParams(context.Background(), params)
+	err = resolver.ValidateParams(resolverDisabledContext(), params)
 	if err == nil {
 		t.Fatalf("expected disabled err")
 	}
@@ -137,7 +137,7 @@ func TestValidateParamsMissing(t *testing.T) {
 		Name:  ParamServiceAccount,
 		Value: *pipelinev1beta1.NewStructuredValues("baz"),
 	}}
-	err = resolver.ValidateParams(resolverContext(), paramsMissingBundle)
+	err = resolver.ValidateParams(context.Background(), paramsMissingBundle)
 	if err == nil {
 		t.Fatalf("expected missing kind err")
 	}
@@ -152,7 +152,7 @@ func TestValidateParamsMissing(t *testing.T) {
 		Name:  ParamServiceAccount,
 		Value: *pipelinev1beta1.NewStructuredValues("baz"),
 	}}
-	err = resolver.ValidateParams(resolverContext(), paramsMissingName)
+	err = resolver.ValidateParams(context.Background(), paramsMissingName)
 	if err == nil {
 		t.Fatalf("expected missing name err")
 	}
@@ -177,7 +177,7 @@ func TestResolveDisabled(t *testing.T) {
 		Name:  ParamServiceAccount,
 		Value: *pipelinev1beta1.NewStructuredValues("baz"),
 	}}
-	_, err = resolver.Resolve(context.Background(), params)
+	_, err = resolver.Resolve(resolverDisabledContext(), params)
 	if err == nil {
 		t.Fatalf("expected disabled err")
 	}
@@ -489,8 +489,8 @@ func asIsMapper(obj runtime.Object) map[string]string {
 	return annotations
 }
 
-func resolverContext() context.Context {
-	return frtesting.ContextWithBundlesResolverEnabled(context.Background())
+func resolverDisabledContext() context.Context {
+	return frtesting.ContextWithBundlesResolverDisabled(context.Background())
 }
 
 func pushImagesToRegistry(t *testing.T, host string, objects map[string][]runtime.Object, mapper test.ObjectAnnotationMapper) map[string]string {

--- a/pkg/resolution/resolver/cluster/resolver_test.go
+++ b/pkg/resolution/resolver/cluster/resolver_test.go
@@ -44,7 +44,7 @@ import (
 
 func TestGetSelector(t *testing.T) {
 	resolver := Resolver{}
-	sel := resolver.GetSelector(resolverContext())
+	sel := resolver.GetSelector(context.Background())
 	if typ, has := sel[resolutioncommon.LabelKeyResolverType]; !has {
 		t.Fatalf("unexpected selector: %v", sel)
 	} else if typ != LabelValueClusterResolverType {
@@ -66,7 +66,7 @@ func TestValidateParams(t *testing.T) {
 		Value: *pipelinev1beta1.NewStructuredValues("baz"),
 	}}
 
-	ctx := framework.InjectResolverConfigToContext(resolverContext(), map[string]string{
+	ctx := framework.InjectResolverConfigToContext(context.Background(), map[string]string{
 		AllowedNamespacesKey: "foo,bar",
 		BlockedNamespacesKey: "abc,def",
 	})
@@ -91,7 +91,7 @@ func TestValidateParamsNotEnabled(t *testing.T) {
 		Name:  NameParam,
 		Value: *pipelinev1beta1.NewStructuredValues("baz"),
 	}}
-	err = resolver.ValidateParams(context.Background(), params)
+	err = resolver.ValidateParams(resolverDisabledContext(), params)
 	if err == nil {
 		t.Fatalf("expected disabled err")
 	}
@@ -157,7 +157,7 @@ func TestValidateParamsFailure(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			resolver := &Resolver{}
 
-			ctx := resolverContext()
+			ctx := context.Background()
 			if len(tc.conf) > 0 {
 				ctx = framework.InjectResolverConfigToContext(ctx, tc.conf)
 			}
@@ -404,6 +404,6 @@ func createRequest(kind, name, namespace string) *v1beta1.ResolutionRequest {
 	return rr
 }
 
-func resolverContext() context.Context {
-	return frtesting.ContextWithClusterResolverEnabled(context.Background())
+func resolverDisabledContext() context.Context {
+	return frtesting.ContextWithClusterResolverDisabled(context.Background())
 }

--- a/pkg/resolution/resolver/framework/testing/featureflag.go
+++ b/pkg/resolution/resolver/framework/testing/featureflag.go
@@ -23,29 +23,29 @@ import (
 	resolverconfig "github.com/tektoncd/pipeline/pkg/apis/config/resolver"
 )
 
-// ContextWithGitResolverEnabled returns a context containing a Config with the enable-git-resolver feature flag enabled.
-func ContextWithGitResolverEnabled(ctx context.Context) context.Context {
-	return contextWithResolverEnabled(ctx, "enable-git-resolver")
+// ContextWithGitResolverDisabled returns a context containing a Config with the enable-git-resolver feature flag disabled.
+func ContextWithGitResolverDisabled(ctx context.Context) context.Context {
+	return contextWithResolverDisabled(ctx, "enable-git-resolver")
 }
 
-// ContextWithHubResolverEnabled returns a context containing a Config with the enable-hub-resolver feature flag enabled.
-func ContextWithHubResolverEnabled(ctx context.Context) context.Context {
-	return contextWithResolverEnabled(ctx, "enable-hub-resolver")
+// ContextWithHubResolverDisabled returns a context containing a Config with the enable-hub-resolver feature flag disabled.
+func ContextWithHubResolverDisabled(ctx context.Context) context.Context {
+	return contextWithResolverDisabled(ctx, "enable-hub-resolver")
 }
 
-// ContextWithBundlesResolverEnabled returns a context containing a Config with the enable-bundles-resolver feature flag enabled.
-func ContextWithBundlesResolverEnabled(ctx context.Context) context.Context {
-	return contextWithResolverEnabled(ctx, "enable-bundles-resolver")
+// ContextWithBundlesResolverDisabled returns a context containing a Config with the enable-bundles-resolver feature flag disabled.
+func ContextWithBundlesResolverDisabled(ctx context.Context) context.Context {
+	return contextWithResolverDisabled(ctx, "enable-bundles-resolver")
 }
 
-// ContextWithClusterResolverEnabled returns a context containing a Config with the enable-cluster-resolver feature flag enabled.
-func ContextWithClusterResolverEnabled(ctx context.Context) context.Context {
-	return contextWithResolverEnabled(ctx, "enable-cluster-resolver")
+// ContextWithClusterResolverDisabled returns a context containing a Config with the enable-cluster-resolver feature flag disabled.
+func ContextWithClusterResolverDisabled(ctx context.Context) context.Context {
+	return contextWithResolverDisabled(ctx, "enable-cluster-resolver")
 }
 
-func contextWithResolverEnabled(ctx context.Context, resolverFlag string) context.Context {
+func contextWithResolverDisabled(ctx context.Context, resolverFlag string) context.Context {
 	featureFlags, _ := resolverconfig.NewFeatureFlagsFromMap(map[string]string{
-		resolverFlag: "true",
+		resolverFlag: "false",
 	})
 	cfg := &resolverconfig.Config{
 		FeatureFlags: featureFlags,

--- a/pkg/resolution/resolver/git/resolver_test.go
+++ b/pkg/resolution/resolver/git/resolver_test.go
@@ -53,7 +53,7 @@ import (
 
 func TestGetSelector(t *testing.T) {
 	resolver := Resolver{}
-	sel := resolver.GetSelector(resolverContext())
+	sel := resolver.GetSelector(context.Background())
 	if typ, has := sel[resolutioncommon.LabelKeyResolverType]; !has {
 		t.Fatalf("unexpected selector: %v", sel)
 	} else if typ != labelValueGitResolverType {
@@ -70,7 +70,7 @@ func TestValidateParams(t *testing.T) {
 		revisionParam: "baz",
 	}
 
-	if err := resolver.ValidateParams(resolverContext(), toParams(paramsWithRevision)); err != nil {
+	if err := resolver.ValidateParams(context.Background(), toParams(paramsWithRevision)); err != nil {
 		t.Fatalf("unexpected error validating params: %v", err)
 	}
 }
@@ -84,7 +84,7 @@ func TestValidateParamsNotEnabled(t *testing.T) {
 		pathParam:     "bar",
 		revisionParam: "baz",
 	}
-	err = resolver.ValidateParams(context.Background(), toParams(someParams))
+	err = resolver.ValidateParams(resolverDisabledContext(), toParams(someParams))
 	if err == nil {
 		t.Fatalf("expected disabled err")
 	}
@@ -137,7 +137,7 @@ func TestValidateParams_Failure(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			resolver := &Resolver{}
-			err := resolver.ValidateParams(resolverContext(), toParams(tc.params))
+			err := resolver.ValidateParams(context.Background(), toParams(tc.params))
 			if err == nil {
 				t.Fatalf("got no error, but expected: %s", tc.expectedErr)
 			}
@@ -151,7 +151,7 @@ func TestValidateParams_Failure(t *testing.T) {
 func TestGetResolutionTimeoutDefault(t *testing.T) {
 	resolver := Resolver{}
 	defaultTimeout := 30 * time.Minute
-	timeout := resolver.GetResolutionTimeout(resolverContext(), defaultTimeout)
+	timeout := resolver.GetResolutionTimeout(context.Background(), defaultTimeout)
 	if timeout != defaultTimeout {
 		t.Fatalf("expected default timeout to be returned")
 	}
@@ -164,7 +164,7 @@ func TestGetResolutionTimeoutCustom(t *testing.T) {
 	config := map[string]string{
 		defaultTimeoutKey: configTimeout.String(),
 	}
-	ctx := framework.InjectResolverConfigToContext(resolverContext(), config)
+	ctx := framework.InjectResolverConfigToContext(context.Background(), config)
 	timeout := resolver.GetResolutionTimeout(ctx, defaultTimeout)
 	if timeout != configTimeout {
 		t.Fatalf("expected timeout from config to be returned")
@@ -180,7 +180,7 @@ func TestResolveNotEnabled(t *testing.T) {
 		pathParam:     "bar",
 		revisionParam: "baz",
 	}
-	_, err = resolver.Resolve(context.Background(), toParams(someParams))
+	_, err = resolver.Resolve(resolverDisabledContext(), toParams(someParams))
 	if err == nil {
 		t.Fatalf("expected disabled err")
 	}
@@ -739,8 +739,8 @@ func createRequest(args *params) *v1beta1.ResolutionRequest {
 	return rr
 }
 
-func resolverContext() context.Context {
-	return frtesting.ContextWithGitResolverEnabled(context.Background())
+func resolverDisabledContext() context.Context {
+	return frtesting.ContextWithGitResolverDisabled(context.Background())
 }
 
 func createError(msg string) error {

--- a/pkg/resolution/resolver/hub/resolver_test.go
+++ b/pkg/resolution/resolver/hub/resolver_test.go
@@ -33,7 +33,7 @@ import (
 
 func TestGetSelector(t *testing.T) {
 	resolver := Resolver{}
-	sel := resolver.GetSelector(resolverContext())
+	sel := resolver.GetSelector(context.Background())
 	if typ, has := sel[resolutioncommon.LabelKeyResolverType]; !has {
 		t.Fatalf("unexpected selector: %v", sel)
 	} else if typ != LabelValueHubResolverType {
@@ -101,7 +101,7 @@ func TestValidateParamsDisabled(t *testing.T) {
 		ParamVersion: "bar",
 		ParamCatalog: "baz",
 	}
-	err = resolver.ValidateParams(context.Background(), toParams(params))
+	err = resolver.ValidateParams(resolverDisabledContext(), toParams(params))
 	if err == nil {
 		t.Fatalf("expected missing name err")
 	}
@@ -299,7 +299,7 @@ func TestResolveDisabled(t *testing.T) {
 		ParamVersion: "bar",
 		ParamCatalog: "baz",
 	}
-	_, err = resolver.Resolve(context.Background(), toParams(params))
+	_, err = resolver.Resolve(resolverDisabledContext(), toParams(params))
 	if err == nil {
 		t.Fatalf("expected missing name err")
 	}
@@ -415,8 +415,8 @@ func TestResolve(t *testing.T) {
 	}
 }
 
-func resolverContext() context.Context {
-	return frtesting.ContextWithHubResolverEnabled(context.Background())
+func resolverDisabledContext() context.Context {
+	return frtesting.ContextWithHubResolverDisabled(context.Background())
 }
 
 func toParams(m map[string]string) []pipelinev1beta1.Param {
@@ -440,7 +440,7 @@ func contextWithConfig() context.Context {
 		"default-type":                          "artifact",
 	}
 
-	return framework.InjectResolverConfigToContext(resolverContext(), config)
+	return framework.InjectResolverConfigToContext(context.Background(), config)
 }
 
 func checkExpectedErr(expectedErr, actualErr error, t *testing.T) {


### PR DESCRIPTION
# Changes

In resolver feature flag [configmap](https://github.com/tektoncd/pipeline/blob/main/config/resolvers/config-feature-flags.yaml), by default all resolvers are enabled but in code the default value to enable resolvers is false. this is to fix them in the code.

/kind bug

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```

