### PR TITLE
[upgrade test] Change to Kind cluster and Unfixed upgrade test release version

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -257,8 +257,7 @@ upgrade to the current release, and validate whether the Tekton pipeline works.
 #### Prerequisites for running upgrade tests locally:
 - Set up the cluster
   - Running against a fresh kind cluster
-    - comment out the default [GKE clutser setup](https://github.com/tektoncd/pipeline/blob/d4c2f75e32a8657f486790da8d665019f5e0550b/test/e2e-tests-upgrade.sh#L32)
-    *TODO: future work on implementation of kind cluster setup https://github.com/tektoncd/pipeline/issues/5689 *
+    - export SKIP_INITIALIZE=true
 
   - Running against a GKE cluster
     - export PROJECT_ID=<my_gcp_project>

--- a/test/e2e-tests-upgrade.sh
+++ b/test/e2e-tests-upgrade.sh
@@ -31,7 +31,9 @@ PREVIOUS_PIPELINE_VERSION=$(curl -L -s -H 'Accept: application/json' $RELEASES |
 
 # Script entry point.
 
-initialize $@
+if [ "${SKIP_INITIALIZE}" != "true" ]; then
+  initialize $@
+fi
 
 header "Setting up environment"
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This commit changes the previous fixed release version input to fetching the latest release version.
The second commit adds the SKIP_INITIALIZE condition which enables running upgrade test against
a kind cluster.

/kind cleanup
Part of #5193
Fixes #5689 
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [n/a] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [na] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [n/a] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
