### PR TITLE
Add finallystarttime to PipelineRun status docs

### DIFF
--- a/docs/pipelineruns.md
+++ b/docs/pipelineruns.md
@@ -1387,6 +1387,8 @@ Your `PipelineRun`'s `status` field can contain the following fields:
     - [`apiVersion`][kubernetes-overview] - The API version for the underlying `TaskRun` or `Run`.
     - [`whenExpressions`](pipelines.md#guard-task-execution-using-when-expressions) - The list of when expressions guarding the execution of this task.
   - `provenance` - Metadata about resources used in the PipelineRun such as the source from where a remote pipeline definition was fetched.
+  - `finallyStartTime`- The time at which the PipelineRun's `finally` Tasks, if any, began
+  executing, in [RFC3339](https://tools.ietf.org/html/rfc3339) format.
 
 ### Configuring usage of `TaskRun` and `Run` embedded statuses
 


### PR DESCRIPTION
# Changes
This commit adds details on `finallyStartTime` to PipelineRun documentation.
/kind documentation
Closes #4660

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- n/a Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- n/a Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- n/a Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
