### PR TITLE
Add conversion config to ResolutionRequest CRD

### DIFF
--- a/config/300-resolutionrequest.yaml
+++ b/config/300-resolutionrequest.yaml
@@ -91,3 +91,11 @@ spec:
         - name: EndTime
           type: string
           jsonPath: .status.conditions[?(@.type=='Succeeded')].lastTransitionTime
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1alpha1", "v1beta1"]
+      clientConfig:
+        service:
+          name: tekton-pipelines-webhook
+          namespace: tekton-pipelines


### PR DESCRIPTION
# Changes

Fixes #5741

I missed this earlier, which led to error messages in the webhook logs and conversion from `v1alpha1.ResolutionRequest` to `v1beta1.Resolutionrequest` not actually working.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Properly configures conversion from v1alpha1.ResolutionRequest to v1beta1.ResolutionRequest
```
