### PR TITLE
feat:support to extract failed task results

### DIFF
--- a/pkg/pod/status.go
+++ b/pkg/pod/status.go
@@ -203,7 +203,7 @@ func setTaskRunStatusBasedOnStepStatus(ctx context.Context, logger *zap.SugaredL
 				}
 
 				taskResults, pipelineResourceResults, filteredResults := filterResultsAndResources(results, specResults)
-				if tr.IsSuccessful() {
+				if tr.IsDone() {
 					trs.TaskRunResults = append(trs.TaskRunResults, taskResults...)
 					trs.ResourcesResult = append(trs.ResourcesResult, pipelineResourceResults...)
 				}

--- a/pkg/pod/status_test.go
+++ b/pkg/pod/status_test.go
@@ -811,6 +811,40 @@ func TestMakeTaskRunStatus(t *testing.T) {
 			},
 		},
 	}, {
+		desc: "the failed task show task results",
+		podStatus: corev1.PodStatus{
+			Phase: corev1.PodFailed,
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name: "step-task-result",
+				State: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{
+						Message: `[{"key":"resultName","value":"resultValue", "type":1}]`,
+					},
+				},
+			}},
+		},
+		want: v1beta1.TaskRunStatus{
+			Status: statusFailure(v1beta1.TaskRunReasonFailed.String(), "build failed for unspecified reasons."),
+			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+				Steps: []v1beta1.StepState{{
+					ContainerState: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							Message: `[{"key":"resultName","value":"resultValue","type":1}]`,
+						},
+					},
+					Name:          "task-result",
+					ContainerName: "step-task-result",
+				}},
+				Sidecars:       []v1beta1.SidecarState{},
+				CompletionTime: &metav1.Time{Time: time.Now()},
+				TaskRunResults: []v1beta1.TaskRunResult{{
+					Name:  "resultName",
+					Type:  v1beta1.ResultsTypeString,
+					Value: *v1beta1.NewStructuredValues("resultValue"),
+				}},
+			},
+		},
+	}, {
 		desc: "taskrun status set to failed if task fails",
 		podStatus: corev1.PodStatus{
 			Phase: corev1.PodFailed,

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -6392,11 +6392,20 @@ spec:
       operator: in
       values:
       - aResultValue
+  - name: final-task-7
+    params:
+    - name: finalParam
+      value: $(tasks.dag-task-3.results.aResult)
+    taskRef:
+      name: final-task
   tasks:
   - name: dag-task-1
     taskRef:
       name: dag-task
   - name: dag-task-2
+    taskRef:
+      name: dag-task
+  - name: dag-task-3
     taskRef:
       name: dag-task
 `)}
@@ -6459,6 +6468,23 @@ status:
   - lastTransitionTime: null
     status: "False"
     type: Succeeded
+`),
+		mustParseTaskRunWithObjectMeta(t,
+			taskRunObjectMeta("test-pipeline-run-final-task-results-dag-task-3-xxyyy", "foo",
+				"test-pipeline-run-final-task-results", "test-pipeline", "dag-task-3", false),
+			`
+spec:
+  serviceAccountName: test-sa
+  taskRef:
+    name: hello-world
+status:
+  conditions:
+  - lastTransitionTime: null
+    status: "False"
+    type: Succeeded
+  taskResults:
+  - name: aResult
+    value: aResultValue
 `),
 	}
 

--- a/pkg/reconciler/pipelinerun/resources/resultrefresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/resultrefresolution.go
@@ -146,8 +146,8 @@ func resolveResultRef(pipelineState PipelineRunState, resultRef *v1beta1.ResultR
 	if referencedPipelineTask == nil {
 		return nil, resultRef.PipelineTask, fmt.Errorf("could not find task %q referenced by result", resultRef.PipelineTask)
 	}
-	if !referencedPipelineTask.isSuccessful() {
-		return nil, resultRef.PipelineTask, fmt.Errorf("task %q referenced by result was not successful", referencedPipelineTask.PipelineTask.Name)
+	if !referencedPipelineTask.isSuccessful() && !referencedPipelineTask.isFailure() {
+		return nil, resultRef.PipelineTask, fmt.Errorf("task %q referenced by result was not finished", referencedPipelineTask.PipelineTask.Name)
 	}
 
 	var runName, runValue, taskRunName string

--- a/pkg/reconciler/pipelinerun/resources/resultrefresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/resultrefresolution_test.go
@@ -377,7 +377,7 @@ func TestTaskParamResolver_ResolveResultRefs(t *testing.T) {
 		want:    nil,
 		wantErr: true,
 	}, {
-		name: "failed resolution: using result reference to a failed task",
+		name: "failed resolution: using result reference to a failed task with no results",
 		pipelineRunState: PipelineRunState{{
 			TaskRunName: "aTaskRun",
 			TaskRun: &v1beta1.TaskRun{
@@ -460,6 +460,42 @@ func TestTaskParamResolver_ResolveResultRefs(t *testing.T) {
 		},
 		want:    nil,
 		wantErr: true,
+	}, {
+		name: "successful resolution: using result reference to a failed task with some results",
+		pipelineRunState: PipelineRunState{{
+			TaskRunName: "aTaskRun",
+			TaskRun: &v1beta1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{Name: "aTaskRun"},
+				Status: v1beta1.TaskRunStatus{
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{failedCondition},
+					},
+					TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+						TaskRunResults: []v1beta1.TaskRunResult{{
+							Name:  "aResult",
+							Value: *v1beta1.NewStructuredValues("aResultValue"),
+						}},
+					},
+				},
+			},
+			PipelineTask: &v1beta1.PipelineTask{
+				Name:    "aTask",
+				TaskRef: &v1beta1.TaskRef{Name: "aTask"},
+			},
+		}},
+		param: v1beta1.Param{
+			Name:  "targetParam",
+			Value: *v1beta1.NewStructuredValues("$(tasks.aTask.results.aResult)"),
+		},
+		want: ResolvedResultRefs{{
+			Value: *v1beta1.NewStructuredValues("aResultValue"),
+			ResultReference: v1beta1.ResultRef{
+				PipelineTask: "aTask",
+				Result:       "aResult",
+			},
+			FromTaskRun: "aTaskRun",
+		}},
+		wantErr: false,
 	}} {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Logf("test name: %s\n", tt.name)


### PR DESCRIPTION
# Changes

If the task fails or succeeds, as long as the task result is output, it can be successfully parsed and can be referenced by the fianl task.

This commit will enable the failed task to parse the task results, and the final task can reference it.

Please see detailed description: #5749

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
PipelineRun can parse task results from failed tasks, and the final task can reference it.
```