### PR TITLE
fix knative downstream tests

### DIFF
--- a/hack/setup-temporary-gopath.sh
+++ b/hack/setup-temporary-gopath.sh
@@ -8,7 +8,7 @@ set -o nounset
 # the current repo directory is not within GOPATH.
 function shim_gopath() {
   local REPO_DIR=$(git rev-parse --show-toplevel)
-  local TEMP_GOPATH="${REPO_DIR}/.gopath"
+  local TEMP_GOPATH="/tmp/.gopath"
   local TEMP_TEKTONCD="${TEMP_GOPATH}/src/github.com/tektoncd"
   local TEMP_PIPELINE="${TEMP_TEKTONCD}/pipeline"
   local NEEDS_MOVE=1
@@ -40,7 +40,7 @@ function shim_gopath() {
 
   mkdir -p "$TEMP_TEKTONCD"
   # This will create a symlink from
-  # (repo-root)/.gopath/src/github.com/tektoncd/pipeline
+  # /tmp/.gopath/src/github.com/tektoncd/pipeline
   # to the user's pipeline checkout.
   ln -s "$REPO_DIR" "$TEMP_PIPELINE"
   echo "Moving to $TEMP_PIPELINE"
@@ -59,7 +59,7 @@ function shim_gopath() {
 # script's execution we just print a message to let them know.
 function shim_gopath_clean() {
   local REPO_DIR=$(git rev-parse --show-toplevel)
-  local TEMP_GOPATH="${REPO_DIR}/.gopath"
+  local TEMP_GOPATH="/tmp/.gopath"
   if [ -d "$TEMP_GOPATH" ] ; then
     # Put the user back at the root of the pipelines repo
     # after all the symlink shenanigans.
@@ -74,7 +74,7 @@ function shim_gopath_clean() {
 # Delete the temp symlink to pipelines repo from the temp GOPATH dir.
 function delete_pipeline_repo_symlink() {
   local REPO_DIR=$(git rev-parse --show-toplevel)
-  local TEMP_GOPATH="${REPO_DIR}/.gopath"
+  local TEMP_GOPATH="/tmp/.gopath"
   if [ -d "$TEMP_GOPATH" ] ; then
     local REPO_SYMLINK="${TEMP_GOPATH}/src/github.com/tektoncd/pipeline"
     if [ -L $REPO_SYMLINK ] ; then

--- a/hack/setup-temporary-gopath.sh
+++ b/hack/setup-temporary-gopath.sh
@@ -8,7 +8,7 @@ set -o nounset
 # the current repo directory is not within GOPATH.
 function shim_gopath() {
   local REPO_DIR=$(git rev-parse --show-toplevel)
-  local TEMP_GOPATH="/tmp/.gopath"
+  local TEMP_GOPATH="$(mktemp -d)/.gopath"
   local TEMP_TEKTONCD="${TEMP_GOPATH}/src/github.com/tektoncd"
   local TEMP_PIPELINE="${TEMP_TEKTONCD}/pipeline"
   local NEEDS_MOVE=1
@@ -40,7 +40,7 @@ function shim_gopath() {
 
   mkdir -p "$TEMP_TEKTONCD"
   # This will create a symlink from
-  # /tmp/.gopath/src/github.com/tektoncd/pipeline
+  # $(mktemp -d)/.gopath/src/github.com/tektoncd/pipeline
   # to the user's pipeline checkout.
   ln -s "$REPO_DIR" "$TEMP_PIPELINE"
   echo "Moving to $TEMP_PIPELINE"
@@ -59,7 +59,7 @@ function shim_gopath() {
 # script's execution we just print a message to let them know.
 function shim_gopath_clean() {
   local REPO_DIR=$(git rev-parse --show-toplevel)
-  local TEMP_GOPATH="/tmp/.gopath"
+  local TEMP_GOPATH="$(mktemp -d)/.gopath"
   if [ -d "$TEMP_GOPATH" ] ; then
     # Put the user back at the root of the pipelines repo
     # after all the symlink shenanigans.
@@ -74,7 +74,7 @@ function shim_gopath_clean() {
 # Delete the temp symlink to pipelines repo from the temp GOPATH dir.
 function delete_pipeline_repo_symlink() {
   local REPO_DIR=$(git rev-parse --show-toplevel)
-  local TEMP_GOPATH="/tmp/.gopath"
+  local TEMP_GOPATH="$(mktemp -d)/.gopath"
   if [ -d "$TEMP_GOPATH" ] ; then
     local REPO_SYMLINK="${TEMP_GOPATH}/src/github.com/tektoncd/pipeline"
     if [ -L $REPO_SYMLINK ] ; then


### PR DESCRIPTION
Signed-off-by: Jason Hall <jason@chainguard.dev>

/assign vdemeester

cc @dprotaso @cardil 

# Changes

This moves the temp gopath to a location outside the repo, so that knative's `go-ls-tags` doesn't consider it when determining which tags to build for.

/kind cleanup

Might fix https://github.com/knative/actions/issues/86

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```

PR friction log:
- unit test flake (timeout didn't happen): https://prow.tekton.dev/view/gs/tekton-prow/pr-logs/pull/tektoncd_pipeline/5763/pull-tekton-pipeline-unit-tests/1593602003307597824
- e2e test flake (ghcr.io failure trying to publish images): https://prow.tekton.dev/view/gs/tekton-prow/pr-logs/pull/tektoncd_pipeline/5763/pull-tekton-pipeline-alpha-integration-tests/1593602003462787072
- unit test flake (cloud events): https://prow.tekton.dev/view/gs/tekton-prow/pr-logs/pull/tektoncd_pipeline/5763/pull-tekton-pipeline-unit-tests/1593634438405689344