### PR TITLE
Bring `Retries` and `RetriesStatus` back

### DIFF
--- a/docs/pipeline-api.md
+++ b/docs/pipeline-api.md
@@ -7076,6 +7076,18 @@ CustomRunSpecStatusMessage
 </tr>
 <tr>
 <td>
+<code>retries</code><br/>
+<em>
+int
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Used for propagating retries count to custom tasks</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>serviceAccountName</code><br/>
 <em>
 string
@@ -8318,6 +8330,18 @@ CustomRunSpecStatusMessage
 <td>
 <em>(Optional)</em>
 <p>Status message for cancellation.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>retries</code><br/>
+<em>
+int
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Used for propagating retries count to custom tasks</p>
 </td>
 </tr>
 <tr>
@@ -13905,6 +13929,20 @@ Kubernetes meta/v1.Time
 <em>(Optional)</em>
 <p>Results reports any output result values to be consumed by later
 tasks in a pipeline.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>retriesStatus</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.CustomRunStatus">
+[]CustomRunStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>RetriesStatus contains the history of CustomRunStatus, in case of a retry.</p>
 </td>
 </tr>
 <tr>

--- a/pkg/apis/pipeline/v1beta1/customrun_types.go
+++ b/pkg/apis/pipeline/v1beta1/customrun_types.go
@@ -64,6 +64,10 @@ type CustomRunSpec struct {
 	// +optional
 	StatusMessage CustomRunSpecStatusMessage `json:"statusMessage,omitempty"`
 
+	// Used for propagating retries count to custom tasks
+	// +optional
+	Retries int `json:"retries,omitempty"`
+
 	// +optional
 	ServiceAccountName string `json:"serviceAccountName"`
 

--- a/pkg/apis/pipeline/v1beta1/customrun_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/customrun_types_test.go
@@ -198,6 +198,7 @@ kind: CustomRun
 metadata:
   name: run
 spec:
+  retries: 3
   customRef:
     apiVersion: example.dev/v0
     kind: Example
@@ -227,6 +228,7 @@ status:
 			Name: "run",
 		},
 		Spec: v1beta1.CustomRunSpec{
+			Retries: 3,
 			CustomRef: &v1beta1.TaskRef{
 				APIVersion: "example.dev/v0",
 				Kind:       "Example",

--- a/pkg/apis/pipeline/v1beta1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1beta1/openapi_generated.go
@@ -803,6 +803,13 @@ func schema_pkg_apis_pipeline_v1beta1_CustomRunSpec(ref common.ReferenceCallback
 							Format:      "",
 						},
 					},
+					"retries": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Used for propagating retries count to custom tasks",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 					"serviceAccountName": {
 						SchemaProps: spec.SchemaProps{
 							Default: "",

--- a/pkg/apis/pipeline/v1beta1/swagger.json
+++ b/pkg/apis/pipeline/v1beta1/swagger.json
@@ -525,6 +525,11 @@
           },
           "x-kubernetes-list-type": "atomic"
         },
+        "retries": {
+          "description": "Used for propagating retries count to custom tasks",
+          "type": "integer",
+          "format": "int32"
+        },
         "serviceAccountName": {
           "type": "string",
           "default": ""

--- a/pkg/apis/run/v1beta1/customrunstatus_types.go
+++ b/pkg/apis/run/v1beta1/customrunstatus_types.go
@@ -57,6 +57,10 @@ type CustomRunStatusFields struct {
 	// +optional
 	Results []CustomRunResult `json:"results,omitempty"`
 
+	// RetriesStatus contains the history of CustomRunStatus, in case of a retry.
+	// +optional
+	RetriesStatus []CustomRunStatus `json:"retriesStatus,omitempty"`
+
 	// ExtraFields holds arbitrary fields provided by the custom task
 	// controller.
 	ExtraFields runtime.RawExtension `json:"extraFields,omitempty"`

--- a/test/artifact_bucket_test.go
+++ b/test/artifact_bucket_test.go
@@ -147,9 +147,9 @@ metadata:
 spec:
   params:
   - name: Url
-	value: https://github.com/pivotal-nader-ziada/gohelloworld
+    value: https://github.com/pivotal-nader-ziada/gohelloworld
   - name: Revision
-	value: master
+    value: master
   type: git
 `, helloworldResourceName))
 	if _, err := c.V1alpha1PipelineResourceClient.Create(ctx, helloworldResource, metav1.CreateOptions{}); err != nil {


### PR DESCRIPTION
# Changes

Prior to this PR, we excluded the `Retries` and `RetriesStatus` (in https://github.com/tektoncd/pipeline/pull/5662, https://github.com/tektoncd/pipeline/pull/5662) because we were not sure what decisions would be make in TEP-0121, Now that we've decided to keep both in TEP-0121, we can safely release Custom Task Beta with them.

/kind feature

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
