### PR TITLE
fix flaky k8s event tests  with new fakerecorder

### DIFF
--- a/pkg/controller/filter_test.go
+++ b/pkg/controller/filter_test.go
@@ -24,9 +24,9 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	fakeruninformer "github.com/tektoncd/pipeline/pkg/client/injection/informers/pipeline/v1alpha1/run/fake"
 	"github.com/tektoncd/pipeline/pkg/controller"
+	eventstest "github.com/tektoncd/pipeline/test/events"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	rtesting "knative.dev/pkg/reconciler/testing"
 )
 
 const (
@@ -462,7 +462,7 @@ func TestFilterOwnerRunRef(t *testing.T) {
 		want: false,
 	}} {
 		t.Run(c.desc, func(t *testing.T) {
-			ctx, _ := rtesting.SetupFakeContext(t)
+			ctx, _ := eventstest.SetupFakeContext(t)
 			runInformer := fakeruninformer.Get(ctx)
 			if c.owner != nil {
 				if err := runInformer.Informer().GetIndexer().Add(c.owner); err != nil {

--- a/pkg/reconciler/customrun/customrun_test.go
+++ b/pkg/reconciler/customrun/customrun_test.go
@@ -28,11 +28,11 @@ import (
 	"github.com/tektoncd/pipeline/pkg/reconciler/events/cloudevent"
 	ttesting "github.com/tektoncd/pipeline/pkg/reconciler/testing"
 	"github.com/tektoncd/pipeline/test"
+	eventstest "github.com/tektoncd/pipeline/test/events"
 	"github.com/tektoncd/pipeline/test/names"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/tools/record"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	cminformer "knative.dev/pkg/configmap/informer"
@@ -65,7 +65,7 @@ func initializeCustomRunControllerAssets(t *testing.T, d test.Data) (test.Assets
 		Controller: ctl,
 		Clients:    c,
 		Informers:  informers,
-		Recorder:   controller.GetEventRecorder(ctx).(*record.FakeRecorder),
+		Recorder:   controller.GetEventRecorder(ctx).(*eventstest.FakeRecorder),
 		Ctx:        ctx,
 	}, cancel
 }

--- a/pkg/reconciler/events/cloudevent/cloud_event_controller_test.go
+++ b/pkg/reconciler/events/cloudevent/cloud_event_controller_test.go
@@ -29,13 +29,11 @@ import (
 	eventstest "github.com/tektoncd/pipeline/test/events"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/tools/record"
 	clock "k8s.io/utils/clock/testing"
 	"knative.dev/pkg/apis"
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
-	rtesting "knative.dev/pkg/reconciler/testing"
 )
 
 var now = time.Date(2022, time.January, 1, 0, 0, 0, 0, time.UTC)
@@ -620,8 +618,8 @@ func TestSendCloudEventWithRetries(t *testing.T) {
 			}
 			ceClient := Get(ctx).(FakeClient)
 			ceClient.CheckCloudEventsUnordered(t, tc.name, tc.wantCEvents)
-			recorder := controller.GetEventRecorder(ctx).(*record.FakeRecorder)
-			if err := eventstest.CheckEventsOrdered(t, recorder.Events, tc.name, tc.wantEvents); err != nil {
+			recorder := controller.GetEventRecorder(ctx).(*eventstest.FakeRecorder)
+			if err := recorder.CheckEventsOrdered(t, recorder.Events, tc.name, tc.wantEvents); err != nil {
 				t.Fatalf(err.Error())
 			}
 		})
@@ -679,7 +677,7 @@ func TestSendCloudEventWithRetriesNoClient(t *testing.T) {
 
 func setupFakeContext(t *testing.T, behaviour FakeClientBehaviour, withClient bool, expectedEventCount int) context.Context {
 	var ctx context.Context
-	ctx, _ = rtesting.SetupFakeContext(t)
+	ctx, _ = eventstest.SetupFakeContext(t)
 	if withClient {
 		ctx = WithClient(ctx, &behaviour, expectedEventCount)
 	}

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -56,7 +56,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ktesting "k8s.io/client-go/testing"
-	"k8s.io/client-go/tools/record"
 	clock "k8s.io/utils/clock/testing"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
@@ -153,7 +152,7 @@ func initializePipelineRunControllerAssets(t *testing.T, d test.Data, opts pipel
 		Clients:    c,
 		Controller: ctl,
 		Informers:  informers,
-		Recorder:   controller.GetEventRecorder(ctx).(*record.FakeRecorder),
+		Recorder:   controller.GetEventRecorder(ctx).(*eventstest.FakeRecorder),
 		Ctx:        ctx,
 	}, cancel
 }
@@ -2952,7 +2951,7 @@ spec:
 				"Normal PipelineRunCouldntCancel PipelineRun \"test-pipeline-fails-to-cancel\" was cancelled but had errors trying to cancel TaskRuns",
 				"Warning InternalError 1 error occurred",
 			}
-			err = eventstest.CheckEventsOrdered(t, testAssets.Recorder.Events, prName, wantEvents)
+			err = testAssets.Recorder.CheckEventsOrdered(t, testAssets.Recorder.Events, prName, wantEvents)
 			if err != nil {
 				t.Errorf(err.Error())
 			}
@@ -3068,7 +3067,7 @@ spec:
 		"Normal PipelineRunCouldntTimeOut PipelineRun \"test-pipeline-fails-to-timeout\" was timed out but had errors trying to time out TaskRuns and/or Runs",
 		"Warning InternalError 1 error occurred",
 	}
-	err = eventstest.CheckEventsOrdered(t, testAssets.Recorder.Events, prName, wantEvents)
+	err = testAssets.Recorder.CheckEventsOrdered(t, testAssets.Recorder.Events, prName, wantEvents)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
@@ -7083,7 +7082,7 @@ func (prt PipelineRunTest) reconcileRun(namespace, pipelineRunName string, wantE
 
 	// Check generated events match what's expected
 	if len(wantEvents) > 0 {
-		if err := eventstest.CheckEventsOrdered(prt.Test, prt.TestAssets.Recorder.Events, pipelineRunName, wantEvents); err != nil {
+		if err := prt.TestAssets.Recorder.CheckEventsOrdered(prt.Test, prt.TestAssets.Recorder.Events, pipelineRunName, wantEvents); err != nil {
 			prt.Test.Errorf(err.Error())
 		}
 	}

--- a/pkg/reconciler/resolutionrequest/resolutionrequest_test.go
+++ b/pkg/reconciler/resolutionrequest/resolutionrequest_test.go
@@ -29,11 +29,11 @@ import (
 	resolutioncommon "github.com/tektoncd/pipeline/pkg/resolution/common"
 	"github.com/tektoncd/pipeline/test"
 	"github.com/tektoncd/pipeline/test/diff"
+	eventstest "github.com/tektoncd/pipeline/test/events"
 	"github.com/tektoncd/pipeline/test/names"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/tools/record"
 	clock "k8s.io/utils/clock/testing"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
@@ -79,7 +79,7 @@ func initializeResolutionRequestControllerAssets(t *testing.T, d test.Data) (tes
 		Controller: ctl,
 		Clients:    c,
 		Informers:  informers,
-		Recorder:   controller.GetEventRecorder(ctx).(*record.FakeRecorder),
+		Recorder:   controller.GetEventRecorder(ctx).(*eventstest.FakeRecorder),
 		Ctx:        ctx,
 	}, cancel
 }

--- a/pkg/reconciler/run/run_test.go
+++ b/pkg/reconciler/run/run_test.go
@@ -32,11 +32,11 @@ import (
 	"github.com/tektoncd/pipeline/pkg/reconciler/events/cloudevent"
 	ttesting "github.com/tektoncd/pipeline/pkg/reconciler/testing"
 	"github.com/tektoncd/pipeline/test"
+	eventstest "github.com/tektoncd/pipeline/test/events"
 	"github.com/tektoncd/pipeline/test/names"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/tools/record"
 	"knative.dev/pkg/apis"
 	cminformer "knative.dev/pkg/configmap/informer"
 	pkgreconciler "knative.dev/pkg/reconciler"
@@ -67,7 +67,7 @@ func initializeRunControllerAssets(t *testing.T, d test.Data) (test.Assets, func
 		Controller: ctl,
 		Clients:    c,
 		Informers:  informers,
-		Recorder:   controller.GetEventRecorder(ctx).(*record.FakeRecorder),
+		Recorder:   controller.GetEventRecorder(ctx).(*eventstest.FakeRecorder),
 		Ctx:        ctx,
 	}, cancel
 }

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -60,7 +60,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
 	ktesting "k8s.io/client-go/testing"
-	"k8s.io/client-go/tools/record"
 	clock "k8s.io/utils/clock/testing"
 	"knative.dev/pkg/apis"
 	cminformer "knative.dev/pkg/configmap/informer"
@@ -497,7 +496,7 @@ func initializeTaskRunControllerAssets(t *testing.T, d test.Data, opts pipeline.
 		Controller: ctl,
 		Clients:    c,
 		Informers:  informers,
-		Recorder:   controller.GetEventRecorder(ctx).(*record.FakeRecorder),
+		Recorder:   controller.GetEventRecorder(ctx).(*eventstest.FakeRecorder),
 		Ctx:        ctx,
 	}, cancel
 }
@@ -701,7 +700,7 @@ spec:
 		t.Errorf("Expected reason %q but was %s", v1beta1.TaskRunReasonRunning.String(), condition.Reason)
 	}
 
-	err = eventstest.CheckEventsOrdered(t, testAssets.Recorder.Events, "reconcile-cloud-events", wantEvents)
+	err = testAssets.Recorder.CheckEventsOrdered(t, testAssets.Recorder.Events, "reconcile-cloud-events", wantEvents)
 	if !(err == nil) {
 		t.Errorf(err.Error())
 	}
@@ -1193,7 +1192,7 @@ spec:
 				t.Fatalf("Expected actions to be logged in the kubeclient, got none")
 			}
 
-			err = eventstest.CheckEventsOrdered(t, testAssets.Recorder.Events, tc.name, tc.wantEvents)
+			err = testAssets.Recorder.CheckEventsOrdered(t, testAssets.Recorder.Events, tc.name, tc.wantEvents)
 			if err != nil {
 				t.Errorf(err.Error())
 			}
@@ -1348,7 +1347,7 @@ spec:
 				t.Fatalf("Expected actions to be logged in the kubeclient, got none")
 			}
 
-			err = eventstest.CheckEventsOrdered(t, testAssets.Recorder.Events, tc.name, tc.wantEvents)
+			err = testAssets.Recorder.CheckEventsOrdered(t, testAssets.Recorder.Events, tc.name, tc.wantEvents)
 			if err != nil {
 				t.Errorf(err.Error())
 			}
@@ -1687,7 +1686,7 @@ spec:
 				t.Errorf("expected 2 actions, got %d. Actions: %#v", len(actions), actions)
 			}
 
-			err := eventstest.CheckEventsOrdered(t, testAssets.Recorder.Events, tc.name, tc.wantEvents)
+			err := testAssets.Recorder.CheckEventsOrdered(t, testAssets.Recorder.Events, tc.name, tc.wantEvents)
 			if !(err == nil) {
 				t.Errorf(err.Error())
 			}
@@ -1965,7 +1964,7 @@ status:
 		"Normal Running Not all Steps",
 		"Normal Succeeded",
 	}
-	err = eventstest.CheckEventsOrdered(t, testAssets.Recorder.Events, "test-reconcile-pod-updateStatus", wantEvents)
+	err = testAssets.Recorder.CheckEventsOrdered(t, testAssets.Recorder.Events, "test-reconcile-pod-updateStatus", wantEvents)
 	if !(err == nil) {
 		t.Errorf(err.Error())
 	}
@@ -2064,7 +2063,7 @@ status:
 		"Normal Started",
 		"Warning Failed TaskRun \"test-taskrun-run-cancelled\" was cancelled",
 	}
-	err = eventstest.CheckEventsOrdered(t, testAssets.Recorder.Events, "test-reconcile-on-cancelled-taskrun", wantEvents)
+	err = testAssets.Recorder.CheckEventsOrdered(t, testAssets.Recorder.Events, "test-reconcile-on-cancelled-taskrun", wantEvents)
 	if !(err == nil) {
 		t.Errorf(err.Error())
 	}
@@ -2137,7 +2136,7 @@ status:
 		"Normal Started",
 		"Warning Failed TaskRun \"test-taskrun-run-timedout\" was cancelled. TaskRun cancelled as pipeline has been cancelled.",
 	}
-	err = eventstest.CheckEventsOrdered(t, testAssets.Recorder.Events, "test-reconcile-on-timedout-taskrun", wantEvents)
+	err = testAssets.Recorder.CheckEventsOrdered(t, testAssets.Recorder.Events, "test-reconcile-on-timedout-taskrun", wantEvents)
 	if !(err == nil) {
 		t.Errorf(err.Error())
 	}
@@ -2208,7 +2207,7 @@ status:
 	if d := cmp.Diff(expectedStatus, condition, ignoreLastTransitionTime); d != "" {
 		t.Fatalf("Did not get expected condition %s", diff.PrintWantGot(d))
 	}
-	err = eventstest.CheckEventsOrdered(t, testAssets.Recorder.Events, taskRun.Name, wantEvents)
+	err = testAssets.Recorder.CheckEventsOrdered(t, testAssets.Recorder.Events, taskRun.Name, wantEvents)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
@@ -2280,7 +2279,7 @@ status:
 	if d := cmp.Diff(expectedStatus, condition, ignoreLastTransitionTime); d != "" {
 		t.Fatalf("Did not get expected condition %s", diff.PrintWantGot(d))
 	}
-	err = eventstest.CheckEventsOrdered(t, testAssets.Recorder.Events, taskRun.Name, wantEvents)
+	err = testAssets.Recorder.CheckEventsOrdered(t, testAssets.Recorder.Events, taskRun.Name, wantEvents)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
@@ -2395,7 +2394,7 @@ status:
 			if d := cmp.Diff(tc.expectedStatus, condition, ignoreLastTransitionTime); d != "" {
 				t.Fatalf("Did not get expected condition %s", diff.PrintWantGot(d))
 			}
-			err = eventstest.CheckEventsOrdered(t, testAssets.Recorder.Events, tc.taskRun.Name, tc.wantEvents)
+			err = testAssets.Recorder.CheckEventsOrdered(t, testAssets.Recorder.Events, tc.taskRun.Name, tc.wantEvents)
 			if !(err == nil) {
 				t.Errorf(err.Error())
 			}
@@ -3543,7 +3542,7 @@ spec:
 				}
 			}
 
-			err = eventstest.CheckEventsOrdered(t, testAssets.Recorder.Events, tt.desc, tt.wantEvents)
+			err = testAssets.Recorder.CheckEventsOrdered(t, testAssets.Recorder.Events, tt.desc, tt.wantEvents)
 			if !(err == nil) {
 				t.Errorf(err.Error())
 			}

--- a/pkg/reconciler/testing/logger.go
+++ b/pkg/reconciler/testing/logger.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	eventstest "github.com/tektoncd/pipeline/test/events"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/record"
 	filteredinformerfactory "knative.dev/pkg/client/injection/kube/informers/factory/filtered"
 	"knative.dev/pkg/injection"
 	logtesting "knative.dev/pkg/logging/testing"
@@ -56,7 +56,7 @@ func TestLogger(t *testing.T) *zap.SugaredLogger {
 // The provided context includes the FilteredInformerFactory LabelKey.
 func setupFakeContextWithLabelKey(t zaptest.TestingT) (context.Context, context.CancelFunc, []controller.Informer) {
 	ctx, c := context.WithCancel(logtesting.TestContextWithLogger(t))
-	ctx = controller.WithEventRecorder(ctx, record.NewFakeRecorder(1000))
+	ctx = controller.WithEventRecorder(ctx, eventstest.NewFakeRecorder(1000))
 	ctx = filteredinformerfactory.WithSelectors(ctx, v1beta1.ManagedByLabelKey)
 	ctx, is := injection.Fake.SetupInformers(ctx, &rest.Config{})
 	return ctx, c, is

--- a/pkg/resolution/resolver/framework/reconciler_test.go
+++ b/pkg/resolution/resolver/framework/reconciler_test.go
@@ -32,10 +32,10 @@ import (
 	resolutioncommon "github.com/tektoncd/pipeline/pkg/resolution/common"
 	"github.com/tektoncd/pipeline/test"
 	"github.com/tektoncd/pipeline/test/diff"
+	eventstest "github.com/tektoncd/pipeline/test/events"
 	"github.com/tektoncd/pipeline/test/names"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/tools/record"
 	clock "k8s.io/utils/clock/testing"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
@@ -267,7 +267,7 @@ func getResolverFrameworkController(ctx context.Context, t *testing.T, d test.Da
 		Controller: ctl,
 		Clients:    c,
 		Informers:  informers,
-		Recorder:   controller.GetEventRecorder(ctx).(*record.FakeRecorder),
+		Recorder:   controller.GetEventRecorder(ctx).(*eventstest.FakeRecorder),
 		Ctx:        ctx,
 	}, cancel
 }

--- a/pkg/resolution/resolver/framework/testing/fakecontroller.go
+++ b/pkg/resolution/resolver/framework/testing/fakecontroller.go
@@ -30,11 +30,11 @@ import (
 	"github.com/tektoncd/pipeline/pkg/resolution/resolver/framework"
 	"github.com/tektoncd/pipeline/test"
 	"github.com/tektoncd/pipeline/test/diff"
+	eventstest "github.com/tektoncd/pipeline/test/events"
 	"github.com/tektoncd/pipeline/test/names"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/tools/record"
 	testclock "k8s.io/utils/clock/testing"
 	"knative.dev/pkg/apis"
 	cminformer "knative.dev/pkg/configmap/informer"
@@ -137,7 +137,7 @@ func initializeResolverFrameworkControllerAssets(ctx context.Context, t *testing
 		Controller: ctl,
 		Clients:    c,
 		Informers:  informers,
-		Recorder:   controller.GetEventRecorder(ctx).(*record.FakeRecorder),
+		Recorder:   controller.GetEventRecorder(ctx).(*eventstest.FakeRecorder),
 		Ctx:        ctx,
 	}, cancel
 }

--- a/test/controller.go
+++ b/test/controller.go
@@ -48,6 +48,7 @@ import (
 	fakeresourceclient "github.com/tektoncd/pipeline/pkg/client/resource/injection/client/fake"
 	fakeresourceinformer "github.com/tektoncd/pipeline/pkg/client/resource/injection/informers/resource/v1alpha1/pipelineresource/fake"
 	cloudeventclient "github.com/tektoncd/pipeline/pkg/reconciler/events/cloudevent"
+	eventstest "github.com/tektoncd/pipeline/test/events"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
@@ -58,7 +59,6 @@ import (
 	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
 	ktesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/tools/record"
 	fakekubeclient "knative.dev/pkg/client/injection/kube/client/fake"
 	fakeconfigmapinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/configmap/fake"
 	fakelimitrangeinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/limitrange/fake"
@@ -120,7 +120,7 @@ type Assets struct {
 	Controller *controller.Impl
 	Clients    Clients
 	Informers  Informers
-	Recorder   *record.FakeRecorder
+	Recorder   *eventstest.FakeRecorder
 	Ctx        context.Context
 }
 

--- a/test/events/events.go
+++ b/test/events/events.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,15 +19,13 @@ import (
 	"fmt"
 	"regexp"
 	"testing"
-	"time"
 )
 
 // CheckEventsOrdered checks that the events received via the given chan are the same as wantEvents,
 // in the same order.
-func CheckEventsOrdered(t *testing.T, eventChan chan string, testName string, wantEvents []string) error {
+func (f *FakeRecorder)CheckEventsOrdered(t *testing.T, eventChan chan string, testName string, wantEvents []string) error {
 	t.Helper()
-	// Sleep 50ms to make sure events have delivered
-	time.Sleep(50 * time.Millisecond)
+	f.waitGroup.Wait()
 	err := eventsFromChannel(eventChan, wantEvents)
 	if err != nil {
 		return fmt.Errorf("error in test %s: %v", testName, err)
@@ -39,38 +37,26 @@ func CheckEventsOrdered(t *testing.T, eventChan chan string, testName string, wa
 // expects to receive. The events must be received in the same order they appear in the
 // wantEvents list. Any extra or too few received events are considered errors.
 func eventsFromChannel(c chan string, wantEvents []string) error {
-	// We get events from a channel, so the timeout is here to avoid waiting
-	// on the channel forever if fewer than expected events are received.
-	// We only hit the timeout in case of failure of the test, so the actual value
-	// of the timeout is not so relevant, it's only used when tests are going to fail.
-	// on the channel forever if fewer than expected events are received
-	timer := time.NewTimer(10 * time.Millisecond)
+	// we loop the channel to collect all events, if the collected events are not
+	// expected events we will return error
+
 	foundEvents := []string{}
-	for ii := 0; ii < len(wantEvents)+1; ii++ {
-		// We loop over all the events that we expect. Once they are all received
-		// we exit the loop. If we never receive enough events, the timeout takes us
-		// out of the loop.
-		select {
-		case event := <-c:
-			foundEvents = append(foundEvents, event)
-			if ii > len(wantEvents)-1 {
-				return fmt.Errorf("received event \"%s\" but not more expected", event)
+	channelEvents := len(c)
+	for ii := 0; ii < channelEvents; ii++ {
+		event := <-c
+		foundEvents = append(foundEvents, event)
+		wantEvent := wantEvents[ii]
+		matching, err := regexp.MatchString(wantEvent, event)
+		if err == nil {
+			if !matching {
+				return fmt.Errorf("expected event \"%s\" but got \"%s\" instead", wantEvent, event)
 			}
-			wantEvent := wantEvents[ii]
-			matching, err := regexp.MatchString(wantEvent, event)
-			if err == nil {
-				if !matching {
-					return fmt.Errorf("expected event \"%s\" but got \"%s\" instead", wantEvent, event)
-				}
-			} else {
-				return fmt.Errorf("something went wrong matching the event: %s", err)
-			}
-		case <-timer.C:
-			if len(foundEvents) != len(wantEvents) {
-				return fmt.Errorf("received %d events but %d expected. Found events: %#v", len(foundEvents), len(wantEvents), foundEvents)
-			}
-			return nil
+		} else {
+			return fmt.Errorf("something went wrong matching the event: %s", err)
 		}
+	}
+	if len(foundEvents) != len(wantEvents) {
+		return fmt.Errorf("received %d events but %d expected. Found events: %#v", len(foundEvents), len(wantEvents), foundEvents)
 	}
 	return nil
 }

--- a/test/events/fake.go
+++ b/test/events/fake.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2022 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package events
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/injection"
+	logtesting "knative.dev/pkg/logging/testing"
+)
+
+// FakeRecorder is used as a fake during tests. It is thread safe. It is usable
+// when created manually and not by NewFakeRecorder, however all events may be
+// thrown away in this case.
+// use addCount and decreaseCount for if event is sent in gorontines
+type FakeRecorder struct {
+	record.FakeRecorder
+	// waitGroup is used to block until all events have been sent
+	waitGroup *sync.WaitGroup
+}
+
+// NewFakeRecorder creates new fake event recorder with event channel with
+// buffer of given size.
+func NewFakeRecorder(bufferSize int) *FakeRecorder {
+	return &FakeRecorder{
+		FakeRecorder: record.FakeRecorder{
+			Events: make(chan string, bufferSize),
+		},
+		waitGroup: &sync.WaitGroup{},
+	}
+}
+
+// addCount can be used to add the count when each event is going to be sent
+func (f FakeRecorder) addCount() {
+	f.waitGroup.Add(1)
+}
+
+// decreaseCount can be used to the decrease the count when each event is sent
+func (f FakeRecorder) decreaseCount() {
+	f.waitGroup.Done()
+}
+
+// SetupFakeContext sets up the the Context and the fake informers for the tests.
+// The optional fs() can be used to edit ctx before the SetupInformer steps
+func SetupFakeContext(t testing.TB, fs ...func(context.Context) context.Context) (context.Context, []controller.Informer) {
+	c, _, is := SetupFakeContextWithCancel(t, fs...)
+	return c, is
+}
+
+// SetupFakeContextWithCancel sets up the the Context and the fake informers for the tests
+// The provided context can be canceled using provided callback.
+// The optional fs() can be used to edit ctx before the SetupInformer steps
+func SetupFakeContextWithCancel(t testing.TB, fs ...func(context.Context) context.Context) (context.Context, context.CancelFunc, []controller.Informer) {
+	ctx, c := context.WithCancel(logtesting.TestContextWithLogger(t))
+	ctx = controller.WithEventRecorder(ctx, NewFakeRecorder(1000))
+	for _, f := range fs {
+		ctx = f(ctx)
+	}
+	ctx, is := injection.Fake.SetupInformers(ctx, &rest.Config{})
+	return ctx, c, is
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This commits fixes flaky k8s event test, https://github.com/tektoncd/pipeline/pull/5748. The tests are flaky
because we have a timer `eventsFromChannel` and it may lead to some
events are not collected and cause errors.

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
