### PR TITLE
TEP-0114 Serve Custom Task Beta

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/pkg/reconciler/customrun"
 	"github.com/tektoncd/pipeline/pkg/reconciler/pipelinerun"
 	"github.com/tektoncd/pipeline/pkg/reconciler/resolutionrequest"
 	"github.com/tektoncd/pipeline/pkg/reconciler/run"
@@ -108,8 +109,7 @@ func main() {
 		pipelinerun.NewController(opts, clock.RealClock{}),
 		run.NewController(),
 		resolutionrequest.NewController(clock.RealClock{}),
-		// TODO(jerop, abayer) uncomment after we align on retries in customruns
-		// customrun.NewController(),
+		customrun.NewController(),
 	)
 }
 

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -59,8 +59,7 @@ var types = map[schema.GroupVersionKind]resourcesemantics.GenericCRD{
 	v1beta1.SchemeGroupVersion.WithKind("ClusterTask"): &v1beta1.ClusterTask{},
 	v1beta1.SchemeGroupVersion.WithKind("TaskRun"):     &v1beta1.TaskRun{},
 	v1beta1.SchemeGroupVersion.WithKind("PipelineRun"): &v1beta1.PipelineRun{},
-	// TODO(jerop, abayer) uncomment after we align on retries in customruns
-	// v1beta1.SchemeGroupVersion.WithKind("CustomRun"):   &v1beta1.CustomRun{},
+	v1beta1.SchemeGroupVersion.WithKind("CustomRun"):   &v1beta1.CustomRun{},
 	// v1
 	v1.SchemeGroupVersion.WithKind("Task"):        &v1.Task{},
 	v1.SchemeGroupVersion.WithKind("Pipeline"):    &v1.Pipeline{},

--- a/config/300-customrun.yaml
+++ b/config/300-customrun.yaml
@@ -26,7 +26,7 @@ spec:
   preserveUnknownFields: false
   versions:
   - name: v1beta1
-    served: false
+    served: true
     storage: true
     schema:
       openAPIV3Schema:


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR reverts https://github.com/tektoncd/pipeline/pull/5736 because we've aligned on TEP-0121 about retries.

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] ~Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing~
- [x] ~Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed~
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Custom Task Beta is available.
```
