### PR TITLE
Add integration upgrade test on older version

### DIFF
--- a/test/e2e-tests-upgrade.sh
+++ b/test/e2e-tests-upgrade.sh
@@ -46,12 +46,15 @@ set +o pipefail
 header "Install the previous release of Tekton pipeline $PREVIOUS_PIPELINE_VERSION"
 install_pipeline_crd_version $PREVIOUS_PIPELINE_VERSION
 
+failed=0
+# The integration test for the older version to prevent regression on existing changes.
+go_test_e2e -timeout=20m ./test || failed=1
+
 # Upgrade to the current release.
 header "Upgrade to the current release of Tekton pipeline"
 install_pipeline_crd
 
 # Run the integration tests.
-failed=0
 go_test_e2e -timeout=20m ./test || failed=1
 
 # Run the post-integration tests.


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This commit adds the integration test on older version to prevent regression of current changes.

To prove that this PR could catch the regression:
- Reproducing #4913 and catch it with the existing change.
- Remove the pointer expression of [`pipelineRunSpec.taskRunSpecs.metadata`](https://github.com/tektoncd/pipeline/blob/f83cd1f63bb216c76a3af46d58614d517113d1c5/pkg/apis/pipeline/v1beta1/pipelinerun_types.go#L568).
- The previous version is set to the release version (v0.35.1) before the PR that introduces the regression.

Test case for regression:
- tested at https://github.com/JeromeJu/pipeline/tree/upgrade-regression-test
- Change ./test/e2e-tests-upgrade to install the previous version of #4913.
- run `./test/e2e-tests-upgrade.sh`, expect 
```
serviceaccount_test.go:163: Failed to create PipelineRun `pipeline-run-with-service-accounts-xtlybuvy`: admission webhook "webhook.pipeline.tekton.dev" denied the request: mutation failed: cannot decode incoming new object: json: unknown field "metadata"
```


<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
/kind misc
fixes: #5782 case i

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [n/a] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
