### PR TITLE
Add v1 clients for examples_test

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -316,7 +316,7 @@ The `Clients` struct contains initialized clients for accessing:
 For example, to create a `Pipeline`:
 
 ```bash
-_, err = clients.PipelineClient.Pipelines.Create(test.Route(namespaceName, pipelineName))
+_, err = clients.V1beta1PipelineClient.Pipelines.Create(test.Route(namespaceName, pipelineName))
 ```
 
 And you can use the client to clean up resources created by your test (e.g. in

--- a/test/README.md
+++ b/test/README.md
@@ -366,7 +366,7 @@ err = WaitForTaskRunState(c, hwTaskRunName, func(tr *v1alpha1.TaskRun) (bool, er
         return true, nil
     }
     return false, nil
-}, "TaskRunHasCondition")
+}, "TaskRunHasCondition", v1beta1Version)
 ```
 
 _[Metrics will be emitted](https://github.com/knative/pkg/tree/master/test#emit-metrics)

--- a/test/artifact_bucket_test.go
+++ b/test/artifact_bucket_test.go
@@ -117,7 +117,7 @@ spec:
 		t.Fatalf("Failed to create TaskRun `%s`: %s", createbuckettaskrun.Name, err)
 	}
 
-	if err := WaitForTaskRunState(ctx, c, createbuckettaskrun.Name, TaskRunSucceed(createbuckettaskrun.Name), "TaskRunSuccess"); err != nil {
+	if err := WaitForTaskRunState(ctx, c, createbuckettaskrun.Name, TaskRunSucceed(createbuckettaskrun.Name), "TaskRunSuccess", v1beta1Version); err != nil {
 		t.Errorf("Error waiting for TaskRun %s to finish: %s", createbuckettaskrun.Name, err)
 	}
 
@@ -252,7 +252,7 @@ spec:
 	}
 
 	// Verify status of PipelineRun (wait for it)
-	if err := WaitForPipelineRunState(ctx, c, bucketTestPipelineRunName, timeout, PipelineRunSucceed(bucketTestPipelineRunName), "PipelineRunCompleted"); err != nil {
+	if err := WaitForPipelineRunState(ctx, c, bucketTestPipelineRunName, timeout, PipelineRunSucceed(bucketTestPipelineRunName), "PipelineRunCompleted", v1beta1Version); err != nil {
 		t.Errorf("Error waiting for PipelineRun %s to finish: %s", bucketTestPipelineRunName, err)
 		t.Fatalf("PipelineRun execution failed")
 	}
@@ -350,7 +350,7 @@ spec:
 		t.Fatalf("Failed to create TaskRun `%s`: %s", deletelbuckettaskrun.Name, err)
 	}
 
-	if err := WaitForTaskRunState(ctx, c, deletelbuckettaskrun.Name, TaskRunSucceed(deletelbuckettaskrun.Name), "TaskRunSuccess"); err != nil {
+	if err := WaitForTaskRunState(ctx, c, deletelbuckettaskrun.Name, TaskRunSucceed(deletelbuckettaskrun.Name), "TaskRunSuccess", v1beta1Version); err != nil {
 		t.Errorf("Error waiting for TaskRun %s to finish: %s", deletelbuckettaskrun.Name, err)
 	}
 }

--- a/test/cancel_test.go
+++ b/test/cancel_test.go
@@ -77,7 +77,7 @@ spec:
 			}
 
 			t.Logf("Waiting for Pipelinerun %s in namespace %s to be started", pipelineRun.Name, namespace)
-			if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, timeout, Running(pipelineRun.Name), "PipelineRunRunning"); err != nil {
+			if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, timeout, Running(pipelineRun.Name), "PipelineRunRunning", v1beta1Version); err != nil {
 				t.Fatalf("Error waiting for PipelineRun %s to be running: %s", pipelineRun.Name, err)
 			}
 
@@ -92,7 +92,7 @@ spec:
 				wg.Add(1)
 				go func(name string) {
 					defer wg.Done()
-					err := WaitForTaskRunState(ctx, c, name, Running(name), "TaskRunRunning")
+					err := WaitForTaskRunState(ctx, c, name, Running(name), "TaskRunRunning", v1beta1Version)
 					if err != nil {
 						t.Errorf("Error waiting for TaskRun %s to be running: %v", name, err)
 					}
@@ -121,7 +121,7 @@ spec:
 			expectedReason := v1beta1.PipelineRunReasonCancelled.String()
 			expectedCondition := FailedWithReason(expectedReason, pipelineRun.Name)
 			t.Logf("Waiting for PipelineRun %s in namespace %s to be cancelled", pipelineRun.Name, namespace)
-			if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, timeout, expectedCondition, expectedReason); err != nil {
+			if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, timeout, expectedCondition, expectedReason, v1beta1Version); err != nil {
 				t.Errorf("Error waiting for PipelineRun %q to finished: %s", pipelineRun.Name, err)
 			}
 
@@ -130,7 +130,7 @@ spec:
 				wg.Add(1)
 				go func(name string) {
 					defer wg.Done()
-					err := WaitForTaskRunState(ctx, c, name, FailedWithReason("TaskRunCancelled", name), "TaskRunCancelled")
+					err := WaitForTaskRunState(ctx, c, name, FailedWithReason("TaskRunCancelled", name), "TaskRunCancelled", v1beta1Version)
 					if err != nil {
 						t.Errorf("Error waiting for TaskRun %s to be finished: %v", name, err)
 					}

--- a/test/clients.go
+++ b/test/clients.go
@@ -43,6 +43,7 @@ import (
 	"testing"
 
 	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
+	v1 "github.com/tektoncd/pipeline/pkg/client/clientset/versioned/typed/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned/typed/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned/typed/pipeline/v1beta1"
 	resolutionversioned "github.com/tektoncd/pipeline/pkg/client/resolution/clientset/versioned"
@@ -65,6 +66,10 @@ type clients struct {
 	V1alpha1PipelineResourceClient  resourcev1alpha1.PipelineResourceInterface
 	V1alpha1RunClient               v1alpha1.RunInterface
 	V1alpha1ResolutionRequestclient resolutionv1alpha1.ResolutionRequestInterface
+	V1PipelineClient                v1.PipelineInterface
+	V1TaskClient                    v1.TaskInterface
+	V1TaskRunClient                 v1.TaskRunInterface
+	V1PipelineRunClient             v1.PipelineRunInterface
 }
 
 // newClients instantiates and returns several clientsets required for making requests to the
@@ -106,5 +111,9 @@ func newClients(t *testing.T, configPath, clusterName, namespace string) *client
 	c.V1alpha1PipelineResourceClient = rcs.TektonV1alpha1().PipelineResources(namespace)
 	c.V1alpha1RunClient = cs.TektonV1alpha1().Runs(namespace)
 	c.V1alpha1ResolutionRequestclient = rrcs.ResolutionV1alpha1().ResolutionRequests(namespace)
+	c.V1PipelineClient = cs.TektonV1().Pipelines(namespace)
+	c.V1TaskClient = cs.TektonV1().Tasks(namespace)
+	c.V1TaskRunClient = cs.TektonV1().TaskRuns(namespace)
+	c.V1PipelineRunClient = cs.TektonV1().PipelineRuns(namespace)
 	return c
 }

--- a/test/cluster_resource_test.go
+++ b/test/cluster_resource_test.go
@@ -78,7 +78,7 @@ func TestClusterResource(t *testing.T) {
 	}
 
 	// Verify status of TaskRun (wait for it)
-	if err := WaitForTaskRunState(ctx, c, taskRunName, TaskRunSucceed(taskRunName), "TaskRunCompleted"); err != nil {
+	if err := WaitForTaskRunState(ctx, c, taskRunName, TaskRunSucceed(taskRunName), "TaskRunCompleted", v1beta1Version); err != nil {
 		t.Errorf("Error waiting for TaskRun %s to finish: %s", taskRunName, err)
 	}
 }

--- a/test/conformance_test.go
+++ b/test/conformance_test.go
@@ -128,7 +128,7 @@ spec:
 				t.Fatalf("Failed to create TaskRun `%s`: %s", tc.tr.Name, err)
 			}
 
-			if err := WaitForTaskRunState(ctx, c, tc.tr.Name, tc.fn(tc.tr.Name), "WaitTaskRunDone"); err != nil {
+			if err := WaitForTaskRunState(ctx, c, tc.tr.Name, tc.fn(tc.tr.Name), "WaitTaskRunDone", v1beta1Version); err != nil {
 				t.Errorf("Error waiting for TaskRun to finish: %s", err)
 				return
 			}

--- a/test/custom_task_test.go
+++ b/test/custom_task_test.go
@@ -129,7 +129,7 @@ spec:
 	}
 
 	// Wait for the PipelineRun to start.
-	if err := WaitForPipelineRunState(ctx, c, pipelineRunName, time.Minute, Running(pipelineRunName), "PipelineRunRunning"); err != nil {
+	if err := WaitForPipelineRunState(ctx, c, pipelineRunName, time.Minute, Running(pipelineRunName), "PipelineRunRunning", v1beta1Version); err != nil {
 		t.Fatalf("Waiting for PipelineRun to start running: %v", err)
 	}
 
@@ -208,7 +208,7 @@ spec:
 		}
 	}
 	// Wait for the PipelineRun to become done/successful.
-	if err := WaitForPipelineRunState(ctx, c, pipelineRunName, time.Minute, PipelineRunSucceed(pipelineRunName), "PipelineRunCompleted"); err != nil {
+	if err := WaitForPipelineRunState(ctx, c, pipelineRunName, time.Minute, PipelineRunSucceed(pipelineRunName), "PipelineRunCompleted", v1beta1Version); err != nil {
 		t.Fatalf("Waiting for PipelineRun to complete successfully: %v", err)
 	}
 
@@ -334,7 +334,7 @@ spec:
 	}
 
 	t.Logf("Waiting for Pipelinerun %s in namespace %s to be started", pipelineRun.Name, namespace)
-	if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, timeout, Running(pipelineRun.Name), "PipelineRunRunning"); err != nil {
+	if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, timeout, Running(pipelineRun.Name), "PipelineRunRunning", v1beta1Version); err != nil {
 		t.Fatalf("Error waiting for PipelineRun %s to be running: %s", pipelineRun.Name, err)
 	}
 
@@ -388,7 +388,7 @@ spec:
 	}
 
 	t.Logf("Waiting for PipelineRun %s in namespace %s to be timed out", pipelineRun.Name, namespace)
-	if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, timeout, FailedWithReason(v1beta1.PipelineRunReasonTimedOut.String(), pipelineRun.Name), "PipelineRunTimedOut"); err != nil {
+	if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, timeout, FailedWithReason(v1beta1.PipelineRunReasonTimedOut.String(), pipelineRun.Name), "PipelineRunTimedOut", v1beta1Version); err != nil {
 		t.Errorf("Error waiting for PipelineRun %s to finish: %s", pipelineRun.Name, err)
 	}
 
@@ -793,7 +793,7 @@ func TestWaitCustomTask_PipelineRun(t *testing.T) {
 			}
 
 			// Wait for the PipelineRun to the desired state
-			if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, timeout, tc.prConditionAccessorFn(pipelineRun.Name), string(tc.wantPrCondition.Type)); err != nil {
+			if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, timeout, tc.prConditionAccessorFn(pipelineRun.Name), string(tc.wantPrCondition.Type), v1beta1Version); err != nil {
 				t.Fatalf("Error waiting for PipelineRun %q to be running: %s", pipelineRun.Name, err)
 			}
 

--- a/test/dag_test.go
+++ b/test/dag_test.go
@@ -207,7 +207,7 @@ spec:
 		t.Fatalf("Failed to create dag-pipeline-run PipelineRun: %s", err)
 	}
 	t.Logf("Waiting for DAG pipeline to complete")
-	if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, timeout, PipelineRunSucceed(pipelineRun.Name), "PipelineRunSuccess"); err != nil {
+	if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, timeout, PipelineRunSucceed(pipelineRun.Name), "PipelineRunSuccess", v1beta1Version); err != nil {
 		t.Fatalf("Error waiting for PipelineRun to finish: %s", err)
 	}
 

--- a/test/duplicate_test.go
+++ b/test/duplicate_test.go
@@ -70,7 +70,7 @@ spec:
 		go func(t *testing.T) {
 			defer wg.Done()
 
-			if err := WaitForTaskRunState(ctx, c, taskrunName, TaskRunSucceed(taskrunName), "TaskRunDuplicatePodTaskRunFailed"); err != nil {
+			if err := WaitForTaskRunState(ctx, c, taskrunName, TaskRunSucceed(taskrunName), "TaskRunDuplicatePodTaskRunFailed", v1beta1Version); err != nil {
 				t.Errorf("Error waiting for TaskRun to finish: %s", err)
 				return
 			}

--- a/test/embed_test.go
+++ b/test/embed_test.go
@@ -62,7 +62,7 @@ func TestTaskRun_EmbeddedResource(t *testing.T) {
 	}
 
 	t.Logf("Waiting for TaskRun %s in namespace %s to complete", embedTaskRunName, namespace)
-	if err := WaitForTaskRunState(ctx, c, embedTaskRunName, TaskRunSucceed(embedTaskRunName), "TaskRunSuccess"); err != nil {
+	if err := WaitForTaskRunState(ctx, c, embedTaskRunName, TaskRunSucceed(embedTaskRunName), "TaskRunSuccess", v1beta1Version); err != nil {
 		t.Errorf("Error waiting for TaskRun %s to finish: %s", embedTaskRunName, err)
 	}
 

--- a/test/entrypoint_test.go
+++ b/test/entrypoint_test.go
@@ -66,7 +66,7 @@ spec:
 	}
 
 	t.Logf("Waiting for TaskRun in namespace %s to finish successfully", namespace)
-	if err := WaitForTaskRunState(ctx, c, epTaskRunName, TaskRunSucceed(epTaskRunName), "TaskRunSuccess"); err != nil {
+	if err := WaitForTaskRunState(ctx, c, epTaskRunName, TaskRunSucceed(epTaskRunName), "TaskRunSuccess", v1beta1Version); err != nil {
 		t.Errorf("Error waiting for TaskRun to finish successfully: %s", err)
 	}
 

--- a/test/examples_test.go
+++ b/test/examples_test.go
@@ -37,6 +37,7 @@ import (
 
 var (
 	defaultKoDockerRepoRE = regexp.MustCompile("gcr.io/christiewilson-catfactory")
+	v1Version             = "v1"
 )
 
 // getCreatedTektonCRD parses output of an external ko invocation provided as
@@ -51,15 +52,28 @@ func getCreatedTektonCRD(input []byte, kind string) (string, error) {
 }
 
 func waitValidatePipelineRunDone(ctx context.Context, t *testing.T, c *clients, pipelineRunName string) {
-	if err := WaitForPipelineRunState(ctx, c, pipelineRunName, timeout, Succeed(pipelineRunName), pipelineRunName); err != nil {
+	if err := WaitForPipelineRunState(ctx, c, pipelineRunName, timeout, Succeed(pipelineRunName), pipelineRunName, v1beta1Version); err != nil {
 		t.Fatalf("Failed waiting for pipeline run done: %v", err)
+	}
+}
+
+func waitValidateV1PipelineRunDone(ctx context.Context, t *testing.T, c *clients, pipelineRunName string) {
+	if err := WaitForPipelineRunState(ctx, c, pipelineRunName, timeout, Succeed(pipelineRunName), pipelineRunName, v1Version); err != nil {
+		t.Fatalf("Failed waiting for V1 pipeline run done: %v", err)
 	}
 }
 
 func waitValidateTaskRunDone(ctx context.Context, t *testing.T, c *clients, taskRunName string) {
 	// Per test basis
-	if err := WaitForTaskRunState(ctx, c, taskRunName, Succeed(taskRunName), taskRunName); err != nil {
+	if err := WaitForTaskRunState(ctx, c, taskRunName, Succeed(taskRunName), taskRunName, v1beta1Version); err != nil {
 		t.Fatalf("Failed waiting for task run done: %v", err)
+	}
+}
+
+func waitValidateV1TaskRunDone(ctx context.Context, t *testing.T, c *clients, taskRunName string) {
+	// Per test basis
+	if err := WaitForTaskRunState(ctx, c, taskRunName, Succeed(taskRunName), taskRunName, v1Version); err != nil {
+		t.Fatalf("Failed waiting for V1 task run done: %v", err)
 	}
 }
 
@@ -237,10 +251,16 @@ func testYamls(t *testing.T, baseDir string, createFunc createFunc, filter pathF
 		path := path // capture range variable
 		testName := extractTestName(baseDir, path)
 		waitValidateFunc := waitValidatePipelineRunDone
+		if strings.Contains(path, "/v1/") {
+			waitValidateFunc = waitValidateV1PipelineRunDone
+		}
 		kind := "pipelinerun"
 
 		if strings.Contains(path, "/taskruns/") {
 			waitValidateFunc = waitValidateTaskRunDone
+			if strings.Contains(path, "/v1/") {
+				waitValidateFunc = waitValidateV1TaskRunDone
+			}
 			kind = "taskrun"
 		}
 

--- a/test/git_checkout_test.go
+++ b/test/git_checkout_test.go
@@ -155,7 +155,7 @@ spec:
 				t.Fatalf("Failed to create PipelineRun %q: %s", gitTestPipelineRunName, err)
 			}
 
-			if err := WaitForPipelineRunState(ctx, c, gitTestPipelineRunName, timeout, PipelineRunSucceed(gitTestPipelineRunName), "PipelineRunCompleted"); err != nil {
+			if err := WaitForPipelineRunState(ctx, c, gitTestPipelineRunName, timeout, PipelineRunSucceed(gitTestPipelineRunName), "PipelineRunCompleted", v1beta1Version); err != nil {
 				t.Errorf("Error waiting for PipelineRun %s to finish: %s", gitTestPipelineRunName, err)
 				t.Fatalf("PipelineRun execution failed")
 			}
@@ -238,7 +238,7 @@ spec:
 				t.Fatalf("Failed to create PipelineRun %q: %s", gitTestPipelineRunName, err)
 			}
 
-			if err := WaitForPipelineRunState(ctx, c, gitTestPipelineRunName, timeout, PipelineRunSucceed(gitTestPipelineRunName), "PipelineRunCompleted"); err != nil {
+			if err := WaitForPipelineRunState(ctx, c, gitTestPipelineRunName, timeout, PipelineRunSucceed(gitTestPipelineRunName), "PipelineRunCompleted", v1beta1Version); err != nil {
 				taskruns, err := c.V1beta1TaskRunClient.List(ctx, metav1.ListOptions{})
 				if err != nil {
 					t.Errorf("Error getting TaskRun list for PipelineRun %s %s", gitTestPipelineRunName, err)

--- a/test/helm_task_test.go
+++ b/test/helm_task_test.go
@@ -98,7 +98,7 @@ func TestHelmDeployPipelineRun(t *testing.T) {
 	}
 
 	// Verify status of PipelineRun (wait for it)
-	if err := WaitForPipelineRunState(ctx, c, helmDeployPipelineRunName, timeout, PipelineRunSucceed(helmDeployPipelineRunName), "PipelineRunCompleted"); err != nil {
+	if err := WaitForPipelineRunState(ctx, c, helmDeployPipelineRunName, timeout, PipelineRunSucceed(helmDeployPipelineRunName), "PipelineRunCompleted", v1beta1Version); err != nil {
 		t.Errorf("Error waiting for PipelineRun %s to finish: %s", helmDeployPipelineRunName, err)
 		t.Fatalf("PipelineRun execution failed; helm may or may not have been installed :(")
 	}
@@ -357,7 +357,7 @@ spec:
 	}
 
 	t.Logf("Waiting for TaskRun %s in namespace %s to complete", helmRemoveAllTaskRunName, namespace)
-	if err := WaitForTaskRunState(ctx, c, helmRemoveAllTaskRunName, TaskRunSucceed(helmRemoveAllTaskRunName), "TaskRunSuccess"); err != nil {
+	if err := WaitForTaskRunState(ctx, c, helmRemoveAllTaskRunName, TaskRunSucceed(helmRemoveAllTaskRunName), "TaskRunSuccess", v1beta1Version); err != nil {
 		t.Logf("TaskRun %s failed to finish: %s", helmRemoveAllTaskRunName, err)
 	}
 }

--- a/test/hermetic_taskrun_test.go
+++ b/test/hermetic_taskrun_test.go
@@ -64,7 +64,7 @@ func TestHermeticTaskRun(t *testing.T) {
 			if _, err := c.V1beta1TaskRunClient.Create(ctx, regularTaskRun, metav1.CreateOptions{}); err != nil {
 				t.Fatalf("Failed to create TaskRun `%s`: %s", regularTaskRunName, err)
 			}
-			if err := WaitForTaskRunState(ctx, c, regularTaskRunName, Succeed(regularTaskRunName), "TaskRunCompleted"); err != nil {
+			if err := WaitForTaskRunState(ctx, c, regularTaskRunName, Succeed(regularTaskRunName), "TaskRunCompleted", v1beta1Version); err != nil {
 				t.Errorf("Error waiting for TaskRun %s to finish: %s", regularTaskRunName, err)
 			}
 
@@ -76,7 +76,7 @@ func TestHermeticTaskRun(t *testing.T) {
 			if _, err := c.V1beta1TaskRunClient.Create(ctx, hermeticTaskRun, metav1.CreateOptions{}); err != nil {
 				t.Fatalf("Failed to create TaskRun `%s`: %s", regularTaskRun.Name, err)
 			}
-			if err := WaitForTaskRunState(ctx, c, hermeticTaskRunName, Failed(hermeticTaskRunName), "Failed"); err != nil {
+			if err := WaitForTaskRunState(ctx, c, hermeticTaskRunName, Failed(hermeticTaskRunName), "Failed", v1beta1Version); err != nil {
 				t.Errorf("Error waiting for TaskRun %s to fail: %s", hermeticTaskRunName, err)
 			}
 		})

--- a/test/ignore_step_error_test.go
+++ b/test/ignore_step_error_test.go
@@ -77,7 +77,7 @@ spec:
 	}
 
 	t.Logf("Waiting for PipelineRun in namespace %s to fail", namespace)
-	if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, timeout, FailedWithReason(pipelinerun.ReasonInvalidTaskResultReference, pipelineRun.Name), "InvalidTaskResultReference"); err != nil {
+	if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, timeout, FailedWithReason(pipelinerun.ReasonInvalidTaskResultReference, pipelineRun.Name), "InvalidTaskResultReference", v1beta1Version); err != nil {
 		t.Errorf("Error waiting for PipelineRun to fail: %s", err)
 	}
 

--- a/test/init_test.go
+++ b/test/init_test.go
@@ -101,11 +101,20 @@ func tearDown(ctx context.Context, t *testing.T, cs *clients, namespace string) 
 			t.Log(string(bs))
 		}
 		header(t, fmt.Sprintf("Dumping logs from Pods in the %s", namespace))
-		taskruns, err := cs.V1beta1TaskRunClient.List(ctx, metav1.ListOptions{})
+		v1beta1Taskruns, err := cs.V1beta1TaskRunClient.List(ctx, metav1.ListOptions{})
 		if err != nil {
-			t.Errorf("Error getting TaskRun list %s", err)
+			t.Errorf("Error getting v1beta1TaskRun list %s", err)
 		}
-		for _, tr := range taskruns.Items {
+		for _, tr := range v1beta1Taskruns.Items {
+			if tr.Status.PodName != "" {
+				CollectPodLogs(ctx, cs, tr.Status.PodName, namespace, t.Logf)
+			}
+		}
+		v1Taskruns, err := cs.V1TaskRunClient.List(ctx, metav1.ListOptions{})
+		if err != nil {
+			t.Errorf("Error getting v1TaskRun list %s", err)
+		}
+		for _, tr := range v1Taskruns.Items {
 			if tr.Status.PodName != "" {
 				CollectPodLogs(ctx, cs, tr.Status.PodName, namespace, t.Logf)
 			}
@@ -196,65 +205,101 @@ func getCRDYaml(ctx context.Context, cs *clients, ns string) ([]byte, error) {
 		output = append(output, bs...)
 	}
 
-	ps, err := cs.V1beta1PipelineClient.List(ctx, metav1.ListOptions{})
+	v1beta1Pipelines, err := cs.V1beta1PipelineClient.List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("could not get pipeline: %w", err)
+		return nil, fmt.Errorf("could not get v1beta1 pipeline: %w", err)
 	}
-	for _, i := range ps.Items {
+	for _, i := range v1beta1Pipelines.Items {
 		i.SetManagedFields(nil)
 		printOrAdd(i)
 	}
 
-	prs, err := cs.V1alpha1PipelineResourceClient.List(ctx, metav1.ListOptions{})
+	v1alpha1PipelineResources, err := cs.V1alpha1PipelineResourceClient.List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("could not get pipelinerun resource: %w", err)
+		return nil, fmt.Errorf("could not get v1alpha1 pipelinerun resource: %w", err)
 	}
-	for _, i := range prs.Items {
+	for _, i := range v1alpha1PipelineResources.Items {
 		i.SetManagedFields(nil)
 		printOrAdd(i)
 	}
 
-	prrs, err := cs.V1beta1PipelineRunClient.List(ctx, metav1.ListOptions{})
+	v1beta1PipelineRuns, err := cs.V1beta1PipelineRunClient.List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("could not get pipelinerun: %w", err)
+		return nil, fmt.Errorf("could not get v1beta1 pipelinerun: %w", err)
 	}
-	for _, i := range prrs.Items {
+	for _, i := range v1beta1PipelineRuns.Items {
 		i.SetManagedFields(nil)
 		printOrAdd(i)
 	}
 
-	ts, err := cs.V1beta1TaskClient.List(ctx, metav1.ListOptions{})
+	v1beta1Tasks, err := cs.V1beta1TaskClient.List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("could not get tasks: %w", err)
+		return nil, fmt.Errorf("could not get v1beta1 tasks: %w", err)
 	}
-	for _, i := range ts.Items {
+	for _, i := range v1beta1Tasks.Items {
 		i.SetManagedFields(nil)
 		printOrAdd(i)
 	}
 
-	cts, err := cs.V1beta1ClusterTaskClient.List(ctx, metav1.ListOptions{})
+	v1beta1ClusterTasks, err := cs.V1beta1ClusterTaskClient.List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("could not get clustertasks: %w", err)
+		return nil, fmt.Errorf("could not get v1beta1 clustertasks: %w", err)
 	}
-	for _, i := range cts.Items {
+	for _, i := range v1beta1ClusterTasks.Items {
 		i.SetManagedFields(nil)
 		printOrAdd(i)
 	}
 
-	trs, err := cs.V1beta1TaskRunClient.List(ctx, metav1.ListOptions{})
+	v1beta1TaskRuns, err := cs.V1beta1TaskRunClient.List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("could not get taskruns: %w", err)
+		return nil, fmt.Errorf("could not get v1beta1 taskruns: %w", err)
 	}
-	for _, i := range trs.Items {
+	for _, i := range v1beta1TaskRuns.Items {
 		i.SetManagedFields(nil)
 		printOrAdd(i)
 	}
 
-	rs, err := cs.V1alpha1RunClient.List(ctx, metav1.ListOptions{})
+	v1Tasks, err := cs.V1TaskClient.List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("could not get runs: %v", err)
+		return nil, fmt.Errorf("could not get v1 tasks: %w", err)
 	}
-	for _, i := range rs.Items {
+	for _, i := range v1Tasks.Items {
+		i.SetManagedFields(nil)
+		printOrAdd(i)
+	}
+
+	v1TaskRuns, err := cs.V1TaskRunClient.List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("could not get v1 taskruns: %w", err)
+	}
+	for _, i := range v1TaskRuns.Items {
+		i.SetManagedFields(nil)
+		printOrAdd(i)
+	}
+
+	v1Pipelines, err := cs.V1PipelineClient.List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("could not get v1 pipeline: %w", err)
+	}
+	for _, i := range v1Pipelines.Items {
+		i.SetManagedFields(nil)
+		printOrAdd(i)
+	}
+
+	v1PipelineRuns, err := cs.V1PipelineRunClient.List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("could not get v1 pipelinerun: %w", err)
+	}
+	for _, i := range v1PipelineRuns.Items {
+		i.SetManagedFields(nil)
+		printOrAdd(i)
+	}
+
+	v1alpha1Runs, err := cs.V1alpha1RunClient.List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("could not get v1alpha1 runs: %v", err)
+	}
+	for _, i := range v1alpha1Runs.Items {
 		i.SetManagedFields(nil)
 		printOrAdd(i)
 	}

--- a/test/kaniko_task_test.go
+++ b/test/kaniko_task_test.go
@@ -84,7 +84,7 @@ func TestKanikoTaskRun(t *testing.T) {
 
 	// Verify status of TaskRun (wait for it)
 
-	if err := WaitForTaskRunState(ctx, c, tr.Name, Succeed(tr.Name), "TaskRunCompleted"); err != nil {
+	if err := WaitForTaskRunState(ctx, c, tr.Name, Succeed(tr.Name), "TaskRunCompleted", v1beta1Version); err != nil {
 		t.Errorf("Error waiting for TaskRun %s to finish: %s", tr.Name, err)
 	}
 

--- a/test/pipelinefinally_test.go
+++ b/test/pipelinefinally_test.go
@@ -225,7 +225,7 @@ spec:
 		t.Fatalf("Failed to create Pipeline Run `%s`: %s", pipelineRun.Name, err)
 	}
 
-	if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, timeout, PipelineRunFailed(pipelineRun.Name), "PipelineRunFailed"); err != nil {
+	if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, timeout, PipelineRunFailed(pipelineRun.Name), "PipelineRunFailed", v1beta1Version); err != nil {
 		t.Fatalf("Waiting for PipelineRun %s to fail: %v", pipelineRun.Name, err)
 	}
 
@@ -262,23 +262,23 @@ spec:
 			}
 			dagTask1EndTime = taskrunItem.Status.CompletionTime
 		case n == "dagtask2":
-			if err := WaitForTaskRunState(ctx, c, taskrunItem.Name, TaskRunSucceed(taskrunItem.Name), "TaskRunSuccess"); err != nil {
+			if err := WaitForTaskRunState(ctx, c, taskrunItem.Name, TaskRunSucceed(taskrunItem.Name), "TaskRunSuccess", v1beta1Version); err != nil {
 				t.Errorf("Error waiting for TaskRun to succeed: %v", err)
 			}
 			dagTask2EndTime = taskrunItem.Status.CompletionTime
 		case n == "dagtask4":
 			t.Fatalf("task %s should have skipped due to when expression", n)
 		case n == "dagtask5":
-			if err := WaitForTaskRunState(ctx, c, taskrunItem.Name, TaskRunSucceed(taskrunItem.Name), "TaskRunSuccess"); err != nil {
+			if err := WaitForTaskRunState(ctx, c, taskrunItem.Name, TaskRunSucceed(taskrunItem.Name), "TaskRunSuccess", v1beta1Version); err != nil {
 				t.Errorf("Error waiting for TaskRun to succeed: %v", err)
 			}
 		case n == "finaltask1":
-			if err := WaitForTaskRunState(ctx, c, taskrunItem.Name, TaskRunSucceed(taskrunItem.Name), "TaskRunSuccess"); err != nil {
+			if err := WaitForTaskRunState(ctx, c, taskrunItem.Name, TaskRunSucceed(taskrunItem.Name), "TaskRunSuccess", v1beta1Version); err != nil {
 				t.Errorf("Error waiting for TaskRun to succeed: %v", err)
 			}
 			finalTaskStartTime = taskrunItem.Status.StartTime
 		case n == "finaltask2":
-			if err := WaitForTaskRunState(ctx, c, taskrunItem.Name, TaskRunSucceed(taskrunItem.Name), "TaskRunSuccess"); err != nil {
+			if err := WaitForTaskRunState(ctx, c, taskrunItem.Name, TaskRunSucceed(taskrunItem.Name), "TaskRunSuccess", v1beta1Version); err != nil {
 				t.Errorf("Error waiting for TaskRun to succeed: %v", err)
 			}
 			for _, p := range taskrunItem.Spec.Params {
@@ -303,7 +303,7 @@ spec:
 				}
 			}
 		case n == "finaltaskconsumingdagtask5":
-			if err := WaitForTaskRunState(ctx, c, taskrunItem.Name, TaskRunSucceed(taskrunItem.Name), "TaskRunSuccess"); err != nil {
+			if err := WaitForTaskRunState(ctx, c, taskrunItem.Name, TaskRunSucceed(taskrunItem.Name), "TaskRunSuccess", v1beta1Version); err != nil {
 				t.Errorf("Error waiting for TaskRun to succeed: %v", err)
 			}
 			for _, p := range taskrunItem.Spec.Params {
@@ -434,7 +434,7 @@ spec:
 		t.Fatalf("Failed to create Pipeline Run `%s`: %s", pipelineRun.Name, err)
 	}
 
-	if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, timeout, PipelineRunFailed(pipelineRun.Name), "PipelineRunFailed"); err != nil {
+	if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, timeout, PipelineRunFailed(pipelineRun.Name), "PipelineRunFailed", v1beta1Version); err != nil {
 		t.Errorf("Error waiting for PipelineRun %s to finish: %s", pipelineRun.Name, err)
 		t.Fatalf("PipelineRun execution failed")
 	}
@@ -527,7 +527,7 @@ spec:
 		t.Fatalf("Failed to create Pipeline Run `%s`: %s", pipelineRun.Name, err)
 	}
 
-	if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, timeout, Running(pipelineRun.Name), "PipelineRunRunning"); err != nil {
+	if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, timeout, Running(pipelineRun.Name), "PipelineRunRunning", v1beta1Version); err != nil {
 		t.Errorf("Error waiting for PipelineRun %s to start: %s", pipelineRun.Name, err)
 		t.Fatalf("PipelineRun execution failed")
 	}
@@ -545,7 +545,7 @@ spec:
 		t.Fatalf("Failed to patch PipelineRun `%s` with graceful stop: %s", pipelineRun.Name, err)
 	}
 
-	if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, timeout, FailedWithReason(v1beta1.PipelineRunReasonCancelled.String(), pipelineRun.Name), "PipelineRunCancelled"); err != nil {
+	if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, timeout, FailedWithReason(v1beta1.PipelineRunReasonCancelled.String(), pipelineRun.Name), "PipelineRunCancelled", v1beta1Version); err != nil {
 		t.Errorf("Error waiting for PipelineRun %s to finish: %s", pipelineRun.Name, err)
 		t.Fatalf("PipelineRun execution failed")
 	}
@@ -642,7 +642,7 @@ spec:
 		t.Fatalf("Failed to create Pipeline Run `%s`: %s", pipelineRun.Name, err)
 	}
 
-	if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, timeout, Running(pipelineRun.Name), "PipelineRunRunning"); err != nil {
+	if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, timeout, Running(pipelineRun.Name), "PipelineRunRunning", v1beta1Version); err != nil {
 		t.Errorf("Error waiting for PipelineRun %s to start: %s", pipelineRun.Name, err)
 		t.Fatalf("PipelineRun execution failed")
 	}
@@ -660,7 +660,7 @@ spec:
 		t.Fatalf("Failed to patch PipelineRun `%s` with graceful stop: %s", pipelineRun.Name, err)
 	}
 
-	if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, timeout, FailedWithReason(v1beta1.PipelineRunReasonCancelled.String(), pipelineRun.Name), "PipelineRunCancelled"); err != nil {
+	if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, timeout, FailedWithReason(v1beta1.PipelineRunReasonCancelled.String(), pipelineRun.Name), "PipelineRunCancelled", v1beta1Version); err != nil {
 		t.Errorf("Error waiting for PipelineRun %s to finish: %s", pipelineRun.Name, err)
 		t.Fatalf("PipelineRun execution failed")
 	}

--- a/test/pipelinerun_test.go
+++ b/test/pipelinerun_test.go
@@ -118,7 +118,7 @@ spec:
 			}
 
 			t.Logf("Waiting for PipelineRun %s in namespace %s to complete", prName, namespace)
-			if err := WaitForPipelineRunState(ctx, c, prName, timeout, PipelineRunSucceed(prName), "PipelineRunSuccess"); err != nil {
+			if err := WaitForPipelineRunState(ctx, c, prName, timeout, PipelineRunSucceed(prName), "PipelineRunSuccess", v1beta1Version); err != nil {
 				t.Fatalf("Error waiting for PipelineRun %s to finish: %s", prName, err)
 			}
 			t.Logf("Making sure the expected TaskRuns %s were created", td.expectedTaskRuns)
@@ -331,7 +331,7 @@ spec:
 			}
 
 			t.Logf("Waiting for PipelineRun %s in namespace %s to complete", prName, namespace)
-			if err := WaitForPipelineRunState(ctx, c, prName, timeout, PipelineRunSucceed(prName), "PipelineRunSuccess"); err != nil {
+			if err := WaitForPipelineRunState(ctx, c, prName, timeout, PipelineRunSucceed(prName), "PipelineRunSuccess", v1beta1Version); err != nil {
 				t.Fatalf("Error waiting for PipelineRun %s to finish: %s", prName, err)
 			}
 			t.Logf("Making sure the expected TaskRuns %s were created", td.expectedTaskRuns)
@@ -502,7 +502,7 @@ spec:
 	}
 
 	t.Logf("Waiting for PipelineRun %s in namespace %s to complete", prName, namespace)
-	if err := WaitForPipelineRunState(ctx, c, prName, timeout, Running(prName), "PipelineRunRunning"); err != nil {
+	if err := WaitForPipelineRunState(ctx, c, prName, timeout, Running(prName), "PipelineRunRunning", v1beta1Version); err != nil {
 		t.Fatalf("Error waiting for PipelineRun %s to finish: %s", prName, err)
 	}
 
@@ -511,7 +511,7 @@ spec:
 	}
 
 	t.Logf("Waiting for PipelineRun %s in namespace %s to complete", prName, namespace)
-	if err := WaitForPipelineRunState(ctx, c, prName, timeout, PipelineRunSucceed(prName), "PipelineRunSuccess"); err != nil {
+	if err := WaitForPipelineRunState(ctx, c, prName, timeout, PipelineRunSucceed(prName), "PipelineRunSuccess", v1beta1Version); err != nil {
 		t.Fatalf("Error waiting for PipelineRun %s to finish: %s", prName, err)
 	}
 
@@ -576,7 +576,7 @@ spec:
 	}
 
 	t.Logf("Waiting for PipelineRun %s in namespace %s to be marked pending", prName, namespace)
-	if err := WaitForPipelineRunState(ctx, c, prName, timeout, PipelineRunPending(prName), "PipelineRunPending"); err != nil {
+	if err := WaitForPipelineRunState(ctx, c, prName, timeout, PipelineRunPending(prName), "PipelineRunPending", v1beta1Version); err != nil {
 		t.Fatalf("Error waiting for PipelineRun %s to be marked pending: %s", prName, err)
 	}
 
@@ -598,7 +598,7 @@ spec:
 	}
 
 	t.Logf("Waiting for PipelineRun %s in namespace %s to complete", prName, namespace)
-	if err := WaitForPipelineRunState(ctx, c, prName, timeout, PipelineRunSucceed(prName), "PipelineRunSuccess"); err != nil {
+	if err := WaitForPipelineRunState(ctx, c, prName, timeout, PipelineRunSucceed(prName), "PipelineRunSuccess", v1beta1Version); err != nil {
 		t.Fatalf("Error waiting for PipelineRun %s to finish: %s", prName, err)
 	}
 }

--- a/test/propagated_params_test.go
+++ b/test/propagated_params_test.go
@@ -95,7 +95,7 @@ func TestPropagatedParams(t *testing.T) {
 			}
 
 			t.Logf("Waiting for PipelineRun %s in namespace %s to complete", prName, namespace)
-			if err := WaitForPipelineRunState(ctx, c, prName, timeout, PipelineRunSucceed(prName), "PipelineRunSuccess"); err != nil {
+			if err := WaitForPipelineRunState(ctx, c, prName, timeout, PipelineRunSucceed(prName), "PipelineRunSuccess", v1beta1Version); err != nil {
 				t.Fatalf("Error waiting for PipelineRun %s to finish: %s", prName, err)
 			}
 			cl, _ := c.V1beta1PipelineRunClient.Get(ctx, prName, metav1.GetOptions{})

--- a/test/resolvers_test.go
+++ b/test/resolvers_test.go
@@ -127,7 +127,7 @@ spec:
 	}
 
 	t.Logf("Waiting for PipelineRun %s in namespace %s to complete", prName, namespace)
-	if err := WaitForPipelineRunState(ctx, c, prName, timeout, PipelineRunSucceed(prName), "PipelineRunSuccess"); err != nil {
+	if err := WaitForPipelineRunState(ctx, c, prName, timeout, PipelineRunSucceed(prName), "PipelineRunSuccess", v1beta1Version); err != nil {
 		t.Fatalf("Error waiting for PipelineRun %s to finish: %s", prName, err)
 	}
 
@@ -191,7 +191,7 @@ spec:
 		Chain(
 			FailedWithReason(pod.ReasonCouldntGetTask, prName),
 			FailedWithMessage("requested resource 'https://artifacthub.io/api/v1/packages/tekton-task/tekton-catalog-tasks/git-clone-this-does-not-exist/0.7.0' not found on hub", prName),
-		), "PipelineRunFailed"); err != nil {
+		), "PipelineRunFailed", v1beta1Version); err != nil {
 		t.Fatalf("Error waiting for PipelineRun to finish with expected error: %s", err)
 	}
 }
@@ -251,7 +251,7 @@ spec:
 	}
 
 	t.Logf("Waiting for PipelineRun %s in namespace %s to complete", prName, namespace)
-	if err := WaitForPipelineRunState(ctx, c, prName, timeout, PipelineRunSucceed(prName), "PipelineRunSuccess"); err != nil {
+	if err := WaitForPipelineRunState(ctx, c, prName, timeout, PipelineRunSucceed(prName), "PipelineRunSuccess", v1beta1Version); err != nil {
 		t.Fatalf("Error waiting for PipelineRun %s to finish: %s", prName, err)
 	}
 }
@@ -356,7 +356,7 @@ spec:
 				Chain(
 					FailedWithReason(pod.ReasonCouldntGetTask, prName),
 					FailedWithMessage(expectedErr, prName),
-				), "PipelineRunFailed"); err != nil {
+				), "PipelineRunFailed", v1beta1Version); err != nil {
 				t.Fatalf("Error waiting for PipelineRun to finish with expected error: %s", err)
 			}
 		})
@@ -421,7 +421,7 @@ spec:
 	}
 
 	t.Logf("Waiting for PipelineRun %s in namespace %s to complete", prName, namespace)
-	if err := WaitForPipelineRunState(ctx, c, prName, timeout, PipelineRunSucceed(prName), "PipelineRunSuccess"); err != nil {
+	if err := WaitForPipelineRunState(ctx, c, prName, timeout, PipelineRunSucceed(prName), "PipelineRunSuccess", v1beta1Version); err != nil {
 		t.Fatalf("Error waiting for PipelineRun %s to finish: %s", prName, err)
 	}
 }
@@ -463,7 +463,7 @@ spec:
 		Chain(
 			FailedWithReason(pipelinerun.ReasonCouldntGetPipeline, prName),
 			FailedWithMessage("pipelines.tekton.dev \"does-not-exist\" not found", prName),
-		), "PipelineRunFailed"); err != nil {
+		), "PipelineRunFailed", v1beta1Version); err != nil {
 		t.Fatalf("Error waiting for PipelineRun to finish with expected error: %s", err)
 	}
 }
@@ -525,7 +525,7 @@ spec:
 	}
 
 	t.Logf("Waiting for TaskRun %s in namespace %s to complete", trName, namespace)
-	if err := WaitForTaskRunState(ctx, c, trName, TaskRunSucceed(trName), "TaskRunSuccess"); err != nil {
+	if err := WaitForTaskRunState(ctx, c, trName, TaskRunSucceed(trName), "TaskRunSuccess", v1beta1Version); err != nil {
 		t.Fatalf("Error waiting for TaskRun %s to finish: %s", trName, err)
 	}
 }
@@ -604,7 +604,7 @@ spec:
 	}
 
 	t.Logf("Waiting for gitea user setup TaskRun in namespace %s to succeed", namespace)
-	if err := WaitForTaskRunState(ctx, c, trName, TaskRunSucceed(trName), "TaskRunSucceed"); err != nil {
+	if err := WaitForTaskRunState(ctx, c, trName, TaskRunSucceed(trName), "TaskRunSucceed", v1beta1Version); err != nil {
 		t.Fatalf("Error waiting for gitea user setup TaskRun to finish: %s", err)
 	}
 

--- a/test/retry_test.go
+++ b/test/retry_test.go
@@ -70,7 +70,7 @@ spec:
 	}
 
 	// Wait for the PipelineRun to fail, when retries are exhausted.
-	if err := WaitForPipelineRunState(ctx, c, pipelineRunName, 5*time.Minute, PipelineRunFailed(pipelineRunName), "PipelineRunFailed"); err != nil {
+	if err := WaitForPipelineRunState(ctx, c, pipelineRunName, 5*time.Minute, PipelineRunFailed(pipelineRunName), "PipelineRunFailed", v1beta1Version); err != nil {
 		t.Fatalf("Waiting for PipelineRun to fail: %v", err)
 	}
 

--- a/test/serviceaccount_test.go
+++ b/test/serviceaccount_test.go
@@ -163,7 +163,7 @@ spec:
 	}
 
 	t.Logf("Waiting for PipelineRun %s in namespace %s to complete", pipelineRun.Name, namespace)
-	if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, timeout, PipelineRunSucceed(pipelineRun.Name), "PipelineRunSuccess"); err != nil {
+	if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, timeout, PipelineRunSucceed(pipelineRun.Name), "PipelineRunSuccess", v1beta1Version); err != nil {
 		t.Fatalf("Error waiting for PipelineRun %s to finish: %s", pipelineRun.Name, err)
 	}
 
@@ -270,7 +270,7 @@ spec:
 	}
 
 	t.Logf("Waiting for PipelineRun %s in namespace %s to complete", pipelineRun.Name, namespace)
-	if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, timeout, PipelineRunSucceed(pipelineRun.Name), "PipelineRunSuccess"); err != nil {
+	if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, timeout, PipelineRunSucceed(pipelineRun.Name), "PipelineRunSuccess", v1beta1Version); err != nil {
 		t.Fatalf("Error waiting for PipelineRun %s to finish: %s", pipelineRun.Name, err)
 	}
 

--- a/test/sidecar_test.go
+++ b/test/sidecar_test.go
@@ -109,7 +109,7 @@ spec:
 				t.Fatalf("Failed to create TaskRun %q: %v", sidecarTaskRunName, err)
 			}
 
-			if err := WaitForTaskRunState(ctx, clients, sidecarTaskRunName, Succeed(sidecarTaskRunName), "TaskRunSucceed"); err != nil {
+			if err := WaitForTaskRunState(ctx, clients, sidecarTaskRunName, Succeed(sidecarTaskRunName), "TaskRunSucceed", v1beta1Version); err != nil {
 				t.Fatalf("Error waiting for TaskRun %q to finish: %v", sidecarTaskRunName, err)
 			}
 

--- a/test/start_time_test.go
+++ b/test/start_time_test.go
@@ -73,7 +73,7 @@ spec:
 	}
 	t.Logf("Created TaskRun %q in namespace %q", tr.Name, namespace)
 	// Wait for the TaskRun to complete.
-	if err := WaitForTaskRunState(ctx, c, tr.Name, TaskRunSucceed(tr.Name), "TaskRunSuccess"); err != nil {
+	if err := WaitForTaskRunState(ctx, c, tr.Name, TaskRunSucceed(tr.Name), "TaskRunSuccess", v1beta1Version); err != nil {
 		t.Errorf("Error waiting for TaskRun to succeed: %v", err)
 	}
 	tr, err = c.V1beta1TaskRunClient.Get(ctx, tr.Name, metav1.GetOptions{})

--- a/test/status_test.go
+++ b/test/status_test.go
@@ -84,7 +84,7 @@ spec:
 	}
 
 	t.Logf("Waiting for TaskRun in namespace %s to fail", namespace)
-	if err := WaitForTaskRunState(ctx, c, taskRun.Name, TaskRunFailed(taskRun.Name), "BuildValidationFailed"); err != nil {
+	if err := WaitForTaskRunState(ctx, c, taskRun.Name, TaskRunFailed(taskRun.Name), "BuildValidationFailed", v1beta1Version); err != nil {
 		t.Errorf("Error waiting for TaskRun to finish: %s", err)
 	}
 
@@ -111,7 +111,7 @@ spec:
 	}
 
 	t.Logf("Waiting for PipelineRun in namespace %s to fail", namespace)
-	if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, timeout, PipelineRunFailed(pipelineRun.Name), "BuildValidationFailed"); err != nil {
+	if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, timeout, PipelineRunFailed(pipelineRun.Name), "BuildValidationFailed", v1beta1Version); err != nil {
 		t.Errorf("Error waiting for TaskRun to finish: %s", err)
 	}
 }
@@ -177,7 +177,7 @@ func TestProvenanceFieldInPipelineRunTaskRunStatus(t *testing.T) {
 	}
 
 	t.Logf("Waiting for PipelineRun %s in namespace %s to complete", prName, namespace)
-	if err := WaitForPipelineRunState(ctx, c, prName, timeout, PipelineRunSucceed(prName), "PipelineRunSuccess"); err != nil {
+	if err := WaitForPipelineRunState(ctx, c, prName, timeout, PipelineRunSucceed(prName), "PipelineRunSuccess", v1beta1Version); err != nil {
 		t.Fatalf("Error waiting for PipelineRun %s to finish: %s", prName, err)
 	}
 
@@ -217,7 +217,7 @@ func TestProvenanceFieldInPipelineRunTaskRunStatus(t *testing.T) {
 	}
 
 	t.Logf("Waiting for TaskRun %s in namespace %s to complete", taskRunName, namespace)
-	if err := WaitForTaskRunState(ctx, c, taskRunName, TaskRunSucceed(taskRunName), "TaskRunSuccess"); err != nil {
+	if err := WaitForTaskRunState(ctx, c, taskRunName, TaskRunSucceed(taskRunName), "TaskRunSuccess", v1beta1Version); err != nil {
 		t.Fatalf("Error waiting for TaskRun %s to finish: %s", taskRunName, err)
 	}
 	// Get the TaskRun.

--- a/test/step_output_test.go
+++ b/test/step_output_test.go
@@ -88,7 +88,7 @@ func TestStepOutput(t *testing.T) {
 	}
 
 	t.Logf("Waiting for TaskRun %q to finish", taskRun.Name)
-	if err := WaitForTaskRunState(ctx, clients, taskRun.Name, Succeed(taskRun.Name), "TaskRunSucceed"); err != nil {
+	if err := WaitForTaskRunState(ctx, clients, taskRun.Name, Succeed(taskRun.Name), "TaskRunSucceed", v1beta1Version); err != nil {
 		t.Errorf("Error waiting for TaskRun %q to finish: %v", taskRun.Name, err)
 	}
 
@@ -162,7 +162,7 @@ func TestStepOutputWithWorkspace(t *testing.T) {
 	}
 
 	t.Logf("Waiting for TaskRun %q to finish", taskRun.Name)
-	if err := WaitForTaskRunState(ctx, clients, taskRun.Name, Succeed(taskRun.Name), "TaskRunSucceed"); err != nil {
+	if err := WaitForTaskRunState(ctx, clients, taskRun.Name, Succeed(taskRun.Name), "TaskRunSucceed", v1beta1Version); err != nil {
 		t.Errorf("Error waiting for TaskRun %q to finish: %v", taskRun.Name, err)
 	}
 

--- a/test/taskrun_test.go
+++ b/test/taskrun_test.go
@@ -84,7 +84,7 @@ spec:
 	}
 
 	t.Logf("Waiting for TaskRun in namespace %s to fail", namespace)
-	if err := WaitForTaskRunState(ctx, c, taskRunName, TaskRunFailed(taskRunName), "TaskRunFailed"); err != nil {
+	if err := WaitForTaskRunState(ctx, c, taskRunName, TaskRunFailed(taskRunName), "TaskRunFailed", v1beta1Version); err != nil {
 		t.Errorf("Error waiting for TaskRun to finish: %s", err)
 	}
 
@@ -176,7 +176,7 @@ spec:
 	}
 
 	t.Logf("Waiting for TaskRun in namespace %s to fail", namespace)
-	if err := WaitForTaskRunState(ctx, c, taskRunName, TaskRunSucceed(taskRunName), "TaskRunSucceed"); err != nil {
+	if err := WaitForTaskRunState(ctx, c, taskRunName, TaskRunSucceed(taskRunName), "TaskRunSucceed", v1beta1Version); err != nil {
 		t.Errorf("Error waiting for TaskRun to finish: %s", err)
 	}
 

--- a/test/tektonbundles_test.go
+++ b/test/tektonbundles_test.go
@@ -158,7 +158,7 @@ spec:
 	}
 
 	t.Logf("Waiting for PipelineRun in namespace %s to finish", namespace)
-	if err := WaitForPipelineRunState(ctx, c, pipelineRunName, timeout, PipelineRunSucceed(pipelineRunName), "PipelineRunCompleted"); err != nil {
+	if err := WaitForPipelineRunState(ctx, c, pipelineRunName, timeout, PipelineRunSucceed(pipelineRunName), "PipelineRunCompleted", v1beta1Version); err != nil {
 		t.Errorf("Error waiting for PipelineRun to finish with error: %s", err)
 	}
 
@@ -306,7 +306,7 @@ spec:
 	}
 
 	t.Logf("Waiting for PipelineRun in namespace %s to finish", namespace)
-	if err := WaitForPipelineRunState(ctx, c, pipelineRunName, timeout, PipelineRunSucceed(pipelineRunName), "PipelineRunCompleted"); err != nil {
+	if err := WaitForPipelineRunState(ctx, c, pipelineRunName, timeout, PipelineRunSucceed(pipelineRunName), "PipelineRunCompleted", v1beta1Version); err != nil {
 		t.Errorf("Error waiting for PipelineRun to finish with error: %s", err)
 	}
 
@@ -422,7 +422,7 @@ spec:
 		Chain(
 			FailedWithReason(pod.ReasonCouldntGetTask, pipelineRunName),
 			FailedWithMessage("does not contain a dev.tekton.image.apiVersion annotation", pipelineRunName),
-		), "PipelineRunFailed"); err != nil {
+		), "PipelineRunFailed", v1beta1Version); err != nil {
 		t.Fatalf("Error waiting for PipelineRun to finish with expected error: %s", err)
 	}
 }
@@ -533,7 +533,7 @@ spec:
 		Chain(
 			FailedWithReason(pipelinerun.ReasonCouldntGetPipeline, pipelineRunName),
 			FailedWithMessage("does not contain a dev.tekton.image.name annotation", pipelineRunName),
-		), "PipelineRunFailed"); err != nil {
+		), "PipelineRunFailed", v1beta1Version); err != nil {
 		t.Fatalf("Error waiting for PipelineRun to finish with expected error: %s", err)
 	}
 }

--- a/test/timeout_test.go
+++ b/test/timeout_test.go
@@ -93,7 +93,7 @@ spec:
 	}
 
 	t.Logf("Waiting for PipelineRun %s in namespace %s to be timed out", pipelineRun.Name, namespace)
-	if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, timeout, FailedWithReason(v1beta1.PipelineRunReasonTimedOut.String(), pipelineRun.Name), "PipelineRunTimedOut"); err != nil {
+	if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, timeout, FailedWithReason(v1beta1.PipelineRunReasonTimedOut.String(), pipelineRun.Name), "PipelineRunTimedOut", v1beta1Version); err != nil {
 		t.Errorf("Error waiting for PipelineRun %s to finish: %s", pipelineRun.Name, err)
 	}
 
@@ -103,7 +103,7 @@ spec:
 	}
 
 	t.Logf("Waiting for PipelineRun %s in namespace %s to be timed out", pipelineRun.Name, namespace)
-	if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, timeout, FailedWithReason(v1beta1.PipelineRunReasonTimedOut.String(), pipelineRun.Name), "PipelineRunTimedOut"); err != nil {
+	if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, timeout, FailedWithReason(v1beta1.PipelineRunReasonTimedOut.String(), pipelineRun.Name), "PipelineRunTimedOut", v1beta1Version); err != nil {
 		t.Errorf("Error waiting for PipelineRun %s to finish: %s", pipelineRun.Name, err)
 	}
 
@@ -113,7 +113,7 @@ spec:
 		wg.Add(1)
 		go func(name string) {
 			defer wg.Done()
-			err := WaitForTaskRunState(ctx, c, name, FailedWithReason(v1beta1.TaskRunReasonCancelled.String(), name), v1beta1.TaskRunReasonCancelled.String())
+			err := WaitForTaskRunState(ctx, c, name, FailedWithReason(v1beta1.TaskRunReasonCancelled.String(), name), v1beta1.TaskRunReasonCancelled.String(), v1beta1Version)
 			if err != nil {
 				t.Errorf("Error waiting for TaskRun %s to timeout: %s", name, err)
 			}
@@ -153,7 +153,7 @@ spec:
 	}
 
 	t.Logf("Waiting for PipelineRun %s in namespace %s to complete", secondPipelineRun.Name, namespace)
-	if err := WaitForPipelineRunState(ctx, c, secondPipelineRun.Name, timeout, PipelineRunSucceed(secondPipelineRun.Name), "PipelineRunSuccess"); err != nil {
+	if err := WaitForPipelineRunState(ctx, c, secondPipelineRun.Name, timeout, PipelineRunSucceed(secondPipelineRun.Name), "PipelineRunSuccess", v1beta1Version); err != nil {
 		t.Fatalf("Error waiting for PipelineRun %s to finish: %s", secondPipelineRun.Name, err)
 	}
 }
@@ -196,7 +196,7 @@ spec:
 
 	failMsg := "\"step-timeout\" exited because the step exceeded the specified timeout limit"
 	t.Logf("Waiting for %s in namespace %s to time out", "step-timeout", namespace)
-	if err := WaitForTaskRunState(ctx, c, taskRun.Name, FailedWithMessage(failMsg, taskRun.Name), "StepTimeout"); err != nil {
+	if err := WaitForTaskRunState(ctx, c, taskRun.Name, FailedWithMessage(failMsg, taskRun.Name), "StepTimeout", v1beta1Version); err != nil {
 		t.Logf("Error in taskRun %s status: %s\n", taskRun.Name, err)
 		t.Errorf("Expected: %s", failMsg)
 	}
@@ -251,7 +251,7 @@ spec:
 
 	failMsg := "\"step-timeout\" exited because the step exceeded the specified timeout limit"
 	t.Logf("Waiting for %s in namespace %s to time out", "step-timeout", namespace)
-	if err := WaitForTaskRunState(ctx, c, taskRun.Name, FailedWithMessage(failMsg, taskRun.Name), "StepTimeout"); err != nil {
+	if err := WaitForTaskRunState(ctx, c, taskRun.Name, FailedWithMessage(failMsg, taskRun.Name), "StepTimeout", v1beta1Version); err != nil {
 		t.Logf("Error in taskRun %s status: %s\n", taskRun.Name, err)
 		t.Errorf("Expected: %s", failMsg)
 	}
@@ -296,7 +296,7 @@ spec:
 	}
 
 	t.Logf("Waiting for TaskRun %s in namespace %s to complete", taskRun.Name, namespace)
-	if err := WaitForTaskRunState(ctx, c, taskRun.Name, FailedWithReason(v1beta1.TaskRunReasonTimedOut.String(), taskRun.Name), v1beta1.TaskRunReasonTimedOut.String()); err != nil {
+	if err := WaitForTaskRunState(ctx, c, taskRun.Name, FailedWithReason(v1beta1.TaskRunReasonTimedOut.String(), taskRun.Name), v1beta1.TaskRunReasonTimedOut.String(), v1beta1Version); err != nil {
 		t.Errorf("Error waiting for TaskRun %s to finish: %s", taskRun.Name, err)
 	}
 
@@ -385,7 +385,7 @@ spec:
 	}
 
 	t.Logf("Waiting for PipelineRun %s with PipelineTask timeout in namespace %s to fail", pipelineRun.Name, namespace)
-	if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, timeout, FailedWithReason(v1beta1.PipelineRunReasonFailed.String(), pipelineRun.Name), "PipelineRunTimedOut"); err != nil {
+	if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, timeout, FailedWithReason(v1beta1.PipelineRunReasonFailed.String(), pipelineRun.Name), "PipelineRunTimedOut", v1beta1Version); err != nil {
 		t.Fatalf("Error waiting for PipelineRun %s to finish: %s", pipelineRun.Name, err)
 	}
 
@@ -423,7 +423,7 @@ spec:
 					}
 				}
 				return false, nil
-			}, v1beta1.TaskRunReasonCancelled.String())
+			}, v1beta1.TaskRunReasonCancelled.String(), v1beta1Version)
 			if err != nil {
 				t.Errorf("Error waiting for TaskRun %s to timeout: %s", name, err)
 			}
@@ -509,7 +509,7 @@ spec:
 	}
 
 	t.Logf("Waiting for PipelineRun %s in namespace %s to be failed", pipelineRun.Name, namespace)
-	if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, timeout, FailedWithReason(v1beta1.PipelineRunReasonFailed.String(), pipelineRun.Name), "PipelineRunFailed"); err != nil {
+	if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, timeout, FailedWithReason(v1beta1.PipelineRunReasonFailed.String(), pipelineRun.Name), "PipelineRunFailed", v1beta1Version); err != nil {
 		t.Errorf("Error waiting for PipelineRun %s to finish: %s", pipelineRun.Name, err)
 	}
 
@@ -550,7 +550,7 @@ spec:
 					}
 				}
 				return false, nil
-			}, v1beta1.TaskRunReasonCancelled.String())
+			}, v1beta1.TaskRunReasonCancelled.String(), v1beta1Version)
 
 			if err != nil {
 				t.Errorf("Error waiting for TaskRun %s to timeout: %s", name, err)

--- a/test/trusted_resources_test.go
+++ b/test/trusted_resources_test.go
@@ -122,7 +122,7 @@ spec:
 	}
 
 	t.Logf("Waiting for PipelineRun in namespace %s to succeed", namespace)
-	if err := WaitForPipelineRunState(ctx, c, pr.Name, timeout, PipelineRunSucceed(pr.Name), "PipelineRunSucceed"); err != nil {
+	if err := WaitForPipelineRunState(ctx, c, pr.Name, timeout, PipelineRunSucceed(pr.Name), "PipelineRunSucceed", v1beta1Version); err != nil {
 		t.Errorf("Error waiting for PipelineRun to finish: %s", err)
 	}
 
@@ -205,7 +205,7 @@ spec:
 	}
 
 	t.Logf("Waiting for PipelineRun in namespace %s to fail", namespace)
-	if err := WaitForPipelineRunState(ctx, c, pr.Name, timeout, PipelineRunFailed(pr.Name), "PipelineRunFailed"); err != nil {
+	if err := WaitForPipelineRunState(ctx, c, pr.Name, timeout, PipelineRunFailed(pr.Name), "PipelineRunFailed", v1beta1Version); err != nil {
 		t.Errorf("Error waiting for PipelineRun to finish: %s", err)
 	}
 

--- a/test/wait.go
+++ b/test/wait.go
@@ -60,8 +60,9 @@ import (
 )
 
 const (
-	interval = 1 * time.Second
-	timeout  = 10 * time.Minute
+	interval       = 1 * time.Second
+	timeout        = 10 * time.Minute
+	v1beta1Version = "v1beta1"
 )
 
 // ConditionAccessorFn is a condition function used polling functions
@@ -82,36 +83,27 @@ func pollImmediateWithContext(ctx context.Context, fn func() (bool, error)) erro
 // interval until inState returns `true` indicating it is done, returns an
 // error or timeout. desc will be used to name the metric that is emitted to
 // track how long it took for name to get into the state checked by inState.
-func WaitForTaskRunState(ctx context.Context, c *clients, name string, inState ConditionAccessorFn, desc string) error {
+// version will be used to determine the client to be applied for the wait.
+func WaitForTaskRunState(ctx context.Context, c *clients, name string, inState ConditionAccessorFn, desc, version string) error {
 	metricName := fmt.Sprintf("WaitForTaskRunState/%s/%s", name, desc)
 	_, span := trace.StartSpan(context.Background(), metricName)
 	defer span.End()
 
 	return pollImmediateWithContext(ctx, func() (bool, error) {
-		r, err := c.V1beta1TaskRunClient.Get(ctx, name, metav1.GetOptions{})
-		if err != nil {
-			return true, err
+		switch version {
+		case "v1":
+			r, err := c.V1TaskRunClient.Get(ctx, name, metav1.GetOptions{})
+			if err != nil {
+				return true, err
+			}
+			return inState(&r.Status)
+		default:
+			r, err := c.V1beta1TaskRunClient.Get(ctx, name, metav1.GetOptions{})
+			if err != nil {
+				return true, err
+			}
+			return inState(&r.Status)
 		}
-		return inState(&r.Status)
-	})
-}
-
-// WaitForV1TaskRunState polls the status of the TaskRun called name from client every
-// interval until inState returns `true` indicating it is done, returns an
-// error or timeout. desc will be used to name the metric that is emitted to
-// track how long it took for name to get into the state checked by inState.
-// TODO: needs to change all WaitForTaskRunState to v1 when switching the stored version
-func WaitForV1TaskRunState(ctx context.Context, c *clients, name string, inState ConditionAccessorFn, desc string) error {
-	metricName := fmt.Sprintf("WaitForV1TaskRunState/%s/%s", name, desc)
-	_, span := trace.StartSpan(context.Background(), metricName)
-	defer span.End()
-
-	return pollImmediateWithContext(ctx, func() (bool, error) {
-		r, err := c.V1TaskRunClient.Get(ctx, name, metav1.GetOptions{})
-		if err != nil {
-			return true, err
-		}
-		return inState(&r.Status)
 	})
 }
 
@@ -175,40 +167,30 @@ func WaitForPodState(ctx context.Context, c *clients, name string, namespace str
 // interval until inState returns `true` indicating it is done, returns an
 // error or timeout. desc will be used to name the metric that is emitted to
 // track how long it took for name to get into the state checked by inState.
-func WaitForPipelineRunState(ctx context.Context, c *clients, name string, polltimeout time.Duration, inState ConditionAccessorFn, desc string) error {
+// version will be used to determine the client to be applied for the wait.
+func WaitForPipelineRunState(ctx context.Context, c *clients, name string, polltimeout time.Duration, inState ConditionAccessorFn, desc, version string) error {
 	metricName := fmt.Sprintf("WaitForPipelineRunState/%s/%s", name, desc)
 	_, span := trace.StartSpan(context.Background(), metricName)
 	defer span.End()
 
 	ctx, cancel := context.WithTimeout(ctx, polltimeout)
 	defer cancel()
-	return pollImmediateWithContext(ctx, func() (bool, error) {
-		r, err := c.V1beta1PipelineRunClient.Get(ctx, name, metav1.GetOptions{})
-		if err != nil {
-			return true, err
-		}
-		return inState(&r.Status)
-	})
-}
 
-// WaitForV1PipelineRunState polls the status of the PipelineRun called name from client every
-// interval until inState returns `true` indicating it is done, returns an
-// error or timeout. desc will be used to name the metric that is emitted to
-// track how long it took for name to get into the state checked by inState.
-// TODO: needs to change all WaitForPipelineRunState to v1 when switching the stored version
-func WaitForV1PipelineRunState(ctx context.Context, c *clients, name string, polltimeout time.Duration, inState ConditionAccessorFn, desc string) error {
-	metricName := fmt.Sprintf("WaitForPipelineRunState/%s/%s", name, desc)
-	_, span := trace.StartSpan(context.Background(), metricName)
-	defer span.End()
-
-	ctx, cancel := context.WithTimeout(ctx, polltimeout)
-	defer cancel()
 	return pollImmediateWithContext(ctx, func() (bool, error) {
-		r, err := c.V1PipelineRunClient.Get(ctx, name, metav1.GetOptions{})
-		if err != nil {
-			return true, err
+		switch version {
+		case "v1":
+			r, err := c.V1PipelineRunClient.Get(ctx, name, metav1.GetOptions{})
+			if err != nil {
+				return true, err
+			}
+			return inState(&r.Status)
+		default:
+			r, err := c.V1beta1PipelineRunClient.Get(ctx, name, metav1.GetOptions{})
+			if err != nil {
+				return true, err
+			}
+			return inState(&r.Status)
 		}
-		return inState(&r.Status)
 	})
 }
 

--- a/test/wait_example_test.go
+++ b/test/wait_example_test.go
@@ -54,7 +54,7 @@ func ExampleWaitForTaskRunState() {
 			}
 		}
 		return false, nil
-	}, "TaskRunHasCondition"); err != nil {
+	}, "TaskRunHasCondition", v1beta1Version); err != nil {
 		t.Errorf("Error waiting for TaskRun taskRunName to finish: %s", err)
 	}
 }
@@ -73,7 +73,7 @@ func ExampleWaitForPipelineRunState() {
 			}
 		}
 		return false, nil
-	}, "PipelineRunHasCondition"); err != nil {
+	}, "PipelineRunHasCondition", v1beta1Version); err != nil {
 		t.Errorf("Error waiting for PipelineRun pipelineRunName to finish: %s", err)
 	}
 }

--- a/test/windows_script_test.go
+++ b/test/windows_script_test.go
@@ -69,7 +69,7 @@ spec:
 	}
 
 	t.Logf("Waiting for TaskRun in namespace %s to finish", namespace)
-	if err := WaitForTaskRunState(ctx, c, taskRunName, TaskRunSucceed(taskRunName), "TaskRunSucceeded"); err != nil {
+	if err := WaitForTaskRunState(ctx, c, taskRunName, TaskRunSucceed(taskRunName), "TaskRunSucceeded", v1beta1Version); err != nil {
 		t.Errorf("Error waiting for TaskRun to finish: %s", err)
 	}
 
@@ -144,7 +144,7 @@ spec:
 	}
 
 	t.Logf("Waiting for TaskRun in namespace %s to fail", namespace)
-	if err := WaitForTaskRunState(ctx, c, taskRunName, TaskRunFailed(taskRunName), "TaskRunFailed"); err != nil {
+	if err := WaitForTaskRunState(ctx, c, taskRunName, TaskRunFailed(taskRunName), "TaskRunFailed", v1beta1Version); err != nil {
 		t.Errorf("Error waiting for TaskRun to finish: %s", err)
 	}
 

--- a/test/windows_test.go
+++ b/test/windows_test.go
@@ -73,7 +73,7 @@ spec:
 	}
 
 	t.Logf("Waiting for TaskRun in namespace %s to finish", namespace)
-	if err := WaitForTaskRunState(ctx, c, taskRunName, TaskRunSucceed(taskRunName), "TaskRunSucceeded"); err != nil {
+	if err := WaitForTaskRunState(ctx, c, taskRunName, TaskRunSucceed(taskRunName), "TaskRunSucceeded", v1beta1Version); err != nil {
 		t.Errorf("Error waiting for TaskRun to finish: %s", err)
 	}
 
@@ -136,7 +136,7 @@ spec:
 	}
 
 	t.Logf("Waiting for TaskRun in namespace %s to fail", namespace)
-	if err := WaitForTaskRunState(ctx, c, taskRunName, TaskRunFailed(taskRunName), "TaskRunFailed"); err != nil {
+	if err := WaitForTaskRunState(ctx, c, taskRunName, TaskRunFailed(taskRunName), "TaskRunFailed", v1beta1Version); err != nil {
 		t.Errorf("Error waiting for TaskRun to finish: %s", err)
 	}
 

--- a/test/workingdir_test.go
+++ b/test/workingdir_test.go
@@ -75,7 +75,7 @@ spec:
 	}
 
 	t.Logf("Waiting for TaskRun in namespace %s to finish successfully", namespace)
-	if err := WaitForTaskRunState(ctx, c, wdTaskRunName, TaskRunSucceed(wdTaskRunName), "TaskRunSuccess"); err != nil {
+	if err := WaitForTaskRunState(ctx, c, wdTaskRunName, TaskRunSucceed(wdTaskRunName), "TaskRunSuccess", v1beta1Version); err != nil {
 		t.Errorf("Error waiting for TaskRun to finish successfully: %s", err)
 	}
 
@@ -148,7 +148,7 @@ spec:
 	}
 
 	t.Logf("Waiting for TaskRun in namespace %s to finish successfully", namespace)
-	if err := WaitForTaskRunState(ctx, c, wdTaskRunName, TaskRunSucceed(wdTaskRunName), "TaskRunSuccess"); err != nil {
+	if err := WaitForTaskRunState(ctx, c, wdTaskRunName, TaskRunSucceed(wdTaskRunName), "TaskRunSuccess", v1beta1Version); err != nil {
 		t.Errorf("Error waiting for TaskRun to finish successfully: %s", err)
 	}
 

--- a/test/workspace_test.go
+++ b/test/workspace_test.go
@@ -81,7 +81,7 @@ spec:
 	}
 
 	t.Logf("Waiting for TaskRun in namespace %s to finish", namespace)
-	if err := WaitForTaskRunState(ctx, c, taskRunName, TaskRunFailed(taskRunName), "error"); err != nil {
+	if err := WaitForTaskRunState(ctx, c, taskRunName, TaskRunFailed(taskRunName), "error", v1beta1Version); err != nil {
 		t.Errorf("Error waiting for TaskRun to finish with error: %s", err)
 	}
 
@@ -243,7 +243,7 @@ spec:
 		t.Fatalf("Failed to create PipelineRun: %s", err)
 	}
 
-	if err := WaitForPipelineRunState(ctx, c, pipelineRunName, 10*time.Second, FailedWithMessage(`pipeline requires workspace with name "foo" be provided by pipelinerun`, pipelineRunName), "PipelineRunHasCondition"); err != nil {
+	if err := WaitForPipelineRunState(ctx, c, pipelineRunName, 10*time.Second, FailedWithMessage(`pipeline requires workspace with name "foo" be provided by pipelinerun`, pipelineRunName), "PipelineRunHasCondition", v1beta1Version); err != nil {
 		t.Fatalf("Failed to wait for PipelineRun %q to finish: %s", pipelineRunName, err)
 	}
 }
@@ -300,7 +300,7 @@ spec:
 	}
 
 	t.Logf("Waiting for TaskRun in namespace %s to finish", namespace)
-	if err := WaitForTaskRunState(ctx, c, taskRunName, TaskRunSucceed(taskRunName), "success"); err != nil {
+	if err := WaitForTaskRunState(ctx, c, taskRunName, TaskRunSucceed(taskRunName), "success", v1beta1Version); err != nil {
 		t.Errorf("Error waiting for TaskRun to finish with error: %s", err)
 	}
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This PR contains 2 commits which accomplish the following:
- Add regarding v1 clients for the prerequisites of the v1-CRD release testing
- Update example_tests wait status setup for v1-CRD examples tests on `Status`

Fixes: https://github.com/tektoncd/pipeline/issues/5793
/kind bug
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [n/a] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [n/a] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [n/a] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
