### PR TITLE
Refactor events to decouple k8s event and cloud event

### DIFF
--- a/pkg/reconciler/events/event_test.go
+++ b/pkg/reconciler/events/event_test.go
@@ -17,15 +17,12 @@ limitations under the License.
 package events
 
 import (
-	"errors"
 	"testing"
-	"time"
 
 	"github.com/tektoncd/pipeline/pkg/apis/config"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/reconciler/events/cloudevent"
-	eventstest "github.com/tektoncd/pipeline/test/events"
+	"github.com/tektoncd/pipeline/pkg/reconciler/events/k8sevent"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
@@ -34,147 +31,6 @@ import (
 	"knative.dev/pkg/controller"
 	rtesting "knative.dev/pkg/reconciler/testing"
 )
-
-func TestSendKubernetesEvents(t *testing.T) {
-	testcases := []struct {
-		name       string
-		before     *apis.Condition
-		after      *apis.Condition
-		wantEvents []string
-	}{{
-		name: "unknown to true with message",
-		before: &apis.Condition{
-			Type:   apis.ConditionSucceeded,
-			Status: corev1.ConditionUnknown,
-		},
-		after: &apis.Condition{
-			Type:    apis.ConditionSucceeded,
-			Status:  corev1.ConditionTrue,
-			Message: "all done",
-		},
-		wantEvents: []string{"Normal Succeeded all done"},
-	}, {
-		name: "true to true",
-		before: &apis.Condition{
-			Type:               apis.ConditionSucceeded,
-			Status:             corev1.ConditionTrue,
-			LastTransitionTime: apis.VolatileTime{Inner: metav1.NewTime(time.Now())},
-		},
-		after: &apis.Condition{
-			Type:               apis.ConditionSucceeded,
-			Status:             corev1.ConditionTrue,
-			LastTransitionTime: apis.VolatileTime{Inner: metav1.NewTime(time.Now().Add(5 * time.Minute))},
-		},
-		wantEvents: []string{},
-	}, {
-		name: "false to false",
-		before: &apis.Condition{
-			Type:   apis.ConditionSucceeded,
-			Status: corev1.ConditionFalse,
-		},
-		after: &apis.Condition{
-			Type:   apis.ConditionSucceeded,
-			Status: corev1.ConditionFalse,
-		},
-		wantEvents: []string{},
-	}, {
-		name: "unknown to unknown",
-		before: &apis.Condition{
-			Type:    apis.ConditionSucceeded,
-			Status:  corev1.ConditionUnknown,
-			Reason:  "",
-			Message: "",
-		},
-		after: &apis.Condition{
-			Type:    apis.ConditionSucceeded,
-			Status:  corev1.ConditionUnknown,
-			Reason:  "foo",
-			Message: "bar",
-		},
-		wantEvents: []string{"Normal foo bar"},
-	}, {
-		name:  "true to nil",
-		after: nil,
-		before: &apis.Condition{
-			Type:   apis.ConditionSucceeded,
-			Status: corev1.ConditionTrue,
-		},
-		wantEvents: []string{},
-	}, {
-		name:   "nil to true",
-		before: nil,
-		after: &apis.Condition{
-			Type:   apis.ConditionSucceeded,
-			Status: corev1.ConditionTrue,
-		},
-		wantEvents: []string{"Normal Succeeded "},
-	}, {
-		name:   "nil to unknown with message",
-		before: nil,
-		after: &apis.Condition{
-			Type:    apis.ConditionSucceeded,
-			Status:  corev1.ConditionUnknown,
-			Message: "just starting",
-		},
-		wantEvents: []string{"Normal Started "},
-	}, {
-		name: "unknown to false with message",
-		before: &apis.Condition{
-			Type:   apis.ConditionSucceeded,
-			Status: corev1.ConditionUnknown,
-		},
-		after: &apis.Condition{
-			Type:    apis.ConditionSucceeded,
-			Status:  corev1.ConditionFalse,
-			Message: "really bad",
-		},
-		wantEvents: []string{"Warning Failed really bad"},
-	}, {
-		name:   "nil to false",
-		before: nil,
-		after: &apis.Condition{
-			Type:   apis.ConditionSucceeded,
-			Status: corev1.ConditionFalse,
-		},
-		wantEvents: []string{"Warning Failed "},
-	}}
-
-	for _, ts := range testcases {
-		fr := record.NewFakeRecorder(1)
-		tr := &corev1.Pod{}
-		sendKubernetesEvents(fr, ts.before, ts.after, tr)
-		err := eventstest.CheckEventsOrdered(t, fr.Events, ts.name, ts.wantEvents)
-		if err != nil {
-			t.Errorf(err.Error())
-		}
-	}
-}
-
-func TestEmitError(t *testing.T) {
-	testcases := []struct {
-		name       string
-		err        error
-		wantEvents []string
-	}{{
-		name:       "with error",
-		err:        errors.New("something went wrong"),
-		wantEvents: []string{"Warning Error something went wrong"},
-	}, {
-		name:       "without error",
-		err:        nil,
-		wantEvents: []string{},
-	}}
-
-	for _, ts := range testcases {
-		fr := record.NewFakeRecorder(1)
-		tr := &corev1.Pod{}
-		EmitError(fr, ts.err, tr)
-		err := eventstest.CheckEventsOrdered(t, fr.Events, ts.name, ts.wantEvents)
-		if err != nil {
-			t.Errorf(err.Error())
-		}
-	}
-}
 
 func TestEmit(t *testing.T) {
 	objectStatus := duckv1.Status{
@@ -234,61 +90,7 @@ func TestEmit(t *testing.T) {
 
 		recorder := controller.GetEventRecorder(ctx).(*record.FakeRecorder)
 		Emit(ctx, nil, after, object)
-		if err := eventstest.CheckEventsOrdered(t, recorder.Events, tc.name, tc.wantEvents); err != nil {
-			t.Fatalf(err.Error())
-		}
-		fakeClient.CheckCloudEventsUnordered(t, tc.name, tc.wantCloudEvents)
-	}
-}
-
-func TestEmitCloudEvents(t *testing.T) {
-
-	object := &v1alpha1.Run{
-		ObjectMeta: metav1.ObjectMeta{
-			SelfLink: "/run/test1",
-		},
-		Status: v1alpha1.RunStatus{},
-	}
-	testcases := []struct {
-		name            string
-		data            map[string]string
-		wantEvents      []string
-		wantCloudEvents []string
-	}{{
-		name:            "without sink",
-		data:            map[string]string{},
-		wantEvents:      []string{},
-		wantCloudEvents: []string{},
-	}, {
-		name:            "with empty string sink",
-		data:            map[string]string{"default-cloud-events-sink": ""},
-		wantEvents:      []string{},
-		wantCloudEvents: []string{},
-	}, {
-		name:            "with sink",
-		data:            map[string]string{"default-cloud-events-sink": "http://mysink"},
-		wantEvents:      []string{},
-		wantCloudEvents: []string{`(?s)dev.tekton.event.run.started.v1.*test1`},
-	}}
-
-	for _, tc := range testcases {
-		// Setup the context and seed test data
-		ctx, _ := rtesting.SetupFakeContext(t)
-		ctx = cloudevent.WithClient(ctx, &cloudevent.FakeClientBehaviour{SendSuccessfully: true}, len(tc.wantCloudEvents))
-		fakeClient := cloudevent.Get(ctx).(cloudevent.FakeClient)
-
-		// Setup the config and add it to the context
-		defaults, _ := config.NewDefaultsFromMap(tc.data)
-		featureFlags, _ := config.NewFeatureFlagsFromMap(map[string]string{})
-		cfg := &config.Config{
-			Defaults:     defaults,
-			FeatureFlags: featureFlags,
-		}
-		ctx = config.ToContext(ctx, cfg)
-
-		recorder := controller.GetEventRecorder(ctx).(*record.FakeRecorder)
-		EmitCloudEvents(ctx, object)
-		if err := eventstest.CheckEventsOrdered(t, recorder.Events, tc.name, tc.wantEvents); err != nil {
+		if err := k8sevent.CheckEventsOrdered(t, recorder.Events, tc.name, tc.wantEvents); err != nil {
 			t.Fatalf(err.Error())
 		}
 		fakeClient.CheckCloudEventsUnordered(t, tc.name, tc.wantCloudEvents)

--- a/pkg/reconciler/events/k8sevent/doc.go
+++ b/pkg/reconciler/events/k8sevent/doc.go
@@ -1,0 +1,17 @@
+/*
+Copyright 2022 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k8sevent

--- a/pkg/reconciler/events/k8sevent/event.go
+++ b/pkg/reconciler/events/k8sevent/event.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2022 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k8sevent
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	"knative.dev/pkg/apis"
+	"knative.dev/pkg/controller"
+)
+
+const (
+	// EventReasonSucceded is the reason set for events about successful completion of TaskRuns / PipelineRuns
+	EventReasonSucceded = "Succeeded"
+	// EventReasonFailed is the reason set for events about unsuccessful completion of TaskRuns / PipelineRuns
+	EventReasonFailed = "Failed"
+	// EventReasonStarted is the reason set for events about the start of TaskRuns / PipelineRuns
+	EventReasonStarted = "Started"
+	// EventReasonError is the reason set for events related to TaskRuns / PipelineRuns reconcile errors
+	EventReasonError = "Error"
+)
+
+// EmitK8sEvents emits kubernetes events for object
+// k8s events are always sent if afterCondition is different from beforeCondition
+func EmitK8sEvents(ctx context.Context, beforeCondition *apis.Condition, afterCondition *apis.Condition, object runtime.Object) {
+	recorder := controller.GetEventRecorder(ctx)
+	// Events that are going to be sent
+	//
+	// Status "ConditionUnknown":
+	//   beforeCondition == nil, emit EventReasonStarted
+	//   beforeCondition != nil, emit afterCondition.Reason
+	//
+	//  Status "ConditionTrue": emit EventReasonSucceded
+	//  Status "ConditionFalse": emit EventReasonFailed
+	if !equality.Semantic.DeepEqual(beforeCondition, afterCondition) && afterCondition != nil {
+		// If the condition changed, and the target condition is not empty, we send an event
+		switch afterCondition.Status {
+		case corev1.ConditionTrue:
+			recorder.Event(object, corev1.EventTypeNormal, EventReasonSucceded, afterCondition.Message)
+		case corev1.ConditionFalse:
+			recorder.Event(object, corev1.EventTypeWarning, EventReasonFailed, afterCondition.Message)
+		case corev1.ConditionUnknown:
+			if beforeCondition == nil {
+				// If the condition changed, the status is "unknown", and there was no condition before,
+				// we emit the "Started event". We ignore further updates of the "unknown" status.
+				recorder.Event(object, corev1.EventTypeNormal, EventReasonStarted, "")
+			} else {
+				// If the condition changed, the status is "unknown", and there was a condition before,
+				// we emit an event that matches the reason and message of the condition.
+				// This is used for instance to signal the transition from "started" to "running"
+				recorder.Event(object, corev1.EventTypeNormal, afterCondition.Reason, afterCondition.Message)
+			}
+		}
+	}
+}
+
+// EmitError emits a failure associated to an error
+func EmitError(c record.EventRecorder, err error, object runtime.Object) {
+	if err != nil {
+		c.Event(object, corev1.EventTypeWarning, EventReasonError, err.Error())
+	}
+}

--- a/pkg/reconciler/events/k8sevent/event_test.go
+++ b/pkg/reconciler/events/k8sevent/event_test.go
@@ -1,0 +1,233 @@
+/*
+Copyright 2022 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k8sevent
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/tektoncd/pipeline/pkg/apis/config"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	"knative.dev/pkg/controller"
+	rtesting "knative.dev/pkg/reconciler/testing"
+)
+
+func TestEmitK8sEventsOnConditions(t *testing.T) {
+	testcases := []struct {
+		name       string
+		before     *apis.Condition
+		after      *apis.Condition
+		wantEvents []string
+	}{{
+		name: "unknown to true with message",
+		before: &apis.Condition{
+			Type:   apis.ConditionSucceeded,
+			Status: corev1.ConditionUnknown,
+		},
+		after: &apis.Condition{
+			Type:    apis.ConditionSucceeded,
+			Status:  corev1.ConditionTrue,
+			Message: "all done",
+		},
+		wantEvents: []string{"Normal Succeeded all done"},
+	}, {
+		name: "true to true",
+		before: &apis.Condition{
+			Type:               apis.ConditionSucceeded,
+			Status:             corev1.ConditionTrue,
+			LastTransitionTime: apis.VolatileTime{Inner: metav1.NewTime(time.Now())},
+		},
+		after: &apis.Condition{
+			Type:               apis.ConditionSucceeded,
+			Status:             corev1.ConditionTrue,
+			LastTransitionTime: apis.VolatileTime{Inner: metav1.NewTime(time.Now().Add(5 * time.Minute))},
+		},
+		wantEvents: []string{},
+	}, {
+		name: "false to false",
+		before: &apis.Condition{
+			Type:   apis.ConditionSucceeded,
+			Status: corev1.ConditionFalse,
+		},
+		after: &apis.Condition{
+			Type:   apis.ConditionSucceeded,
+			Status: corev1.ConditionFalse,
+		},
+		wantEvents: []string{},
+	}, {
+		name: "unknown to unknown",
+		before: &apis.Condition{
+			Type:    apis.ConditionSucceeded,
+			Status:  corev1.ConditionUnknown,
+			Reason:  "",
+			Message: "",
+		},
+		after: &apis.Condition{
+			Type:    apis.ConditionSucceeded,
+			Status:  corev1.ConditionUnknown,
+			Reason:  "foo",
+			Message: "bar",
+		},
+		wantEvents: []string{"Normal foo bar"},
+	}, {
+		name:  "true to nil",
+		after: nil,
+		before: &apis.Condition{
+			Type:   apis.ConditionSucceeded,
+			Status: corev1.ConditionTrue,
+		},
+		wantEvents: []string{},
+	}, {
+		name:   "nil to true",
+		before: nil,
+		after: &apis.Condition{
+			Type:   apis.ConditionSucceeded,
+			Status: corev1.ConditionTrue,
+		},
+		wantEvents: []string{"Normal Succeeded "},
+	}, {
+		name:   "nil to unknown with message",
+		before: nil,
+		after: &apis.Condition{
+			Type:    apis.ConditionSucceeded,
+			Status:  corev1.ConditionUnknown,
+			Message: "just starting",
+		},
+		wantEvents: []string{"Normal Started "},
+	}, {
+		name: "unknown to false with message",
+		before: &apis.Condition{
+			Type:   apis.ConditionSucceeded,
+			Status: corev1.ConditionUnknown,
+		},
+		after: &apis.Condition{
+			Type:    apis.ConditionSucceeded,
+			Status:  corev1.ConditionFalse,
+			Message: "really bad",
+		},
+		wantEvents: []string{"Warning Failed really bad"},
+	}, {
+		name:   "nil to false",
+		before: nil,
+		after: &apis.Condition{
+			Type:   apis.ConditionSucceeded,
+			Status: corev1.ConditionFalse,
+		},
+		wantEvents: []string{"Warning Failed "},
+	}}
+
+	for _, ts := range testcases {
+		tr := &corev1.Pod{}
+		ctx, _ := rtesting.SetupFakeContext(t)
+		recorder := controller.GetEventRecorder(ctx).(*record.FakeRecorder)
+		EmitK8sEvents(ctx, ts.before, ts.after, tr)
+		err := CheckEventsOrdered(t, recorder.Events, ts.name, ts.wantEvents)
+		if err != nil {
+			t.Errorf(err.Error())
+		}
+	}
+}
+
+func TestEmitK8sEvents(t *testing.T) {
+	objectStatus := duckv1.Status{
+		Conditions: []apis.Condition{{
+			Type:   apis.ConditionSucceeded,
+			Status: corev1.ConditionUnknown,
+			Reason: v1beta1.PipelineRunReasonStarted.String(),
+		}},
+	}
+	object := &v1beta1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			SelfLink: "/pipelineruns/test1",
+		},
+		Status: v1beta1.PipelineRunStatus{Status: objectStatus},
+	}
+	after := &apis.Condition{
+		Type:    apis.ConditionSucceeded,
+		Status:  corev1.ConditionUnknown,
+		Message: "just starting",
+	}
+	testcases := []struct {
+		name       string
+		data       map[string]string
+		wantEvents []string
+	}{{
+		name:       "without sink",
+		data:       map[string]string{},
+		wantEvents: []string{"Normal Started"},
+	}, {
+		name:       "with empty string sink",
+		data:       map[string]string{"default-cloud-events-sink": ""},
+		wantEvents: []string{"Normal Started"},
+	}, {
+		name:       "with sink",
+		data:       map[string]string{"default-cloud-events-sink": "http://mysink"},
+		wantEvents: []string{"Normal Started"},
+	}}
+
+	for _, tc := range testcases {
+		// Setup the context and seed test data
+		ctx, _ := rtesting.SetupFakeContext(t)
+
+		// Setup the config and add it to the context
+		defaults, _ := config.NewDefaultsFromMap(tc.data)
+		featureFlags, _ := config.NewFeatureFlagsFromMap(map[string]string{})
+		cfg := &config.Config{
+			Defaults:     defaults,
+			FeatureFlags: featureFlags,
+		}
+		ctx = config.ToContext(ctx, cfg)
+
+		recorder := controller.GetEventRecorder(ctx).(*record.FakeRecorder)
+		EmitK8sEvents(ctx, nil, after, object)
+		if err := CheckEventsOrdered(t, recorder.Events, tc.name, tc.wantEvents); err != nil {
+			t.Fatalf(err.Error())
+		}
+	}
+}
+
+func TestEmitError(t *testing.T) {
+	testcases := []struct {
+		name       string
+		err        error
+		wantEvents []string
+	}{{
+		name:       "with error",
+		err:        errors.New("something went wrong"),
+		wantEvents: []string{"Warning Error something went wrong"},
+	}, {
+		name:       "without error",
+		err:        nil,
+		wantEvents: []string{},
+	}}
+
+	for _, ts := range testcases {
+		fr := record.NewFakeRecorder(1)
+		tr := &corev1.Pod{}
+		EmitError(fr, ts.err, tr)
+		err := CheckEventsOrdered(t, fr.Events, ts.name, ts.wantEvents)
+		if err != nil {
+			t.Errorf(err.Error())
+		}
+	}
+}

--- a/pkg/reconciler/events/k8sevent/events.go
+++ b/pkg/reconciler/events/k8sevent/events.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package events
+package k8sevent
 
 import (
 	"fmt"

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -39,13 +39,13 @@ import (
 	resourcev1alpha1 "github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1"
 	resolutionutil "github.com/tektoncd/pipeline/pkg/internal/resolution"
 	"github.com/tektoncd/pipeline/pkg/reconciler/events/cloudevent"
+	"github.com/tektoncd/pipeline/pkg/reconciler/events/k8sevent"
 	"github.com/tektoncd/pipeline/pkg/reconciler/pipelinerun/resources"
 	ttesting "github.com/tektoncd/pipeline/pkg/reconciler/testing"
 	"github.com/tektoncd/pipeline/pkg/reconciler/volumeclaim"
 	resolutioncommon "github.com/tektoncd/pipeline/pkg/resolution/common"
 	"github.com/tektoncd/pipeline/test"
 	"github.com/tektoncd/pipeline/test/diff"
-	eventstest "github.com/tektoncd/pipeline/test/events"
 	"github.com/tektoncd/pipeline/test/names"
 	"github.com/tektoncd/pipeline/test/parse"
 	"gomodules.xyz/jsonpatch/v2"
@@ -2951,7 +2951,7 @@ spec:
 				"Normal PipelineRunCouldntCancel PipelineRun \"test-pipeline-fails-to-cancel\" was cancelled but had errors trying to cancel TaskRuns",
 				"Warning InternalError 1 error occurred",
 			}
-			err = eventstest.CheckEventsOrdered(t, testAssets.Recorder.Events, prName, wantEvents)
+			err = k8sevent.CheckEventsOrdered(t, testAssets.Recorder.Events, prName, wantEvents)
 			if err != nil {
 				t.Errorf(err.Error())
 			}
@@ -3067,7 +3067,7 @@ spec:
 		"Normal PipelineRunCouldntTimeOut PipelineRun \"test-pipeline-fails-to-timeout\" was timed out but had errors trying to time out TaskRuns and/or Runs",
 		"Warning InternalError 1 error occurred",
 	}
-	err = eventstest.CheckEventsOrdered(t, testAssets.Recorder.Events, prName, wantEvents)
+	err = k8sevent.CheckEventsOrdered(t, testAssets.Recorder.Events, prName, wantEvents)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
@@ -7082,7 +7082,7 @@ func (prt PipelineRunTest) reconcileRun(namespace, pipelineRunName string, wantE
 
 	// Check generated events match what's expected
 	if len(wantEvents) > 0 {
-		if err := eventstest.CheckEventsOrdered(prt.Test, prt.TestAssets.Recorder.Events, pipelineRunName, wantEvents); err != nil {
+		if err := k8sevent.CheckEventsOrdered(prt.Test, prt.TestAssets.Recorder.Events, pipelineRunName, wantEvents); err != nil {
 			prt.Test.Errorf(err.Error())
 		}
 	}

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -41,6 +41,7 @@ import (
 	resolutionutil "github.com/tektoncd/pipeline/pkg/internal/resolution"
 	podconvert "github.com/tektoncd/pipeline/pkg/pod"
 	"github.com/tektoncd/pipeline/pkg/reconciler/events/cloudevent"
+	"github.com/tektoncd/pipeline/pkg/reconciler/events/k8sevent"
 	"github.com/tektoncd/pipeline/pkg/reconciler/taskrun/resources"
 	ttesting "github.com/tektoncd/pipeline/pkg/reconciler/testing"
 	"github.com/tektoncd/pipeline/pkg/reconciler/volumeclaim"
@@ -48,7 +49,6 @@ import (
 	"github.com/tektoncd/pipeline/pkg/workspace"
 	"github.com/tektoncd/pipeline/test"
 	"github.com/tektoncd/pipeline/test/diff"
-	eventstest "github.com/tektoncd/pipeline/test/events"
 	"github.com/tektoncd/pipeline/test/names"
 	"github.com/tektoncd/pipeline/test/parse"
 	corev1 "k8s.io/api/core/v1"
@@ -701,7 +701,7 @@ spec:
 		t.Errorf("Expected reason %q but was %s", v1beta1.TaskRunReasonRunning.String(), condition.Reason)
 	}
 
-	err = eventstest.CheckEventsOrdered(t, testAssets.Recorder.Events, "reconcile-cloud-events", wantEvents)
+	err = k8sevent.CheckEventsOrdered(t, testAssets.Recorder.Events, "reconcile-cloud-events", wantEvents)
 	if !(err == nil) {
 		t.Errorf(err.Error())
 	}
@@ -1193,7 +1193,7 @@ spec:
 				t.Fatalf("Expected actions to be logged in the kubeclient, got none")
 			}
 
-			err = eventstest.CheckEventsOrdered(t, testAssets.Recorder.Events, tc.name, tc.wantEvents)
+			err = k8sevent.CheckEventsOrdered(t, testAssets.Recorder.Events, tc.name, tc.wantEvents)
 			if err != nil {
 				t.Errorf(err.Error())
 			}
@@ -1348,7 +1348,7 @@ spec:
 				t.Fatalf("Expected actions to be logged in the kubeclient, got none")
 			}
 
-			err = eventstest.CheckEventsOrdered(t, testAssets.Recorder.Events, tc.name, tc.wantEvents)
+			err = k8sevent.CheckEventsOrdered(t, testAssets.Recorder.Events, tc.name, tc.wantEvents)
 			if err != nil {
 				t.Errorf(err.Error())
 			}
@@ -1687,7 +1687,7 @@ spec:
 				t.Errorf("expected 2 actions, got %d. Actions: %#v", len(actions), actions)
 			}
 
-			err := eventstest.CheckEventsOrdered(t, testAssets.Recorder.Events, tc.name, tc.wantEvents)
+			err := k8sevent.CheckEventsOrdered(t, testAssets.Recorder.Events, tc.name, tc.wantEvents)
 			if !(err == nil) {
 				t.Errorf(err.Error())
 			}
@@ -1965,7 +1965,7 @@ status:
 		"Normal Running Not all Steps",
 		"Normal Succeeded",
 	}
-	err = eventstest.CheckEventsOrdered(t, testAssets.Recorder.Events, "test-reconcile-pod-updateStatus", wantEvents)
+	err = k8sevent.CheckEventsOrdered(t, testAssets.Recorder.Events, "test-reconcile-pod-updateStatus", wantEvents)
 	if !(err == nil) {
 		t.Errorf(err.Error())
 	}
@@ -2064,7 +2064,7 @@ status:
 		"Normal Started",
 		"Warning Failed TaskRun \"test-taskrun-run-cancelled\" was cancelled",
 	}
-	err = eventstest.CheckEventsOrdered(t, testAssets.Recorder.Events, "test-reconcile-on-cancelled-taskrun", wantEvents)
+	err = k8sevent.CheckEventsOrdered(t, testAssets.Recorder.Events, "test-reconcile-on-cancelled-taskrun", wantEvents)
 	if !(err == nil) {
 		t.Errorf(err.Error())
 	}
@@ -2137,7 +2137,7 @@ status:
 		"Normal Started",
 		"Warning Failed TaskRun \"test-taskrun-run-timedout\" was cancelled. TaskRun cancelled as pipeline has been cancelled.",
 	}
-	err = eventstest.CheckEventsOrdered(t, testAssets.Recorder.Events, "test-reconcile-on-timedout-taskrun", wantEvents)
+	err = k8sevent.CheckEventsOrdered(t, testAssets.Recorder.Events, "test-reconcile-on-timedout-taskrun", wantEvents)
 	if !(err == nil) {
 		t.Errorf(err.Error())
 	}
@@ -2208,7 +2208,7 @@ status:
 	if d := cmp.Diff(expectedStatus, condition, ignoreLastTransitionTime); d != "" {
 		t.Fatalf("Did not get expected condition %s", diff.PrintWantGot(d))
 	}
-	err = eventstest.CheckEventsOrdered(t, testAssets.Recorder.Events, taskRun.Name, wantEvents)
+	err = k8sevent.CheckEventsOrdered(t, testAssets.Recorder.Events, taskRun.Name, wantEvents)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
@@ -2280,7 +2280,7 @@ status:
 	if d := cmp.Diff(expectedStatus, condition, ignoreLastTransitionTime); d != "" {
 		t.Fatalf("Did not get expected condition %s", diff.PrintWantGot(d))
 	}
-	err = eventstest.CheckEventsOrdered(t, testAssets.Recorder.Events, taskRun.Name, wantEvents)
+	err = k8sevent.CheckEventsOrdered(t, testAssets.Recorder.Events, taskRun.Name, wantEvents)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
@@ -2395,7 +2395,7 @@ status:
 			if d := cmp.Diff(tc.expectedStatus, condition, ignoreLastTransitionTime); d != "" {
 				t.Fatalf("Did not get expected condition %s", diff.PrintWantGot(d))
 			}
-			err = eventstest.CheckEventsOrdered(t, testAssets.Recorder.Events, tc.taskRun.Name, tc.wantEvents)
+			err = k8sevent.CheckEventsOrdered(t, testAssets.Recorder.Events, tc.taskRun.Name, tc.wantEvents)
 			if !(err == nil) {
 				t.Errorf(err.Error())
 			}
@@ -3543,7 +3543,7 @@ spec:
 				}
 			}
 
-			err = eventstest.CheckEventsOrdered(t, testAssets.Recorder.Events, tt.desc, tt.wantEvents)
+			err = k8sevent.CheckEventsOrdered(t, testAssets.Recorder.Events, tt.desc, tt.wantEvents)
 			if !(err == nil) {
 				t.Errorf(err.Error())
 			}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This commit refactors the code in events to decouple the k8s events emit
and cloud events emit. This commit fixes https://github.com/tektoncd/pipeline/issues/4404. This could avoid circular dependencies. The `events` in `test` is also moved to k8sevent pkg. 
This also pave the path for https://github.com/tektoncd/pipeline/pull/5770

/kind cleanup

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
