### PR TITLE
Correct required v.s. optional fields in run status

### DIFF
--- a/docs/pipeline-api.md
+++ b/docs/pipeline-api.md
@@ -2217,7 +2217,6 @@ Kubernetes meta/v1.Time
 </em>
 </td>
 <td>
-<em>(Optional)</em>
 <p>StartTime is the time the PipelineRun is actually started.</p>
 </td>
 </tr>
@@ -2231,7 +2230,6 @@ Kubernetes meta/v1.Time
 </em>
 </td>
 <td>
-<em>(Optional)</em>
 <p>CompletionTime is the time the PipelineRun completed.</p>
 </td>
 </tr>
@@ -2314,6 +2312,7 @@ Provenance
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Provenance contains some key authenticated metadata about how a software artifact was built (what sources, what inputs/outputs, etc.).</p>
 </td>
 </tr>
@@ -4991,7 +4990,6 @@ Kubernetes meta/v1.Time
 </em>
 </td>
 <td>
-<em>(Optional)</em>
 <p>StartTime is the time the build is actually started.</p>
 </td>
 </tr>
@@ -5005,7 +5003,6 @@ Kubernetes meta/v1.Time
 </em>
 </td>
 <td>
-<em>(Optional)</em>
 <p>CompletionTime is the time the build completed.</p>
 </td>
 </tr>
@@ -5089,6 +5086,7 @@ Provenance
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Provenance contains some key authenticated metadata about how a software artifact was built (what sources, what inputs/outputs, etc.).</p>
 </td>
 </tr>
@@ -9582,7 +9580,6 @@ Kubernetes meta/v1.Time
 </em>
 </td>
 <td>
-<em>(Optional)</em>
 <p>StartTime is the time the PipelineRun is actually started.</p>
 </td>
 </tr>
@@ -9596,7 +9593,6 @@ Kubernetes meta/v1.Time
 </em>
 </td>
 <td>
-<em>(Optional)</em>
 <p>CompletionTime is the time the PipelineRun completed.</p>
 </td>
 </tr>
@@ -9709,6 +9705,7 @@ Provenance
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Provenance contains some key authenticated metadata about how a software artifact was built (what sources, what inputs/outputs, etc.).</p>
 </td>
 </tr>
@@ -13024,7 +13021,6 @@ Kubernetes meta/v1.Time
 </em>
 </td>
 <td>
-<em>(Optional)</em>
 <p>StartTime is the time the build is actually started.</p>
 </td>
 </tr>
@@ -13038,7 +13034,6 @@ Kubernetes meta/v1.Time
 </em>
 </td>
 <td>
-<em>(Optional)</em>
 <p>CompletionTime is the time the build completed.</p>
 </td>
 </tr>
@@ -13152,6 +13147,7 @@ Provenance
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Provenance contains some key authenticated metadata about how a software artifact was built (what sources, what inputs/outputs, etc.).</p>
 </td>
 </tr>

--- a/pkg/apis/pipeline/v1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1/pipelinerun_types.go
@@ -399,11 +399,9 @@ type ChildStatusReference struct {
 // consume these fields via duck typing.
 type PipelineRunStatusFields struct {
 	// StartTime is the time the PipelineRun is actually started.
-	// +optional
 	StartTime *metav1.Time `json:"startTime,omitempty"`
 
 	// CompletionTime is the time the PipelineRun completed.
-	// +optional
 	CompletionTime *metav1.Time `json:"completionTime,omitempty"`
 
 	// Results are the list of results written out by the pipeline task's containers
@@ -429,6 +427,7 @@ type PipelineRunStatusFields struct {
 	FinallyStartTime *metav1.Time `json:"finallyStartTime,omitempty"`
 
 	// Provenance contains some key authenticated metadata about how a software artifact was built (what sources, what inputs/outputs, etc.).
+	// +optional
 	Provenance *Provenance `json:"provenance,omitempty"`
 }
 

--- a/pkg/apis/pipeline/v1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1/taskrun_types.go
@@ -201,11 +201,9 @@ type TaskRunStatusFields struct {
 	PodName string `json:"podName"`
 
 	// StartTime is the time the build is actually started.
-	// +optional
 	StartTime *metav1.Time `json:"startTime,omitempty"`
 
 	// CompletionTime is the time the build completed.
-	// +optional
 	CompletionTime *metav1.Time `json:"completionTime,omitempty"`
 
 	// Steps describes the state of each build step container.
@@ -233,6 +231,7 @@ type TaskRunStatusFields struct {
 	TaskSpec *TaskSpec `json:"taskSpec,omitempty"`
 
 	// Provenance contains some key authenticated metadata about how a software artifact was built (what sources, what inputs/outputs, etc.).
+	// +optional
 	Provenance *Provenance `json:"provenance,omitempty"`
 }
 

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
@@ -418,11 +418,9 @@ type ChildStatusReference struct {
 // consume these fields via duck typing.
 type PipelineRunStatusFields struct {
 	// StartTime is the time the PipelineRun is actually started.
-	// +optional
 	StartTime *metav1.Time `json:"startTime,omitempty"`
 
 	// CompletionTime is the time the PipelineRun completed.
-	// +optional
 	CompletionTime *metav1.Time `json:"completionTime,omitempty"`
 
 	// Deprecated - use ChildReferences instead.
@@ -458,6 +456,7 @@ type PipelineRunStatusFields struct {
 	FinallyStartTime *metav1.Time `json:"finallyStartTime,omitempty"`
 
 	// Provenance contains some key authenticated metadata about how a software artifact was built (what sources, what inputs/outputs, etc.).
+	// +optional
 	Provenance *Provenance `json:"provenance,omitempty"`
 }
 

--- a/pkg/apis/pipeline/v1beta1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_types.go
@@ -232,11 +232,9 @@ type TaskRunStatusFields struct {
 	PodName string `json:"podName"`
 
 	// StartTime is the time the build is actually started.
-	// +optional
 	StartTime *metav1.Time `json:"startTime,omitempty"`
 
 	// CompletionTime is the time the build completed.
-	// +optional
 	CompletionTime *metav1.Time `json:"completionTime,omitempty"`
 
 	// Steps describes the state of each build step container.
@@ -276,6 +274,7 @@ type TaskRunStatusFields struct {
 	TaskSpec *TaskSpec `json:"taskSpec,omitempty"`
 
 	// Provenance contains some key authenticated metadata about how a software artifact was built (what sources, what inputs/outputs, etc.).
+	// +optional
 	Provenance *Provenance `json:"provenance,omitempty"`
 }
 


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

/kind misc 

Fixes https://github.com/tektoncd/pipeline/issues/5818.

Prior, `startTime` and `completionTime` are marked as optional fields in Run status, and `provenance` field was not marked as optional in Run status.

Now, we remove `+optional` tag for `startTime` and `completionTime` in Run status, and add `+optional` tag for the `provenance` field.

Signed-off-by: Chuang Wang <chuangw@google.com>

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Remove optional tag for `startTime` and `completionTime` in TaskRun/PipelineRun status, and add option tag for `provenance` field in TaskRun/PipelineRun status.
```
