### PR TITLE
Add embedded-status to config-feature-flags.yaml

### DIFF
--- a/config/config-feature-flags.yaml
+++ b/config/config-feature-flags.yaml
@@ -90,3 +90,8 @@ data:
   # in the TaskRun/PipelineRun such as the source from where a remote Task/Pipeline
   # definition was fetched.
   enable-provenance-in-status: "false"
+  # Setting this flag to "full" to enable full embedding of `TaskRun` and `Run` statuses in the
+  # `PipelineRun` status. Set it to "minimal" to populate the `ChildReferences` field in the
+  # `PipelineRun` status with name, kind, and API version information for each `TaskRun` and
+  # `Run` in the `PipelineRun` instead. Set it to "both" to do both.
+  embedded-status: "full"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This commit adds the `embedded-status` flag to config-feature-flags. This is added
for more visibilities of the pipelineRunStatus embeddedStatus feature flag.The related 
documentations are already in the codebase.

/kind misc

fixes: #5824 
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [n/a] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
