### PR TITLE
Remove return error in GetTaskFunc and GetPipelineFunc

### DIFF
--- a/pkg/reconciler/pipelinerun/resources/pipelineref_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelineref_test.go
@@ -199,7 +199,7 @@ func TestGetPipelineFunc(t *testing.T) {
 				t.Fatalf("failed to upload test image: %s", err.Error())
 			}
 
-			fn, err := resources.GetPipelineFunc(ctx, kubeclient, tektonclient, nil, &v1beta1.PipelineRun{
+			fn := resources.GetPipelineFunc(ctx, kubeclient, tektonclient, nil, &v1beta1.PipelineRun{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "default"},
 				Spec: v1beta1.PipelineRunSpec{
 					PipelineRef:        tc.ref,
@@ -270,10 +270,7 @@ func TestGetPipelineFuncSpecAlreadyFetched(t *testing.T) {
 		Spec: pipelineSpec,
 	}
 
-	fn, err := resources.GetPipelineFunc(ctx, kubeclient, tektonclient, nil, pipelineRun)
-	if err != nil {
-		t.Fatalf("failed to get pipeline fn: %s", err.Error())
-	}
+	fn := resources.GetPipelineFunc(ctx, kubeclient, tektonclient, nil, pipelineRun)
 	actualPipeline, actualConfigSource, err := fn(ctx, name)
 	if err != nil {
 		t.Fatalf("failed to call pipelinefn: %s", err.Error())
@@ -302,16 +299,13 @@ func TestGetPipelineFunc_RemoteResolution(t *testing.T) {
 
 	resolved := test.NewResolvedResource([]byte(pipelineYAML), nil, sampleConfigSource.DeepCopy(), nil)
 	requester := test.NewRequester(resolved, nil)
-	fn, err := resources.GetPipelineFunc(ctx, nil, nil, requester, &v1beta1.PipelineRun{
+	fn := resources.GetPipelineFunc(ctx, nil, nil, requester, &v1beta1.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{Namespace: "default"},
 		Spec: v1beta1.PipelineRunSpec{
 			PipelineRef:        pipelineRef,
 			ServiceAccountName: "default",
 		},
 	})
-	if err != nil {
-		t.Fatalf("failed to get pipeline fn: %s", err.Error())
-	}
 
 	resolvedPipeline, resolvedConfigSource, err := fn(ctx, pipelineRef.Name)
 	if err != nil {
@@ -361,7 +355,7 @@ func TestGetPipelineFunc_RemoteResolution_ReplacedParams(t *testing.T) {
 			Value: *v1beta1.NewStructuredValues("test-pipeline"),
 		}},
 	}
-	fn, err := resources.GetPipelineFunc(ctx, nil, nil, requester, &v1beta1.PipelineRun{
+	fn := resources.GetPipelineFunc(ctx, nil, nil, requester, &v1beta1.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-pipeline",
 			Namespace: "default",
@@ -375,9 +369,6 @@ func TestGetPipelineFunc_RemoteResolution_ReplacedParams(t *testing.T) {
 			}},
 		},
 	})
-	if err != nil {
-		t.Fatalf("failed to get pipeline fn: %s", err.Error())
-	}
 
 	resolvedPipeline, resolvedConfigSource, err := fn(ctx, pipelineRef.Name)
 	if err != nil {
@@ -405,7 +396,7 @@ func TestGetPipelineFunc_RemoteResolution_ReplacedParams(t *testing.T) {
 		},
 	}
 
-	fnNotMatching, err := resources.GetPipelineFunc(ctx, nil, nil, requester, &v1beta1.PipelineRun{
+	fnNotMatching := resources.GetPipelineFunc(ctx, nil, nil, requester, &v1beta1.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "other-pipeline",
 			Namespace: "default",
@@ -419,9 +410,6 @@ func TestGetPipelineFunc_RemoteResolution_ReplacedParams(t *testing.T) {
 			}},
 		},
 	})
-	if err != nil {
-		t.Fatalf("failed to get pipeline fn: %s", err.Error())
-	}
 
 	_, _, err = fnNotMatching(ctx, pipelineRefNotMatching.Name)
 	if err == nil {
@@ -440,16 +428,13 @@ func TestGetPipelineFunc_RemoteResolutionInvalidData(t *testing.T) {
 	resolvesTo := []byte("INVALID YAML")
 	resource := test.NewResolvedResource(resolvesTo, nil, nil, nil)
 	requester := test.NewRequester(resource, nil)
-	fn, err := resources.GetPipelineFunc(ctx, nil, nil, requester, &v1beta1.PipelineRun{
+	fn := resources.GetPipelineFunc(ctx, nil, nil, requester, &v1beta1.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{Namespace: "default"},
 		Spec: v1beta1.PipelineRunSpec{
 			PipelineRef:        pipelineRef,
 			ServiceAccountName: "default",
 		},
 	})
-	if err != nil {
-		t.Fatalf("failed to get pipeline fn: %s", err.Error())
-	}
 	if _, _, err := fn(ctx, pipelineRef.Name); err == nil {
 		t.Fatalf("expected error due to invalid pipeline data but saw none")
 	}
@@ -735,10 +720,7 @@ func TestGetPipelineFunc_RemoteResolution_TrustedResourceVerification_Success(t 
 					ServiceAccountName: "default",
 				},
 			}
-			fn, err := resources.GetPipelineFunc(ctx, nil, nil, tc.requester, pr)
-			if err != nil {
-				t.Fatalf("failed to get pipeline fn: %s", err.Error())
-			}
+			fn := resources.GetPipelineFunc(ctx, nil, nil, tc.requester, pr)
 
 			resolvedPipeline, source, err := fn(ctx, pipelineRef.Name)
 			if err != nil {
@@ -817,10 +799,7 @@ func TestGetPipelineFunc_RemoteResolution_TrustedResourceVerification_Error(t *t
 					ServiceAccountName: "default",
 				},
 			}
-			fn, err := resources.GetPipelineFunc(ctx, nil, nil, tc.requester, pr)
-			if err != nil {
-				t.Fatalf("failed to get pipeline fn: %s", err.Error())
-			}
+			fn := resources.GetPipelineFunc(ctx, nil, nil, tc.requester, pr)
 
 			resolvedPipeline, source, err := fn(ctx, pipelineRef.Name)
 			if err == nil || !errors.Is(err, tc.expectedErr) {

--- a/pkg/reconciler/taskrun/resources/taskref_test.go
+++ b/pkg/reconciler/taskrun/resources/taskref_test.go
@@ -445,10 +445,7 @@ func TestGetTaskFunc(t *testing.T) {
 					TaskRef: tc.ref,
 				},
 			}
-			fn, err := resources.GetTaskFunc(ctx, kubeclient, tektonclient, nil, trForFunc, tc.ref, "", "default", "default")
-			if err != nil {
-				t.Fatalf("failed to get task fn: %s", err.Error())
-			}
+			fn := resources.GetTaskFunc(ctx, kubeclient, tektonclient, nil, trForFunc, tc.ref, "", "default", "default")
 
 			task, configSource, err := fn(ctx, tc.ref.Name)
 			if err != nil {
@@ -515,10 +512,7 @@ echo hello
 		Spec: TaskSpec,
 	}
 
-	fn, err := resources.GetTaskFuncFromTaskRun(ctx, kubeclient, tektonclient, nil, TaskRun)
-	if err != nil {
-		t.Fatalf("failed to get Task fn: %s", err.Error())
-	}
+	fn := resources.GetTaskFuncFromTaskRun(ctx, kubeclient, tektonclient, nil, TaskRun)
 	actualTask, actualConfigSource, err := fn(ctx, name)
 	if err != nil {
 		t.Fatalf("failed to call Taskfn: %s", err.Error())
@@ -554,10 +548,7 @@ func TestGetTaskFunc_RemoteResolution(t *testing.T) {
 			ServiceAccountName: "default",
 		},
 	}
-	fn, err := resources.GetTaskFunc(ctx, nil, nil, requester, tr, tr.Spec.TaskRef, "", "default", "default")
-	if err != nil {
-		t.Fatalf("failed to get task fn: %s", err.Error())
-	}
+	fn := resources.GetTaskFunc(ctx, nil, nil, requester, tr, tr.Spec.TaskRef, "", "default", "default")
 
 	resolvedTask, resolvedConfigSource, err := fn(ctx, taskRef.Name)
 	if err != nil {
@@ -621,10 +612,7 @@ func TestGetTaskFunc_RemoteResolution_ReplacedParams(t *testing.T) {
 			}},
 		},
 	}
-	fn, err := resources.GetTaskFunc(ctx, nil, nil, requester, tr, tr.Spec.TaskRef, "", "default", "default")
-	if err != nil {
-		t.Fatalf("failed to get task fn: %s", err.Error())
-	}
+	fn := resources.GetTaskFunc(ctx, nil, nil, requester, tr, tr.Spec.TaskRef, "", "default", "default")
 
 	resolvedTask, resolvedConfigSource, err := fn(ctx, taskRef.Name)
 	if err != nil {
@@ -666,10 +654,7 @@ func TestGetTaskFunc_RemoteResolution_ReplacedParams(t *testing.T) {
 			}},
 		},
 	}
-	fnNotMatching, err := resources.GetTaskFunc(ctx, nil, nil, requester, trNotMatching, trNotMatching.Spec.TaskRef, "", "default", "default")
-	if err != nil {
-		t.Fatalf("failed to get task fn: %s", err.Error())
-	}
+	fnNotMatching := resources.GetTaskFunc(ctx, nil, nil, requester, trNotMatching, trNotMatching.Spec.TaskRef, "", "default", "default")
 
 	_, _, err = fnNotMatching(ctx, taskRefNotMatching.Name)
 	if err == nil {
@@ -695,10 +680,7 @@ func TestGetPipelineFunc_RemoteResolutionInvalidData(t *testing.T) {
 			ServiceAccountName: "default",
 		},
 	}
-	fn, err := resources.GetTaskFunc(ctx, nil, nil, requester, tr, tr.Spec.TaskRef, "", "default", "default")
-	if err != nil {
-		t.Fatalf("failed to get pipeline fn: %s", err.Error())
-	}
+	fn := resources.GetTaskFunc(ctx, nil, nil, requester, tr, tr.Spec.TaskRef, "", "default", "default")
 	if _, _, err := fn(ctx, taskRef.Name); err == nil {
 		t.Fatalf("expected error due to invalid pipeline data but saw none")
 	}
@@ -979,10 +961,7 @@ func TestGetTaskFunc_RemoteResolution_TrustedResourceVerification_Success(t *tes
 					ServiceAccountName: "default",
 				},
 			}
-			fn, err := resources.GetTaskFunc(ctx, nil, nil, tc.requester, tr, tr.Spec.TaskRef, "", "default", "default")
-			if err != nil {
-				t.Fatalf("failed to get task fn: %s", err.Error())
-			}
+			fn := resources.GetTaskFunc(ctx, nil, nil, tc.requester, tr, tr.Spec.TaskRef, "", "default", "default")
 
 			resolvedTask, source, err := fn(ctx, taskRef.Name)
 
@@ -1063,10 +1042,7 @@ func TestGetTaskFunc_RemoteResolution_TrustedResourceVerification_Error(t *testi
 					ServiceAccountName: "default",
 				},
 			}
-			fn, err := resources.GetTaskFunc(ctx, nil, nil, tc.requester, tr, tr.Spec.TaskRef, "", "default", "default")
-			if err != nil {
-				t.Fatalf("failed to get task fn: %s", err.Error())
-			}
+			fn := resources.GetTaskFunc(ctx, nil, nil, tc.requester, tr, tr.Spec.TaskRef, "", "default", "default")
 
 			resolvedTask, source, err := fn(ctx, taskRef.Name)
 

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -322,12 +322,7 @@ func (c *Reconciler) prepare(ctx context.Context, tr *v1beta1.TaskRun) (*v1beta1
 	logger := logging.FromContext(ctx)
 	tr.SetDefaults(ctx)
 
-	getTaskfunc, err := resources.GetTaskFuncFromTaskRun(ctx, c.KubeClientSet, c.PipelineClientSet, c.resolutionRequester, tr)
-	if err != nil {
-		logger.Errorf("Failed to fetch task reference %s: %v", tr.Spec.TaskRef.Name, err)
-		tr.Status.MarkResourceFailed(podconvert.ReasonFailedResolution, err)
-		return nil, nil, err
-	}
+	getTaskfunc := resources.GetTaskFuncFromTaskRun(ctx, c.KubeClientSet, c.PipelineClientSet, c.resolutionRequester, tr)
 
 	taskMeta, taskSpec, err := resources.GetTaskData(ctx, tr, getTaskfunc)
 	switch {


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This commit removes the error return in GetTaskFunc and GetPipelineFunc, no errors are ever created and returned in these functions and should be removed.

/kind cleanup

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
