### PR TITLE
TEP-0127: Larger results using sidecar logs - parsing sidecar logs to extract results

### DIFF
--- a/pkg/apis/pipeline/sidecarlogs.go
+++ b/pkg/apis/pipeline/sidecarlogs.go
@@ -14,10 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package sidecarlogsvalidation
+package pipeline
 
 const (
 	// ReservedResultsSidecarName is the name of the results sidecar that outputs the results to stdout
 	// when the results-from feature-flag is set to "sidecar-logs".
 	ReservedResultsSidecarName = "tekton-log-results"
+
+	// ReservedResultsSidecarContainerName is the name of the results sidecar container that is injected
+	// by the reconciler.
+	ReservedResultsSidecarContainerName = "sidecar-tekton-log-results"
 )

--- a/pkg/apis/pipeline/v1beta1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_types.go
@@ -186,6 +186,8 @@ const (
 	TaskRunReasonsResultsVerificationFailed TaskRunReason = "TaskRunResultsVerificationFailed"
 	// AwaitingTaskRunResults is the reason set when waiting upon `TaskRun` results and signatures to verify
 	AwaitingTaskRunResults TaskRunReason = "AwaitingTaskRunResults"
+	// TaskRunReasonResultLargerThanAllowedLimit is the reason set when one of the results exceeds its maximum allowed limit of 1 KB
+	TaskRunReasonResultLargerThanAllowedLimit TaskRunReason = "TaskRunResultLargerThanAllowedLimit"
 )
 
 func (t TaskRunReason) String() string {

--- a/pkg/pod/entrypoint_test.go
+++ b/pkg/pod/entrypoint_test.go
@@ -23,6 +23,8 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/pipeline/pkg/apis/config"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/test/diff"
 	corev1 "k8s.io/api/core/v1"
@@ -94,6 +96,74 @@ func TestOrderContainers(t *testing.T) {
 		TerminationMessagePath: "/tekton/termination",
 	}}
 	got, err := orderContainers([]string{}, steps, nil, nil, true)
+	if err != nil {
+		t.Fatalf("orderContainers: %v", err)
+	}
+	if d := cmp.Diff(want, got); d != "" {
+		t.Errorf("Diff %s", diff.PrintWantGot(d))
+	}
+}
+
+func TestOrderContainersWithResultsSidecarLogs(t *testing.T) {
+	steps := []corev1.Container{{
+		Image:   "step-1",
+		Command: []string{"cmd"},
+		Args:    []string{"arg1", "arg2"},
+	}, {
+		Image:        "step-2",
+		Command:      []string{"cmd1", "cmd2", "cmd3"}, // multiple cmd elements
+		Args:         []string{"arg1", "arg2"},
+		VolumeMounts: []corev1.VolumeMount{volumeMount}, // pre-existing volumeMount
+	}, {
+		Image:   "step-3",
+		Command: []string{"cmd"},
+		Args:    []string{"arg1", "arg2"},
+	}}
+	want := []corev1.Container{{
+		Image:   "step-1",
+		Command: []string{entrypointBinary},
+		Args: []string{
+			"-wait_file", "/tekton/downward/ready",
+			"-wait_file_content",
+			"-post_file", "/tekton/run/0/out",
+			"-termination_path", "/tekton/termination",
+			"-step_metadata_dir", "/tekton/run/0/status",
+			"-dont_send_results_to_termination_path",
+			"-entrypoint", "cmd", "--",
+			"arg1", "arg2",
+		},
+		VolumeMounts:           []corev1.VolumeMount{downwardMount},
+		TerminationMessagePath: "/tekton/termination",
+	}, {
+		Image:   "step-2",
+		Command: []string{entrypointBinary},
+		Args: []string{
+			"-wait_file", "/tekton/run/0/out",
+			"-post_file", "/tekton/run/1/out",
+			"-termination_path", "/tekton/termination",
+			"-step_metadata_dir", "/tekton/run/1/status",
+			"-dont_send_results_to_termination_path",
+			"-entrypoint", "cmd1", "--",
+			"cmd2", "cmd3",
+			"arg1", "arg2",
+		},
+		VolumeMounts:           []corev1.VolumeMount{volumeMount},
+		TerminationMessagePath: "/tekton/termination",
+	}, {
+		Image:   "step-3",
+		Command: []string{entrypointBinary},
+		Args: []string{
+			"-wait_file", "/tekton/run/1/out",
+			"-post_file", "/tekton/run/2/out",
+			"-termination_path", "/tekton/termination",
+			"-step_metadata_dir", "/tekton/run/2/status",
+			"-dont_send_results_to_termination_path",
+			"-entrypoint", "cmd", "--",
+			"arg1", "arg2",
+		},
+		TerminationMessagePath: "/tekton/termination",
+	}}
+	got, err := orderContainers([]string{"-dont_send_results_to_termination_path"}, steps, nil, nil, true)
 	if err != nil {
 		t.Fatalf("orderContainers: %v", err)
 	}
@@ -651,11 +721,23 @@ func TestStopSidecars(t *testing.T) {
 		Name:  injectedSidecar.Name,
 		Image: nopImage,
 	}
+	// This is a container that is added by the controller for accessing sidecar logs.
+	// This should not be stopped as long as results-from is set to sidecar-logs.
+	resultsSidecar := corev1.Container{
+		Name:  pipeline.ReservedResultsSidecarContainerName,
+		Image: "original-injected-image",
+	}
+	// This container can be stopped if the results-from is not set to sidecar-logs.
+	stoppedResultsSidecar := corev1.Container{
+		Name:  pipeline.ReservedResultsSidecarContainerName,
+		Image: nopImage,
+	}
 
 	for _, c := range []struct {
-		desc           string
-		pod            corev1.Pod
-		wantContainers []corev1.Container
+		desc                   string
+		pod                    corev1.Pod
+		resultExtractionMethod string
+		wantContainers         []corev1.Container
 	}{{
 		desc: "Running sidecars (incl injected) should be stopped",
 		pod: corev1.Pod{
@@ -681,6 +763,57 @@ func TestStopSidecars(t *testing.T) {
 			},
 		},
 		wantContainers: []corev1.Container{stepContainer, stoppedSidecarContainer, stoppedInjectedSidecar},
+	}, {
+		desc: "Results Sidecar should not be stopped",
+		pod: corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-pod",
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{stepContainer, sidecarContainer, resultsSidecar},
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				ContainerStatuses: []corev1.ContainerStatus{{
+					// Step state doesn't matter.
+				}, {
+					Name: sidecarContainer.Name,
+					// Sidecar is running.
+					State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(time.Now())}},
+				}, {
+					Name: resultsSidecar.Name,
+					// Results sidecar is running.
+					State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(time.Now())}},
+				}},
+			},
+		},
+		resultExtractionMethod: "sidecar-logs",
+		wantContainers:         []corev1.Container{stepContainer, stoppedSidecarContainer, resultsSidecar},
+	}, {
+		desc: "Results Sidecar should be stopped result method is not sidecar logs",
+		pod: corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-pod",
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{stepContainer, sidecarContainer, resultsSidecar},
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				ContainerStatuses: []corev1.ContainerStatus{{
+					// Step state doesn't matter.
+				}, {
+					Name: sidecarContainer.Name,
+					// Sidecar is running.
+					State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(time.Now())}},
+				}, {
+					Name: resultsSidecar.Name,
+					// Results sidecar is running.
+					State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(time.Now())}},
+				}},
+			},
+		},
+		wantContainers: []corev1.Container{stepContainer, stoppedSidecarContainer, stoppedResultsSidecar},
 	}, {
 		desc: "Pending Pod should not be updated",
 		pod: corev1.Pod{
@@ -722,6 +855,13 @@ func TestStopSidecars(t *testing.T) {
 	}} {
 		t.Run(c.desc, func(t *testing.T) {
 			ctx := context.Background()
+			if c.resultExtractionMethod != "" {
+				ctx = config.ToContext(ctx, &config.Config{
+					FeatureFlags: &config.FeatureFlags{
+						ResultExtractionMethod: c.resultExtractionMethod,
+					},
+				})
+			}
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 			kubeclient := fakek8s.NewSimpleClientset(&c.pod)

--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -25,7 +25,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/tektoncd/pipeline/internal/sidecarlogsvalidation"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
@@ -478,7 +477,7 @@ func createResultsSidecar(taskSpec v1beta1.TaskSpec, image string) v1beta1.Sidec
 	resultsStr := strings.Join(names, ",")
 	command := []string{"/ko-app/sidecarlogresults", "-results-dir", pipeline.DefaultResultPath, "-result-names", resultsStr}
 	return v1beta1.Sidecar{
-		Name:    sidecarlogsvalidation.ReservedResultsSidecarName,
+		Name:    pipeline.ReservedResultsSidecarName,
 		Image:   image,
 		Command: command,
 	}

--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/tektoncd/pipeline/internal/sidecarlogsvalidation"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
@@ -1835,7 +1834,7 @@ _EOF_
 					}}, implicitVolumeMounts...),
 					TerminationMessagePath: "/tekton/termination",
 				}, {
-					Name:  fmt.Sprintf("sidecar-%s", sidecarlogsvalidation.ReservedResultsSidecarName),
+					Name:  pipeline.ReservedResultsSidecarContainerName,
 					Image: "",
 					Command: []string{
 						"/ko-app/sidecarlogresults",

--- a/test/larger_results_sidecar_logs_test.go
+++ b/test/larger_results_sidecar_logs_test.go
@@ -1,0 +1,385 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2022 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/tektoncd/pipeline/pkg/apis/config"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/test/parse"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/system"
+	knativetest "knative.dev/pkg/test"
+)
+
+var (
+	ignoreTaskRunStatusFields = cmpopts.IgnoreFields(v1beta1.TaskRunStatusFields{}, "Steps", "TaskRunResults")
+	ignoreSidecarState        = cmpopts.IgnoreFields(v1beta1.SidecarState{}, "ImageID")
+
+	requireSidecarLogResultsGate = map[string]string{
+		"results-from": "sidecar-logs",
+	}
+)
+
+func TestLargerResultsSidecarLogs(t *testing.T) {
+	t.Parallel()
+	type tests struct {
+		name            string
+		pipelineName    string
+		pipelineRunFunc func(*testing.T, string) (*v1beta1.PipelineRun, *v1beta1.PipelineRun, []*v1beta1.TaskRun)
+	}
+
+	tds := []tests{{
+		name:            "larger results via sidecar logs",
+		pipelineName:    "larger-results-sidecar-logs",
+		pipelineRunFunc: getLargerResultsPipelineRun,
+	}}
+
+	for _, td := range tds {
+		td := td
+		t.Run(td.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			c, namespace := setUpSidecarLogs(ctx, t, requireAllGates(requireSidecarLogResultsGate))
+
+			knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
+			defer tearDown(ctx, t, c, namespace)
+
+			t.Logf("Setting up test resources for %q test in namespace %s", td.name, namespace)
+			pipelineRun, expectedResolvedPipelineRun, expectedTaskRuns := td.pipelineRunFunc(t, namespace)
+			prName := pipelineRun.Name
+			_, err := c.V1beta1PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{})
+			if err != nil {
+				t.Fatalf("Failed to create PipelineRun `%s`: %s", prName, err)
+			}
+
+			t.Logf("Waiting for PipelineRun %s in namespace %s to complete", prName, namespace)
+			if err := WaitForPipelineRunState(ctx, c, prName, timeout, PipelineRunSucceed(prName), "PipelineRunSuccess", v1beta1Version); err != nil {
+				t.Fatalf("Error waiting for PipelineRun %s to finish: %s", prName, err)
+			}
+			cl, _ := c.V1beta1PipelineRunClient.Get(ctx, prName, metav1.GetOptions{})
+			d := cmp.Diff(expectedResolvedPipelineRun, cl,
+				ignoreTypeMeta,
+				ignoreObjectMeta,
+				ignoreCondition,
+				ignorePipelineRunStatus,
+				ignoreTaskRunStatus,
+				ignoreConditions,
+				ignoreContainerStates,
+				ignoreStepState,
+			)
+			if d != "" {
+				t.Fatalf(`The resolved spec does not match the expected spec. Here is the diff: %v`, d)
+			}
+			for _, tr := range expectedTaskRuns {
+				t.Logf("Checking Taskrun %s", tr.Name)
+				taskrun, _ := c.V1beta1TaskRunClient.Get(ctx, tr.Name, metav1.GetOptions{})
+				d = cmp.Diff(tr, taskrun,
+					ignoreTypeMeta,
+					ignoreObjectMeta,
+					ignoreCondition,
+					ignoreTaskRunStatus,
+					ignoreContainerStates,
+					ignoreStepState,
+					ignoreTaskRunSpec,
+					ignoreTaskRunStatusFields,
+					ignoreSidecarState,
+				)
+				if d != "" {
+					t.Fatalf(`The expected taskrun does not match created taskrun. Here is the diff: %v`, d)
+				}
+			}
+			t.Logf("Successfully finished test %q", td.name)
+		})
+	}
+}
+
+func getLargerResultsPipelineRun(t *testing.T, namespace string) (*v1beta1.PipelineRun, *v1beta1.PipelineRun, []*v1beta1.TaskRun) {
+	pipelineRun := parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
+metadata:
+  name: larger-results-sidecar-logs
+  namespace: %s
+spec:
+  pipelineSpec:
+    tasks:
+      - name: task1
+        taskSpec:
+          results:
+            - name: result1
+            - name: result2
+          steps:
+           - name: step1
+             image: alpine
+             script: |
+               echo -n "%s"| tee $(results.result1.path);
+               echo -n "%s"| tee $(results.result2.path);
+      - name: task2
+        params:
+          - name: param1
+            value: "$(tasks.task1.results.result1)"
+          - name: param2
+            value: "$(tasks.task1.results.result2)"
+        taskSpec:
+          params:
+            - name: param1
+              type: string
+              default: abc
+            - name: param2
+              type: string
+              default: def
+          results:
+            - name: large-result
+          steps:
+            - name: step1
+              image: alpine
+              script: |
+                echo -n "$(params.param1)">> $(results.large-result.path);
+                echo -n "$(params.param2)">> $(results.large-result.path);
+    results:
+      - name: large-result 
+        value: $(tasks.task2.results.large-result)
+`, namespace, strings.Repeat("a", 2000), strings.Repeat("b", 2000)))
+	expectedPipelineRun := parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
+metadata:
+  name: larger-results-sidecar-logs
+  namespace: %s
+spec:
+  serviceAccountName: default
+  timeout: 1h
+  pipelineSpec:
+    tasks:
+      - name: task1
+        taskSpec:
+          results:
+            - name: result1
+              type: string
+            - name: result2
+              type: string
+          steps:
+           - name: step1
+             image: alpine
+             script: |
+               echo -n "%s"| tee $(results.result1.path);
+               echo -n "%s"| tee $(results.result2.path);
+      - name: task2
+        params:
+          - name: param1
+            value: "$(tasks.task1.results.result1)"
+          - name: param2
+            value: "$(tasks.task1.results.result2)"
+        taskSpec:
+          params:
+            - name: param1
+              type: string
+              default: abc
+            - name: param2
+              type: string
+              default: def
+          results:
+            - name: large-result
+              type: string
+          steps:
+            - name: step1
+              image: alpine
+              script: |
+                echo -n "$(params.param1)">> $(results.large-result.path);
+                echo -n "$(params.param2)">> $(results.large-result.path);
+    results:
+      - name: large-result 
+        value: $(tasks.task2.results.large-result)
+status:
+  pipelineSpec:
+    tasks:
+      - name: task1
+        taskSpec:
+          results:
+            - name: result1
+              type: string
+            - name: result2
+              type: string
+          steps:
+            - name: step1
+              image: alpine
+              script: |
+                echo -n "%s"| tee $(results.result1.path);
+                echo -n "%s"| tee $(results.result2.path);
+      - name: task2
+        params:
+          - name: param1
+            value: "$(tasks.task1.results.result1)"
+          - name: param2
+            value: "$(tasks.task1.results.result2)"
+        taskSpec:
+          params:
+            - name: param1
+              type: string
+              default: abc
+            - name: param2
+              type: string
+              default: def
+          results:
+            - name: large-result
+              type: string
+          steps:
+            - name: step1
+              image: alpine
+              script: |
+                echo -n "$(params.param1)">> $(results.large-result.path);
+                echo -n "$(params.param2)">> $(results.large-result.path);
+    results:
+      - name: large-result 
+        value: $(tasks.task2.results.large-result)
+  pipelineResults:
+    - name: large-result
+      value: %s%s
+`, namespace, strings.Repeat("a", 2000), strings.Repeat("b", 2000), strings.Repeat("a", 2000), strings.Repeat("b", 2000), strings.Repeat("a", 2000), strings.Repeat("b", 2000)))
+	taskRun1 := parse.MustParseV1beta1TaskRun(t, fmt.Sprintf(`
+metadata:
+  name: larger-results-sidecar-logs-task1
+  namespace: %s
+spec:
+  serviceAccountName: default
+  timeout: 1h
+  taskSpec:
+    results:
+      - name: result1
+        type: string
+      - name: result2
+        type: string
+    steps:
+      - name: step1
+        image: alpine
+        script: |
+          echo -n "%s"| tee $(results.result1.path);
+          echo -n "%s"| tee $(results.result2.path);
+status:
+  conditions:
+    - type: "Succeeded"
+      status: "True"
+      reason: "Succeeded"
+  podName: larger-results-sidecar-logs-task1-pod
+  taskSpec:
+    results:
+      - name: result1
+        type: string
+      - name: result2
+        type: string
+    steps:
+      - name: step1
+        image: alpine
+        script: |
+          echo -n "%s"| tee /tekton/results/result1;
+          echo -n "%s"| tee /tekton/results/result2;
+  taskResults:
+    - name: result1
+      type: string
+      value: %s
+    - name: result2
+      type: string
+      value: %s
+  sidecars:
+    - name: tekton-log-results
+      container: sidecar-tekton-log-results    
+`, namespace, strings.Repeat("a", 2000), strings.Repeat("b", 2000), strings.Repeat("a", 2000), strings.Repeat("b", 2000), strings.Repeat("a", 2000), strings.Repeat("b", 2000)))
+	taskRun2 := parse.MustParseV1beta1TaskRun(t, fmt.Sprintf(`
+metadata:
+  name: larger-results-sidecar-logs-task2
+  namespace: %s
+spec:
+  serviceAccountName: default
+  timeout: 1h
+  params:
+    - name: param1
+      type: string
+      value: %s 
+    - name: param2
+      type: string 
+      value: %s
+  taskSpec:
+    params:
+      - name: param1
+        type: string
+        default: abc
+      - name: param2
+        type: string
+        default: def
+    results:
+      - name: large-result
+        type: string
+    steps:
+     - name: step1
+       image: alpine
+       script: |
+         echo -n "$(params.param1)">> $(results.large-result.path);
+         echo -n "$(params.param2)">> $(results.large-result.path);
+status:
+  conditions:
+    - type: "Succeeded"
+      status: "True"
+      reason: "Succeeded"
+  podName: larger-results-sidecar-logs-task2-pod
+  taskSpec:
+    params:
+      - name: param1
+        type: string
+        default: abc
+      - name: param2
+        type: string
+        default: def
+    results:
+      - name: large-result
+        type: string
+    steps:
+     - name: step1
+       image: alpine
+       script: |
+         echo -n "%s">> /tekton/results/large-result;
+         echo -n "%s">> /tekton/results/large-result;
+  taskResults:
+    - name: large-result
+      type: string
+      value: %s%s
+  sidecars:
+    - name: tekton-log-results
+      container: sidecar-tekton-log-results    
+`, namespace, strings.Repeat("a", 2000), strings.Repeat("b", 2000), strings.Repeat("a", 2000), strings.Repeat("b", 2000), strings.Repeat("a", 2000), strings.Repeat("b", 2000)))
+	return pipelineRun, expectedPipelineRun, []*v1beta1.TaskRun{taskRun1, taskRun2}
+}
+
+func setUpSidecarLogs(ctx context.Context, t *testing.T, fn ...func(context.Context, *testing.T, *clients, string)) (*clients, string) {
+	c, ns := setup(ctx, t)
+	configMapData := map[string]string{
+		"results-from": "sidecar-logs",
+	}
+
+	if err := updateConfigMap(ctx, c.KubeClient, system.Namespace(), config.GetFeatureFlagsConfigName(), configMapData); err != nil {
+		t.Fatal(err)
+	}
+	return c, ns
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

This PR addresses a part of [TEP-0127](https://github.com/tektoncd/community/blob/main/teps/0127-larger-results-via-sidecar-logs.md) - parsing logs to extract results into the task run CRD.

The taskrun reconciler fetches the logs of the injected sidecar container `sidecar-tekton-log-results`. The logs are already structured and can be un-marshalled via json. The reconciler parses these logs and adds the results to the task run CRD. If the size of the result is greater than the `max-result-size` configured by the user then the TaskRun fails with reason `TaskRunResultLargerThanAllowedLimit`.

Before approving this PR, review https://github.com/tektoncd/pipeline/pull/5834

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Parsing sidecar logs to extract results into the task run CRD.
```
/kind feature