### PR TITLE
Align the naming when referring to a TaskRun in comments in taskrun_types.go

### DIFF
--- a/docs/pipeline-api.md
+++ b/docs/pipeline-api.md
@@ -1129,7 +1129,7 @@ TaskRunSpecStatus
 </td>
 <td>
 <em>(Optional)</em>
-<p>Used for cancelling a taskrun (and maybe more later on)</p>
+<p>Used for cancelling a TaskRun (and maybe more later on)</p>
 </td>
 </tr>
 <tr>
@@ -4550,7 +4550,7 @@ reasons that emerge from underlying resources are not included here</p>
 </tr>
 </thead>
 <tbody><tr><td><p>&#34;TaskRunCancelled&#34;</p></td>
-<td><p>TaskRunReasonCancelled is the reason set when the Taskrun is cancelled by the user</p>
+<td><p>TaskRunReasonCancelled is the reason set when the TaskRun is cancelled by the user</p>
 </td>
 </tr><tr><td><p>&#34;Failed&#34;</p></td>
 <td><p>TaskRunReasonFailed is the reason set when the TaskRun completed with a failure</p>
@@ -4568,7 +4568,7 @@ reasons that emerge from underlying resources are not included here</p>
 <td><p>TaskRunReasonSuccessful is the reason set when the TaskRun completed successfully</p>
 </td>
 </tr><tr><td><p>&#34;TaskRunTimeout&#34;</p></td>
-<td><p>TaskRunReasonTimedOut is the reason set when the Taskrun has timed out</p>
+<td><p>TaskRunReasonTimedOut is the reason set when the TaskRun has timed out</p>
 </td>
 </tr></tbody>
 </table>
@@ -4762,7 +4762,7 @@ TaskRunSpecStatus
 </td>
 <td>
 <em>(Optional)</em>
-<p>Used for cancelling a taskrun (and maybe more later on)</p>
+<p>Used for cancelling a TaskRun (and maybe more later on)</p>
 </td>
 </tr>
 <tr>
@@ -4877,7 +4877,7 @@ Kubernetes core/v1.ResourceRequirements
 (<em>Appears on:</em><a href="#tekton.dev/v1.TaskRunSpec">TaskRunSpec</a>)
 </p>
 <div>
-<p>TaskRunSpecStatus defines the taskrun spec status the user can provide</p>
+<p>TaskRunSpecStatus defines the TaskRun spec status the user can provide</p>
 </div>
 <h3 id="tekton.dev/v1.TaskRunSpecStatusMessage">TaskRunSpecStatusMessage
 (<code>string</code> alias)</h3>
@@ -7887,7 +7887,7 @@ TaskRunSpecStatus
 </td>
 <td>
 <em>(Optional)</em>
-<p>Used for cancelling a taskrun (and maybe more later on)</p>
+<p>Used for cancelling a TaskRun (and maybe more later on)</p>
 </td>
 </tr>
 <tr>
@@ -12811,7 +12811,7 @@ TaskRunSpecStatus
 </td>
 <td>
 <em>(Optional)</em>
-<p>Used for cancelling a taskrun (and maybe more later on)</p>
+<p>Used for cancelling a TaskRun (and maybe more later on)</p>
 </td>
 </tr>
 <tr>
@@ -12926,7 +12926,7 @@ Kubernetes core/v1.ResourceRequirements
 (<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskRunSpec">TaskRunSpec</a>)
 </p>
 <div>
-<p>TaskRunSpecStatus defines the taskrun spec status the user can provide</p>
+<p>TaskRunSpecStatus defines the TaskRun spec status the user can provide</p>
 </div>
 <h3 id="tekton.dev/v1beta1.TaskRunSpecStatusMessage">TaskRunSpecStatusMessage
 (<code>string</code> alias)</h3>
@@ -13097,7 +13097,7 @@ All TaskRunStatus stored in RetriesStatus will have no date within the RetriesSt
 </td>
 <td>
 <em>(Optional)</em>
-<p>Results from Resources built during the taskRun. currently includes
+<p>Results from Resources built during the TaskRun. currently includes
 the digest of build container images</p>
 </td>
 </tr>

--- a/pkg/apis/pipeline/v1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1/openapi_generated.go
@@ -3465,7 +3465,7 @@ func schema_pkg_apis_pipeline_v1_TaskRunSpec(ref common.ReferenceCallback) commo
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Used for cancelling a taskrun (and maybe more later on)",
+							Description: "Used for cancelling a TaskRun (and maybe more later on)",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/apis/pipeline/v1/swagger.json
+++ b/pkg/apis/pipeline/v1/swagger.json
@@ -1801,7 +1801,7 @@
           "x-kubernetes-list-type": "atomic"
         },
         "status": {
-          "description": "Used for cancelling a taskrun (and maybe more later on)",
+          "description": "Used for cancelling a TaskRun (and maybe more later on)",
           "type": "string"
         },
         "statusMessage": {

--- a/pkg/apis/pipeline/v1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1/taskrun_types.go
@@ -48,7 +48,7 @@ type TaskRunSpec struct {
 	TaskRef *TaskRef `json:"taskRef,omitempty"`
 	// +optional
 	TaskSpec *TaskSpec `json:"taskSpec,omitempty"`
-	// Used for cancelling a taskrun (and maybe more later on)
+	// Used for cancelling a TaskRun (and maybe more later on)
 	// +optional
 	Status TaskRunSpecStatus `json:"status,omitempty"`
 	// Status message for cancellation.
@@ -83,7 +83,7 @@ type TaskRunSpec struct {
 	ComputeResources *corev1.ResourceRequirements `json:"computeResources,omitempty"`
 }
 
-// TaskRunSpecStatus defines the taskrun spec status the user can provide
+// TaskRunSpecStatus defines the TaskRun spec status the user can provide
 type TaskRunSpecStatus string
 
 const (
@@ -141,9 +141,9 @@ const (
 	TaskRunReasonSuccessful TaskRunReason = "Succeeded"
 	// TaskRunReasonFailed is the reason set when the TaskRun completed with a failure
 	TaskRunReasonFailed TaskRunReason = "Failed"
-	// TaskRunReasonCancelled is the reason set when the Taskrun is cancelled by the user
+	// TaskRunReasonCancelled is the reason set when the TaskRun is cancelled by the user
 	TaskRunReasonCancelled TaskRunReason = "TaskRunCancelled"
-	// TaskRunReasonTimedOut is the reason set when the Taskrun has timed out
+	// TaskRunReasonTimedOut is the reason set when the TaskRun has timed out
 	TaskRunReasonTimedOut TaskRunReason = "TaskRunTimeout"
 	// TaskRunReasonResolvingTaskRef indicates that the TaskRun is waiting for
 	// its taskRef to be asynchronously resolved.
@@ -339,7 +339,7 @@ type TaskRunList struct {
 	Items           []TaskRun `json:"items"`
 }
 
-// GetPipelineRunPVCName for taskrun gets pipelinerun
+// GetPipelineRunPVCName for TaskRun gets pipelinerun
 func (tr *TaskRun) GetPipelineRunPVCName() string {
 	if tr == nil {
 		return ""
@@ -368,7 +368,7 @@ func (tr *TaskRun) IsDone() bool {
 	return !tr.Status.GetCondition(apis.ConditionSucceeded).IsUnknown()
 }
 
-// HasStarted function check whether taskrun has valid start time set in its status
+// HasStarted function check whether TaskRun has valid start time set in its status
 func (tr *TaskRun) HasStarted() bool {
 	return tr.Status.StartTime != nil && !tr.Status.StartTime.IsZero()
 }

--- a/pkg/apis/pipeline/v1beta1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1beta1/openapi_generated.go
@@ -4784,7 +4784,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunSpec(ref common.ReferenceCallback) 
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Used for cancelling a taskrun (and maybe more later on)",
+							Description: "Used for cancelling a TaskRun (and maybe more later on)",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -5013,7 +5013,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunStatus(ref common.ReferenceCallback
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Results from Resources built during the taskRun. currently includes the digest of build container images",
+							Description: "Results from Resources built during the TaskRun. currently includes the digest of build container images",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -5175,7 +5175,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunStatusFields(ref common.ReferenceCa
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Results from Resources built during the taskRun. currently includes the digest of build container images",
+							Description: "Results from Resources built during the TaskRun. currently includes the digest of build container images",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{

--- a/pkg/apis/pipeline/v1beta1/swagger.json
+++ b/pkg/apis/pipeline/v1beta1/swagger.json
@@ -2807,7 +2807,7 @@
           "x-kubernetes-list-type": "atomic"
         },
         "status": {
-          "description": "Used for cancelling a taskrun (and maybe more later on)",
+          "description": "Used for cancelling a TaskRun (and maybe more later on)",
           "type": "string"
         },
         "statusMessage": {
@@ -2898,7 +2898,7 @@
           "$ref": "#/definitions/v1beta1.Provenance"
         },
         "resourcesResult": {
-          "description": "Results from Resources built during the taskRun. currently includes the digest of build container images",
+          "description": "Results from Resources built during the TaskRun. currently includes the digest of build container images",
           "type": "array",
           "items": {
             "default": {},
@@ -2982,7 +2982,7 @@
           "$ref": "#/definitions/v1beta1.Provenance"
         },
         "resourcesResult": {
-          "description": "Results from Resources built during the taskRun. currently includes the digest of build container images",
+          "description": "Results from Resources built during the TaskRun. currently includes the digest of build container images",
           "type": "array",
           "items": {
             "default": {},

--- a/pkg/apis/pipeline/v1beta1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_types.go
@@ -50,7 +50,7 @@ type TaskRunSpec struct {
 	TaskRef *TaskRef `json:"taskRef,omitempty"`
 	// +optional
 	TaskSpec *TaskSpec `json:"taskSpec,omitempty"`
-	// Used for cancelling a taskrun (and maybe more later on)
+	// Used for cancelling a TaskRun (and maybe more later on)
 	// +optional
 	Status TaskRunSpecStatus `json:"status,omitempty"`
 	// Status message for cancellation.
@@ -85,7 +85,7 @@ type TaskRunSpec struct {
 	ComputeResources *corev1.ResourceRequirements `json:"computeResources,omitempty"`
 }
 
-// TaskRunSpecStatus defines the taskrun spec status the user can provide
+// TaskRunSpecStatus defines the TaskRun spec status the user can provide
 type TaskRunSpecStatus string
 
 const (
@@ -166,9 +166,9 @@ const (
 	TaskRunReasonSuccessful TaskRunReason = "Succeeded"
 	// TaskRunReasonFailed is the reason set when the TaskRun completed with a failure
 	TaskRunReasonFailed TaskRunReason = "Failed"
-	// TaskRunReasonCancelled is the reason set when the Taskrun is cancelled by the user
+	// TaskRunReasonCancelled is the reason set when the TaskRun is cancelled by the user
 	TaskRunReasonCancelled TaskRunReason = "TaskRunCancelled"
-	// TaskRunReasonTimedOut is the reason set when the Taskrun has timed out
+	// TaskRunReasonTimedOut is the reason set when the TaskRun has timed out
 	TaskRunReasonTimedOut TaskRunReason = "TaskRunTimeout"
 	// TaskRunReasonResolvingTaskRef indicates that the TaskRun is waiting for
 	// its taskRef to be asynchronously resolved.
@@ -256,7 +256,7 @@ type TaskRunStatusFields struct {
 	// +listType=atomic
 	RetriesStatus []TaskRunStatus `json:"retriesStatus,omitempty"`
 
-	// Results from Resources built during the taskRun. currently includes
+	// Results from Resources built during the TaskRun. currently includes
 	// the digest of build container images
 	// +optional
 	// +listType=atomic
@@ -417,7 +417,7 @@ type TaskRunList struct {
 	Items           []TaskRun `json:"items"`
 }
 
-// GetPipelineRunPVCName for taskrun gets pipelinerun
+// GetPipelineRunPVCName for TaskRun gets pipelinerun
 func (tr *TaskRun) GetPipelineRunPVCName() string {
 	if tr == nil {
 		return ""
@@ -446,7 +446,7 @@ func (tr *TaskRun) IsDone() bool {
 	return !tr.Status.GetCondition(apis.ConditionSucceeded).IsUnknown()
 }
 
-// HasStarted function check whether taskrun has valid start time set in its status
+// HasStarted function check whether TaskRun has valid start time set in its status
 func (tr *TaskRun) HasStarted() bool {
 	return tr.Status.StartTime != nil && !tr.Status.StartTime.IsZero()
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

There are different ways of referring to TaskRuns: taskrun, task run, TaskRun, taskRun, Taskrun, which kind of drove me crazy when I was updating taskrun_types.go 😅, this PR align those naming as `TaskRun`.

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
