### PR TITLE
TEP-0121: Modify metrics recorder for TaskRun Retries

### DIFF
--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -96,6 +96,7 @@ var (
 // converge the two. It then updates the Status block of the Task Run
 // resource with the current status of the resource.
 func (c *Reconciler) ReconcileKind(ctx context.Context, tr *v1beta1.TaskRun) pkgreconciler.Event {
+	defer c.durationAndCountMetrics(ctx, tr)
 	logger := logging.FromContext(ctx)
 	ctx = cloudevent.ToContext(ctx, c.cloudEventClient)
 	// By this time, params and workspaces should not be propagated for embedded tasks so we cannot
@@ -445,7 +446,6 @@ func (c *Reconciler) prepare(ctx context.Context, tr *v1beta1.TaskRun) (*v1beta1
 // error but it does not sync updates back to etcd. It does not emit events.
 // `reconcile` consumes spec and resources returned by `prepare`
 func (c *Reconciler) reconcile(ctx context.Context, tr *v1beta1.TaskRun, rtr *resources.ResolvedTaskResources) error {
-	defer c.durationAndCountMetrics(ctx, tr)
 	logger := logging.FromContext(ctx)
 	recorder := controller.GetEventRecorder(ctx)
 	var err error


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Openning this PR originally because a `DATA RACE` (Dirty Read) error 
occurs when I was implementing https://github.com/tektoncd/pipeline/pull/5844, see [error msg](
https://prow.tekton.dev/view/gs/tekton-prow/pr-logs/pull/tektoncd_pipeline/5844/pull-tekton-pipeline-unit-tests/1600899786926460928).

Basically, the reason is that [durationAndCountMetrics()](https://github.com/tektoncd/pipeline/blob/3279a4310399655b78df0bfeb805a931b0e84481/pkg/reconciler/taskrun/taskrun.go#L448) is reading 
the `taskRun` object in one goroutine, while retryTaskRun() (which is
called in [finishReconcileUpdateEmitEvents](https://github.com/tektoncd/pipeline/blob/3279a4310399655b78df0bfeb805a931b0e84481/pkg/reconciler/taskrun/taskrun.go#L292)) is writing the `taskRun` object.

After digging into it, there's one more concern which looks like a bug:
[durationAndCountMetrics()](https://github.com/tektoncd/pipeline/blob/3279a4310399655b78df0bfeb805a931b0e84481/pkg/reconciler/taskrun/taskrun.go#L448) in [reconcile()](https://github.com/tektoncd/pipeline/blob/3279a4310399655b78df0bfeb805a931b0e84481/pkg/reconciler/taskrun/taskrun.go#L447) only counts the taskrun numbers
where the taskruns that have no preparation error / not cancelled right after
scheduled / not timed out before calling `reconcile()` (for example,
be pending for a long time.).

To address the problem mentioned above, this PR moves 
`durationAndCountMetrics()` outside of [reconcile()](https://github.com/tektoncd/pipeline/blob/3279a4310399655b78df0bfeb805a931b0e84481/pkg/reconciler/taskrun/taskrun.go#L447) to [ReconcileKind()](https://github.com/tektoncd/pipeline/blob/3279a4310399655b78df0bfeb805a931b0e84481/pkg/reconciler/taskrun/taskrun.go#L98)
to make sure it is reading the taskRun object that has no further update.

---
**Related Background Info**

The recording metrics logic was originally in the ReconcileKind() function,
but the commit https://github.com/tektoncd/pipeline/commit/137521906ce3e1df9440a3248f932ddb5a653e35 addressing the recount issue **moves that logic
to `reconcile()`** [1] (probably for better code style? 🤔). 

This is a blocker for https://github.com/tektoncd/pipeline/pull/5844.

[1] https://github.com/tektoncd/pipeline/commit/137521906ce3e1df9440a3248f932ddb5a653e35#diff-6e67e9c647bbe2a08807ff5ccbdd7dc9036df373e56b9774d3996f92ab7ceabaL138-L145

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] ~Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing~
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] ~Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)~
- [x] ~Release notes contains the string "action required" if the change requires additional action from users switching to the new release~

# Release Notes

```release-note
NONE
```
