### PR TITLE
Fix apiVersion assignment in ChildReference Conversion

### DIFF
--- a/pkg/apis/pipeline/v1beta1/pipelinerun_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_conversion.go
@@ -410,7 +410,7 @@ func convertTaskRunsToChildReference(ctx context.Context, taskRuns map[string]*P
 		csr := v1.ChildStatusReference{}
 		// The apiVersion is defaulted to 'v1beta1' all taskRuns are populated by v1beta1
 		// PipelineRunStatus reconcilers when `embedded-status` is `Full` or `Both`.
-		csr.TypeMeta.APIVersion = "v1beta1"
+		csr.TypeMeta.APIVersion = "tekton.dev/v1beta1"
 		csr.TypeMeta.Kind = "TaskRun"
 		csr.Name = name
 		csr.PipelineTaskName = status.PipelineTaskName
@@ -425,13 +425,13 @@ func convertTaskRunsToChildReference(ctx context.Context, taskRuns map[string]*P
 	return csrs
 }
 
-// convertRunsToChildReference handles the deprecated `status.runs`` field PipelineRunRunStatus.
+// convertRunsToChildReference handles the deprecated `status.runs` field PipelineRunRunStatus.
 func convertRunsToChildReference(ctx context.Context, runs map[string]*PipelineRunRunStatus) []v1.ChildStatusReference {
 	csrs := []v1.ChildStatusReference{}
 	for name, status := range runs {
 		csr := v1.ChildStatusReference{}
 		// The apiViersion is set to 'v1alpha1' as Run is only in `v1alpha1`.
-		csr.TypeMeta.APIVersion = "v1alpha1"
+		csr.TypeMeta.APIVersion = "tekton.dev/v1alpha1"
 		csr.TypeMeta.Kind = "Run"
 		csr.Name = name
 		csr.PipelineTaskName = status.PipelineTaskName

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_conversion_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_conversion_test.go
@@ -39,13 +39,13 @@ import (
 
 var (
 	childRefTaskRuns = []v1beta1.ChildStatusReference{{
-		TypeMeta:         runtime.TypeMeta{Kind: "TaskRun", APIVersion: "v1beta1"},
+		TypeMeta:         runtime.TypeMeta{Kind: "TaskRun", APIVersion: "tekton.dev/v1beta1"},
 		Name:             "tr-0",
 		PipelineTaskName: "ptn",
 		WhenExpressions:  []v1beta1.WhenExpression{{Input: "default-value", Operator: "in", Values: []string{"val"}}},
 	}}
 	childRefRuns = []v1beta1.ChildStatusReference{{
-		TypeMeta:         runtime.TypeMeta{Kind: "Run", APIVersion: "v1alpha1"},
+		TypeMeta:         runtime.TypeMeta{Kind: "Run", APIVersion: "tekton.dev/v1alpha1"},
 		Name:             "r-0",
 		PipelineTaskName: "ptn-0",
 		WhenExpressions:  []v1beta1.WhenExpression{{Input: "default-value-0", Operator: "in", Values: []string{"val-0", "val-1"}}},
@@ -640,11 +640,11 @@ func TestPipelineRunConversionEmbeddedStatusConvertTo(t *testing.T) {
 			Status: v1.PipelineRunStatus{
 				PipelineRunStatusFields: v1.PipelineRunStatusFields{
 					ChildReferences: []v1.ChildStatusReference{{
-						TypeMeta:         runtime.TypeMeta{Kind: "TaskRun", APIVersion: "v1beta1"},
+						TypeMeta:         runtime.TypeMeta{Kind: "TaskRun", APIVersion: "tekton.dev/v1beta1"},
 						Name:             "tr-0",
 						PipelineTaskName: "ptn",
 						WhenExpressions:  []v1.WhenExpression{{Input: "default-value", Operator: "in", Values: []string{"val"}}},
-					}, {TypeMeta: runtime.TypeMeta{Kind: "Run", APIVersion: "v1alpha1"},
+					}, {TypeMeta: runtime.TypeMeta{Kind: "Run", APIVersion: "tekton.dev/v1alpha1"},
 						Name:             "r-0",
 						PipelineTaskName: "ptn-0",
 						WhenExpressions:  []v1.WhenExpression{{Input: "default-value-0", Operator: "in", Values: []string{"val-0", "val-1"}}},
@@ -694,11 +694,11 @@ func TestPipelineRunConversionEmbeddedStatusConvertFrom(t *testing.T) {
 			Status: v1.PipelineRunStatus{
 				PipelineRunStatusFields: v1.PipelineRunStatusFields{
 					ChildReferences: []v1.ChildStatusReference{{
-						TypeMeta:         runtime.TypeMeta{Kind: "TaskRun", APIVersion: "v1beta1"},
+						TypeMeta:         runtime.TypeMeta{Kind: "TaskRun", APIVersion: "tekton.dev/v1beta1"},
 						Name:             "tr-0",
 						PipelineTaskName: "ptn",
 						WhenExpressions:  []v1.WhenExpression{{Input: "default-value", Operator: "in", Values: []string{"val"}}},
-					}, {TypeMeta: runtime.TypeMeta{Kind: "Run", APIVersion: "v1alpha1"},
+					}, {TypeMeta: runtime.TypeMeta{Kind: "Run", APIVersion: "tekton.dev/v1alpha1"},
 						Name:             "r-0",
 						PipelineTaskName: "ptn-0",
 						WhenExpressions:  []v1.WhenExpression{{Input: "default-value-0", Operator: "in", Values: []string{"val-0", "val-1"}}},


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This commit fixes the apiVersion in ChildReference Conversion from `v1beta1` to `tekton.dev/v1beta1` and similar for `v1alpha1`.
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
/kind bug
# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [n/a] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [n/a] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
