### PR TITLE
TEP-0114: Enable Custom Tasks in Pipelines by Default

### DIFF
--- a/config/config-feature-flags.yaml
+++ b/config/config-feature-flags.yaml
@@ -72,9 +72,7 @@ data:
   enable-tekton-oci-bundles: "false"
   # Setting this flag to "true" enables the use of custom tasks from
   # within pipelines.
-  # This is an experimental feature and thus should still be considered
-  # an alpha feature.
-  enable-custom-tasks: "false"
+  enable-custom-tasks: "true"
   # Setting this flag will determine which gated features are enabled.
   # Acceptable values are "stable", "beta", or "alpha".
   enable-api-fields: "stable"

--- a/docs/install.md
+++ b/docs/install.md
@@ -408,7 +408,7 @@ not running.
 and use Workspaces to mount credentials from Secrets instead.
 The default is `false`. For more information, see the [associated issue](https://github.com/tektoncd/pipeline/issues/3399).
 
-- `enable-custom-tasks`: set this flag to `"true"` to enable the
+- `enable-custom-tasks`: set this flag to `"false"` to disable the
 use of custom tasks in pipelines.
 
 - `enable-api-fields`: set this flag to "stable" to allow only the

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -1564,9 +1564,6 @@ no `runAfter` can be specified in `finally` tasks.
 
 ## Using Custom Tasks
 
-**Note: This is only allowed if `enable-custom-tasks` is set to
-`"true"` in the `feature-flags` configmap, see [`install.md`](./install.md#customizing-the-pipelines-controller-behavior)**
-
 [Custom Tasks](https://github.com/tektoncd/community/blob/main/teps/0002-custom-tasks.md)
 can implement behavior that doesn't correspond directly to running a workload in a `Pod` on the cluster.
 For example, a custom task might execute some operation outside of the cluster and wait for its execution to complete.

--- a/pkg/apis/config/feature_flags.go
+++ b/pkg/apis/config/feature_flags.go
@@ -73,7 +73,7 @@ const (
 	// DefaultEnableTektonOciBundles is the default value for "enable-tekton-oci-bundles".
 	DefaultEnableTektonOciBundles = false
 	// DefaultEnableCustomTasks is the default value for "enable-custom-tasks".
-	DefaultEnableCustomTasks = false
+	DefaultEnableCustomTasks = true
 	// DefaultEnableAPIFields is the default value for "enable-api-fields".
 	DefaultEnableAPIFields = StableAPIFields
 	// DefaultSendCloudEventsForRuns is the default value for "send-cloudevents-for-runs".

--- a/pkg/apis/config/feature_flags_test.go
+++ b/pkg/apis/config/feature_flags_test.go
@@ -140,6 +140,7 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 			expectedConfig: &config.FeatureFlags{
 				EnableAPIFields:                  "stable",
 				EmbeddedStatus:                   "full",
+				EnableCustomTasks:                config.DefaultEnableCustomTasks,
 				EnableSpire:                      true,
 				ResourceVerificationMode:         config.DefaultResourceVerificationMode,
 				RunningInEnvWithInjectedSidecars: config.DefaultRunningInEnvWithInjectedSidecars,
@@ -158,6 +159,7 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 				RunningInEnvWithInjectedSidecars: config.DefaultRunningInEnvWithInjectedSidecars,
 				AwaitSidecarReadiness:            config.DefaultAwaitSidecarReadiness,
 				ResultExtractionMethod:           config.ResultExtractionMethodSidecarLogs,
+				EnableCustomTasks:                config.DefaultEnableCustomTasks,
 				MaxResultSize:                    8192,
 				CustomTaskVersion:                config.DefaultCustomTaskVersion,
 			},

--- a/pkg/apis/pipeline/v1/pipeline_types_test.go
+++ b/pkg/apis/pipeline/v1/pipeline_types_test.go
@@ -320,7 +320,6 @@ func TestPipelineTask_Validate_Failure(t *testing.T) {
 			Message: `invalid value: custom task ref must specify kind`,
 			Paths:   []string{"taskRef.kind"},
 		},
-		wc: enableFeatures(t, []string{"enable-custom-tasks"}),
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/apis/pipeline/v1beta1/pipeline_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types_test.go
@@ -359,7 +359,6 @@ func TestPipelineTask_Validate_Failure(t *testing.T) {
 			Message: `invalid value: custom task ref must specify kind`,
 			Paths:   []string{"taskRef.kind"},
 		},
-		wc: enableFeatures(t, []string{"enable-custom-tasks"}),
 	}, {
 		name: "invalid bundle without bundle name",
 		p: PipelineTask{
@@ -707,7 +706,7 @@ func TestPipelineTaskList_Validate(t *testing.T) {
 			TaskRef: &TaskRef{Name: "task"},
 		}},
 		path: "tasks",
-		wc:   enableFeatures(t, []string{"enable-custom-tasks", "enable-tekton-oci-bundles"}),
+		wc:   enableFeatures(t, []string{"enable-tekton-oci-bundles"}),
 	}, {
 		name: "validate list of tasks with valid custom task and bundle but invalid regular task",
 		tasks: PipelineTaskList{{
@@ -722,7 +721,7 @@ func TestPipelineTaskList_Validate(t *testing.T) {
 		}},
 		path:          "tasks",
 		expectedError: apis.ErrGeneric(`invalid value: taskRef must specify name`, "tasks[2].taskRef.name"),
-		wc:            enableFeatures(t, []string{"enable-custom-tasks", "enable-tekton-oci-bundles"}),
+		wc:            enableFeatures(t, []string{"enable-tekton-oci-bundles"}),
 	}, {
 		name: "validate list of tasks with valid custom task but invalid bundle and invalid regular task",
 		tasks: PipelineTaskList{{
@@ -738,7 +737,7 @@ func TestPipelineTaskList_Validate(t *testing.T) {
 		path: "tasks",
 		expectedError: apis.ErrGeneric(`invalid value: taskRef must specify name`, "tasks[2].taskRef.name").Also(
 			apis.ErrGeneric(`missing field(s)`, "tasks[1].taskRef.name")),
-		wc: enableFeatures(t, []string{"enable-custom-tasks", "enable-tekton-oci-bundles"}),
+		wc: enableFeatures(t, []string{"enable-tekton-oci-bundles"}),
 	}, {
 		name: "validate all three invalid tasks - custom task, bundle and regular task",
 		tasks: PipelineTaskList{{
@@ -755,7 +754,7 @@ func TestPipelineTaskList_Validate(t *testing.T) {
 		expectedError: apis.ErrGeneric(`invalid value: taskRef must specify name`, "tasks[2].taskRef.name").Also(
 			apis.ErrGeneric(`missing field(s)`, "tasks[1].taskRef.name")).Also(
 			apis.ErrGeneric(`invalid value: custom task ref must specify kind`, "tasks[0].taskRef.kind")),
-		wc: enableFeatures(t, []string{"enable-custom-tasks", "enable-tekton-oci-bundles"}),
+		wc: enableFeatures(t, []string{"enable-tekton-oci-bundles"}),
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
@@ -55,7 +55,6 @@ func TestPipeline_Validate_Success(t *testing.T) {
 				Tasks: []PipelineTask{{Name: "foo", TaskRef: &TaskRef{APIVersion: "example.dev/v0", Kind: "Example", Name: ""}}},
 			},
 		},
-		wc: enableFeatures(t, []string{"enable-custom-tasks"}),
 	}, {
 		name: "pipelinetask custom task spec",
 		p: &Pipeline{
@@ -73,7 +72,6 @@ func TestPipeline_Validate_Success(t *testing.T) {
 				}},
 			},
 		},
-		wc: enableFeatures(t, []string{"enable-custom-tasks"}),
 	}, {
 		name: "valid pipeline with params, resources, workspaces, task results, and pipeline results",
 		p: &Pipeline{
@@ -777,10 +775,10 @@ func TestValidatePipelineTasks_Failure(t *testing.T) {
 			},
 		}},
 		finalTasks: nil,
-		expectedError: apis.FieldError{
+		expectedError: *apis.ErrGeneric("").Also(&apis.FieldError{
 			Message: "taskSpec.apiVersion cannot be specified when using taskSpec.steps",
 			Paths:   []string{"tasks[0].taskSpec.apiVersion"},
-		},
+		}).Also(apis.ErrInvalidValue("custom task spec must specify kind", "tasks[0].taskSpec.kind")),
 	}, {
 		name: "kind with steps",
 		tasks: []PipelineTask{{

--- a/pkg/reconciler/pipelinerun/cancel_test.go
+++ b/pkg/reconciler/pipelinerun/cancel_test.go
@@ -376,7 +376,7 @@ func TestCancelPipelineRun(t *testing.T) {
 			}
 			ctx, _ := ttesting.SetupFakeContext(t)
 			cfg := config.NewStore(logtesting.TestLogger(t))
-			cfg.OnConfigChanged(withCustomTasks(withEmbeddedStatus(newFeatureFlagsConfigMap(), tc.embeddedStatus)))
+			cfg.OnConfigChanged(withEmbeddedStatus(newFeatureFlagsConfigMap(), tc.embeddedStatus))
 			ctx = cfg.ToContext(ctx)
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
@@ -637,7 +637,7 @@ func TestGetChildObjectsFromPRStatusForTaskNames(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx, _ := ttesting.SetupFakeContext(t)
 			cfg := config.NewStore(logtesting.TestLogger(t))
-			cm := withCustomTasks(withEmbeddedStatus(newFeatureFlagsConfigMap(), tc.embeddedStatus))
+			cm := withEmbeddedStatus(newFeatureFlagsConfigMap(), tc.embeddedStatus)
 			if tc.useV1Beta1CustomTask {
 				cm = withCustomTaskVersion(cm, config.CustomTaskVersionBeta)
 			}

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -110,7 +110,6 @@ var (
 
 const (
 	apiFieldsFeatureFlag           = "enable-api-fields"
-	customTasksFeatureFlag         = "enable-custom-tasks"
 	ociBundlesFeatureFlag          = "enable-tekton-oci-bundles"
 	embeddedStatusFeatureFlag      = "embedded-status"
 	maxMatrixCombinationsCountFlag = "default-max-matrix-combinations-count"
@@ -703,7 +702,7 @@ spec:
 			if embeddedStatus == "" {
 				embeddedStatus = config.DefaultEmbeddedStatus
 			}
-			cms := []*corev1.ConfigMap{withCustomTasks(withEmbeddedStatus(newFeatureFlagsConfigMap(), embeddedStatus))}
+			cms := []*corev1.ConfigMap{withEmbeddedStatus(newFeatureFlagsConfigMap(), embeddedStatus)}
 
 			d := test.Data{
 				PipelineRuns: []*v1beta1.PipelineRun{tc.pr},
@@ -898,7 +897,7 @@ spec:
 			if embeddedStatus == "" {
 				embeddedStatus = config.DefaultEmbeddedStatus
 			}
-			cms := []*corev1.ConfigMap{withCustomTaskVersion(withCustomTasks(withEmbeddedStatus(newFeatureFlagsConfigMap(), embeddedStatus)), "v1beta1")}
+			cms := []*corev1.ConfigMap{withCustomTaskVersion(withEmbeddedStatus(newFeatureFlagsConfigMap(), embeddedStatus), "v1beta1")}
 
 			d := test.Data{
 				PipelineRuns: []*v1beta1.PipelineRun{tc.pr},
@@ -1642,12 +1641,6 @@ func withEnabledAlphaAPIFields(cm *corev1.ConfigMap) *corev1.ConfigMap {
 	return newCM
 }
 
-func withCustomTasks(cm *corev1.ConfigMap) *corev1.ConfigMap {
-	newCM := cm.DeepCopy()
-	newCM.Data[customTasksFeatureFlag] = "true"
-	return newCM
-}
-
 func withOCIBundles(cm *corev1.ConfigMap) *corev1.ConfigMap {
 	newCM := cm.DeepCopy()
 	newCM.Data[ociBundlesFeatureFlag] = "true"
@@ -1802,7 +1795,7 @@ status:
     type: Succeeded
   startTime: "2021-12-31T23:58:59Z"
 `)}
-	cms := []*corev1.ConfigMap{withCustomTasks(newFeatureFlagsConfigMap())}
+	cms := []*corev1.ConfigMap{newFeatureFlagsConfigMap()}
 	d := test.Data{
 		PipelineRuns: prs,
 		Pipelines:    ps,
@@ -1916,7 +1909,7 @@ status:
   creationTime: "2021-12-31T11:58:58Z"
 `)}
 
-			cms := []*corev1.ConfigMap{withCustomTasks(newFeatureFlagsConfigMap())}
+			cms := []*corev1.ConfigMap{newFeatureFlagsConfigMap()}
 			d := test.Data{
 				PipelineRuns: prs,
 				Pipelines:    ps,
@@ -3511,7 +3504,7 @@ spec:
     pipelineTaskName: hello-world-1
 `)}
 
-	cms := []*corev1.ConfigMap{withCustomTasks(newFeatureFlagsConfigMap())}
+	cms := []*corev1.ConfigMap{newFeatureFlagsConfigMap()}
 	d := test.Data{
 		PipelineRuns: prs,
 		Pipelines:    ps,
@@ -3730,7 +3723,7 @@ spec:
     taskServiceAccountName: custom-sa
 `)}
 
-	cms := []*corev1.ConfigMap{withCustomTasks(newFeatureFlagsConfigMap())}
+	cms := []*corev1.ConfigMap{newFeatureFlagsConfigMap()}
 	d := test.Data{
 		PipelineRuns: prs,
 		Pipelines:    ps,
@@ -5025,7 +5018,7 @@ spec:
 		Tasks:        ts,
 		TaskRuns:     trs,
 		Runs:         rs,
-		ConfigMaps:   []*corev1.ConfigMap{withCustomTasks(withEmbeddedStatus(newFeatureFlagsConfigMap(), embeddedStatus))},
+		ConfigMaps:   []*corev1.ConfigMap{withEmbeddedStatus(newFeatureFlagsConfigMap(), embeddedStatus)},
 	}
 	prt := newPipelineRunTest(d, t)
 	defer prt.Cancel()
@@ -5381,7 +5374,7 @@ spec:
 		Tasks:        ts,
 		TaskRuns:     trs,
 		Runs:         rs,
-		ConfigMaps:   []*corev1.ConfigMap{withCustomTasks(withEmbeddedStatus(newFeatureFlagsConfigMap(), embeddedStatus))},
+		ConfigMaps:   []*corev1.ConfigMap{withEmbeddedStatus(newFeatureFlagsConfigMap(), embeddedStatus)},
 	}
 
 	prt := newPipelineRunTest(d, t)
@@ -6008,7 +6001,7 @@ status:
 	trs := []*v1beta1.TaskRun{taskRunDone, taskRunOrphaned}
 	runs := []*v1alpha1.Run{orphanedRun}
 
-	cms := []*corev1.ConfigMap{withCustomTasks(withEmbeddedStatus(newFeatureFlagsConfigMap(), embeddedStatus))}
+	cms := []*corev1.ConfigMap{withEmbeddedStatus(newFeatureFlagsConfigMap(), embeddedStatus)}
 
 	d := test.Data{
 		PipelineRuns: prs,
@@ -6208,7 +6201,7 @@ spec:
         name: some-custom-task
 `)
 
-	cms := []*corev1.ConfigMap{withCustomTasks(withEmbeddedStatus(newFeatureFlagsConfigMap(), embeddedStatus))}
+	cms := []*corev1.ConfigMap{withEmbeddedStatus(newFeatureFlagsConfigMap(), embeddedStatus)}
 
 	d := test.Data{
 		PipelineRuns: []*v1beta1.PipelineRun{pr},
@@ -10989,7 +10982,7 @@ spec:
 
 			ts := []*v1beta1.Task{simpleHelloWorldTask}
 
-			cms := []*corev1.ConfigMap{withEmbeddedStatus(withCustomTasks(newFeatureFlagsConfigMap()), tc.embeddedStatusVal)}
+			cms := []*corev1.ConfigMap{withEmbeddedStatus(newFeatureFlagsConfigMap(), tc.embeddedStatusVal)}
 
 			d := test.Data{
 				PipelineRuns: prs,

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
@@ -2061,12 +2061,6 @@ func TestResolvePipelineRun_CustomTask(t *testing.T) {
 	pipelineState := PipelineRunState{}
 	ctx := context.Background()
 	cfg := config.NewStore(logtesting.TestLogger(t))
-	cfg.OnConfigChanged(&corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{Name: config.GetFeatureFlagsConfigName()},
-		Data: map[string]string{
-			"enable-custom-tasks": "true",
-		},
-	})
 	ctx = cfg.ToContext(ctx)
 	for _, task := range pts {
 		ps, err := ResolvePipelineTask(ctx, pr, nopGetTask, nopGetTaskRun, getRun, task, nil)
@@ -2883,12 +2877,6 @@ func TestIsCustomTask(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
 			cfg := config.NewStore(logtesting.TestLogger(t))
-			cfg.OnConfigChanged(&corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{Name: config.GetFeatureFlagsConfigName()},
-				Data: map[string]string{
-					"enable-custom-tasks": "true",
-				},
-			})
 			ctx = cfg.ToContext(ctx)
 			rpt, err := ResolvePipelineTask(ctx, pr, getTask, getTaskRun, getRun, tc.pt, nil)
 			if err != nil {

--- a/pkg/reconciler/pipelinerun/timeout_test.go
+++ b/pkg/reconciler/pipelinerun/timeout_test.go
@@ -278,7 +278,7 @@ func TestTimeoutPipelineRun(t *testing.T) {
 			}
 			ctx, _ := ttesting.SetupFakeContext(t)
 			cfg := config.NewStore(logtesting.TestLogger(t))
-			cm := withCustomTasks(withEmbeddedStatus(newFeatureFlagsConfigMap(), tc.embeddedStatus))
+			cm := withEmbeddedStatus(newFeatureFlagsConfigMap(), tc.embeddedStatus)
 			if tc.useV1Beta1CustomTasks {
 				cm = withCustomTaskVersion(cm, config.CustomTaskVersionBeta)
 			}

--- a/test/featureflags.go
+++ b/test/featureflags.go
@@ -14,16 +14,6 @@ import (
 	"knative.dev/pkg/system"
 )
 
-// combineGates returns a setup func wrapping multiple requireAnyGate or requireAllGates calls, and will skip
-// the current test if any of the gate-check funcs fail.
-func combineGates(gateFuncs ...func(context.Context, *testing.T, *clients, string)) func(context.Context, *testing.T, *clients, string) {
-	return func(ctx context.Context, t *testing.T, c *clients, namespace string) {
-		for _, gf := range gateFuncs {
-			gf(ctx, t, c, namespace)
-		}
-	}
-}
-
 // requireAnyGate returns a setup func that will skip the current
 // test if none of the feature-flags in the given map match
 // what's in the feature-flags ConfigMap. It will fatally fail


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

In this change, we enable Custom Tasks in Pipelines by default by flipping `enable-custom-tasks` from `"false"` to `"true"`.

We will remove this feature flag soon.

See issue - https://github.com/tektoncd/pipeline/issues/5155.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Custom Tasks in Pipelines are enabled by default. To disable, set `enable-custom-tasks` feature flag `"false"`.
```
