### PR TITLE
[cmd/entrypoint] remove ioutil for new go version

### DIFF
--- a/cmd/entrypoint/post_writer_test.go
+++ b/cmd/entrypoint/post_writer_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -33,7 +32,7 @@ func TestRealPostWriter_WriteFileContent(t *testing.T) {
 				if _, err := os.Stat(tt.file); err != nil {
 					t.Fatalf("Failed to create a file %q", tt.file)
 				}
-				b, err := ioutil.ReadFile(tt.file)
+				b, err := os.ReadFile(tt.file)
 				if err != nil {
 					t.Fatalf("Failed to read the file %q", tt.file)
 				}

--- a/cmd/entrypoint/runner_test.go
+++ b/cmd/entrypoint/runner_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -29,7 +28,7 @@ func TestRealRunnerSignalForwarding(t *testing.T) {
 }
 
 func TestRealRunnerStdoutAndStderrPaths(t *testing.T) {
-	tmp, err := ioutil.TempDir("", "")
+	tmp, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -45,7 +44,7 @@ func TestRealRunnerStdoutAndStderrPaths(t *testing.T) {
 	}
 
 	for _, path := range []string{"stdout", "subpath/stderr"} {
-		if got, err := ioutil.ReadFile(filepath.Join(tmp, path)); err != nil {
+		if got, err := os.ReadFile(filepath.Join(tmp, path)); err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		} else if gotString := strings.TrimSpace(string(got)); gotString != expectedString {
 			t.Errorf("%v: got: %v, wanted: %v", path, gotString, expectedString)
@@ -54,7 +53,7 @@ func TestRealRunnerStdoutAndStderrPaths(t *testing.T) {
 }
 
 func TestRealRunnerStdoutAndStderrSamePath(t *testing.T) {
-	tmp, err := ioutil.TempDir("", "")
+	tmp, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -72,7 +71,7 @@ func TestRealRunnerStdoutAndStderrSamePath(t *testing.T) {
 
 	// Since writes to stdout and stderr might be racy, we only check for lengths here.
 	expectedSize := (len(expectedString) + 1) * 2
-	if got, err := ioutil.ReadFile(path); err != nil {
+	if got, err := os.ReadFile(path); err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	} else if gotSize := len(got); gotSize != expectedSize {
 		t.Errorf("got: %v, wanted: %v", gotSize, expectedSize)
@@ -80,7 +79,7 @@ func TestRealRunnerStdoutAndStderrSamePath(t *testing.T) {
 }
 
 func TestRealRunnerStdoutPathWithSignal(t *testing.T) {
-	tmp, err := ioutil.TempDir("", "")
+	tmp, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -113,7 +112,7 @@ func TestRealRunnerStdoutPathWithSignal(t *testing.T) {
 	if err := rr.Run(context.Background(), "sh", "-c", fmt.Sprintf("echo %s && sleep 20", expectedString)); err == nil || err.Error() != expectedError {
 		t.Fatalf("Expected error %v but got %v", expectedError, err)
 	}
-	if got, err := ioutil.ReadFile(path); err != nil {
+	if got, err := os.ReadFile(path); err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	} else if gotString := strings.TrimSpace(string(got)); gotString != expectedString {
 		t.Errorf("got: %v, wanted: %v", gotString, expectedString)

--- a/cmd/entrypoint/subcommands/cp_test.go
+++ b/cmd/entrypoint/subcommands/cp_test.go
@@ -18,7 +18,6 @@ package subcommands
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -29,7 +28,7 @@ func TestCp(t *testing.T) {
 	src := filepath.Join(tmp, "foo.txt")
 	dst := filepath.Join(tmp, "bar.txt")
 
-	if err := ioutil.WriteFile(src, []byte("hello world"), 0700); err != nil {
+	if err := os.WriteFile(src, []byte("hello world"), 0700); err != nil {
 		t.Fatalf("error writing source file: %v", err)
 	}
 

--- a/cmd/entrypoint/subcommands/decode_script.go
+++ b/cmd/entrypoint/subcommands/decode_script.go
@@ -21,7 +21,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 )
 
@@ -35,7 +34,7 @@ func decodeScript(scriptPath string) error {
 	if err != nil {
 		return fmt.Errorf("error decoding script file %q: %w", scriptPath, err)
 	}
-	err = ioutil.WriteFile(scriptPath, decodedBytes, permissions)
+	err = os.WriteFile(scriptPath, decodedBytes, permissions)
 	if err != nil {
 		return fmt.Errorf("error writing decoded script file %q: %w", scriptPath, err)
 	}

--- a/cmd/entrypoint/subcommands/decode_script_test.go
+++ b/cmd/entrypoint/subcommands/decode_script_test.go
@@ -19,7 +19,7 @@ package subcommands
 import (
 	"encoding/base64"
 	"errors"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -40,7 +40,7 @@ echo "Hello World!"
 			t.Errorf("temporary script file %q was not cleaned up: %v", src, err)
 		}
 	}()
-	if err := ioutil.WriteFile(src, []byte(encoded), mode); err != nil {
+	if err := os.WriteFile(src, []byte(encoded), mode); err != nil {
 		t.Fatalf("error writing encoded script: %v", err)
 	}
 
@@ -58,7 +58,7 @@ echo "Hello World!"
 		t.Fatalf("unexpected error statting decoded script: %v", err)
 	}
 	mod := info.Mode()
-	b, err := ioutil.ReadAll(file)
+	b, err := io.ReadAll(file)
 	if err != nil {
 		t.Fatalf("unexpected error reading content of decoded script: %v", err)
 	}
@@ -84,7 +84,7 @@ func TestDecodeScriptInvalidBase64(t *testing.T) {
 	invalidData := []byte("!")
 	expectedError := base64.CorruptInputError(0)
 
-	src, err := ioutil.TempFile("", "decode-script-test-*")
+	src, err := os.CreateTemp("", "decode-script-test-*")
 	if err != nil {
 		t.Fatalf("error creating temp file: %v", err)
 	}

--- a/cmd/entrypoint/subcommands/init_test.go
+++ b/cmd/entrypoint/subcommands/init_test.go
@@ -1,7 +1,6 @@
 package subcommands
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -11,7 +10,7 @@ func TestEntrypointInit(t *testing.T) {
 	tmp := t.TempDir()
 	src := filepath.Join(tmp, "foo.txt")
 	dst := filepath.Join(tmp, "bar.txt")
-	if err := ioutil.WriteFile(src, []byte("hello world"), 0700); err != nil {
+	if err := os.WriteFile(src, []byte("hello world"), 0700); err != nil {
 		t.Fatalf("error writing source file: %v", err)
 	}
 

--- a/cmd/entrypoint/waiter_test.go
+++ b/cmd/entrypoint/waiter_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -30,7 +29,7 @@ func TestRealWaiterWaitMissingFile(t *testing.T) {
 	// Create a temp file and then immediately delete it to get
 	// a legitimate tmp path and ensure the file doesnt exist
 	// prior to testing Wait().
-	tmp, err := ioutil.TempFile("", "real_waiter_test_file")
+	tmp, err := os.CreateTemp("", "real_waiter_test_file")
 	if err != nil {
 		t.Errorf("error creating temp file: %v", err)
 	}
@@ -58,7 +57,7 @@ func TestRealWaiterWaitMissingFile(t *testing.T) {
 }
 
 func TestRealWaiterWaitWithFile(t *testing.T) {
-	tmp, err := ioutil.TempFile("", "real_waiter_test_file")
+	tmp, err := os.CreateTemp("", "real_waiter_test_file")
 	if err != nil {
 		t.Errorf("error creating temp file: %v", err)
 	}
@@ -82,7 +81,7 @@ func TestRealWaiterWaitWithFile(t *testing.T) {
 }
 
 func TestRealWaiterWaitMissingContent(t *testing.T) {
-	tmp, err := ioutil.TempFile("", "real_waiter_test_file")
+	tmp, err := os.CreateTemp("", "real_waiter_test_file")
 	if err != nil {
 		t.Errorf("error creating temp file: %v", err)
 	}
@@ -109,7 +108,7 @@ func TestRealWaiterWaitMissingContent(t *testing.T) {
 }
 
 func TestRealWaiterWaitWithContent(t *testing.T) {
-	tmp, err := ioutil.TempFile("", "real_waiter_test_file")
+	tmp, err := os.CreateTemp("", "real_waiter_test_file")
 	if err != nil {
 		t.Errorf("error creating temp file: %v", err)
 	}
@@ -123,7 +122,7 @@ func TestRealWaiterWaitWithContent(t *testing.T) {
 		}
 		close(doneCh)
 	}()
-	if err := ioutil.WriteFile(tmp.Name(), []byte("😺"), 0700); err != nil {
+	if err := os.WriteFile(tmp.Name(), []byte("😺"), 0700); err != nil {
 		t.Errorf("error writing content to temp file: %v", err)
 	}
 	delay := time.NewTimer(2 * testWaitPollingInterval)
@@ -136,7 +135,7 @@ func TestRealWaiterWaitWithContent(t *testing.T) {
 }
 
 func TestRealWaiterWaitWithErrorWaitfile(t *testing.T) {
-	tmp, err := ioutil.TempFile("", "real_waiter_test_file*.err")
+	tmp, err := os.CreateTemp("", "real_waiter_test_file*.err")
 	if err != nil {
 		t.Errorf("error creating temp file: %v", err)
 	}
@@ -167,7 +166,7 @@ func TestRealWaiterWaitWithErrorWaitfile(t *testing.T) {
 }
 
 func TestRealWaiterWaitWithBreakpointOnFailure(t *testing.T) {
-	tmp, err := ioutil.TempFile("", "real_waiter_test_file*.err")
+	tmp, err := os.CreateTemp("", "real_waiter_test_file*.err")
 	if err != nil {
 		t.Errorf("error creating temp file: %v", err)
 	}


### PR DESCRIPTION
The `io/ioutil` has been deprecated from go 1.16 version, we should remove it.
https://go.dev/doc/go1.16#ioutil

ref: https://github.com/tektoncd/pipeline/issues/5874