### PR TITLE
Added govet to our Golang linter suite

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,4 @@
+# Documentation: https://golangci-lint.run/usage/configuration/
 linters-settings:
   errcheck:
     exclude: .errcheck.txt
@@ -21,11 +22,15 @@ linters:
   - goimports
   - gomodguard
   - gosec
+  - govet
   - gocritic
   - revive
   - misspell
   - unconvert
   - depguard
+    # To keep this PR small, I'm going to add one linter at a time.
+    #- unused
+    #- whitespace
 output:
   uniq-by-line: false
 issues:

--- a/cmd/nop/main.go
+++ b/cmd/nop/main.go
@@ -26,7 +26,7 @@ import (
 func main() {
 	if len(os.Args) >= 2 && os.Args[1] == "tekton_run_indefinitely" {
 		log.Println("Waiting indefinitely...")
-		ch := make(chan os.Signal)
+		ch := make(chan os.Signal, 1)
 		signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
 		log.Println("received signal:", <-ch)
 	}

--- a/internal/sidecarlogresults/sidecarlogresults_test.go
+++ b/internal/sidecarlogresults/sidecarlogresults_test.go
@@ -43,7 +43,7 @@ func TestLookForResults_FanOutAndWait(t *testing.T) {
 				wantResults = append(wantResults, encodedResult...)
 			}
 			dir2 := t.TempDir()
-			go createRun(t, dir2, false)
+			createRun(t, dir2, false)
 			got := new(bytes.Buffer)
 			err := LookForResults(got, dir2, dir, resultNames)
 			if err != nil {

--- a/pkg/apis/pipeline/v1/pipelinerun_validation_test.go
+++ b/pkg/apis/pipeline/v1/pipelinerun_validation_test.go
@@ -94,7 +94,7 @@ func TestPipelineRun_Invalid(t *testing.T) {
 			},
 			Status: v1.PipelineRunStatus{
 				PipelineRunStatusFields: v1.PipelineRunStatusFields{
-					StartTime: &metav1.Time{time.Now()},
+					StartTime: &metav1.Time{Time: time.Now()},
 				},
 			},
 		},

--- a/pkg/apis/pipeline/v1alpha1/run_types_test.go
+++ b/pkg/apis/pipeline/v1alpha1/run_types_test.go
@@ -296,7 +296,7 @@ func TestRunGetTimeOut(t *testing.T) {
 		name: "runWithTimeout",
 		run: v1alpha1.Run{
 			TypeMeta: metav1.TypeMeta{Kind: "kind", APIVersion: "apiVersion"},
-			Spec:     v1alpha1.RunSpec{Timeout: &metav1.Duration{10 * time.Second}},
+			Spec:     v1alpha1.RunSpec{Timeout: &metav1.Duration{Duration: 10 * time.Second}},
 		},
 		expectedValue: 10 * time.Second,
 	}}
@@ -344,7 +344,7 @@ func TestRunHasTimedOut(t *testing.T) {
 		name: "runWithStartTimeAndTimeout",
 		run: v1alpha1.Run{
 			TypeMeta: metav1.TypeMeta{Kind: "kind", APIVersion: "apiVersion"},
-			Spec:     v1alpha1.RunSpec{Timeout: &metav1.Duration{10 * time.Second}},
+			Spec:     v1alpha1.RunSpec{Timeout: &metav1.Duration{Duration: 10 * time.Second}},
 			Status: v1alpha1.RunStatus{RunStatusFields: v1alpha1.RunStatusFields{
 				StartTime: &metav1.Time{Time: now.Add(-1 * (apisconfig.DefaultTimeoutMinutes + 1) * time.Minute)},
 			}}},
@@ -353,14 +353,14 @@ func TestRunHasTimedOut(t *testing.T) {
 		name: "runWithNoStartTimeAndTimeout",
 		run: v1alpha1.Run{
 			TypeMeta: metav1.TypeMeta{Kind: "kind", APIVersion: "apiVersion"},
-			Spec:     v1alpha1.RunSpec{Timeout: &metav1.Duration{1 * time.Second}},
+			Spec:     v1alpha1.RunSpec{Timeout: &metav1.Duration{Duration: 1 * time.Second}},
 		},
 		expectedValue: false,
 	}, {
 		name: "runWithStartTimeAndTimeout2",
 		run: v1alpha1.Run{
 			TypeMeta: metav1.TypeMeta{Kind: "kind", APIVersion: "apiVersion"},
-			Spec:     v1alpha1.RunSpec{Timeout: &metav1.Duration{10 * time.Second}},
+			Spec:     v1alpha1.RunSpec{Timeout: &metav1.Duration{Duration: 10 * time.Second}},
 			Status: v1alpha1.RunStatus{RunStatusFields: v1alpha1.RunStatusFields{
 				StartTime: &metav1.Time{Time: now},
 			}}},

--- a/pkg/apis/pipeline/v1beta1/customrun_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/customrun_types_test.go
@@ -291,7 +291,7 @@ func TestRunGetTimeOut(t *testing.T) {
 		name: "runWithTimeout",
 		customRun: v1beta1.CustomRun{
 			TypeMeta: metav1.TypeMeta{Kind: "kind", APIVersion: "apiVersion"},
-			Spec:     v1beta1.CustomRunSpec{Timeout: &metav1.Duration{10 * time.Second}},
+			Spec:     v1beta1.CustomRunSpec{Timeout: &metav1.Duration{Duration: 10 * time.Second}},
 		},
 		expectedValue: 10 * time.Second,
 	}}
@@ -339,7 +339,7 @@ func TestRunHasTimedOut(t *testing.T) {
 		name: "runWithStartTimeAndTimeout",
 		customRun: v1beta1.CustomRun{
 			TypeMeta: metav1.TypeMeta{Kind: "kind", APIVersion: "apiVersion"},
-			Spec:     v1beta1.CustomRunSpec{Timeout: &metav1.Duration{10 * time.Second}},
+			Spec:     v1beta1.CustomRunSpec{Timeout: &metav1.Duration{Duration: 10 * time.Second}},
 			Status: v1beta1.CustomRunStatus{CustomRunStatusFields: v1beta1.CustomRunStatusFields{
 				StartTime: &metav1.Time{Time: now.Add(-1 * (apisconfig.DefaultTimeoutMinutes + 1) * time.Minute)},
 			}}},
@@ -348,14 +348,14 @@ func TestRunHasTimedOut(t *testing.T) {
 		name: "runWithNoStartTimeAndTimeout",
 		customRun: v1beta1.CustomRun{
 			TypeMeta: metav1.TypeMeta{Kind: "kind", APIVersion: "apiVersion"},
-			Spec:     v1beta1.CustomRunSpec{Timeout: &metav1.Duration{1 * time.Second}},
+			Spec:     v1beta1.CustomRunSpec{Timeout: &metav1.Duration{Duration: time.Second}},
 		},
 		expectedValue: false,
 	}, {
 		name: "runWithStartTimeAndTimeout2",
 		customRun: v1beta1.CustomRun{
 			TypeMeta: metav1.TypeMeta{Kind: "kind", APIVersion: "apiVersion"},
-			Spec:     v1beta1.CustomRunSpec{Timeout: &metav1.Duration{10 * time.Second}},
+			Spec:     v1beta1.CustomRunSpec{Timeout: &metav1.Duration{Duration: 10 * time.Second}},
 			Status: v1beta1.CustomRunStatus{CustomRunStatusFields: v1beta1.CustomRunStatusFields{
 				StartTime: &metav1.Time{Time: now},
 			}}},

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_validation_test.go
@@ -466,7 +466,7 @@ func TestPipelineRun_Invalid(t *testing.T) {
 			},
 			Status: v1beta1.PipelineRunStatus{
 				PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
-					StartTime: &metav1.Time{time.Now()},
+					StartTime: &metav1.Time{Time: time.Now()},
 				},
 			},
 		},

--- a/pkg/internal/affinityassistant/transformer_test.go
+++ b/pkg/internal/affinityassistant/transformer_test.go
@@ -169,7 +169,7 @@ func TestNewTransformerWithNodeAffinity(t *testing.T) {
 			Spec: corev1.PodSpec{
 				Affinity: &corev1.Affinity{PodAffinity: &corev1.PodAffinity{
 					RequiredDuringSchedulingIgnoredDuringExecution:  []corev1.PodAffinityTerm{*podAffinityTerm},
-					PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{{100, *podAffinityTerm}},
+					PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{{Weight: 100, PodAffinityTerm: *podAffinityTerm}},
 				}},
 			},
 		},
@@ -186,7 +186,7 @@ func TestNewTransformerWithNodeAffinity(t *testing.T) {
 					TopologyKey: "kubernetes.io/hostname",
 				}},
 				PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
-					{100, *podAffinityTerm},
+					{Weight: 100, PodAffinityTerm: *podAffinityTerm},
 				},
 			},
 		},
@@ -200,7 +200,7 @@ func TestNewTransformerWithNodeAffinity(t *testing.T) {
 				Affinity: &corev1.Affinity{
 					PodAffinity: &corev1.PodAffinity{
 						RequiredDuringSchedulingIgnoredDuringExecution:  []corev1.PodAffinityTerm{*podAffinityTerm},
-						PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{{100, *podAffinityTerm}},
+						PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{{Weight: 100, PodAffinityTerm: *podAffinityTerm}},
 					},
 					NodeAffinity: nodeAffinity},
 			},
@@ -221,7 +221,7 @@ func TestNewTransformerWithNodeAffinity(t *testing.T) {
 					},
 				},
 				PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
-					{100, *podAffinityTerm},
+					{Weight: 100, PodAffinityTerm: *podAffinityTerm},
 				},
 			},
 			NodeAffinity: nodeAffinity,

--- a/test/custom_task_test.go
+++ b/test/custom_task_test.go
@@ -469,7 +469,7 @@ func TestWaitCustomTask_Run(t *testing.T) {
 	}, {
 		name:                "Wait Task Timed Out",
 		duration:            "2s",
-		timeout:             &metav1.Duration{time.Second},
+		timeout:             &metav1.Duration{Duration: time.Second},
 		conditionAccessorFn: Failed,
 		wantCondition: apis.Condition{
 			Type:   apis.ConditionSucceeded,
@@ -479,7 +479,7 @@ func TestWaitCustomTask_Run(t *testing.T) {
 	}, {
 		name:                "Wait Task Retries on Timed Out",
 		duration:            "2s",
-		timeout:             &metav1.Duration{time.Second},
+		timeout:             &metav1.Duration{Duration: time.Second},
 		retries:             2,
 		conditionAccessorFn: Failed,
 		wantCondition: apis.Condition{
@@ -617,7 +617,7 @@ func TestWaitCustomTask_PipelineRun(t *testing.T) {
 	}{{
 		name:                  "Wait Task Has Succeeded",
 		runDuration:           "1s",
-		prTimeout:             &metav1.Duration{time.Second * 60},
+		prTimeout:             &metav1.Duration{Duration: time.Minute},
 		prConditionAccessorFn: Succeed,
 		wantPrCondition: apis.Condition{
 			Type:   apis.ConditionSucceeded,
@@ -639,7 +639,7 @@ func TestWaitCustomTask_PipelineRun(t *testing.T) {
 	}, {
 		name:                  "Wait Task Is Running",
 		runDuration:           "2s",
-		prTimeout:             &metav1.Duration{time.Second * 5},
+		prTimeout:             &metav1.Duration{Duration: time.Second * 5},
 		prConditionAccessorFn: Running,
 		wantPrCondition: apis.Condition{
 			Type:   apis.ConditionSucceeded,
@@ -661,7 +661,7 @@ func TestWaitCustomTask_PipelineRun(t *testing.T) {
 	}, {
 		name:                  "Wait Task Failed When PipelineRun Is Timeout",
 		runDuration:           "2s",
-		prTimeout:             &metav1.Duration{time.Second},
+		prTimeout:             &metav1.Duration{Duration: time.Second},
 		prConditionAccessorFn: Failed,
 		wantPrCondition: apis.Condition{
 			Type:   apis.ConditionSucceeded,
@@ -683,7 +683,7 @@ func TestWaitCustomTask_PipelineRun(t *testing.T) {
 	}, {
 		name:                  "Wait Task Failed on Timeout",
 		runDuration:           "2s",
-		runTimeout:            &metav1.Duration{time.Second},
+		runTimeout:            &metav1.Duration{Duration: time.Second},
 		prConditionAccessorFn: Failed,
 		wantPrCondition: apis.Condition{
 			Type:   apis.ConditionSucceeded,
@@ -705,7 +705,7 @@ func TestWaitCustomTask_PipelineRun(t *testing.T) {
 	}, {
 		name:                  "Wait Task Retries on Timeout",
 		runDuration:           "2s",
-		runTimeout:            &metav1.Duration{time.Second},
+		runTimeout:            &metav1.Duration{Duration: time.Second},
 		runRetries:            1,
 		prConditionAccessorFn: Failed,
 		wantPrCondition: apis.Condition{
@@ -742,7 +742,7 @@ func TestWaitCustomTask_PipelineRun(t *testing.T) {
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.prTimeout == nil {
-				tc.prTimeout = &metav1.Duration{time.Second * 60}
+				tc.prTimeout = &metav1.Duration{Duration: time.Minute}
 			}
 			p := &v1beta1.Pipeline{
 				ObjectMeta: metav1.ObjectMeta{
@@ -905,7 +905,7 @@ func TestWaitCustomTask_V1Beta1_PipelineRun(t *testing.T) {
 	}{{
 		name:                  "Wait Task Has Succeeded",
 		customRunDuration:     "1s",
-		prTimeout:             &metav1.Duration{time.Second * 60},
+		prTimeout:             &metav1.Duration{Duration: time.Minute},
 		prConditionAccessorFn: Succeed,
 		wantPrCondition: apis.Condition{
 			Type:   apis.ConditionSucceeded,
@@ -927,7 +927,7 @@ func TestWaitCustomTask_V1Beta1_PipelineRun(t *testing.T) {
 	}, {
 		name:                  "Wait Task Is Running",
 		customRunDuration:     "2s",
-		prTimeout:             &metav1.Duration{time.Second * 5},
+		prTimeout:             &metav1.Duration{Duration: time.Second * 5},
 		prConditionAccessorFn: Running,
 		wantPrCondition: apis.Condition{
 			Type:   apis.ConditionSucceeded,
@@ -971,7 +971,7 @@ func TestWaitCustomTask_V1Beta1_PipelineRun(t *testing.T) {
 	}, {
 		name:                  "Wait Task Failed on Timeout",
 		customRunDuration:     "2s",
-		customRunTimeout:      &metav1.Duration{time.Second},
+		customRunTimeout:      &metav1.Duration{Duration: time.Second},
 		prConditionAccessorFn: Failed,
 		wantPrCondition: apis.Condition{
 			Type:   apis.ConditionSucceeded,
@@ -993,7 +993,7 @@ func TestWaitCustomTask_V1Beta1_PipelineRun(t *testing.T) {
 	}, {
 		name:                  "Wait Task Retries on Timeout",
 		customRunDuration:     "2s",
-		customRunTimeout:      &metav1.Duration{time.Second},
+		customRunTimeout:      &metav1.Duration{Duration: time.Second},
 		customRunRetries:      1,
 		prConditionAccessorFn: Failed,
 		wantPrCondition: apis.Condition{
@@ -1030,7 +1030,7 @@ func TestWaitCustomTask_V1Beta1_PipelineRun(t *testing.T) {
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.prTimeout == nil {
-				tc.prTimeout = &metav1.Duration{time.Second * 60}
+				tc.prTimeout = &metav1.Duration{Duration: time.Minute}
 			}
 			p := &v1beta1.Pipeline{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR adds `govet` to our Golang linter suite. There are no expected functional changes
in this PR.

Also:
- fixed two minor issues uncovered by `go vet`:
  - cmd/nop/main.go:30:3: misuse of unbuffered os.Signal channel as argument to signal.Notify
  - internal/sidecarlogresults/sidecarlogresults_test.go:46:4: call to (*T).Fatal from a non-test goroutine
- fixed unkeyed composite literal fields in various `_test.go` files.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [N/A] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [N/A] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [N/A] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [N/A] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
