### PR TITLE
TEP-0127-: Larger results using sidecar logs - Always enforce ReservedSidecarName validation

### DIFF
--- a/pkg/apis/pipeline/v1/task_validation.go
+++ b/pkg/apis/pipeline/v1/task_validation.go
@@ -93,7 +93,7 @@ func (ts *TaskSpec) Validate(ctx context.Context) (errs *apis.FieldError) {
 	}
 
 	errs = errs.Also(validateSteps(ctx, mergedSteps).ViaField("steps"))
-	errs = errs.Also(validateSidecarNames(ctx, ts.Sidecars))
+	errs = errs.Also(validateSidecarNames(ts.Sidecars))
 	errs = errs.Also(ValidateParameterTypes(ctx, ts.Params).ViaField("params"))
 	errs = errs.Also(ValidateParameterVariables(ctx, ts.Steps, ts.Params))
 	errs = errs.Also(validateTaskContextVariables(ctx, ts.Steps))
@@ -101,11 +101,11 @@ func (ts *TaskSpec) Validate(ctx context.Context) (errs *apis.FieldError) {
 	return errs
 }
 
-func validateSidecarNames(ctx context.Context, sidecars []Sidecar) (errs *apis.FieldError) {
+func validateSidecarNames(sidecars []Sidecar) (errs *apis.FieldError) {
 	for _, sc := range sidecars {
-		if config.FromContextOrDefaults(ctx).FeatureFlags.ResultExtractionMethod == config.ResultExtractionMethodSidecarLogs && sc.Name == pipeline.ReservedResultsSidecarName {
+		if sc.Name == pipeline.ReservedResultsSidecarName {
 			errs = errs.Also(&apis.FieldError{
-				Message: fmt.Sprintf("Invalid sidecar name %v. This is reserved by the controller because the results-from feature flag has been set to %v", sc.Name, config.ResultExtractionMethodSidecarLogs),
+				Message: fmt.Sprintf("Invalid: cannot use reserved sidecar name %v ", sc.Name),
 				Paths:   []string{"sidecars"},
 			})
 		}

--- a/pkg/apis/pipeline/v1beta1/task_validation.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation.go
@@ -93,7 +93,7 @@ func (ts *TaskSpec) Validate(ctx context.Context) (errs *apis.FieldError) {
 	}
 
 	errs = errs.Also(validateSteps(ctx, mergedSteps).ViaField("steps"))
-	errs = errs.Also(validateSidecarNames(ctx, ts.Sidecars))
+	errs = errs.Also(validateSidecarNames(ts.Sidecars))
 	errs = errs.Also(ts.Resources.Validate(ctx).ViaField("resources"))
 	errs = errs.Also(ValidateParameterTypes(ctx, ts.Params).ViaField("params"))
 	errs = errs.Also(ValidateParameterVariables(ctx, ts.Steps, ts.Params))
@@ -103,11 +103,11 @@ func (ts *TaskSpec) Validate(ctx context.Context) (errs *apis.FieldError) {
 	return errs
 }
 
-func validateSidecarNames(ctx context.Context, sidecars []Sidecar) (errs *apis.FieldError) {
+func validateSidecarNames(sidecars []Sidecar) (errs *apis.FieldError) {
 	for _, sc := range sidecars {
-		if config.FromContextOrDefaults(ctx).FeatureFlags.ResultExtractionMethod == config.ResultExtractionMethodSidecarLogs && sc.Name == pipeline.ReservedResultsSidecarName {
+		if sc.Name == pipeline.ReservedResultsSidecarName {
 			errs = errs.Also(&apis.FieldError{
-				Message: fmt.Sprintf("Invalid sidecar name %v. This is reserved by the controller because the results-from feature flag has been set to %v", sc.Name, config.ResultExtractionMethodSidecarLogs),
+				Message: fmt.Sprintf("Invalid: cannot use reserved sidecar name %v ", sc.Name),
 				Paths:   []string{"sidecars"},
 			})
 		}

--- a/pkg/apis/pipeline/v1beta1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/test/diff"
 	corev1 "k8s.io/api/core/v1"
@@ -1413,32 +1414,22 @@ func TestTaskSpecValidateError(t *testing.T) {
 
 func TestTaskSpecValidateErrorSidecarName(t *testing.T) {
 	tests := []struct {
-		name                   string
-		sidecars               []v1beta1.Sidecar
-		resultExtractionMethod string
-		expectedError          apis.FieldError
+		name          string
+		sidecars      []v1beta1.Sidecar
+		expectedError apis.FieldError
 	}{{
 		name: "cannot use reserved sidecar name",
 		sidecars: []v1beta1.Sidecar{{
 			Name:  "tekton-log-results",
 			Image: "my-image",
 		}},
-		resultExtractionMethod: "sidecar-logs",
 		expectedError: apis.FieldError{
-			Message: fmt.Sprintf("Invalid sidecar name tekton-log-results. This is reserved by the controller because the results-from feature flag has been set to %v", config.ResultExtractionMethodSidecarLogs),
+			Message: fmt.Sprintf("Invalid: cannot use reserved sidecar name %v ", pipeline.ReservedResultsSidecarName),
 			Paths:   []string{"sidecars"},
 		},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
-			if tt.resultExtractionMethod != "" {
-				ctx = config.ToContext(ctx, &config.Config{
-					FeatureFlags: &config.FeatureFlags{
-						ResultExtractionMethod: tt.resultExtractionMethod,
-					},
-				})
-			}
 			ts := &v1beta1.TaskSpec{
 				Steps: []v1beta1.Step{{
 					Name:  "does-not-matter",
@@ -1446,7 +1437,7 @@ func TestTaskSpecValidateErrorSidecarName(t *testing.T) {
 				}},
 				Sidecars: tt.sidecars,
 			}
-			err := ts.Validate(ctx)
+			err := ts.Validate(context.Background())
 			if err == nil {
 				t.Fatalf("Expected an error, got nothing for %v", ts)
 			}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

Prior to this, when validating sidecar name, we would only throw a validation error if the user specifies a sidecar with the same name as ReservedSidecarName and if the `featureflag: results-from` is set to `sidecar-logs`.

This PR does a validation check regardless of what the `results-from` feature flag is set to. This way, pipelines don't break due to a change in a feature flag.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Always enforce ReservedSidecarName validation check regardless of what the `results-from` feature flag is set to.
```
/kind feature