### PR TITLE
[pkg/pullrequest] cleanup ioutil for new go version

### DIFF
--- a/pkg/pullrequest/api.go
+++ b/pkg/pullrequest/api.go
@@ -19,7 +19,7 @@ package pullrequest
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strconv"
 
 	"github.com/hashicorp/go-multierror"
@@ -61,7 +61,7 @@ func (h *Handler) Download(ctx context.Context) (*Resource, error) {
 	h.logger.Info("finding combined status")
 	status, out, err := h.client.Repositories.ListStatus(ctx, h.repo, pr.Sha, &scm.ListOptions{})
 	if err != nil {
-		body, _ := ioutil.ReadAll(out.Body)
+		body, _ := io.ReadAll(out.Body)
 		defer out.Body.Close()
 		h.logger.Warnf("%v: %s", err, string(body))
 		return nil, fmt.Errorf("finding combined status for pr %d: %w", h.prNum, err)

--- a/pkg/pullrequest/disk.go
+++ b/pkg/pullrequest/disk.go
@@ -20,7 +20,6 @@ import (
 	"encoding/gob"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -122,7 +121,7 @@ func labelsToDisk(path string, labels []*scm.Label) error {
 	for _, l := range labels {
 		name := url.QueryEscape(l.Name)
 		labelPath := filepath.Join(path, name)
-		if err := ioutil.WriteFile(labelPath, []byte{}, 0600); err != nil {
+		if err := os.WriteFile(labelPath, []byte{}, 0600); err != nil {
 			return err
 		}
 		manifest[name] = true
@@ -146,7 +145,7 @@ func refToDisk(name, path string, r scm.PullRequestBranch) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(filepath.Join(path, name+".json"), b, 0600)
+	return os.WriteFile(filepath.Join(path, name+".json"), b, 0600)
 }
 
 func toDisk(path string, r interface{}, perm os.FileMode) error {
@@ -154,7 +153,7 @@ func toDisk(path string, r interface{}, perm os.FileMode) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(path, b, perm)
+	return os.WriteFile(path, b, perm)
 }
 
 // FromDisk outputs a PullRequest object from an on-disk representation at the specified path.
@@ -170,7 +169,7 @@ func FromDisk(path string, disableJSONComments bool) (*Resource, error) {
 	// If pr.json exists in output directory, preload r.PR
 	prPath := filepath.Join(path, "pr.json")
 	if _, err := os.Stat(prPath); err == nil {
-		b, err := ioutil.ReadFile(prPath)
+		b, err := os.ReadFile(prPath)
 		if err != nil {
 			return nil, err
 		}
@@ -244,7 +243,7 @@ func manifestFromDisk(path string) (Manifest, error) {
 }
 
 func commentsFromDisk(path string, disableStrictJSON bool) ([]*scm.Comment, Manifest, error) {
-	fis, err := ioutil.ReadDir(path)
+	fis, err := os.ReadDir(path)
 	if isNotExistError(err) {
 		return nil, nil, nil
 	}
@@ -256,7 +255,7 @@ func commentsFromDisk(path string, disableStrictJSON bool) ([]*scm.Comment, Mani
 		if fi.Name() == manifestPath {
 			continue
 		}
-		b, err := ioutil.ReadFile(filepath.Join(path, fi.Name()))
+		b, err := os.ReadFile(filepath.Join(path, fi.Name()))
 		if err != nil {
 			return nil, nil, err
 		}
@@ -284,7 +283,7 @@ func commentsFromDisk(path string, disableStrictJSON bool) ([]*scm.Comment, Mani
 }
 
 func labelsFromDisk(path string) ([]*scm.Label, Manifest, error) {
-	fis, err := ioutil.ReadDir(path)
+	fis, err := os.ReadDir(path)
 	if isNotExistError(err) {
 		return nil, nil, nil
 	}
@@ -312,7 +311,7 @@ func labelsFromDisk(path string) ([]*scm.Label, Manifest, error) {
 }
 
 func statusesFromDisk(path string) ([]*scm.Status, error) {
-	fis, err := ioutil.ReadDir(path)
+	fis, err := os.ReadDir(path)
 	if isNotExistError(err) {
 		return nil, nil
 	}
@@ -322,7 +321,7 @@ func statusesFromDisk(path string) ([]*scm.Status, error) {
 
 	statuses := []*scm.Status{}
 	for _, fi := range fis {
-		b, err := ioutil.ReadFile(filepath.Join(path, fi.Name()))
+		b, err := os.ReadFile(filepath.Join(path, fi.Name()))
 		if err != nil {
 			return nil, err
 		}
@@ -336,7 +335,7 @@ func statusesFromDisk(path string) ([]*scm.Status, error) {
 }
 
 func refFromDisk(path, name string) (scm.PullRequestBranch, error) {
-	b, err := ioutil.ReadFile(filepath.Join(path, name))
+	b, err := os.ReadFile(filepath.Join(path, name))
 	if err != nil {
 		return scm.PullRequestBranch{}, err
 	}

--- a/pkg/pullrequest/disk_test.go
+++ b/pkg/pullrequest/disk_test.go
@@ -18,7 +18,6 @@ package pullrequest
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -96,7 +95,7 @@ func TestToDisk(t *testing.T) {
 	checkRef("base.json", rsrc.PR.Base)
 
 	// Check the Statuses
-	fis, err := ioutil.ReadDir(filepath.Join(d, "status"))
+	fis, err := os.ReadDir(filepath.Join(d, "status"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -117,7 +116,7 @@ func TestToDisk(t *testing.T) {
 		}
 	}
 	// Check the labels
-	fis, err = ioutil.ReadDir(filepath.Join(d, "labels"))
+	fis, err = os.ReadDir(filepath.Join(d, "labels"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -154,7 +153,7 @@ func TestToDisk(t *testing.T) {
 	}
 
 	// Check the comments
-	fis, err = ioutil.ReadDir(filepath.Join(d, "comments"))
+	fis, err = os.ReadDir(filepath.Join(d, "comments"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -214,7 +213,7 @@ func TestFromDiskWithoutComments(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err := ioutil.WriteFile(p, b, 0700); err != nil {
+		if err := os.WriteFile(p, b, 0700); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -256,7 +255,7 @@ func TestFromDisk(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err := ioutil.WriteFile(p, b, 0700); err != nil {
+		if err := os.WriteFile(p, b, 0700); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -290,7 +289,7 @@ func TestFromDisk(t *testing.T) {
 	}
 	labels := []string{"hey", "you", "size%2Flgtm"}
 	for _, l := range labels {
-		if err := ioutil.WriteFile(filepath.Join(d, l), []byte{}, 0700); err != nil {
+		if err := os.WriteFile(filepath.Join(d, l), []byte{}, 0700); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -322,7 +321,7 @@ func TestFromDisk(t *testing.T) {
 	writeManifest(t, manifest, filepath.Join(d, "comments", manifestPath))
 
 	// Comments can also be plain text.
-	if err := ioutil.WriteFile(filepath.Join(d, "comments", "plain"), []byte("plaincomment"), 0700); err != nil {
+	if err := os.WriteFile(filepath.Join(d, "comments", "plain"), []byte("plaincomment"), 0700); err != nil {
 		t.Fatal(err)
 	}
 
@@ -396,7 +395,7 @@ func TestFromDisk(t *testing.T) {
 
 func readAndUnmarshal(t *testing.T, p string, v interface{}) {
 	t.Helper()
-	b, err := ioutil.ReadFile(p)
+	b, err := os.ReadFile(p)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -501,7 +500,7 @@ func TestCommentsFromDisk(t *testing.T) {
 			fileNames := []string{}
 			for fileName, contents := range tt.files {
 				fileNames = append(fileNames, fileName)
-				if err := ioutil.WriteFile(filepath.Join(d, "comments", fileName), contents, 0700); err != nil {
+				if err := os.WriteFile(filepath.Join(d, "comments", fileName), contents, 0700); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -709,7 +708,7 @@ func TestLabelsFromDisk(t *testing.T) {
 			d := t.TempDir()
 
 			for _, l := range tt.args.fileNames {
-				if err := ioutil.WriteFile(filepath.Join(d, l), []byte{}, 0700); err != nil {
+				if err := os.WriteFile(filepath.Join(d, l), []byte{}, 0700); err != nil {
 					t.Errorf("Error creating label: %s", err)
 				}
 			}
@@ -759,7 +758,7 @@ func TestFromDiskPRShaWithNullHeadAndBase(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err := ioutil.WriteFile(p, b, 0700); err != nil {
+		if err := os.WriteFile(p, b, 0700); err != nil {
 			t.Fatal(err)
 		}
 	}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
[pkg/pullrequest] cleanup ioutil for new go version

Ref: https://github.com/tektoncd/pipeline/issues/5874

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
