### PR TITLE
Replaced `deadcode` linter with `unused` linter.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,7 +16,6 @@ linters-settings:
 linters:
   disable-all: true
   enable:
-  - deadcode
   - errcheck
   - gofmt
   - goimports
@@ -28,8 +27,8 @@ linters:
   - misspell
   - unconvert
   - depguard
-    # To keep this PR small, I'm going to add one linter at a time.
-    #- unused
+  - unused
+    # TODO: enable whitespace linter
     #- whitespace
 output:
   uniq-by-line: false
@@ -39,6 +38,13 @@ issues:
     linters:
     - errcheck
     - gosec
+  - path: test/pipelinerun_test\.go
+    linters:
+    - unused
+  - path: pkg/reconciler/pipelinerun/pipelinerun_test\.go
+    # This 11,000+ line file is too big for unused code detection.
+    linters:
+    - unused
   max-issues-per-linter: 0
   max-same-issues: 0
   include:

--- a/test/multiarch_utils.go
+++ b/test/multiarch_utils.go
@@ -18,7 +18,6 @@ package test
 
 import (
 	"os"
-	"regexp"
 	"runtime"
 	"testing"
 
@@ -26,9 +25,8 @@ import (
 )
 
 var (
-	imageNames      = initImageNames()
-	excludedTests   = initExcludedTests()
-	imagesMappingRE map[*regexp.Regexp][]byte
+	imageNames    = initImageNames()
+	excludedTests = initExcludedTests()
 )
 
 const (
@@ -41,10 +39,6 @@ const (
 	// dockerize image
 	dockerizeImage
 )
-
-func init() {
-	imagesMappingRE = getImagesMappingRE()
-}
 
 // getTestArch returns architecture of the cluster where test suites will be executed.
 // default value is similar to build architecture, TEST_RUNTIME_ARCH is used when test target cluster has another architecture
@@ -83,57 +77,8 @@ func initImageNames() map[int]string {
 	}
 }
 
-// getImagesMappingRE generates the map ready to search and replace image names with regexp for examples files.
-// search is done using "image: <name>" pattern.
-func getImagesMappingRE() map[*regexp.Regexp][]byte {
-	imageNamesMapping := imageNamesMapping()
-	imageMappingRE := make(map[*regexp.Regexp][]byte, len(imageNamesMapping))
-
-	for existingImage, archSpecificImage := range imageNamesMapping {
-		imageMappingRE[regexp.MustCompile("(?im)image: "+existingImage+"$")] = []byte("image: " + archSpecificImage)
-		imageMappingRE[regexp.MustCompile("(?im)default: "+existingImage+"$")] = []byte("default: " + archSpecificImage)
-	}
-
-	return imageMappingRE
-}
-
-// imageNamesMapping provides mapping between image name in the examples yaml files and desired image name for specific arch.
-// by default empty map is returned.
-func imageNamesMapping() map[string]string {
-
-	switch getTestArch() {
-	case "s390x":
-		return map[string]string{
-			"registry":                              getTestImage(registryImage),
-			"node":                                  "node:alpine3.11",
-			"gcr.io/cloud-builders/git":             "alpine/git:latest",
-			"docker:dind":                           "ibmcom/docker-s390x:20.10",
-			"docker":                                "docker:18.06.3",
-			"mikefarah/yq:3":                        "danielxlee/yq:2.4.0",
-			"stedolan/jq":                           "ibmcom/jq-s390x:latest",
-			"amd64/ubuntu":                          "s390x/ubuntu",
-			"gcr.io/kaniko-project/executor:v1.3.0": getTestImage(kanikoImage),
-		}
-	case "ppc64le":
-		return map[string]string{
-			"registry":                              getTestImage(registryImage),
-			"node":                                  "node:alpine3.11",
-			"gcr.io/cloud-builders/git":             "alpine/git:latest",
-			"docker:dind":                           "ibmcom/docker-ppc64le:19.03-dind",
-			"docker":                                "docker:18.06.3",
-			"mikefarah/yq:3":                        "danielxlee/yq:2.4.0",
-			"stedolan/jq":                           "ibmcom/jq-ppc64le:latest",
-			"gcr.io/kaniko-project/executor:v1.3.0": getTestImage(kanikoImage),
-		}
-
-	}
-
-	return make(map[string]string)
-}
-
 // initExcludedTests provides list of excluded tests for e2e and exanples tests
 func initExcludedTests() sets.String {
-
 	switch getTestArch() {
 	case "s390x":
 		return sets.NewString(


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The `deadcode` linter is deprecated and unsupported. The `unused` linter is the drop-in replacement.

Note that configuration skips unused code detection in files where it is failing for unknown reasons.

Also: moved several vars and related functions from multiarch_utils to examples_test. These were only used in examples_test, and while the two files are part of the same package, the `unused` linter had trouble identifying that they were in fact in use in examples_test.

There are no expected functional changes in this PR.

/kind cleanup
/hold

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [N/A] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [N/A] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [N/A] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
