### PR TITLE
WIP: When pipelineRun failed to create taskRun then should mark pipelineRun failed

### DIFF
--- a/pkg/apis/pipeline/v1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1/pipeline_validation.go
@@ -103,6 +103,8 @@ func (l PipelineTaskList) Validate(ctx context.Context, taskNames sets.String, p
 		taskNames.Insert(t.Name)
 		// validate custom task, dag, or final task
 		errs = errs.Also(t.Validate(ctx).ViaFieldIndex(path, i))
+		// validate taskref to prevent creating invalid data
+		errs = errs.Also(t.TaskRef.Validate(ctx))
 	}
 	return errs
 }

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation.go
@@ -107,6 +107,8 @@ func (l PipelineTaskList) Validate(ctx context.Context, taskNames sets.String, p
 		taskNames.Insert(t.Name)
 		// validate custom task, bundle, dag, or final task
 		errs = errs.Also(t.Validate(ctx).ViaFieldIndex(path, i))
+		// validate taskref to prevent creating invalid data
+		errs = errs.Also(t.TaskRef.Validate(ctx))
 	}
 	return errs
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Mark pipelineRun failed when create Taskrun failed & Add validation for pipeline.spec.task.taskRef

It will be successed  when create pipeline even Pipeline.Spec.Tasks[].TaskRef is invalid.
So add taskRef validation in webhook.

If pielineRun create taskRun failed then pipelineRun will freeze in a status and not change. It is
confused for users.

And now it will mark pipelineRun as failed and return a permanent error.

Related  issue: https://github.com/tektoncd/pipeline/issues/5673

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
