### PR TITLE
Enabled the `whitespace` linter.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,8 +28,7 @@ linters:
   - unconvert
   - depguard
   - unused
-    # TODO: enable whitespace linter
-    #- whitespace
+  - whitespace
 output:
   uniq-by-line: false
 issues:

--- a/cmd/entrypoint/subcommands/subcommands_test.go
+++ b/cmd/entrypoint/subcommands/subcommands_test.go
@@ -58,7 +58,6 @@ func TestProcessSuccessfulSubcommands(t *testing.T) {
 			t.Errorf("unexpected return value from step-init command w/ params: %v", returnValue)
 		}
 	})
-
 }
 
 // TestProcessIgnoresNonSubcommands checks that any input to Process which
@@ -84,7 +83,6 @@ func TestProcessIgnoresNonSubcommands(t *testing.T) {
 	})
 
 	t.Run(DecodeScriptCommand, func(t *testing.T) {
-
 		if err := Process([]string{DecodeScriptCommand}); err != nil {
 			t.Errorf("unexpected error processing command with 0 additional args: %v", err)
 		}

--- a/cmd/imagedigestexporter/main.go
+++ b/cmd/imagedigestexporter/main.go
@@ -73,7 +73,6 @@ func main() {
 			Value:        imageResource.URL,
 			ResourceName: imageResource.Name,
 		})
-
 	}
 
 	if err := termination.WriteMessage(*terminationMessagePath, output); err != nil {

--- a/pkg/apis/pipeline/v1/container_types.go
+++ b/pkg/apis/pipeline/v1/container_types.go
@@ -22,7 +22,6 @@ import (
 
 // Step runs a subcomponent of a Task
 type Step struct {
-
 	// Name of the Step specified as a DNS_LABEL.
 	// Each Step in a Task must have a unique name.
 	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
@@ -191,7 +190,6 @@ func (s *Step) SetContainerFields(c corev1.Container) {
 
 // StepTemplate is a template for a Step
 type StepTemplate struct {
-
 	// Image reference name.
 	// More info: https://kubernetes.io/docs/concepts/containers/images
 	// This field is optional to allow higher level config management to default or override
@@ -308,7 +306,6 @@ func (s *StepTemplate) ToK8sContainer() *corev1.Container {
 
 // Sidecar has nearly the same data structure as Step but does not have the ability to timeout.
 type Sidecar struct {
-
 	// Name of the Sidecar specified as a DNS_LABEL.
 	// Each Sidecar in a Task must have a unique name (DNS_LABEL).
 	// Cannot be updated.

--- a/pkg/apis/pipeline/v1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1/pipeline_validation.go
@@ -309,7 +309,6 @@ func taskContainsResult(resultExpression string, pipelineTaskNames sets.String, 
 			if strings.HasPrefix(value, "finally") && !pipelineFinallyTaskNames.Has(pipelineTaskName) {
 				return false
 			}
-
 		}
 	}
 	return true

--- a/pkg/apis/pipeline/v1/pipelinerun_types_test.go
+++ b/pkg/apis/pipeline/v1/pipelinerun_types_test.go
@@ -228,7 +228,6 @@ func TestPipelineRunTimeouts(t *testing.T) {
 		expectedTasksTimeout:   &metav1.Duration{Duration: 10 * time.Minute},
 		expectedFinallyTimeout: &metav1.Duration{Duration: 50 * time.Minute},
 	}, {
-
 		name:                   "pipeline and finally timeout set",
 		timeouts:               &v1.TimeoutFields{Pipeline: &metav1.Duration{Duration: time.Hour}, Finally: &metav1.Duration{Duration: 10 * time.Minute}},
 		expectedTasksTimeout:   &metav1.Duration{Duration: 50 * time.Minute},

--- a/pkg/apis/pipeline/v1/pipelinerun_validation.go
+++ b/pkg/apis/pipeline/v1/pipelinerun_validation.go
@@ -227,7 +227,6 @@ func validateSpecStatus(status PipelineRunSpecStatus) *apis.FieldError {
 		PipelineRunSpecStatusCancelledRunFinally,
 		PipelineRunSpecStatusStoppedRunFinally,
 		PipelineRunSpecStatusPending), "status")
-
 }
 
 func validateTimeoutDuration(field string, d *metav1.Duration) (errs *apis.FieldError) {

--- a/pkg/apis/pipeline/v1/result_validation_test.go
+++ b/pkg/apis/pipeline/v1/result_validation_test.go
@@ -175,7 +175,6 @@ func TestResultsValidateError(t *testing.T) {
 			if d := cmp.Diff(tt.expectedError.Error(), err.Error(), cmpopts.IgnoreUnexported(apis.FieldError{})); d != "" {
 				t.Errorf("TaskSpec.Validate() errors diff %s", diff.PrintWantGot(d))
 			}
-
 		})
 	}
 }

--- a/pkg/apis/pipeline/v1/task_types.go
+++ b/pkg/apis/pipeline/v1/task_types.go
@@ -54,7 +54,6 @@ func (*Task) GetGroupVersionKind() schema.GroupVersionKind {
 
 // TaskSpec defines the desired state of Task.
 type TaskSpec struct {
-
 	// Params is a list of input parameters required to run the task. Params
 	// must be supplied as inputs in TaskRuns unless they declare a default
 	// value.

--- a/pkg/apis/pipeline/v1/task_validation.go
+++ b/pkg/apis/pipeline/v1/task_validation.go
@@ -445,7 +445,6 @@ func validateStepObjectUsageAsWhole(step Step, prefix string, vars sets.String) 
 	}
 	for i, arg := range step.Args {
 		errs = errs.Also(validateTaskNoObjectReferenced(arg, prefix, vars).ViaFieldIndex("args", i))
-
 	}
 	for _, env := range step.Env {
 		errs = errs.Also(validateTaskNoObjectReferenced(env.Value, prefix, vars).ViaFieldKey("env", env.Name))
@@ -475,7 +474,6 @@ func validateStepArrayUsage(step Step, prefix string, vars sets.String) *apis.Fi
 	}
 	for i, arg := range step.Args {
 		errs = errs.Also(validateTaskArraysIsolated(arg, prefix, vars).ViaFieldIndex("args", i))
-
 	}
 	for _, env := range step.Env {
 		errs = errs.Also(validateTaskNoArrayReferenced(env.Value, prefix, vars).ViaFieldKey("env", env.Name))

--- a/pkg/apis/pipeline/v1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1/task_validation_test.go
@@ -1518,7 +1518,6 @@ func TestStepOnError(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 // TestIncompatibleAPIVersions exercises validation of fields that

--- a/pkg/apis/pipeline/v1/workspace_validation_test.go
+++ b/pkg/apis/pipeline/v1/workspace_validation_test.go
@@ -123,7 +123,6 @@ func TestWorkspaceBindingValidateValid(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestWorkspaceBindingValidateInvalid(t *testing.T) {

--- a/pkg/apis/pipeline/v1beta1/container_types.go
+++ b/pkg/apis/pipeline/v1beta1/container_types.go
@@ -7,7 +7,6 @@ import (
 
 // Step runs a subcomponent of a Task
 type Step struct {
-
 	// Name of the Step specified as a DNS_LABEL.
 	// Each Step in a Task must have a unique name.
 	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
@@ -271,7 +270,6 @@ func (s *Step) SetContainerFields(c corev1.Container) {
 
 // StepTemplate is a template for a Step
 type StepTemplate struct {
-
 	// Deprecated. This field will be removed in a future release.
 	// Default name for each Step specified as a DNS_LABEL.
 	// Each Step in a Task must have a unique name.
@@ -489,7 +487,6 @@ func (s *StepTemplate) ToK8sContainer() *corev1.Container {
 
 // Sidecar has nearly the same data structure as Step but does not have the ability to timeout.
 type Sidecar struct {
-
 	// Name of the Sidecar specified as a DNS_LABEL.
 	// Each Sidecar in a Task must have a unique name (DNS_LABEL).
 	// Cannot be updated.

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation.go
@@ -315,7 +315,6 @@ func taskContainsResult(resultExpression string, pipelineTaskNames sets.String, 
 			if strings.HasPrefix(value, "finally") && !pipelineFinallyTaskNames.Has(pipelineTaskName) {
 				return false
 			}
-
 		}
 	}
 	return true
@@ -425,7 +424,6 @@ func validateDeclaredResources(resources []PipelineDeclaredResource, tasks []Pip
 				required = append(required, output.Resource)
 			}
 		}
-
 	}
 	for _, t := range finalTasks {
 		if t.Resources != nil {

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_types_test.go
@@ -337,7 +337,6 @@ func TestPipelineRunTimeouts(t *testing.T) {
 		expectedTasksTimeout:   &metav1.Duration{Duration: 10 * time.Minute},
 		expectedFinallyTimeout: &metav1.Duration{Duration: 50 * time.Minute},
 	}, {
-
 		name:                   "pipeline and finally timeout set",
 		timeouts:               &v1beta1.TimeoutFields{Pipeline: &metav1.Duration{Duration: time.Hour}, Finally: &metav1.Duration{Duration: 10 * time.Minute}},
 		expectedTasksTimeout:   &metav1.Duration{Duration: 50 * time.Minute},

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_validation.go
@@ -270,7 +270,6 @@ func validateSpecStatus(status PipelineRunSpecStatus) *apis.FieldError {
 		PipelineRunSpecStatusCancelledRunFinally,
 		PipelineRunSpecStatusStoppedRunFinally,
 		PipelineRunSpecStatusPending), "status")
-
 }
 
 func validateTimeoutDuration(field string, d *metav1.Duration) (errs *apis.FieldError) {

--- a/pkg/apis/pipeline/v1beta1/resource_types.go
+++ b/pkg/apis/pipeline/v1beta1/resource_types.go
@@ -147,7 +147,6 @@ type ResultType int
 // of string, and then fail the running TaskRun because it doesn't know how to interpret
 // the string value that the TaskRun's entrypoint will emit when it completes.
 func (r *ResultType) UnmarshalJSON(data []byte) error {
-
 	var asInt int
 	var intErr error
 

--- a/pkg/apis/pipeline/v1beta1/resource_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/resource_types_test.go
@@ -141,7 +141,6 @@ func TestApplyTaskModifier_AlreadyAdded(t *testing.T) {
 }
 
 func TestPipelineResourceResult_UnmarshalJSON(t *testing.T) {
-
 	testcases := []struct {
 		name string
 		data string

--- a/pkg/apis/pipeline/v1beta1/resource_types_validation.go
+++ b/pkg/apis/pipeline/v1beta1/resource_types_validation.go
@@ -96,7 +96,6 @@ func validateTaskRunResources(ctx context.Context, resources []TaskResourceBindi
 		if r.ResourceSpec != nil && r.ResourceSpec.Validate(ctx) != nil {
 			return r.ResourceSpec.Validate(ctx)
 		}
-
 	}
 	return nil
 }

--- a/pkg/apis/pipeline/v1beta1/result_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/result_validation_test.go
@@ -175,7 +175,6 @@ func TestResultsValidateError(t *testing.T) {
 			if d := cmp.Diff(tt.expectedError.Error(), err.Error(), cmpopts.IgnoreUnexported(apis.FieldError{})); d != "" {
 				t.Errorf("TaskSpec.Validate() errors diff %s", diff.PrintWantGot(d))
 			}
-
 		})
 	}
 }

--- a/pkg/apis/pipeline/v1beta1/resultref.go
+++ b/pkg/apis/pipeline/v1beta1/resultref.go
@@ -171,7 +171,6 @@ func stripVarSubExpression(expression string) string {
 // - Output: "", "", 0, "", error
 // TODO: may use regex for each type to handle possible reference formats
 func parseExpression(substitutionExpression string) (string, string, int, string, error) {
-
 	if looksLikeResultRef(substitutionExpression) {
 		subExpressions := strings.Split(substitutionExpression, ".")
 		// For string result: tasks.<taskName>.results.<stringResultName>

--- a/pkg/apis/pipeline/v1beta1/task_validation.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation.go
@@ -466,7 +466,6 @@ func validateStepObjectUsageAsWhole(step Step, prefix string, vars sets.String) 
 	}
 	for i, arg := range step.Args {
 		errs = errs.Also(validateTaskNoObjectReferenced(arg, prefix, vars).ViaFieldIndex("args", i))
-
 	}
 	for _, env := range step.Env {
 		errs = errs.Also(validateTaskNoObjectReferenced(env.Value, prefix, vars).ViaFieldKey("env", env.Name))
@@ -496,7 +495,6 @@ func validateStepArrayUsage(step Step, prefix string, vars sets.String) *apis.Fi
 	}
 	for i, arg := range step.Args {
 		errs = errs.Also(validateTaskArraysIsolated(arg, prefix, vars).ViaFieldIndex("args", i))
-
 	}
 	for _, env := range step.Env {
 		errs = errs.Also(validateTaskNoArrayReferenced(env.Value, prefix, vars).ViaFieldKey("env", env.Name))

--- a/pkg/apis/pipeline/v1beta1/taskrun_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_validation_test.go
@@ -956,7 +956,6 @@ func TestResources_Validate(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestResources_Invalidate(t *testing.T) {

--- a/pkg/apis/pipeline/v1beta1/workspace_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/workspace_validation_test.go
@@ -120,7 +120,6 @@ func TestWorkspaceBindingValidateValid(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestWorkspaceBindingValidateInvalid(t *testing.T) {

--- a/pkg/apis/resource/v1alpha1/pipelineresource_validation_test.go
+++ b/pkg/apis/resource/v1alpha1/pipelineresource_validation_test.go
@@ -168,7 +168,6 @@ func TestResourceValidation_Invalid(t *testing.T) {
 		}, {
 			name: "missing spec",
 			res: &v1alpha1.PipelineResource{
-
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "temp",
 				},
@@ -300,5 +299,4 @@ func TestAllowedGCSStorageType(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/pkg/apis/validate/metadata_test.go
+++ b/pkg/apis/validate/metadata_test.go
@@ -25,7 +25,6 @@ import (
 )
 
 func TestMetadataInvalidLongName(t *testing.T) {
-
 	invalidMetas := []*metav1.ObjectMeta{
 		{Name: strings.Repeat("s", validate.MaxLength+1)},
 		{Name: "bad,name"},

--- a/pkg/artifacts/artifact_storage_test.go
+++ b/pkg/artifacts/artifact_storage_test.go
@@ -163,7 +163,6 @@ func TestNeedsPVC(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestInitializeArtifactStorage(t *testing.T) {

--- a/pkg/artifacts/artifacts_storage.go
+++ b/pkg/artifacts/artifacts_storage.go
@@ -119,7 +119,6 @@ func InitializeArtifactStorage(ctx context.Context, images pipeline.Images, pr *
 // CleanupArtifactStorage will delete the PipelineRun's artifact storage PVC if it exists. The PVC is created for using
 // an output workspace or artifacts from one Task to another Task. No other PVCs will be impacted by this cleanup.
 func CleanupArtifactStorage(ctx context.Context, pr *v1beta1.PipelineRun, c kubernetes.Interface) error {
-
 	if needsPVC(ctx) {
 		err := deletePVC(ctx, pr, c)
 		if err != nil {

--- a/pkg/internal/affinityassistant/transformer_test.go
+++ b/pkg/internal/affinityassistant/transformer_test.go
@@ -90,7 +90,6 @@ func TestNewTransformer(t *testing.T) {
 }
 
 func TestNewTransformerWithNodeAffinity(t *testing.T) {
-
 	nodeAffinity := &corev1.NodeAffinity{
 		RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
 			NodeSelectorTerms: []corev1.NodeSelectorTerm{{

--- a/pkg/internal/computeresources/transformer_test.go
+++ b/pkg/internal/computeresources/transformer_test.go
@@ -944,7 +944,6 @@ func cmpRequestsAndLimits(t *testing.T, want, got corev1.PodSpec) {
 		t.Errorf("Expected %d init containers, got %d", len(want.InitContainers), len(got.InitContainers))
 	} else {
 		for i, c := range got.InitContainers {
-
 			// compare name only if present in "want" so we can be sure which container gets which resources
 			if want.InitContainers[i].Name != "" {
 				if d := cmp.Diff(want.InitContainers[i].Name, c.Name); d != "" {
@@ -963,7 +962,6 @@ func cmpRequestsAndLimits(t *testing.T, want, got corev1.PodSpec) {
 		t.Errorf("Expected %d containers, got %d", len(want.Containers), len(got.Containers))
 	} else {
 		for i, c := range got.Containers {
-
 			// compare name only if present in "want" so we can be sure which container gets which resources
 			if want.Containers[i].Name != "" {
 				if d := cmp.Diff(want.Containers[i].Name, c.Name); d != "" {

--- a/pkg/pipelinerunmetrics/metrics.go
+++ b/pkg/pipelinerunmetrics/metrics.go
@@ -209,7 +209,6 @@ func nilInsertTag(task, taskrun string) []tag.Mutator {
 // count for number of PipelineRuns succeed or failed
 // returns an error if its failed to log the metrics
 func (r *Recorder) DurationAndCount(pr *v1beta1.PipelineRun, beforeCondition *apis.Condition) error {
-
 	if !r.initialized {
 		return fmt.Errorf("ignoring the metrics recording for %s , failed to initialize the metrics recorder", pr.Name)
 	}

--- a/pkg/pipelinerunmetrics/metrics_test.go
+++ b/pkg/pipelinerunmetrics/metrics_test.go
@@ -329,7 +329,6 @@ func TestRecordPipelineRunDurationCount(t *testing.T) {
 			} else {
 				metricstest.CheckStatsNotReported(t, "pipelinerun_count")
 			}
-
 		})
 	}
 }
@@ -374,7 +373,6 @@ func TestRecordRunningPipelineRunsCount(t *testing.T) {
 		t.Errorf("RunningPipelineRuns: %v", err)
 	}
 	metricstest.CheckLastValueData(t, "running_pipelineruns_count", map[string]string{}, 1)
-
 }
 
 func unregisterMetrics() {

--- a/pkg/pod/entrypoint_lookup.go
+++ b/pkg/pod/entrypoint_lookup.go
@@ -57,7 +57,6 @@ func resolveEntrypoints(ctx context.Context, cache EntrypointCache, namespace, s
 	// can skip lookups while resolving the same TaskRun.
 	localCache := map[name.Reference]imageData{}
 	for i, s := range steps {
-
 		// If the command is already specified, there's nothing to resolve.
 		if len(s.Command) > 0 {
 			continue

--- a/pkg/pod/entrypoint_lookup_impl_test.go
+++ b/pkg/pod/entrypoint_lookup_impl_test.go
@@ -177,9 +177,7 @@ func TestGetImageWithImagePullSecrets(t *testing.T) {
 			if (err != nil) != tc.wantErr {
 				t.Fatalf("get() = %+v, %v, wantErr %t", i, err, tc.wantErr)
 			}
-
 		})
-
 	}
 }
 

--- a/pkg/pod/entrypoint_test.go
+++ b/pkg/pod/entrypoint_test.go
@@ -488,7 +488,6 @@ func TestEntryPointOnError(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestEntryPointStepOutputConfigs(t *testing.T) {

--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -1279,7 +1279,6 @@ _EOF_
 		{
 			desc: "setting host aliases",
 			ts: v1beta1.TaskSpec{
-
 				Steps: []v1beta1.Step{
 					{
 						Name:    "host-aliases",
@@ -1948,7 +1947,6 @@ _EOF_
 }
 
 func TestPodBuildwithAlphaAPIEnabled(t *testing.T) {
-
 	placeScriptsContainer := corev1.Container{
 		Name:         "place-scripts",
 		Image:        "busybox",

--- a/pkg/pod/script.go
+++ b/pkg/pod/script.go
@@ -225,7 +225,6 @@ cat > ${scriptfile} << '%s'
 
 			initContainer.Args[1] += fmt.Sprintf(initScriptDirective, tmpFile, heredoc, debugScript.content, heredoc)
 		}
-
 	}
 
 	return containers

--- a/pkg/pod/script_test.go
+++ b/pkg/pod/script_test.go
@@ -430,7 +430,6 @@ _EOF_
 	if len(gotSidecars) != 1 {
 		t.Errorf("Wanted 1 sidecar, got %v", len(gotSidecars))
 	}
-
 }
 
 func TestConvertScripts_Windows(t *testing.T) {
@@ -601,7 +600,6 @@ sidecar-1
 	if len(gotSidecars) != 1 {
 		t.Errorf("Wanted 1 sidecar, got %v", len(gotSidecars))
 	}
-
 }
 
 func TestConvertScripts_Windows_SidecarOnly(t *testing.T) {
@@ -649,5 +647,4 @@ sidecar-1
 	if len(gotSidecars) != 1 {
 		t.Errorf("Wanted 1 sidecar, got %v", len(gotSidecars))
 	}
-
 }

--- a/pkg/pod/status.go
+++ b/pkg/pod/status.go
@@ -220,7 +220,6 @@ func setTaskRunStatusBasedOnStepStatus(ctx context.Context, logger *zap.SugaredL
 	}
 
 	return merr
-
 }
 
 func setTaskRunStatusBasedOnSidecarStatus(sidecarStatuses []corev1.ContainerStatus, trs *v1beta1.TaskRunStatus) {

--- a/pkg/pod/status_test.go
+++ b/pkg/pod/status_test.go
@@ -92,7 +92,6 @@ func TestSetTaskRunStatusBasedOnStepStatus(t *testing.T) {
 			if merr != nil {
 				t.Errorf("setTaskRunStatusBasedOnStepStatus: %s", merr)
 			}
-
 		})
 	}
 }
@@ -169,7 +168,6 @@ func TestSetTaskRunStatusBasedOnStepStatus_sidecar_logs(t *testing.T) {
 			if d := cmp.Diff(wantErr.Error(), merr.Error()); d != "" {
 				t.Errorf("Got unexpected error  %s", diff.PrintWantGot(d))
 			}
-
 		})
 	}
 }
@@ -1385,11 +1383,9 @@ func TestMakeTaskRunStatusAlpha(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestMakeRunStatusJSONError(t *testing.T) {
-
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "pod",
@@ -1498,7 +1494,6 @@ func TestMakeRunStatusJSONError(t *testing.T) {
 	if d := cmp.Diff(wantTr, gotTr, ignoreVolatileTime, ensureTimeNotNil); d != "" {
 		t.Errorf("Diff %s", diff.PrintWantGot(d))
 	}
-
 }
 
 func TestSidecarsReady(t *testing.T) {

--- a/pkg/pullrequest/disk_test.go
+++ b/pkg/pullrequest/disk_test.go
@@ -232,7 +232,6 @@ func TestFromDiskWithoutComments(t *testing.T) {
 	if d := cmp.Diff(rsrc.PR.Head, head); d != "" {
 		t.Errorf("Get Head %s", diff.PrintWantGot(d))
 	}
-
 }
 
 func TestFromDisk(t *testing.T) {
@@ -774,5 +773,4 @@ func TestFromDiskPRShaWithNullHeadAndBase(t *testing.T) {
 	if rsrc.PR.Sha != expectedSha {
 		t.Errorf("FromDisk() returned sha `%s`, expected `%s`", rsrc.PR.Sha, expectedSha)
 	}
-
 }

--- a/pkg/reconciler/customrun/customrun_test.go
+++ b/pkg/reconciler/customrun/customrun_test.go
@@ -136,7 +136,6 @@ func TestReconcile_CloudEvents(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-
 			objectStatus := duckv1.Status{
 				Conditions: []apis.Condition{},
 			}
@@ -200,7 +199,6 @@ func TestReconcile_CloudEvents(t *testing.T) {
 }
 
 func TestReconcile_CloudEvents_Disabled(t *testing.T) {
-
 	cmSinkOn := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{Name: config.GetDefaultsConfigName(), Namespace: system.Namespace()},
 		Data: map[string]string{
@@ -241,7 +239,6 @@ func TestReconcile_CloudEvents_Disabled(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-
 			objectStatus := duckv1.Status{
 				Conditions: []apis.Condition{
 					{

--- a/pkg/reconciler/events/cloudevent/cloud_event_controller_test.go
+++ b/pkg/reconciler/events/cloudevent/cloud_event_controller_test.go
@@ -546,7 +546,6 @@ func TestInitializeCloudEvents(t *testing.T) {
 }
 
 func TestSendCloudEventWithRetries(t *testing.T) {
-
 	objectStatus := duckv1.Status{
 		Conditions: []apis.Condition{{
 			Type:   apis.ConditionSucceeded,
@@ -630,7 +629,6 @@ func TestSendCloudEventWithRetries(t *testing.T) {
 }
 
 func TestSendCloudEventWithRetriesInvalid(t *testing.T) {
-
 	tests := []struct {
 		name       string
 		object     objectWithCondition
@@ -667,7 +665,6 @@ func TestSendCloudEventWithRetriesInvalid(t *testing.T) {
 }
 
 func TestSendCloudEventWithRetriesNoClient(t *testing.T) {
-
 	ctx := setupFakeContext(t, FakeClientBehaviour{}, false, 0)
 	err := SendCloudEventWithRetries(ctx, &v1beta1.TaskRun{Status: v1beta1.TaskRunStatus{}})
 	if err == nil {
@@ -679,7 +676,6 @@ func TestSendCloudEventWithRetriesNoClient(t *testing.T) {
 }
 
 func TestEmitCloudEvents(t *testing.T) {
-
 	object := &v1alpha1.Run{
 		ObjectMeta: metav1.ObjectMeta{
 			SelfLink: "/run/test1",

--- a/pkg/reconciler/events/cloudevent/cloudevent_test.go
+++ b/pkg/reconciler/events/cloudevent/cloudevent_test.go
@@ -178,7 +178,6 @@ func TestEventForTaskRun(t *testing.T) {
 
 	for _, c := range taskRunTests {
 		t.Run(c.desc, func(t *testing.T) {
-
 			got, err := eventForTaskRun(c.taskRun)
 			if err != nil {
 				t.Fatalf("I did not expect an error but I got %s", err)
@@ -236,7 +235,6 @@ func TestEventForPipelineRun(t *testing.T) {
 
 	for _, c := range pipelineRunTests {
 		t.Run(c.desc, func(t *testing.T) {
-
 			got, err := eventForPipelineRun(c.pipelineRun)
 			if err != nil {
 				t.Fatalf("I did not expect an error but I got %s", err)
@@ -294,7 +292,6 @@ func TestEventForRun(t *testing.T) {
 
 	for _, c := range runTests {
 		t.Run(c.desc, func(t *testing.T) {
-
 			got, err := eventForRun(c.run)
 			if err != nil {
 				t.Fatalf("I did not expect an error but I got %s", err)
@@ -352,7 +349,6 @@ func TestEventForCustomRun(t *testing.T) {
 
 	for _, c := range runTests {
 		t.Run(c.desc, func(t *testing.T) {
-
 			got, err := eventForCustomRun(c.run)
 			if err != nil {
 				t.Fatalf("I did not expect an error but I got %s", err)

--- a/pkg/reconciler/events/cloudevent/cloudeventsfakeclient_test.go
+++ b/pkg/reconciler/events/cloudevent/cloudeventsfakeclient_test.go
@@ -48,7 +48,6 @@ func TestSend_Success(t *testing.T) {
 		if err != nil {
 			t.Fatalf("got err %v", err)
 		}
-
 	}
 	fakeClient.CheckCloudEventsUnordered(t, "send cloud events", wantEvents)
 }
@@ -70,5 +69,4 @@ func TestSend_Error(t *testing.T) {
 	if err == nil {
 		t.Fatalf("want err but got nil")
 	}
-
 }

--- a/pkg/reconciler/events/cloudevent/interface.go
+++ b/pkg/reconciler/events/cloudevent/interface.go
@@ -24,7 +24,6 @@ import (
 
 // objectWithCondition is implemented by TaskRun, PipelineRun and Run
 type objectWithCondition interface {
-
 	// Object requires GetObjectKind() and DeepCopyObject()
 	runtime.Object
 

--- a/pkg/reconciler/pipeline/dag/dag_test.go
+++ b/pkg/reconciler/pipeline/dag/dag_test.go
@@ -767,5 +767,4 @@ func TestFindCyclesInDependencies(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/pkg/reconciler/pipelinerun/affinity_assistant.go
+++ b/pkg/reconciler/pipelinerun/affinity_assistant.go
@@ -87,7 +87,6 @@ func getClaimName(w v1beta1.WorkspaceBinding, ownerReference metav1.OwnerReferen
 }
 
 func (c *Reconciler) cleanupAffinityAssistants(ctx context.Context, pr *v1beta1.PipelineRun) error {
-
 	// omit cleanup if the feature is disabled
 	if c.isAffinityAssistantDisabled(ctx) {
 		return nil
@@ -187,7 +186,6 @@ func affinityAssistantStatefulSet(name string, pr *v1beta1.PipelineRun, claimNam
 						Name: "workspace",
 						VolumeSource: corev1.VolumeSource{
 							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-
 								// A Pod mounting a PersistentVolumeClaim that has a StorageClass with
 								// volumeBindingMode: Immediate
 								// the PV is allocated on a Node first, and then the pod need to be

--- a/pkg/reconciler/pipelinerun/affinity_assistant_test.go
+++ b/pkg/reconciler/pipelinerun/affinity_assistant_test.go
@@ -374,7 +374,6 @@ func TestDisableAffinityAssistant(t *testing.T) {
 }
 
 func TestGetAssistantAffinityMergedWithPodTemplateAffinity(t *testing.T) {
-
 	assistantPodAffinityTerm := corev1.WeightedPodAffinityTerm{
 		Weight: 100,
 		PodAffinityTerm: corev1.PodAffinityTerm{
@@ -515,6 +514,5 @@ spec:
 				t.Errorf("affinity diff: %s", diff.PrintWantGot(d))
 			}
 		})
-
 	}
 }

--- a/pkg/reconciler/pipelinerun/cancel_test.go
+++ b/pkg/reconciler/pipelinerun/cancel_test.go
@@ -367,7 +367,6 @@ func TestCancelPipelineRun(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-
 			d := test.Data{
 				PipelineRuns: []*v1beta1.PipelineRun{tc.pipelineRun},
 				TaskRuns:     tc.taskRuns,

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -747,7 +747,6 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1beta1.PipelineRun, get
 // pipeline run state, and starts them
 // after all DAG tasks are done, it's responsible for scheduling final tasks and start executing them
 func (c *Reconciler) runNextSchedulableTask(ctx context.Context, pr *v1beta1.PipelineRun, pipelineRunFacts *resources.PipelineRunFacts, as artifacts.ArtifactStorageInterface) error {
-
 	logger := logging.FromContext(ctx)
 	recorder := controller.GetEventRecorder(ctx)
 
@@ -822,7 +821,6 @@ func (c *Reconciler) runNextSchedulableTask(ctx context.Context, pr *v1beta1.Pip
 				recorder.Eventf(pr, corev1.EventTypeWarning, "TaskRunCreationFailed", "Failed to create TaskRun %q: %v", rpt.TaskRunName, err)
 				return fmt.Errorf("error creating TaskRun called %s for PipelineTask %s from PipelineRun %s: %w", rpt.TaskRunName, rpt.PipelineTask.Name, pr.Name, err)
 			}
-
 		}
 	}
 	return nil
@@ -1135,7 +1133,6 @@ func getTaskrunWorkspaces(ctx context.Context, pr *v1beta1.PipelineRun, rpt *res
 				return nil, "", fmt.Errorf("expected workspace %q to be provided by pipelinerun for pipeline task %q", pipelineWorkspace, rpt.PipelineTask.Name)
 			}
 		}
-
 	}
 	return workspaces, pipelinePVCWorkspaceName, nil
 }
@@ -1317,7 +1314,6 @@ func storePipelineSpecAndMergeMeta(ctx context.Context, pr *v1beta1.PipelineRun,
 
 		// Propagate annotations from Pipeline to PipelineRun. PipelineRun annotations take precedences over Pipeline.
 		pr.ObjectMeta.Annotations = kmap.Union(meta.Annotations, pr.ObjectMeta.Annotations)
-
 	}
 
 	// Propagate ConfigSource from remote resolution to PipelineRun Status

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -540,7 +540,6 @@ spec:
 
 	// A PVC should have been created to deal with output -> input linking
 	ensurePVCCreated(prt.TestAssets.Ctx, t, clients, expectedTaskRun.GetPipelineRunPVCName(), "foo")
-
 }
 
 // TestReconcile_CustomTask runs "Reconcile" on a PipelineRun with one Custom
@@ -3050,7 +3049,6 @@ func TestReconcileCancelledFailsTaskRunCancellation(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-
 			// TestReconcileCancelledFailsTaskRunCancellation runs "Reconcile" on a PipelineRun with a single TaskRun.
 			// The TaskRun cannot be cancelled. Check that the pipelinerun cancel fails, that reconcile fails and
 			// an event is generated
@@ -3468,7 +3466,6 @@ spec:
 		if d := cmp.Diff(actual, expectedTaskRuns[i], ignoreResourceVersion, ignoreTypeMeta); d != "" {
 			t.Errorf("expected to see TaskRun %v created. Diff %s", expectedTaskRuns[i], diff.PrintWantGot(d))
 		}
-
 	}
 }
 
@@ -4409,7 +4406,6 @@ spec:
 		for _, ws := range tr.Spec.Workspaces {
 			propagatedAffinityAssistantName := tr.Annotations["pipeline.tekton.dev/affinity-assistant"]
 			if ws.PersistentVolumeClaim != nil {
-
 				if propagatedAffinityAssistantName != expectedAffinityAssistantName1 && propagatedAffinityAssistantName != expectedAffinityAssistantName2 {
 					t.Fatalf("found taskRun with PVC workspace, but with unexpected AffinityAssistantAnnotation value; expected %s or %s, got %s", expectedAffinityAssistantName1, expectedAffinityAssistantName2, propagatedAffinityAssistantName)
 				}
@@ -4631,7 +4627,6 @@ spec:
 	hasSeenWorkspaceWithRunSubPathAndPipelineTaskSubPath1 := false
 	for _, tr := range taskRuns.Items {
 		for _, ws := range tr.Spec.Workspaces {
-
 			if ws.PersistentVolumeClaim == nil {
 				t.Fatalf("found taskRun workspace that is not PersistentVolumeClaim workspace. Did only expect PersistentVolumeClaims workspaces")
 			}
@@ -5256,7 +5251,6 @@ status:
 	if d := cmp.Diff(expectedPr, reconciledRun, ignoreResourceVersion, ignoreLastTransitionTime, ignoreCompletionTime, ignoreStartTime); d != "" {
 		t.Errorf("expected to see pipeline run results created. Diff %s", diff.PrintWantGot(d))
 	}
-
 }
 
 func TestReconcileWithPipelineResults(t *testing.T) {
@@ -5578,7 +5572,6 @@ status:
 	if d := cmp.Diff(expectedPr, reconciledRun, ignoreResourceVersion, ignoreLastTransitionTime, ignoreCompletionTime, ignoreStartTime); d != "" {
 		t.Errorf("expected to see pipeline run results created. Diff %s", diff.PrintWantGot(d))
 	}
-
 }
 
 func TestReconcileWithPipelineResults_OnFailedPipelineRun(t *testing.T) {
@@ -6360,7 +6353,6 @@ func TestReconcilePipeline_FinalTasks(t *testing.T) {
 
 		pipelineRunStatusFalse: true,
 	}, {
-
 		// pipeline run should result in error when a dag task is successful but the final task fails
 
 		// pipelineRunName - "pipeline-run-with-dag-successful-but-final-failing"
@@ -6426,7 +6418,6 @@ func TestReconcilePipeline_FinalTasks(t *testing.T) {
 
 		pipelineRunStatusFalse: true,
 	}, {
-
 		// pipeline run should result in error when a dag task and final task both are executed and resulted in failure
 
 		// pipelineRunName - "pipeline-run-with-dag-and-final-failing"
@@ -6492,7 +6483,6 @@ func TestReconcilePipeline_FinalTasks(t *testing.T) {
 
 		pipelineRunStatusFalse: true,
 	}, {
-
 		// pipeline run should not schedule final tasks until dag tasks are done i.e.
 		// dag task 1 fails but dag task 2 is still running, pipeline run should not schedule and create task run for final task
 
@@ -6565,7 +6555,6 @@ func TestReconcilePipeline_FinalTasks(t *testing.T) {
 
 		pipelineRunStatusUnknown: true,
 	}, {
-
 		// pipeline run should not schedule final tasks until dag tasks are done i.e.
 		// dag task is still running and no other dag task available to schedule,
 		// pipeline run should not schedule and create task run for final task
@@ -6681,7 +6670,6 @@ func TestReconcilePipeline_FinalTasks(t *testing.T) {
 			if d := cmp.Diff(reconciledRun.Status.TaskRuns, tt.expectedTaskRuns); d != "" {
 				t.Fatalf("Expected PipelineRunTaskRun status to match TaskRun(s) status, but got a mismatch for %s: %s", tt.name, d)
 			}
-
 		})
 	}
 }
@@ -8301,7 +8289,6 @@ spec:
 			}
 		})
 	}
-
 }
 
 func TestGetTaskrunWorkspaces_Success(t *testing.T) {
@@ -11088,7 +11075,6 @@ spec:
 	reconciledRun, _ := prt.reconcileRun("foo", "test-pipelinerun", []string{}, false)
 
 	checkPipelineRunConditionStatusAndReason(t, reconciledRun, corev1.ConditionUnknown, v1beta1.PipelineRunReasonRunning.String())
-
 }
 
 func TestReconcile_verifyResolvedPipeline_Error(t *testing.T) {

--- a/pkg/reconciler/pipelinerun/pipelinerun_updatestatus_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_updatestatus_test.go
@@ -113,7 +113,6 @@ pipelineTaskName: task-4
 }
 
 func TestUpdatePipelineRunStatusFromTaskRuns(t *testing.T) {
-
 	prUID := types.UID("11111111-1111-1111-1111-111111111111")
 
 	taskRunsPRStatusData := getUpdateStatusTaskRunsData(t)

--- a/pkg/reconciler/pipelinerun/resources/apply_test.go
+++ b/pkg/reconciler/pipelinerun/resources/apply_test.go
@@ -3358,7 +3358,6 @@ func TestApplyTaskResultsToPipelineResults(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestApplyTaskRunContext(t *testing.T) {

--- a/pkg/reconciler/pipelinerun/resources/input_output_steps_test.go
+++ b/pkg/reconciler/pipelinerun/resources/input_output_steps_test.go
@@ -267,7 +267,6 @@ func TestGetInputSteps(t *testing.T) {
 			if d := cmp.Diff(tc.expectedtaskInputResources, taskInputResources, cmpopts.SortSlices(lessTaskResourceBindings)); d != "" {
 				t.Errorf("error comparing task resource inputs %s", diff.PrintWantGot(d))
 			}
-
 		})
 	}
 }

--- a/pkg/reconciler/pipelinerun/resources/pipelineref_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelineref_test.go
@@ -120,7 +120,6 @@ func TestLocalPipelineRef(t *testing.T) {
 			if resolvedConfigSource != nil {
 				t.Errorf("expected configsource is nil, but got %v", resolvedConfigSource)
 			}
-
 		})
 	}
 }

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -354,7 +354,6 @@ func (t ResolvedPipelineTask) isScheduled() bool {
 func (t ResolvedPipelineTask) isStarted() bool {
 	if t.IsCustomTask() {
 		return t.RunObject != nil && t.RunObject.GetStatusCondition().GetCondition(apis.ConditionSucceeded) != nil
-
 	}
 	return t.TaskRun != nil && t.TaskRun.Status.GetCondition(apis.ConditionSucceeded) != nil
 }
@@ -556,7 +555,6 @@ func (t *ResolvedPipelineTask) IsFinallySkipped(facts *PipelineRunFacts) TaskSki
 		IsSkipped:      skippingReason != v1beta1.None,
 		SkippingReason: skippingReason,
 	}
-
 }
 
 // GetRun is a function that will retrieve a Run by name.
@@ -744,7 +742,6 @@ func (t *ResolvedPipelineTask) resolveTaskResources(
 	providedResources map[string]*resourcev1alpha1.PipelineResource,
 	taskRun *v1beta1.TaskRun,
 ) error {
-
 	spec, taskName, kind, err := resolveTask(ctx, taskRun, getTask, pipelineTask)
 	if err != nil {
 		return err

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
@@ -1252,7 +1252,6 @@ func TestIsFailure(t *testing.T) {
 		},
 		want: false,
 	}, {
-
 		name: "run running",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
@@ -1268,7 +1267,6 @@ func TestIsFailure(t *testing.T) {
 		},
 		want: false,
 	}, {
-
 		name: "run succeeded",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
@@ -1284,7 +1282,6 @@ func TestIsFailure(t *testing.T) {
 		},
 		want: true,
 	}, {
-
 		name: "run failed",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
@@ -1300,7 +1297,6 @@ func TestIsFailure(t *testing.T) {
 		},
 		want: false,
 	}, {
-
 		name: "run failed: retries remaining",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task", Retries: 1},
@@ -1316,7 +1312,6 @@ func TestIsFailure(t *testing.T) {
 		},
 		want: true,
 	}, {
-
 		name: "run failed: no retries remaining",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task", Retries: 1},
@@ -1664,7 +1659,6 @@ func TestIsFailure(t *testing.T) {
 			if got := tc.rpt.isFailure(); got != tc.want {
 				t.Errorf("expected isFailure: %t but got %t", tc.want, got)
 			}
-
 		})
 	}
 }
@@ -3304,7 +3298,6 @@ func TestResolvedPipelineRunTask_IsFinalTask(t *testing.T) {
 	if d := cmp.Diff(true, state[1].IsFinalTask(facts)); d != "" {
 		t.Fatalf("Didn't get expected isFinallySkipped from finally task %s: %s", finallyTaskName, diff.PrintWantGot(d))
 	}
-
 }
 
 func TestGetTaskRunName(t *testing.T) {
@@ -3891,7 +3884,6 @@ func TestIsSuccessful(t *testing.T) {
 		},
 		want: false,
 	}, {
-
 		name: "run running",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
@@ -3907,7 +3899,6 @@ func TestIsSuccessful(t *testing.T) {
 		},
 		want: true,
 	}, {
-
 		name: "run succeeded",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
@@ -3923,7 +3914,6 @@ func TestIsSuccessful(t *testing.T) {
 		},
 		want: false,
 	}, {
-
 		name: "run failed",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
@@ -3939,7 +3929,6 @@ func TestIsSuccessful(t *testing.T) {
 		},
 		want: false,
 	}, {
-
 		name: "run failed: retries remaining",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task", Retries: 1},
@@ -3955,7 +3944,6 @@ func TestIsSuccessful(t *testing.T) {
 		},
 		want: false,
 	}, {
-
 		name: "run failed: no retries remaining",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task", Retries: 1},
@@ -4296,7 +4284,6 @@ func TestIsSuccessful(t *testing.T) {
 			if got := tc.rpt.isSuccessful(); got != tc.want {
 				t.Errorf("expected isSuccessful: %t but got %t", tc.want, got)
 			}
-
 		})
 	}
 }
@@ -4327,7 +4314,6 @@ func TestIsRunning(t *testing.T) {
 		},
 		want: true,
 	}, {
-
 		name: "run running",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
@@ -4343,7 +4329,6 @@ func TestIsRunning(t *testing.T) {
 		},
 		want: false,
 	}, {
-
 		name: "run succeeded",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
@@ -4359,7 +4344,6 @@ func TestIsRunning(t *testing.T) {
 		},
 		want: false,
 	}, {
-
 		name: "run failed",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
@@ -4375,7 +4359,6 @@ func TestIsRunning(t *testing.T) {
 		},
 		want: true,
 	}, {
-
 		name: "run failed: retries remaining",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task", Retries: 1},
@@ -4391,7 +4374,6 @@ func TestIsRunning(t *testing.T) {
 		},
 		want: false,
 	}, {
-
 		name: "run failed: no retries remaining",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task", Retries: 1},
@@ -4717,7 +4699,6 @@ func TestIsRunning(t *testing.T) {
 			if got := tc.rpt.IsRunning(); got != tc.want {
 				t.Errorf("expected IsRunning: %t but got %t", tc.want, got)
 			}
-
 		})
 	}
 }

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
@@ -239,7 +239,6 @@ func TestPipelineRunFacts_CheckDAGTasksDoneDone(t *testing.T) {
 				if d := cmp.Diff(tc.ptExpected[i], isDone); d != "" {
 					t.Errorf("Didn't get expected (ResolvedPipelineTask) isDone %s", diff.PrintWantGot(d))
 				}
-
 			}
 		})
 	}
@@ -572,7 +571,6 @@ func TestGetNextTasks(t *testing.T) {
 }
 
 func TestGetNextTaskWithRetries(t *testing.T) {
-
 	var taskCancelledByStatusState = PipelineRunState{{
 		PipelineTask: &pts[4], // 2 retries needed
 		TaskRunName:  "pipelinerun-mytask1",
@@ -1664,7 +1662,6 @@ func TestPipelineRunState_GetFinalTasksAndNames(t *testing.T) {
 }
 
 func TestGetPipelineConditionStatus(t *testing.T) {
-
 	var taskRetriedState = PipelineRunState{{
 		PipelineTask: &pts[3], // 1 retry needed
 		TaskRunName:  "pipelinerun-mytask1",
@@ -1978,7 +1975,6 @@ func TestGetPipelineConditionStatus(t *testing.T) {
 }
 
 func TestGetPipelineConditionStatus_WithFinalTasks(t *testing.T) {
-
 	// pipeline state with one DAG successful, one final task failed
 	dagSucceededFinalFailed := PipelineRunState{{
 		TaskRunName:  "task0taskrun",

--- a/pkg/reconciler/pipelinerun/resources/resultrefresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/resultrefresolution_test.go
@@ -173,7 +173,6 @@ var pipelineRunState = PipelineRunState{{
 }}
 
 func TestTaskParamResolver_ResolveResultRefs(t *testing.T) {
-
 	for _, tt := range []struct {
 		name             string
 		pipelineRunState PipelineRunState

--- a/pkg/reconciler/pipelinerun/resources/validate_params_test.go
+++ b/pkg/reconciler/pipelinerun/resources/validate_params_test.go
@@ -30,7 +30,6 @@ import (
 )
 
 func TestValidateParamTypesMatching_Valid(t *testing.T) {
-
 	stringValue := *v1beta1.NewStructuredValues("stringValue")
 	arrayValue := *v1beta1.NewStructuredValues("arrayValue", "arrayValue")
 
@@ -69,7 +68,6 @@ func TestValidateParamTypesMatching_Valid(t *testing.T) {
 }
 
 func TestValidateParamTypesMatching_Invalid(t *testing.T) {
-
 	stringValue := *v1beta1.NewStructuredValues("stringValue")
 	arrayValue := *v1beta1.NewStructuredValues("arrayValue", "arrayValue")
 
@@ -118,7 +116,6 @@ func TestValidateParamTypesMatching_Invalid(t *testing.T) {
 }
 
 func TestValidateRequiredParametersProvided_Valid(t *testing.T) {
-
 	stringValue := *v1beta1.NewStructuredValues("stringValue")
 	arrayValue := *v1beta1.NewStructuredValues("arrayValue", "arrayValue")
 
@@ -161,7 +158,6 @@ func TestValidateRequiredParametersProvided_Valid(t *testing.T) {
 }
 
 func TestValidateRequiredParametersProvided_Invalid(t *testing.T) {
-
 	stringValue := *v1beta1.NewStructuredValues("stringValue")
 	arrayValue := *v1beta1.NewStructuredValues("arrayValue", "arrayValue")
 

--- a/pkg/reconciler/pipelinerun/timeout_test.go
+++ b/pkg/reconciler/pipelinerun/timeout_test.go
@@ -269,7 +269,6 @@ func TestTimeoutPipelineRun(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-
 			d := test.Data{
 				PipelineRuns: []*v1beta1.PipelineRun{tc.pipelineRun},
 				TaskRuns:     tc.taskRuns,

--- a/pkg/reconciler/resolutionrequest/resolutionrequest_test.go
+++ b/pkg/reconciler/resolutionrequest/resolutionrequest_test.go
@@ -184,7 +184,6 @@ func TestReconcile(t *testing.T) {
 			}
 			if d := cmp.Diff(*tc.expectedStatus, reconciledRR.Status, ignoreLastTransitionTime); d != "" {
 				t.Errorf("ResolutionRequest status doesn't match %s", diff.PrintWantGot(d))
-
 			}
 		})
 	}

--- a/pkg/reconciler/run/run_test.go
+++ b/pkg/reconciler/run/run_test.go
@@ -138,7 +138,6 @@ func TestReconcile_CloudEvents(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-
 			objectStatus := duckv1.Status{
 				Conditions: []apis.Condition{},
 			}
@@ -202,7 +201,6 @@ func TestReconcile_CloudEvents(t *testing.T) {
 }
 
 func TestReconcile_CloudEvents_Disabled(t *testing.T) {
-
 	cmSinkOn := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{Name: config.GetDefaultsConfigName(), Namespace: system.Namespace()},
 		Data: map[string]string{
@@ -243,7 +241,6 @@ func TestReconcile_CloudEvents_Disabled(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-
 			objectStatus := duckv1.Status{
 				Conditions: []apis.Condition{
 					{

--- a/pkg/reconciler/taskrun/resources/image_exporter.go
+++ b/pkg/reconciler/taskrun/resources/image_exporter.go
@@ -35,7 +35,6 @@ func AddOutputImageDigestExporter(
 	taskSpec *v1beta1.TaskSpec,
 	gr GetResource,
 ) error {
-
 	output := []*image.Resource{}
 	if tr.Spec.Resources != nil && len(tr.Spec.Resources.Outputs) > 0 {
 		for _, trb := range tr.Spec.Resources.Outputs {

--- a/pkg/reconciler/taskrun/resources/input_resource_test.go
+++ b/pkg/reconciler/taskrun/resources/input_resource_test.go
@@ -107,7 +107,6 @@ var (
 )
 
 func setUp() {
-
 	rs := []*resourcev1alpha1.PipelineResource{{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "the-git",

--- a/pkg/reconciler/taskrun/resources/output_resource_test.go
+++ b/pkg/reconciler/taskrun/resources/output_resource_test.go
@@ -39,7 +39,6 @@ var (
 )
 
 func outputTestResourceSetup() {
-
 	rs := []*resourcev1alpha1.PipelineResource{{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "source-git",
@@ -158,7 +157,6 @@ func outputTestResourceSetup() {
 }
 
 func TestValidOutputResources(t *testing.T) {
-
 	for _, c := range []struct {
 		name        string
 		desc        string

--- a/pkg/reconciler/taskrun/resources/taskref_test.go
+++ b/pkg/reconciler/taskrun/resources/taskref_test.go
@@ -529,7 +529,6 @@ echo hello
 	if d := cmp.Diff(sampleConfigSource, actualConfigSource); d != "" {
 		t.Errorf("configSources did not match: %s", diff.PrintWantGot(d))
 	}
-
 }
 
 func TestGetTaskFunc_RemoteResolution(t *testing.T) {

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -1708,7 +1708,6 @@ spec:
 			}
 		})
 	}
-
 }
 
 func TestReconcileGetTaskError(t *testing.T) {
@@ -2739,7 +2738,6 @@ status:
 }
 
 func TestReconcileCloudEvents(t *testing.T) {
-
 	taskRunWithNoCEResources := parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun-no-ce-resources
@@ -4334,7 +4332,6 @@ spec:
 	if reconciledRun.Status.PodName != podName {
 		t.Fatalf("First reconcile created pod %s but TaskRun now has another pod name %s", podName, reconciledRun.Status.PodName)
 	}
-
 }
 
 func TestStopSidecars_ClientGetPodForTaskSpecWithSidecars(t *testing.T) {
@@ -4561,7 +4558,6 @@ func Test_validateTaskSpecRequestResources_ValidResources(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func Test_validateTaskSpecRequestResources_InvalidResources(t *testing.T) {
@@ -4917,7 +4913,6 @@ status:
 			if condition.Type != apis.ConditionSucceeded || condition.Reason != tc.reason {
 				t.Errorf("Expected TaskRun to terminate with %s reason. Final conditions were:\n%#v", tc.reason, tr.Status.Conditions)
 			}
-
 		})
 	}
 }
@@ -5083,7 +5078,6 @@ status:
 			if condition.Type != apis.ConditionSucceeded || condition.Status != corev1.ConditionFalse || condition.Reason != tc.wantFailedReason {
 				t.Errorf("Expected TaskRun to fail with reason \"%s\" but it did not. Final conditions were:\n%#v", tc.wantFailedReason, tr.Status.Conditions)
 			}
-
 		})
 	}
 }
@@ -5223,7 +5217,6 @@ status:
 		t.Errorf("Error reconciling TaskRun. Got error %v", err)
 	}
 	return
-
 }
 
 func TestReconcile_verifyResolvedTask_Error(t *testing.T) {
@@ -5323,7 +5316,6 @@ status:
 			if condition.Type != apis.ConditionSucceeded || condition.Status != corev1.ConditionFalse || condition.Reason != podconvert.ReasonResourceVerificationFailed {
 				t.Errorf("Expected TaskRun to fail with reason \"%s\" but it did not. Final conditions were:\n%#v", podconvert.ReasonResourceVerificationFailed, tr.Status.Conditions)
 			}
-
 		})
 	}
 }

--- a/pkg/reconciler/taskrun/validate_resources.go
+++ b/pkg/reconciler/taskrun/validate_resources.go
@@ -244,9 +244,7 @@ func validateTaskSpecRequestResources(taskSpec *v1beta1.TaskSpec) error {
 							return fmt.Errorf("Invalid request resource value: %v must be less or equal to limit %v", request.String(), limit.String())
 						}
 					}
-
 				}
-
 			}
 		}
 	}
@@ -533,7 +531,6 @@ func validateContainerParamArrayIndexing(c *corev1.Container, arrayParams map[st
 		}
 		if e.SecretRef != nil {
 			extractParamIndex(e.SecretRef.LocalObjectReference.Name, arrayParams, outofBoundParams)
-
 		}
 	}
 

--- a/pkg/reconciler/taskrun/validate_resources_test.go
+++ b/pkg/reconciler/taskrun/validate_resources_test.go
@@ -879,7 +879,6 @@ func TestValidateResult(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestValidateParamArrayIndex(t *testing.T) {
@@ -1075,5 +1074,4 @@ func TestValidateParamArrayIndex(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/pkg/reconciler/volumeclaim/pvchandler_test.go
+++ b/pkg/reconciler/volumeclaim/pvchandler_test.go
@@ -37,7 +37,6 @@ var _ PvcHandler = (*defaultPVCHandler)(nil)
 // TestCreatePersistentVolumeClaimsForWorkspaces tests that given a TaskRun with volumeClaimTemplate workspace,
 // a PVC is created, with the expected name and that it has the expected OwnerReference.
 func TestCreatePersistentVolumeClaimsForWorkspaces(t *testing.T) {
-
 	// given
 
 	// 2 workspaces with volumeClaimTemplate
@@ -119,7 +118,6 @@ func TestCreatePersistentVolumeClaimsForWorkspaces(t *testing.T) {
 // TestCreatePersistentVolumeClaimsForWorkspacesWithoutMetadata tests that given a volumeClaimTemplate workspace
 // without a metadata part, a PVC is created, with the expected name.
 func TestCreatePersistentVolumeClaimsForWorkspacesWithoutMetadata(t *testing.T) {
-
 	// given
 
 	// workspace with volumeClaimTemplate without metadata

--- a/pkg/remote/resolution/resolver_test.go
+++ b/pkg/remote/resolution/resolver_test.go
@@ -72,7 +72,6 @@ func TestGet_Successful(t *testing.T) {
 		if _, _, err := resolver.Get(ctx, "foo", "bar"); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-
 	}
 }
 

--- a/pkg/resolution/resolver/bundle/resolver_test.go
+++ b/pkg/resolution/resolver/bundle/resolver_test.go
@@ -157,7 +157,6 @@ func TestValidateParamsMissing(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected missing name err")
 	}
-
 }
 
 func TestResolveDisabled(t *testing.T) {
@@ -437,7 +436,6 @@ func TestResolve(t *testing.T) {
 						},
 						EntryPoint: tc.args.name,
 					}
-
 				} else {
 					expectedError = createError(tc.args.bundle, tc.expectedErrMessage)
 					expectedStatus.Status.Conditions[0].Message = expectedError.Error()
@@ -445,7 +443,6 @@ func TestResolve(t *testing.T) {
 			}
 
 			frtesting.RunResolverReconcileTest(ctx, t, d, resolver, request, expectedStatus, expectedError)
-
 		})
 	}
 }

--- a/pkg/resolution/resolver/framework/reconciler_test.go
+++ b/pkg/resolution/resolver/framework/reconciler_test.go
@@ -239,7 +239,6 @@ func TestReconcile(t *testing.T) {
 				}
 				if d := cmp.Diff(*tc.expectedStatus, reconciledRR.Status, ignoreLastTransitionTime); d != "" {
 					t.Errorf("ResolutionRequest status doesn't match %s", diff.PrintWantGot(d))
-
 				}
 			}
 		})

--- a/pkg/resolution/resolver/git/resolver.go
+++ b/pkg/resolution/resolver/git/resolver.go
@@ -267,7 +267,6 @@ func (r *Resolver) resolveAnonymousGit(ctx context.Context, params map[string]st
 		URL:      params[urlParam],
 		Path:     params[pathParam],
 	}, nil
-
 }
 
 var _ framework.ConfigWatcher = &Resolver{}

--- a/pkg/resolution/resolver/git/resolver_test.go
+++ b/pkg/resolution/resolver/git/resolver_test.go
@@ -94,7 +94,6 @@ func TestValidateParamsNotEnabled(t *testing.T) {
 }
 
 func TestValidateParams_Failure(t *testing.T) {
-
 	testCases := []struct {
 		name        string
 		params      map[string]string

--- a/pkg/spire/spire_mock_test.go
+++ b/pkg/spire/spire_mock_test.go
@@ -118,7 +118,6 @@ func TestSpireMock_CheckHashSimilarities(t *testing.T) {
 
 // Task run sign, modify signature/hash/svid/content and verify
 func TestSpireMock_CheckTamper(t *testing.T) {
-
 	tests := []struct {
 		// description of test case
 		desc string
@@ -236,9 +235,7 @@ func TestSpireMock_CheckTamper(t *testing.T) {
 				t.Fatalf("test %v expected verify %v, got %v", tt.desc, tt.verify, verified)
 			}
 		}
-
 	}
-
 }
 
 // Task result sign and verify
@@ -278,7 +275,6 @@ func TestSpireMock_TaskRunResultsSign(t *testing.T) {
 	for _, tt := range testCases {
 		ctx := context.Background()
 		for _, tr := range testTaskRuns() {
-
 			var err error
 			if !tt.skipEntryCreate {
 				// Pod should not be nil, but it isn't used in mocking
@@ -509,7 +505,6 @@ func TestSpireMock_TaskRunResultsSignTamper(t *testing.T) {
 	for _, tt := range testCases {
 		ctx := context.Background()
 		for _, tr := range testTaskRuns() {
-
 			var err error
 			// Pod should not be nil, but it isn't used in mocking
 			// implementation so should not matter

--- a/pkg/spire/spire_test.go
+++ b/pkg/spire/spire_test.go
@@ -290,7 +290,6 @@ func TestSpire_CheckTamper(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-
 		for _, tr := range testTaskRuns() {
 			if !tt.skipAnnotation {
 				err := cc.AppendStatusInternalAnnotation(ctx, tr)
@@ -326,9 +325,7 @@ func TestSpire_CheckTamper(t *testing.T) {
 				t.Fatalf("test %v expected verify %v, got %v", tt.desc, tt.verify, verified)
 			}
 		}
-
 	}
-
 }
 
 func TestSpire_TaskRunResultsSign(t *testing.T) {
@@ -411,7 +408,6 @@ func TestSpire_TaskRunResultsSign(t *testing.T) {
 
 			for _, results := range tt.pipelineResourceResults {
 				success := func() bool {
-
 					sigResults, err := ec.Sign(ctx, results)
 					if err != nil {
 						return false
@@ -633,10 +629,8 @@ func TestSpire_TaskRunResultsSignTamper(t *testing.T) {
 	for _, tt := range testCases {
 		ctx := context.Background()
 		for _, tr := range testTaskRuns() {
-
 			results := genPr()
 			success := func() bool {
-
 				resp := &fakeworkloadapi.X509SVIDResponse{
 					Bundle: ca.X509Bundle(),
 					SVIDs:  makeX509SVIDs(ca, spiffeid.RequireFromPath(td, getTaskrunPath(tr))),

--- a/pkg/substitution/substitution.go
+++ b/pkg/substitution/substitution.go
@@ -72,7 +72,6 @@ func ValidateVariableP(value, prefix string, vars sets.String) *apis.FieldError 
 				Message: errString,
 				Paths:   []string{""},
 			}
-
 		}
 		for _, v := range vs {
 			v = TrimArrayIndex(v)
@@ -112,7 +111,6 @@ func ValidateVariableProhibitedP(value, prefix string, vars sets.String) *apis.F
 				Message: errString,
 				Paths:   []string{""},
 			}
-
 		}
 		for _, v := range vs {
 			v = strings.TrimSuffix(v, "[*]")
@@ -180,7 +178,6 @@ func ValidateVariableIsolatedP(value, prefix string, vars sets.String) *apis.Fie
 				Message: errString,
 				Paths:   []string{""},
 			}
-
 		}
 		firstMatch, _ := extractExpressionFromString(value, prefix)
 		for _, v := range vs {

--- a/pkg/taskrunmetrics/metrics.go
+++ b/pkg/taskrunmetrics/metrics.go
@@ -110,7 +110,6 @@ var (
 // to log the TaskRun related metrics
 func NewRecorder(ctx context.Context) (*Recorder, error) {
 	once.Do(func() {
-
 		r = &Recorder{
 			initialized: true,
 
@@ -281,7 +280,6 @@ func nilInsertTag(task, taskrun string) []tag.Mutator {
 // count for number of TaskRuns succeed or failed
 // returns an error if its failed to log the metrics
 func (r *Recorder) DurationAndCount(ctx context.Context, tr *v1beta1.TaskRun, beforeCondition *apis.Condition) error {
-
 	if !r.initialized {
 		return fmt.Errorf("ignoring the metrics recording for %s , failed to initialize the metrics recorder", tr.Name)
 	}

--- a/pkg/taskrunmetrics/metrics_test.go
+++ b/pkg/taskrunmetrics/metrics_test.go
@@ -96,7 +96,6 @@ func TestMetricsOnStore(t *testing.T) {
 	// Comparing function assign to struct with the one which should yield same value
 	if reflect.ValueOf(metrics.insertTaskTag).Pointer() != reflect.ValueOf(taskrunInsertTag).Pointer() {
 		t.Fatalf("metrics recorder shouldn't change during this OnStore call")
-
 	}
 
 	// Config shouldn't change when incorrect config map is pass
@@ -112,7 +111,6 @@ func TestMetricsOnStore(t *testing.T) {
 	// Comparing function assign to struct with the one which should yield same value
 	if reflect.ValueOf(metrics.insertTaskTag).Pointer() != reflect.ValueOf(taskrunInsertTag).Pointer() {
 		t.Fatalf("metrics recorder shouldn't change during this OnStore call")
-
 	}
 
 	// We test when we pass correct config
@@ -126,7 +124,6 @@ func TestMetricsOnStore(t *testing.T) {
 	MetricsOnStore(logger)(config.GetMetricsConfigName(), cfg)
 	if reflect.ValueOf(metrics.insertTaskTag).Pointer() != reflect.ValueOf(nilInsertTag).Pointer() {
 		t.Fatalf("metrics recorder didn't change during OnStore call")
-
 	}
 }
 
@@ -375,7 +372,6 @@ func TestRecordTaskRunDurationCount(t *testing.T) {
 				metricstest.CheckLastValueData(t, c.metricName, c.expectedDurationTags, c.expectedDuration)
 			} else {
 				metricstest.CheckStatsNotReported(t, c.metricName)
-
 			}
 		})
 	}
@@ -490,7 +486,6 @@ func TestRecordPodLatency(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestTaskRunIsOfPipelinerun(t *testing.T) {

--- a/pkg/trustedresources/verifier/verifier.go
+++ b/pkg/trustedresources/verifier/verifier.go
@@ -89,7 +89,6 @@ func FromPolicy(ctx context.Context, k8s kubernetes.Interface, policy *v1alpha1.
 		return verifiers, ErrorEmptyPublicKeys
 	}
 	return verifiers, nil
-
 }
 
 // fromKeyRef parses the given keyRef, loads the key and returns an appropriate

--- a/pkg/trustedresources/verifier/verifier_test.go
+++ b/pkg/trustedresources/verifier/verifier_test.go
@@ -74,7 +74,6 @@ func TestFromConfigMap_Error(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestFromPolicy_Success(t *testing.T) {

--- a/pkg/trustedresources/verify_test.go
+++ b/pkg/trustedresources/verify_test.go
@@ -67,7 +67,6 @@ func TestVerifyInterface_Task_Success(t *testing.T) {
 	if err != nil {
 		t.Fatalf("VerifyInterface() get err %v", err)
 	}
-
 }
 
 func TestVerifyInterface_Task_Error(t *testing.T) {
@@ -123,7 +122,6 @@ func TestVerifyInterface_Task_Error(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestVerifyTask_Configmap_Success(t *testing.T) {
@@ -144,7 +142,6 @@ func TestVerifyTask_Configmap_Success(t *testing.T) {
 	if err != nil {
 		t.Errorf("VerifyTask() get err %v", err)
 	}
-
 }
 
 func TestVerifyTask_Configmap_Error(t *testing.T) {
@@ -194,7 +191,6 @@ func TestVerifyTask_Configmap_Error(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestVerifyTask_VerificationPolicy_Success(t *testing.T) {
@@ -493,8 +489,7 @@ func TestPrepareObjectMeta(t *testing.T) {
 			Annotations: map[string]string{"foo": "bar"},
 		},
 		wantErr: true,
-	},
-	}
+	}}
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
@@ -512,8 +507,6 @@ func TestPrepareObjectMeta(t *testing.T) {
 			if signature == nil {
 				t.Fatal("signature is not extracted")
 			}
-
 		})
 	}
-
 }

--- a/pkg/workspace/validate_test.go
+++ b/pkg/workspace/validate_test.go
@@ -82,7 +82,6 @@ func TestValidateBindingsValid(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestValidateBindingsInvalid(t *testing.T) {

--- a/test/cancel_test.go
+++ b/test/cancel_test.go
@@ -151,7 +151,6 @@ spec:
 				if taskrunItem.Spec.StatusMessage != v1beta1.TaskRunCancelledByPipelineMsg {
 					t.Fatalf("Status message is set to %s while it should be %s.", taskrunItem.Spec.StatusMessage, v1beta1.TaskRunCancelledByPipelineMsg)
 				}
-
 			}
 
 			matchKinds := map[string][]string{"PipelineRun": {pipelineRun.Name}}

--- a/test/controller_test.go
+++ b/test/controller_test.go
@@ -61,7 +61,6 @@ func TestResourceVersionReactor(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-
 			lastHandlerInvoked := false
 
 			ns := tc.deployment.Namespace

--- a/test/entrypoint_test.go
+++ b/test/entrypoint_test.go
@@ -69,5 +69,4 @@ spec:
 	if err := WaitForTaskRunState(ctx, c, epTaskRunName, TaskRunSucceed(epTaskRunName), "TaskRunSuccess", v1beta1Version); err != nil {
 		t.Errorf("Error waiting for TaskRun to finish successfully: %s", err)
 	}
-
 }

--- a/test/ignore_step_error_test.go
+++ b/test/ignore_step_error_test.go
@@ -104,5 +104,4 @@ spec:
 			t.Fatalf("task1 should have initialized a result \"result1\" to \"123\"")
 		}
 	}
-
 }

--- a/test/pipelinerun_test.go
+++ b/test/pipelinerun_test.go
@@ -514,7 +514,6 @@ spec:
 	if err := WaitForPipelineRunState(ctx, c, prName, timeout, PipelineRunSucceed(prName), "PipelineRunSuccess", v1beta1Version); err != nil {
 		t.Fatalf("Error waiting for PipelineRun %s to finish: %s", prName, err)
 	}
-
 }
 
 // TestPipelineRunPending tests that a Pending PipelineRun is not run until the pending

--- a/test/resolvers_test.go
+++ b/test/resolvers_test.go
@@ -130,7 +130,6 @@ spec:
 	if err := WaitForPipelineRunState(ctx, c, prName, timeout, PipelineRunSucceed(prName), "PipelineRunSuccess", v1beta1Version); err != nil {
 		t.Fatalf("Error waiting for PipelineRun %s to finish: %s", prName, err)
 	}
-
 }
 
 func TestHubResolver_Failure(t *testing.T) {

--- a/test/status_test.go
+++ b/test/status_test.go
@@ -230,7 +230,6 @@ func TestProvenanceFieldInPipelineRunTaskRunStatus(t *testing.T) {
 	if d := cmp.Diff(expectedTaskRunProvenance, taskRun.Status.Provenance); d != "" {
 		t.Errorf("provenance did not match: %s", diff.PrintWantGot(d))
 	}
-
 }
 
 func getExampleTask(t *testing.T, taskName, namespace string) *v1beta1.Task {

--- a/test/timeout_test.go
+++ b/test/timeout_test.go
@@ -215,7 +215,6 @@ spec:
 	} else if exitcode := tr.Status.Steps[2].Terminated.ExitCode; exitcode != 1 {
 		t.Logf("step-canceled exited with exit code %d, expected exit code 1", exitcode)
 	}
-
 }
 
 // TestStepTimeoutWithWS is an integration test that will verify a Step can be timed out.
@@ -555,7 +554,6 @@ spec:
 			if err != nil {
 				t.Errorf("Error waiting for TaskRun %s to timeout: %s", name, err)
 			}
-
 		}(taskrunItem)
 	}
 	wg.Wait()

--- a/test/trusted_resources_test.go
+++ b/test/trusted_resources_test.go
@@ -134,7 +134,6 @@ spec:
 	if pr.Status.GetCondition(apis.ConditionSucceeded).IsFalse() {
 		t.Errorf("Expected PipelineRun to succeed but instead found condition: %s", pr.Status.GetCondition(apis.ConditionSucceeded))
 	}
-
 }
 
 func TestTrustedResourcesVerify_ConfigMap_Error(t *testing.T) {
@@ -220,7 +219,6 @@ spec:
 	if pr.Status.Conditions[0].Reason != pod.ReasonResourceVerificationFailed {
 		t.Errorf("Expected PipelineRun fail condition is: %s but got: %s", pod.ReasonResourceVerificationFailed, pr.Status.Conditions[0].Reason)
 	}
-
 }
 
 func TestTrustedResourcesVerify_VerificationPolicy_Success(t *testing.T) {
@@ -319,7 +317,6 @@ spec:
 	if pr.Status.GetCondition(apis.ConditionSucceeded).IsFalse() {
 		t.Errorf("Expected PipelineRun to succeed but instead found condition: %s", pr.Status.GetCondition(apis.ConditionSucceeded))
 	}
-
 }
 
 func TestTrustedResourcesVerify_VerificationPolicy_Error(t *testing.T) {
@@ -423,7 +420,6 @@ spec:
 	if pr.Status.Conditions[0].Reason != pod.ReasonResourceVerificationFailed {
 		t.Errorf("Expected PipelineRun fail condition is: %s but got: %s", pod.ReasonResourceVerificationFailed, pr.Status.Conditions[0].Reason)
 	}
-
 }
 
 func setupResourceVerificationConfig(ctx context.Context, t *testing.T, keyInConfigMap bool, fn ...func(context.Context, *testing.T, *clients, string)) (*clients, string, string, signature.Signer) {

--- a/test/workingdir_test.go
+++ b/test/workingdir_test.go
@@ -166,5 +166,4 @@ spec:
 			t.Logf("Found a working dir container called `%s` in `%s`  when it should have been excluded:", stat.Name, tr.Status.PodName)
 		}
 	}
-
 }


### PR DESCRIPTION
# Changes

There are no expected functional changes in this PR; changes to `.go` files should be whitespace only.

I used an `ex` script to cleanup white issues that the linter identified:

```
ex - $FILENAME <<EOF
%s/\n\n}/\r}/g
%s/\n\n\t}/\r\t}/g
%s/\n\n\t\t}/\r\t\t}/g
%s/\n\n\t\t\t}/\r\t\t\t}/g
%s/\n\n\t\t\t\t}/\r\t\t\t\t}/g
%s/{\n\n/{\r/g
%s/}\n\n}/}\r}/g
%s/}\n\n\t}/}\r\t}/g
%s/}\n\n\t\t}/}\r\t\t}/g
%s/}\n\n\t\t\t}/}\r\t\t\t}/g
%s/)\n\n\t}/)\r\t}/g
%s/)\n\n}/)\r}/g
wq
EOF
```

/kind cleanup
/hold

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [N/A] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [N/A] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [N/A] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [N/A] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
