### PR TITLE
docs: fixing wrong matrix syntax in some places

### DIFF
--- a/docs/matrix.md
+++ b/docs/matrix.md
@@ -175,11 +175,12 @@ tasks:
   taskRef:
     name: task-4
   matrix:
-  - name: values
-    value: 
-    - (tasks.task-1.results.foo) # string
-    - (tasks.task-2.results.bar) # string
-    - (tasks.task-3.results.rad) # string
+    params:
+    - name: values
+      value:
+      - (tasks.task-1.results.foo) # string
+      - (tasks.task-2.results.bar) # string
+      - (tasks.task-3.results.rad) # string
 ```
 
 For further information, see the example in [`PipelineRun` with `Matrix` and `Results`][pr-with-matrix-and-results].
@@ -194,8 +195,9 @@ tasks:
   taskRef:
     name: task-5
   matrix:
-  - name: values
-    value: (tasks.task-4.results.foo) # array
+    params:
+    - name: values
+      value: (tasks.task-4.results.foo) # array
 ```
 
 #### Results from fanned out PipelineTasks

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -375,6 +375,7 @@ spec:
       taskRef:
         name: browser-test
       matrix:
+        params:
         - name: browser
           value:
           - chrome
@@ -1238,6 +1239,7 @@ spec:
         - name: url
           value: "someURL"
       matrix:
+        params:
         - name: slack-channel
           value:
           - "foo"
@@ -1696,6 +1698,7 @@ spec:
         - name: foo
           value: bah
       matrix:
+        params:
         - name: bar
           value:
             - qux


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The syntax changed between the first iteration and nowadays, but some
of the docs is still using the old syntax. This fixes it.

It might need to be cherry-pick in some release branches, not sure
which ones

/kind documentation

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
