### PR TITLE
Add sidecarlogresults to images in release pipeline

### DIFF
--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -11,7 +11,7 @@ spec:
       default: github.com/tektoncd/pipeline
     - name: images
       description: List of cmd/* paths to be published as images
-      default: "controller webhook entrypoint nop kubeconfigwriter git-init imagedigestexporter pullrequest-init workingdirinit resolvers"
+      default: "controller webhook entrypoint nop kubeconfigwriter git-init imagedigestexporter pullrequest-init workingdirinit resolvers sidecarlogresults"
     - name: versionTag
       description: The vX.Y.Z version that the artifacts should be tagged with (including `v`)
     - name: imageRegistry


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

In this change, we add sidecarlogresults to the images parameter in the release pipeline. Without this change, the release pipeline fails because of an unexpected image.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- ~[ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing~
- ~[ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed~
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- ~[ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)~
- ~[ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release~

# Release Notes

```release-note
NONE
```
