### PR TITLE
Cleanup unit tests to use idiomatic Go.

### DIFF
--- a/pkg/spire/spire_mock_test.go
+++ b/pkg/spire/spire_mock_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 // Simple task run sign/verify
-func TestSpireMock_TaskRunSign(t *testing.T) {
+func TestMock_TaskRunSign(t *testing.T) {
 	spireMockClient := &MockClient{}
 	var (
 		cc ControllerAPIClient = spireMockClient
@@ -55,7 +55,7 @@ func TestSpireMock_TaskRunSign(t *testing.T) {
 }
 
 // test CheckSpireVerifiedFlag(tr *v1beta1.TaskRun) bool
-func TestSpireMock_CheckSpireVerifiedFlag(t *testing.T) {
+func TestMock_CheckSpireVerifiedFlag(t *testing.T) {
 	spireMockClient := &MockClient{}
 	var (
 		cc ControllerAPIClient = spireMockClient
@@ -79,7 +79,7 @@ func TestSpireMock_CheckSpireVerifiedFlag(t *testing.T) {
 }
 
 // Task run check signed status is not the same with two taskruns
-func TestSpireMock_CheckHashSimilarities(t *testing.T) {
+func TestMock_CheckHashSimilarities(t *testing.T) {
 	spireMockClient := &MockClient{}
 	var (
 		cc ControllerAPIClient = spireMockClient
@@ -117,7 +117,7 @@ func TestSpireMock_CheckHashSimilarities(t *testing.T) {
 }
 
 // Task run sign, modify signature/hash/svid/content and verify
-func TestSpireMock_CheckTamper(t *testing.T) {
+func TestMock_CheckTamper(t *testing.T) {
 	tests := []struct {
 		// description of test case
 		desc string
@@ -239,7 +239,7 @@ func TestSpireMock_CheckTamper(t *testing.T) {
 }
 
 // Task result sign and verify
-func TestSpireMock_TaskRunResultsSign(t *testing.T) {
+func TestMock_TaskRunResultsSign(t *testing.T) {
 	spireMockClient := &MockClient{}
 	var (
 		cc ControllerAPIClient   = spireMockClient
@@ -315,7 +315,7 @@ func TestSpireMock_TaskRunResultsSign(t *testing.T) {
 }
 
 // Task result sign, modify signature/content and verify
-func TestSpireMock_TaskRunResultsSignTamper(t *testing.T) {
+func TestMock_TaskRunResultsSignTamper(t *testing.T) {
 	spireMockClient := &MockClient{}
 	var (
 		cc ControllerAPIClient   = spireMockClient


### PR DESCRIPTION
# Changes

This PR is a follow-on from https://github.com/tektoncd/pipeline/pull/5904#issuecomment-1361398213 to make spire tests more readable, easier to understand, and conformant with [idiomatic Golang style](https://goo.gle/go-style).

There are no expected functional changes in this PR.

Changes:
- `spire_mock_test.go`: Renamed test functions from `TestSpireMock_*` --> `TestMock_*`
- `spire_test.go`:
  - Renamed test functions from `TestSpire_*` --> `Test*`
  - use concise helper function names -([style guide](https://google.github.io/styleguide/go/decisions#getters))
  - in-lined test data in place of `testSingleTaskRun()`, `testSinglePipelineResourceResults()` helpers
  - eliminated unnecessary helper functions (`genPr()` and `success := func()...`)
  - localized setup to just the tests that need it ([style guide](https://google.github.io/styleguide/go/best-practices#keep-setup-code-scoped-to-specific-tests))
  - use naming conventions `got`, `want` in tests

/kind cleanup

Ref: https://github.com/tektoncd/pipeline/issues/5899

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [N/A] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [N/A] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [N/A] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
