### PR TITLE
Enabled `dupword` and `usestdlibvars` linters.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,6 +17,7 @@ linters:
   disable-all: true
   enable:
   - depguard
+  - dupword
   - errcheck
   - gocritic
   - gofmt
@@ -29,6 +30,7 @@ linters:
   - revive
   - unconvert
   - unused
+  - usestdlibvars
   - whitespace
 output:
   uniq-by-line: false


### PR DESCRIPTION
# Changes

This PR enables linters `dupword` and `usestdlibvars`.

Given cleanup in https://github.com/tektoncd/pipeline/pull/5923, there are no required code changes for this linter to lint clean.

This PR cannot be merged until https://github.com/tektoncd/plumbing/pull/1308 is live in plumbing.

Context: https://github.com/tektoncd/pipeline/issues/5899

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [N/A] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [N/A] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [N/A] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [N/A] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
