### PR TITLE
Cleanup: delete duplicate words.

### DIFF
--- a/cmd/entrypoint/runner.go
+++ b/cmd/entrypoint/runner.go
@@ -85,7 +85,7 @@ func (rr *realRunner) Run(ctx context.Context, args ...string) error {
 	cmd := exec.CommandContext(ctx, name, args...)
 
 	// Build a list of tee readers that we'll read from after the command is
-	// is started. If we are not configured to tee stdout/stderr this will be
+	// started. If we are not configured to tee stdout/stderr this will be
 	// empty and contents will not be copied.
 	var readers []*namedReader
 	if rr.stdoutPath != "" {

--- a/pkg/apis/pipeline/v1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1/pipelinerun_types.go
@@ -98,7 +98,7 @@ func (pr *PipelineRun) IsGracefullyStopped() bool {
 	return pr.Spec.Status == PipelineRunSpecStatusStoppedRunFinally
 }
 
-// PipelineTimeout returns the the applicable timeout for the PipelineRun
+// PipelineTimeout returns the applicable timeout for the PipelineRun
 func (pr *PipelineRun) PipelineTimeout(ctx context.Context) time.Duration {
 	if pr.Spec.Timeouts != nil && pr.Spec.Timeouts.Pipeline != nil {
 		return pr.Spec.Timeouts.Pipeline.Duration
@@ -106,7 +106,7 @@ func (pr *PipelineRun) PipelineTimeout(ctx context.Context) time.Duration {
 	return time.Duration(config.FromContextOrDefaults(ctx).Defaults.DefaultTimeoutMinutes) * time.Minute
 }
 
-// TasksTimeout returns the the tasks timeout for the PipelineRun, if set,
+// TasksTimeout returns the tasks timeout for the PipelineRun, if set,
 // or the tasks timeout computed from the Pipeline and Finally timeouts, if those are set.
 func (pr *PipelineRun) TasksTimeout() *metav1.Duration {
 	t := pr.Spec.Timeouts
@@ -125,7 +125,7 @@ func (pr *PipelineRun) TasksTimeout() *metav1.Duration {
 	return nil
 }
 
-// FinallyTimeout returns the the finally timeout for the PipelineRun, if set,
+// FinallyTimeout returns the finally timeout for the PipelineRun, if set,
 // or the finally timeout computed from the Pipeline and Tasks timeouts, if those are set.
 func (pr *PipelineRun) FinallyTimeout() *metav1.Duration {
 	t := pr.Spec.Timeouts

--- a/pkg/apis/pipeline/v1/result_validation.go
+++ b/pkg/apis/pipeline/v1/result_validation.go
@@ -23,7 +23,7 @@ import (
 	"knative.dev/pkg/apis"
 )
 
-// ResultNameFormat Constant used to define the the regex Result.Name should follow
+// ResultNameFormat Constant used to define the regex Result.Name should follow
 const ResultNameFormat = `^([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$`
 
 var resultNameFormatRegex = regexp.MustCompile(ResultNameFormat)

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
@@ -97,7 +97,7 @@ func (pr *PipelineRun) IsGracefullyStopped() bool {
 	return pr.Spec.Status == PipelineRunSpecStatusStoppedRunFinally
 }
 
-// PipelineTimeout returns the the applicable timeout for the PipelineRun
+// PipelineTimeout returns the applicable timeout for the PipelineRun
 func (pr *PipelineRun) PipelineTimeout(ctx context.Context) time.Duration {
 	if pr.Spec.Timeout != nil {
 		return pr.Spec.Timeout.Duration
@@ -108,7 +108,7 @@ func (pr *PipelineRun) PipelineTimeout(ctx context.Context) time.Duration {
 	return time.Duration(config.FromContextOrDefaults(ctx).Defaults.DefaultTimeoutMinutes) * time.Minute
 }
 
-// TasksTimeout returns the the tasks timeout for the PipelineRun, if set,
+// TasksTimeout returns the tasks timeout for the PipelineRun, if set,
 // or the tasks timeout computed from the Pipeline and Finally timeouts, if those are set.
 func (pr *PipelineRun) TasksTimeout() *metav1.Duration {
 	t := pr.Spec.Timeouts
@@ -127,7 +127,7 @@ func (pr *PipelineRun) TasksTimeout() *metav1.Duration {
 	return nil
 }
 
-// FinallyTimeout returns the the finally timeout for the PipelineRun, if set,
+// FinallyTimeout returns the finally timeout for the PipelineRun, if set,
 // or the finally timeout computed from the Pipeline and Tasks timeouts, if those are set.
 func (pr *PipelineRun) FinallyTimeout() *metav1.Duration {
 	t := pr.Spec.Timeouts

--- a/pkg/apis/pipeline/v1beta1/resultref.go
+++ b/pkg/apis/pipeline/v1beta1/resultref.go
@@ -51,7 +51,7 @@ const (
 	exactVariableSubstitutionFormat = `^\$\([_a-zA-Z0-9.-]+(\.[_a-zA-Z0-9.-]+)*(\[([0-9]+|\*)\])?\)$`
 	// arrayIndexing will match all `[int]` and `[*]` for parseExpression
 	arrayIndexing = `\[([0-9])*\*?\]`
-	// ResultNameFormat Constant used to define the the regex Result.Name should follow
+	// ResultNameFormat Constant used to define the regex Result.Name should follow
 	ResultNameFormat = `^([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$`
 )
 

--- a/pkg/apis/pipeline/v1beta1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_types.go
@@ -142,7 +142,7 @@ type TaskRunStatus struct {
 	TaskRunStatusFields `json:",inline"`
 }
 
-// TaskRunConditionType is an enum used to store TaskRun custom conditions
+// TaskRunConditionType is an enum used to store TaskRun custom
 // conditions such as one used in spire results verification
 type TaskRunConditionType string
 

--- a/pkg/apis/resolution/v1alpha1/resolution_request_validation.go
+++ b/pkg/apis/resolution/v1alpha1/resolution_request_validation.go
@@ -30,7 +30,7 @@ func (rr *ResolutionRequest) Validate(ctx context.Context) (errs *apis.FieldErro
 	return errs.Also(rr.Spec.Validate(ctx).ViaField("spec"))
 }
 
-// Validate checks the the spec field of a ResolutionRequest is valid.
+// Validate checks the spec field of a ResolutionRequest is valid.
 func (rs *ResolutionRequestSpec) Validate(ctx context.Context) (errs *apis.FieldError) {
 	return nil
 }

--- a/pkg/apis/resolution/v1beta1/resolution_request_validation.go
+++ b/pkg/apis/resolution/v1beta1/resolution_request_validation.go
@@ -30,7 +30,7 @@ func (rr *ResolutionRequest) Validate(ctx context.Context) (errs *apis.FieldErro
 	return errs.Also(rr.Spec.Validate(ctx).ViaField("spec"))
 }
 
-// Validate checks the the spec field of a ResolutionRequest is valid.
+// Validate checks the spec field of a ResolutionRequest is valid.
 func (rs *ResolutionRequestSpec) Validate(ctx context.Context) (errs *apis.FieldError) {
 	return nil
 }

--- a/pkg/artifacts/artifacts_storage.go
+++ b/pkg/artifacts/artifacts_storage.go
@@ -128,7 +128,7 @@ func CleanupArtifactStorage(ctx context.Context, pr *v1beta1.PipelineRun, c kube
 	return nil
 }
 
-// needsPVC checks if the Tekton is is configured to use a bucket for artifact storage,
+// needsPVC checks if the Tekton is configured to use a bucket for artifact storage,
 // returning true if instead a PVC is needed.
 func needsPVC(ctx context.Context) bool {
 	bucketConfig := config.FromContextOrDefaults(ctx).ArtifactBucket

--- a/pkg/names/generate.go
+++ b/pkg/names/generate.go
@@ -26,7 +26,7 @@ import (
 // NameGenerator generates names for objects. Some backends may have more information
 // available to guide selection of new names and this interface hides those details.
 type NameGenerator interface {
-	// RestrictLengthWithRandomSuffix generates a valid name from the base name, adding a random suffix to the
+	// RestrictLengthWithRandomSuffix generates a valid name from the base name, adding a random suffix to
 	// the base. If base is valid, the returned name must also be valid. The generator is
 	// responsible for knowing the maximum valid name length.
 	RestrictLengthWithRandomSuffix(base string) string

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -318,7 +318,7 @@ func (c *Reconciler) resolvePipelineState(
 				return nil, err
 			}
 			// If we just return c.customRunLister.CustomRuns(...).Get(...) and there is no run, we end up returning
-			// a v1beta1.RunObject that that won't == nil, so do an explicit check.
+			// a v1beta1.RunObject that won't == nil, so do an explicit check.
 			if r == nil {
 				return nil, nil
 			}
@@ -333,7 +333,7 @@ func (c *Reconciler) resolvePipelineState(
 					return nil, err
 				}
 				// If we just return c.runLister.Runs(...).Get(...) and there is no run, we end up returning
-				// a v1beta1.RunObject that that won't == nil, so do an explicit check.
+				// a v1beta1.RunObject that won't == nil, so do an explicit check.
 				if r == nil {
 					return nil, nil
 				}

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -472,7 +472,7 @@ func (t *ResolvedPipelineTask) skipBecauseResultReferencesAreMissing(facts *Pipe
 func (t *ResolvedPipelineTask) skipBecausePipelineRunPipelineTimeoutReached(facts *PipelineRunFacts) bool {
 	if t.checkParentsDone(facts) {
 		if facts.TimeoutsState.PipelineTimeout != nil && *facts.TimeoutsState.PipelineTimeout != config.NoTimeoutDuration && facts.TimeoutsState.StartTime != nil {
-			// If the elapsed time since the PipelineRun's start time is greater than the the PipelineRun's Pipeline timeout, skip.
+			// If the elapsed time since the PipelineRun's start time is greater than the PipelineRun's Pipeline timeout, skip.
 			return facts.TimeoutsState.Clock.Since(*facts.TimeoutsState.StartTime) > *facts.TimeoutsState.PipelineTimeout
 		}
 	}
@@ -485,7 +485,7 @@ func (t *ResolvedPipelineTask) skipBecausePipelineRunPipelineTimeoutReached(fact
 func (t *ResolvedPipelineTask) skipBecausePipelineRunTasksTimeoutReached(facts *PipelineRunFacts) bool {
 	if t.checkParentsDone(facts) && !t.IsFinalTask(facts) {
 		if facts.TimeoutsState.TasksTimeout != nil && *facts.TimeoutsState.TasksTimeout != config.NoTimeoutDuration && facts.TimeoutsState.StartTime != nil {
-			// If the elapsed time since the PipelineRun's start time is greater than the the PipelineRun's Tasks timeout, skip.
+			// If the elapsed time since the PipelineRun's start time is greater than the PipelineRun's Tasks timeout, skip.
 			return facts.TimeoutsState.Clock.Since(*facts.TimeoutsState.StartTime) > *facts.TimeoutsState.TasksTimeout
 		}
 	}
@@ -498,7 +498,7 @@ func (t *ResolvedPipelineTask) skipBecausePipelineRunTasksTimeoutReached(facts *
 func (t *ResolvedPipelineTask) skipBecausePipelineRunFinallyTimeoutReached(facts *PipelineRunFacts) bool {
 	if t.checkParentsDone(facts) && t.IsFinalTask(facts) {
 		if facts.TimeoutsState.FinallyTimeout != nil && *facts.TimeoutsState.FinallyTimeout != config.NoTimeoutDuration && facts.TimeoutsState.FinallyStartTime != nil {
-			// If the elapsed time since the PipelineRun's finally start time is greater than the the PipelineRun's finally timeout, skip.
+			// If the elapsed time since the PipelineRun's finally start time is greater than the PipelineRun's finally timeout, skip.
 			return facts.TimeoutsState.Clock.Since(*facts.TimeoutsState.FinallyStartTime) > *facts.TimeoutsState.FinallyTimeout
 		}
 	}

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
@@ -2195,10 +2195,10 @@ func TestResolvePipelineRun_PipelineTaskHasNoResources(t *testing.T) {
 		Outputs:  map[string]*resourcev1alpha1.PipelineResource{},
 	}
 	if d := cmp.Diff(pipelineState[0].ResolvedTaskResources, expectedTaskResources, cmpopts.IgnoreUnexported(v1beta1.TaskRunSpec{})); d != "" {
-		t.Fatalf("Expected resources where only Tasks were resolved but but actual differed %s", diff.PrintWantGot(d))
+		t.Fatalf("Expected resources where only Tasks were resolved but actual differed %s", diff.PrintWantGot(d))
 	}
 	if d := cmp.Diff(pipelineState[1].ResolvedTaskResources, expectedTaskResources, cmpopts.IgnoreUnexported(v1beta1.TaskRunSpec{})); d != "" {
-		t.Fatalf("Expected resources where only Tasks were resolved but but actual differed %s", diff.PrintWantGot(d))
+		t.Fatalf("Expected resources where only Tasks were resolved but actual differed %s", diff.PrintWantGot(d))
 	}
 }
 

--- a/pkg/reconciler/testing/logger.go
+++ b/pkg/reconciler/testing/logger.go
@@ -41,12 +41,12 @@ func SetupDefaultContext(t *testing.T) (context.Context, []controller.Informer) 
 	return WithLogger(ctx, t), informer
 }
 
-// WithLogger returns the the Logger
+// WithLogger returns the Logger
 func WithLogger(ctx context.Context, t *testing.T) context.Context {
 	return logging.WithLogger(ctx, TestLogger(t))
 }
 
-// TestLogger sets up the the Logger
+// TestLogger sets up the Logger
 func TestLogger(t *testing.T) *zap.SugaredLogger {
 	logger := zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller()))
 	return logger.Sugar().Named(t.Name())

--- a/pkg/spire/spire.go
+++ b/pkg/spire/spire.go
@@ -52,7 +52,7 @@ const (
 	KeyResultManifest = "RESULT_MANIFEST"
 	// WorkloadAPI is the name of the SPIFFE/SPIRE CSI Driver volume
 	WorkloadAPI = "spiffe-workload-api"
-	// VolumeMountPath is the volume mount in the the pods to access the SPIFFE/SPIRE agent workload API
+	// VolumeMountPath is the volume mount in the pods to access the SPIFFE/SPIRE agent workload API
 	VolumeMountPath = "/spiffe-workload-api"
 )
 

--- a/pkg/substitution/substitution_test.go
+++ b/pkg/substitution/substitution_test.go
@@ -370,17 +370,17 @@ func TestApplyReplacements(t *testing.T) {
 			name: "single replacement requested multiple matches",
 			args: args{
 				input:        "this $(is) a string $(is) a string",
-				replacements: map[string]string{"is": "a"},
+				replacements: map[string]string{"is": "foo"},
 			},
-			expectedOutput: "this a a string a a string",
+			expectedOutput: "this foo a string foo a string",
 		},
 		{
 			name: "multiple replacements requested",
 			args: args{
 				input:        "this $(is) a $(string) $(is) a $(string)",
-				replacements: map[string]string{"is": "a", "string": "sstring"},
+				replacements: map[string]string{"is": "foo", "string": "sstring"},
 			},
-			expectedOutput: "this a a sstring a a sstring",
+			expectedOutput: "this foo a sstring foo a sstring",
 		},
 		{
 			name: "multiple replacements requested nothing replaced",

--- a/test/custom_task_test.go
+++ b/test/custom_task_test.go
@@ -278,7 +278,7 @@ func WaitForRunSpecCancelled(ctx context.Context, c *clients, name string, desc 
 }
 
 // TestPipelineRunCustomTaskTimeout is an integration test that will
-// verify that pipelinerun timeout works and leads to the the correct Run Spec.status
+// verify that pipelinerun timeout works and leads to the correct Run Spec.status
 func TestPipelineRunCustomTaskTimeout(t *testing.T) {
 	// cancel the context after we have waited a suitable buffer beyond the given deadline.
 	ctx, cancel := context.WithTimeout(context.Background(), timeout+2*time.Minute)

--- a/test/pullrequest/http.go
+++ b/test/pullrequest/http.go
@@ -29,7 +29,7 @@ func reflect(w http.ResponseWriter, r *http.Request) {
 
 // ServeHTTP serves the proxy HTTP handler. Any POST requests will reflect
 // provided data back to the client, any other methods will attempt to read
-// an HTTP response from from <data dir>/<url path>/<method>, e.g.
+// an HTTP response from <data dir>/<url path>/<method>, e.g.
 // testdata/github.com/foo/bar/GET.
 // The server will also check headers provided by the client. If they do not
 // match, an error is returned (this is useful for verifying auth headers are

--- a/test/resolvers_test.go
+++ b/test/resolvers_test.go
@@ -237,7 +237,6 @@ spec:
           - name: revision
             value: main
         params:
-        params:
           - name: url
             value: https://github.com/tektoncd/pipeline
           - name: deleteExisting

--- a/test/timeout_test.go
+++ b/test/timeout_test.go
@@ -39,7 +39,7 @@ import (
 )
 
 // TestPipelineRunTimeout is an integration test that will
-// verify that pipelinerun timeout works and leads to the the correct TaskRun statuses
+// verify that pipelinerun timeout works and leads to the correct TaskRun statuses
 // and pod deletions.
 func TestPipelineRunTimeout(t *testing.T) {
 	t.Parallel()
@@ -432,7 +432,7 @@ spec:
 }
 
 // TestPipelineRunTasksTimeout is an integration test that will
-// verify that pipelinerun tasksTimeout works and leads to the the correct PipelineRun and TaskRun statuses
+// verify that pipelinerun tasksTimeout works and leads to the correct PipelineRun and TaskRun statuses
 // and pod deletions.
 func TestPipelineRunTasksTimeout(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
# Changes

Cleanup: delete duplicate words.

There are no expected functional changes in this PR.

The code changes are duplicate words discovered by the `dupword` linter, for example,
`the the` --> `the`. Occasional deduped words appear in unit test strings where I've uniqified the words in question.

The `dupword` linter will be enabled in
https://github.com/tektoncd/pipeline/pull/5918.

Context: https://github.com/tektoncd/pipeline/issues/5899

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [N/A] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [N/A] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [N/A] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [N/A] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
