### PR TITLE
Enabled additional linters.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,6 +16,8 @@ linters-settings:
 linters:
   disable-all: true
   enable:
+  - bodyclose
+  - decorder
   - depguard
   - errcheck
   - gocritic
@@ -27,6 +29,7 @@ linters:
   - govet
   - misspell
   - revive
+  - typecheck
   - unconvert
   - unused
   - whitespace


### PR DESCRIPTION
# Changes

Enabled `bodyclose`, `decorder`, and `typecheck`.

These currently lint clean, so there are no needed code changes.

Context: https://github.com/tektoncd/pipeline/issues/5899

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [N/A] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [N/A] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [N/A] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [N/A] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
