### PR TITLE
Enabled `thelper` linter.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,6 +31,7 @@ linters:
   - misspell
   - revive
   - typecheck
+  - thelper
   - unconvert
   - unused
   - usestdlibvars

--- a/pkg/apis/config/artifact_bucket_test.go
+++ b/pkg/apis/config/artifact_bucket_test.go
@@ -91,6 +91,7 @@ func TestGetArtifactBucketConfigName(t *testing.T) {
 }
 
 func verifyConfigFileWithExpectedArtifactBucketConfig(t *testing.T, fileName string, expectedConfig *config.ArtifactBucket) {
+	t.Helper()
 	cm := test.ConfigMapFromTestFile(t, fileName)
 	if ab, err := config.NewArtifactBucketFromConfigMap(cm); err == nil {
 		if d := cmp.Diff(ab, expectedConfig); d != "" {

--- a/pkg/apis/config/artifact_pvc_test.go
+++ b/pkg/apis/config/artifact_pvc_test.go
@@ -89,6 +89,7 @@ func TestGetArtifactPVCConfigName(t *testing.T) {
 }
 
 func verifyConfigFileWithExpectedArtifactPVCConfig(t *testing.T, fileName string, expectedConfig *config.ArtifactPVC) {
+	t.Helper()
 	cm := test.ConfigMapFromTestFile(t, fileName)
 	if ab, err := config.NewArtifactPVCFromConfigMap(cm); err == nil {
 		if d := cmp.Diff(ab, expectedConfig); d != "" {

--- a/pkg/apis/config/default_test.go
+++ b/pkg/apis/config/default_test.go
@@ -310,6 +310,7 @@ func verifyConfigFileWithExpectedConfig(t *testing.T, fileName string, expectedC
 }
 
 func verifyConfigFileWithExpectedError(t *testing.T, fileName string) {
+	t.Helper()
 	cm := test.ConfigMapFromTestFile(t, fileName)
 	if _, err := config.NewDefaultsFromConfigMap(cm); err == nil {
 		t.Errorf("NewDefaultsFromConfigMap(actual) was expected to return an error")

--- a/pkg/apis/config/feature_flags_test.go
+++ b/pkg/apis/config/feature_flags_test.go
@@ -302,6 +302,7 @@ func TestCheckWarnResourceVerificationMode(t *testing.T) {
 }
 
 func verifyConfigFileWithExpectedFeatureFlagsConfig(t *testing.T, fileName string, expectedConfig *config.FeatureFlags) {
+	t.Helper()
 	cm := test.ConfigMapFromTestFile(t, fileName)
 	if flags, err := config.NewFeatureFlagsFromConfigMap(cm); err == nil {
 		if d := cmp.Diff(expectedConfig, flags); d != "" {

--- a/pkg/apis/config/metrics_test.go
+++ b/pkg/apis/config/metrics_test.go
@@ -69,6 +69,7 @@ func TestNewMetricsFromEmptyConfigMap(t *testing.T) {
 }
 
 func verifyConfigFileWithExpectedMetricsConfig(t *testing.T, fileName string, expectedConfig *config.Metrics) {
+	t.Helper()
 	cm := test.ConfigMapFromTestFile(t, fileName)
 	if ab, err := config.NewMetricsFromConfigMap(cm); err == nil {
 		if d := cmp.Diff(ab, expectedConfig); d != "" {

--- a/pkg/apis/config/resolver/feature_flags_test.go
+++ b/pkg/apis/config/resolver/feature_flags_test.go
@@ -115,6 +115,7 @@ func TestNewFeatureFlagsConfigMapErrors(t *testing.T) {
 }
 
 func verifyConfigFileWithExpectedFeatureFlagsConfig(t *testing.T, fileName string, expectedConfig *resolver.FeatureFlags) {
+	t.Helper()
 	cm := test.ConfigMapFromTestFile(t, fileName)
 	if flags, err := resolver.NewFeatureFlagsFromConfigMap(cm); err == nil {
 		if d := cmp.Diff(expectedConfig, flags); d != "" {

--- a/pkg/apis/config/trusted_resources_test.go
+++ b/pkg/apis/config/trusted_resources_test.go
@@ -61,6 +61,7 @@ func TestNewTrustedResourcesFromEmptyConfigMap(t *testing.T) {
 }
 
 func verifyConfigFileWithExpectedTrustedResourcesConfig(t *testing.T, fileName string, expectedConfig *config.TrustedResources) {
+	t.Helper()
 	cm := test.ConfigMapFromTestFile(t, fileName)
 	if ab, err := config.NewTrustedResourcesConfigFromConfigMap(cm); err == nil {
 		if d := cmp.Diff(ab, expectedConfig); d != "" {

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
@@ -3639,6 +3639,7 @@ func getTaskSpec() TaskSpec {
 }
 
 func enableFeatures(t *testing.T, features []string) func(context.Context) context.Context {
+	t.Helper()
 	return func(ctx context.Context) context.Context {
 		s := config.NewStore(logtesting.TestLogger(t))
 		data := make(map[string]string)

--- a/pkg/apis/pipeline/v1beta1/pipelineref_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelineref_validation_test.go
@@ -193,6 +193,7 @@ func TestPipelineRef_Valid(t *testing.T) {
 }
 
 func enableTektonOCIBundles(t *testing.T) func(context.Context) context.Context {
+	t.Helper()
 	return func(ctx context.Context) context.Context {
 		s := config.NewStore(logtesting.TestLogger(t))
 		s.OnConfigChanged(&corev1.ConfigMap{

--- a/pkg/credentials/initialize_test.go
+++ b/pkg/credentials/initialize_test.go
@@ -74,6 +74,7 @@ func TestTryCopyCredFileMissing(t *testing.T) {
 }
 
 func writeFakeCred(t *testing.T, dir, name, contents string) string {
+	t.Helper()
 	flags := os.O_RDWR | os.O_CREATE | os.O_TRUNC
 	path := filepath.Join(dir, name)
 	cred, err := os.OpenFile(path, flags, 0600)

--- a/pkg/entrypoint/entrypointer_test.go
+++ b/pkg/entrypoint/entrypointer_test.go
@@ -688,6 +688,7 @@ func (f *fakeResultsWriter) Run(ctx context.Context, args ...string) error {
 }
 
 func createTmpDir(t *testing.T, name string) string {
+	t.Helper()
 	tmpDir, err := os.MkdirTemp("", name)
 	if err != nil {
 		t.Fatalf("unexpected error creating temporary dir: %v", err)

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -30,6 +30,7 @@ import (
 const fileMode = 0755 // rwxr-xr-x
 
 func withTemporaryGitConfig(t *testing.T) {
+	t.Helper()
 	gitConfigDir := t.TempDir()
 	key := "GIT_CONFIG_GLOBAL"
 	t.Setenv(key, filepath.Join(gitConfigDir, "config"))
@@ -173,7 +174,7 @@ func TestValidateGitAuth(t *testing.T) {
 			}
 
 			validateGitAuth(logger, credsDir, tt.url)
-			checkLogMessage(tt.logMessage, log, 0, t)
+			checkLogMessage(t, tt.logMessage, log, 0)
 		})
 	}
 }
@@ -379,13 +380,14 @@ func TestFetch(t *testing.T) {
 			if tt.spec.Submodules {
 				logLine = 1
 			}
-			checkLogMessage(tt.logMessage, log, logLine, t)
+			checkLogMessage(t, tt.logMessage, log, logLine)
 		})
 	}
 }
 
 // Create a temporary Git dir locally for testing against instead of using a potentially flaky remote URL.
 func createTempGit(t *testing.T, logger *zap.SugaredLogger, gitDir string, submodPath string) {
+	t.Helper()
 	if _, err := run(logger, "", "init", gitDir); err != nil {
 		t.Fatal(err)
 	}
@@ -417,15 +419,17 @@ func createTempGit(t *testing.T, logger *zap.SugaredLogger, gitDir string, submo
 	}
 }
 
-func checkLogMessage(logMessage string, log *observer.ObservedLogs, logLine int, t *testing.T) {
-	if logMessage != "" {
-		allLogLines := log.All()
-		if len(allLogLines) == 0 {
-			t.Fatal("We didn't receive any logging")
-		}
-		gotmsg := allLogLines[logLine].Message
-		if !strings.Contains(gotmsg, logMessage) {
-			t.Errorf("log message: '%s'\n should contain: '%s'", logMessage, gotmsg)
-		}
+func checkLogMessage(t *testing.T, logMessage string, log *observer.ObservedLogs, logLine int) {
+	t.Helper()
+	if logMessage == "" {
+		return
+	}
+	allLogLines := log.All()
+	if len(allLogLines) == 0 {
+		t.Fatal("We didn't receive any logging")
+	}
+	gotmsg := allLogLines[logLine].Message
+	if !strings.Contains(gotmsg, logMessage) {
+		t.Errorf("log message: '%s'\n should contain: '%s'", logMessage, gotmsg)
 	}
 }

--- a/pkg/internal/computeresources/limitrange/limitrange_test.go
+++ b/pkg/internal/computeresources/limitrange/limitrange_test.go
@@ -34,6 +34,7 @@ import (
 )
 
 func setupTestData(t *testing.T, serviceaccounts []corev1.ServiceAccount, limitranges []corev1.LimitRange) (context.Context, func()) {
+	t.Helper()
 	ctx, _ := ttesting.SetupFakeContext(t)
 	ctx, cancel := context.WithCancel(ctx)
 	kubeclient := fakekubeclient.Get(ctx)

--- a/pkg/internal/computeresources/transformer_test.go
+++ b/pkg/internal/computeresources/transformer_test.go
@@ -939,6 +939,7 @@ func TestTransformerMultipleContainer(t *testing.T) {
 }
 
 func cmpRequestsAndLimits(t *testing.T, want, got corev1.PodSpec) {
+	t.Helper()
 	// diff init containers
 	if len(want.InitContainers) != len(got.InitContainers) {
 		t.Errorf("Expected %d init containers, got %d", len(want.InitContainers), len(got.InitContainers))

--- a/pkg/pod/entrypoint_lookup_impl_test.go
+++ b/pkg/pod/entrypoint_lookup_impl_test.go
@@ -182,6 +182,7 @@ func TestGetImageWithImagePullSecrets(t *testing.T) {
 }
 
 func mustRandomImage(t *testing.T) v1.Image {
+	t.Helper()
 	img, err := random.Image(10, 10)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/pullrequest/api_test.go
+++ b/pkg/pullrequest/api_test.go
@@ -77,6 +77,7 @@ func defaultResource() *Resource {
 }
 
 func newHandler(t *testing.T) (*Handler, *fake.Data) {
+	t.Helper()
 	logger := zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller())).Sugar()
 	client, data := fake.NewDefault()
 

--- a/pkg/reconciler/customrun/customrun_test.go
+++ b/pkg/reconciler/customrun/customrun_test.go
@@ -45,6 +45,7 @@ import (
 )
 
 func initializeCustomRunControllerAssets(t *testing.T, d test.Data) (test.Assets, func()) {
+	t.Helper()
 	ctx, _ := ttesting.SetupFakeContext(t)
 	ctx = ttesting.SetupFakeCloudClientContext(ctx, d.ExpectedCloudEventCount)
 	ctx, cancel := context.WithCancel(ctx)

--- a/pkg/reconciler/events/cloudevent/cloud_event_controller_test.go
+++ b/pkg/reconciler/events/cloudevent/cloud_event_controller_test.go
@@ -770,8 +770,8 @@ func TestEmitCloudEventsWhenConditionChange(t *testing.T) {
 }
 
 func setupFakeContext(t *testing.T, behaviour FakeClientBehaviour, withClient bool, expectedEventCount int) context.Context {
-	var ctx context.Context
-	ctx, _ = rtesting.SetupFakeContext(t)
+	t.Helper()
+	ctx, _ := rtesting.SetupFakeContext(t)
 	if withClient {
 		ctx = WithClient(ctx, &behaviour, expectedEventCount)
 	}

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -126,12 +126,14 @@ type PipelineRunTest struct {
 // getPipelineRunController returns an instance of the PipelineRun controller/reconciler that has been seeded with
 // d, where d represents the state of the system (existing resources) needed for the test.
 func getPipelineRunController(t *testing.T, d test.Data) (test.Assets, func()) {
+	t.Helper()
 	return initializePipelineRunControllerAssets(t, d, pipeline.Options{Images: images})
 }
 
 // initiailizePipelinerunControllerAssets is a shared helper for
 // controller initialization.
 func initializePipelineRunControllerAssets(t *testing.T, d test.Data, opts pipeline.Options) (test.Assets, func()) {
+	t.Helper()
 	ctx, _ := ttesting.SetupFakeContext(t)
 	ctx = ttesting.SetupFakeCloudClientContext(ctx, d.ExpectedCloudEventCount)
 	ctx, cancel := context.WithCancel(ctx)
@@ -232,9 +234,11 @@ func TestReconcile(t *testing.T) {
 	}
 }
 
+// runTestReconcileWithEmbeddedStatus runs "Reconcile" on a PipelineRun with one
+// Task that has not been started yet.  It verifies that the TaskRun is created,
+// it checks the resulting API actions, status and events.
 func runTestReconcileWithEmbeddedStatus(t *testing.T, embeddedStatus string) {
-	// TestReconcile runs "Reconcile" on a PipelineRun with one Task that has not been started yet.
-	// It verifies that the TaskRun is created, it checks the resulting API actions, status and events.
+	t.Helper()
 	names.TestingSeed()
 	prs := []*v1beta1.PipelineRun{parse.MustParseV1beta1PipelineRun(t, `
 metadata:
@@ -465,7 +469,7 @@ spec:
 		PipelineResources: rs,
 		ConfigMaps:        []*corev1.ConfigMap{withEmbeddedStatus(newFeatureFlagsConfigMap(), embeddedStatus)},
 	}
-	prt := newPipelineRunTest(d, t)
+	prt := newPipelineRunTest(t, d)
 	defer prt.Cancel()
 
 	wantEvents := []string{
@@ -708,7 +712,7 @@ spec:
 				PipelineRuns: []*v1beta1.PipelineRun{tc.pr},
 				ConfigMaps:   cms,
 			}
-			prt := newPipelineRunTest(d, t)
+			prt := newPipelineRunTest(t, d)
 			defer prt.Cancel()
 
 			wantEvents := []string{
@@ -903,7 +907,7 @@ spec:
 				PipelineRuns: []*v1beta1.PipelineRun{tc.pr},
 				ConfigMaps:   cms,
 			}
-			prt := newPipelineRunTest(d, t)
+			prt := newPipelineRunTest(t, d)
 			defer prt.Cancel()
 
 			wantEvents := []string{
@@ -966,6 +970,7 @@ func TestReconcile_PipelineSpecTaskSpec(t *testing.T) {
 }
 
 func runTestReconcilePipelineSpecTaskSpec(t *testing.T, embeddedStatus string) {
+	t.Helper()
 	names.TestingSeed()
 
 	prs := []*v1beta1.PipelineRun{
@@ -998,7 +1003,7 @@ spec:
 		Pipelines:    ps,
 		ConfigMaps:   []*corev1.ConfigMap{withEmbeddedStatus(newFeatureFlagsConfigMap(), embeddedStatus)},
 	}
-	prt := newPipelineRunTest(d, t)
+	prt := newPipelineRunTest(t, d)
 	defer prt.Cancel()
 
 	wantEvents := []string{
@@ -1458,7 +1463,7 @@ spec:
 				Tasks:        ts,
 				ConfigMaps:   cms,
 			}
-			prt := newPipelineRunTest(d, t)
+			prt := newPipelineRunTest(t, d)
 			defer prt.Cancel()
 
 			wantEvents := append(tc.wantEvents, "Warning InternalError 1 error occurred") //nolint
@@ -1569,7 +1574,7 @@ status:
 		Tasks:        ts,
 		TaskRuns:     trs,
 	}
-	prt := newPipelineRunTest(d, t)
+	prt := newPipelineRunTest(t, d)
 	defer prt.Cancel()
 
 	wantEvents := []string{
@@ -1695,9 +1700,11 @@ func TestReconcileOnCancelledPipelineRun(t *testing.T) {
 	}
 }
 
+// runTestReconcileOnCancelledPipelineRun runs "Reconcile" on a PipelineRun that
+// has been cancelled.  It verifies that reconcile is successful, the pipeline
+// status updated and events generated.
 func runTestReconcileOnCancelledPipelineRun(t *testing.T, embeddedStatus string) {
-	// TestReconcileOnCancelledPipelineRun runs "Reconcile" on a PipelineRun that has been cancelled.
-	// It verifies that reconcile is successful, the pipeline status updated and events generated.
+	t.Helper()
 
 	testCases := []struct {
 		name       string
@@ -1727,7 +1734,7 @@ func runTestReconcileOnCancelledPipelineRun(t *testing.T, embeddedStatus string)
 				TaskRuns:     trs,
 				ConfigMaps:   cms,
 			}
-			prt := newPipelineRunTest(d, t)
+			prt := newPipelineRunTest(t, d)
 			defer prt.Cancel()
 
 			wantEvents := []string{
@@ -1802,7 +1809,7 @@ status:
 		ConfigMaps:   cms,
 		CustomRuns:   runs,
 	}
-	prt := newPipelineRunTest(d, t)
+	prt := newPipelineRunTest(t, d)
 	defer prt.Cancel()
 
 	wantEvents := []string{
@@ -1916,7 +1923,7 @@ status:
 				ConfigMaps:   cms,
 				Runs:         runs,
 			}
-			prt := newPipelineRunTest(d, t)
+			prt := newPipelineRunTest(t, d)
 			defer prt.Cancel()
 
 			wantEvents := []string{
@@ -2001,6 +2008,7 @@ func TestReconcileOnCancelledRunFinallyPipelineRun(t *testing.T) {
 }
 
 func runTestReconcileOnCancelledRunFinallyPipelineRun(t *testing.T, embeddedStatus string) {
+	t.Helper()
 	// TestReconcileOnCancelledRunFinallyPipelineRun runs "Reconcile" on a PipelineRun that has been gracefully cancelled.
 	// It verifies that reconcile is successful, the pipeline status updated and events generated.
 	prs := []*v1beta1.PipelineRun{createCancelledPipelineRun(t, "test-pipeline-run-cancelled-run-finally", v1beta1.PipelineRunSpecStatusCancelledRunFinally)}
@@ -2013,7 +2021,7 @@ func runTestReconcileOnCancelledRunFinallyPipelineRun(t *testing.T, embeddedStat
 		Tasks:        ts,
 		ConfigMaps:   cms,
 	}
-	prt := newPipelineRunTest(d, t)
+	prt := newPipelineRunTest(t, d)
 	defer prt.Cancel()
 
 	wantEvents := []string{
@@ -2076,9 +2084,12 @@ func TestReconcileOnCancelledRunFinallyPipelineRunWithFinalTask(t *testing.T) {
 	}
 }
 
+// runTestReconcileOnCancelledRunFinallyPipelineRunWithFinalTask runs
+// "Reconcile" on a PipelineRun that has been gracefully cancelled.  It verifies
+// that reconcile is successful, final tasks run, the pipeline status updated
+// and events generated.
 func runTestReconcileOnCancelledRunFinallyPipelineRunWithFinalTask(t *testing.T, embeddedStatus string) {
-	// TestReconcileOnCancelledRunFinallyPipelineRunWithFinalTask runs "Reconcile" on a PipelineRun that has been gracefully cancelled.
-	// It verifies that reconcile is successful, final tasks run, the pipeline status updated and events generated.
+	t.Helper()
 	prs := []*v1beta1.PipelineRun{createCancelledPipelineRun(t, "test-pipeline-run-cancelled-run-finally", v1beta1.PipelineRunSpecStatusCancelledRunFinally)}
 	ps := []*v1beta1.Pipeline{
 		parse.MustParseV1beta1Pipeline(t, `
@@ -2113,7 +2124,7 @@ spec:
 		Tasks:        ts,
 		ConfigMaps:   cms,
 	}
-	prt := newPipelineRunTest(d, t)
+	prt := newPipelineRunTest(t, d)
 	defer prt.Cancel()
 
 	wantEvents := []string{
@@ -2194,7 +2205,7 @@ spec:
 		Tasks:        ts,
 		TaskRuns:     trs,
 	}
-	prt := newPipelineRunTest(d, t)
+	prt := newPipelineRunTest(t, d)
 	defer prt.Cancel()
 
 	wantEvents := []string{
@@ -2262,6 +2273,7 @@ func TestReconcileOnCancelledRunFinallyPipelineRunWithFinalTaskAndRetries(t *tes
 }
 
 func runTestReconcileOnCancelledRunFinallyPipelineRunWithFinalTaskAndRetries(t *testing.T, embeddedStatus string) {
+	t.Helper()
 	// Pipeline has a DAG task "hello-world-1" and Finally task "hello-world-2"
 	ps := []*v1beta1.Pipeline{{
 		ObjectMeta: baseObjectMeta("test-pipeline", "foo"),
@@ -2342,7 +2354,7 @@ func runTestReconcileOnCancelledRunFinallyPipelineRunWithFinalTaskAndRetries(t *
 		Tasks:        ts,
 		ConfigMaps:   cms,
 	}
-	prt := newPipelineRunTest(d, t)
+	prt := newPipelineRunTest(t, d)
 	defer prt.Cancel()
 
 	wantEvents := []string{
@@ -2546,7 +2558,7 @@ status:
 				Tasks:        ts,
 				TaskRuns:     tc.taskRuns,
 			}
-			prt := newPipelineRunTest(d, t)
+			prt := newPipelineRunTest(t, d)
 			defer prt.Cancel()
 
 			wantEvents := append([]string{}, tc.expectedEvents...)
@@ -2608,7 +2620,7 @@ spec:
 		Tasks:        ts,
 		TaskRuns:     trs,
 	}
-	prt := newPipelineRunTest(d, t)
+	prt := newPipelineRunTest(t, d)
 	defer prt.Cancel()
 
 	var wantEvents []string
@@ -2645,7 +2657,7 @@ status:
 		Pipelines:    ps,
 		Tasks:        ts,
 	}
-	prt := newPipelineRunTest(d, t)
+	prt := newPipelineRunTest(t, d)
 	defer prt.Cancel()
 
 	wantEvents := []string{
@@ -2726,7 +2738,7 @@ spec:
 		Tasks:        ts,
 		TaskRuns:     trs,
 	}
-	prt := newPipelineRunTest(d, t)
+	prt := newPipelineRunTest(t, d)
 	defer prt.Cancel()
 
 	wantEvents := []string{
@@ -2824,7 +2836,7 @@ status:
 		Tasks:        ts,
 		TaskRuns:     trs,
 	}
-	prt := newPipelineRunTest(d, t)
+	prt := newPipelineRunTest(t, d)
 	defer prt.Cancel()
 
 	wantEvents := []string{
@@ -2937,7 +2949,7 @@ spec:
 		Tasks:        ts,
 		TaskRuns:     trs,
 	}
-	prt := newPipelineRunTest(d, t)
+	prt := newPipelineRunTest(t, d)
 	defer prt.Cancel()
 
 	wantEvents := []string{
@@ -3006,7 +3018,7 @@ spec:
 		Pipelines:    ps,
 		Tasks:        ts,
 	}
-	prt := newPipelineRunTest(d, t)
+	prt := newPipelineRunTest(t, d)
 	defer prt.Cancel()
 
 	reconciledRun, clients := prt.reconcileRun("foo", "test-pipeline-run", []string{}, false)
@@ -3311,7 +3323,7 @@ spec:
 		Pipelines:    ps,
 		Tasks:        ts,
 	}
-	prt := newPipelineRunTest(d, t)
+	prt := newPipelineRunTest(t, d)
 	defer prt.Cancel()
 
 	_, clients := prt.reconcileRun("foo", "test-pipeline-run-with-labels", []string{}, false)
@@ -3366,7 +3378,7 @@ spec:
 				Pipelines:    ps,
 				Tasks:        ts,
 			}
-			prt := newPipelineRunTest(d, t)
+			prt := newPipelineRunTest(t, d)
 			defer prt.Cancel()
 
 			_, clients := prt.reconcileRun("foo", "test-pipeline-run-with-labels", []string{}, false)
@@ -3424,7 +3436,7 @@ metadata:
 		Pipelines:    ps,
 		Tasks:        ts,
 	}
-	prt := newPipelineRunTest(d, t)
+	prt := newPipelineRunTest(t, d)
 	defer prt.Cancel()
 
 	_, clients := prt.reconcileRun("foo", "test-pipeline-run-different-service-accs", []string{}, false)
@@ -3504,7 +3516,7 @@ spec:
 		Pipelines:    ps,
 		ConfigMaps:   cms,
 	}
-	prt := newPipelineRunTest(d, t)
+	prt := newPipelineRunTest(t, d)
 	defer prt.Cancel()
 
 	_, clients := prt.reconcileRun("foo", "test-pipeline-run-different-service-accs", []string{}, false)
@@ -3558,7 +3570,7 @@ spec:
 		Pipelines:    ps,
 		Tasks:        ts,
 	}
-	prt := newPipelineRunTest(d, t)
+	prt := newPipelineRunTest(t, d)
 	defer prt.Cancel()
 
 	_, clients := prt.reconcileRun("foo", prName, []string{}, false)
@@ -3626,7 +3638,7 @@ spec:
 		Pipelines:    ps,
 		ConfigMaps:   cms,
 	}
-	prt := newPipelineRunTest(d, t)
+	prt := newPipelineRunTest(t, d)
 	defer prt.Cancel()
 
 	_, clients := prt.reconcileRun("foo", prName, []string{}, false)
@@ -3690,6 +3702,7 @@ func TestReconcileWithWhenExpressionsWithTaskResultsAndParams(t *testing.T) {
 }
 
 func runTestReconcileWithWhenExpressionsWithTaskResultsAndParams(t *testing.T, embeddedStatus string) {
+	t.Helper()
 	names.TestingSeed()
 	ps := []*v1beta1.Pipeline{parse.MustParseV1beta1Pipeline(t, `
 metadata:
@@ -3781,7 +3794,7 @@ status:
 		TaskRuns:     trs,
 		ConfigMaps:   []*corev1.ConfigMap{withEmbeddedStatus(newFeatureFlagsConfigMap(), embeddedStatus)},
 	}
-	prt := newPipelineRunTest(d, t)
+	prt := newPipelineRunTest(t, d)
 	defer prt.Cancel()
 
 	wantEvents := []string{
@@ -3971,7 +3984,7 @@ spec:
 		Pipelines:    ps,
 		Tasks:        ts,
 	}
-	prt := newPipelineRunTest(d, t)
+	prt := newPipelineRunTest(t, d)
 	defer prt.Cancel()
 
 	wantEvents := []string{
@@ -4142,7 +4155,7 @@ status:
 		Tasks:        ts,
 		TaskRuns:     trs,
 	}
-	prt := newPipelineRunTest(d, t)
+	prt := newPipelineRunTest(t, d)
 	defer prt.Cancel()
 
 	wantEvents := []string{
@@ -4260,7 +4273,7 @@ spec:
 		Pipelines:    ps,
 		Tasks:        ts,
 	}
-	prt := newPipelineRunTest(d, t)
+	prt := newPipelineRunTest(t, d)
 	defer prt.Cancel()
 
 	reconciledRun, clients := prt.reconcileRun("foo", pipelineRunName, []string{}, false)
@@ -4373,7 +4386,7 @@ spec:
 		Pipelines:    ps,
 		Tasks:        ts,
 	}
-	prt := newPipelineRunTest(d, t)
+	prt := newPipelineRunTest(t, d)
 	defer prt.Cancel()
 
 	reconciledRun, clients := prt.reconcileRun("foo", pipelineRunName, []string{}, false)
@@ -4506,7 +4519,7 @@ spec:
 		Pipelines:    ps,
 		Tasks:        ts,
 	}
-	prt := newPipelineRunTest(d, t)
+	prt := newPipelineRunTest(t, d)
 	defer prt.Cancel()
 
 	reconciledRun, clients := prt.reconcileRun("foo", "test-pipeline-run", []string{}, false)
@@ -4648,7 +4661,7 @@ status:
 		Tasks:        ts,
 		TaskRuns:     trs,
 	}
-	prt := newPipelineRunTest(d, t)
+	prt := newPipelineRunTest(t, d)
 	defer prt.Cancel()
 
 	_, clients := prt.reconcileRun("foo", "test-pipeline-run-different-service-accs", []string{}, false)
@@ -4736,7 +4749,7 @@ spec:
 		PipelineRuns: prs,
 		Tasks:        ts,
 	}
-	prt := newPipelineRunTest(d, t)
+	prt := newPipelineRunTest(t, d)
 	defer prt.Cancel()
 
 	reconciledRun, clients := prt.reconcileRun("foo", "test-pipeline-run-different-service-accs", []string{}, false)
@@ -4802,6 +4815,7 @@ func TestReconcileWithFinallyResults(t *testing.T) {
 }
 
 func runTestReconcileWithFinallyResults(t *testing.T, embeddedStatus string) {
+	t.Helper()
 	names.TestingSeed()
 	ps := []*v1beta1.Pipeline{parse.MustParseV1beta1Pipeline(t, `
 metadata:
@@ -4915,7 +4929,7 @@ spec:
 		Runs:         rs,
 		ConfigMaps:   []*corev1.ConfigMap{withEmbeddedStatus(newFeatureFlagsConfigMap(), embeddedStatus)},
 	}
-	prt := newPipelineRunTest(d, t)
+	prt := newPipelineRunTest(t, d)
 	defer prt.Cancel()
 	reconciledRun, _ := prt.reconcileRun("foo", "test-pipeline-run-finally-results", []string{}, false)
 
@@ -5184,6 +5198,7 @@ func TestReconcileWithPipelineResults(t *testing.T) {
 }
 
 func runTestReconcileWithPipelineResults(t *testing.T, embeddedStatus string) {
+	t.Helper()
 	names.TestingSeed()
 	ps := []*v1beta1.Pipeline{parse.MustParseV1beta1Pipeline(t, `
 metadata:
@@ -5271,7 +5286,7 @@ spec:
 		ConfigMaps:   []*corev1.ConfigMap{withEmbeddedStatus(newFeatureFlagsConfigMap(), embeddedStatus)},
 	}
 
-	prt := newPipelineRunTest(d, t)
+	prt := newPipelineRunTest(t, d)
 	defer prt.Cancel()
 	reconciledRun, _ := prt.reconcileRun("foo", "test-pipeline-run-results", []string{}, false)
 
@@ -5505,6 +5520,7 @@ func TestReconcileWithPipelineResults_OnFailedPipelineRun(t *testing.T) {
 }
 
 func runTestReconcileWithPipelineResultsOnFailedPipelineRun(t *testing.T, embeddedStatus string) {
+	t.Helper()
 	names.TestingSeed()
 	ps := []*v1beta1.Pipeline{parse.MustParseV1beta1Pipeline(t, `
 metadata:
@@ -5619,7 +5635,7 @@ status:
 		TaskRuns:     trs,
 		ConfigMaps:   []*corev1.ConfigMap{withEmbeddedStatus(newFeatureFlagsConfigMap(), embeddedStatus)},
 	}
-	prt := newPipelineRunTest(d, t)
+	prt := newPipelineRunTest(t, d)
 	defer prt.Cancel()
 
 	reconciledRun, _ := prt.reconcileRun("foo", "test-failed-pr-with-task-results", []string{}, false)
@@ -5790,6 +5806,7 @@ func TestReconcileOutOfSyncPipelineRun(t *testing.T) {
 }
 
 func runTestReconcileOutOfSyncPipelineRun(t *testing.T, embeddedStatus string) {
+	t.Helper()
 	ctx := context.Background()
 
 	prOutOfSyncName := "test-pipeline-run-out-of-sync"
@@ -5904,7 +5921,7 @@ status:
 		Runs:         runs,
 		ConfigMaps:   cms,
 	}
-	prt := newPipelineRunTest(d, t)
+	prt := newPipelineRunTest(t, d)
 	defer prt.Cancel()
 
 	reconciledRun, clients := prt.reconcileRun("foo", prOutOfSync.Name, []string{}, false)
@@ -6071,6 +6088,7 @@ func TestUpdatePipelineRunStatusFromInformer(t *testing.T) {
 }
 
 func runTestUpdatePipelineRunStatusFromInformer(t *testing.T, embeddedStatus string) {
+	t.Helper()
 	names.TestingSeed()
 
 	pr := parse.MustParseV1beta1PipelineRun(t, `
@@ -6100,7 +6118,7 @@ spec:
 		PipelineRuns: []*v1beta1.PipelineRun{pr},
 		ConfigMaps:   cms,
 	}
-	prt := newPipelineRunTest(d, t)
+	prt := newPipelineRunTest(t, d)
 	defer prt.Cancel()
 
 	wantEvents := []string{
@@ -6521,7 +6539,7 @@ func TestReconcilePipeline_FinalTasks(t *testing.T) {
 				Tasks:        tt.ts,
 				TaskRuns:     tt.trs,
 			}
-			prt := newPipelineRunTest(d, t)
+			prt := newPipelineRunTest(t, d)
 			defer prt.Cancel()
 
 			reconciledRun, clients := prt.reconcileRun("foo", tt.pipelineRunName, []string{}, false)
@@ -6610,6 +6628,7 @@ func getPipeline(p string, spec v1beta1.PipelineSpec) []*v1beta1.Pipeline {
 }
 
 func getTaskRun(t *testing.T, tr, pr, p, tl string, status corev1.ConditionStatus) *v1beta1.TaskRun {
+	t.Helper()
 	return createHelloWorldTaskRunWithStatusTaskLabel(t, tr, "foo", pr, p, "", tl,
 		apis.Condition{
 			Type:   apis.ConditionSucceeded,
@@ -6695,7 +6714,7 @@ spec:
 		ConfigMaps:              cms,
 		ExpectedCloudEventCount: len(wantEvents),
 	}
-	prt := newPipelineRunTest(d, t)
+	prt := newPipelineRunTest(t, d)
 	defer prt.Cancel()
 
 	reconciledRun, clients := prt.reconcileRun("foo", "test-pipelinerun", wantEvents, false)
@@ -6745,6 +6764,7 @@ func TestReconcilePipeline_TaskSpecMetadata(t *testing.T) {
 }
 
 func runTestReconcilePipelineTaskSpecMetadata(t *testing.T, embeddedStatus string) {
+	t.Helper()
 	names.TestingSeed()
 
 	prs := []*v1beta1.PipelineRun{
@@ -6790,7 +6810,7 @@ spec:
 		Pipelines:    ps,
 		ConfigMaps:   []*corev1.ConfigMap{withEmbeddedStatus(newFeatureFlagsConfigMap(), embeddedStatus)},
 	}
-	prt := newPipelineRunTest(d, t)
+	prt := newPipelineRunTest(t, d)
 	defer prt.Cancel()
 
 	reconciledRun, clients := prt.reconcileRun("foo", "test-pipeline-run-success", []string{}, false)
@@ -6907,7 +6927,7 @@ status:
 		Tasks:        ts,
 		TaskRuns:     trs,
 	}
-	prt := newPipelineRunTest(d, t)
+	prt := newPipelineRunTest(t, d)
 	defer prt.Cancel()
 
 	_, clients := prt.reconcileRun("foo", pipelineRunName, []string{}, false)
@@ -7085,7 +7105,7 @@ status:
 		Tasks:        ts,
 		TaskRuns:     trs,
 	}
-	prt := newPipelineRunTest(d, t)
+	prt := newPipelineRunTest(t, d)
 	defer prt.Cancel()
 
 	reconciledRun, clients := prt.reconcileRun("foo", "test-pipeline-run-final-task-results", []string{}, false)
@@ -7148,7 +7168,7 @@ spec:
 
 // newPipelineRunTest returns PipelineRunTest with a new PipelineRun controller created with specified state through data
 // This PipelineRunTest can be reused for multiple PipelineRuns by calling reconcileRun for each pipelineRun
-func newPipelineRunTest(data test.Data, t *testing.T) *PipelineRunTest {
+func newPipelineRunTest(t *testing.T, data test.Data) *PipelineRunTest {
 	t.Helper()
 	testAssets, cancel := getPipelineRunController(t, data)
 	return &PipelineRunTest{
@@ -7225,6 +7245,7 @@ func TestReconcile_RemotePipelineRef(t *testing.T) {
 }
 
 func runTestReconcileRemotePipelineRef(t *testing.T, embeddedStatus string) {
+	t.Helper()
 	names.TestingSeed()
 
 	ctx := context.Background()
@@ -7287,7 +7308,7 @@ metadata:
 		ConfigMaps: cms,
 	}
 
-	prt := newPipelineRunTest(d, t)
+	prt := newPipelineRunTest(t, d)
 	defer prt.Cancel()
 
 	wantEvents := []string{
@@ -7356,6 +7377,7 @@ func TestReconcile_OptionalWorkspacesOmitted(t *testing.T) {
 }
 
 func runTestReconcileOptionalWorkspacesOmitted(t *testing.T, embeddedStatus string) {
+	t.Helper()
 	names.TestingSeed()
 
 	ctx := context.Background()
@@ -7394,7 +7416,7 @@ spec:
 		ConfigMaps: []*corev1.ConfigMap{withEmbeddedStatus(newFeatureFlagsConfigMap(), embeddedStatus)},
 	}
 
-	prt := newPipelineRunTest(d, t)
+	prt := newPipelineRunTest(t, d)
 	defer prt.Cancel()
 
 	reconciledRun, clients := prt.reconcileRun("foo", "test-pipeline-run-success", nil, false)
@@ -7507,7 +7529,7 @@ spec:
 		}},
 	}
 
-	prt := newPipelineRunTest(d, t)
+	prt := newPipelineRunTest(t, d)
 	defer prt.Cancel()
 
 	run1, _ := prt.reconcileRun("foo", "pipelinerun-param-invalid-result-variable", nil, true)
@@ -7559,7 +7581,7 @@ spec:
 		}},
 	}
 
-	prt := newPipelineRunTest(d, t)
+	prt := newPipelineRunTest(t, d)
 	defer prt.Cancel()
 
 	wantEvents := []string(nil)
@@ -7634,7 +7656,7 @@ spec:
 		}},
 	}
 
-	prt := newPipelineRunTest(d, t)
+	prt := newPipelineRunTest(t, d)
 	defer prt.Cancel()
 
 	wantEvents := []string(nil)
@@ -7693,7 +7715,7 @@ spec:
 		}},
 	}
 
-	prt := newPipelineRunTest(d, t)
+	prt := newPipelineRunTest(t, d)
 	defer prt.Cancel()
 
 	wantEvents := []string(nil)
@@ -7755,7 +7777,7 @@ spec:
 		}},
 	}
 
-	prt := newPipelineRunTest(d, t)
+	prt := newPipelineRunTest(t, d)
 	defer prt.Cancel()
 
 	wantEvents := []string(nil)
@@ -7882,6 +7904,7 @@ func createHelloWorldTaskRunWithStatus(
 	trName, ns, prName, pName, podName string,
 	condition apis.Condition,
 ) *v1beta1.TaskRun {
+	t.Helper()
 	p := createHelloWorldTaskRun(t, trName, ns, prName, pName)
 	p.Status = v1beta1.TaskRunStatus{
 		Status: duckv1.Status{
@@ -7899,6 +7922,7 @@ func createHelloWorldTaskRunWithStatusTaskLabel(
 	trName, ns, prName, pName, podName, taskLabel string,
 	condition apis.Condition,
 ) *v1beta1.TaskRun {
+	t.Helper()
 	p := createHelloWorldTaskRunWithStatus(t, trName, ns, prName, pName, podName, condition)
 	p.Labels[pipeline.PipelineTaskLabelKey] = taskLabel
 
@@ -7906,6 +7930,7 @@ func createHelloWorldTaskRunWithStatusTaskLabel(
 }
 
 func createHelloWorldTaskRun(t *testing.T, trName, ns, prName, pName string) *v1beta1.TaskRun {
+	t.Helper()
 	return parse.MustParseV1beta1TaskRun(t, fmt.Sprintf(`
 metadata:
   name: %s
@@ -7921,6 +7946,7 @@ spec:
 }
 
 func createCancelledPipelineRun(t *testing.T, prName string, specStatus v1beta1.PipelineRunSpecStatus) *v1beta1.PipelineRun {
+	t.Helper()
 	return parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   name: %s
@@ -8040,24 +8066,28 @@ func filterChildRefsForKind(childRefs []v1beta1.ChildStatusReference, kind strin
 }
 
 func mustParseTaskRunWithObjectMeta(t *testing.T, objectMeta metav1.ObjectMeta, asYAML string) *v1beta1.TaskRun {
+	t.Helper()
 	tr := parse.MustParseV1beta1TaskRun(t, asYAML)
 	tr.ObjectMeta = objectMeta
 	return tr
 }
 
 func mustParseCustomRunWithObjectMeta(t *testing.T, objectMeta metav1.ObjectMeta, asYAML string) *v1beta1.CustomRun {
+	t.Helper()
 	r := parse.MustParseCustomRun(t, asYAML)
 	r.ObjectMeta = objectMeta
 	return r
 }
 
 func mustParseRunWithObjectMeta(t *testing.T, objectMeta metav1.ObjectMeta, asYAML string) *v1alpha1.Run {
+	t.Helper()
 	r := parse.MustParseRun(t, asYAML)
 	r.ObjectMeta = objectMeta
 	return r
 }
 
 func helloWorldPipelineWithRunAfter(t *testing.T) *v1beta1.Pipeline {
+	t.Helper()
 	return parse.MustParseV1beta1Pipeline(t, `
 metadata:
   name: test-pipeline
@@ -8322,7 +8352,7 @@ spec:
 		Pipelines:    ps,
 		Tasks:        ts,
 	}
-	prt := newPipelineRunTest(d, t)
+	prt := newPipelineRunTest(t, d)
 	defer prt.Cancel()
 
 	_, clients := prt.reconcileRun("foo", prName, []string{}, false)
@@ -8393,7 +8423,7 @@ spec:
 		Pipelines:    ps,
 		Tasks:        ts,
 	}
-	prt := newPipelineRunTest(d, t)
+	prt := newPipelineRunTest(t, d)
 	defer prt.Cancel()
 
 	_, clients := prt.reconcileRun("foo", prName, []string{}, false)
@@ -8893,7 +8923,7 @@ spec:
 			if tt.tr != nil {
 				d.TaskRuns = []*v1beta1.TaskRun{tt.tr}
 			}
-			prt := newPipelineRunTest(d, t)
+			prt := newPipelineRunTest(t, d)
 			defer prt.Cancel()
 
 			_, clients := prt.reconcileRun("foo", "pr", []string{}, false)
@@ -9501,7 +9531,7 @@ spec:
 			if tt.tr != nil {
 				d.TaskRuns = []*v1beta1.TaskRun{tt.tr}
 			}
-			prt := newPipelineRunTest(d, t)
+			prt := newPipelineRunTest(t, d)
 			defer prt.Cancel()
 
 			_, clients := prt.reconcileRun("foo", "pr", []string{}, false)
@@ -9963,7 +9993,7 @@ status:
 				PipelineRuns: tt.prs,
 				ConfigMaps:   cms,
 			}
-			prt := newPipelineRunTest(d, t)
+			prt := newPipelineRunTest(t, d)
 			defer prt.Cancel()
 
 			_, clients := prt.reconcileRun("foo", "pr", []string{}, false)
@@ -10495,7 +10525,7 @@ spec:
 			if tt.tr != nil {
 				d.TaskRuns = []*v1beta1.TaskRun{tt.tr}
 			}
-			prt := newPipelineRunTest(d, t)
+			prt := newPipelineRunTest(t, d)
 			defer prt.Cancel()
 
 			_, clients := prt.reconcileRun("foo", "pr", []string{}, false)
@@ -10566,6 +10596,7 @@ func TestReconcile_SetDefaults(t *testing.T) {
 }
 
 func runTestReconcileWithoutDefaults(t *testing.T, embeddedStatus string) {
+	t.Helper()
 	names.TestingSeed()
 	prs := []*v1beta1.PipelineRun{parse.MustParseV1beta1PipelineRun(t, `
 metadata:
@@ -10638,7 +10669,7 @@ spec:
 		ClusterTasks: clusterTasks,
 		ConfigMaps:   []*corev1.ConfigMap{withEmbeddedStatus(newFeatureFlagsConfigMap(), embeddedStatus)},
 	}
-	prt := newPipelineRunTest(d, t)
+	prt := newPipelineRunTest(t, d)
 	defer prt.Cancel()
 
 	wantEvents := []string{
@@ -10811,7 +10842,7 @@ spec:
 				PipelineRuns: []*v1beta1.PipelineRun{tc.pipelineRun},
 				Pipelines:    []*v1beta1.Pipeline{tc.pipeline},
 			}
-			prt := newPipelineRunTest(d, t)
+			prt := newPipelineRunTest(t, d)
 			defer prt.Cancel()
 
 			reconciledRun, clients := prt.reconcileRun("default", tc.pipelineRun.Name, []string{}, false)
@@ -10896,7 +10927,7 @@ spec:
 				Tasks:        ts,
 				ConfigMaps:   cms,
 			}
-			prt := newPipelineRunTest(d, t)
+			prt := newPipelineRunTest(t, d)
 			defer prt.Cancel()
 
 			pr, clients := prt.reconcileRun("foo", pipelineRunName, []string{}, false)
@@ -10989,7 +11020,7 @@ spec:
 		ConfigMaps:           cms,
 		VerificationPolicies: vps,
 	}
-	prt := newPipelineRunTest(d, t)
+	prt := newPipelineRunTest(t, d)
 	defer prt.Cancel()
 
 	reconciledRun, _ := prt.reconcileRun("foo", "test-pipelinerun", []string{}, false)
@@ -11108,7 +11139,7 @@ spec:
 				ConfigMaps:           cms,
 				VerificationPolicies: vps,
 			}
-			prt := newPipelineRunTest(d, t)
+			prt := newPipelineRunTest(t, d)
 			defer prt.Cancel()
 
 			reconciledRun, _ := prt.reconcileRun("foo", "test-pipelinerun", []string{}, true)

--- a/pkg/reconciler/pipelinerun/pipelinerun_updatestatus_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_updatestatus_test.go
@@ -58,6 +58,7 @@ type updateStatusTaskRunsData struct {
 }
 
 func getUpdateStatusTaskRunsData(t *testing.T) updateStatusTaskRunsData {
+	t.Helper()
 	prTask1Yaml := `
 pipelineTaskName: task-1
 status: {}
@@ -446,6 +447,7 @@ type updateStatusChildRefsData struct {
 }
 
 func getUpdateStatusChildRefsData(t *testing.T) updateStatusChildRefsData {
+	t.Helper()
 	prTask1Yaml := `
 apiVersion: tekton.dev/v1beta1
 kind: TaskRun
@@ -1229,6 +1231,7 @@ func prStatusFromInputs(embeddedStatus string, status duckv1.Status, taskRuns ma
 }
 
 func getTestTaskRunsAndRuns(t *testing.T) ([]*v1beta1.TaskRun, []*v1beta1.TaskRun, []*v1beta1.TaskRun, []v1beta1.RunObject, []v1beta1.RunObject, []v1beta1.RunObject) {
+	t.Helper()
 	allTaskRuns := []*v1beta1.TaskRun{
 		parse.MustParseV1beta1TaskRun(t, `
 metadata:
@@ -1311,6 +1314,7 @@ metadata:
 }
 
 func mustParsePipelineRunTaskRunStatus(t *testing.T, yamlStr string) *v1beta1.PipelineRunTaskRunStatus {
+	t.Helper()
 	var output v1beta1.PipelineRunTaskRunStatus
 	if err := yaml.Unmarshal([]byte(yamlStr), &output); err != nil {
 		t.Fatalf("parsing task run status %s: %v", yamlStr, err)
@@ -1319,6 +1323,7 @@ func mustParsePipelineRunTaskRunStatus(t *testing.T, yamlStr string) *v1beta1.Pi
 }
 
 func mustParseChildStatusReference(t *testing.T, yamlStr string) v1beta1.ChildStatusReference {
+	t.Helper()
 	var output v1beta1.ChildStatusReference
 	if err := yaml.Unmarshal([]byte(yamlStr), &output); err != nil {
 		t.Fatalf("parsing task run status %s: %v", yamlStr, err)

--- a/pkg/reconciler/resolutionrequest/resolutionrequest_test.go
+++ b/pkg/reconciler/resolutionrequest/resolutionrequest_test.go
@@ -61,6 +61,7 @@ func getResolutionRequestController(t *testing.T, d test.Data) (test.Assets, fun
 }
 
 func initializeResolutionRequestControllerAssets(t *testing.T, d test.Data) (test.Assets, func()) {
+	t.Helper()
 	ctx, _ := ttesting.SetupFakeContext(t)
 	ctx, cancel := context.WithCancel(ctx)
 	c, informers := test.SeedTestData(t, ctx, d)

--- a/pkg/reconciler/run/run_test.go
+++ b/pkg/reconciler/run/run_test.go
@@ -47,6 +47,7 @@ import (
 )
 
 func initializeRunControllerAssets(t *testing.T, d test.Data) (test.Assets, func()) {
+	t.Helper()
 	ctx, _ := ttesting.SetupFakeContext(t)
 	ctx = ttesting.SetupFakeCloudClientContext(ctx, d.ExpectedCloudEventCount)
 	ctx, cancel := context.WithCancel(ctx)

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -485,6 +485,7 @@ func getTaskRunController(t *testing.T, d test.Data) (test.Assets, func()) {
 }
 
 func initializeTaskRunControllerAssets(t *testing.T, d test.Data, opts pipeline.Options) (test.Assets, func()) {
+	t.Helper()
 	ctx, _ := ttesting.SetupFakeContext(t)
 	ctx = ttesting.SetupFakeCloudClientContext(ctx, d.ExpectedCloudEventCount)
 	ctx, cancel := context.WithCancel(ctx)

--- a/pkg/reconciler/testing/configmap.go
+++ b/pkg/reconciler/testing/configmap.go
@@ -50,6 +50,7 @@ func ConfigMapFromTestFile(t *testing.T, name string) *corev1.ConfigMap {
 
 // EnableFeatureFlagField enables a boolean feature flag in an existing context (for use in testing).
 func EnableFeatureFlagField(ctx context.Context, t *testing.T, flagName string) context.Context {
+	t.Helper()
 	featureFlags, err := config.NewFeatureFlagsFromMap(map[string]string{
 		flagName: "true",
 	})

--- a/pkg/reconciler/testing/logger.go
+++ b/pkg/reconciler/testing/logger.go
@@ -23,6 +23,7 @@ import (
 
 // SetupFakeContext sets up the Context and the fake filtered informers for the tests.
 func SetupFakeContext(t *testing.T) (context.Context, []controller.Informer) {
+	t.Helper()
 	ctx, _, informer := setupFakeContextWithLabelKey(t)
 	return WithLogger(ctx, t), informer
 }
@@ -37,12 +38,14 @@ func SetupFakeCloudClientContext(ctx context.Context, expectedEventCount int) co
 
 // SetupDefaultContext sets up the Context and the default filtered informers for the tests.
 func SetupDefaultContext(t *testing.T) (context.Context, []controller.Informer) {
+	t.Helper()
 	ctx, _, informer := setupDefaultContextWithLabelKey(t)
 	return WithLogger(ctx, t), informer
 }
 
 // WithLogger returns the Logger
 func WithLogger(ctx context.Context, t *testing.T) context.Context {
+	t.Helper()
 	return logging.WithLogger(ctx, TestLogger(t))
 }
 

--- a/pkg/resolution/resolver/bundle/resolver_test.go
+++ b/pkg/resolution/resolver/bundle/resolver_test.go
@@ -520,6 +520,7 @@ type imageRef struct {
 // to map an object to the annotations for it.
 // NOTE: Every image pushed to the registry has a default tag named "latest".
 func pushToRegistry(t *testing.T, registry, imageName string, data []runtime.Object, mapper test.ObjectAnnotationMapper) *imageRef {
+	t.Helper()
 	ref, err := test.CreateImageWithAnnotations(fmt.Sprintf("%s/%s:latest", registry, imageName), mapper, data...)
 	if err != nil {
 		t.Fatalf("couldn't push the image: %v", err)

--- a/pkg/resolution/resolver/git/resolver_test.go
+++ b/pkg/resolution/resolver/git/resolver_test.go
@@ -564,6 +564,7 @@ func TestResolve(t *testing.T) {
 
 // createTestRepo is used to instantiate a local test repository with the desired commits.
 func createTestRepo(t *testing.T, commits []commitForRepo) (string, []string) {
+	t.Helper()
 	commitSHAs := []string{}
 
 	t.Helper()
@@ -685,6 +686,7 @@ func writeAndCommitToTestRepo(t *testing.T, worktree *git.Worktree, repoDir stri
 
 // withTemporaryGitConfig resets the .gitconfig for the duration of the test.
 func withTemporaryGitConfig(t *testing.T) {
+	t.Helper()
 	gitConfigDir := t.TempDir()
 	key := "GIT_CONFIG_GLOBAL"
 	t.Setenv(key, filepath.Join(gitConfigDir, "config"))

--- a/pkg/resolution/resolver/hub/resolver_test.go
+++ b/pkg/resolution/resolver/hub/resolver_test.go
@@ -82,7 +82,7 @@ func TestValidateParams(t *testing.T) {
 
 			err := resolver.ValidateParams(contextWithConfig(), toParams(params))
 			if tc.expectedErr != nil {
-				checkExpectedErr(tc.expectedErr, err, t)
+				checkExpectedErr(t, tc.expectedErr, err)
 			} else if err != nil {
 				t.Fatalf("unexpected error validating params: %v", err)
 			}
@@ -215,7 +215,7 @@ func TestResolveVersion(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			resVer, err := resolveVersion(tc.version, tc.hubType)
 			if tc.expectedErr != nil {
-				checkExpectedErr(tc.expectedErr, err, t)
+				checkExpectedErr(t, tc.expectedErr, err)
 			} else {
 				if err != nil {
 					t.Fatalf("unexpected error resolving, %v", err)
@@ -402,7 +402,7 @@ func TestResolve(t *testing.T) {
 
 			output, err := resolver.Resolve(contextWithConfig(), toParams(params))
 			if tc.expectedErr != nil {
-				checkExpectedErr(tc.expectedErr, err, t)
+				checkExpectedErr(t, tc.expectedErr, err)
 			} else {
 				if err != nil {
 					t.Fatalf("unexpected error resolving: %v", err)
@@ -443,7 +443,8 @@ func contextWithConfig() context.Context {
 	return framework.InjectResolverConfigToContext(context.Background(), config)
 }
 
-func checkExpectedErr(expectedErr, actualErr error, t *testing.T) {
+func checkExpectedErr(t *testing.T, expectedErr, actualErr error) {
+	t.Helper()
 	if actualErr == nil {
 		t.Fatalf("expected err '%v' but didn't get one", expectedErr)
 	}

--- a/pkg/status/status_test.go
+++ b/pkg/status/status_test.go
@@ -516,6 +516,7 @@ pr-run-1:
 }
 
 func mustParseTaskRunStatusMap(t *testing.T, yamlStr string) map[string]*v1beta1.PipelineRunTaskRunStatus {
+	t.Helper()
 	var output map[string]*v1beta1.PipelineRunTaskRunStatus
 	if err := yaml.Unmarshal([]byte(yamlStr), &output); err != nil {
 		t.Fatalf("parsing task run status map %s: %v", yamlStr, err)
@@ -524,6 +525,7 @@ func mustParseTaskRunStatusMap(t *testing.T, yamlStr string) map[string]*v1beta1
 }
 
 func mustParseRunStatusMap(t *testing.T, yamlStr string) map[string]*v1beta1.PipelineRunRunStatus {
+	t.Helper()
 	var output map[string]*v1beta1.PipelineRunRunStatus
 	if err := yaml.Unmarshal([]byte(yamlStr), &output); err != nil {
 		t.Fatalf("parsing run status map %s: %v", yamlStr, err)

--- a/test/cluster_resource_test.go
+++ b/test/cluster_resource_test.go
@@ -84,6 +84,7 @@ func TestClusterResource(t *testing.T) {
 }
 
 func getClusterResource(t *testing.T, name, sname string) *resourcev1alpha1.PipelineResource {
+	t.Helper()
 	return parse.MustParsePipelineResource(t, fmt.Sprintf(`
 metadata:
   name: %s
@@ -122,6 +123,7 @@ func getClusterResourceTaskSecret(namespace, name string) *corev1.Secret {
 }
 
 func getClusterResourceTask(t *testing.T, namespace, name, configName string) *v1beta1.Task {
+	t.Helper()
 	return parse.MustParseV1beta1Task(t, fmt.Sprintf(`
 metadata:
   name: %s
@@ -158,6 +160,7 @@ spec:
 }
 
 func getClusterResourceTaskRun(t *testing.T, namespace, name, taskName, resName string) *v1beta1.TaskRun {
+	t.Helper()
 	return parse.MustParseV1beta1TaskRun(t, fmt.Sprintf(`
 metadata:
   name: %s

--- a/test/controller.go
+++ b/test/controller.go
@@ -129,6 +129,7 @@ type Assets struct {
 
 // AddToInformer returns a function to add ktesting.Actions to the cache store
 func AddToInformer(t *testing.T, store cache.Store) func(ktesting.Action) (bool, runtime.Object, error) {
+	t.Helper()
 	return func(action ktesting.Action) (bool, runtime.Object, error) {
 		switch a := action.(type) {
 		case ktesting.CreateActionImpl:
@@ -175,6 +176,7 @@ func AddToInformer(t *testing.T, store cache.Store) func(ktesting.Action) (bool,
 // given Data.
 // nolint: revive
 func SeedTestData(t *testing.T, ctx context.Context, d Data) (Clients, Informers) {
+	t.Helper()
 	c := Clients{
 		Kube:               fakekubeclient.Get(ctx),
 		Pipeline:           fakepipelineclient.Get(ctx),

--- a/test/custom_task_test.go
+++ b/test/custom_task_test.go
@@ -388,6 +388,7 @@ spec:
 }
 
 func applyController(t *testing.T) {
+	t.Helper()
 	t.Log("Creating Wait Custom Task Controller...")
 	cmd := exec.Command("ko", "apply", "-f", "./config/controller.yaml")
 	cmd.Dir = waitTaskDir
@@ -398,6 +399,7 @@ func applyController(t *testing.T) {
 }
 
 func applyV1Beta1Controller(t *testing.T) {
+	t.Helper()
 	t.Log("Creating Wait v1beta1.CustomRun Custom Task Controller...")
 	cmd := exec.Command("ko", "apply", "-f", "./config/controller.yaml")
 	cmd.Dir = betaWaitTaskDir
@@ -408,6 +410,7 @@ func applyV1Beta1Controller(t *testing.T) {
 }
 
 func cleanUpController(t *testing.T) {
+	t.Helper()
 	t.Log("Tearing down Wait Custom Task Controller...")
 	cmd := exec.Command("ko", "delete", "-f", "./config/controller.yaml")
 	cmd.Dir = waitTaskDir
@@ -418,6 +421,7 @@ func cleanUpController(t *testing.T) {
 }
 
 func cleanUpV1Beta1Controller(t *testing.T) {
+	t.Helper()
 	t.Log("Tearing down Wait v1beta1.CustomRun Custom Task Controller...")
 	cmd := exec.Command("ko", "delete", "-f", "./config/controller.yaml")
 	cmd.Dir = betaWaitTaskDir
@@ -1168,6 +1172,7 @@ func TestWaitCustomTask_V1Beta1_PipelineRun(t *testing.T) {
 }
 
 func setUpCustomTask(ctx context.Context, t *testing.T, fn ...func(context.Context, *testing.T, *clients, string)) (*clients, string) {
+	t.Helper()
 	c, ns := setup(ctx, t, requireAnyGate(neededFeatureFlags))
 	// Note that this may not work if we run e2e tests in parallel since this feature flag forces custom tasks to be
 	// created as v1alpha1.Run with this value. i.e. Don't add t.Parallel() for this test.
@@ -1185,6 +1190,7 @@ func setUpCustomTask(ctx context.Context, t *testing.T, fn ...func(context.Conte
 }
 
 func setUpV1Beta1CustomTask(ctx context.Context, t *testing.T, fn ...func(context.Context, *testing.T, *clients, string)) (*clients, string) {
+	t.Helper()
 	c, ns := setup(ctx, t, requireAnyGate(neededFeatureFlags))
 	// Note that this may not work if we run e2e tests in parallel since this feature flag forces custom tasks to be
 	// created as v1beta1.CustomRuns i.e. Don't add t.Parallel() for this test.

--- a/test/dag_test.go
+++ b/test/dag_test.go
@@ -216,6 +216,7 @@ spec:
 }
 
 func verifyExpectedOrder(ctx context.Context, t *testing.T, c clientset.TaskRunInterface, prName string) {
+	t.Helper()
 	t.Logf("Verifying order of execution")
 
 	taskRunsResp, err := c.List(ctx, metav1.ListOptions{})

--- a/test/duplicate_test.go
+++ b/test/duplicate_test.go
@@ -67,7 +67,7 @@ spec:
 		if _, err := c.V1beta1TaskRunClient.Create(ctx, taskrun, metav1.CreateOptions{}); err != nil {
 			t.Fatalf("Error creating taskrun: %v", err)
 		}
-		go func(t *testing.T) {
+		go func(t *testing.T) { //nolint: thelper
 			defer wg.Done()
 
 			if err := WaitForTaskRunState(ctx, c, taskrunName, TaskRunSucceed(taskrunName), "TaskRunDuplicatePodTaskRunFailed", v1beta1Version); err != nil {

--- a/test/embed_test.go
+++ b/test/embed_test.go
@@ -71,6 +71,7 @@ func TestTaskRun_EmbeddedResource(t *testing.T) {
 }
 
 func getEmbeddedTask(t *testing.T, taskName, namespace string, args []string) *v1beta1.Task {
+	t.Helper()
 	var argsForYaml []string
 	for _, s := range args {
 		argsForYaml = append(argsForYaml, fmt.Sprintf("'%s'", s))
@@ -94,6 +95,7 @@ spec:
 }
 
 func getEmbeddedTaskRun(t *testing.T, trName, namespace, taskName string) *v1beta1.TaskRun {
+	t.Helper()
 	return parse.MustParseV1beta1TaskRun(t, fmt.Sprintf(`
 metadata:
   name: %s

--- a/test/featureflags.go
+++ b/test/featureflags.go
@@ -20,6 +20,7 @@ import (
 // the test if it cannot get the feature-flag configmap.
 func requireAnyGate(gates map[string]string) func(context.Context, *testing.T, *clients, string) {
 	return func(ctx context.Context, t *testing.T, c *clients, namespace string) {
+		t.Helper()
 		featureFlagsCM, err := c.KubeClient.CoreV1().ConfigMaps(system.Namespace()).Get(ctx, config.GetFeatureFlagsConfigName(), metav1.GetOptions{})
 		if err != nil {
 			t.Fatalf("Failed to get ConfigMap `%s`: %s", config.GetFeatureFlagsConfigName(), err)
@@ -57,6 +58,7 @@ func requireAnyGate(gates map[string]string) func(context.Context, *testing.T, *
 // the test if it cannot get the feature-flag configmap.
 func requireAllGates(gates map[string]string) func(context.Context, *testing.T, *clients, string) {
 	return func(ctx context.Context, t *testing.T, c *clients, namespace string) {
+		t.Helper()
 		featureFlagsCM, err := c.KubeClient.CoreV1().ConfigMaps(system.Namespace()).Get(ctx, config.GetFeatureFlagsConfigName(), metav1.GetOptions{})
 		if err != nil {
 			t.Fatalf("Failed to get ConfigMap `%s`: %s", config.GetFeatureFlagsConfigName(), err)
@@ -91,6 +93,7 @@ func requireAllGates(gates map[string]string) func(context.Context, *testing.T, 
 // GetEmbeddedStatus gets the current value for the "embedded-status" feature flag.
 // If the flag is not set, it returns the default value.
 func GetEmbeddedStatus(ctx context.Context, t *testing.T, kubeClient kubernetes.Interface) string {
+	t.Helper()
 	featureFlagsCM, err := kubeClient.CoreV1().ConfigMaps(system.Namespace()).Get(ctx, config.GetFeatureFlagsConfigName(), metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Failed to get ConfigMap `%s`: %s", config.GetFeatureFlagsConfigName(), err)

--- a/test/hermetic_taskrun_test.go
+++ b/test/hermetic_taskrun_test.go
@@ -84,6 +84,7 @@ func TestHermeticTaskRun(t *testing.T) {
 }
 
 func taskRun(t *testing.T, name, namespace, executionMode string) *v1beta1.TaskRun {
+	t.Helper()
 	return parse.MustParseV1beta1TaskRun(t, fmt.Sprintf(`
 metadata:
   annotations:
@@ -107,6 +108,7 @@ spec:
 }
 
 func unpriviligedTaskRun(t *testing.T, name, namespace, executionMode string) *v1beta1.TaskRun {
+	t.Helper()
 	return parse.MustParseV1beta1TaskRun(t, fmt.Sprintf(`
 metadata:
   annotations:

--- a/test/init_test.go
+++ b/test/init_test.go
@@ -54,6 +54,7 @@ func init() {
 }
 
 func setup(ctx context.Context, t *testing.T, fn ...func(context.Context, *testing.T, *clients, string)) (*clients, string) {
+	t.Helper()
 	skipIfExcluded(t)
 
 	t.Helper()
@@ -132,6 +133,7 @@ func tearDown(ctx context.Context, t *testing.T, cs *clients, namespace string) 
 }
 
 func initializeLogsAndMetrics(t *testing.T) {
+	t.Helper()
 	initMetrics.Do(func() {
 		flag.Parse()
 		flag.Set("alsologtostderr", "true")
@@ -144,6 +146,7 @@ func initializeLogsAndMetrics(t *testing.T) {
 }
 
 func createNamespace(ctx context.Context, t *testing.T, namespace string, kubeClient kubernetes.Interface) {
+	t.Helper()
 	t.Logf("Create namespace %s to deploy to", namespace)
 	labels := map[string]string{
 		"tekton.dev/test-e2e": "true",
@@ -159,6 +162,7 @@ func createNamespace(ctx context.Context, t *testing.T, namespace string, kubeCl
 }
 
 func getDefaultSA(ctx context.Context, t *testing.T, kubeClient kubernetes.Interface, namespace string) string {
+	t.Helper()
 	configDefaultsCM, err := kubeClient.CoreV1().ConfigMaps(system.Namespace()).Get(ctx, config.GetDefaultsConfigName(), metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Failed to get ConfigMap `%s`: %s", config.GetDefaultsConfigName(), err)
@@ -171,6 +175,7 @@ func getDefaultSA(ctx context.Context, t *testing.T, kubeClient kubernetes.Inter
 }
 
 func verifyServiceAccountExistence(ctx context.Context, t *testing.T, namespace string, kubeClient kubernetes.Interface) {
+	t.Helper()
 	defaultSA := getDefaultSA(ctx, t, kubeClient, namespace)
 	t.Logf("Verify SA %q is created in namespace %q", defaultSA, namespace)
 

--- a/test/kaniko_task_test.go
+++ b/test/kaniko_task_test.go
@@ -134,6 +134,7 @@ func TestKanikoTaskRun(t *testing.T) {
 }
 
 func getGitResource(t *testing.T) *v1alpha1.PipelineResource {
+	t.Helper()
 	return parse.MustParsePipelineResource(t, fmt.Sprintf(`
 metadata:
   name: %s
@@ -148,6 +149,7 @@ spec:
 }
 
 func getImageResource(t *testing.T, repo string) *v1alpha1.PipelineResource {
+	t.Helper()
 	return parse.MustParsePipelineResource(t, fmt.Sprintf(`
 metadata:
   name: %s
@@ -160,6 +162,7 @@ spec:
 }
 
 func getTask(t *testing.T, repo, namespace string) *v1beta1.Task {
+	t.Helper()
 	return parse.MustParseV1beta1Task(t, fmt.Sprintf(`
 metadata:
   name: %s
@@ -191,6 +194,7 @@ spec:
 }
 
 func getTaskRun(t *testing.T, namespace, task, git, image string) *v1beta1.TaskRun {
+	t.Helper()
 	return parse.MustParseV1beta1TaskRun(t, fmt.Sprintf(`
 metadata:
   name: %s

--- a/test/ko_test.go
+++ b/test/ko_test.go
@@ -26,12 +26,11 @@ import (
 	"testing"
 )
 
-var (
-	// Wether missing KO_DOCKER_REPO environment variable should be fatal or not
-	missingKoFatal = "true"
-)
+// missingKoFatal makes missing KO_DOCKER_REPO envvar fatal or optional
+var missingKoFatal = "true"
 
 func ensureDockerRepo(t *testing.T) string {
+	t.Helper()
 	repo, err := getDockerRepo()
 	if err != nil {
 		if missingKoFatal == "false" {

--- a/test/larger_results_sidecar_logs_test.go
+++ b/test/larger_results_sidecar_logs_test.go
@@ -121,6 +121,7 @@ func TestLargerResultsSidecarLogs(t *testing.T) {
 }
 
 func getLargerResultsPipelineRun(t *testing.T, namespace string) (*v1beta1.PipelineRun, *v1beta1.PipelineRun, []*v1beta1.TaskRun) {
+	t.Helper()
 	pipelineRun := parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   name: larger-results-sidecar-logs
@@ -373,6 +374,7 @@ status:
 }
 
 func setUpSidecarLogs(ctx context.Context, t *testing.T, fn ...func(context.Context, *testing.T, *clients, string)) (*clients, string) {
+	t.Helper()
 	c, ns := setup(ctx, t)
 	configMapData := map[string]string{
 		"results-from": "sidecar-logs",

--- a/test/multiarch_utils.go
+++ b/test/multiarch_utils.go
@@ -109,6 +109,7 @@ func getTestImage(image int) string {
 
 // skipIfExcluded checks if test name is in the excluded list and skip it
 func skipIfExcluded(t *testing.T) {
+	t.Helper()
 	if excludedTests.Has(t.Name()) {
 		t.Skipf("skip for %s architecture", getTestArch())
 	}

--- a/test/parse/yaml.go
+++ b/test/parse/yaml.go
@@ -27,6 +27,7 @@ import (
 
 // MustParseV1beta1TaskRun takes YAML and parses it into a *v1beta1.TaskRun
 func MustParseV1beta1TaskRun(t *testing.T, yaml string) *v1beta1.TaskRun {
+	t.Helper()
 	var tr v1beta1.TaskRun
 	yaml = `apiVersion: tekton.dev/v1beta1
 kind: TaskRun
@@ -37,6 +38,7 @@ kind: TaskRun
 
 // MustParseV1TaskRun takes YAML and parses it into a *v1.TaskRun
 func MustParseV1TaskRun(t *testing.T, yaml string) *v1.TaskRun {
+	t.Helper()
 	var tr v1.TaskRun
 	yaml = `apiVersion: tekton.dev/v1
 kind: TaskRun
@@ -47,6 +49,7 @@ kind: TaskRun
 
 // MustParseRun takes YAML and parses it into a *v1alpha1.Run
 func MustParseRun(t *testing.T, yaml string) *v1alpha1.Run {
+	t.Helper()
 	var r v1alpha1.Run
 	yaml = `apiVersion: tekton.dev/v1alpha1
 kind: Run
@@ -57,6 +60,7 @@ kind: Run
 
 // MustParseV1beta1Task takes YAML and parses it into a *v1beta1.Task
 func MustParseV1beta1Task(t *testing.T, yaml string) *v1beta1.Task {
+	t.Helper()
 	var task v1beta1.Task
 	yaml = `apiVersion: tekton.dev/v1beta1
 kind: Task
@@ -67,6 +71,7 @@ kind: Task
 
 // MustParseCustomRun takes YAML and parses it into a *v1beta1.CustomRun
 func MustParseCustomRun(t *testing.T, yaml string) *v1beta1.CustomRun {
+	t.Helper()
 	var r v1beta1.CustomRun
 	yaml = `apiVersion: tekton.dev/v1beta1
 kind: CustomRun
@@ -77,6 +82,7 @@ kind: CustomRun
 
 // MustParseV1Task takes YAML and parses it into a *v1.Task
 func MustParseV1Task(t *testing.T, yaml string) *v1.Task {
+	t.Helper()
 	var task v1.Task
 	yaml = `apiVersion: tekton.dev/v1
 kind: Task
@@ -87,6 +93,7 @@ kind: Task
 
 // MustParseClusterTask takes YAML and parses it into a *v1beta1.ClusterTask
 func MustParseClusterTask(t *testing.T, yaml string) *v1beta1.ClusterTask {
+	t.Helper()
 	var clusterTask v1beta1.ClusterTask
 	yaml = `apiVersion: tekton.dev/v1beta1
 kind: ClusterTask
@@ -97,6 +104,7 @@ kind: ClusterTask
 
 // MustParseV1beta1PipelineRun takes YAML and parses it into a *v1beta1.PipelineRun
 func MustParseV1beta1PipelineRun(t *testing.T, yaml string) *v1beta1.PipelineRun {
+	t.Helper()
 	var pr v1beta1.PipelineRun
 	yaml = `apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
@@ -107,6 +115,7 @@ kind: PipelineRun
 
 // MustParseV1PipelineRun takes YAML and parses it into a *v1.PipelineRun
 func MustParseV1PipelineRun(t *testing.T, yaml string) *v1.PipelineRun {
+	t.Helper()
 	var pr v1.PipelineRun
 	yaml = `apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -117,6 +126,7 @@ kind: PipelineRun
 
 // MustParseV1beta1Pipeline takes YAML and parses it into a *v1beta1.Pipeline
 func MustParseV1beta1Pipeline(t *testing.T, yaml string) *v1beta1.Pipeline {
+	t.Helper()
 	var pipeline v1beta1.Pipeline
 	yaml = `apiVersion: tekton.dev/v1beta1
 kind: Pipeline
@@ -127,6 +137,7 @@ kind: Pipeline
 
 // MustParseV1Pipeline takes YAML and parses it into a *v1.Pipeline
 func MustParseV1Pipeline(t *testing.T, yaml string) *v1.Pipeline {
+	t.Helper()
 	var pipeline v1.Pipeline
 	yaml = `apiVersion: tekton.dev/v1
 kind: Pipeline
@@ -137,6 +148,7 @@ kind: Pipeline
 
 // MustParsePipelineResource takes YAML and parses it into a *resourcev1alpha1.PipelineResource
 func MustParsePipelineResource(t *testing.T, yaml string) *resourcev1alpha1.PipelineResource {
+	t.Helper()
 	var resource resourcev1alpha1.PipelineResource
 	yaml = `apiVersion: tekton.dev/v1alpha1
 kind: PipelineResource
@@ -147,6 +159,7 @@ kind: PipelineResource
 
 // MustParseVerificationPolicy takes YAML and parses it into a *v1alpha1.VerificationPolicy
 func MustParseVerificationPolicy(t *testing.T, yaml string) *v1alpha1.VerificationPolicy {
+	t.Helper()
 	var v v1alpha1.VerificationPolicy
 	yaml = `apiVersion: tekton.dev/v1alpha1
 kind: VerificationPolicy
@@ -156,6 +169,7 @@ kind: VerificationPolicy
 }
 
 func mustParseYAML(t *testing.T, yaml string, i runtime.Object) {
+	t.Helper()
 	if _, _, err := scheme.Codecs.UniversalDeserializer().Decode([]byte(yaml), nil, i); err != nil {
 		t.Fatalf("mustParseYAML (%s): %v", yaml, err)
 	}

--- a/test/pipelinefinally_test.go
+++ b/test/pipelinefinally_test.go
@@ -717,6 +717,7 @@ func isCancelled(t *testing.T, taskRunName string, conds duckv1.Conditions) bool
 }
 
 func getSuccessTask(t *testing.T, namespace string) *v1beta1.Task {
+	t.Helper()
 	return parse.MustParseV1beta1Task(t, fmt.Sprintf(`
 metadata:
   name: %s
@@ -729,6 +730,7 @@ spec:
 }
 
 func getFailTask(t *testing.T, namespace string) *v1beta1.Task {
+	t.Helper()
 	return parse.MustParseV1beta1Task(t, fmt.Sprintf(`
 metadata:
   name: %s
@@ -741,6 +743,7 @@ spec:
 }
 
 func getDelaySuccessTask(t *testing.T, namespace string) *v1beta1.Task {
+	t.Helper()
 	return parse.MustParseV1beta1Task(t, fmt.Sprintf(`
 metadata:
   name: %s
@@ -753,6 +756,7 @@ spec:
 }
 
 func getTaskVerifyingStatus(t *testing.T, namespace string) *v1beta1.Task {
+	t.Helper()
 	return parse.MustParseV1beta1Task(t, fmt.Sprintf(`
 metadata:
   name: %s
@@ -770,6 +774,7 @@ spec:
 }
 
 func getSuccessTaskProducingResults(t *testing.T, namespace string) *v1beta1.Task {
+	t.Helper()
 	return parse.MustParseV1beta1Task(t, fmt.Sprintf(`
 metadata:
   name: %s
@@ -784,6 +789,7 @@ spec:
 }
 
 func getDelaySuccessTaskProducingResults(t *testing.T, namespace string) *v1beta1.Task {
+	t.Helper()
 	return parse.MustParseV1beta1Task(t, fmt.Sprintf(`
 metadata:
   name: %s
@@ -798,6 +804,7 @@ spec:
 }
 
 func getSuccessTaskConsumingResults(t *testing.T, namespace string, paramName string) *v1beta1.Task {
+	t.Helper()
 	return parse.MustParseV1beta1Task(t, fmt.Sprintf(`
 metadata:
   name: %s
@@ -812,6 +819,7 @@ spec:
 }
 
 func getPipelineRun(t *testing.T, namespace, p string) *v1beta1.PipelineRun {
+	t.Helper()
 	return parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   name: %s

--- a/test/pipelinerun_test.go
+++ b/test/pipelinerun_test.go
@@ -404,6 +404,7 @@ spec:
 }
 
 func getUpdatedStatusSpecPipeline(t *testing.T, namespace string, taskName string) *v1beta1.Pipeline {
+	t.Helper()
 	return parse.MustParseV1beta1Pipeline(t, fmt.Sprintf(`
 metadata:
   name: pipeline-status-spec-updated
@@ -423,6 +424,7 @@ spec:
 }
 
 func getHelloWorldPipelineWithSingularTask(t *testing.T, namespace string, taskName string) *v1beta1.Pipeline {
+	t.Helper()
 	return parse.MustParseV1beta1Pipeline(t, fmt.Sprintf(`
 metadata:
   name: %s
@@ -603,6 +605,7 @@ spec:
 }
 
 func getFanInFanOutTasks(t *testing.T, namespace string) map[string]*v1beta1.Task {
+	t.Helper()
 	return map[string]*v1beta1.Task{
 		"create-file": parse.MustParseV1beta1Task(t, fmt.Sprintf(`
 metadata:
@@ -695,6 +698,7 @@ spec:
 }
 
 func getFanInFanOutPipeline(t *testing.T, namespace string, tasks map[string]*v1beta1.Task) *v1beta1.Pipeline {
+	t.Helper()
 	return parse.MustParseV1beta1Pipeline(t, fmt.Sprintf(`
 metadata:
   name: %s
@@ -753,6 +757,7 @@ spec:
 }
 
 func getFanInFanOutGitResources(t *testing.T) map[string]*v1alpha1.PipelineResource {
+	t.Helper()
 	return map[string]*v1alpha1.PipelineResource{
 		"kritis-resource-git": parse.MustParsePipelineResource(t, fmt.Sprintf(`
 metadata:
@@ -779,6 +784,7 @@ func getPipelineRunServiceAccount(suffix int, namespace string) *corev1.ServiceA
 	}
 }
 func getFanInFanOutPipelineRun(t *testing.T, _ int, namespace string, pipelineName string, resources map[string]*v1alpha1.PipelineResource) *v1beta1.PipelineRun {
+	t.Helper()
 	return parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   name: %s
@@ -823,6 +829,7 @@ func getPipelineRunSecret(suffix int, namespace string) *corev1.Secret {
 }
 
 func getUpdatedStatusSpecPipelineRun(t *testing.T, _ int, namespace string, pipelineName string, _ map[string]*v1alpha1.PipelineResource) *v1beta1.PipelineRun {
+	t.Helper()
 	return parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   name: "pipeline-task-update"
@@ -838,6 +845,7 @@ spec:
 }
 
 func getHelloWorldPipelineRun(t *testing.T, suffix int, namespace string, pipelineName string, _ map[string]*v1alpha1.PipelineResource) *v1beta1.PipelineRun {
+	t.Helper()
 	return parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   labels:
@@ -896,6 +904,7 @@ func collectMatchingEvents(ctx context.Context, kubeClient kubernetes.Interface,
 // checkLabelPropagation checks that labels are correctly propagating from
 // Pipelines, PipelineRuns, and Tasks to TaskRuns and Pods.
 func checkLabelPropagation(ctx context.Context, t *testing.T, c *clients, namespace string, pipelineRunName string, tr *v1beta1.TaskRun) {
+	t.Helper()
 	// Our controllers add 4 labels automatically. If custom labels are set on
 	// the Pipeline, PipelineRun, or Task then the map will have to be resized.
 	labels := make(map[string]string, 4)
@@ -949,6 +958,7 @@ func checkLabelPropagation(ctx context.Context, t *testing.T, c *clients, namesp
 // checkAnnotationPropagation checks that annotations are correctly propagating from
 // Pipelines, PipelineRuns, and Tasks to TaskRuns and Pods.
 func checkAnnotationPropagation(ctx context.Context, t *testing.T, c *clients, namespace string, pipelineRunName string, tr *v1beta1.TaskRun) {
+	t.Helper()
 	annotations := make(map[string]string)
 
 	// Check annotation propagation to PipelineRuns.
@@ -986,6 +996,7 @@ func checkAnnotationPropagation(ctx context.Context, t *testing.T, c *clients, n
 }
 
 func getPodForTaskRun(ctx context.Context, t *testing.T, kubeClient kubernetes.Interface, namespace string, tr *v1beta1.TaskRun) *corev1.Pod {
+	t.Helper()
 	// The Pod name has a random suffix, so we filter by label to find the one we care about.
 	pods, err := kubeClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: pipeline.TaskRunLabelKey + " = " + tr.Name,
@@ -1000,6 +1011,7 @@ func getPodForTaskRun(ctx context.Context, t *testing.T, kubeClient kubernetes.I
 }
 
 func assertLabelsMatch(t *testing.T, expectedLabels, actualLabels map[string]string) {
+	t.Helper()
 	for key, expectedVal := range expectedLabels {
 		if actualVal := actualLabels[key]; actualVal != expectedVal {
 			t.Errorf("Expected labels containing %s=%s but labels were %v", key, expectedVal, actualLabels)
@@ -1008,6 +1020,7 @@ func assertLabelsMatch(t *testing.T, expectedLabels, actualLabels map[string]str
 }
 
 func assertAnnotationsMatch(t *testing.T, expectedAnnotations, actualAnnotations map[string]string) {
+	t.Helper()
 	for key, expectedVal := range expectedAnnotations {
 		if actualVal := actualAnnotations[key]; actualVal != expectedVal {
 			t.Errorf("Expected annotations containing %s=%s but annotations were %v", key, expectedVal, actualAnnotations)

--- a/test/propagated_params_test.go
+++ b/test/propagated_params_test.go
@@ -135,6 +135,7 @@ func TestPropagatedParams(t *testing.T) {
 }
 
 func getPropagatedParamPipelineRun(t *testing.T, namespace string) (*v1beta1.PipelineRun, *v1beta1.PipelineRun, []*v1beta1.TaskRun) {
+	t.Helper()
 	pipelineRun := parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   name: propagated-parameters-fully
@@ -252,6 +253,7 @@ status:
 }
 
 func getPropagatedParamTaskLevelPipelineRun(t *testing.T, namespace string) (*v1beta1.PipelineRun, *v1beta1.PipelineRun, []*v1beta1.TaskRun) {
+	t.Helper()
 	pipelineRun := parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   name: propagated-parameters-task-level
@@ -336,6 +338,7 @@ status:
 }
 
 func getPropagatedParamTaskLevelDefaultPipelineRun(t *testing.T, namespace string) (*v1beta1.PipelineRun, *v1beta1.PipelineRun, []*v1beta1.TaskRun) {
+	t.Helper()
 	pipelineRun := parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   name: propagated-parameters-default-task-level

--- a/test/registry_test.go
+++ b/test/registry_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func withRegistry(ctx context.Context, t *testing.T, c *clients, namespace string) {
+	t.Helper()
 	deployment := getRegistryDeployment(namespace)
 	if _, err := c.KubeClient.AppsV1().Deployments(namespace).Create(ctx, deployment, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create the local registry deployment: %v", err)

--- a/test/retry_test.go
+++ b/test/retry_test.go
@@ -161,6 +161,7 @@ spec:
 // This method is necessary because PipelineRunTaskRunStatus and TaskRunStatus
 // don't have an IsFailed method.
 func isFailed(t *testing.T, taskRunName string, conds duckv1.Conditions) bool {
+	t.Helper()
 	for _, c := range conds {
 		if c.Type == apis.ConditionSucceeded {
 			if c.Status != corev1.ConditionFalse {

--- a/test/status_test.go
+++ b/test/status_test.go
@@ -233,6 +233,7 @@ func TestProvenanceFieldInPipelineRunTaskRunStatus(t *testing.T) {
 }
 
 func getExampleTask(t *testing.T, taskName, namespace string) *v1beta1.Task {
+	t.Helper()
 	return parse.MustParseV1beta1Task(t, fmt.Sprintf(`
 metadata:
   name: %s
@@ -250,6 +251,7 @@ spec:
 }
 
 func getExamplePipeline(t *testing.T, pipelineName, taskName, namespace string) *v1beta1.Pipeline {
+	t.Helper()
 	return parse.MustParseV1beta1Pipeline(t, fmt.Sprintf(`
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline
@@ -272,6 +274,7 @@ spec:
 }
 
 func getExamplePipelineRun(t *testing.T, prName, pipelineName, namespace string) *v1beta1.PipelineRun {
+	t.Helper()
 	return parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
 metadata:
   name: %s

--- a/test/trusted_resources_test.go
+++ b/test/trusted_resources_test.go
@@ -422,6 +422,7 @@ spec:
 }
 
 func setupResourceVerificationConfig(ctx context.Context, t *testing.T, keyInConfigMap bool, fn ...func(context.Context, *testing.T, *clients, string)) (*clients, string, string, signature.Signer) {
+	t.Helper()
 	c, ns := setup(ctx, t, requireAnyGate(neededFeatureFlags))
 	secretName, signer := setSecretAndConfig(ctx, t, c.KubeClient, ns, keyInConfigMap)
 	return c, ns, secretName, signer
@@ -468,6 +469,7 @@ func setSecretAndConfig(ctx context.Context, t *testing.T, client kubernetes.Int
 }
 
 func removeResourceVerificationConfig(ctx context.Context, t *testing.T, c *clients, namespace string, secretName string) {
+	t.Helper()
 	resetSecretAndConfig(ctx, t, c.KubeClient, secretName, namespace)
 	tearDown(ctx, t, c, namespace)
 }


### PR DESCRIPTION
# Changes

This linter cleans up our test output by omiting helper functions from test failure messages, instead labeling the failure with the calling function's details. This makes it easier to locate the true origin of the failure.

There are no expected functional changes in this PR.

The code changes in this PR are all changes to testing code to comply with Go style and best practices, specifically `t.Helper`:

- https://pkg.go.dev/testing#T.Helper
- https://goo.gle/go-style/best-practices#error-handling-in-test-helpers

Context: https://github.com/tektoncd/pipeline/issues/5899

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [N/A] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [N/A] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [N/A] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
