### PR TITLE
Cleanup: fix failures from updated `golangci-lint`.

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -101,7 +101,7 @@ func main() {
 	go func() {
 		// start the web server on port and accept requests
 		log.Printf("Readiness and health check server listening on port %s", port)
-		log.Fatal(http.ListenAndServe(":"+port, mux))
+		log.Fatal(http.ListenAndServe(":"+port, mux)) // #nosec G114 -- see https://github.com/securego/gosec#available-rules
 	}()
 
 	ctx = filteredinformerfactory.WithSelectors(ctx, v1beta1.ManagedByLabelKey)

--- a/cmd/entrypoint/runner.go
+++ b/cmd/entrypoint/runner.go
@@ -8,7 +8,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/git-init/main.go
+++ b/cmd/git-init/main.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/imagedigestexporter/main.go
+++ b/cmd/imagedigestexporter/main.go
@@ -33,7 +33,9 @@ var (
 	terminationMessagePath = flag.String("terminationMessagePath", "/tekton/termination", "Location of file containing termination message")
 )
 
-/* The input of this go program will be a JSON string with all the output PipelineResources of type
+/*
+	The input of this go program will be a JSON string with all the output PipelineResources of type
+
 Image, which will include the path to where the index.json file will be located. The program will
 read the related index.json file(s) and log another JSON string including the name of the image resource
 and the digests.

--- a/cmd/pullrequest-init/main.go
+++ b/cmd/pullrequest-init/main.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -242,7 +242,7 @@ func main() {
 	go func() {
 		// start the web server on port and accept requests
 		log.Printf("Readiness and health check server listening on port %s", port)
-		log.Fatal(http.ListenAndServe(":"+port, mux))
+		log.Fatal(http.ListenAndServe(":"+port, mux)) // #nosec G114 -- see https://github.com/securego/gosec#available-rules
 	}()
 
 	sharedmain.MainWithContext(ctx, serviceName,

--- a/pkg/apis/pipeline/pod/template.go
+++ b/pkg/apis/pipeline/pod/template.go
@@ -155,6 +155,7 @@ func (tpl *Template) ToAffinityAssistantTemplate() *AffinityAssistantTemplate {
 }
 
 // PodTemplate holds pod specific configuration
+//
 //nolint:revive
 type PodTemplate = Template
 

--- a/pkg/apis/pipeline/v1/container_types.go
+++ b/pkg/apis/pipeline/v1/container_types.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/apis/pipeline/v1/taskrun_defaults_test.go
+++ b/pkg/apis/pipeline/v1/taskrun_defaults_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/apis/pipeline/v1beta1/resource_types_validation.go
+++ b/pkg/apis/pipeline/v1beta1/resource_types_validation.go
@@ -73,9 +73,9 @@ func (tr *TaskRunResources) Validate(ctx context.Context) *apis.FieldError {
 }
 
 // validateTaskRunResources validates that
-//	1. resource is not declared more than once
-//	2. if both resource reference and resource spec is defined at the same time
-//	3. at least resource ref or resource spec is defined
+//  1. resource is not declared more than once
+//  2. if both resource reference and resource spec is defined at the same time
+//  3. at least resource ref or resource spec is defined
 func validateTaskRunResources(ctx context.Context, resources []TaskResourceBinding, path string) *apis.FieldError {
 	encountered := sets.NewString()
 	for _, r := range resources {

--- a/pkg/apis/pipeline/v1beta1/taskrun_defaults_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_defaults_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/controller/filter.go
+++ b/pkg/controller/filter.go
@@ -34,10 +34,10 @@ import (
 // For example, a controller impl that wants to be notified of updates to Runs
 // which reference a Task with apiVersion "example.dev/v0" and kind "Example":
 //
-//     runinformer.Get(ctx).Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-//       FilterFunc: FilterRunRef("example.dev/v0", "Example"),
-//       Handler:    controller.HandleAll(impl.Enqueue),
-//     })
+//	runinformer.Get(ctx).Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+//	  FilterFunc: FilterRunRef("example.dev/v0", "Example"),
+//	  Handler:    controller.HandleAll(impl.Enqueue),
+//	})
 func FilterRunRef(apiVersion, kind string) func(interface{}) bool {
 	return func(obj interface{}) bool {
 		r, ok := obj.(*v1alpha1.Run)
@@ -67,10 +67,10 @@ func FilterRunRef(apiVersion, kind string) func(interface{}) bool {
 // For example, a controller impl that wants to be notified of updates to TaskRuns that are controlled by
 // a Run which references a custom task with apiVersion "example.dev/v0" and kind "Example":
 //
-//     taskruninformer.Get(ctx).Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-//       FilterFunc: FilterOwnerRunRef("example.dev/v0", "Example"),
-//       Handler:    controller.HandleAll(impl.Enqueue),
-//     })
+//	taskruninformer.Get(ctx).Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+//	  FilterFunc: FilterOwnerRunRef("example.dev/v0", "Example"),
+//	  Handler:    controller.HandleAll(impl.Enqueue),
+//	})
 func FilterOwnerRunRef(runLister listersalpha.RunLister, apiVersion, kind string) func(interface{}) bool {
 	return func(obj interface{}) bool {
 		object, ok := obj.(metav1.Object)
@@ -114,10 +114,10 @@ func FilterOwnerRunRef(runLister listersalpha.RunLister, apiVersion, kind string
 // For example, a controller impl that wants to be notified of updates to CustomRuns
 // which reference a Task with apiVersion "example.dev/v0" and kind "Example":
 //
-//     customruninformer.Get(ctx).Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-//       FilterFunc: FilterCustomRunRef("example.dev/v0", "Example"),
-//       Handler:    controller.HandleAll(impl.Enqueue),
-//     })
+//	customruninformer.Get(ctx).Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+//	  FilterFunc: FilterCustomRunRef("example.dev/v0", "Example"),
+//	  Handler:    controller.HandleAll(impl.Enqueue),
+//	})
 func FilterCustomRunRef(apiVersion, kind string) func(interface{}) bool {
 	return func(obj interface{}) bool {
 		r, ok := obj.(*v1beta1.CustomRun)
@@ -147,10 +147,10 @@ func FilterCustomRunRef(apiVersion, kind string) func(interface{}) bool {
 // For example, a controller impl that wants to be notified of updates to TaskRuns that are controlled by
 // a CustomRun which references a custom task with apiVersion "example.dev/v0" and kind "Example":
 //
-//     taskruninformer.Get(ctx).Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-//       FilterFunc: FilterOwnerCustomRunRef("example.dev/v0", "Example"),
-//       Handler:    controller.HandleAll(impl.Enqueue),
-//     })
+//	taskruninformer.Get(ctx).Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+//	  FilterFunc: FilterOwnerCustomRunRef("example.dev/v0", "Example"),
+//	  Handler:    controller.HandleAll(impl.Enqueue),
+//	})
 func FilterOwnerCustomRunRef(customRunLister listersbeta.CustomRunLister, apiVersion, kind string) func(interface{}) bool {
 	return func(obj interface{}) bool {
 		object, ok := obj.(metav1.Object)

--- a/pkg/internal/affinityassistant/transformer_test.go
+++ b/pkg/internal/affinityassistant/transformer_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/internal/computeresources/compare/compare.go
+++ b/pkg/internal/computeresources/compare/compare.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/internal/computeresources/limitrange/limitrange_test.go
+++ b/pkg/internal/computeresources/limitrange/limitrange_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/internal/computeresources/transformer_test.go
+++ b/pkg/internal/computeresources/transformer_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/reconciler/doc.go
+++ b/pkg/reconciler/doc.go
@@ -21,10 +21,12 @@ limitations under the License.
 //
 // Despite defining a Reconciler, each of the packages here are expected to
 // expose a controller constructor like:
-//    func NewController(...) *controller.Impl { ... }
+//
+//	func NewController(...) *controller.Impl { ... }
+//
 // These constructors will:
-// 1. Construct the Reconciler,
-// 2. Construct a controller.Impl with that Reconciler,
-// 3. Wire the assorted informers this Reconciler watches to call appropriate
-//   enqueue methods on the controller.
+//  1. Construct the Reconciler,
+//  2. Construct a controller.Impl with that Reconciler,
+//  3. Wire the assorted informers this Reconciler watches to call appropriate
+//     enqueue methods on the controller.
 package reconciler

--- a/pkg/reconciler/pipelinerun/resources/input_output_steps_test.go
+++ b/pkg/reconciler/pipelinerun/resources/input_output_steps_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/reconciler/resolutionrequest/doc.go
+++ b/pkg/reconciler/resolutionrequest/doc.go
@@ -21,8 +21,8 @@ that global settings and constraints are enforced independent of
 the "type" of ResolutionRequest being resolved.
 
 Examples of the kinds of global settings that need to be enforced include:
-	* Ensuring that the object's Status fields are correctly initialized.
-	* Ensuring that all ResolutionRequests eventually get timed out.
-	* Ensuring that ResolutionRequests with populated Data field are marked as complete.
+  - Ensuring that the object's Status fields are correctly initialized.
+  - Ensuring that all ResolutionRequests eventually get timed out.
+  - Ensuring that ResolutionRequests with populated Data field are marked as complete.
 */
 package resolutionrequest

--- a/pkg/reconciler/taskrun/resources/output_resource.go
+++ b/pkg/reconciler/taskrun/resources/output_resource.go
@@ -37,8 +37,10 @@ var (
 // target directory.
 // Steps executed:
 //  1. If taskrun has owner reference as pipelinerun then all outputs are copied to parents PVC
+//
 // and also runs any custom upload steps (upload to blob store)
-//  2.  If taskrun does not have pipelinerun as owner reference then all outputs resources execute their custom
+//  2. If taskrun does not have pipelinerun as owner reference then all outputs resources execute their custom
+//
 // upload steps (like upload to blob store )
 //
 // Resource source path determined

--- a/pkg/reconciler/taskrun/resources/volume.go
+++ b/pkg/reconciler/taskrun/resources/volume.go
@@ -36,14 +36,14 @@ func GetPVCVolume(name string) corev1.Volume {
 // Specifically, they have the following structure as defined by
 // (pkg/apis/resource/v1alpha1/storage.ArtifactBucket).GetSecretsVolumes():
 //
-// corev1.Volume{
-//   Name: fmt.Sprintf("volume-bucket-%s", sec.SecretName),
-//   VolumeSource: corev1.VolumeSource{
-//     Secret: &corev1.SecretVolumeSource{
-//       SecretName: sec.SecretName,
-//     },
-//   },
-// }
+//	corev1.Volume{
+//	  Name: fmt.Sprintf("volume-bucket-%s", sec.SecretName),
+//	  VolumeSource: corev1.VolumeSource{
+//	    Secret: &corev1.SecretVolumeSource{
+//	      SecretName: sec.SecretName,
+//	    },
+//	  },
+//	}
 //
 // Any new volumes that don't match this structure are added regardless of whether they are already
 // present in the list of volumes.

--- a/pkg/remote/errors.go
+++ b/pkg/remote/errors.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/termination/parse_test.go
+++ b/pkg/termination/parse_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/termination/write_test.go
+++ b/pkg/termination/write_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/dag_test.go
+++ b/test/dag_test.go
@@ -40,14 +40,15 @@ const sleepDuration = 15 * time.Second
 
 // TestDAGPipelineRun creates a graph of arbitrary Tasks, then looks at the corresponding
 // TaskRun start times to ensure they were run in the order intended, which is:
-//                              |
-//                       pipeline-task-1
-//                      /               \
-//  pipeline-task-2-parallel-1    pipeline-task-2-parallel-2
-//                      \                /
-//                       pipeline-task-3
-//                              |
-//                       pipeline-task-4
+//
+//	                            |
+//	                     pipeline-task-1
+//	                    /               \
+//	pipeline-task-2-parallel-1    pipeline-task-2-parallel-2
+//	                    \                /
+//	                     pipeline-task-3
+//	                            |
+//	                     pipeline-task-4
 func TestDAGPipelineRun(t *testing.T) {
 	ctx := context.Background()
 	ctx, cancel := context.WithCancel(ctx)

--- a/test/gohelloworld/main.go
+++ b/test/gohelloworld/main.go
@@ -31,6 +31,7 @@ func main() {
 	log.Print("Hello world sample started.")
 
 	http.HandleFunc("/", handler)
+	// #nosec G114 -- see https://github.com/securego/gosec#available-rules
 	if err := http.ListenAndServe(":8080", nil); err != nil {
 		panic(err)
 	}

--- a/test/registry_test.go
+++ b/test/registry_test.go
@@ -8,7 +8,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
# Changes

Cleanup: fix failures from updated `golangci-lint` in https://github.com/tektoncd/plumbing/pull/1309.

There are no functional changes expected in this PR.

- `go fmt` whitespace
- Added several #nosec directives

Context: https://github.com/tektoncd/pipeline/issues/5899

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [N/A] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [N/A] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [N/A] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [N/A] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
