### PR TITLE
tekton: fix KO_CONFIG_PATH on release pipeline

### DIFF
--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -128,7 +128,8 @@ spec:
       set -ex
 
       # Use the generated `.ko.yaml`
-      KO_CONFIG_PATH=/workspace/.ko.yaml
+      export KO_CONFIG_PATH=/workspace
+      cat ${KO_CONFIG_PATH}/.ko.yaml
 
       # Setup docker-auth
       DOCKER_CONFIG=~/.docker


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

- Export the `KO_CONFIG_PATH` variable 🤦
- Using KO_CONFIG_PATH pointing to a file doesn't seem to work with ko
  0.12.0 (https://github.com/ko-build/ko/issues/919)

Fixes #1199

Will need to be backport for 0.41, 0.42 and 0.43 release branch and
have a bugfix release for those 3.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
