### PR TITLE
Use the golangci-lint configured in Makefile in build tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,6 +170,10 @@ $(BIN)/golangci-lint: ; $(info $(M) getting golangci-lint $(GOLANGCI_VERSION))
 golangci-lint: | $(GOLANGCILINT) ; $(info $(M) running golangci-lint…) @ ## Run golangci-lint
 	$Q $(GOLANGCILINT) run --modules-download-mode=vendor --max-issues-per-linter=0 --max-same-issues=0 --deadline 5m
 
+.PHONY: golangci-lint-check
+golangci-lint-check: | $(GOLANGCILINT) ; $(info $(M) Testing if golint has been done…) @ ## Run golangci-lint for build tests CI job
+	$Q $(GOLANGCILINT) run -j 1 --color=never
+
 GOIMPORTS = $(BIN)/goimports
 $(BIN)/goimports: PACKAGE=golang.org/x/tools/cmd/goimports
 

--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -33,7 +33,7 @@ function check_go_lint() {
     header "Testing if golint has been done"
 
     # deadline of 5m, and show all the issues
-    golangci-lint -j 1 --color=never run
+    GOFLAGS="-mod=mod" make golangci-lint-check
 
     if [[ $? != 0 ]]; then
         results_banner "Go Lint" 1


### PR DESCRIPTION
# Changes

We hit an issue on https://github.com/tektoncd/pipeline/pull/5941 due to the golangci-lint installed on the `test-runner` image being upgraded and reporting new issues that weren't encountered at the time of the v0.43.0 release. Ideally, the build tests job should be using the same golangci-lint version as is defined in the Makefile, so let's switch to calling a make target.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
