### PR TITLE
Register informers for v1 TaskRun and PipelineRun

### DIFF
--- a/pkg/apis/pipeline/v1/register.go
+++ b/pkg/apis/pipeline/v1/register.go
@@ -50,8 +50,11 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&TaskList{},
 		&Pipeline{},
 		&PipelineList{},
-	) // TODO(#4983): v1 types go here
-
+		&TaskRun{},
+		&TaskRunList{},
+		&PipelineRun{},
+		&PipelineRunList{},
+	)
 	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
 	return nil
 }


### PR DESCRIPTION
This commit registers the v1 types so knative can generate informers for them.

Example error reported in PipelineRun logs (despite PipelineRun succeeding):
```
W0104 10:47:46.925165   85977 reflector.go:347] github.com/tektoncd/pipeline/pkg/client/informers/externalversions/factory.go:117: watch of *v1.PipelineRun ended with: an error on the server ("unable to decode an event from the watch stream: unable to decode watch event: no kind \"PipelineRun\" is registered for version \"tekton.dev/v1\" in scheme \"github.com/tektoncd/pipeline/pkg/client/clientset/versioned/scheme/register.go:32\"") has prevented the request from succeeding
```

/kind bug
FYI @JeromeJu @bendory 

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- n/a Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
   - Since this only appears in the logs, and the PipelineRun still succeeds, I'm not sure how I could write a test for this.
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- n/a Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
bug fix: register informers for v1 TaskRun and PipelineRun
```
