### PR TITLE
[TEP-0091] enable kms in trusted resources

### DIFF
--- a/docs/trusted-resources.md
+++ b/docs/trusted-resources.md
@@ -11,9 +11,6 @@ Trusted Resources is a feature which can be used to sign Tekton Resources and ve
 
 Verification failure will mark corresponding taskrun/pipelinerun as Failed status and stop the execution.
 
-**Note:** KMS is not currently supported and will be supported in the following work.
-
-
 ## Instructions
 
 ### Sign Resources
@@ -157,7 +154,11 @@ spec:
 To learn more about regex syntax please refer to [syntax](https://pkg.go.dev/regexp/syntax).
 To learn more about `ConfigSource` please refer to resolvers doc for more context. e.g. [gitresolver](./git-resolver.md)
 
- `key` is used to store the public key, note that secretRef and data cannot be configured at the same time.
+ `key` is used to store the public key, `key` can be configured with `secretRef`, `data`, `kms` note that only 1 of these 3 fields can be configured.
+
+  * `secretRef`: refers to secret in cluster to store the public key.
+  * `data`: contains the inline data of the pubic key in "PEM-encoded byte slice" format.
+  * `kms`: refers to the uri of the public key, it should follow the format defined in [sigstore](https://docs.sigstore.dev/cosign/kms_support).
 
 `hashAlgorithm` is the algorithm for the public key, by default is `sha256`. It also supports `SHA224`, `SHA384`, `SHA512`.
 

--- a/vendor/github.com/sigstore/sigstore/pkg/signature/kms/fake/doc.go
+++ b/vendor/github.com/sigstore/sigstore/pkg/signature/kms/fake/doc.go
@@ -1,0 +1,17 @@
+//
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package fake contains utilities to help test KMS providers.
+package fake

--- a/vendor/github.com/sigstore/sigstore/pkg/signature/kms/fake/signer.go
+++ b/vendor/github.com/sigstore/sigstore/pkg/signature/kms/fake/signer.go
@@ -1,0 +1,155 @@
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package fake implements fake signer to be used in tests
+package fake
+
+import (
+	"context"
+	"crypto"
+	"io"
+
+	"github.com/sigstore/sigstore/pkg/signature"
+	sigkms "github.com/sigstore/sigstore/pkg/signature/kms"
+	"github.com/sigstore/sigstore/pkg/signature/options"
+)
+
+// KmsCtxKey is used to look up the private key in the struct.
+type KmsCtxKey struct{}
+
+// SignerVerifier creates and verifies digital signatures over a message using an in-memory signer
+type SignerVerifier struct {
+	signer signature.SignerVerifier
+}
+
+// ReferenceScheme is a scheme for fake KMS keys. Do not use in production.
+const ReferenceScheme = "fakekms://"
+
+func init() {
+	sigkms.AddProvider(ReferenceScheme, func(ctx context.Context, _ string, hf crypto.Hash, _ ...signature.RPCOption) (sigkms.SignerVerifier, error) {
+		return LoadSignerVerifier(ctx, hf)
+	})
+}
+
+// LoadSignerVerifier generates a signer/verifier using the default ECDSA signer or loads
+// a signer from a provided private key and hash. The context should contain a mapping from
+// a string "priv" to a crypto.PrivateKey (RSA, ECDSA, or ED25519).
+func LoadSignerVerifier(ctx context.Context, hf crypto.Hash) (*SignerVerifier, error) {
+	val := ctx.Value(KmsCtxKey{})
+	if val == nil {
+		signer, _, err := signature.NewDefaultECDSASignerVerifier()
+		if err != nil {
+			return nil, err
+		}
+		sv := &SignerVerifier{
+			signer: signer,
+		}
+		return sv, nil
+	}
+	signer, err := signature.LoadSignerVerifier(val.(crypto.PrivateKey), hf)
+	if err != nil {
+		return nil, err
+	}
+	sv := &SignerVerifier{
+		signer: signer,
+	}
+	return sv, nil
+}
+
+// SignMessage signs the provided message using the in-memory signer.
+func (g *SignerVerifier) SignMessage(message io.Reader, opts ...signature.SignOption) ([]byte, error) {
+	return g.signer.SignMessage(message, opts...)
+}
+
+// PublicKey returns the public key that can be used to verify signatures created by
+// this signer.
+func (g *SignerVerifier) PublicKey(opts ...signature.PublicKeyOption) (crypto.PublicKey, error) {
+	return g.signer.PublicKey(opts...)
+}
+
+// VerifySignature verifies the signature for the given message. Unless provided
+// in an option, the digest of the message will be computed using the hash function specified
+// when the SignerVerifier was created.
+//
+// This function returns nil if the verification succeeded, and an error message otherwise.
+//
+// This function recognizes the following Options listed in order of preference:
+//
+// - WithDigest()
+//
+// All other options are ignored if specified.
+func (g *SignerVerifier) VerifySignature(signature, message io.Reader, opts ...signature.VerifyOption) error {
+	return g.signer.VerifySignature(signature, message, opts...)
+}
+
+// CreateKey returns the signer's public key.
+func (g *SignerVerifier) CreateKey(etx context.Context, algorithm string) (crypto.PublicKey, error) {
+	pub, err := g.signer.PublicKey()
+	if err != nil {
+		return nil, err
+	}
+	return pub, nil
+}
+
+type cryptoSignerWrapper struct {
+	ctx      context.Context
+	hashFunc crypto.Hash
+	sv       *SignerVerifier
+	errFunc  func(error)
+}
+
+func (c cryptoSignerWrapper) Public() crypto.PublicKey {
+	pk, err := c.sv.PublicKey(options.WithContext(c.ctx))
+	if err != nil && c.errFunc != nil {
+		c.errFunc(err)
+	}
+	return pk
+}
+
+func (c cryptoSignerWrapper) Sign(_ io.Reader, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
+	hashFunc := c.hashFunc
+	if opts != nil {
+		hashFunc = opts.HashFunc()
+	}
+	gcpOptions := []signature.SignOption{
+		options.WithContext(c.ctx),
+		options.WithDigest(digest),
+		options.WithCryptoSignerOpts(hashFunc),
+	}
+
+	return c.sv.SignMessage(nil, gcpOptions...)
+}
+
+// CryptoSigner returns a crypto.Signer object that uses the underlying SignerVerifier, along with a crypto.SignerOpts object
+// that allows the KMS to be used in APIs that only accept the standard golang objects
+func (g *SignerVerifier) CryptoSigner(ctx context.Context, errFunc func(error)) (crypto.Signer, crypto.SignerOpts, error) {
+	csw := &cryptoSignerWrapper{
+		ctx:      ctx,
+		sv:       g,
+		hashFunc: crypto.SHA256,
+		errFunc:  errFunc,
+	}
+
+	return csw, crypto.SHA256, nil
+}
+
+// SupportedAlgorithms returns a list with the default algorithm
+func (g *SignerVerifier) SupportedAlgorithms() (result []string) {
+	return []string{"ecdsa-p256-sha256"}
+}
+
+// DefaultAlgorithm returns the default algorithm for the signer
+func (g *SignerVerifier) DefaultAlgorithm() string {
+	return "ecdsa-p256-sha256"
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -761,6 +761,7 @@ github.com/sigstore/sigstore/pkg/signature
 github.com/sigstore/sigstore/pkg/signature/kms
 github.com/sigstore/sigstore/pkg/signature/kms/aws
 github.com/sigstore/sigstore/pkg/signature/kms/azure
+github.com/sigstore/sigstore/pkg/signature/kms/fake
 github.com/sigstore/sigstore/pkg/signature/kms/gcp
 github.com/sigstore/sigstore/pkg/signature/kms/hashivault
 github.com/sigstore/sigstore/pkg/signature/options


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This commit enables kms in trusted resources, before this commit kms field is added to VerificationPolicy and provider libraries are pulled into vendor. This commit adds the function code to use kms when fetching verifiers from VerificationPolicy.

/kind feature

Signed-off-by: Yongxuan Zhang yongxuanzhang@google.com

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
enable KMS in VerificationPolicy for trusted resources
```
