### PR TITLE
Fix embedded-status conversion for PipelineRuns

### DIFF
--- a/pkg/apis/config/testing/feature_flags.go
+++ b/pkg/apis/config/testing/feature_flags.go
@@ -1,0 +1,24 @@
+package testing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tektoncd/pipeline/pkg/apis/config"
+)
+
+// SetEmbeddedStatus sets the "embedded-status" feature flag in an existing context (for use in testing)
+func SetEmbeddedStatus(ctx context.Context, t *testing.T, embeddedStatus string) context.Context {
+	t.Helper()
+	flags, err := config.NewFeatureFlagsFromMap(map[string]string{
+		"embedded-status": embeddedStatus,
+	})
+	if err != nil {
+		t.Fatalf("error creating feature flags from map: %v", err)
+	}
+	cfg := &config.Config{
+		FeatureFlags: flags,
+	}
+	ctx = config.ToContext(ctx, cfg)
+	return ctx
+}

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_conversion.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/tektoncd/pipeline/pkg/apis/config"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/apis/version"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -54,7 +55,7 @@ func (pr *PipelineRun) ConvertTo(ctx context.Context, to apis.Convertible) error
 		if err := serializePipelineRunStatusRuns(&sink.ObjectMeta, &pr.Status); err != nil {
 			return err
 		}
-		if err := pr.Status.ConvertTo(ctx, &sink.Status); err != nil {
+		if err := pr.Status.convertTo(ctx, &sink.Status); err != nil {
 			return err
 		}
 		return pr.Spec.ConvertTo(ctx, &sink.Spec)
@@ -117,13 +118,15 @@ func (pr *PipelineRun) ConvertFrom(ctx context.Context, from apis.Convertible) e
 		if err := deserializePipelineRunResources(&pr.ObjectMeta, &pr.Spec); err != nil {
 			return err
 		}
-		if err := deserializePipelineRunStatusTaskRuns(&pr.ObjectMeta, &pr.Status); err != nil {
+		taskRuns, err := deserializePipelineRunStatusTaskRuns(&pr.ObjectMeta)
+		if err != nil {
 			return err
 		}
-		if err := deserializePipelineRunStatusRuns(&pr.ObjectMeta, &pr.Status); err != nil {
+		runs, err := deserializePipelineRunStatusRuns(&pr.ObjectMeta)
+		if err != nil {
 			return err
 		}
-		if err := pr.Status.ConvertFrom(ctx, &source.Status); err != nil {
+		if err := pr.Status.convertFrom(ctx, &source.Status, taskRuns, runs); err != nil {
 			return err
 		}
 		return pr.Spec.ConvertFrom(ctx, &source.Spec)
@@ -235,8 +238,7 @@ func (ptrs *PipelineTaskRunSpec) convertFrom(ctx context.Context, source v1.Pipe
 	ptrs.ComputeResources = source.ComputeResources
 }
 
-// ConvertTo implements apis.Convertible
-func (prs *PipelineRunStatus) ConvertTo(ctx context.Context, sink *v1.PipelineRunStatus) error {
+func (prs *PipelineRunStatus) convertTo(ctx context.Context, sink *v1.PipelineRunStatus) error {
 	sink.Status = prs.Status
 	sink.StartTime = prs.StartTime
 	sink.CompletionTime = prs.CompletionTime
@@ -271,6 +273,7 @@ func (prs *PipelineRunStatus) ConvertTo(ctx context.Context, sink *v1.PipelineRu
 		prs.Provenance.convertTo(ctx, &new)
 		sink.Provenance = &new
 	}
+
 	// If embedded-status is set to "both", both ChildReferences and TaskRuns/Runs
 	// will be populated. In this case, use the value from ChildReferences.
 	if sink.ChildReferences == nil {
@@ -284,8 +287,7 @@ func (prs *PipelineRunStatus) ConvertTo(ctx context.Context, sink *v1.PipelineRu
 	return nil
 }
 
-// ConvertFrom implements apis.Convertible
-func (prs *PipelineRunStatus) ConvertFrom(ctx context.Context, source *v1.PipelineRunStatus) error {
+func (prs *PipelineRunStatus) convertFrom(ctx context.Context, source *v1.PipelineRunStatus, taskRuns map[string]*PipelineRunTaskRunStatus, runs map[string]*PipelineRunRunStatus) error {
 	prs.Status = source.Status
 	prs.StartTime = source.StartTime
 	prs.CompletionTime = source.CompletionTime
@@ -309,12 +311,20 @@ func (prs *PipelineRunStatus) ConvertFrom(ctx context.Context, source *v1.Pipeli
 		new.convertFrom(ctx, st)
 		prs.SkippedTasks = append(prs.SkippedTasks, new)
 	}
-	prs.ChildReferences = nil
-	for _, cr := range source.ChildReferences {
-		new := ChildStatusReference{}
-		new.convertFrom(ctx, cr)
-		prs.ChildReferences = append(prs.ChildReferences, new)
+	embeddedStatus := config.FromContextOrDefaults(ctx).FeatureFlags.EmbeddedStatus
+	if embeddedStatus == config.BothEmbeddedStatus || embeddedStatus == config.MinimalEmbeddedStatus {
+		prs.ChildReferences = nil
+		for _, cr := range source.ChildReferences {
+			new := ChildStatusReference{}
+			new.convertFrom(ctx, cr)
+			prs.ChildReferences = append(prs.ChildReferences, new)
+		}
 	}
+	if embeddedStatus == config.BothEmbeddedStatus || embeddedStatus == config.FullEmbeddedStatus {
+		prs.TaskRuns = taskRuns
+		prs.Runs = runs
+	}
+
 	prs.FinallyStartTime = source.FinallyStartTime
 	if source.Provenance != nil {
 		new := Provenance{}
@@ -453,16 +463,13 @@ func serializePipelineRunStatusTaskRuns(meta *metav1.ObjectMeta, status *Pipelin
 	return version.SerializeToMetadata(meta, status.TaskRuns, taskRunsAnnotationKey)
 }
 
-func deserializePipelineRunStatusTaskRuns(meta *metav1.ObjectMeta, status *PipelineRunStatus) error {
+func deserializePipelineRunStatusTaskRuns(meta *metav1.ObjectMeta) (map[string]*PipelineRunTaskRunStatus, error) {
 	taskRuns := make(map[string]*PipelineRunTaskRunStatus)
 	err := version.DeserializeFromMetadata(meta, &taskRuns, taskRunsAnnotationKey)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	if len(taskRuns) != 0 {
-		status.TaskRuns = taskRuns
-	}
-	return nil
+	return taskRuns, nil
 }
 
 func serializePipelineRunStatusRuns(meta *metav1.ObjectMeta, status *PipelineRunStatus) error {
@@ -472,14 +479,11 @@ func serializePipelineRunStatusRuns(meta *metav1.ObjectMeta, status *PipelineRun
 	return version.SerializeToMetadata(meta, status.Runs, runsAnnotationKey)
 }
 
-func deserializePipelineRunStatusRuns(meta *metav1.ObjectMeta, status *PipelineRunStatus) error {
+func deserializePipelineRunStatusRuns(meta *metav1.ObjectMeta) (map[string]*PipelineRunRunStatus, error) {
 	runs := make(map[string]*PipelineRunRunStatus)
 	err := version.DeserializeFromMetadata(meta, &runs, runsAnnotationKey)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	if len(runs) != 0 {
-		status.Runs = runs
-	}
-	return nil
+	return runs, nil
 }


### PR DESCRIPTION
This commit updates conversion for PipelineRun child objects stored in the status to depend on the value of the feature flag `embedded-status`.

Possibly fixes #5964
/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- n/a Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- n/a Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Update PipelineRun conversion between API versions to account for embedded-status feature flag
```
