### PR TITLE
[WIP] Picking out `task_interface` and `pipeline_interface`

### DIFF
--- a/docs/pipeline-api.md
+++ b/docs/pipeline-api.md
@@ -9248,7 +9248,7 @@ optional: false - the resource is considered required (default/equivalent of not
 </tr>
 </tbody>
 </table>
-<h3 id="tekton.dev/v1beta1.PipelineObject">PipelineObject
+<h3 id="tekton.dev/objectInterface.PipelineObject">PipelineObject
 </h3>
 <div>
 <p>PipelineObject is implemented by Pipeline and ClusterPipeline</p>

--- a/pkg/apis/pipeline/objectInterface/pipeline_interface.go
+++ b/pkg/apis/pipeline/objectInterface/pipeline_interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2023 The Tekton Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,17 +14,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1beta1
+package objectInterface
 
 import (
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 )
 
-// TaskObject is implemented by Task and ClusterTask
-type TaskObject interface {
+// PipelineObject is implemented by Pipeline and ClusterPipeline
+type PipelineObject interface {
 	apis.Defaultable
-	TaskMetadata() metav1.ObjectMeta
-	TaskSpec() TaskSpec
-	Copy() TaskObject
+	PipelineMetadata() metav1.ObjectMeta
+	PipelineSpec() v1.PipelineSpec
+	Copy() PipelineObject
 }

--- a/pkg/apis/pipeline/objectInterface/task_interface.go
+++ b/pkg/apis/pipeline/objectInterface/task_interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Tekton Authors
+Copyright 2023 The Tekton Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,17 +14,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1beta1
+package objectInterface
 
 import (
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 )
 
-// PipelineObject is implemented by Pipeline and ClusterPipeline
-type PipelineObject interface {
+// TaskObject is implemented by Task and ClusterTask
+type TaskObject interface {
 	apis.Defaultable
-	PipelineMetadata() metav1.ObjectMeta
-	PipelineSpec() PipelineSpec
-	Copy() PipelineObject
+	TaskMetadata() metav1.ObjectMeta
+	TaskSpec() v1.TaskSpec
+	Copy() TaskObject
 }

--- a/pkg/apis/pipeline/v1beta1/cluster_task_types.go
+++ b/pkg/apis/pipeline/v1beta1/cluster_task_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"github.com/tektoncd/pipeline/pkg/apis/objectInterface"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -65,7 +66,7 @@ func (t *ClusterTask) TaskMetadata() metav1.ObjectMeta {
 }
 
 // Copy returns a DeepCopy of the ClusterTask
-func (t *ClusterTask) Copy() TaskObject {
+func (t *ClusterTask) Copy() objectInterface.TaskObject {
 	return t.DeepCopy()
 }
 

--- a/pkg/apis/pipeline/v1beta1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
+	"github.com/tektoncd/pipeline/pkg/apis/objectInterface"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/version"
 
@@ -76,7 +77,7 @@ func (p *Pipeline) PipelineSpec() PipelineSpec {
 }
 
 // Copy returns a deep copy of the Pipeline, implementing PipelineObject
-func (p *Pipeline) Copy() PipelineObject {
+func (p *Pipeline) Copy() objectInterface.PipelineObject {
 	return p.DeepCopy()
 }
 

--- a/pkg/apis/pipeline/v1beta1/task_types.go
+++ b/pkg/apis/pipeline/v1beta1/task_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"github.com/tektoncd/pipeline/pkg/apis/objectInterface"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -69,7 +70,7 @@ func (t *Task) TaskMetadata() metav1.ObjectMeta {
 }
 
 // Copy returns a deep copy of the task
-func (t *Task) Copy() TaskObject {
+func (t *Task) Copy() objectInterface.TaskObject {
 	return t.DeepCopy()
 }
 

--- a/pkg/reconciler/pipelinerun/pipelinespec/pipelinespec.go
+++ b/pkg/reconciler/pipelinerun/pipelinespec/pipelinespec.go
@@ -21,13 +21,14 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/tektoncd/pipeline/pkg/apis/objectInterface"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	resolutionutil "github.com/tektoncd/pipeline/pkg/internal/resolution"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // GetPipeline is a function used to retrieve Pipelines.
-type GetPipeline func(context.Context, string) (v1beta1.PipelineObject, *v1beta1.ConfigSource, error)
+type GetPipeline func(context.Context, string) (objectInterface.PipelineObject, *v1beta1.ConfigSource, error)
 
 // GetPipelineData will retrieve the Pipeline metadata and Spec associated with the
 // provided PipelineRun. This can come from a reference Pipeline or from the PipelineRun's

--- a/pkg/reconciler/pipelinerun/pipelinespec/pipelinespec_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinespec/pipelinespec_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/pipeline/pkg/apis/objectInterface"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/test/diff"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -51,7 +52,7 @@ func TestGetPipelineSpec_Ref(t *testing.T) {
 			},
 		},
 	}
-	gt := func(ctx context.Context, n string) (v1beta1.PipelineObject, *v1beta1.ConfigSource, error) {
+	gt := func(ctx context.Context, n string) (objectInterface.PipelineObject, *v1beta1.ConfigSource, error) {
 		return pipeline, nil, nil
 	}
 	resolvedObjectMeta, pipelineSpec, err := GetPipelineData(context.Background(), pr, gt)
@@ -89,7 +90,7 @@ func TestGetPipelineSpec_Embedded(t *testing.T) {
 			},
 		},
 	}
-	gt := func(ctx context.Context, n string) (v1beta1.PipelineObject, *v1beta1.ConfigSource, error) {
+	gt := func(ctx context.Context, n string) (objectInterface.PipelineObject, *v1beta1.ConfigSource, error) {
 		return nil, nil, errors.New("shouldn't be called")
 	}
 	resolvedObjectMeta, pipelineSpec, err := GetPipelineData(context.Background(), pr, gt)
@@ -117,7 +118,7 @@ func TestGetPipelineSpec_Invalid(t *testing.T) {
 			Name: "mypipelinerun",
 		},
 	}
-	gt := func(ctx context.Context, n string) (v1beta1.PipelineObject, *v1beta1.ConfigSource, error) {
+	gt := func(ctx context.Context, n string) (objectInterface.PipelineObject, *v1beta1.ConfigSource, error) {
 		return nil, nil, errors.New("shouldn't be called")
 	}
 	_, _, err := GetPipelineData(context.Background(), tr, gt)
@@ -166,7 +167,7 @@ func TestGetPipelineData_ResolutionSuccess(t *testing.T) {
 		EntryPoint: "foo/bar",
 	}
 
-	getPipeline := func(ctx context.Context, n string) (v1beta1.PipelineObject, *v1beta1.ConfigSource, error) {
+	getPipeline := func(ctx context.Context, n string) (objectInterface.PipelineObject, *v1beta1.ConfigSource, error) {
 		return &v1beta1.Pipeline{
 			ObjectMeta: *sourceMeta.DeepCopy(),
 			Spec:       *sourceSpec.DeepCopy(),
@@ -200,7 +201,7 @@ func TestGetPipelineSpec_Error(t *testing.T) {
 			},
 		},
 	}
-	gt := func(ctx context.Context, n string) (v1beta1.PipelineObject, *v1beta1.ConfigSource, error) {
+	gt := func(ctx context.Context, n string) (objectInterface.PipelineObject, *v1beta1.ConfigSource, error) {
 		return nil, nil, errors.New("something went wrong")
 	}
 	_, _, err := GetPipelineData(context.Background(), tr, gt)
@@ -222,7 +223,7 @@ func TestGetPipelineData_ResolutionError(t *testing.T) {
 			},
 		},
 	}
-	getPipeline := func(ctx context.Context, n string) (v1beta1.PipelineObject, *v1beta1.ConfigSource, error) {
+	getPipeline := func(ctx context.Context, n string) (objectInterface.PipelineObject, *v1beta1.ConfigSource, error) {
 		return nil, nil, errors.New("something went wrong")
 	}
 	ctx := context.Background()
@@ -245,7 +246,7 @@ func TestGetPipelineData_ResolvedNilPipeline(t *testing.T) {
 			},
 		},
 	}
-	getPipeline := func(ctx context.Context, n string) (v1beta1.PipelineObject, *v1beta1.ConfigSource, error) {
+	getPipeline := func(ctx context.Context, n string) (objectInterface.PipelineObject, *v1beta1.ConfigSource, error) {
 		return nil, nil, nil
 	}
 	ctx := context.Background()

--- a/pkg/trustedresources/verify.go
+++ b/pkg/trustedresources/verify.go
@@ -41,7 +41,7 @@ const (
 
 // VerifyTask verifies the signature and public key against task.
 // source is from ConfigSource.URI, which will be used to match policy patterns. k8s is used to fetch secret from cluster
-func VerifyTask(ctx context.Context, taskObj v1beta1.TaskObject, k8s kubernetes.Interface, source string, policies []*v1alpha1.VerificationPolicy) error {
+func VerifyTask(ctx context.Context, taskObj v1beta1.Task, k8s kubernetes.Interface, source string, policies []*v1alpha1.VerificationPolicy) error {
 	tm, signature, err := prepareObjectMeta(taskObj.TaskMetadata())
 	if err != nil {
 		return err

--- a/pkg/trustedresources/verify.go
+++ b/pkg/trustedresources/verify.go
@@ -27,6 +27,7 @@ import (
 	"regexp"
 
 	"github.com/sigstore/sigstore/pkg/signature"
+	"github.com/tektoncd/pipeline/pkg/apis/objectInterface"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/trustedresources/verifier"
@@ -59,7 +60,7 @@ func VerifyTask(ctx context.Context, taskObj v1beta1.Task, k8s kubernetes.Interf
 
 // VerifyPipeline verifies the signature and public key against pipeline.
 // source is from ConfigSource.URI, which will be used to match policy patterns, k8s is used to fetch secret from cluster
-func VerifyPipeline(ctx context.Context, pipelineObj v1beta1.PipelineObject, k8s kubernetes.Interface, source string, policies []*v1alpha1.VerificationPolicy) error {
+func VerifyPipeline(ctx context.Context, pipelineObj objectInterface.PipelineObject, k8s kubernetes.Interface, source string, policies []*v1alpha1.VerificationPolicy) error {
 	pm, signature, err := prepareObjectMeta(pipelineObj.PipelineMetadata())
 	if err != nil {
 		return err

--- a/pkg/trustedresources/verify_test.go
+++ b/pkg/trustedresources/verify_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/sigstore/sigstore/pkg/signature"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
+	"github.com/tektoncd/pipeline/pkg/apis/objectInterface"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/trustedresources/verifier"
@@ -376,7 +377,7 @@ func TestVerifyPipeline_Success(t *testing.T) {
 
 	tcs := []struct {
 		name     string
-		pipeline v1beta1.PipelineObject
+		pipeline objectInterface.PipelineObject
 		source   string
 	}{{
 		name:     "Signed git source Task Passes Verification",
@@ -413,7 +414,7 @@ func TestVerifyPipeline_Error(t *testing.T) {
 
 	tcs := []struct {
 		name     string
-		pipeline v1beta1.PipelineObject
+		pipeline objectInterface.PipelineObject
 		source   string
 	}{{
 		name:     "Tampered Task Fails Verification with tampered content",

--- a/pkg/trustedresources/verify_test.go
+++ b/pkg/trustedresources/verify_test.go
@@ -138,7 +138,7 @@ func TestVerifyTask_Configmap_Success(t *testing.T) {
 		t.Fatal("fail to sign task", err)
 	}
 
-	err = VerifyTask(ctx, signedTask, nil, "", []*v1alpha1.VerificationPolicy{})
+	err = VerifyTask(ctx, *signedTask, nil, "", []*v1alpha1.VerificationPolicy{})
 	if err != nil {
 		t.Errorf("VerifyTask() get err %v", err)
 	}
@@ -161,7 +161,7 @@ func TestVerifyTask_Configmap_Error(t *testing.T) {
 
 	tcs := []struct {
 		name          string
-		task          v1beta1.TaskObject
+		task          *v1beta1.Task
 		keypath       string
 		expectedError error
 	}{{
@@ -185,7 +185,7 @@ func TestVerifyTask_Configmap_Error(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx = test.SetupTrustedResourceKeyConfig(ctx, tc.keypath, config.EnforceResourceVerificationMode)
-			err := VerifyTask(ctx, tc.task, nil, "", []*v1alpha1.VerificationPolicy{})
+			err := VerifyTask(ctx, *tc.task, nil, "", []*v1alpha1.VerificationPolicy{})
 			if !errors.Is(err, tc.expectedError) {
 				t.Errorf("VerifyTask got: %v, want: %v", err, tc.expectedError)
 			}
@@ -243,7 +243,7 @@ func TestVerifyTask_VerificationPolicy_Success(t *testing.T) {
 
 	tcs := []struct {
 		name   string
-		task   v1beta1.TaskObject
+		task   *v1beta1.Task
 		source string
 		signer signature.SignerVerifier
 	}{{
@@ -262,7 +262,7 @@ func TestVerifyTask_VerificationPolicy_Success(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			err := VerifyTask(ctx, tc.task, k8sclient, tc.source, vps)
+			err := VerifyTask(ctx, *tc.task, k8sclient, tc.source, vps)
 			if err != nil {
 				t.Fatalf("VerifyTask() get err %v", err)
 			}
@@ -287,31 +287,31 @@ func TestVerifyTask_VerificationPolicy_Error(t *testing.T) {
 
 	tcs := []struct {
 		name               string
-		task               v1beta1.TaskObject
+		task               v1beta1.Task
 		source             string
 		verificationPolicy []*v1alpha1.VerificationPolicy
 		expectedError      error
 	}{{
 		name:               "modified Task fails verification",
-		task:               tamperedTask,
+		task:               *tamperedTask,
 		source:             "git+https://github.com/tektoncd/catalog.git",
 		verificationPolicy: vps,
 		expectedError:      ErrorResourceVerificationFailed,
 	}, {
 		name:               "task not matching pattern fails verification",
-		task:               signedTask,
+		task:               *signedTask,
 		source:             "wrong source",
 		verificationPolicy: vps,
 		expectedError:      ErrorNoMatchedPolicies,
 	}, {
 		name:               "verification fails with empty policy",
-		task:               tamperedTask,
+		task:               *tamperedTask,
 		source:             "git+https://github.com/tektoncd/catalog.git",
 		verificationPolicy: []*v1alpha1.VerificationPolicy{},
 		expectedError:      ErrorEmptyVerificationConfig,
 	}, {
 		name:   "Verification fails with regex error",
-		task:   signedTask,
+		task:   *signedTask,
 		source: "git+https://github.com/tektoncd/catalog.git",
 		verificationPolicy: []*v1alpha1.VerificationPolicy{
 			{
@@ -328,7 +328,7 @@ func TestVerifyTask_VerificationPolicy_Error(t *testing.T) {
 		expectedError: ErrorRegexMatch,
 	}, {
 		name:   "Verification fails with error from policy",
-		task:   signedTask,
+		task:   *signedTask,
 		source: "git+https://github.com/tektoncd/catalog.git",
 		verificationPolicy: []*v1alpha1.VerificationPolicy{
 			{


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This commit changes the Task Object reference logics to get prepared for potential removal and restriction on usage of the v1beta1 Task Interface as it would not be moved forward to v1.

This is drafted to first decouple the usage at the `verify.go`.

/kind misc
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
