### PR TITLE
TEP-0114: Remove Feature Flag `enable-custom-tasks`

### DIFF
--- a/config/config-feature-flags.yaml
+++ b/config/config-feature-flags.yaml
@@ -70,9 +70,6 @@ data:
   # This is an experimental feature and thus should still be considered
   # an alpha feature.
   enable-tekton-oci-bundles: "false"
-  # Setting this flag to "true" enables the use of custom tasks from
-  # within pipelines.
-  enable-custom-tasks: "true"
   # Setting this flag will determine which gated features are enabled.
   # Acceptable values are "stable", "beta", or "alpha".
   enable-api-fields: "stable"

--- a/docs/install.md
+++ b/docs/install.md
@@ -466,9 +466,6 @@ not running.
 and use Workspaces to mount credentials from Secrets instead.
 The default is `false`. For more information, see the [associated issue](https://github.com/tektoncd/pipeline/issues/3399).
 
-- `enable-custom-tasks`: set this flag to `"false"` to disable the
-use of custom tasks in pipelines.
-
 - `enable-api-fields`: set this flag to "stable" to allow only the
 most stable features to be used. Set it to "alpha" to allow [alpha
 features](#alpha-features) to be used.
@@ -517,7 +514,6 @@ Features currently in "alpha" are:
 | Feature                                                                                               | Proposal                                                                                                                        | Release                                                              | Individual Flag             |
 |:------------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------|:----------------------------|
 | [Bundles ](./pipelineruns.md#tekton-bundles)                                                          | [TEP-0005](https://github.com/tektoncd/community/blob/main/teps/0005-tekton-oci-bundles.md)                                | [v0.18.0](https://github.com/tektoncd/pipeline/releases/tag/v0.18.0) | `enable-tekton-oci-bundles` |
-| [`Runs` and `Custom Tasks`](./runs.md)                                                                | [TEP-0002](https://github.com/tektoncd/community/blob/main/teps/0002-custom-tasks.md)                                      | [v0.19.0](https://github.com/tektoncd/pipeline/releases/tag/v0.19.0) | `enable-custom-tasks`       |
 | [Isolated `Step` & `Sidecar` `Workspaces`](./workspaces.md#isolated-workspaces)                       | [TEP-0029](https://github.com/tektoncd/community/blob/main/teps/0029-step-workspaces.md)                                   | [v0.24.0](https://github.com/tektoncd/pipeline/releases/tag/v0.24.0) |                             |
 | [Hermetic Execution Mode](./hermetic.md)                                                              | [TEP-0025](https://github.com/tektoncd/community/blob/main/teps/0025-hermekton.md)                                         | [v0.25.0](https://github.com/tektoncd/pipeline/releases/tag/v0.25.0) |                             |
 | [Propagated `Parameters`](./taskruns.md#propagated-parameters)                                        | [TEP-0107](https://github.com/tektoncd/community/blob/main/teps/0107-propagating-parameters.md)                            | [v0.36.0](https://github.com/tektoncd/pipeline/releases/tag/v0.36.0) |                             |

--- a/pkg/apis/config/feature_flags.go
+++ b/pkg/apis/config/feature_flags.go
@@ -72,8 +72,6 @@ const (
 	DefaultRequireGitSSHSecretKnownHosts = false
 	// DefaultEnableTektonOciBundles is the default value for "enable-tekton-oci-bundles".
 	DefaultEnableTektonOciBundles = false
-	// DefaultEnableCustomTasks is the default value for "enable-custom-tasks".
-	DefaultEnableCustomTasks = true
 	// DefaultEnableAPIFields is the default value for "enable-api-fields".
 	DefaultEnableAPIFields = StableAPIFields
 	// DefaultSendCloudEventsForRuns is the default value for "send-cloudevents-for-runs".
@@ -99,7 +97,6 @@ const (
 	awaitSidecarReadinessKey            = "await-sidecar-readiness"
 	requireGitSSHSecretKnownHostsKey    = "require-git-ssh-secret-known-hosts" // nolint: gosec
 	enableTektonOCIBundles              = "enable-tekton-oci-bundles"
-	enableCustomTasks                   = "enable-custom-tasks"
 	enableAPIFields                     = "enable-api-fields"
 	sendCloudEventsForRuns              = "send-cloudevents-for-runs"
 	embeddedStatus                      = "embedded-status"
@@ -119,7 +116,6 @@ type FeatureFlags struct {
 	RunningInEnvWithInjectedSidecars bool
 	RequireGitSSHSecretKnownHosts    bool
 	EnableTektonOCIBundles           bool
-	EnableCustomTasks                bool
 	ScopeWhenExpressionsToTask       bool
 	EnableAPIFields                  string
 	SendCloudEventsForRuns           bool
@@ -206,13 +202,9 @@ func NewFeatureFlagsFromMap(cfgMap map[string]string) (*FeatureFlags, error) {
 	// defeat the purpose of having a single shared gate for all alpha features.
 	if tc.EnableAPIFields == AlphaAPIFields {
 		tc.EnableTektonOCIBundles = true
-		tc.EnableCustomTasks = true
 		tc.EnableSpire = true
 	} else {
 		if err := setFeature(enableTektonOCIBundles, DefaultEnableTektonOciBundles, &tc.EnableTektonOCIBundles); err != nil {
-			return nil, err
-		}
-		if err := setFeature(enableCustomTasks, DefaultEnableCustomTasks, &tc.EnableCustomTasks); err != nil {
 			return nil, err
 		}
 		if err := setFeature(enableSpire, DefaultEnableSpire, &tc.EnableSpire); err != nil {

--- a/pkg/apis/config/feature_flags_test.go
+++ b/pkg/apis/config/feature_flags_test.go
@@ -45,7 +45,6 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 				DisableCredsInit:         config.DefaultDisableCredsInit,
 				AwaitSidecarReadiness:    config.DefaultAwaitSidecarReadiness,
 				EnableTektonOCIBundles:   config.DefaultEnableTektonOciBundles,
-				EnableCustomTasks:        config.DefaultEnableCustomTasks,
 				EnableAPIFields:          config.DefaultEnableAPIFields,
 				SendCloudEventsForRuns:   config.DefaultSendCloudEventsForRuns,
 				EmbeddedStatus:           config.DefaultEmbeddedStatus,
@@ -64,7 +63,6 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 				AwaitSidecarReadiness:            false,
 				RequireGitSSHSecretKnownHosts:    true,
 				EnableTektonOCIBundles:           true,
-				EnableCustomTasks:                true,
 				EnableAPIFields:                  "alpha",
 				SendCloudEventsForRuns:           true,
 				EmbeddedStatus:                   "both",
@@ -83,7 +81,6 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 				// These are prescribed as true by enabling "alpha" API fields, even
 				// if the submitted text value is "false".
 				EnableTektonOCIBundles: true,
-				EnableCustomTasks:      true,
 				EnableSpire:            true,
 
 				DisableAffinityAssistant:         config.DefaultDisableAffinityAssistant,
@@ -104,7 +101,6 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 			expectedConfig: &config.FeatureFlags{
 				EnableAPIFields:        "stable",
 				EnableTektonOCIBundles: true,
-				EnableCustomTasks:      true,
 
 				DisableAffinityAssistant:         config.DefaultDisableAffinityAssistant,
 				DisableCredsInit:                 config.DefaultDisableCredsInit,
@@ -125,7 +121,6 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 				EnableAPIFields: "beta",
 
 				EnableTektonOCIBundles:           config.DefaultEnableTektonOciBundles,
-				EnableCustomTasks:                config.DefaultEnableCustomTasks,
 				DisableAffinityAssistant:         config.DefaultDisableAffinityAssistant,
 				DisableCredsInit:                 config.DefaultDisableCredsInit,
 				RunningInEnvWithInjectedSidecars: config.DefaultRunningInEnvWithInjectedSidecars,
@@ -144,7 +139,6 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 			expectedConfig: &config.FeatureFlags{
 				EnableAPIFields:                  "stable",
 				EmbeddedStatus:                   "full",
-				EnableCustomTasks:                config.DefaultEnableCustomTasks,
 				EnableSpire:                      true,
 				ResourceVerificationMode:         config.DefaultResourceVerificationMode,
 				RunningInEnvWithInjectedSidecars: config.DefaultRunningInEnvWithInjectedSidecars,
@@ -163,7 +157,6 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 				RunningInEnvWithInjectedSidecars: config.DefaultRunningInEnvWithInjectedSidecars,
 				AwaitSidecarReadiness:            config.DefaultAwaitSidecarReadiness,
 				ResultExtractionMethod:           config.ResultExtractionMethodSidecarLogs,
-				EnableCustomTasks:                config.DefaultEnableCustomTasks,
 				MaxResultSize:                    8192,
 				CustomTaskVersion:                config.DefaultCustomTaskVersion,
 			},
@@ -189,7 +182,6 @@ func TestNewFeatureFlagsFromEmptyConfigMap(t *testing.T) {
 		AwaitSidecarReadiness:            config.DefaultAwaitSidecarReadiness,
 		RequireGitSSHSecretKnownHosts:    config.DefaultRequireGitSSHSecretKnownHosts,
 		EnableTektonOCIBundles:           config.DefaultEnableTektonOciBundles,
-		EnableCustomTasks:                config.DefaultEnableCustomTasks,
 		EnableAPIFields:                  config.DefaultEnableAPIFields,
 		SendCloudEventsForRuns:           config.DefaultSendCloudEventsForRuns,
 		EmbeddedStatus:                   config.DefaultEmbeddedStatus,

--- a/pkg/apis/config/testdata/feature-flags-enable-api-fields-overrides-bundles-and-custom-tasks.yaml
+++ b/pkg/apis/config/testdata/feature-flags-enable-api-fields-overrides-bundles-and-custom-tasks.yaml
@@ -5,6 +5,5 @@ metadata:
   namespace: tekton-pipelines
 data:
   enable-tekton-oci-bundles: "false"
-  enable-custom-tasks: "false"
   enable-spire: "false"
   enable-api-fields: "alpha"

--- a/pkg/apis/pipeline/v1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1/pipeline_types.go
@@ -476,13 +476,11 @@ func (pt PipelineTask) Validate(ctx context.Context) (errs *apis.FieldError) {
 
 	errs = errs.Also(pt.validateEmbeddedOrType())
 
-	cfg := config.FromContextOrDefaults(ctx)
-	// If EnableCustomTasks feature flag is on, validate custom task specifications
-	// pipeline task having taskRef with APIVersion is classified as custom task
+	// Pipeline task having taskRef/taskSpec with APIVersion is classified as custom task
 	switch {
-	case cfg.FeatureFlags.EnableCustomTasks && pt.TaskRef != nil && pt.TaskRef.APIVersion != "":
+	case pt.TaskRef != nil && pt.TaskRef.APIVersion != "":
 		errs = errs.Also(pt.validateCustomTask())
-	case cfg.FeatureFlags.EnableCustomTasks && pt.TaskSpec != nil && pt.TaskSpec.APIVersion != "":
+	case pt.TaskSpec != nil && pt.TaskSpec.APIVersion != "":
 		errs = errs.Also(pt.validateCustomTask())
 	default:
 		errs = errs.Also(pt.validateTask(ctx))

--- a/pkg/apis/pipeline/v1beta1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types.go
@@ -463,12 +463,11 @@ func (pt PipelineTask) Validate(ctx context.Context) (errs *apis.FieldError) {
 	errs = errs.Also(pt.validateEmbeddedOrType())
 
 	cfg := config.FromContextOrDefaults(ctx)
-	// If EnableCustomTasks feature flag is on, validate custom task specifications
-	// pipeline task having taskRef with APIVersion is classified as custom task
+	// Pipeline task having taskRef/taskSpec with APIVersion is classified as custom task
 	switch {
-	case cfg.FeatureFlags.EnableCustomTasks && pt.TaskRef != nil && pt.TaskRef.APIVersion != "":
+	case pt.TaskRef != nil && pt.TaskRef.APIVersion != "":
 		errs = errs.Also(pt.validateCustomTask())
-	case cfg.FeatureFlags.EnableCustomTasks && pt.TaskSpec != nil && pt.TaskSpec.APIVersion != "":
+	case pt.TaskSpec != nil && pt.TaskSpec.APIVersion != "":
 		errs = errs.Also(pt.validateCustomTask())
 		// If EnableTektonOCIBundles feature flag is on, validate bundle specifications
 	case cfg.FeatureFlags.EnableTektonOCIBundles && pt.TaskRef != nil && pt.TaskRef.Bundle != "":

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -632,8 +632,7 @@ func isCustomTask(ctx context.Context, rpt ResolvedPipelineTask) bool {
 		rpt.PipelineTask.TaskRef.Kind != ""
 	isTaskSpecCustomTask := rpt.PipelineTask.TaskSpec != nil && rpt.PipelineTask.TaskSpec.APIVersion != "" &&
 		rpt.PipelineTask.TaskSpec.Kind != ""
-	cfg := config.FromContextOrDefaults(ctx)
-	return cfg.FeatureFlags.EnableCustomTasks && !invalidSpec && (isTaskRefCustomTask || isTaskSpecCustomTask)
+	return !invalidSpec && (isTaskRefCustomTask || isTaskSpecCustomTask)
 }
 
 // ResolvePipelineTask retrieves a single Task's instance using the getTask to fetch

--- a/test/custom_task_test.go
+++ b/test/custom_task_test.go
@@ -1173,7 +1173,7 @@ func TestWaitCustomTask_V1Beta1_PipelineRun(t *testing.T) {
 
 func setUpCustomTask(ctx context.Context, t *testing.T, fn ...func(context.Context, *testing.T, *clients, string)) (*clients, string) {
 	t.Helper()
-	c, ns := setup(ctx, t, requireAnyGate(neededFeatureFlags))
+	c, ns := setup(ctx, t, fn...)
 	// Note that this may not work if we run e2e tests in parallel since this feature flag forces custom tasks to be
 	// created as v1alpha1.Run with this value. i.e. Don't add t.Parallel() for this test.
 	configMapData := map[string]string{
@@ -1184,14 +1184,12 @@ func setUpCustomTask(ctx context.Context, t *testing.T, fn ...func(context.Conte
 		t.Fatal(err)
 	}
 
-	// Sleep 5s to
-
 	return c, ns
 }
 
 func setUpV1Beta1CustomTask(ctx context.Context, t *testing.T, fn ...func(context.Context, *testing.T, *clients, string)) (*clients, string) {
 	t.Helper()
-	c, ns := setup(ctx, t, requireAnyGate(neededFeatureFlags))
+	c, ns := setup(ctx, t, fn...)
 	// Note that this may not work if we run e2e tests in parallel since this feature flag forces custom tasks to be
 	// created as v1beta1.CustomRuns i.e. Don't add t.Parallel() for this test.
 	configMapData := map[string]string{


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

Custom Tasks have been promoted to the beta version, hence, enable-custom-tasks is not required anymore. This commit removes the feature flag.

/kind misc

fix #5861

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Removed the feature flag `enable-custom-tasks`.
```
