### PR TITLE
Fix task parameter value substitution error due to `propagateParams`

### DIFF
--- a/pkg/reconciler/pipelinerun/resources/apply_test.go
+++ b/pkg/reconciler/pipelinerun/resources/apply_test.go
@@ -1450,6 +1450,260 @@ func TestApplyParameters(t *testing.T) {
 			}},
 		},
 	},
+		{
+			name: "tasks with the same parameter name but referencing different values",
+			original: v1beta1.PipelineSpec{
+				Params: []v1beta1.ParamSpec{
+					{
+						Name: "param1",
+						Default: &v1beta1.ParamValue{
+							Type:      v1beta1.ParamTypeString,
+							StringVal: "a",
+						},
+						Type: v1beta1.ParamTypeString,
+					},
+				},
+				Tasks: []v1beta1.PipelineTask{
+					{
+						Name: "previous-task-with-result",
+					},
+					{
+						Name: "print-msg",
+						TaskSpec: &v1beta1.EmbeddedTask{
+							TaskSpec: v1beta1.TaskSpec{
+								Params: []v1beta1.ParamSpec{
+									{
+										Name: "param1",
+										Type: v1beta1.ParamTypeString,
+									},
+								},
+							},
+						},
+						Params: []v1beta1.Param{
+							{
+								Name: "param1",
+								Value: v1beta1.ParamValue{
+									Type:      v1beta1.ParamTypeString,
+									StringVal: "$(tasks.previous-task-with-result.results.Output)",
+								},
+							},
+						},
+					},
+					{
+						Name: "print-msg-2",
+						TaskSpec: &v1beta1.EmbeddedTask{
+							TaskSpec: v1beta1.TaskSpec{
+								Params: []v1beta1.ParamSpec{
+									{
+										Name: "param1",
+										Type: v1beta1.ParamTypeString,
+									},
+								},
+							},
+						},
+						Params: []v1beta1.Param{
+							{
+								Name: "param1",
+								Value: v1beta1.ParamValue{
+									Type:      v1beta1.ParamTypeString,
+									StringVal: "$(params.param1)",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: v1beta1.PipelineSpec{
+				Params: []v1beta1.ParamSpec{
+					{
+						Name: "param1",
+						Default: &v1beta1.ParamValue{
+							Type:      v1beta1.ParamTypeString,
+							StringVal: "a",
+						},
+						Type: v1beta1.ParamTypeString,
+					},
+				},
+				Tasks: []v1beta1.PipelineTask{
+					{
+						Name: "previous-task-with-result",
+					},
+					{
+						Name: "print-msg",
+						TaskSpec: &v1beta1.EmbeddedTask{
+							TaskSpec: v1beta1.TaskSpec{
+								Params: []v1beta1.ParamSpec{
+									{
+										Name: "param1",
+										Type: v1beta1.ParamTypeString,
+									},
+								},
+							},
+						},
+						Params: []v1beta1.Param{
+							{
+								Name: "param1",
+								Value: v1beta1.ParamValue{
+									Type:      v1beta1.ParamTypeString,
+									StringVal: "$(tasks.previous-task-with-result.results.Output)",
+								},
+							},
+						},
+					},
+					{
+						Name: "print-msg-2",
+						TaskSpec: &v1beta1.EmbeddedTask{
+							TaskSpec: v1beta1.TaskSpec{
+								Params: []v1beta1.ParamSpec{
+									{
+										Name: "param1",
+										Type: v1beta1.ParamTypeString,
+									},
+								},
+							},
+						},
+						Params: []v1beta1.Param{
+							{
+								Name: "param1",
+								Value: v1beta1.ParamValue{
+									Type:      v1beta1.ParamTypeString,
+									StringVal: "a",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "finally tasks with the same parameter name but referencing different values",
+			original: v1beta1.PipelineSpec{
+				Params: []v1beta1.ParamSpec{
+					{
+						Name: "param1",
+						Default: &v1beta1.ParamValue{
+							Type:      v1beta1.ParamTypeString,
+							StringVal: "a",
+						},
+						Type: v1beta1.ParamTypeString,
+					},
+				},
+				Tasks: []v1beta1.PipelineTask{
+					{
+						Name: "previous-task-with-result",
+					},
+				},
+				Finally: []v1beta1.PipelineTask{
+					{
+						Name: "print-msg",
+						TaskSpec: &v1beta1.EmbeddedTask{
+							TaskSpec: v1beta1.TaskSpec{
+								Params: []v1beta1.ParamSpec{
+									{
+										Name: "param1",
+										Type: v1beta1.ParamTypeString,
+									},
+								},
+							},
+						},
+						Params: []v1beta1.Param{
+							{
+								Name: "param1",
+								Value: v1beta1.ParamValue{
+									Type:      v1beta1.ParamTypeString,
+									StringVal: "$(tasks.previous-task-with-result.results.Output)",
+								},
+							},
+						},
+					},
+					{
+						Name: "print-msg-2",
+						TaskSpec: &v1beta1.EmbeddedTask{
+							TaskSpec: v1beta1.TaskSpec{
+								Params: []v1beta1.ParamSpec{
+									{
+										Name: "param1",
+										Type: v1beta1.ParamTypeString,
+									},
+								},
+							},
+						},
+						Params: []v1beta1.Param{
+							{
+								Name: "param1",
+								Value: v1beta1.ParamValue{
+									Type:      v1beta1.ParamTypeString,
+									StringVal: "$(params.param1)",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: v1beta1.PipelineSpec{
+				Params: []v1beta1.ParamSpec{
+					{
+						Name: "param1",
+						Default: &v1beta1.ParamValue{
+							Type:      v1beta1.ParamTypeString,
+							StringVal: "a",
+						},
+						Type: v1beta1.ParamTypeString,
+					},
+				},
+				Tasks: []v1beta1.PipelineTask{
+					{
+						Name: "previous-task-with-result",
+					},
+				},
+				Finally: []v1beta1.PipelineTask{
+					{
+						Name: "print-msg",
+						TaskSpec: &v1beta1.EmbeddedTask{
+							TaskSpec: v1beta1.TaskSpec{
+								Params: []v1beta1.ParamSpec{
+									{
+										Name: "param1",
+										Type: v1beta1.ParamTypeString,
+									},
+								},
+							},
+						},
+						Params: []v1beta1.Param{
+							{
+								Name: "param1",
+								Value: v1beta1.ParamValue{
+									Type:      v1beta1.ParamTypeString,
+									StringVal: "$(tasks.previous-task-with-result.results.Output)",
+								},
+							},
+						},
+					},
+					{
+						Name: "print-msg-2",
+						TaskSpec: &v1beta1.EmbeddedTask{
+							TaskSpec: v1beta1.TaskSpec{
+								Params: []v1beta1.ParamSpec{
+									{
+										Name: "param1",
+										Type: v1beta1.ParamTypeString,
+									},
+								},
+							},
+						},
+						Params: []v1beta1.Param{
+							{
+								Name: "param1",
+								Value: v1beta1.ParamValue{
+									Type:      v1beta1.ParamTypeString,
+									StringVal: "a",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	} {
 		tt := tt // capture range variable
 		ctx := context.Background()


### PR DESCRIPTION
# Changes
fix [Tekton incorrectly maps pipeline parameters and task outputs with the same name](https://github.com/tektoncd/pipeline/issues/5988)

`propagateParams` modifications to replacements should be limited to this function so as not to interfere with
 the parameters of subsequent tasks

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
