### PR TITLE
make the webhook controller name configurable

### DIFF
--- a/config/webhook.yaml
+++ b/config/webhook.yaml
@@ -105,6 +105,15 @@ spec:
         # containerPort "https-webhook" to the same value.
         - name: WEBHOOK_PORT
           value: "8443"
+        # if you change WEBHOOK_ADMISSION_CONTROLLER_NAME, you will also need to update
+        # the webhooks.name in 500-webhooks.yaml to include the new names of admission webhooks.
+        # Additionally, you will also need to change the resource names (metadata.name) of
+        # "MutatingWebhookConfiguration" and "ValidatingWebhookConfiguration" in 500-webhooks.yaml
+        # to reflect the change in the name of the admission webhook.
+        # Followed by changing the webhook's Role in 200-clusterrole.yaml to update the "resourceNames" of
+        # "mutatingwebhookconfigurations" and "validatingwebhookconfigurations" resources.
+        - name: WEBHOOK_ADMISSION_CONTROLLER_NAME
+          value: webhook.pipeline.tekton.dev
         - name: WEBHOOK_SERVICE_NAME
           value: tekton-pipelines-webhook
         - name: WEBHOOK_SECRET_NAME


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Introduce a new env. variable to provide the admission controller name - `WEBHOOK_ADMISSION_CONTROLLER_NAME`

The `webhook` contains multiple controllers including mutating/validating `webhook` and the conversion controller. All controllers are hard coded to `webhook.pipeline.tekton.dev`, `config.webhook.pipeline.tekton.dev`, and `validation.webhook.pipeline.tekton.dev`.

This commit adds a new env. variable in the `webhook` deployment such that the controller name can be configured from the deployment yaml if needed. Also added instructions in webhook deployment with the list of changes you will have to apply if you change the default value.

Signed-off-by: pritidesai <pdesai@us.ibm.com>

/kind feature

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
The webhook controller name can be configured using WEBHOOK_ADMISSION_CONTROLLER_NAME environment variable in webhook deployment.
```
