### PR TITLE
Document behavior of feature-flag flips

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -420,7 +420,12 @@ file lists the keys you can customize along with their default values.
 ### Customizing the Pipelines Controller behavior
 
 To customize the behavior of the Pipelines Controller, modify the ConfigMap `feature-flags` via
-`kubectl edit configmap feature-flags -n tekton-pipelines`. The flags in this ConfigMap are as follows:
+`kubectl edit configmap feature-flags -n tekton-pipelines`.
+
+**Note:** Changing feature flags may result in undefined behavior for TaskRuns and PipelineRuns
+that are running while the change occurs.
+
+The flags in this ConfigMap are as follows:
 
 - `disable-affinity-assistant` - set this flag to `true` to disable the [Affinity Assistant](./workspaces.md#specifying-workspace-order-in-a-pipeline-and-affinity-assistants)
   that is used to provide Node Affinity for `TaskRun` pods that share workspace volume.

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -1354,9 +1354,6 @@ func updatePipelineRunStatusFromChildObjects(ctx context.Context, logger *zap.Su
 	return validateChildObjectsInPipelineRunStatus(ctx, pr.Status)
 }
 
-// TODO: https://github.com/tektoncd/pipeline/issues/5999 integration tests for changing
-// feature flags could help prevent validation errors when the feature-flag is being switched.
-// In such case, the error could keep the pipelineRun run indefinitely.
 func validateChildObjectsInPipelineRunStatus(ctx context.Context, prs v1beta1.PipelineRunStatus) error {
 	cfg := config.FromContextOrDefaults(ctx)
 


### PR DESCRIPTION
This commit clarifies that Tekton doesn't make guarantees about the behavior of running TaskRuns and PipelineRuns if feature flags are modified during their execution.

Alternatively, we could store the value of the feature flags at the start of execution in a PipelineRun or TaskRun's status. This remains an option we can explore in the future.

/kind documentation
Closes https://github.com/tektoncd/pipeline/issues/5999

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- n/a Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- n/a Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- n/a Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
