### PR TITLE
Increase `timeout` in Conversion Integration Test to Prevent Flake

### DIFF
--- a/test/conversion_test.go
+++ b/test/conversion_test.go
@@ -415,7 +415,7 @@ spec:
           echo "Hello World!"
     workspaces:
     - name: output
-  timeout: 20s
+  timeout: 60s
   workspaces:
     - name: output
       emptyDir: {}
@@ -539,7 +539,7 @@ spec:
     value: 1
     type: string
   serviceAccountName: default
-  timeout: 20s
+  timeout: 60s
   podTemplate:
     securityContext:
       fsGroup: 65532


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This commit increases the `timeout` length in conversion_test to prevent flake in that pipeline could fail waiting for the TaskRun to get done given the previous `timeout`.

Potential flake observed at:
https://prow.tekton.dev/view/gs/tekton-prow/pr-logs/pull/tektoncd_pipeline/6022/pull-tekton-pipeline-integration-tests/1617909197544886272
```
    stream.go:254: D 15:51:47.598 tekton-pipelines-controller-5cc86f7df8-tcwgv [github.com.tektoncd.pipeline.pkg.reconciler.pipelinerun.Reconciler] [arendelle-xrpr8/git-resolver-clone-vktppyly] tracerProvider doesn't provide a traceId, tracing is disabled
=== CONT  TestTaskRunCRDConversion
    conversion_test.go:869: Failed waiting for v1beta1 TaskRun done: "task-run-c-r-d-conversion-wskyiehs" failed
    panic.go:500: ############################################
    panic.go:500: ### Dumping objects from arendelle-msvkl ###
    panic.go:500: ############################################
```

/kind misc
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [n/a] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [n/a] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
