### PR TITLE
Use remote resolution in release pipeline

### DIFF
--- a/tekton/release-pipeline.yaml
+++ b/tekton/release-pipeline.yaml
@@ -107,7 +107,14 @@ spec:
     - name: publish-images
       runAfter: [unit-tests, build]
       taskRef:
-        name: publish-release
+        resolver: git
+        params:
+        - name: url
+          value: https://github.com/tektoncd/pipeline.git
+        - name: revision
+          value: $(params.gitRevision)
+        - name: pathInRepo
+          value: tekton/publish.yaml
       params:
         - name: package
           value: $(params.package)


### PR DESCRIPTION
Currently, the publish-release task on the dogfood cluster doesn't necessarily match the publish-release task in the repo. This means if the publish-release task is modified on a certain branch, or we change the images being released, these changes aren't reflected on the dogfood cluster and releases will fail.

This commit updates the release pipeline to use remote resolution to fetch the publish-release task from the repo at the revision being released. This will allow backport releases to succeed, and releases done after we modify the images being built.

/kind bug
Fixes #5969

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- n/a Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- n/a Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- n/a Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- n/a Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
