### PR TITLE
Increase memory limit for remote resolvers deployment

### DIFF
--- a/config/resolvers/resolvers-deployment.yaml
+++ b/config/resolvers/resolvers-deployment.yaml
@@ -70,7 +70,7 @@ spec:
             memory: 100Mi
           limits:
             cpu: 1000m
-            memory: 1000Mi
+            memory: 4Gi
         ports:
         - name: metrics
           containerPort: 9090


### PR DESCRIPTION
# Changes

We tried using remote resolution for Pipelines' own release process, and it failed. Eventually, we discovered that the problem was that the `tekton-pipelines-remote-resolvers-...` pod kept getting OOM killed when trying to clone pipeline.git. Since we were using anonymous git cloning for resolution, not the authenticated API-based resolution, a full clone has to be performed, and that apparently spiked RAM usage in the container past the existing `1000Mi` memory limit. I manually bumped that limit to `4Gi`, at which point the resolution actually worked. So let's bump that here too.

I may be overshooting on the new limit, though. =)

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Prevent OOM-kills of remote resolver pod when cloning large git repositories by increasing container's memory limit.
```
