### PR TITLE
minor doc update for array and object results

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -912,14 +912,20 @@ Tasks can emit [`Results`](tasks.md#emitting-results) when they execute. A Pipel
 Sharing `Results` between `Tasks` in a `Pipeline` happens via
 [variable substitution](variables.md#variables-available-in-a-pipeline) - one `Task` emits
 a `Result` and another receives it as a `Parameter` with a variable such as
-`$(tasks.<task-name>.results.<result-name>)`. Array `Results` is supported as alpha feature and
-can be referred as `$(tasks.<task-name>.results.<result-name>[*])`. Array indexing can be rererred
-as `$(tasks.<task-name>.results.<result-name>[i])` where `i` is the index.
-Object `Results` is supported as alpha feature and can be referred as
-`$(tasks.<task-name>.results.<result-name>[*])`, object elements can be referred as
-`$(tasks.<task-name>.results.<result-name>.key)`.
+`$(tasks.<task-name>.results.<result-name>)`. Pipeline support two new types of
+results and parameters: array `[]string` and object `map[string]string`.
+Both are alpha features and can be enabled by setting `enable-api-fields` to `alpha`.
 
-**Note:** Whole Array and Object `Results` cannot be referred in `script` and `args`.
+| Result Type | Parameter Type | Specification                                    | `enable-api-fields` |
+|-------------|----------------|--------------------------------------------------|-------------------|
+| string      | string         | `$(tasks.<task-name>.results.<result-name>)`     | stable            |
+| array       | array          | `$(tasks.<task-name>.results.<result-name>[*])`  | alpha             |
+| array       | string         | `$(tasks.<task-name>.results.<result-name>[i])`  | alpha             |
+| object      | object         | `$(tasks.<task-name>.results.<result-name>[*])`  | alpha             |
+| object      | string         | `$(tasks.<task-name>.results.<result-name>.key)` | alpha             |
+
+**Note:** Whole Array and Object `Results` (using star notation) cannot be referred in `script` and `args`.
+
 **Note:** `Matrix` does not support `object` and `array` results.
 
 When one `Task` receives the `Results` of another, there is a dependency created between those


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Being explicit about the types of results supported - array - `[]string` and object - `map[string]string`. Introducing a table with the type of the result and the type of a parameter which is consuming the result along with the specification. The table with the explicit types will help the users to understand how to consume array and/or object results into array or object or  string parameter.

This is for the preparation of a potential promotion of https://github.com/tektoncd/pipeline/issues/5688. 

Signed-off-by: pritidesai <pdesai@us.ibm.com>

/kind documentation

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
