### PR TITLE
Fix outdated remote resolution documentation

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -18,7 +18,7 @@ This guide explains how to install Tekton Pipelines. It covers the following top
         - [Example configuration for an S3 bucket](#example-configuration-for-an-s3-bucket)
         - [Example configuration for a GCS bucket](#example-configuration-for-a-gcs-bucket)
 - [Configuring CloudEvents notifications](#configuring-cloudevents-notifications)
-- [Installing and configuring remote Task and Pipeline resolution](#installing-and-configuring-remote-task-and-pipeline-resolution)
+- [Configuring remote Task and Pipeline resolution](#configuring-built-in-remote-task-and-pipeline-resolution)
 - [Configuring self-signed cert for private registry](#configuring-self-signed-cert-for-private-registry)
 - [Customizing basic execution parameters](#customizing-basic-execution-parameters)
     - [Customizing the Pipelines Controller behavior](#customizing-the-pipelines-controller-behavior)
@@ -272,19 +272,19 @@ data:
 
 ## Configuring built-in remote Task and Pipeline resolution
 
-Three remote resolvers are currently provided as part of the Tekton Pipelines installation.
-By default, these remote resolvers are disabled. Each resolver is enabled by setting
+Four remote resolvers are currently provided as part of the Tekton Pipelines installation.
+By default, these remote resolvers are enabled. Each resolver can be disabled by setting
 the appropriate feature flag in the `resolvers-feature-flags` ConfigMap in the `tekton-pipelines-resolvers`
 namespace:
 
-1. [The `bundles` resolver](./bundle-resolver.md), enabled by setting the `enable-bundles-resolver`
-  feature flag to `true`.
-1. [The `git` resolver](./git-resolver.md), enabled by setting the `enable-git-resolver`
-   feature flag to `true`.
-1. [The `hub` resolver](./hub-resolver.md), enabled by setting the `enable-hub-resolver`
-   feature flag to `true`.
-1. [The `cluster` resolver](./cluster-resolver.md), enabled by setting the `enable-cluster-resolver`
-   feature flag to `true`.
+1. [The `bundles` resolver](./bundle-resolver.md), disabled by setting the `enable-bundles-resolver`
+  feature flag to `false`.
+1. [The `git` resolver](./git-resolver.md), disabled by setting the `enable-git-resolver`
+   feature flag to `false`.
+1. [The `hub` resolver](./hub-resolver.md), disabled by setting the `enable-hub-resolver`
+   feature flag to `false`.
+1. [The `cluster` resolver](./cluster-resolver.md), disabled by setting the `enable-cluster-resolver`
+   feature flag to `false`.
 
 ## Configuring CloudEvents notifications
 
@@ -511,23 +511,23 @@ Alpha features in the following table are still in development and their syntax 
 
 Features currently in "alpha" are:
 
-| Feature                                                                                               | Proposal                                                                                                                        | Release                                                              | Individual Flag             |
-|:------------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------|:----------------------------|
-| [Bundles ](./pipelineruns.md#tekton-bundles)                                                          | [TEP-0005](https://github.com/tektoncd/community/blob/main/teps/0005-tekton-oci-bundles.md)                                | [v0.18.0](https://github.com/tektoncd/pipeline/releases/tag/v0.18.0) | `enable-tekton-oci-bundles` |
-| [Isolated `Step` & `Sidecar` `Workspaces`](./workspaces.md#isolated-workspaces)                       | [TEP-0029](https://github.com/tektoncd/community/blob/main/teps/0029-step-workspaces.md)                                   | [v0.24.0](https://github.com/tektoncd/pipeline/releases/tag/v0.24.0) |                             |
-| [Hermetic Execution Mode](./hermetic.md)                                                              | [TEP-0025](https://github.com/tektoncd/community/blob/main/teps/0025-hermekton.md)                                         | [v0.25.0](https://github.com/tektoncd/pipeline/releases/tag/v0.25.0) |                             |
-| [Propagated `Parameters`](./taskruns.md#propagated-parameters)                                        | [TEP-0107](https://github.com/tektoncd/community/blob/main/teps/0107-propagating-parameters.md)                            | [v0.36.0](https://github.com/tektoncd/pipeline/releases/tag/v0.36.0) |                             |
-| [Propagated `Workspaces`](./pipelineruns.md#propagated-workspaces)                                    | [TEP-0111](https://github.com/tektoncd/community/blob/main/teps/0111-propagating-workspaces.md)                      |            v0.40.0                                                          |                             |
-| [Windows Scripts](./tasks.md#windows-scripts)                                                         | [TEP-0057](https://github.com/tektoncd/community/blob/main/teps/0057-windows-support.md)                                   | [v0.28.0](https://github.com/tektoncd/pipeline/releases/tag/v0.28.0) |                             |
-| [Debug](./debug.md)                                                                                   | [TEP-0042](https://github.com/tektoncd/community/blob/main/teps/0042-taskrun-breakpoint-on-failure.md)                     | [v0.26.0](https://github.com/tektoncd/pipeline/releases/tag/v0.26.0) |                             |
-| [Step and Sidecar Overrides](./taskruns.md#overriding-task-steps-and-sidecars)                        | [TEP-0094](https://github.com/tektoncd/community/blob/main/teps/0094-specifying-resource-requirements-at-runtime.md)       |   [v0.34.0](https://github.com/tektoncd/pipeline/releases/tag/v0.34.0)                                                                   |                             |
-| [Matrix](./matrix.md)                                                                                 | [TEP-0090](https://github.com/tektoncd/community/blob/main/teps/0090-matrix.md)                                            | [v0.38.0](https://github.com/tektoncd/pipeline/releases/tag/v0.38.0) |                             |
-| [Embedded Statuses](pipelineruns.md#configuring-usage-of-taskrun-and-run-embedded-statuses)           | [TEP-0100](https://github.com/tektoncd/community/blob/main/teps/0100-embedded-taskruns-and-runs-status-in-pipelineruns.md) |   [v0.35.0](https://github.com/tektoncd/pipeline/releases/tag/v0.35.0)     |     `embedded-status`                 |
-| [Task-level Resource Requirements](compute-resources.md#task-level-compute-resources-configuration)   | [TEP-0104](https://github.com/tektoncd/community/blob/main/teps/0104-tasklevel-resource-requirements.md)                   | [v0.39.0](https://github.com/tektoncd/pipeline/releases/tag/v0.39.0)  |                             |
-| [Object Params and Results](pipelineruns.md#specifying-parameters)                                    | [TEP-0075](https://github.com/tektoncd/community/blob/main/teps/0075-object-param-and-result-types.md)                     | [v0.38.0](https://github.com/tektoncd/pipeline/releases/tag/v0.38.0) |                             |
-| [Array Results](pipelineruns.md#specifying-parameters)                                                | [TEP-0076](https://github.com/tektoncd/community/blob/main/teps/0076-array-result-types.md)                                | [v0.38.0](https://github.com/tektoncd/pipeline/releases/tag/v0.38.0) |                             |
-| [Trusted Resources](./trusted-resources.md)                                                | [TEP-0091](https://github.com/tektoncd/community/blob/main/teps/0091-trusted-resources.md)                                | N/A |     `resource-verification-mode`                        |
-|[`Provenance` field in Status](pipeline-api.md#provenance) |[issue#5550](https://github.com/tektoncd/pipeline/issues/5550)|N/A|`enable-provenance-in-status`|
+| Feature                                                                                             | Proposal                                                                                                                   | Release                                                              | Individual Flag               |
+|:----------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------|:------------------------------|
+| [Bundles ](./pipelineruns.md#tekton-bundles)                                                        | [TEP-0005](https://github.com/tektoncd/community/blob/main/teps/0005-tekton-oci-bundles.md)                                | [v0.18.0](https://github.com/tektoncd/pipeline/releases/tag/v0.18.0) | `enable-tekton-oci-bundles`   |
+| [Isolated `Step` & `Sidecar` `Workspaces`](./workspaces.md#isolated-workspaces)                     | [TEP-0029](https://github.com/tektoncd/community/blob/main/teps/0029-step-workspaces.md)                                   | [v0.24.0](https://github.com/tektoncd/pipeline/releases/tag/v0.24.0) |                               |
+| [Hermetic Execution Mode](./hermetic.md)                                                            | [TEP-0025](https://github.com/tektoncd/community/blob/main/teps/0025-hermekton.md)                                         | [v0.25.0](https://github.com/tektoncd/pipeline/releases/tag/v0.25.0) |                               |
+| [Propagated `Parameters`](./taskruns.md#propagated-parameters)                                      | [TEP-0107](https://github.com/tektoncd/community/blob/main/teps/0107-propagating-parameters.md)                            | [v0.36.0](https://github.com/tektoncd/pipeline/releases/tag/v0.36.0) |                               |
+| [Propagated `Workspaces`](./pipelineruns.md#propagated-workspaces)                                  | [TEP-0111](https://github.com/tektoncd/community/blob/main/teps/0111-propagating-workspaces.md)                            | v0.40.0                                                              |                               |
+| [Windows Scripts](./tasks.md#windows-scripts)                                                       | [TEP-0057](https://github.com/tektoncd/community/blob/main/teps/0057-windows-support.md)                                   | [v0.28.0](https://github.com/tektoncd/pipeline/releases/tag/v0.28.0) |                               |
+| [Debug](./debug.md)                                                                                 | [TEP-0042](https://github.com/tektoncd/community/blob/main/teps/0042-taskrun-breakpoint-on-failure.md)                     | [v0.26.0](https://github.com/tektoncd/pipeline/releases/tag/v0.26.0) |                               |
+| [Step and Sidecar Overrides](./taskruns.md#overriding-task-steps-and-sidecars)                      | [TEP-0094](https://github.com/tektoncd/community/blob/main/teps/0094-specifying-resource-requirements-at-runtime.md)       | [v0.34.0](https://github.com/tektoncd/pipeline/releases/tag/v0.34.0) |                               |
+| [Matrix](./matrix.md)                                                                               | [TEP-0090](https://github.com/tektoncd/community/blob/main/teps/0090-matrix.md)                                            | [v0.38.0](https://github.com/tektoncd/pipeline/releases/tag/v0.38.0) |                               |
+| [Embedded Statuses](pipelineruns.md#configuring-usage-of-taskrun-and-run-embedded-statuses)         | [TEP-0100](https://github.com/tektoncd/community/blob/main/teps/0100-embedded-taskruns-and-runs-status-in-pipelineruns.md) | [v0.35.0](https://github.com/tektoncd/pipeline/releases/tag/v0.35.0) | `embedded-status`             |
+| [Task-level Resource Requirements](compute-resources.md#task-level-compute-resources-configuration) | [TEP-0104](https://github.com/tektoncd/community/blob/main/teps/0104-tasklevel-resource-requirements.md)                   | [v0.39.0](https://github.com/tektoncd/pipeline/releases/tag/v0.39.0) |                               |
+| [Object Params and Results](pipelineruns.md#specifying-parameters)                                  | [TEP-0075](https://github.com/tektoncd/community/blob/main/teps/0075-object-param-and-result-types.md)                     | [v0.38.0](https://github.com/tektoncd/pipeline/releases/tag/v0.38.0) |                               |
+| [Array Results](pipelineruns.md#specifying-parameters)                                              | [TEP-0076](https://github.com/tektoncd/community/blob/main/teps/0076-array-result-types.md)                                | [v0.38.0](https://github.com/tektoncd/pipeline/releases/tag/v0.38.0) |                               |
+| [Trusted Resources](./trusted-resources.md)                                                         | [TEP-0091](https://github.com/tektoncd/community/blob/main/teps/0091-trusted-resources.md)                                 | N/A                                                                  | `resource-verification-mode`  |
+| [`Provenance` field in Status](pipeline-api.md#provenance)                                          | [issue#5550](https://github.com/tektoncd/pipeline/issues/5550)                                                             | N/A                                                                  | `enable-provenance-in-status` |
 | [Larger Results via Sidecar Logs](#enabling-larger-results-using-sidecar-logs)                      | [TEP-0127](https://github.com/tektoncd/community/blob/main/teps/0127-larger-results-via-sidecar-logs.md)                   | [v0.43.0](https://github.com/tektoncd/pipeline/releases/tag/v0.43.0) | `results-from`                |
 
 ### Beta Features

--- a/docs/pipelineruns.md
+++ b/docs/pipelineruns.md
@@ -178,11 +178,11 @@ so long as the artifact adheres to the [contract](tekton-bundle-contracts.md).
 
 #### Remote Pipelines
 
-**([alpha only](https://github.com/tektoncd/pipeline/blob/main/docs/install.md#alpha-features))**
+**([beta feature](https://github.com/tektoncd/pipeline/blob/main/docs/install.md#beta-features))**
 
 A `pipelineRef` field may specify a Pipeline in a remote location such as git.
 Support for specific types of remote will depend on the Resolvers your
-cluster's operator has installed. For more information please check the [Tekton resolution repo](https://github.com/tektoncd/resolution). The below example demonstrates
+cluster's operator has installed. For more information including a tutorial, please check [resolution docs](resolution.md). The below example demonstrates
 referencing a Pipeline in git:
 
 ```yaml
@@ -1455,17 +1455,17 @@ taskRuns:
 The following tables shows how to read the overall status of a `PipelineRun`.
 Completion time is set once a `PipelineRun` reaches status `True` or `False`:
 
-`status`|`reason`|`completionTime` is set|Description
-:-------|:-------|:---------------------:|--------------:
-Unknown|Started|No|The `PipelineRun` has just been picked up by the controller.
-Unknown|Running|No|The `PipelineRun` has been validate and started to perform its work.
-Unknown|Cancelled|No|The user requested the PipelineRun to be cancelled. Cancellation has not be done yet.
-True|Succeeded|Yes|The `PipelineRun` completed successfully.
-True|Completed|Yes|The `PipelineRun` completed successfully, one or more Tasks were skipped.
-False|Failed|Yes|The `PipelineRun` failed because one of the `TaskRuns` failed.
-False|\[Error message\]|Yes|The `PipelineRun` failed with a permanent error (usually validation).
-False|Cancelled|Yes|The `PipelineRun` was cancelled successfully.
-False|PipelineRunTimeout|Yes|The `PipelineRun` timed out.
+`status` | `reason`           | `completionTime` is set |                                                                           Description
+:--------|:-------------------|:-----------------------:|-------------------------------------------------------------------------------------:
+Unknown  | Started            |           No            |                          The `PipelineRun` has just been picked up by the controller.
+Unknown  | Running            |           No            |                  The `PipelineRun` has been validate and started to perform its work.
+Unknown  | Cancelled          |           No            | The user requested the PipelineRun to be cancelled. Cancellation has not be done yet.
+True     | Succeeded          |           Yes           |                                             The `PipelineRun` completed successfully.
+True     | Completed          |           Yes           |             The `PipelineRun` completed successfully, one or more Tasks were skipped.
+False    | Failed             |           Yes           |                        The `PipelineRun` failed because one of the `TaskRuns` failed.
+False    | \[Error message\]  |           Yes           |                 The `PipelineRun` failed with a permanent error (usually validation).
+False    | Cancelled          |           Yes           |                                         The `PipelineRun` was cancelled successfully.
+False    | PipelineRunTimeout |           Yes           |                                                          The `PipelineRun` timed out.
 
 When a `PipelineRun` changes status, [events](events.md#pipelineruns) are triggered accordingly.
 

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -13,6 +13,7 @@ weight: 400
   - [Specifying `Workspaces`](#specifying-workspaces)
   - [Specifying `Parameters`](#specifying-parameters)
   - [Adding `Tasks` to the `Pipeline`](#adding-tasks-to-the-pipeline)
+    - [Specifying Remote Tasks](#specifying-remote-tasks)
     - [Specifying `Resources` in `PipelineTasks`](#specifying-resources-in-pipelinetasks)
     - [Specifying `Parameters` in `PipelineTasks`](#specifying-parameters-in-pipelinetasks)
     - [Specifying `Matrix` in `PipelineTasks`](#specifying-matrix-in-pipelinetasks)
@@ -315,6 +316,29 @@ tasks:
 ```
 
 Note that any `task` specified in `taskSpec` will be the same version as the `Pipeline`.
+
+### Specifying Remote Tasks
+
+**([beta feature](https://github.com/tektoncd/pipeline/blob/main/docs/install.md#beta-features))**
+
+A `taskRef` field may specify a Task in a remote location such as git.
+Support for specific types of remote will depend on the Resolvers your
+cluster's operator has installed. For more information including a tutorial, please check [resolution docs](resolution.md). The below example demonstrates referencing a Task in git:
+
+```yaml
+tasks:
+- name: "go-build"
+  taskRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/tektoncd/catalog.git
+    - name: revision
+      # value can use params declared at the pipeline level or a static value like main
+      value: $(params.gitRevision) 
+    - name: pathInRepo
+      value: task/golang-build/0.3/golang-build.yaml
+```
 
 ### Specifying `Resources` in `PipelineTasks`
 
@@ -1778,8 +1802,8 @@ We try to list as many known Custom Tasks as possible here so that users can eas
 
 #### v1beta1.CustomRun
 
-| Custom Task | Description |
-|:---|:--- |
+| Custom Task                      | Description                                                                                                                      |
+|:---------------------------------|:---------------------------------------------------------------------------------------------------------------------------------|
 | [Wait Task Beta][wait-task-beta] | Waits a given amount of time before succeeding, specified by an input parameter named duration. Support `timeout` and `retries`. |
 
 #### v1alpha1.Run

--- a/docs/resolution.md
+++ b/docs/resolution.md
@@ -1,23 +1,18 @@
 # Tekton Pipeline Remote Resolution Docs
 
+Remote Resolution is a Tekton feature that allows users to fetch tasks and pipelines from remote sources outside the cluster. Tekton provides a few built-in resolvers that can fetch from git repositories, OCI registries etc as well as a framework for writing custom resolvers.
+
+Remote Resolution was initially created as a separate project in [TEP-060](https://github.com/tektoncd/community/blob/main/teps/0060-remote-resource-resolution.md) and migrated into the core pipelines project in [#4710](https://github.com/tektoncd/pipeline/issues/4710).
+
 ## Getting Started Tutorial
 
 For new users getting started with Tekton Pipeline remote resolution, check out the
 [resolution-getting-started.md](./resolution-getting-started.md) tutorial.
 
-## Built-in Resolvers
+## Configuring Built-in Resolvers
 
-These resolvers are enabled by setting the appropriate feature flag in the `resolvers-feature-flags` 
-ConfigMap in the `tekton-pipelines-resolvers` namespace.
-
-1. [The `bundles` resolver](./bundle-resolver.md), enabled by setting the `enable-bundles-resolver`
-   feature flag to `true`.
-1. [The `git` resolver](./git-resolver.md), enabled by setting the `enable-git-resolver`
-   feature flag to `true`.
-1. [The `hub` resolver](./hub-resolver.md), enabled by setting the `enable-hub-resolver`
-   feature flag to `true`.
-1. [The `cluster` resolver](./cluster-resolver.md), enabled by setting the `enable-cluster-resolver`
-   feature flag to `true`.
+These resolvers are enabled by setting the appropriate feature flag in the `resolvers-feature-flags`
+ConfigMap in the `tekton-pipelines-resolvers` namespace. See the [section in install.md](install.md#configuring-built-in-remote-task-and-pipeline-resolution) for details.
 
 ## Developer Howto: Writing a Resolver From Scratch
 

--- a/docs/taskruns.md
+++ b/docs/taskruns.md
@@ -11,8 +11,8 @@ weight: 300
 - [Overview](#overview)
 - [Configuring a `TaskRun`](#configuring-a-taskrun)
   - [Specifying the target `Task`](#specifying-the-target-task)
-  - [Tekton Bundles](#tekton-bundles)
-  - [Remote Tasks](#remote-tasks)
+    - [Tekton Bundles](#tekton-bundles)
+    - [Remote Tasks](#remote-tasks)
   - [Specifying `Parameters`](#specifying-parameters)
     - [Propagated Parameters](#propagated-parameters)
     - [Propagated Object Parameters](#propagated-object-parameters)
@@ -116,7 +116,7 @@ spec:
           - --destination=gcr.io/my-project/gohelloworld
 ```
 
-### Tekton Bundles
+#### Tekton Bundles
 
 **Note: This is only allowed if `enable-tekton-oci-bundles` is set to
 `"true"` or `enable-api-fields` is set to `"alpha"` in the `feature-flags`
@@ -166,14 +166,13 @@ of the same named `Task` to be run at once.
 the artifact adheres to the [contract](tekton-bundle-contracts.md). Additionally, you may also use the `tkn`
 cli *(coming soon)*.
 
-### Remote Tasks
+#### Remote Tasks
 
-**([alpha only](https://github.com/tektoncd/pipeline/blob/main/docs/install.md#alpha-features))**
+**([beta feature](https://github.com/tektoncd/pipeline/blob/main/docs/install.md#beta-features))**
 
 A `taskRef` field may specify a Task in a remote location such as git.
 Support for specific types of remote will depend on the Resolvers your
-cluster's operator has installed. For more information please check the [Tekton resolution repo](https://github.com/tektoncd/resolution). The below example demonstrates
-referencing a Task in git:
+cluster's operator has installed. For more information including a tutorial, please check [resolution docs](resolution.md). The below example demonstrates referencing a Task in git:
 
 ```yaml
 spec:
@@ -779,20 +778,20 @@ steps:
 
 The following tables shows how to read the overall status of a `TaskRun`:
 
-`status`|`reason`|`message`|`completionTime` is set|Description
-:-------|:-------|:--|:---------------------:|--------------:
-Unknown|Started|n/a|No|The TaskRun has just been picked up by the controller.
-Unknown|Pending|n/a|No|The TaskRun is waiting on a Pod in status Pending.
-Unknown|Running|n/a|No|The TaskRun has been validated and started to perform its work.
-Unknown|TaskRunCancelled|n/a|No|The user requested the TaskRun to be cancelled. Cancellation has not been done yet.
-True|Succeeded|n/a|Yes|The TaskRun completed successfully.
-False|Failed|n/a|Yes|The TaskRun failed because one of the steps failed.
-False|\[Error message\]|n/a|No|The TaskRun encountered a non-permanent error, and it's still running. It may ultimately succeed.
-False|\[Error message\]|n/a|Yes|The TaskRun failed with a permanent error (usually validation).
-False|TaskRunCancelled|n/a|Yes|The TaskRun was cancelled successfully.
-False|TaskRunCancelled|TaskRun cancelled as the PipelineRun it belongs to has timed out.|Yes|The TaskRun was cancelled because the PipelineRun timed out.
-False|TaskRunTimeout|n/a|Yes|The TaskRun timed out.
-False|TaskRunImagePullFailed|n/a|Yes|The TaskRun failed due to one of its steps not being able to pull the image.
+`status` | `reason`               | `message`                                                         | `completionTime` is set |                                                                                       Description
+:--------|:-----------------------|:------------------------------------------------------------------|:-----------------------:|-------------------------------------------------------------------------------------------------:
+Unknown  | Started                | n/a                                                               |           No            |                                            The TaskRun has just been picked up by the controller.
+Unknown  | Pending                | n/a                                                               |           No            |                                                The TaskRun is waiting on a Pod in status Pending.
+Unknown  | Running                | n/a                                                               |           No            |                                   The TaskRun has been validated and started to perform its work.
+Unknown  | TaskRunCancelled       | n/a                                                               |           No            |               The user requested the TaskRun to be cancelled. Cancellation has not been done yet.
+True     | Succeeded              | n/a                                                               |           Yes           |                                                               The TaskRun completed successfully.
+False    | Failed                 | n/a                                                               |           Yes           |                                               The TaskRun failed because one of the steps failed.
+False    | \[Error message\]      | n/a                                                               |           No            | The TaskRun encountered a non-permanent error, and it's still running. It may ultimately succeed.
+False    | \[Error message\]      | n/a                                                               |           Yes           |                                   The TaskRun failed with a permanent error (usually validation).
+False    | TaskRunCancelled       | n/a                                                               |           Yes           |                                                           The TaskRun was cancelled successfully.
+False    | TaskRunCancelled       | TaskRun cancelled as the PipelineRun it belongs to has timed out. |           Yes           |                                      The TaskRun was cancelled because the PipelineRun timed out.
+False    | TaskRunTimeout         | n/a                                                               |           Yes           |                                                                            The TaskRun timed out.
+False    | TaskRunImagePullFailed | n/a                                                               |           Yes           |                      The TaskRun failed due to one of its steps not being able to pull the image.
 
 When a `TaskRun` changes status, [events](events.md#taskruns) are triggered accordingly.
 
@@ -805,9 +804,9 @@ the first retry.
 
 Some examples:
 
-| `TaskRun` Name       | `Pod` Name    |
-|----------------------|---------------|
-| task-run             | task-run-pod  |
+| `TaskRun` Name                                                             | `Pod` Name                                                      |
+|----------------------------------------------------------------------------|-----------------------------------------------------------------|
+| task-run                                                                   | task-run-pod                                                    |
 | task-run-0123456789-0123456789-0123456789-0123456789-0123456789-0123456789 | task-run-0123456789-01234560d38957287bb0283c59440df14069f59-pod |
 
 


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This commit fixes a few issues with our docs on remote resolution:
- Update feature stability from alpha to beta
- Add a section on specifying remote tasks in pipelines
- Fix outdated configuration/install docs to indicate resolvers are enabled by default
- Define resolution and link to the TEP

Partially addresses #6045

/kind documentation

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
