### PR TITLE
Fix converted legacy bundle->remote resolver syntax to be case-insensitive for kind

### DIFF
--- a/pkg/resolution/resolver/bundle/bundle.go
+++ b/pkg/resolution/resolver/bundle/bundle.go
@@ -109,7 +109,7 @@ func GetEntry(ctx context.Context, keychain authn.Keychain, opts RequestOptions)
 		lKind := l.Annotations[BundleAnnotationKind]
 		lName := l.Annotations[BundleAnnotationName]
 
-		if opts.Kind == lKind && opts.EntryName == lName {
+		if strings.ToLower(opts.Kind) == strings.ToLower(lKind) && opts.EntryName == lName {
 			obj, err := readTarLayer(layerMap[l.Digest.String()])
 			if err != nil {
 				// This could still be a raw layer so try to read it as that instead.

--- a/pkg/resolution/resolver/bundle/resolver_test.go
+++ b/pkg/resolution/resolver/bundle/resolver_test.go
@@ -283,6 +283,7 @@ func TestResolve(t *testing.T) {
 		name               string
 		args               *params
 		imageName          string
+		kindInBundle       string
 		expectedStatus     *v1beta1.ResolutionRequestStatus
 		expectedErrMessage string
 	}{
@@ -293,6 +294,16 @@ func TestResolve(t *testing.T) {
 				name:   "example-task",
 				kind:   "task",
 			},
+			imageName:      "single-task",
+			expectedStatus: internal.CreateResolutionRequestStatusWithData(taskAsYAML),
+		}, {
+			name: "single task: param kind is capitalized, but kind in bundle is not",
+			args: &params{
+				bundle: fmt.Sprintf("%s@%s:%s", testImages["single-task"].uri, testImages["single-task"].algo, testImages["single-task"].hex),
+				name:   "example-task",
+				kind:   "Task",
+			},
+			kindInBundle:   "task",
 			imageName:      "single-task",
 			expectedStatus: internal.CreateResolutionRequestStatusWithData(taskAsYAML),
 		}, {
@@ -419,9 +430,12 @@ func TestResolve(t *testing.T) {
 						expectedStatus.Annotations = make(map[string]string)
 					}
 
-					if tc.args.kind != "" {
+					switch {
+					case tc.kindInBundle != "":
+						expectedStatus.Annotations[ResolverAnnotationKind] = tc.kindInBundle
+					case tc.args.kind != "":
 						expectedStatus.Annotations[ResolverAnnotationKind] = tc.args.kind
-					} else {
+					default:
 						expectedStatus.Annotations[ResolverAnnotationKind] = "task"
 					}
 


### PR DESCRIPTION
# Changes

fixes #6058

When we finished deprecating the legacy bundle resolution syntax, we recommended users change from:
```
      taskRef:
        name: git-batch-merge
        bundle: gcr.io/tekton-releases/catalog/upstream/git-batch-merge:0.2
```
to
```
      taskRef:
        resolver: bundles
        params:
          - name: bundle
            value: gcr.io/tekton-releases/catalog/upstream/git-batch-merge:0.2
          - name: name
            value: git-batch-merge
          - name: kind
            value: Task
```

But that created a problem - we have been comparing the `kind` parameter to the `dev.tekton.image.kind` annotation value in the bundle, which is generally all lower-case. Since we generally use `Task`, `Pipeline`, etc for `kind` values in our syntax, we've created a situation where the "normal" way to specify a `kind`, i.e., capitalized, is not going to work for most, if not all, bundles.

To fix this, we're changing the check in the remote bundles resolver to do a case-insensitive comparison.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
The remote bundles resolver now matches the kind value in its parameters and in bundle layers in a case-insensitive manner.
```
