### PR TITLE
[TEP 0122] Add FeatureFlags Field to TaskRun.Status.Provenance

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/tektoncd/plumbing v0.0.0-20220817140952-3da8ce01aeeb
 	go.opencensus.io v0.24.0
 	go.uber.org/zap v1.24.0
-	golang.org/x/oauth2 v0.4.0
+	golang.org/x/oauth2 v0.4.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.2.0
 	gopkg.in/square/go-jose.v2 v2.6.0
 	k8s.io/api v0.25.4

--- a/pkg/apis/pipeline/v1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1/openapi_generated.go
@@ -2072,11 +2072,17 @@ func schema_pkg_apis_pipeline_v1_Provenance(ref common.ReferenceCallback) common
 							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.ConfigSource"),
 						},
 					},
+					"featureFlags": {
+						SchemaProps: spec.SchemaProps{
+							Description: "FeatureFlags identifies the feature flags that were used during the task/pipeline run",
+							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/config.FeatureFlags"),
+						},
+					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.ConfigSource"},
+			"github.com/tektoncd/pipeline/pkg/apis/config.FeatureFlags", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.ConfigSource"},
 	}
 }
 

--- a/pkg/apis/pipeline/v1/provenance.go
+++ b/pkg/apis/pipeline/v1/provenance.go
@@ -13,6 +13,8 @@ limitations under the License.
 
 package v1
 
+import "github.com/tektoncd/pipeline/pkg/apis/config"
+
 // Provenance contains some key authenticated metadata about how a software artifact was
 // built (what sources, what inputs/outputs, etc.). For now, it only contains the subfield
 // `ConfigSource` that identifies the source where a build config file came from.
@@ -22,6 +24,9 @@ package v1
 type Provenance struct {
 	// ConfigSource identifies the source where a resource came from.
 	ConfigSource *ConfigSource `json:"configSource,omitempty"`
+
+	// FeatureFlags identifies the feature flags that were used during the task/pipeline run
+	FeatureFlags *config.FeatureFlags `json:"featureFlags,omitempty"`
 }
 
 // ConfigSource identifies the source where a resource came from.

--- a/pkg/apis/pipeline/v1/swagger.json
+++ b/pkg/apis/pipeline/v1/swagger.json
@@ -1036,6 +1036,10 @@
         "configSource": {
           "description": "ConfigSource identifies the source where a resource came from.",
           "$ref": "#/definitions/v1.ConfigSource"
+        },
+        "featureFlags": {
+          "description": "FeatureFlags identifies the feature flags that were used during the task/pipeline run",
+          "$ref": "#/definitions/github.com.tektoncd.pipeline.pkg.apis.config.FeatureFlags"
         }
       }
     },

--- a/pkg/apis/pipeline/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/pipeline/v1/zz_generated.deepcopy.go
@@ -22,6 +22,7 @@ limitations under the License.
 package v1
 
 import (
+	config "github.com/tektoncd/pipeline/pkg/apis/config"
 	pod "github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
 	v1beta1 "github.com/tektoncd/pipeline/pkg/apis/run/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -848,6 +849,11 @@ func (in *Provenance) DeepCopyInto(out *Provenance) {
 		in, out := &in.ConfigSource, &out.ConfigSource
 		*out = new(ConfigSource)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.FeatureFlags != nil {
+		in, out := &in.FeatureFlags, &out.FeatureFlags
+		*out = new(config.FeatureFlags)
+		**out = **in
 	}
 	return
 }

--- a/pkg/apis/pipeline/v1beta1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1beta1/openapi_generated.go
@@ -2972,11 +2972,17 @@ func schema_pkg_apis_pipeline_v1beta1_Provenance(ref common.ReferenceCallback) c
 							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.ConfigSource"),
 						},
 					},
+					"featureFlags": {
+						SchemaProps: spec.SchemaProps{
+							Description: "FeatureFlags identifies the feature flags that were used during the task/pipeline run",
+							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/config.FeatureFlags"),
+						},
+					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.ConfigSource"},
+			"github.com/tektoncd/pipeline/pkg/apis/config.FeatureFlags", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.ConfigSource"},
 	}
 }
 

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_conversion_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_conversion_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/tektoncd/pipeline/pkg/apis/config"
 	pod "github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -308,6 +309,15 @@ func TestPipelineRunConversion(t *testing.T) {
 						ConfigSource: &v1beta1.ConfigSource{
 							URI:    "test-uri",
 							Digest: map[string]string{"sha256": "digest"},
+						},
+						FeatureFlags: &config.FeatureFlags{
+							RunningInEnvWithInjectedSidecars: config.DefaultRunningInEnvWithInjectedSidecars,
+							EnableAPIFields:                  config.DefaultEnableAPIFields,
+							AwaitSidecarReadiness:            config.DefaultAwaitSidecarReadiness,
+							ResourceVerificationMode:         config.DefaultResourceVerificationMode,
+							ResultExtractionMethod:           config.DefaultResultExtractionMethod,
+							MaxResultSize:                    config.DefaultMaxResultSize,
+							CustomTaskVersion:                config.DefaultCustomTaskVersion,
 						},
 					},
 				},

--- a/pkg/apis/pipeline/v1beta1/provenance.go
+++ b/pkg/apis/pipeline/v1beta1/provenance.go
@@ -13,6 +13,8 @@ limitations under the License.
 
 package v1beta1
 
+import "github.com/tektoncd/pipeline/pkg/apis/config"
+
 // Provenance contains some key authenticated metadata about how a software artifact was
 // built (what sources, what inputs/outputs, etc.). For now, it only contains the subfield
 // `ConfigSource` that identifies the source where a build config file came from.
@@ -22,6 +24,9 @@ package v1beta1
 type Provenance struct {
 	// ConfigSource identifies the source where a resource came from.
 	ConfigSource *ConfigSource `json:"configSource,omitempty"`
+
+	// FeatureFlags identifies the feature flags that were used during the task/pipeline run
+	FeatureFlags *config.FeatureFlags `json:"featureFlags,omitempty"`
 }
 
 // ConfigSource identifies the source where a resource came from.

--- a/pkg/apis/pipeline/v1beta1/provenance_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/provenance_conversion.go
@@ -20,15 +20,25 @@ import (
 )
 
 func (p Provenance) convertTo(ctx context.Context, sink *v1.Provenance) {
-	new := v1.ConfigSource{}
-	p.ConfigSource.convertTo(ctx, &new)
-	sink.ConfigSource = &new
+	if p.ConfigSource != nil {
+		new := v1.ConfigSource{}
+		p.ConfigSource.convertTo(ctx, &new)
+		sink.ConfigSource = &new
+	}
+	if p.FeatureFlags != nil {
+		sink.FeatureFlags = p.FeatureFlags
+	}
 }
 
 func (p *Provenance) convertFrom(ctx context.Context, source v1.Provenance) {
-	new := ConfigSource{}
-	new.convertFrom(ctx, *source.ConfigSource)
-	p.ConfigSource = &new
+	if source.ConfigSource != nil {
+		new := ConfigSource{}
+		new.convertFrom(ctx, *source.ConfigSource)
+		p.ConfigSource = &new
+	}
+	if source.FeatureFlags != nil {
+		p.FeatureFlags = source.FeatureFlags
+	}
 }
 
 func (cs ConfigSource) convertTo(ctx context.Context, sink *v1.ConfigSource) {

--- a/pkg/apis/pipeline/v1beta1/swagger.json
+++ b/pkg/apis/pipeline/v1beta1/swagger.json
@@ -1680,6 +1680,10 @@
         "configSource": {
           "description": "ConfigSource identifies the source where a resource came from.",
           "$ref": "#/definitions/v1beta1.ConfigSource"
+        },
+        "featureFlags": {
+          "description": "FeatureFlags identifies the feature flags that were used during the task/pipeline run",
+          "$ref": "#/definitions/github.com.tektoncd.pipeline.pkg.apis.config.FeatureFlags"
         }
       }
     },

--- a/pkg/apis/pipeline/v1beta1/taskrun_conversion_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_conversion_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/pipeline/pkg/apis/config"
 	pod "github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -235,6 +236,15 @@ func TestTaskRunConversion(t *testing.T) {
 						ConfigSource: &v1beta1.ConfigSource{
 							URI:    "test-uri",
 							Digest: map[string]string{"sha256": "digest"},
+						},
+						FeatureFlags: &config.FeatureFlags{
+							RunningInEnvWithInjectedSidecars: config.DefaultRunningInEnvWithInjectedSidecars,
+							EnableAPIFields:                  config.DefaultEnableAPIFields,
+							AwaitSidecarReadiness:            config.DefaultAwaitSidecarReadiness,
+							ResourceVerificationMode:         config.DefaultResourceVerificationMode,
+							ResultExtractionMethod:           config.DefaultResultExtractionMethod,
+							MaxResultSize:                    config.DefaultMaxResultSize,
+							CustomTaskVersion:                config.DefaultCustomTaskVersion,
 						},
 					}},
 			},

--- a/pkg/apis/pipeline/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/pipeline/v1beta1/zz_generated.deepcopy.go
@@ -22,6 +22,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	config "github.com/tektoncd/pipeline/pkg/apis/config"
 	pod "github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
 	v1alpha1 "github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1"
 	runv1beta1 "github.com/tektoncd/pipeline/pkg/apis/run/v1beta1"
@@ -1289,6 +1290,11 @@ func (in *Provenance) DeepCopyInto(out *Provenance) {
 		in, out := &in.ConfigSource, &out.ConfigSource
 		*out = new(ConfigSource)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.FeatureFlags != nil {
+		in, out := &in.FeatureFlags, &out.FeatureFlags
+		*out = new(config.FeatureFlags)
+		**out = **in
 	}
 	return
 }

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -1264,11 +1264,14 @@ func storePipelineSpecAndMergeMeta(ctx context.Context, pr *v1beta1.PipelineRun,
 	// Propagate ConfigSource from remote resolution to PipelineRun Status
 	// This lives outside of the status.spec check to avoid the case where only the spec is available in the first reconcile and source comes in next reconcile.
 	cfg := config.FromContextOrDefaults(ctx)
-	if cfg.FeatureFlags.EnableProvenanceInStatus && meta != nil && meta.ConfigSource != nil {
+	if cfg.FeatureFlags.EnableProvenanceInStatus {
 		if pr.Status.Provenance == nil {
 			pr.Status.Provenance = &v1beta1.Provenance{}
 		}
-		if pr.Status.Provenance.ConfigSource == nil {
+		// Store FeatureFlags in the Provenance.
+		pr.Status.Provenance.FeatureFlags = cfg.FeatureFlags
+
+		if meta != nil && meta.ConfigSource != nil && pr.Status.Provenance.ConfigSource == nil {
 			pr.Status.Provenance.ConfigSource = meta.ConfigSource
 		}
 	}

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -5029,6 +5029,16 @@ metadata:
 			PipelineSpec: ps.DeepCopy(),
 			Provenance: &v1beta1.Provenance{
 				ConfigSource: configSource.DeepCopy(),
+				FeatureFlags: &config.FeatureFlags{
+					RunningInEnvWithInjectedSidecars: config.DefaultRunningInEnvWithInjectedSidecars,
+					EnableAPIFields:                  config.DefaultEnableAPIFields,
+					AwaitSidecarReadiness:            config.DefaultAwaitSidecarReadiness,
+					ResourceVerificationMode:         config.DefaultResourceVerificationMode,
+					EnableProvenanceInStatus:         true,
+					ResultExtractionMethod:           config.DefaultResultExtractionMethod,
+					MaxResultSize:                    config.DefaultMaxResultSize,
+					CustomTaskVersion:                config.DefaultCustomTaskVersion,
+				},
 			},
 		},
 	}

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -957,17 +957,20 @@ func storeTaskSpecAndMergeMeta(ctx context.Context, tr *v1beta1.TaskRun, ts *v1b
 		}
 	}
 
-	// Propagate ConfigSource from remote resolution to TaskRun Status
-	// This lives outside of the status.spec check to avoid the case where only the spec is available in the first reconcile and source comes in next reconcile.
 	cfg := config.FromContextOrDefaults(ctx)
-	if cfg.FeatureFlags.EnableProvenanceInStatus && meta != nil && meta.ConfigSource != nil {
+	if cfg.FeatureFlags.EnableProvenanceInStatus {
 		if tr.Status.Provenance == nil {
 			tr.Status.Provenance = &v1beta1.Provenance{}
 		}
-		if tr.Status.Provenance.ConfigSource == nil {
+		// Store FeatureFlags in the Provenance.
+		tr.Status.Provenance.FeatureFlags = cfg.FeatureFlags
+		// Propagate ConfigSource from remote resolution to TaskRun Status
+		// This lives outside of the status.spec check to avoid the case where only the spec is available in the first reconcile and source comes in next reconcile.
+		if meta != nil && meta.ConfigSource != nil && tr.Status.Provenance.ConfigSource == nil {
 			tr.Status.Provenance.ConfigSource = meta.ConfigSource
 		}
 	}
+
 	return nil
 }
 

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -4159,6 +4159,16 @@ spec:
 			TaskSpec: ts.DeepCopy(),
 			Provenance: &v1beta1.Provenance{
 				ConfigSource: configSource.DeepCopy(),
+				FeatureFlags: &config.FeatureFlags{
+					RunningInEnvWithInjectedSidecars: config.DefaultRunningInEnvWithInjectedSidecars,
+					EnableAPIFields:                  config.DefaultEnableAPIFields,
+					AwaitSidecarReadiness:            config.DefaultAwaitSidecarReadiness,
+					ResourceVerificationMode:         config.DefaultResourceVerificationMode,
+					EnableProvenanceInStatus:         true,
+					ResultExtractionMethod:           config.DefaultResultExtractionMethod,
+					MaxResultSize:                    config.DefaultMaxResultSize,
+					CustomTaskVersion:                config.DefaultCustomTaskVersion,
+				},
 			},
 		},
 	}


### PR DESCRIPTION
[TEP0122] Adds feature flags field to `TaskRun.Status.Provenance`

For`Tekton Chains` to pick up the feature flags used for the build, this PR [surfaces them](https://github.com/tektoncd/community/blob/main/teps/0122-complete-build-instructions-and-parameters.md#configuration-feature-flags) in the `TaskRun.Status.Provenance` field. Like `ConfigSource`, this field is only populated if the 
feature flag: `enable-provenance-in-status` is set to `"true"`.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Add FeatureFlags field to TaskRun.Status.Provenance
```
/kind feature