### PR TITLE
remove results from status when type mismatched and add more logs

### DIFF
--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -1877,31 +1877,23 @@ spec:
   taskRef:
     name: test-results-task
 status:
-  taskResults:
-  - name: aResult
-    type: string
-    value: aResultValue
   conditions:
   - reason: ToBeRetried
     status: Unknown
     type: Succeeded
-    message: "missmatched Types for these results, map[aResult:[array]]"
+    message: "mismatched types:  \"aResult\": task result is expected to be \"array\" type but was initialized to a different type \"string\""
   sideCars:
   retriesStatus:
   - conditions:
     - reason: TaskRunValidationFailed
       status: "False"
       type: "Succeeded"
-      message: "missmatched Types for these results, map[aResult:[array]]"
+      message: "mismatched types:  \"aResult\": task result is expected to be \"array\" type but was initialized to a different type \"string\""
     startTime: "2021-12-31T23:59:59Z"
     completionTime: "2022-01-01T00:00:00Z"
     podName: "test-taskrun-results-type-mismatched-pod"
-    taskResults:
-    - name: aResult
-      type: string
-      value: aResultValue
 `)
-		reconciliatonError = fmt.Errorf("1 error occurred:\n\t* missmatched Types for these results, map[aResult:[array]]")
+		reconciliatonError = fmt.Errorf("1 error occurred:\n\t* mismatched types:  \"aResult\": task result is expected to be \"array\" type but was initialized to a different type \"string\"")
 		toBeRetriedTaskRun = parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun-to-be-retried
@@ -4892,7 +4884,7 @@ spec:
     results:
       - name: result1
     steps:
-    - script: echo foo >> $(results.result1.path)  
+    - script: echo foo >> $(results.result1.path)
       image: myimage
       name: mycontainer
 status:
@@ -4900,7 +4892,7 @@ status:
     results:
       - name: result1
     steps:
-    - script: echo foo >> $(results.result1.path)  
+    - script: echo foo >> $(results.result1.path)
       image: myimage
       name: mycontainer
 `)
@@ -5082,6 +5074,9 @@ status:
     - name: aResult
       type: string
       value: aResultValue
+    - name: objectResult
+      type: string
+      value: objectResultValue
 `)
 
 	taskRunResultsObjectMissKey := parse.MustParseV1beta1TaskRun(t, `
@@ -5096,8 +5091,8 @@ status:
     - name: aResult
       type: array
       value:
-       - 1
-       - 2
+       - "1"
+       - "2"
     - name: objectResult
       type: object
       value:
@@ -5123,16 +5118,28 @@ status:
 		taskRun          *v1beta1.TaskRun
 		wantFailedReason string
 		expectedError    error
+		expectedResults  []v1beta1.TaskRunResult
 	}{{
 		name:             "taskrun results type mismatched",
 		taskRun:          taskRunResultsTypeMismatched,
 		wantFailedReason: podconvert.ReasonFailedValidation,
-		expectedError:    fmt.Errorf("1 error occurred:\n\t* missmatched Types for these results, map[aResult:[array]]"),
+		expectedError:    fmt.Errorf("1 error occurred:\n\t* mismatched types:  \"aResult\": task result is expected to be \"array\" type but was initialized to a different type \"string\", \"objectResult\": task result is expected to be \"object\" type but was initialized to a different type \"string\""),
+		expectedResults:  nil,
 	}, {
 		name:             "taskrun results object miss key",
 		taskRun:          taskRunResultsObjectMissKey,
 		wantFailedReason: podconvert.ReasonFailedValidation,
 		expectedError:    fmt.Errorf("1 error occurred:\n\t* missing keys for these results which are required in TaskResult's properties map[objectResult:[commit]]"),
+		expectedResults: []v1beta1.TaskRunResult{
+			{
+				Name:  "aResult",
+				Type:  "array",
+				Value: *v1beta1.NewArrayOrString("1", "2"),
+			}, {
+				Name:  "objectResult",
+				Type:  "object",
+				Value: *v1beta1.NewObject(map[string]string{"url": "abc"}),
+			}},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			testAssets, cancel := getTaskRunController(t, d)
@@ -5146,6 +5153,9 @@ status:
 			tr, err := testAssets.Clients.Pipeline.TektonV1beta1().TaskRuns(tc.taskRun.Namespace).Get(testAssets.Ctx, tc.taskRun.Name, metav1.GetOptions{})
 			if err != nil {
 				t.Fatalf("getting updated taskrun: %v", err)
+			}
+			if d := cmp.Diff(tr.Status.TaskRunResults, tc.expectedResults); d != "" {
+				t.Errorf("got unexpected results %s", diff.PrintWantGot(d))
 			}
 			condition := tr.Status.GetCondition(apis.ConditionSucceeded)
 			if condition.Type != apis.ConditionSucceeded || condition.Status != corev1.ConditionFalse || condition.Reason != tc.wantFailedReason {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This commit fixes https://github.com/tektoncd/pipeline/issues/6023. Before this commit we only log the result name
and needed types, but omit the want types and the invalid results are in
status. This commit adds the want types in error message and remove
invalid results from status

/kind bug

Signed-off-by: Yongxuan Zhang yongxuanzhang@google.com

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
taskrun results which have type mismatched are removed from taskrun status
```
