### PR TITLE
matrix with array results indexing

### DIFF
--- a/examples/v1beta1/pipelineruns/alpha/pipelinerun-with-matrix-and-results.yaml
+++ b/examples/v1beta1/pipelineruns/alpha/pipelinerun-with-matrix-and-results.yaml
@@ -9,11 +9,12 @@ spec:
   params:
     - name: platform
     - name: browser
+    - name: url
   steps:
     - name: echo
       image: alpine
       script: |
-        echo "$(params.platform) and $(params.browser)"
+        echo "Visit $(params.url) on $(params.platform) using $(params.browser)."
 ---
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
@@ -26,40 +27,45 @@ spec:
       - name: get-platforms
         taskSpec:
           results:
-            - name: one
-            - name: two
-            - name: three
+            - name: platforms
+              type: array
           steps:
-            - name: echo
-              image: alpine
+            - name: produce-a-list-of-platforms
+              image: bash:latest
               script: |
-                printf linux | tee /tekton/results/one
-                printf mac | tee /tekton/results/two
-                printf windows | tee /tekton/results/three
-      - name: get-browsers
+                #!/usr/bin/env bash
+                echo -n "[\"linux\",\"mac\",\"windows\"]" | tee $(results.platforms.path)
+      - name: get-browsers-and-url
         taskSpec:
           results:
-            - name: one
-            - name: two
-            - name: three
+            - name: browsers
+              type: array
+            - name: url
           steps:
-            - name: echo
-              image: alpine
+            - name: produce-a-list-of-browsers
+              image: bash:latest
               script: |
-                printf chrome | tee /tekton/results/one
-                printf safari | tee /tekton/results/two
-                printf firefox | tee /tekton/results/three
+                #!/usr/bin/env bash
+                echo -n "[\"chrome\",\"safari\",\"firefox\"]" | tee $(results.browsers.path)
+            - name: produce-url
+              image: bash:latest
+              script: |
+                #!/usr/bin/env bash
+                echo -n "myfavoritesitedotcom" | tee $(results.url.path)
       - name: platforms-and-browsers-dag
         matrix:
           params:
             - name: platform
               value:
-                - $(tasks.get-platforms.results.one)
-                - $(tasks.get-platforms.results.two)
-                - $(tasks.get-platforms.results.three)
+                - $(tasks.get-platforms.results.platforms[0])
+                - $(tasks.get-platforms.results.platforms[1])
+                - $(tasks.get-platforms.results.platforms[2])
             - name: browser
               value:
-                - $(tasks.get-browsers.results.one)
-                - $(tasks.get-browsers.results.two)
+                - $(tasks.get-browsers-and-url.results.browsers[0])
+                - $(tasks.get-browsers-and-url.results.browsers[2])
+            - name: url
+              value:
+                - $(tasks.get-browsers-and-url.results.url)
         taskRef:
           name: platform-browsers


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

While an array cannot be feed into matrix param directly using the start notation, it is possible to index into an array results. Updating an existing example to showcase that usage. I will update the [doc](https://github.com/tektoncd/pipeline/blob/main/docs/matrix.md#specifying-results-in-a-matrix) in a follow up PR.

Signed-off-by: pritidesai <pdesai@us.ibm.com>

/kind misc

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
