### PR TITLE
cleaning up examples to avoid writing to results using path

### DIFF
--- a/examples/v1/pipelineruns/ignore-step-error.yaml
+++ b/examples/v1/pipelineruns/ignore-step-error.yaml
@@ -55,7 +55,6 @@ spec:
             - image: alpine
               name: verify-a-task-result
               script: |
-                ls /tekton/results/
                 if [ $(params.task1-result) == 123 ]; then
                     echo "Yay! the task result matches which was initialized in the previous task while ignoring the step error"
                 else

--- a/examples/v1/pipelineruns/pipelinerun-with-when-expressions.yaml
+++ b/examples/v1/pipelineruns/pipelinerun-with-when-expressions.yaml
@@ -57,9 +57,9 @@ spec:
               image: alpine
               script: |
                 if test -f $(workspaces.source.path)/$(params.path); then
-                  printf yes | tee /tekton/results/exists
+                  printf yes | tee $(results.exists.path)
                 else
-                  printf no | tee /tekton/results/exists
+                  printf no | tee $(results.exists.path)
                 fi
       - name: echo-file-exists # when expression using task result, evaluates to true
         when:

--- a/examples/v1/pipelineruns/pipelinerun.yaml
+++ b/examples/v1/pipelineruns/pipelinerun.yaml
@@ -186,7 +186,7 @@ spec:
     workingDir: $(workspaces.source.path)
     image: stedolan/jq
     script: |
-      cat $(params.CONTEXT)/image-digested | jq '.[0].value' -rj | tee /tekton/results/IMAGE_DIGEST
+      cat $(params.CONTEXT)/image-digested | jq '.[0].value' -rj | tee $(results.IMAGE_DIGEST.path)
 ---
 # This task deploys with kubectl apply -f <filename>
 apiVersion: tekton.dev/v1

--- a/examples/v1/taskruns/task-result.yaml
+++ b/examples/v1/taskruns/task-result.yaml
@@ -16,9 +16,9 @@ spec:
         image: bash:latest
         script: |
           #!/usr/bin/env bash
-          date +%s | tee /tekton/results/current-date-unix-timestamp
+          date +%s | tee $(results.current-date-unix-timestamp.path)
       - name: print-date-human-readable
         image: bash:latest
         script: |
           #!/usr/bin/env bash
-          date | tee /tekton/results/current-date-human-readable
+          date | tee $(results.current-date-human-readable.path)

--- a/examples/v1beta1/pipelineruns/ignore-step-error.yaml
+++ b/examples/v1beta1/pipelineruns/ignore-step-error.yaml
@@ -54,7 +54,6 @@ spec:
             - image: alpine
               name: verify-a-task-result
               script: |
-                ls /tekton/results/
                 if [ $(params.task1-result) == 123 ]; then
                     echo "Yay! the task result matches which was initialized in the previous task while ignoring the step error"
                 else

--- a/examples/v1beta1/pipelineruns/pipelinerun-with-when-expressions.yaml
+++ b/examples/v1beta1/pipelineruns/pipelinerun-with-when-expressions.yaml
@@ -56,9 +56,9 @@ spec:
               image: alpine
               script: |
                 if test -f $(workspaces.source.path)/$(params.path); then
-                  printf yes | tee /tekton/results/exists
+                  printf yes | tee $(results.exists.path)
                 else
-                  printf no | tee /tekton/results/exists
+                  printf no | tee $(results.exists.path)
                 fi
       - name: echo-file-exists # when expression using task result, evaluates to true
         when:

--- a/examples/v1beta1/pipelineruns/pipelinerun.yaml
+++ b/examples/v1beta1/pipelineruns/pipelinerun.yaml
@@ -102,7 +102,7 @@ spec:
     workingDir: $(workspaces.source.path)
     image: stedolan/jq
     script: |
-      cat $(params.CONTEXT)/image-digested | jq '.[0].value' -rj | tee /tekton/results/IMAGE_DIGEST
+      cat $(params.CONTEXT)/image-digested | jq '.[0].value' -rj | tee $(results.IMAGE_DIGEST.path)
 ---
 # This task deploys with kubectl apply -f <filename>
 apiVersion: tekton.dev/v1beta1

--- a/examples/v1beta1/taskruns/alpha/large-task-result.yaml
+++ b/examples/v1beta1/taskruns/alpha/large-task-result.yaml
@@ -17,12 +17,12 @@ spec:
         image: bash:latest
         script: |
           #!/usr/bin/env bash
-          cat /dev/urandom | head -c 2500 | base64 | tee /tekton/results/result1 #about 1 K result
-          cat /dev/urandom | head -c 2500 | base64 | tee /tekton/results/result2 #about 4 K result
+          cat /dev/urandom | head -c 2500 | base64 | tee $(results.result1.path) #about 1 K result
+          cat /dev/urandom | head -c 2500 | base64 | tee $(results.result2.path) #about 4 K result
       - name: step2
         image: bash:latest
         script: |
           #!/usr/bin/env bash
-          cat /dev/urandom | head -c 2500 | base64 | tee /tekton/results/result3 #about 1 K result
-          cat /dev/urandom | head -c 2500 | base64 | tee /tekton/results/result4 #about 4 K result
-          cat /dev/urandom | head -c 2500 | base64 | tee /tekton/results/result5 #about 4 K result
+          cat /dev/urandom | head -c 2500 | base64 | tee $(results.result3.path) #about 1 K result
+          cat /dev/urandom | head -c 2500 | base64 | tee $(results.result4.path) #about 4 K result
+          cat /dev/urandom | head -c 2500 | base64 | tee $(results.result5.path) #about 4 K result

--- a/examples/v1beta1/taskruns/task-result.yaml
+++ b/examples/v1beta1/taskruns/task-result.yaml
@@ -16,9 +16,9 @@ spec:
         image: bash:latest
         script: |
           #!/usr/bin/env bash
-          date +%s | tee /tekton/results/current-date-unix-timestamp
+          date +%s | tee $(results.current-date-unix-timestamp.path)
       - name: print-date-human-readable
         image: bash:latest
         script: |
           #!/usr/bin/env bash
-          date | tee /tekton/results/current-date-human-readable
+          date | tee $(results.current-date-human-readable.path)


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

We recommend to not use tekton reserved internal paths in scripts, specially, for task results. Our code base has a few examples which initializes the task results using the reserved path `/tekton/results/...` instead of using the path variable i.e. `$(results.myresult.path)`. Cleaning up examples to include path variables while initializing the results.

Signed-off-by: pritidesai <pdesai@us.ibm.com>

/kind cleanup

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
