### PR TITLE
Switch the release pipeline to use GitHub API for task resolution

### DIFF
--- a/tekton/release-pipeline.yaml
+++ b/tekton/release-pipeline.yaml
@@ -109,8 +109,10 @@ spec:
       taskRef:
         resolver: git
         params:
-        - name: url
-          value: https://github.com/tektoncd/pipeline.git
+        - name: repo
+          value: pipeline
+        - name: org
+          value: tektoncd
         - name: revision
           value: $(params.gitRevision)
         - name: pathInRepo


### PR DESCRIPTION
# Changes

fixes #6091

(this can be merged before https://github.com/tektoncd/plumbing/pull/1333, but it'd definitely be beter for that Plumbing PR to merge first)

This switches how we resolve the `publish-release` `Task` in `release-pipeline` from an anonymous git clone to using the GitHub API. The full clone approach is almost always timing out, in part thanks to #6025, but even if it finished successfully every time, it'd still be adding at least a minute of extra time to the pipeline execution for no particularly good reason. Using the GitHub API-based resolution instead means no clone is needed, with the resolver just making a couple very specific API calls to get the contents of the specified file. So yeah, much faster!

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
