### PR TITLE
Typo in error message fix

### DIFF
--- a/pkg/reconciler/taskrun/resources/taskresourceresolution.go
+++ b/pkg/reconciler/taskrun/resources/taskresourceresolution.go
@@ -78,7 +78,7 @@ func ResolveTaskResources(ts *v1beta1.TaskSpec, taskName string, kind v1beta1.Ta
 // instantiating it from the embedded spec.
 func GetResourceFromBinding(r v1beta1.PipelineResourceBinding, getter GetResource) (*resourcev1alpha1.PipelineResource, error) {
 	if (r.ResourceRef != nil && r.ResourceRef.Name != "") && r.ResourceSpec != nil {
-		return nil, errors.New("Both ResourseRef and ResourceSpec are defined. Expected only one")
+		return nil, errors.New("Both ResourceRef and ResourceSpec are defined. Expected only one")
 	}
 	if r.ResourceRef != nil && r.ResourceRef.Name != "" {
 		return getter(r.ResourceRef.Name)
@@ -91,5 +91,5 @@ func GetResourceFromBinding(r v1beta1.PipelineResourceBinding, getter GetResourc
 			Spec: *r.ResourceSpec,
 		}, nil
 	}
-	return nil, errors.New("Neither ResourseRef nor ResourceSpec is defined")
+	return nil, errors.New("Neither ResourceRef nor ResourceSpec is defined")
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Typo in error message fix（modify ResourseRef to ResourceRef）

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
