### PR TITLE
Remove Updating labels and annotations…

### DIFF
--- a/pkg/apis/pipeline/v1/metadata_types.go
+++ b/pkg/apis/pipeline/v1/metadata_types.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2023 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+// TektonObjectMeta is a subset of ObjectMeta that are usually persisted in the runtime status field.
+type TektonObjectMeta struct {
+	// Map of string keys and values that can be used to organize and categorize
+	// (scope and select) objects. May match selectors of replication controllers
+	// and services.
+	// More info: http://kubernetes.io/docs/user-guide/labels
+	// +optional
+	Labels map[string]string `json:"labels,omitempty"`
+
+	// Annotations is an unstructured key value map stored with a resource that may be
+	// set by external tools to store and retrieve arbitrary metadata. They are not
+	// queryable and should be preserved when modifying objects.
+	// More info: http://kubernetes.io/docs/user-guide/annotations
+	// +optional
+	Annotations map[string]string `json:"annotations,omitempty"`
+}

--- a/pkg/apis/pipeline/v1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1/pipelinerun_types.go
@@ -438,8 +438,11 @@ type PipelineRunStatusFields struct {
 	// +listType=atomic
 	Results []PipelineRunResult `json:"results,omitempty"`
 
-	// PipelineRunSpec contains the exact spec used to instantiate the run
+	// PipelineRunSpec contains the Spec from the dereferenced Pipeline definition used to instantiate this PipelineRun.
 	PipelineSpec *PipelineSpec `json:"pipelineSpec,omitempty"`
+
+	// PipelineMeta contains the exact Pipeline metadata to instantiate the PipelineRun
+	PipelineMeta *TektonObjectMeta `json:"pipelineMetadata,omitempty"`
 
 	// list of tasks that were skipped due to when expressions evaluating to false
 	// +optional

--- a/pkg/apis/pipeline/v1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1/taskrun_types.go
@@ -235,6 +235,9 @@ type TaskRunStatusFields struct {
 	// TaskSpec contains the Spec from the dereferenced Task definition used to instantiate this TaskRun.
 	TaskSpec *TaskSpec `json:"taskSpec,omitempty"`
 
+	// TaskMeta contains the exact Task metadata to instantiate the run
+	TaskMeta *TektonObjectMeta `json:"taskMetadata,omitempty"`
+
 	// Provenance contains some key authenticated metadata about how a software artifact was built (what sources, what inputs/outputs, etc.).
 	// +optional
 	Provenance *Provenance `json:"provenance,omitempty"`

--- a/vendor/knative.dev/pkg/logging/testing/util.go
+++ b/vendor/knative.dev/pkg/logging/testing/util.go
@@ -28,8 +28,8 @@ import (
 // TestLogger gets a logger to use in unit and end to end tests
 func TestLogger(t zaptest.TestingT) *zap.SugaredLogger {
 	opts := zaptest.WrapOptions(
-		zap.AddCaller(),
-		zap.Development(),
+	// zap.AddCaller(),
+	// zap.Development(),
 	)
 
 	return zaptest.NewLogger(t, opts).Sugar()


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Labels and Annotations on PipelineRun and TaskRun won't be mutated by the controller anymore. Usually, a controller doesn't modify the metadata of the object it reconcile.

This effectively remove the propagation of annotations and labels from Task to TaskRun, and Pipeline to PipelineRun.

This is an "attempt" to fix https://github.com/tektoncd/pipeline/issues/5146 **but** it is mainly opened to start some discussion around it. Mainly the following :

One feature that we "want" is that labels and annotations from a `Task` and a `TaskRun` are both inherited by the `Pod`. Same goes for `PipelineRun`. Prior to this change, we get away with it by merging it at the `TaskRun` or `PipelineRun` level — which cause issues in the past (and still might), like https://github.com/tektoncd/pipeline/issues/5297.
Even if this PR propose to remove this "feature", we still want the same behavior (aka a `Pod` gets its labels from both the `Task` and the `TaskRun`). Because we are only "caching" the spec of the `Task` in `TaskRun.status` (and same goes for `PipelineRun`), we would have to query the metadata for the `Task` each time. Using informers, it wouldn't cost that much, but we would run the same possible race as we did before and that's the reason we use `TaskRun.status` and `PipelineRun.status` as source of truth for the spec in all reconciler loop for a given object. 

So the question is the following : **Where should we store the `Task` (and `Pipeline` for `PipelineRun`) labels and annotations in a `TaskRun` object ?** Because we have already release `v1`, we can only do "additive" changes, so, most likely, the only way would be to have a `taskMetadata` field in the `status` in addition to `taskSpec`.
But I am curious if anyone has any other ideas 👼🏼.

/cc @imjasonh @afrittoli @abayer @lbernick @jerop @chuangw6 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>


# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
