### PR TITLE
validate emit results are defined in taskspec

### DIFF
--- a/pkg/apis/pipeline/v1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1/task_validation_test.go
@@ -289,6 +289,18 @@ func TestTaskSpecValidate(t *testing.T) {
 			}},
 		},
 	}, {
+		name: "valid results path variable in script",
+		fields: fields{
+			Steps: []v1.Step{{
+				Name:  "step-name",
+				Image: "my-image",
+				Script: `
+				#!/usr/bin/env bash
+				date | tee $(results.a-result.path)`,
+			}},
+			Results: []v1.TaskResult{{Name: "a-result"}},
+		},
+	}, {
 		name: "valid path variable for legacy credential helper (aka creds-init)",
 		fields: fields{
 			Steps: []v1.Step{{
@@ -540,6 +552,22 @@ func TestTaskSpecValidateError(t *testing.T) {
 		expectedError: apis.FieldError{
 			Message: `missing field(s)`,
 			Paths:   []string{"steps"},
+		},
+	}, {
+		name: "step script refers to nonexistent result",
+		fields: fields{
+			Steps: []v1.Step{{
+				Name:  "step-name",
+				Image: "my-image",
+				Script: `
+				#!/usr/bin/env bash
+				date | tee $(results.non-exist.path)`,
+			}},
+			Results: []v1.TaskResult{{Name: "a-result"}},
+		},
+		expectedError: apis.FieldError{
+			Message: `non-existent variable in "\n\t\t\t\t#!/usr/bin/env bash\n\t\t\t\tdate | tee $(results.non-exist.path)"`,
+			Paths:   []string{"steps[0].script"},
 		},
 	}, {
 		name: "invalid param name format",

--- a/pkg/apis/pipeline/v1beta1/task_validation.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation.go
@@ -99,6 +99,7 @@ func (ts *TaskSpec) Validate(ctx context.Context) (errs *apis.FieldError) {
 	errs = errs.Also(ValidateParameterVariables(ctx, ts.Steps, ts.Params))
 	errs = errs.Also(ValidateResourcesVariables(ctx, ts.Steps, ts.Resources))
 	errs = errs.Also(validateTaskContextVariables(ctx, ts.Steps))
+	errs = errs.Also(validateTaskResultsVariables(ctx, ts.Steps, ts.Results))
 	errs = errs.Also(validateResults(ctx, ts.Results).ViaField("results"))
 	return errs
 }
@@ -406,6 +407,18 @@ func validateTaskContextVariables(ctx context.Context, steps []Step) *apis.Field
 	)
 	errs := validateVariables(ctx, steps, "context\\.taskRun", taskRunContextNames)
 	return errs.Also(validateVariables(ctx, steps, "context\\.task", taskContextNames))
+}
+
+// validateTaskResultsVariables validates if the results referenced in step script are defined in task results
+func validateTaskResultsVariables(ctx context.Context, steps []Step, results []TaskResult) (errs *apis.FieldError) {
+	resultsNames := sets.NewString()
+	for _, r := range results {
+		resultsNames.Insert(r.Name)
+	}
+	for idx, step := range steps {
+		errs = errs.Also(validateTaskVariable(step.Script, "results", resultsNames).ViaField("script").ViaFieldIndex("steps", idx))
+	}
+	return errs
 }
 
 // ValidateResourcesVariables validates all variables within a TaskResources against a slice of Steps

--- a/pkg/apis/pipeline/v1beta1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation_test.go
@@ -325,6 +325,18 @@ func TestTaskSpecValidate(t *testing.T) {
 			}},
 		},
 	}, {
+		name: "valid results path variable in script",
+		fields: fields{
+			Steps: []v1beta1.Step{{
+				Name:  "step-name",
+				Image: "my-image",
+				Script: `
+				#!/usr/bin/env bash
+				date | tee $(results.a-result.path)`,
+			}},
+			Results: []v1beta1.TaskResult{{Name: "a-result"}},
+		},
+	}, {
 		name: "valid path variable for legacy credential helper (aka creds-init)",
 		fields: fields{
 			Steps: []v1beta1.Step{{
@@ -652,6 +664,22 @@ func TestTaskSpecValidateError(t *testing.T) {
 		expectedError: apis.FieldError{
 			Message: `expected exactly one, got both`,
 			Paths:   []string{"resources.outputs.name"},
+		},
+	}, {
+		name: "step script refers to nonexistent result",
+		fields: fields{
+			Steps: []v1beta1.Step{{
+				Name:  "step-name",
+				Image: "my-image",
+				Script: `
+				#!/usr/bin/env bash
+				date | tee $(results.non-exist.path)`,
+			}},
+			Results: []v1beta1.TaskResult{{Name: "a-result"}},
+		},
+		expectedError: apis.FieldError{
+			Message: `non-existent variable in "\n\t\t\t\t#!/usr/bin/env bash\n\t\t\t\tdate | tee $(results.non-exist.path)"`,
+			Paths:   []string{"steps[0].script"},
 		},
 	}, {
 		name: "invalid param name format",


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Task results are emitted in step script by writing to results path, before this commit we don't have validation of checking the results defined in taskspec. This commit adds the check in validation.

/kind bug

Signed-off-by: Yongxuan Zhang yongxuanzhang@google.com

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Tasks results emitted in script but don't defined in taskspec will fail
```
