### PR TITLE
Add security context for example PRs using catalog git-clone

### DIFF
--- a/examples/v1beta1/pipelineruns/pipelinerun-with-final-tasks.yaml
+++ b/examples/v1beta1/pipelineruns/pipelinerun-with-final-tasks.yaml
@@ -90,6 +90,9 @@ spec:
   pipelineRef:
     name: clone-cleanup-workspace
   serviceAccountName: 'default'
+  podTemplate:
+    securityContext:
+      fsGroup: 65532 # Make volumes accessible by non-root user for git-clone catalog task
   workspaces:
     - name: git-source
       volumeClaimTemplate:

--- a/examples/v1beta1/pipelineruns/pipelinerun.yaml
+++ b/examples/v1beta1/pipelineruns/pipelinerun.yaml
@@ -245,6 +245,9 @@ spec:
   pipelineRef:
     name: "demo.pipeline"
   serviceAccountName: 'default'
+  podTemplate:
+    securityContext:
+      fsGroup: 65532  # Make volumes accessible by non-root user for git-clone catalog task
   workspaces:
   - name: git-source
     volumeClaimTemplate:

--- a/test/yamls/v1beta1/pipelineruns/pipelinerun-with-final-tasks.yaml
+++ b/test/yamls/v1beta1/pipelineruns/pipelinerun-with-final-tasks.yaml
@@ -88,6 +88,9 @@ spec:
   pipelineRef:
     name: clone-cleanup-workspace
   serviceAccountName: 'default'
+  podTemplate:
+    securityContext:
+      fsGroup: 65532 # Make volumes accessible by non-root user for git-clone catalog task
   workspaces:
     - name: git-source
       volumeClaimTemplate:

--- a/test/yamls/v1beta1/pipelineruns/pipelinerun.yaml
+++ b/test/yamls/v1beta1/pipelineruns/pipelinerun.yaml
@@ -248,6 +248,9 @@ spec:
   pipelineRef:
     name: demo-pipeline
   serviceAccountName: 'default'
+  podTemplate:
+    securityContext:
+      fsGroup: 65532 # Make volumes accessible by non-root user for git-clone catalog task
   workspaces:
   - name: git-source
     volumeClaimTemplate:


### PR DESCRIPTION
The newest versions of the git-clone catalog task don't run as root. Using this task requires setting the pod's security context to allow writes to volumes from non-root users.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- n/a Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- n/a Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- n/a Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
