### PR TITLE
If pod was evicted, prefer pod status message.

### DIFF
--- a/pkg/pod/status.go
+++ b/pkg/pod/status.go
@@ -423,7 +423,10 @@ func areStepsComplete(pod *corev1.Pod) bool {
 }
 
 func getFailureMessage(logger *zap.SugaredLogger, pod *corev1.Pod) string {
-	// If the pod was evicted return the eviction message.
+	// If a pod was evicted, use the pods status message before trying to
+	// determine a failure message from the pod's container statuses. A
+	// container may have a generic exit code that contains less information,
+	// such as an exit code and message related to not being located.
 	if pod.Status.Reason == evicted {
 		return pod.Status.Message
 	}

--- a/pkg/pod/status.go
+++ b/pkg/pod/status.go
@@ -81,7 +81,10 @@ const (
 	timeFormat = "2006-01-02T15:04:05.000Z07:00"
 )
 
-const oomKilled = "OOMKilled"
+const (
+	oomKilled = "OOMKilled"
+	evicted   = "Evicted"
+)
 
 // SidecarsReady returns true if all of the Pod's sidecars are Ready or
 // Terminated.
@@ -420,6 +423,11 @@ func areStepsComplete(pod *corev1.Pod) bool {
 }
 
 func getFailureMessage(logger *zap.SugaredLogger, pod *corev1.Pod) string {
+	// If the pod was evicted return the eviction message.
+	if pod.Status.Reason == evicted {
+		return pod.Status.Message
+	}
+
 	// First, try to surface an error about the actual init container that failed.
 	for _, status := range pod.Status.InitContainerStatuses {
 		if msg := extractContainerFailureMessage(logger, status, pod.ObjectMeta); len(msg) > 0 {


### PR DESCRIPTION
If a pod was evicted, use the pods status message instead of trying to determine a failure message from the pod's container statuses. A container may have a generic exit code that contains less information, such as an exit code and message related to not being located.

```
state:
  terminated:
    exitCode: 137
    finishedAt: null
    message: The container could not be located when the pod was terminated
    reason: ContainerStatusUnknown
    startedAt: null
```

This leads to pipeline status conditions that are less helpful than the eviction message from the pod.

```
status:
  completionTime: "2023-02-08T18:45:37Z"
  conditions:
  - lastTransitionTime: "2023-02-08T18:45:37Z"
    message: |
      "step" exited with code 137 (image: "docker-pullable://...."); for logs run: kubectl -n namespace pod logs step
```

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
