### PR TITLE
[TEP074] Cleanup variables.md after Removal of PipelineResources

### DIFF
--- a/docs/variables.md
+++ b/docs/variables.md
@@ -99,16 +99,6 @@ variable via `resources.inputs.<resourceName>.<variableName>` or
 | `httpsProxy` | The value of the resource's `httpsProxy` parameter. |
 | `noProxy` | The value of the resource's `noProxy` parameter. |
 
-#### Variables for the `PullRequest` type
-
-| Variable | Description |
-| -------- | ----------- |
-| `name` | The name of the resource. |
-| `type` | Type value of `"pullRequest"`.|
-| `url` | The URL of the pull request. |
-| `provider` | Provider value, either `"github"` or `"gitlab"`. |
-| `insecure-skip-tls-verify` | The value of the resource's `insecure-skip-tls-verify` parameter, either `"true"` or `"false"`. |
-
 #### Variables for the `Image` type
 
 | Variable | Description |
@@ -125,30 +115,6 @@ variable via `resources.inputs.<resourceName>.<variableName>` or
 | `name` | The name of the resource. |
 | `type` | Type value of `"gcs"`. |
 | `location` | The fully qualified address of the blob storage. |
-
-#### Variables for the `Cluster` type
-
-| Variable | Description |
-| -------- | ----------- |
-| `name` | The name of the resource. |
-| `type` | Type value of `"cluster"`. |
-| `url` | Host URL of the master node. |
-| `username` | The user with access to the cluster. |
-| `password` | The password for the user specified in `username`. |
-| `namespace` | The namespace to target in the cluster. |
-| `token` | The bearer token. |
-| `insecure` | Whether to verify the TLS connection to the server, either `"true"` or `"false"`. |
-| `cadata` | Stringified PEM-encoded bytes from the relevant root certificate bundle. |
-| `clientKeyData` | Stringified PEM-encoded bytes from the client key file for TLS. |
-| `clientCertificateData` | Stringified PEM-encoded bytes from the client certificate file for TLS. |
-
-#### Variables for the `CloudEvent` type
-
-| Variable | Description |
-| -------- | ----------- |
-| `name` | The name of the resource. |
-| `type` | Type value of `"cloudEvent"`. |
-| `target-uri` | The URI to hit with cloud event payloads. |
 
 ## Fields that accept variable substitutions
 


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This commit cleanups the `cloudevent`, `pullrequest` and `cluster` pipelineResources in variables.md

/kind misc
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [n/a] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [n/a] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [n/a] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
