### PR TITLE
context variables in `pipelineRun` workspaces

### DIFF
--- a/docs/pipelineruns.md
+++ b/docs/pipelineruns.md
@@ -912,6 +912,9 @@ workspaces:
     subPath: my-subdir
 ```
 
+`workspaces[].subPath` can be an absolute value or can reference `pipelineRun` context variables, such as,
+`$(context.pipelineRun.name)` or `$(context.pipelineRun.uid)`.
+
 For more information, see the following topics:
 - For information on mapping `Workspaces` to `Volumes`, see [Specifying `Workspaces` in `PipelineRuns`](workspaces.md#specifying-workspaces-in-pipelineruns).
 - For a list of supported `Volume` types, see [Specifying `VolumeSources` in `Workspaces`](workspaces.md#specifying-volumesources-in-workspaces).

--- a/examples/v1beta1/pipelineruns/pipelinerun-using-parameterized-subpath-of-workspace.yaml
+++ b/examples/v1beta1/pipelineruns/pipelinerun-using-parameterized-subpath-of-workspace.yaml
@@ -70,6 +70,7 @@ spec:
         - name: local-ws
           workspace: ws
 ---
+
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
@@ -88,4 +89,26 @@ spec:
             - ReadWriteOnce
           resources:
             requests:
-              storage: 1Gi
+              storage: 16Mi
+---
+
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: pr-parameterized-subpath-
+spec:
+  pipelineRef:
+    name: pipeline-using-parameterized-subpaths
+  params:
+    - name: subPath-path
+      value: dir-2
+  workspaces:
+    - name: ws
+      subPath: $(context.pipelineRun.name)
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 16Mi

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -53,6 +53,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/reconciler/volumeclaim"
 	"github.com/tektoncd/pipeline/pkg/remote"
 	resolution "github.com/tektoncd/pipeline/pkg/resolution/resource"
+	"github.com/tektoncd/pipeline/pkg/substitution"
 	"github.com/tektoncd/pipeline/pkg/trustedresources"
 	"github.com/tektoncd/pipeline/pkg/workspace"
 	"go.opentelemetry.io/otel/attribute"
@@ -1089,6 +1090,16 @@ func getTaskrunWorkspaces(ctx context.Context, pr *v1beta1.PipelineRun, rpt *res
 			}
 		}
 	}
+
+	// replace pipelineRun context variables in workspace subPath in the workspace binding
+	var p string
+	if pr.Spec.PipelineRef != nil {
+		p = pr.Spec.PipelineRef.Name
+	}
+	for j := range workspaces {
+		workspaces[j].SubPath = substitution.ApplyReplacements(workspaces[j].SubPath, resources.GetContextReplacements(p, pr))
+	}
+
 	return workspaces, pipelinePVCWorkspaceName, nil
 }
 

--- a/pkg/reconciler/pipelinerun/resources/apply.go
+++ b/pkg/reconciler/pipelinerun/resources/apply.go
@@ -139,7 +139,8 @@ func paramsFromPipelineRun(ctx context.Context, pr *v1beta1.PipelineRun) (map[st
 	return stringReplacements, arrayReplacements, objectReplacements
 }
 
-func getContextReplacements(pipelineName string, pr *v1beta1.PipelineRun) map[string]string {
+// GetContextReplacements returns the pipelineRun context which can be used to replace context variables in the specifications
+func GetContextReplacements(pipelineName string, pr *v1beta1.PipelineRun) map[string]string {
 	return map[string]string{
 		"context.pipelineRun.name":      pr.Name,
 		"context.pipeline.name":         pipelineName,
@@ -149,9 +150,9 @@ func getContextReplacements(pipelineName string, pr *v1beta1.PipelineRun) map[st
 }
 
 // ApplyContexts applies the substitution from $(context.(pipelineRun|pipeline).*) with the specified values.
-// Currently supports only name substitution. Uses "" as a default if name is not specified.
+// Currently, supports only name substitution. Uses "" as a default if name is not specified.
 func ApplyContexts(spec *v1beta1.PipelineSpec, pipelineName string, pr *v1beta1.PipelineRun) *v1beta1.PipelineSpec {
-	return ApplyReplacements(spec, getContextReplacements(pipelineName, pr), map[string][]string{}, map[string]map[string]string{})
+	return ApplyReplacements(spec, GetContextReplacements(pipelineName, pr), map[string][]string{}, map[string]map[string]string{})
 }
 
 // ApplyPipelineTaskContexts applies the substitution from $(context.pipelineTask.*) with the specified values.

--- a/pkg/reconciler/pipelinerun/resources/pipelineref.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelineref.go
@@ -82,7 +82,7 @@ func GetPipelineFunc(ctx context.Context, k8s kubernetes.Interface, tekton clien
 	case pr != nil && pr.Resolver != "" && requester != nil:
 		return func(ctx context.Context, name string) (v1beta1.PipelineObject, *v1beta1.ConfigSource, error) {
 			stringReplacements, arrayReplacements, objectReplacements := paramsFromPipelineRun(ctx, pipelineRun)
-			for k, v := range getContextReplacements("", pipelineRun) {
+			for k, v := range GetContextReplacements("", pipelineRun) {
 				stringReplacements[k] = v
 			}
 			replacedParams := replaceParamValues(pr.Params, stringReplacements, arrayReplacements, objectReplacements)


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

`pipelineRun` specification includes a list of `workspaces` which are mapped by the `pipeline` so that the `pipelineTask` can utilize those volumes as a workspace in the `taskRuns`.

Now, workspaces listed as part of the pipelineRun specification supports specifying `subPath`. This `subPath` is a location on the volume where the `pipelineTask` stores/reads the workspace's data. This `subPath` could be any string value and could be a common location on the volume for the entire `pipeline`. Before this commit, such `subPath` value allowed only hardcoded strings. Now, in case of a shared volume, it is often necessary to assign a dedicated directory to each pipelineRun. This can be achieved by specifying `subPath` in each `pipelineTask` workspace declaration. But for a pipeline with a huge number of tasks (100 to 150), repeating the same configuration for each `pipelineTask` is painful and error prone.

This commit introduces a support for specifying `pipelineRun` context variables in the `pipelineRun.workspaces.subPath` so that each `pipelineTask` does not have to repeat the same configuration.

/kind feature

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Support for using pipelineRun context variables in pipelineRun.workspaces[].subPath.
```
