### PR TITLE
TEP-0118: Added `Matrix.Include` field in preview mode

### DIFF
--- a/docs/matrix.md
+++ b/docs/matrix.md
@@ -12,6 +12,7 @@ weight: 406
   - [Concurrency Control](#concurrency-control)
   - [Parameters](#parameters)
     - [Specifying both `params` and `matrix` in a `PipelineTask`](#specifying-both-params-and-matrix-in-a-pipelinetask)
+  - [Include](#Include)
   - [Context Variables](#context-variables)
   - [Results](#results)
     - [Specifying Results in a Matrix](#specifying-results-in-a-matrix)
@@ -24,7 +25,7 @@ weight: 406
 ## Overview
 
 `Matrix` is used to fan out `Tasks` in a `Pipeline`. This doc will explain the details of `matrix` support in
-Tekton. 
+Tekton.
 
 Documentation for specifying `Matrix` in a `Pipeline`:
 - [Specifying `Matrix` in `Tasks`](pipelines.md#specifying-matrix-in-pipelinetasks)
@@ -40,12 +41,12 @@ A `Matrix` supports the following features:
 * [Concurrency Control](#concurrency-control)
 * [Parameters](#parameters)
 * [Context Variables](#context-variables)
-* [Results](#results) 
+* [Results](#results)
 
 ### Concurrency Control
 
 The default maximum count of `TaskRuns` or `Runs` from a given `Matrix` is **256**. To customize the maximum count of
-`TaskRuns` or `Runs` generated from a given `Matrix`, configure the `default-max-matrix-combinations-count` in 
+`TaskRuns` or `Runs` generated from a given `Matrix`, configure the `default-max-matrix-combinations-count` in
 [config defaults](/config/config-defaults.yaml). When a `Matrix` in `PipelineTask` would generate more than the maximum
 `TaskRuns` or `Runs`, the `Pipeline` validation would fail.
 
@@ -92,7 +93,7 @@ spec:
       default:
         - chrome
         - safari
-        - firefox    
+        - firefox
   tasks:
   - name: fetch-repository
     taskRef:
@@ -110,7 +111,7 @@ spec:
   ...
 ```
 
-A `Parameter` can be passed to either the `matrix` or `params` field, not both. 
+A `Parameter` can be passed to either the `matrix` or `params` field, not both.
 
 For further details on specifying `Parameters` in the `Pipeline` and passing them to
 `PipelineTasks`, see [documentation](pipelines.md#specifying-parameters).
@@ -148,9 +149,15 @@ spec:
   ...
 ```
 
+### Include
+> :warning: This feature is in a preview mode.
+> It is still in a very early stage of development and is not yet fully functional.
+
+The `Include` section in the `Matrix` field exists, but is not yet functional.
+
 ### Context Variables
 
-Similarly to the `Parameters` in the `Params` field, the `Parameters` in the `Matrix` field will accept 
+Similarly to the `Parameters` in the `Params` field, the `Parameters` in the `Matrix` field will accept
 [context variables](variables.md) that will be substituted, including:
 
 * `PipelineRun` name, namespace and uid
@@ -161,7 +168,7 @@ Similarly to the `Parameters` in the `Params` field, the `Parameters` in the `Ma
 
 #### Specifying Results in a Matrix
 
-Consuming `Results` from previous `TaskRuns` or `Runs` in a `Matrix`, which would dynamically generate 
+Consuming `Results` from previous `TaskRuns` or `Runs` in a `Matrix`, which would dynamically generate
 `TaskRuns` or `Runs` from the fanned out `PipelineTask`, is supported. Producing `Results` in from a
 `PipelineTask` with a `Matrix` is not yet supported - see [further details](#results-from-fanned-out-pipelinetasks).
 
@@ -203,7 +210,7 @@ tasks:
 
 Consuming `Results` from fanned out `PipelineTasks` will not be in the supported in the initial iteration
 of `Matrix`. Supporting consuming `Results` from fanned out `PipelineTasks` will be revisited after array
-and object `Results` are supported. 
+and object `Results` are supported.
 
 ## Fan Out
 
@@ -487,7 +494,7 @@ status:
         name: platforms-and-browsers
         taskRef:
           apiVersion: cel.tekton.dev/v1alpha1
-          kind: CEL  
+          kind: CEL
   startTime: "2022-06-28T20:49:40Z"
   completionTime: "2022-06-28T20:49:41Z"
   conditions:
@@ -495,7 +502,7 @@ status:
       message: 'Tasks Completed: 1 (Failed: 0, Cancelled 0), Skipped: 0'
       reason: Succeeded
       status: "True"
-      type: Succeeded  
+      type: Succeeded
   childReferences:
     - apiVersion: tekton.dev/v1alpha1
       kind: Run
@@ -533,11 +540,11 @@ status:
 
 ## Retries
 
-The `retries` field is used to specify the number of times a `PipelineTask` should be retried when its `TaskRun` or 
-`Run` fails, see the [documentation][retries] for further details. When a `PipelineTask` is fanned out using `Matrix`, 
+The `retries` field is used to specify the number of times a `PipelineTask` should be retried when its `TaskRun` or
+`Run` fails, see the [documentation][retries] for further details. When a `PipelineTask` is fanned out using `Matrix`,
 a given `TaskRun` or `Run` executed will be retried as much as the field in the `retries` field of the `PipelineTask`.
 
-For example, the `PipelineTask` in this `PipelineRun` will be fanned out into three `TaskRuns` each of which will be 
+For example, the `PipelineTask` in this `PipelineRun` will be fanned out into three `TaskRuns` each of which will be
 retried once:
 
 ```yaml

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -336,7 +336,7 @@ tasks:
       value: https://github.com/tektoncd/catalog.git
     - name: revision
       # value can use params declared at the pipeline level or a static value like main
-      value: $(params.gitRevision) 
+      value: $(params.gitRevision)
     - name: pathInRepo
       value: task/golang-build/0.3/golang-build.yaml
 ```
@@ -1322,7 +1322,7 @@ results:
     value: $(finally.check-count.results.comment-count-validate)
 finally:
   - name: check-count
-    taskRef: 
+    taskRef:
       name: example-task-name
 ```
 
@@ -1810,7 +1810,7 @@ Consult the documentation of the custom task that you are using to determine whe
 Pipelines do not support the following items with custom tasks:
 * Pipeline Resources
 
-### Known Custom Tasks 
+### Known Custom Tasks
 
 We try to list as many known Custom Tasks as possible here so that users can easily find what they want. Please feel free to share the Custom Task you implemented in this table.
 
@@ -1828,7 +1828,7 @@ We try to list as many known Custom Tasks as possible here so that users can eas
 | [Common Expression Language][cel]| Provides Common Expression Language support in Tekton Pipelines.
 | [Wait][wait]| Waits a given amount of time, specified by a `Parameter` named "duration", before succeeding.
 | [Approvals][approvals]| Pauses the execution of `PipelineRuns` and waits for manual approvals.
-| [Pipelines in Pipelines][pipelines-in-pipelines]| Defines and executes a `Pipeline` in a `Pipeline`. 
+| [Pipelines in Pipelines][pipelines-in-pipelines]| Defines and executes a `Pipeline` in a `Pipeline`.
 | [Task Group][task-group]| Groups `Tasks` together as a `Task`.
 | [Pipeline in a Pod][pipeline-in-pod]| Runs `Pipeline` in a `Pod`.
 

--- a/pkg/apis/pipeline/v1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1/openapi_generated.go
@@ -30,67 +30,68 @@ import (
 
 func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenAPIDefinition {
 	return map[string]common.OpenAPIDefinition{
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/pod.AffinityAssistantTemplate":   schema_pkg_apis_pipeline_pod_AffinityAssistantTemplate(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/pod.Template":                    schema_pkg_apis_pipeline_pod_Template(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.ChildStatusReference":         schema_pkg_apis_pipeline_v1_ChildStatusReference(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.ConfigSource":                 schema_pkg_apis_pipeline_v1_ConfigSource(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.EmbeddedTask":                 schema_pkg_apis_pipeline_v1_EmbeddedTask(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Matrix":                       schema_pkg_apis_pipeline_v1_Matrix(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Param":                        schema_pkg_apis_pipeline_v1_Param(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.ParamSpec":                    schema_pkg_apis_pipeline_v1_ParamSpec(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.ParamValue":                   schema_pkg_apis_pipeline_v1_ParamValue(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Pipeline":                     schema_pkg_apis_pipeline_v1_Pipeline(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineList":                 schema_pkg_apis_pipeline_v1_PipelineList(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineRef":                  schema_pkg_apis_pipeline_v1_PipelineRef(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineResult":               schema_pkg_apis_pipeline_v1_PipelineResult(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineRun":                  schema_pkg_apis_pipeline_v1_PipelineRun(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineRunList":              schema_pkg_apis_pipeline_v1_PipelineRunList(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineRunResult":            schema_pkg_apis_pipeline_v1_PipelineRunResult(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineRunRunStatus":         schema_pkg_apis_pipeline_v1_PipelineRunRunStatus(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineRunSpec":              schema_pkg_apis_pipeline_v1_PipelineRunSpec(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineRunStatus":            schema_pkg_apis_pipeline_v1_PipelineRunStatus(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineRunStatusFields":      schema_pkg_apis_pipeline_v1_PipelineRunStatusFields(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineRunTaskRunStatus":     schema_pkg_apis_pipeline_v1_PipelineRunTaskRunStatus(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineSpec":                 schema_pkg_apis_pipeline_v1_PipelineSpec(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineTask":                 schema_pkg_apis_pipeline_v1_PipelineTask(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineTaskMetadata":         schema_pkg_apis_pipeline_v1_PipelineTaskMetadata(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineTaskParam":            schema_pkg_apis_pipeline_v1_PipelineTaskParam(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineTaskRun":              schema_pkg_apis_pipeline_v1_PipelineTaskRun(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineTaskRunSpec":          schema_pkg_apis_pipeline_v1_PipelineTaskRunSpec(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineTaskRunTemplate":      schema_pkg_apis_pipeline_v1_PipelineTaskRunTemplate(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineWorkspaceDeclaration": schema_pkg_apis_pipeline_v1_PipelineWorkspaceDeclaration(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PropertySpec":                 schema_pkg_apis_pipeline_v1_PropertySpec(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Provenance":                   schema_pkg_apis_pipeline_v1_Provenance(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.ResolverRef":                  schema_pkg_apis_pipeline_v1_ResolverRef(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.ResultRef":                    schema_pkg_apis_pipeline_v1_ResultRef(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Sidecar":                      schema_pkg_apis_pipeline_v1_Sidecar(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.SidecarState":                 schema_pkg_apis_pipeline_v1_SidecarState(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.SkippedTask":                  schema_pkg_apis_pipeline_v1_SkippedTask(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Step":                         schema_pkg_apis_pipeline_v1_Step(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.StepOutputConfig":             schema_pkg_apis_pipeline_v1_StepOutputConfig(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.StepState":                    schema_pkg_apis_pipeline_v1_StepState(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.StepTemplate":                 schema_pkg_apis_pipeline_v1_StepTemplate(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Task":                         schema_pkg_apis_pipeline_v1_Task(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskList":                     schema_pkg_apis_pipeline_v1_TaskList(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskRef":                      schema_pkg_apis_pipeline_v1_TaskRef(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskResult":                   schema_pkg_apis_pipeline_v1_TaskResult(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskRun":                      schema_pkg_apis_pipeline_v1_TaskRun(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskRunDebug":                 schema_pkg_apis_pipeline_v1_TaskRunDebug(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskRunInputs":                schema_pkg_apis_pipeline_v1_TaskRunInputs(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskRunList":                  schema_pkg_apis_pipeline_v1_TaskRunList(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskRunResult":                schema_pkg_apis_pipeline_v1_TaskRunResult(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskRunSidecarSpec":           schema_pkg_apis_pipeline_v1_TaskRunSidecarSpec(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskRunSpec":                  schema_pkg_apis_pipeline_v1_TaskRunSpec(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskRunStatus":                schema_pkg_apis_pipeline_v1_TaskRunStatus(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskRunStatusFields":          schema_pkg_apis_pipeline_v1_TaskRunStatusFields(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskRunStepSpec":              schema_pkg_apis_pipeline_v1_TaskRunStepSpec(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskSpec":                     schema_pkg_apis_pipeline_v1_TaskSpec(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TimeoutFields":                schema_pkg_apis_pipeline_v1_TimeoutFields(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.WhenExpression":               schema_pkg_apis_pipeline_v1_WhenExpression(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.WorkspaceBinding":             schema_pkg_apis_pipeline_v1_WorkspaceBinding(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.WorkspaceDeclaration":         schema_pkg_apis_pipeline_v1_WorkspaceDeclaration(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.WorkspacePipelineTaskBinding": schema_pkg_apis_pipeline_v1_WorkspacePipelineTaskBinding(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.WorkspaceUsage":               schema_pkg_apis_pipeline_v1_WorkspaceUsage(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/pod.AffinityAssistantTemplate":   schema_pkg_apis_pipeline_pod_AffinityAssistantTemplate(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/pod.Template":                    schema_pkg_apis_pipeline_pod_Template(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.ChildStatusReference":         schema_pkg_apis_pipeline_v1_ChildStatusReference(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.ConfigSource":                 schema_pkg_apis_pipeline_v1_ConfigSource(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.EmbeddedTask":                 schema_pkg_apis_pipeline_v1_EmbeddedTask(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.Matrix":                       schema_pkg_apis_pipeline_v1_Matrix(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.MatrixInclude":                schema_pkg_apis_pipeline_v1_MatrixInclude(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.Param":                        schema_pkg_apis_pipeline_v1_Param(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.ParamSpec":                    schema_pkg_apis_pipeline_v1_ParamSpec(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.ParamValue":                   schema_pkg_apis_pipeline_v1_ParamValue(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.Pipeline":                     schema_pkg_apis_pipeline_v1_Pipeline(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.PipelineList":                 schema_pkg_apis_pipeline_v1_PipelineList(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.PipelineRef":                  schema_pkg_apis_pipeline_v1_PipelineRef(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.PipelineResult":               schema_pkg_apis_pipeline_v1_PipelineResult(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.PipelineRun":                  schema_pkg_apis_pipeline_v1_PipelineRun(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.PipelineRunList":              schema_pkg_apis_pipeline_v1_PipelineRunList(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.PipelineRunResult":            schema_pkg_apis_pipeline_v1_PipelineRunResult(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.PipelineRunRunStatus":         schema_pkg_apis_pipeline_v1_PipelineRunRunStatus(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.PipelineRunSpec":              schema_pkg_apis_pipeline_v1_PipelineRunSpec(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.PipelineRunStatus":            schema_pkg_apis_pipeline_v1_PipelineRunStatus(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.PipelineRunStatusFields":      schema_pkg_apis_pipeline_v1_PipelineRunStatusFields(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.PipelineRunTaskRunStatus":     schema_pkg_apis_pipeline_v1_PipelineRunTaskRunStatus(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.PipelineSpec":                 schema_pkg_apis_pipeline_v1_PipelineSpec(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.PipelineTask":                 schema_pkg_apis_pipeline_v1_PipelineTask(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.PipelineTaskMetadata":         schema_pkg_apis_pipeline_v1_PipelineTaskMetadata(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.PipelineTaskParam":            schema_pkg_apis_pipeline_v1_PipelineTaskParam(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.PipelineTaskRun":              schema_pkg_apis_pipeline_v1_PipelineTaskRun(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.PipelineTaskRunSpec":          schema_pkg_apis_pipeline_v1_PipelineTaskRunSpec(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.PipelineTaskRunTemplate":      schema_pkg_apis_pipeline_v1_PipelineTaskRunTemplate(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.PipelineWorkspaceDeclaration": schema_pkg_apis_pipeline_v1_PipelineWorkspaceDeclaration(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.PropertySpec":                 schema_pkg_apis_pipeline_v1_PropertySpec(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.Provenance":                   schema_pkg_apis_pipeline_v1_Provenance(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.ResolverRef":                  schema_pkg_apis_pipeline_v1_ResolverRef(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.ResultRef":                    schema_pkg_apis_pipeline_v1_ResultRef(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.Sidecar":                      schema_pkg_apis_pipeline_v1_Sidecar(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.SidecarState":                 schema_pkg_apis_pipeline_v1_SidecarState(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.SkippedTask":                  schema_pkg_apis_pipeline_v1_SkippedTask(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.Step":                         schema_pkg_apis_pipeline_v1_Step(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.StepOutputConfig":             schema_pkg_apis_pipeline_v1_StepOutputConfig(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.StepState":                    schema_pkg_apis_pipeline_v1_StepState(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.StepTemplate":                 schema_pkg_apis_pipeline_v1_StepTemplate(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.Task":                         schema_pkg_apis_pipeline_v1_Task(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.TaskList":                     schema_pkg_apis_pipeline_v1_TaskList(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.TaskRef":                      schema_pkg_apis_pipeline_v1_TaskRef(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.TaskResult":                   schema_pkg_apis_pipeline_v1_TaskResult(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.TaskRun":                      schema_pkg_apis_pipeline_v1_TaskRun(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.TaskRunDebug":                 schema_pkg_apis_pipeline_v1_TaskRunDebug(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.TaskRunInputs":                schema_pkg_apis_pipeline_v1_TaskRunInputs(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.TaskRunList":                  schema_pkg_apis_pipeline_v1_TaskRunList(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.TaskRunResult":                schema_pkg_apis_pipeline_v1_TaskRunResult(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.TaskRunSidecarSpec":           schema_pkg_apis_pipeline_v1_TaskRunSidecarSpec(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.TaskRunSpec":                  schema_pkg_apis_pipeline_v1_TaskRunSpec(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.TaskRunStatus":                schema_pkg_apis_pipeline_v1_TaskRunStatus(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.TaskRunStatusFields":          schema_pkg_apis_pipeline_v1_TaskRunStatusFields(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.TaskRunStepSpec":              schema_pkg_apis_pipeline_v1_TaskRunStepSpec(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.TaskSpec":                     schema_pkg_apis_pipeline_v1_TaskSpec(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.TimeoutFields":                schema_pkg_apis_pipeline_v1_TimeoutFields(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.WhenExpression":               schema_pkg_apis_pipeline_v1_WhenExpression(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.WorkspaceBinding":             schema_pkg_apis_pipeline_v1_WorkspaceBinding(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.WorkspaceDeclaration":         schema_pkg_apis_pipeline_v1_WorkspaceDeclaration(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.WorkspacePipelineTaskBinding": schema_pkg_apis_pipeline_v1_WorkspacePipelineTaskBinding(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1.WorkspaceUsage":               schema_pkg_apis_pipeline_v1_WorkspaceUsage(ref),
 	}
 }
 
@@ -425,7 +426,7 @@ func schema_pkg_apis_pipeline_v1_ChildStatusReference(ref common.ReferenceCallba
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.WhenExpression"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.WhenExpression"),
 									},
 								},
 							},
@@ -435,7 +436,7 @@ func schema_pkg_apis_pipeline_v1_ChildStatusReference(ref common.ReferenceCallba
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.WhenExpression"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1.WhenExpression"},
 	}
 }
 
@@ -511,7 +512,7 @@ func schema_pkg_apis_pipeline_v1_EmbeddedTask(ref common.ReferenceCallback) comm
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Default: map[string]interface{}{},
-							Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineTaskMetadata"),
+							Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.PipelineTaskMetadata"),
 						},
 					},
 					"params": {
@@ -527,7 +528,7 @@ func schema_pkg_apis_pipeline_v1_EmbeddedTask(ref common.ReferenceCallback) comm
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.ParamSpec"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.ParamSpec"),
 									},
 								},
 							},
@@ -553,7 +554,7 @@ func schema_pkg_apis_pipeline_v1_EmbeddedTask(ref common.ReferenceCallback) comm
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Step"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.Step"),
 									},
 								},
 							},
@@ -581,7 +582,7 @@ func schema_pkg_apis_pipeline_v1_EmbeddedTask(ref common.ReferenceCallback) comm
 					"stepTemplate": {
 						SchemaProps: spec.SchemaProps{
 							Description: "StepTemplate can be used as the basis for all step containers within the Task, so that the steps inherit settings on the base container.",
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.StepTemplate"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.StepTemplate"),
 						},
 					},
 					"sidecars": {
@@ -597,7 +598,7 @@ func schema_pkg_apis_pipeline_v1_EmbeddedTask(ref common.ReferenceCallback) comm
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Sidecar"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.Sidecar"),
 									},
 								},
 							},
@@ -616,7 +617,7 @@ func schema_pkg_apis_pipeline_v1_EmbeddedTask(ref common.ReferenceCallback) comm
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.WorkspaceDeclaration"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.WorkspaceDeclaration"),
 									},
 								},
 							},
@@ -635,7 +636,7 @@ func schema_pkg_apis_pipeline_v1_EmbeddedTask(ref common.ReferenceCallback) comm
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskResult"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.TaskResult"),
 									},
 								},
 							},
@@ -645,7 +646,7 @@ func schema_pkg_apis_pipeline_v1_EmbeddedTask(ref common.ReferenceCallback) comm
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.ParamSpec", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineTaskMetadata", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Sidecar", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Step", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.StepTemplate", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskResult", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.WorkspaceDeclaration", "k8s.io/api/core/v1.Volume", "k8s.io/apimachinery/pkg/runtime.RawExtension"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1.ParamSpec", "github.com/tekton/pipeline/pkg/apis/pipeline/v1.PipelineTaskMetadata", "github.com/tekton/pipeline/pkg/apis/pipeline/v1.Sidecar", "github.com/tekton/pipeline/pkg/apis/pipeline/v1.Step", "github.com/tekton/pipeline/pkg/apis/pipeline/v1.StepTemplate", "github.com/tekton/pipeline/pkg/apis/pipeline/v1.TaskResult", "github.com/tekton/pipeline/pkg/apis/pipeline/v1.WorkspaceDeclaration", "k8s.io/api/core/v1.Volume", "k8s.io/apimachinery/pkg/runtime.RawExtension"},
 	}
 }
 
@@ -669,7 +670,26 @@ func schema_pkg_apis_pipeline_v1_Matrix(ref common.ReferenceCallback) common.Ope
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Param"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.Param"),
+									},
+								},
+							},
+						},
+					},
+					"include": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
+						SchemaProps: spec.SchemaProps{
+							Description: "Include is a list of MatrixInclude Note this field is in preview mode and not yet supported",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: map[string]interface{}{},
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.MatrixInclude"),
 									},
 								},
 							},
@@ -679,7 +699,48 @@ func schema_pkg_apis_pipeline_v1_Matrix(ref common.ReferenceCallback) common.Ope
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Param"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1.MatrixInclude", "github.com/tekton/pipeline/pkg/apis/pipeline/v1.Param"},
+	}
+}
+
+func schema_pkg_apis_pipeline_v1_MatrixInclude(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "MatrixInclude allows passing in a specific combinations of Parameters into the Matrix. Note this struct is in preview mode and not yet supported",
+				Type:        []string{"object"},
+				Properties: map[string]spec.Schema{
+					"name": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Name the specified combination",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"params": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
+						SchemaProps: spec.SchemaProps{
+							Description: "Params takes only `Parameters` of type `\"string\"` The names of the `params` must match the names of the `params` in the underlying `Task`",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: map[string]interface{}{},
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.Param"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Dependencies: []string{
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1.Param"},
 	}
 }
 
@@ -700,7 +761,7 @@ func schema_pkg_apis_pipeline_v1_Param(ref common.ReferenceCallback) common.Open
 					"value": {
 						SchemaProps: spec.SchemaProps{
 							Default: map[string]interface{}{},
-							Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.ParamValue"),
+							Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.ParamValue"),
 						},
 					},
 				},
@@ -708,7 +769,7 @@ func schema_pkg_apis_pipeline_v1_Param(ref common.ReferenceCallback) common.Open
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.ParamValue"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1.ParamValue"},
 	}
 }
 
@@ -750,7 +811,7 @@ func schema_pkg_apis_pipeline_v1_ParamSpec(ref common.ReferenceCallback) common.
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PropertySpec"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.PropertySpec"),
 									},
 								},
 							},
@@ -759,7 +820,7 @@ func schema_pkg_apis_pipeline_v1_ParamSpec(ref common.ReferenceCallback) common.
 					"default": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Default is the value a parameter takes if no input value is supplied. If default is set, a Task may be executed without a supplied value for the parameter.",
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.ParamValue"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.ParamValue"),
 						},
 					},
 				},
@@ -767,7 +828,7 @@ func schema_pkg_apis_pipeline_v1_ParamSpec(ref common.ReferenceCallback) common.
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.ParamValue", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PropertySpec"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1.ParamValue", "github.com/tekton/pipeline/pkg/apis/pipeline/v1.PropertySpec"},
 	}
 }
 
@@ -865,14 +926,14 @@ func schema_pkg_apis_pipeline_v1_Pipeline(ref common.ReferenceCallback) common.O
 						SchemaProps: spec.SchemaProps{
 							Description: "Spec holds the desired state of the Pipeline from the client",
 							Default:     map[string]interface{}{},
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineSpec"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.PipelineSpec"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineSpec", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1.PipelineSpec", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }
 
@@ -910,7 +971,7 @@ func schema_pkg_apis_pipeline_v1_PipelineList(ref common.ReferenceCallback) comm
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Pipeline"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.Pipeline"),
 									},
 								},
 							},
@@ -921,7 +982,7 @@ func schema_pkg_apis_pipeline_v1_PipelineList(ref common.ReferenceCallback) comm
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Pipeline", "k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1.Pipeline", "k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"},
 	}
 }
 
@@ -986,7 +1047,7 @@ func schema_pkg_apis_pipeline_v1_PipelineResult(ref common.ReferenceCallback) co
 						SchemaProps: spec.SchemaProps{
 							Description: "Value the expression used to retrieve the value",
 							Default:     map[string]interface{}{},
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.ParamValue"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.ParamValue"),
 						},
 					},
 				},
@@ -994,7 +1055,7 @@ func schema_pkg_apis_pipeline_v1_PipelineResult(ref common.ReferenceCallback) co
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.ParamValue"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1.ParamValue"},
 	}
 }
 
@@ -1028,20 +1089,20 @@ func schema_pkg_apis_pipeline_v1_PipelineRun(ref common.ReferenceCallback) commo
 					"spec": {
 						SchemaProps: spec.SchemaProps{
 							Default: map[string]interface{}{},
-							Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineRunSpec"),
+							Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.PipelineRunSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Default: map[string]interface{}{},
-							Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineRunStatus"),
+							Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.PipelineRunStatus"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineRunSpec", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineRunStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1.PipelineRunSpec", "github.com/tekton/pipeline/pkg/apis/pipeline/v1.PipelineRunStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }
 
@@ -1079,7 +1140,7 @@ func schema_pkg_apis_pipeline_v1_PipelineRunList(ref common.ReferenceCallback) c
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineRun"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.PipelineRun"),
 									},
 								},
 							},
@@ -1089,7 +1150,7 @@ func schema_pkg_apis_pipeline_v1_PipelineRunList(ref common.ReferenceCallback) c
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineRun", "k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1.PipelineRun", "k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"},
 	}
 }
 
@@ -1112,7 +1173,7 @@ func schema_pkg_apis_pipeline_v1_PipelineRunResult(ref common.ReferenceCallback)
 						SchemaProps: spec.SchemaProps{
 							Description: "Value is the result returned from the execution of this PipelineRun",
 							Default:     map[string]interface{}{},
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.ParamValue"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.ParamValue"),
 						},
 					},
 				},
@@ -1120,7 +1181,7 @@ func schema_pkg_apis_pipeline_v1_PipelineRunResult(ref common.ReferenceCallback)
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.ParamValue"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1.ParamValue"},
 	}
 }
 
@@ -1157,7 +1218,7 @@ func schema_pkg_apis_pipeline_v1_PipelineRunRunStatus(ref common.ReferenceCallba
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.WhenExpression"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.WhenExpression"),
 									},
 								},
 							},
@@ -1167,7 +1228,7 @@ func schema_pkg_apis_pipeline_v1_PipelineRunRunStatus(ref common.ReferenceCallba
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.WhenExpression", "github.com/tektoncd/pipeline/pkg/apis/run/v1beta1.CustomRunStatus"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1.WhenExpression", "github.com/tektoncd/pipeline/pkg/apis/run/v1beta1.CustomRunStatus"},
 	}
 }
 
@@ -1180,12 +1241,12 @@ func schema_pkg_apis_pipeline_v1_PipelineRunSpec(ref common.ReferenceCallback) c
 				Properties: map[string]spec.Schema{
 					"pipelineRef": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineRef"),
+							Ref: ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.PipelineRef"),
 						},
 					},
 					"pipelineSpec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineSpec"),
+							Ref: ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.PipelineSpec"),
 						},
 					},
 					"params": {
@@ -1201,7 +1262,7 @@ func schema_pkg_apis_pipeline_v1_PipelineRunSpec(ref common.ReferenceCallback) c
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Param"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.Param"),
 									},
 								},
 							},
@@ -1217,14 +1278,14 @@ func schema_pkg_apis_pipeline_v1_PipelineRunSpec(ref common.ReferenceCallback) c
 					"timeouts": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Time after which the Pipeline times out. Currently three keys are accepted in the map pipeline, tasks and finally with Timeouts.pipeline >= Timeouts.tasks + Timeouts.finally",
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TimeoutFields"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.TimeoutFields"),
 						},
 					},
 					"taskRunTemplate": {
 						SchemaProps: spec.SchemaProps{
 							Description: "TaskRunTemplate represent template of taskrun",
 							Default:     map[string]interface{}{},
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineTaskRunTemplate"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.PipelineTaskRunTemplate"),
 						},
 					},
 					"workspaces": {
@@ -1240,7 +1301,7 @@ func schema_pkg_apis_pipeline_v1_PipelineRunSpec(ref common.ReferenceCallback) c
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.WorkspaceBinding"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.WorkspaceBinding"),
 									},
 								},
 							},
@@ -1259,7 +1320,7 @@ func schema_pkg_apis_pipeline_v1_PipelineRunSpec(ref common.ReferenceCallback) c
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineTaskRunSpec"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.PipelineTaskRunSpec"),
 									},
 								},
 							},
@@ -1269,7 +1330,7 @@ func schema_pkg_apis_pipeline_v1_PipelineRunSpec(ref common.ReferenceCallback) c
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Param", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineRef", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineSpec", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineTaskRunSpec", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineTaskRunTemplate", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TimeoutFields", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.WorkspaceBinding"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1.Param", "github.com/tekton/pipeline/pkg/apis/pipeline/v1.PipelineRef", "github.com/tekton/pipeline/pkg/apis/pipeline/v1.PipelineSpec", "github.com/tekton/pipeline/pkg/apis/pipeline/v1.PipelineTaskRunSpec", "github.com/tekton/pipeline/pkg/apis/pipeline/v1.PipelineTaskRunTemplate", "github.com/tekton/pipeline/pkg/apis/pipeline/v1.TimeoutFields", "github.com/tekton/pipeline/pkg/apis/pipeline/v1.WorkspaceBinding"},
 	}
 }
 
@@ -1348,7 +1409,7 @@ func schema_pkg_apis_pipeline_v1_PipelineRunStatus(ref common.ReferenceCallback)
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineRunResult"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.PipelineRunResult"),
 									},
 								},
 							},
@@ -1357,7 +1418,7 @@ func schema_pkg_apis_pipeline_v1_PipelineRunStatus(ref common.ReferenceCallback)
 					"pipelineSpec": {
 						SchemaProps: spec.SchemaProps{
 							Description: "PipelineRunSpec contains the exact spec used to instantiate the run",
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineSpec"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.PipelineSpec"),
 						},
 					},
 					"skippedTasks": {
@@ -1373,7 +1434,7 @@ func schema_pkg_apis_pipeline_v1_PipelineRunStatus(ref common.ReferenceCallback)
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.SkippedTask"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.SkippedTask"),
 									},
 								},
 							},
@@ -1392,7 +1453,7 @@ func schema_pkg_apis_pipeline_v1_PipelineRunStatus(ref common.ReferenceCallback)
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.ChildStatusReference"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.ChildStatusReference"),
 									},
 								},
 							},
@@ -1407,14 +1468,14 @@ func schema_pkg_apis_pipeline_v1_PipelineRunStatus(ref common.ReferenceCallback)
 					"provenance": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Provenance contains some key authenticated metadata about how a software artifact was built (what sources, what inputs/outputs, etc.).",
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Provenance"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.Provenance"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.ChildStatusReference", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineRunResult", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineSpec", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Provenance", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.SkippedTask", "k8s.io/apimachinery/pkg/apis/meta/v1.Time", "knative.dev/pkg/apis.Condition"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1.ChildStatusReference", "github.com/tekton/pipeline/pkg/apis/pipeline/v1.PipelineRunResult", "github.com/tekton/pipeline/pkg/apis/pipeline/v1.PipelineSpec", "github.com/tekton/pipeline/pkg/apis/pipeline/v1.Provenance", "github.com/tekton/pipeline/pkg/apis/pipeline/v1.SkippedTask", "k8s.io/apimachinery/pkg/apis/meta/v1.Time", "knative.dev/pkg/apis.Condition"},
 	}
 }
 
@@ -1450,7 +1511,7 @@ func schema_pkg_apis_pipeline_v1_PipelineRunStatusFields(ref common.ReferenceCal
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineRunResult"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.PipelineRunResult"),
 									},
 								},
 							},
@@ -1459,7 +1520,7 @@ func schema_pkg_apis_pipeline_v1_PipelineRunStatusFields(ref common.ReferenceCal
 					"pipelineSpec": {
 						SchemaProps: spec.SchemaProps{
 							Description: "PipelineRunSpec contains the exact spec used to instantiate the run",
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineSpec"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.PipelineSpec"),
 						},
 					},
 					"skippedTasks": {
@@ -1475,7 +1536,7 @@ func schema_pkg_apis_pipeline_v1_PipelineRunStatusFields(ref common.ReferenceCal
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.SkippedTask"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.SkippedTask"),
 									},
 								},
 							},
@@ -1494,7 +1555,7 @@ func schema_pkg_apis_pipeline_v1_PipelineRunStatusFields(ref common.ReferenceCal
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.ChildStatusReference"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.ChildStatusReference"),
 									},
 								},
 							},
@@ -1509,14 +1570,14 @@ func schema_pkg_apis_pipeline_v1_PipelineRunStatusFields(ref common.ReferenceCal
 					"provenance": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Provenance contains some key authenticated metadata about how a software artifact was built (what sources, what inputs/outputs, etc.).",
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Provenance"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.Provenance"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.ChildStatusReference", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineRunResult", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineSpec", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Provenance", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.SkippedTask", "k8s.io/apimachinery/pkg/apis/meta/v1.Time"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1.ChildStatusReference", "github.com/tekton/pipeline/pkg/apis/pipeline/v1.PipelineRunResult", "github.com/tekton/pipeline/pkg/apis/pipeline/v1.PipelineSpec", "github.com/tekton/pipeline/pkg/apis/pipeline/v1.Provenance", "github.com/tekton/pipeline/pkg/apis/pipeline/v1.SkippedTask", "k8s.io/apimachinery/pkg/apis/meta/v1.Time"},
 	}
 }
 
@@ -1537,7 +1598,7 @@ func schema_pkg_apis_pipeline_v1_PipelineRunTaskRunStatus(ref common.ReferenceCa
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Status is the TaskRunStatus for the corresponding TaskRun",
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskRunStatus"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.TaskRunStatus"),
 						},
 					},
 					"whenExpressions": {
@@ -1553,7 +1614,7 @@ func schema_pkg_apis_pipeline_v1_PipelineRunTaskRunStatus(ref common.ReferenceCa
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.WhenExpression"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.WhenExpression"),
 									},
 								},
 							},
@@ -1563,7 +1624,7 @@ func schema_pkg_apis_pipeline_v1_PipelineRunTaskRunStatus(ref common.ReferenceCa
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskRunStatus", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.WhenExpression"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1.TaskRunStatus", "github.com/tekton/pipeline/pkg/apis/pipeline/v1.WhenExpression"},
 	}
 }
 
@@ -1594,7 +1655,7 @@ func schema_pkg_apis_pipeline_v1_PipelineSpec(ref common.ReferenceCallback) comm
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineTask"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.PipelineTask"),
 									},
 								},
 							},
@@ -1613,7 +1674,7 @@ func schema_pkg_apis_pipeline_v1_PipelineSpec(ref common.ReferenceCallback) comm
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.ParamSpec"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.ParamSpec"),
 									},
 								},
 							},
@@ -1632,7 +1693,7 @@ func schema_pkg_apis_pipeline_v1_PipelineSpec(ref common.ReferenceCallback) comm
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineWorkspaceDeclaration"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.PipelineWorkspaceDeclaration"),
 									},
 								},
 							},
@@ -1651,7 +1712,7 @@ func schema_pkg_apis_pipeline_v1_PipelineSpec(ref common.ReferenceCallback) comm
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineResult"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.PipelineResult"),
 									},
 								},
 							},
@@ -1670,7 +1731,7 @@ func schema_pkg_apis_pipeline_v1_PipelineSpec(ref common.ReferenceCallback) comm
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineTask"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.PipelineTask"),
 									},
 								},
 							},
@@ -1680,7 +1741,7 @@ func schema_pkg_apis_pipeline_v1_PipelineSpec(ref common.ReferenceCallback) comm
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.ParamSpec", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineResult", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineTask", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineWorkspaceDeclaration"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1.ParamSpec", "github.com/tekton/pipeline/pkg/apis/pipeline/v1.PipelineResult", "github.com/tekton/pipeline/pkg/apis/pipeline/v1.PipelineTask", "github.com/tekton/pipeline/pkg/apis/pipeline/v1.PipelineWorkspaceDeclaration"},
 	}
 }
 
@@ -1701,13 +1762,13 @@ func schema_pkg_apis_pipeline_v1_PipelineTask(ref common.ReferenceCallback) comm
 					"taskRef": {
 						SchemaProps: spec.SchemaProps{
 							Description: "TaskRef is a reference to a task definition.",
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskRef"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.TaskRef"),
 						},
 					},
 					"taskSpec": {
 						SchemaProps: spec.SchemaProps{
 							Description: "TaskSpec is a specification of a task",
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.EmbeddedTask"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.EmbeddedTask"),
 						},
 					},
 					"when": {
@@ -1718,7 +1779,7 @@ func schema_pkg_apis_pipeline_v1_PipelineTask(ref common.ReferenceCallback) comm
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.WhenExpression"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.WhenExpression"),
 									},
 								},
 							},
@@ -1764,7 +1825,7 @@ func schema_pkg_apis_pipeline_v1_PipelineTask(ref common.ReferenceCallback) comm
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Param"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.Param"),
 									},
 								},
 							},
@@ -1773,7 +1834,7 @@ func schema_pkg_apis_pipeline_v1_PipelineTask(ref common.ReferenceCallback) comm
 					"matrix": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Matrix declares parameters used to fan out this task.",
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Matrix"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.Matrix"),
 						},
 					},
 					"workspaces": {
@@ -1789,7 +1850,7 @@ func schema_pkg_apis_pipeline_v1_PipelineTask(ref common.ReferenceCallback) comm
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.WorkspacePipelineTaskBinding"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.WorkspacePipelineTaskBinding"),
 									},
 								},
 							},
@@ -1805,7 +1866,7 @@ func schema_pkg_apis_pipeline_v1_PipelineTask(ref common.ReferenceCallback) comm
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.EmbeddedTask", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Matrix", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Param", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskRef", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.WhenExpression", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.WorkspacePipelineTaskBinding", "k8s.io/apimachinery/pkg/apis/meta/v1.Duration"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1.EmbeddedTask", "github.com/tekton/pipeline/pkg/apis/pipeline/v1.Matrix", "github.com/tekton/pipeline/pkg/apis/pipeline/v1.Param", "github.com/tekton/pipeline/pkg/apis/pipeline/v1.TaskRef", "github.com/tekton/pipeline/pkg/apis/pipeline/v1.WhenExpression", "github.com/tekton/pipeline/pkg/apis/pipeline/v1.WorkspacePipelineTaskBinding", "k8s.io/apimachinery/pkg/apis/meta/v1.Duration"},
 	}
 }
 
@@ -1935,7 +1996,7 @@ func schema_pkg_apis_pipeline_v1_PipelineTaskRunSpec(ref common.ReferenceCallbac
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskRunStepSpec"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.TaskRunStepSpec"),
 									},
 								},
 							},
@@ -1953,7 +2014,7 @@ func schema_pkg_apis_pipeline_v1_PipelineTaskRunSpec(ref common.ReferenceCallbac
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskRunSidecarSpec"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.TaskRunSidecarSpec"),
 									},
 								},
 							},
@@ -1961,7 +2022,7 @@ func schema_pkg_apis_pipeline_v1_PipelineTaskRunSpec(ref common.ReferenceCallbac
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineTaskMetadata"),
+							Ref: ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.PipelineTaskMetadata"),
 						},
 					},
 					"computeResources": {
@@ -1974,7 +2035,7 @@ func schema_pkg_apis_pipeline_v1_PipelineTaskRunSpec(ref common.ReferenceCallbac
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/pod.Template", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineTaskMetadata", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskRunSidecarSpec", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskRunStepSpec", "k8s.io/api/core/v1.ResourceRequirements"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1.PipelineTaskMetadata", "github.com/tekton/pipeline/pkg/apis/pipeline/v1.TaskRunSidecarSpec", "github.com/tekton/pipeline/pkg/apis/pipeline/v1.TaskRunStepSpec", "github.com/tektoncd/pipeline/pkg/apis/pipeline/pod.Template", "k8s.io/api/core/v1.ResourceRequirements"},
 	}
 }
 
@@ -2069,7 +2130,7 @@ func schema_pkg_apis_pipeline_v1_Provenance(ref common.ReferenceCallback) common
 					"configSource": {
 						SchemaProps: spec.SchemaProps{
 							Description: "ConfigSource identifies the source where a resource came from.",
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.ConfigSource"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.ConfigSource"),
 						},
 					},
 					"featureFlags": {
@@ -2082,7 +2143,7 @@ func schema_pkg_apis_pipeline_v1_Provenance(ref common.ReferenceCallback) common
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/config.FeatureFlags", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.ConfigSource"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1.ConfigSource", "github.com/tektoncd/pipeline/pkg/apis/config.FeatureFlags"},
 	}
 }
 
@@ -2113,7 +2174,7 @@ func schema_pkg_apis_pipeline_v1_ResolverRef(ref common.ReferenceCallback) commo
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Param"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.Param"),
 									},
 								},
 							},
@@ -2123,7 +2184,7 @@ func schema_pkg_apis_pipeline_v1_ResolverRef(ref common.ReferenceCallback) commo
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Param"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1.Param"},
 	}
 }
 
@@ -2444,7 +2505,7 @@ func schema_pkg_apis_pipeline_v1_Sidecar(ref common.ReferenceCallback) common.Op
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.WorkspaceUsage"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.WorkspaceUsage"),
 									},
 								},
 							},
@@ -2455,7 +2516,7 @@ func schema_pkg_apis_pipeline_v1_Sidecar(ref common.ReferenceCallback) common.Op
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.WorkspaceUsage", "k8s.io/api/core/v1.ContainerPort", "k8s.io/api/core/v1.EnvFromSource", "k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.Lifecycle", "k8s.io/api/core/v1.Probe", "k8s.io/api/core/v1.ResourceRequirements", "k8s.io/api/core/v1.SecurityContext", "k8s.io/api/core/v1.VolumeDevice", "k8s.io/api/core/v1.VolumeMount"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1.WorkspaceUsage", "k8s.io/api/core/v1.ContainerPort", "k8s.io/api/core/v1.EnvFromSource", "k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.Lifecycle", "k8s.io/api/core/v1.Probe", "k8s.io/api/core/v1.ResourceRequirements", "k8s.io/api/core/v1.SecurityContext", "k8s.io/api/core/v1.VolumeDevice", "k8s.io/api/core/v1.VolumeMount"},
 	}
 }
 
@@ -2546,7 +2607,7 @@ func schema_pkg_apis_pipeline_v1_SkippedTask(ref common.ReferenceCallback) commo
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.WhenExpression"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.WhenExpression"),
 									},
 								},
 							},
@@ -2557,7 +2618,7 @@ func schema_pkg_apis_pipeline_v1_SkippedTask(ref common.ReferenceCallback) commo
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.WhenExpression"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1.WhenExpression"},
 	}
 }
 
@@ -2758,7 +2819,7 @@ func schema_pkg_apis_pipeline_v1_Step(ref common.ReferenceCallback) common.OpenA
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.WorkspaceUsage"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.WorkspaceUsage"),
 									},
 								},
 							},
@@ -2774,13 +2835,13 @@ func schema_pkg_apis_pipeline_v1_Step(ref common.ReferenceCallback) common.OpenA
 					"stdoutConfig": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Stores configuration for the stdout stream of the step.",
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.StepOutputConfig"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.StepOutputConfig"),
 						},
 					},
 					"stderrConfig": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Stores configuration for the stderr stream of the step.",
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.StepOutputConfig"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.StepOutputConfig"),
 						},
 					},
 				},
@@ -2788,7 +2849,7 @@ func schema_pkg_apis_pipeline_v1_Step(ref common.ReferenceCallback) common.OpenA
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.StepOutputConfig", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.WorkspaceUsage", "k8s.io/api/core/v1.EnvFromSource", "k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.ResourceRequirements", "k8s.io/api/core/v1.SecurityContext", "k8s.io/api/core/v1.VolumeDevice", "k8s.io/api/core/v1.VolumeMount", "k8s.io/apimachinery/pkg/apis/meta/v1.Duration"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1.StepOutputConfig", "github.com/tekton/pipeline/pkg/apis/pipeline/v1.WorkspaceUsage", "k8s.io/api/core/v1.EnvFromSource", "k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.ResourceRequirements", "k8s.io/api/core/v1.SecurityContext", "k8s.io/api/core/v1.VolumeDevice", "k8s.io/api/core/v1.VolumeMount", "k8s.io/apimachinery/pkg/apis/meta/v1.Duration"},
 	}
 }
 
@@ -3065,14 +3126,14 @@ func schema_pkg_apis_pipeline_v1_Task(ref common.ReferenceCallback) common.OpenA
 						SchemaProps: spec.SchemaProps{
 							Description: "Spec holds the desired state of the Task from the client",
 							Default:     map[string]interface{}{},
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskSpec"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.TaskSpec"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskSpec", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1.TaskSpec", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }
 
@@ -3110,7 +3171,7 @@ func schema_pkg_apis_pipeline_v1_TaskList(ref common.ReferenceCallback) common.O
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Task"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.Task"),
 									},
 								},
 							},
@@ -3121,7 +3182,7 @@ func schema_pkg_apis_pipeline_v1_TaskList(ref common.ReferenceCallback) common.O
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Task", "k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1.Task", "k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"},
 	}
 }
 
@@ -3190,7 +3251,7 @@ func schema_pkg_apis_pipeline_v1_TaskResult(ref common.ReferenceCallback) common
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PropertySpec"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.PropertySpec"),
 									},
 								},
 							},
@@ -3208,7 +3269,7 @@ func schema_pkg_apis_pipeline_v1_TaskResult(ref common.ReferenceCallback) common
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PropertySpec"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1.PropertySpec"},
 	}
 }
 
@@ -3242,20 +3303,20 @@ func schema_pkg_apis_pipeline_v1_TaskRun(ref common.ReferenceCallback) common.Op
 					"spec": {
 						SchemaProps: spec.SchemaProps{
 							Default: map[string]interface{}{},
-							Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskRunSpec"),
+							Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.TaskRunSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Default: map[string]interface{}{},
-							Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskRunStatus"),
+							Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.TaskRunStatus"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskRunSpec", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskRunStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1.TaskRunSpec", "github.com/tekton/pipeline/pkg/apis/pipeline/v1.TaskRunStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }
 
@@ -3310,7 +3371,7 @@ func schema_pkg_apis_pipeline_v1_TaskRunInputs(ref common.ReferenceCallback) com
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Param"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.Param"),
 									},
 								},
 							},
@@ -3320,7 +3381,7 @@ func schema_pkg_apis_pipeline_v1_TaskRunInputs(ref common.ReferenceCallback) com
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Param"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1.Param"},
 	}
 }
 
@@ -3358,7 +3419,7 @@ func schema_pkg_apis_pipeline_v1_TaskRunList(ref common.ReferenceCallback) commo
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskRun"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.TaskRun"),
 									},
 								},
 							},
@@ -3369,7 +3430,7 @@ func schema_pkg_apis_pipeline_v1_TaskRunList(ref common.ReferenceCallback) commo
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskRun", "k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1.TaskRun", "k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"},
 	}
 }
 
@@ -3399,7 +3460,7 @@ func schema_pkg_apis_pipeline_v1_TaskRunResult(ref common.ReferenceCallback) com
 						SchemaProps: spec.SchemaProps{
 							Description: "Value the given value of the result",
 							Default:     map[string]interface{}{},
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.ParamValue"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.ParamValue"),
 						},
 					},
 				},
@@ -3407,7 +3468,7 @@ func schema_pkg_apis_pipeline_v1_TaskRunResult(ref common.ReferenceCallback) com
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.ParamValue"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1.ParamValue"},
 	}
 }
 
@@ -3451,7 +3512,7 @@ func schema_pkg_apis_pipeline_v1_TaskRunSpec(ref common.ReferenceCallback) commo
 				Properties: map[string]spec.Schema{
 					"debug": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskRunDebug"),
+							Ref: ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.TaskRunDebug"),
 						},
 					},
 					"params": {
@@ -3466,7 +3527,7 @@ func schema_pkg_apis_pipeline_v1_TaskRunSpec(ref common.ReferenceCallback) commo
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Param"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.Param"),
 									},
 								},
 							},
@@ -3482,12 +3543,12 @@ func schema_pkg_apis_pipeline_v1_TaskRunSpec(ref common.ReferenceCallback) commo
 					"taskRef": {
 						SchemaProps: spec.SchemaProps{
 							Description: "no more than one of the TaskRef and TaskSpec may be specified.",
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskRef"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.TaskRef"),
 						},
 					},
 					"taskSpec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskSpec"),
+							Ref: ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.TaskSpec"),
 						},
 					},
 					"status": {
@@ -3536,7 +3597,7 @@ func schema_pkg_apis_pipeline_v1_TaskRunSpec(ref common.ReferenceCallback) commo
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.WorkspaceBinding"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.WorkspaceBinding"),
 									},
 								},
 							},
@@ -3555,7 +3616,7 @@ func schema_pkg_apis_pipeline_v1_TaskRunSpec(ref common.ReferenceCallback) commo
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskRunStepSpec"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.TaskRunStepSpec"),
 									},
 								},
 							},
@@ -3574,7 +3635,7 @@ func schema_pkg_apis_pipeline_v1_TaskRunSpec(ref common.ReferenceCallback) commo
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskRunSidecarSpec"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.TaskRunSidecarSpec"),
 									},
 								},
 							},
@@ -3590,7 +3651,7 @@ func schema_pkg_apis_pipeline_v1_TaskRunSpec(ref common.ReferenceCallback) commo
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/pod.Template", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Param", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskRef", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskRunDebug", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskRunSidecarSpec", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskRunStepSpec", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskSpec", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.WorkspaceBinding", "k8s.io/api/core/v1.ResourceRequirements", "k8s.io/apimachinery/pkg/apis/meta/v1.Duration"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1.Param", "github.com/tekton/pipeline/pkg/apis/pipeline/v1.TaskRef", "github.com/tekton/pipeline/pkg/apis/pipeline/v1.TaskRunDebug", "github.com/tekton/pipeline/pkg/apis/pipeline/v1.TaskRunSidecarSpec", "github.com/tekton/pipeline/pkg/apis/pipeline/v1.TaskRunStepSpec", "github.com/tekton/pipeline/pkg/apis/pipeline/v1.TaskSpec", "github.com/tekton/pipeline/pkg/apis/pipeline/v1.WorkspaceBinding", "github.com/tektoncd/pipeline/pkg/apis/pipeline/pod.Template", "k8s.io/api/core/v1.ResourceRequirements", "k8s.io/apimachinery/pkg/apis/meta/v1.Duration"},
 	}
 }
 
@@ -3677,7 +3738,7 @@ func schema_pkg_apis_pipeline_v1_TaskRunStatus(ref common.ReferenceCallback) com
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.StepState"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.StepState"),
 									},
 								},
 							},
@@ -3696,7 +3757,7 @@ func schema_pkg_apis_pipeline_v1_TaskRunStatus(ref common.ReferenceCallback) com
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskRunStatus"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.TaskRunStatus"),
 									},
 								},
 							},
@@ -3715,7 +3776,7 @@ func schema_pkg_apis_pipeline_v1_TaskRunStatus(ref common.ReferenceCallback) com
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskRunResult"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.TaskRunResult"),
 									},
 								},
 							},
@@ -3734,7 +3795,7 @@ func schema_pkg_apis_pipeline_v1_TaskRunStatus(ref common.ReferenceCallback) com
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.SidecarState"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.SidecarState"),
 									},
 								},
 							},
@@ -3743,13 +3804,13 @@ func schema_pkg_apis_pipeline_v1_TaskRunStatus(ref common.ReferenceCallback) com
 					"taskSpec": {
 						SchemaProps: spec.SchemaProps{
 							Description: "TaskSpec contains the Spec from the dereferenced Task definition used to instantiate this TaskRun.",
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskSpec"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.TaskSpec"),
 						},
 					},
 					"provenance": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Provenance contains some key authenticated metadata about how a software artifact was built (what sources, what inputs/outputs, etc.).",
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Provenance"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.Provenance"),
 						},
 					},
 				},
@@ -3757,7 +3818,7 @@ func schema_pkg_apis_pipeline_v1_TaskRunStatus(ref common.ReferenceCallback) com
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Provenance", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.SidecarState", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.StepState", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskRunResult", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskRunStatus", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskSpec", "k8s.io/apimachinery/pkg/apis/meta/v1.Time", "knative.dev/pkg/apis.Condition"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1.Provenance", "github.com/tekton/pipeline/pkg/apis/pipeline/v1.SidecarState", "github.com/tekton/pipeline/pkg/apis/pipeline/v1.StepState", "github.com/tekton/pipeline/pkg/apis/pipeline/v1.TaskRunResult", "github.com/tekton/pipeline/pkg/apis/pipeline/v1.TaskRunStatus", "github.com/tekton/pipeline/pkg/apis/pipeline/v1.TaskSpec", "k8s.io/apimachinery/pkg/apis/meta/v1.Time", "knative.dev/pkg/apis.Condition"},
 	}
 }
 
@@ -3801,7 +3862,7 @@ func schema_pkg_apis_pipeline_v1_TaskRunStatusFields(ref common.ReferenceCallbac
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.StepState"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.StepState"),
 									},
 								},
 							},
@@ -3820,7 +3881,7 @@ func schema_pkg_apis_pipeline_v1_TaskRunStatusFields(ref common.ReferenceCallbac
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskRunStatus"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.TaskRunStatus"),
 									},
 								},
 							},
@@ -3839,7 +3900,7 @@ func schema_pkg_apis_pipeline_v1_TaskRunStatusFields(ref common.ReferenceCallbac
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskRunResult"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.TaskRunResult"),
 									},
 								},
 							},
@@ -3858,7 +3919,7 @@ func schema_pkg_apis_pipeline_v1_TaskRunStatusFields(ref common.ReferenceCallbac
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.SidecarState"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.SidecarState"),
 									},
 								},
 							},
@@ -3867,13 +3928,13 @@ func schema_pkg_apis_pipeline_v1_TaskRunStatusFields(ref common.ReferenceCallbac
 					"taskSpec": {
 						SchemaProps: spec.SchemaProps{
 							Description: "TaskSpec contains the Spec from the dereferenced Task definition used to instantiate this TaskRun.",
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskSpec"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.TaskSpec"),
 						},
 					},
 					"provenance": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Provenance contains some key authenticated metadata about how a software artifact was built (what sources, what inputs/outputs, etc.).",
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Provenance"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.Provenance"),
 						},
 					},
 				},
@@ -3881,7 +3942,7 @@ func schema_pkg_apis_pipeline_v1_TaskRunStatusFields(ref common.ReferenceCallbac
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Provenance", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.SidecarState", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.StepState", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskRunResult", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskRunStatus", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskSpec", "k8s.io/apimachinery/pkg/apis/meta/v1.Time"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1.Provenance", "github.com/tekton/pipeline/pkg/apis/pipeline/v1.SidecarState", "github.com/tekton/pipeline/pkg/apis/pipeline/v1.StepState", "github.com/tekton/pipeline/pkg/apis/pipeline/v1.TaskRunResult", "github.com/tekton/pipeline/pkg/apis/pipeline/v1.TaskRunStatus", "github.com/tekton/pipeline/pkg/apis/pipeline/v1.TaskSpec", "k8s.io/apimachinery/pkg/apis/meta/v1.Time"},
 	}
 }
 
@@ -3936,7 +3997,7 @@ func schema_pkg_apis_pipeline_v1_TaskSpec(ref common.ReferenceCallback) common.O
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.ParamSpec"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.ParamSpec"),
 									},
 								},
 							},
@@ -3962,7 +4023,7 @@ func schema_pkg_apis_pipeline_v1_TaskSpec(ref common.ReferenceCallback) common.O
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Step"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.Step"),
 									},
 								},
 							},
@@ -3990,7 +4051,7 @@ func schema_pkg_apis_pipeline_v1_TaskSpec(ref common.ReferenceCallback) common.O
 					"stepTemplate": {
 						SchemaProps: spec.SchemaProps{
 							Description: "StepTemplate can be used as the basis for all step containers within the Task, so that the steps inherit settings on the base container.",
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.StepTemplate"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.StepTemplate"),
 						},
 					},
 					"sidecars": {
@@ -4006,7 +4067,7 @@ func schema_pkg_apis_pipeline_v1_TaskSpec(ref common.ReferenceCallback) common.O
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Sidecar"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.Sidecar"),
 									},
 								},
 							},
@@ -4025,7 +4086,7 @@ func schema_pkg_apis_pipeline_v1_TaskSpec(ref common.ReferenceCallback) common.O
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.WorkspaceDeclaration"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.WorkspaceDeclaration"),
 									},
 								},
 							},
@@ -4044,7 +4105,7 @@ func schema_pkg_apis_pipeline_v1_TaskSpec(ref common.ReferenceCallback) common.O
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskResult"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1.TaskResult"),
 									},
 								},
 							},
@@ -4054,7 +4115,7 @@ func schema_pkg_apis_pipeline_v1_TaskSpec(ref common.ReferenceCallback) common.O
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.ParamSpec", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Sidecar", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Step", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.StepTemplate", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskResult", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.WorkspaceDeclaration", "k8s.io/api/core/v1.Volume"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1.ParamSpec", "github.com/tekton/pipeline/pkg/apis/pipeline/v1.Sidecar", "github.com/tekton/pipeline/pkg/apis/pipeline/v1.Step", "github.com/tekton/pipeline/pkg/apis/pipeline/v1.StepTemplate", "github.com/tekton/pipeline/pkg/apis/pipeline/v1.TaskResult", "github.com/tekton/pipeline/pkg/apis/pipeline/v1.WorkspaceDeclaration", "k8s.io/api/core/v1.Volume"},
 	}
 }
 

--- a/pkg/apis/pipeline/v1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1/pipeline_types.go
@@ -212,6 +212,24 @@ type Matrix struct {
 	// The names of the `params` in the `Matrix` must match the names of the `params` in the underlying `Task` that they will be substituting.
 	// +listType=atomic
 	Params []Param `json:"params,omitempty"`
+
+	// Include is a list of MatrixInclude
+	// Note this field is in preview mode and not yet supported
+	// +optional
+	// +listType=atomic
+	Include []MatrixInclude `json:"include,omitempty"`
+}
+
+// MatrixInclude allows passing in a specific combinations of Parameters into the Matrix.
+// Note this struct is in preview mode and not yet supported
+type MatrixInclude struct {
+	// Name the specified combination
+	Name string `json:"name,omitempty"`
+
+	// Params takes only `Parameters` of type `"string"`
+	// The names of the `params` must match the names of the `params` in the underlying `Task`
+	// +listType=atomic
+	Params []Param `json:"params,omitempty"`
 }
 
 // validateRefOrSpec validates at least one of taskRef or taskSpec is specified
@@ -275,7 +293,7 @@ func (pt PipelineTask) validateTask(ctx context.Context) (errs *apis.FieldError)
 
 // IsMatrixed return whether pipeline task is matrixed
 func (pt *PipelineTask) IsMatrixed() bool {
-	return pt.Matrix != nil && len(pt.Matrix.Params) > 0
+	return pt.Matrix != nil && (len(pt.Matrix.Params) > 0 || len(pt.Matrix.Include) > 0)
 }
 
 func (pt *PipelineTask) validateMatrix(ctx context.Context) (errs *apis.FieldError) {

--- a/pkg/apis/pipeline/v1/pipeline_types_test.go
+++ b/pkg/apis/pipeline/v1/pipeline_types_test.go
@@ -532,15 +532,14 @@ func TestPipelineTaskList_Deps(t *testing.T) {
 				Values:   []string{"foo"},
 			}},
 			Matrix: &Matrix{
-				[]Param{{
+				Params: []Param{{
 					Value: ParamValue{
 						Type: ParamTypeArray,
 						ArrayVal: []string{
 							"$(tasks.task-2.results.result)",
 							"$(tasks.task-5.results.result)",
 						},
-					}},
-				},
+					}}},
 			},
 		}, {
 			Name: "task-7",
@@ -893,10 +892,49 @@ func TestPipelineTask_IsMatrixed(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "matrixed",
+			name: "matrixed with params",
 			arg: arg{
 				Matrix: &Matrix{
 					Params: []Param{{Name: "platform", Value: ParamValue{ArrayVal: []string{"linux", "windows"}}}},
+				},
+			},
+			expected: true,
+		}, {
+			name: "matrixed with include",
+			arg: arg{
+				Matrix: &Matrix{
+					Include: []MatrixInclude{
+						{Name: "build-1"},
+						{Params: []Param{
+							{Name: "IMAGE", Value: ParamValue{StringVal: "image-1"}},
+							{Name: "DOCKERFILE", Value: ParamValue{StringVal: "path/to/Dockerfile1"}},
+						}},
+						{Name: "build-2"},
+						{Params: []Param{
+							{Name: "IMAGE", Value: ParamValue{StringVal: "image-2"}},
+							{Name: "DOCKERFILE", Value: ParamValue{StringVal: "path/to/Dockerfile2"}},
+						}},
+						{Name: "build-3"},
+						{Params: []Param{
+							{Name: "IMAGE", Value: ParamValue{StringVal: "image-3"}},
+							{Name: "DOCKERFILE", Value: ParamValue{StringVal: "path/to/Dockerfile3"}},
+						}},
+					},
+				},
+			},
+			expected: true,
+		}, {
+			name: "matrixed with params and include",
+			arg: arg{
+				Matrix: &Matrix{
+					Params: []Param{{Name: "GOARCH", Value: ParamValue{ArrayVal: []string{"linux/amd64", "linux/ppc64le", "linux/s390x"}}}},
+					Include: []MatrixInclude{
+						{Name: "s390x-no-race"},
+						{Params: []Param{
+							{Name: "GOARCH", Value: ParamValue{StringVal: "linux/s390x"}},
+							{Name: "flags", Value: ParamValue{StringVal: "-cover -v"}},
+						}},
+					},
 				},
 			},
 			expected: true,

--- a/pkg/apis/pipeline/v1/swagger.json
+++ b/pkg/apis/pipeline/v1/swagger.json
@@ -7,7 +7,7 @@
   },
   "paths": {},
   "definitions": {
-    "pod.AffinityAssistantTemplate": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.pod.AffinityAssistantTemplate": {
       "description": "AffinityAssistantTemplate holds pod specific configuration and is a subset of the generic pod Template",
       "type": "object",
       "properties": {
@@ -39,7 +39,7 @@
         }
       }
     },
-    "pod.Template": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.pod.Template": {
       "description": "Template holds pod specific configuration",
       "type": "object",
       "properties": {
@@ -151,7 +151,7 @@
         }
       }
     },
-    "v1.ChildStatusReference": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.ChildStatusReference": {
       "description": "ChildStatusReference is used to point to the statuses of individual TaskRuns and Runs within this PipelineRun.",
       "type": "object",
       "properties": {
@@ -174,13 +174,13 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1.WhenExpression"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.WhenExpression"
           },
           "x-kubernetes-list-type": "atomic"
         }
       }
     },
-    "v1.ConfigSource": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.ConfigSource": {
       "description": "ConfigSource identifies the source where a resource came from. This can include Git repositories, Task Bundles, file checksums, or other information that allows users to identify where the resource came from and what version was used.",
       "type": "object",
       "properties": {
@@ -202,7 +202,7 @@
         }
       }
     },
-    "v1.EmbeddedTask": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.EmbeddedTask": {
       "description": "EmbeddedTask is used to define a Task inline within a Pipeline's PipelineTasks.",
       "type": "object",
       "properties": {
@@ -218,14 +218,14 @@
         },
         "metadata": {
           "default": {},
-          "$ref": "#/definitions/v1.PipelineTaskMetadata"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.PipelineTaskMetadata"
         },
         "params": {
           "description": "Params is a list of input parameters required to run the task. Params must be supplied as inputs in TaskRuns unless they declare a default value.",
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1.ParamSpec"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.ParamSpec"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -234,7 +234,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1.TaskResult"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.TaskResult"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -243,7 +243,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1.Sidecar"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.Sidecar"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -254,14 +254,14 @@
         },
         "stepTemplate": {
           "description": "StepTemplate can be used as the basis for all step containers within the Task, so that the steps inherit settings on the base container.",
-          "$ref": "#/definitions/v1.StepTemplate"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.StepTemplate"
         },
         "steps": {
           "description": "Steps are the steps of the build; each step is run sequentially with the source mounted into /workspace.",
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1.Step"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.Step"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -279,28 +279,56 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1.WorkspaceDeclaration"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.WorkspaceDeclaration"
           },
           "x-kubernetes-list-type": "atomic"
         }
       }
     },
-    "v1.Matrix": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.Matrix": {
       "description": "Matrix is used to fan out Tasks in a Pipeline",
       "type": "object",
       "properties": {
+        "include": {
+          "description": "Include is a list of MatrixInclude Note this field is in preview mode and not yet supported",
+          "type": "array",
+          "items": {
+            "default": {},
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.MatrixInclude"
+          },
+          "x-kubernetes-list-type": "atomic"
+        },
         "params": {
           "description": "Params is a list of parameters used to fan out the pipelineTask Params takes only `Parameters` of type `\"array\"` Each array element is supplied to the `PipelineTask` by substituting `params` of type `\"string\"` in the underlying `Task`. The names of the `params` in the `Matrix` must match the names of the `params` in the underlying `Task` that they will be substituting.",
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1.Param"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.Param"
           },
           "x-kubernetes-list-type": "atomic"
         }
       }
     },
-    "v1.Param": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.MatrixInclude": {
+      "description": "MatrixInclude allows passing in a specific combinations of Parameters into the Matrix. Note this struct is in preview mode and not yet supported",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Name the specified combination",
+          "type": "string"
+        },
+        "params": {
+          "description": "Params takes only `Parameters` of type `\"string\"` The names of the `params` must match the names of the `params` in the underlying `Task`",
+          "type": "array",
+          "items": {
+            "default": {},
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.Param"
+          },
+          "x-kubernetes-list-type": "atomic"
+        }
+      }
+    },
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.Param": {
       "description": "Param declares an ParamValues to use for the parameter called name.",
       "type": "object",
       "required": [
@@ -314,11 +342,11 @@
         },
         "value": {
           "default": {},
-          "$ref": "#/definitions/v1.ParamValue"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.ParamValue"
         }
       }
     },
-    "v1.ParamSpec": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.ParamSpec": {
       "description": "ParamSpec defines arbitrary parameters needed beyond typed inputs (such as resources). Parameter values are provided by users as inputs on a TaskRun or PipelineRun.",
       "type": "object",
       "required": [
@@ -327,7 +355,7 @@
       "properties": {
         "default": {
           "description": "Default is the value a parameter takes if no input value is supplied. If default is set, a Task may be executed without a supplied value for the parameter.",
-          "$ref": "#/definitions/v1.ParamValue"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.ParamValue"
         },
         "description": {
           "description": "Description is a user-facing description of the parameter that may be used to populate a UI.",
@@ -343,7 +371,7 @@
           "type": "object",
           "additionalProperties": {
             "default": {},
-            "$ref": "#/definitions/v1.PropertySpec"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.PropertySpec"
           }
         },
         "type": {
@@ -352,7 +380,7 @@
         }
       }
     },
-    "v1.ParamValue": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.ParamValue": {
       "description": "ResultValue is a type alias of ParamValue",
       "type": "object",
       "required": [
@@ -388,7 +416,7 @@
         }
       }
     },
-    "v1.Pipeline": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.Pipeline": {
       "description": "Pipeline describes a list of Tasks to execute. It expresses how outputs of tasks feed into inputs of subsequent tasks.",
       "type": "object",
       "properties": {
@@ -407,11 +435,11 @@
         "spec": {
           "description": "Spec holds the desired state of the Pipeline from the client",
           "default": {},
-          "$ref": "#/definitions/v1.PipelineSpec"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.PipelineSpec"
         }
       }
     },
-    "v1.PipelineList": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.PipelineList": {
       "description": "PipelineList contains a list of Pipeline",
       "type": "object",
       "required": [
@@ -426,7 +454,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1.Pipeline"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.Pipeline"
           }
         },
         "kind": {
@@ -439,7 +467,7 @@
         }
       }
     },
-    "v1.PipelineRef": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.PipelineRef": {
       "description": "PipelineRef can be used to refer to a specific instance of a Pipeline.",
       "type": "object",
       "properties": {
@@ -453,7 +481,7 @@
         }
       }
     },
-    "v1.PipelineResult": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.PipelineResult": {
       "description": "PipelineResult used to describe the results of a pipeline",
       "type": "object",
       "required": [
@@ -478,11 +506,11 @@
         "value": {
           "description": "Value the expression used to retrieve the value",
           "default": {},
-          "$ref": "#/definitions/v1.ParamValue"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.ParamValue"
         }
       }
     },
-    "v1.PipelineRun": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.PipelineRun": {
       "description": "PipelineRun represents a single execution of a Pipeline. PipelineRuns are how the graph of Tasks declared in a Pipeline are executed; they specify inputs to Pipelines such as parameter values and capture operational aspects of the Tasks execution such as service account and tolerations. Creating a PipelineRun creates TaskRuns for Tasks in the referenced Pipeline.",
       "type": "object",
       "properties": {
@@ -500,15 +528,15 @@
         },
         "spec": {
           "default": {},
-          "$ref": "#/definitions/v1.PipelineRunSpec"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.PipelineRunSpec"
         },
         "status": {
           "default": {},
-          "$ref": "#/definitions/v1.PipelineRunStatus"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.PipelineRunStatus"
         }
       }
     },
-    "v1.PipelineRunList": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.PipelineRunList": {
       "description": "PipelineRunList contains a list of PipelineRun",
       "type": "object",
       "properties": {
@@ -520,7 +548,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1.PipelineRun"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.PipelineRun"
           }
         },
         "kind": {
@@ -533,7 +561,7 @@
         }
       }
     },
-    "v1.PipelineRunResult": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.PipelineRunResult": {
       "description": "PipelineRunResult used to describe the results of a pipeline",
       "type": "object",
       "required": [
@@ -549,11 +577,11 @@
         "value": {
           "description": "Value is the result returned from the execution of this PipelineRun",
           "default": {},
-          "$ref": "#/definitions/v1.ParamValue"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.ParamValue"
         }
       }
     },
-    "v1.PipelineRunRunStatus": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.PipelineRunRunStatus": {
       "description": "PipelineRunRunStatus contains the name of the PipelineTask for this Run and the Run's Status",
       "type": "object",
       "properties": {
@@ -570,13 +598,13 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1.WhenExpression"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.WhenExpression"
           },
           "x-kubernetes-list-type": "atomic"
         }
       }
     },
-    "v1.PipelineRunSpec": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.PipelineRunSpec": {
       "description": "PipelineRunSpec defines the desired state of PipelineRun",
       "type": "object",
       "properties": {
@@ -585,15 +613,15 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1.Param"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.Param"
           },
           "x-kubernetes-list-type": "atomic"
         },
         "pipelineRef": {
-          "$ref": "#/definitions/v1.PipelineRef"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.PipelineRef"
         },
         "pipelineSpec": {
-          "$ref": "#/definitions/v1.PipelineSpec"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.PipelineSpec"
         },
         "status": {
           "description": "Used for cancelling a pipelinerun (and maybe more later on)",
@@ -604,31 +632,31 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1.PipelineTaskRunSpec"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.PipelineTaskRunSpec"
           },
           "x-kubernetes-list-type": "atomic"
         },
         "taskRunTemplate": {
           "description": "TaskRunTemplate represent template of taskrun",
           "default": {},
-          "$ref": "#/definitions/v1.PipelineTaskRunTemplate"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.PipelineTaskRunTemplate"
         },
         "timeouts": {
           "description": "Time after which the Pipeline times out. Currently three keys are accepted in the map pipeline, tasks and finally with Timeouts.pipeline \u003e= Timeouts.tasks + Timeouts.finally",
-          "$ref": "#/definitions/v1.TimeoutFields"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.TimeoutFields"
         },
         "workspaces": {
           "description": "Workspaces holds a set of workspace bindings that must match names with those declared in the pipeline.",
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1.WorkspaceBinding"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.WorkspaceBinding"
           },
           "x-kubernetes-list-type": "atomic"
         }
       }
     },
-    "v1.PipelineRunStatus": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.PipelineRunStatus": {
       "description": "PipelineRunStatus defines the observed state of PipelineRun",
       "type": "object",
       "properties": {
@@ -645,7 +673,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1.ChildStatusReference"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.ChildStatusReference"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -674,18 +702,18 @@
         },
         "pipelineSpec": {
           "description": "PipelineRunSpec contains the exact spec used to instantiate the run",
-          "$ref": "#/definitions/v1.PipelineSpec"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.PipelineSpec"
         },
         "provenance": {
           "description": "Provenance contains some key authenticated metadata about how a software artifact was built (what sources, what inputs/outputs, etc.).",
-          "$ref": "#/definitions/v1.Provenance"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.Provenance"
         },
         "results": {
           "description": "Results are the list of results written out by the pipeline task's containers",
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1.PipelineRunResult"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.PipelineRunResult"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -694,7 +722,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1.SkippedTask"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.SkippedTask"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -704,7 +732,7 @@
         }
       }
     },
-    "v1.PipelineRunStatusFields": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.PipelineRunStatusFields": {
       "description": "PipelineRunStatusFields holds the fields of PipelineRunStatus' status. This is defined separately and inlined so that other types can readily consume these fields via duck typing.",
       "type": "object",
       "properties": {
@@ -713,7 +741,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1.ChildStatusReference"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.ChildStatusReference"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -727,18 +755,18 @@
         },
         "pipelineSpec": {
           "description": "PipelineRunSpec contains the exact spec used to instantiate the run",
-          "$ref": "#/definitions/v1.PipelineSpec"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.PipelineSpec"
         },
         "provenance": {
           "description": "Provenance contains some key authenticated metadata about how a software artifact was built (what sources, what inputs/outputs, etc.).",
-          "$ref": "#/definitions/v1.Provenance"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.Provenance"
         },
         "results": {
           "description": "Results are the list of results written out by the pipeline task's containers",
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1.PipelineRunResult"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.PipelineRunResult"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -747,7 +775,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1.SkippedTask"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.SkippedTask"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -757,7 +785,7 @@
         }
       }
     },
-    "v1.PipelineRunTaskRunStatus": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.PipelineRunTaskRunStatus": {
       "description": "PipelineRunTaskRunStatus contains the name of the PipelineTask for this TaskRun and the TaskRun's Status",
       "type": "object",
       "properties": {
@@ -767,20 +795,20 @@
         },
         "status": {
           "description": "Status is the TaskRunStatus for the corresponding TaskRun",
-          "$ref": "#/definitions/v1.TaskRunStatus"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.TaskRunStatus"
         },
         "whenExpressions": {
           "description": "WhenExpressions is the list of checks guarding the execution of the PipelineTask",
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1.WhenExpression"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.WhenExpression"
           },
           "x-kubernetes-list-type": "atomic"
         }
       }
     },
-    "v1.PipelineSpec": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.PipelineSpec": {
       "description": "PipelineSpec defines the desired state of Pipeline.",
       "type": "object",
       "properties": {
@@ -793,7 +821,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1.PipelineTask"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.PipelineTask"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -802,7 +830,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1.ParamSpec"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.ParamSpec"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -811,7 +839,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1.PipelineResult"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.PipelineResult"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -820,7 +848,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1.PipelineTask"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.PipelineTask"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -829,19 +857,19 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1.PipelineWorkspaceDeclaration"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.PipelineWorkspaceDeclaration"
           },
           "x-kubernetes-list-type": "atomic"
         }
       }
     },
-    "v1.PipelineTask": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.PipelineTask": {
       "description": "PipelineTask defines a task in a Pipeline, passing inputs from both Params and from the output of previous tasks.",
       "type": "object",
       "properties": {
         "matrix": {
           "description": "Matrix declares parameters used to fan out this task.",
-          "$ref": "#/definitions/v1.Matrix"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.Matrix"
         },
         "name": {
           "description": "Name is the name of this task within the context of a Pipeline. Name is used as a coordinate with the `from` and `runAfter` fields to establish the execution order of tasks relative to one another.",
@@ -852,7 +880,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1.Param"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.Param"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -872,11 +900,11 @@
         },
         "taskRef": {
           "description": "TaskRef is a reference to a task definition.",
-          "$ref": "#/definitions/v1.TaskRef"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.TaskRef"
         },
         "taskSpec": {
           "description": "TaskSpec is a specification of a task",
-          "$ref": "#/definitions/v1.EmbeddedTask"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.EmbeddedTask"
         },
         "timeout": {
           "description": "Time after which the TaskRun times out. Defaults to 1 hour. Specified TaskRun timeout should be less than 24h. Refer Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration",
@@ -887,7 +915,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1.WhenExpression"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.WhenExpression"
           }
         },
         "workspaces": {
@@ -895,13 +923,13 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1.WorkspacePipelineTaskBinding"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.WorkspacePipelineTaskBinding"
           },
           "x-kubernetes-list-type": "atomic"
         }
       }
     },
-    "v1.PipelineTaskMetadata": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.PipelineTaskMetadata": {
       "description": "PipelineTaskMetadata contains the labels or annotations for an EmbeddedTask",
       "type": "object",
       "properties": {
@@ -921,7 +949,7 @@
         }
       }
     },
-    "v1.PipelineTaskParam": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.PipelineTaskParam": {
       "description": "PipelineTaskParam is used to provide arbitrary string parameters to a Task.",
       "type": "object",
       "required": [
@@ -939,7 +967,7 @@
         }
       }
     },
-    "v1.PipelineTaskRun": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.PipelineTaskRun": {
       "description": "PipelineTaskRun reports the results of running a step in the Task. Each task has the potential to succeed or fail (based on the exit code) and produces logs.",
       "type": "object",
       "properties": {
@@ -948,7 +976,7 @@
         }
       }
     },
-    "v1.PipelineTaskRunSpec": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.PipelineTaskRunSpec": {
       "description": "PipelineTaskRunSpec  can be used to configure specific specs for a concrete Task",
       "type": "object",
       "properties": {
@@ -957,7 +985,7 @@
           "$ref": "#/definitions/v1.ResourceRequirements"
         },
         "metadata": {
-          "$ref": "#/definitions/v1.PipelineTaskMetadata"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.PipelineTaskMetadata"
         },
         "pipelineTaskName": {
           "type": "string"
@@ -972,7 +1000,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1.TaskRunSidecarSpec"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.TaskRunSidecarSpec"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -980,13 +1008,13 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1.TaskRunStepSpec"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.TaskRunStepSpec"
           },
           "x-kubernetes-list-type": "atomic"
         }
       }
     },
-    "v1.PipelineTaskRunTemplate": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.PipelineTaskRunTemplate": {
       "description": "PipelineTaskRunTemplate is used to specify run specifications for all Task in pipelinerun.",
       "type": "object",
       "properties": {
@@ -998,7 +1026,7 @@
         }
       }
     },
-    "v1.PipelineWorkspaceDeclaration": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.PipelineWorkspaceDeclaration": {
       "description": "WorkspacePipelineDeclaration creates a named slot in a Pipeline that a PipelineRun is expected to populate with a workspace binding. Deprecated: use PipelineWorkspaceDeclaration type instead",
       "type": "object",
       "required": [
@@ -1020,7 +1048,7 @@
         }
       }
     },
-    "v1.PropertySpec": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.PropertySpec": {
       "description": "PropertySpec defines the struct for object keys",
       "type": "object",
       "properties": {
@@ -1029,13 +1057,13 @@
         }
       }
     },
-    "v1.Provenance": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.Provenance": {
       "description": "Provenance contains some key authenticated metadata about how a software artifact was built (what sources, what inputs/outputs, etc.). For now, it only contains the subfield `ConfigSource` that identifies the source where a build config file came from. In future, it can be expanded as needed to include more metadata about the build. This field aims to be used to carry minimum amount of the authenticated metadata in *Run status so that Tekton Chains can pick it up and record in the provenance it generates.",
       "type": "object",
       "properties": {
         "configSource": {
           "description": "ConfigSource identifies the source where a resource came from.",
-          "$ref": "#/definitions/v1.ConfigSource"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.ConfigSource"
         },
         "featureFlags": {
           "description": "FeatureFlags identifies the feature flags that were used during the task/pipeline run",
@@ -1043,7 +1071,7 @@
         }
       }
     },
-    "v1.ResolverRef": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.ResolverRef": {
       "description": "ResolverRef can be used to refer to a Pipeline or Task in a remote location like a git repo. This feature is in beta and these fields are only available when the beta feature gate is enabled.",
       "type": "object",
       "properties": {
@@ -1052,7 +1080,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1.Param"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.Param"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -1062,7 +1090,7 @@
         }
       }
     },
-    "v1.ResultRef": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.ResultRef": {
       "description": "ResultRef is a type that represents a reference to a task run result",
       "type": "object",
       "required": [
@@ -1091,7 +1119,7 @@
         }
       }
     },
-    "v1.Sidecar": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.Sidecar": {
       "description": "Sidecar has nearly the same data structure as Step but does not have the ability to timeout.",
       "type": "object",
       "required": [
@@ -1244,13 +1272,13 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1.WorkspaceUsage"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.WorkspaceUsage"
           },
           "x-kubernetes-list-type": "atomic"
         }
       }
     },
-    "v1.SidecarState": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.SidecarState": {
       "description": "SidecarState reports the results of running a sidecar in a Task.",
       "type": "object",
       "properties": {
@@ -1277,7 +1305,7 @@
         }
       }
     },
-    "v1.SkippedTask": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.SkippedTask": {
       "description": "SkippedTask is used to describe the Tasks that were skipped due to their When Expressions evaluating to False. This is a struct because we are looking into including more details about the When Expressions that caused this Task to be skipped.",
       "type": "object",
       "required": [
@@ -1300,13 +1328,13 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1.WhenExpression"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.WhenExpression"
           },
           "x-kubernetes-list-type": "atomic"
         }
       }
     },
-    "v1.Step": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.Step": {
       "description": "Step runs a subcomponent of a Task",
       "type": "object",
       "required": [
@@ -1383,11 +1411,11 @@
         },
         "stderrConfig": {
           "description": "Stores configuration for the stderr stream of the step.",
-          "$ref": "#/definitions/v1.StepOutputConfig"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.StepOutputConfig"
         },
         "stdoutConfig": {
           "description": "Stores configuration for the stdout stream of the step.",
-          "$ref": "#/definitions/v1.StepOutputConfig"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.StepOutputConfig"
         },
         "timeout": {
           "description": "Timeout is the time after which the step times out. Defaults to never. Refer to Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration",
@@ -1424,13 +1452,13 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1.WorkspaceUsage"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.WorkspaceUsage"
           },
           "x-kubernetes-list-type": "atomic"
         }
       }
     },
-    "v1.StepOutputConfig": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.StepOutputConfig": {
       "description": "StepOutputConfig stores configuration for a step output stream.",
       "type": "object",
       "properties": {
@@ -1440,7 +1468,7 @@
         }
       }
     },
-    "v1.StepState": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.StepState": {
       "description": "StepState reports the results of running a step in a Task.",
       "type": "object",
       "properties": {
@@ -1467,7 +1495,7 @@
         }
       }
     },
-    "v1.StepTemplate": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.StepTemplate": {
       "description": "StepTemplate is a template for a Step",
       "type": "object",
       "properties": {
@@ -1554,7 +1582,7 @@
         }
       }
     },
-    "v1.Task": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.Task": {
       "description": "Task represents a collection of sequential steps that are run as part of a Pipeline using a set of inputs and producing a set of outputs. Tasks execute when TaskRuns are created that provide the input parameters and resources and output resources the Task requires.",
       "type": "object",
       "properties": {
@@ -1573,11 +1601,11 @@
         "spec": {
           "description": "Spec holds the desired state of the Task from the client",
           "default": {},
-          "$ref": "#/definitions/v1.TaskSpec"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.TaskSpec"
         }
       }
     },
-    "v1.TaskList": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.TaskList": {
       "description": "TaskList contains a list of Task",
       "type": "object",
       "required": [
@@ -1592,7 +1620,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1.Task"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.Task"
           }
         },
         "kind": {
@@ -1605,7 +1633,7 @@
         }
       }
     },
-    "v1.TaskRef": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.TaskRef": {
       "description": "TaskRef can be used to refer to a specific instance of a task.",
       "type": "object",
       "properties": {
@@ -1623,7 +1651,7 @@
         }
       }
     },
-    "v1.TaskResult": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.TaskResult": {
       "description": "TaskResult used to describe the results of a task",
       "type": "object",
       "required": [
@@ -1644,7 +1672,7 @@
           "type": "object",
           "additionalProperties": {
             "default": {},
-            "$ref": "#/definitions/v1.PropertySpec"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.PropertySpec"
           }
         },
         "type": {
@@ -1653,7 +1681,7 @@
         }
       }
     },
-    "v1.TaskRun": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.TaskRun": {
       "description": "TaskRun represents a single execution of a Task. TaskRuns are how the steps specified in a Task are executed; they specify the parameters and resources used to run the steps in a Task.",
       "type": "object",
       "properties": {
@@ -1671,15 +1699,15 @@
         },
         "spec": {
           "default": {},
-          "$ref": "#/definitions/v1.TaskRunSpec"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.TaskRunSpec"
         },
         "status": {
           "default": {},
-          "$ref": "#/definitions/v1.TaskRunStatus"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.TaskRunStatus"
         }
       }
     },
-    "v1.TaskRunDebug": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.TaskRunDebug": {
       "description": "TaskRunDebug defines the breakpoint config for a particular TaskRun",
       "type": "object",
       "properties": {
@@ -1693,7 +1721,7 @@
         }
       }
     },
-    "v1.TaskRunInputs": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.TaskRunInputs": {
       "description": "TaskRunInputs holds the input values that this task was invoked with.",
       "type": "object",
       "properties": {
@@ -1701,13 +1729,13 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1.Param"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.Param"
           },
           "x-kubernetes-list-type": "atomic"
         }
       }
     },
-    "v1.TaskRunList": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.TaskRunList": {
       "description": "TaskRunList contains a list of TaskRun",
       "type": "object",
       "required": [
@@ -1722,7 +1750,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1.TaskRun"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.TaskRun"
           }
         },
         "kind": {
@@ -1735,7 +1763,7 @@
         }
       }
     },
-    "v1.TaskRunResult": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.TaskRunResult": {
       "description": "TaskRunResult used to describe the results of a task",
       "type": "object",
       "required": [
@@ -1755,11 +1783,11 @@
         "value": {
           "description": "Value the given value of the result",
           "default": {},
-          "$ref": "#/definitions/v1.ParamValue"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.ParamValue"
         }
       }
     },
-    "v1.TaskRunSidecarSpec": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.TaskRunSidecarSpec": {
       "description": "TaskRunSidecarSpec is used to override the values of a Sidecar in the corresponding Task.",
       "type": "object",
       "required": [
@@ -1779,7 +1807,7 @@
         }
       }
     },
-    "v1.TaskRunSpec": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.TaskRunSpec": {
       "description": "TaskRunSpec defines the desired state of TaskRun",
       "type": "object",
       "properties": {
@@ -1788,13 +1816,13 @@
           "$ref": "#/definitions/v1.ResourceRequirements"
         },
         "debug": {
-          "$ref": "#/definitions/v1.TaskRunDebug"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.TaskRunDebug"
         },
         "params": {
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1.Param"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.Param"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -1816,7 +1844,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1.TaskRunSidecarSpec"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.TaskRunSidecarSpec"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -1833,16 +1861,16 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1.TaskRunStepSpec"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.TaskRunStepSpec"
           },
           "x-kubernetes-list-type": "atomic"
         },
         "taskRef": {
           "description": "no more than one of the TaskRef and TaskSpec may be specified.",
-          "$ref": "#/definitions/v1.TaskRef"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.TaskRef"
         },
         "taskSpec": {
-          "$ref": "#/definitions/v1.TaskSpec"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.TaskSpec"
         },
         "timeout": {
           "description": "Time after which one retry attempt times out. Defaults to 1 hour. Specified build timeout should be less than 24h. Refer Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration",
@@ -1853,13 +1881,13 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1.WorkspaceBinding"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.WorkspaceBinding"
           },
           "x-kubernetes-list-type": "atomic"
         }
       }
     },
-    "v1.TaskRunStatus": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.TaskRunStatus": {
       "description": "TaskRunStatus defines the observed state of TaskRun",
       "type": "object",
       "required": [
@@ -1900,14 +1928,14 @@
         },
         "provenance": {
           "description": "Provenance contains some key authenticated metadata about how a software artifact was built (what sources, what inputs/outputs, etc.).",
-          "$ref": "#/definitions/v1.Provenance"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.Provenance"
         },
         "results": {
           "description": "Results are the list of results written out by the task's containers",
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1.TaskRunResult"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.TaskRunResult"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -1916,7 +1944,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1.TaskRunStatus"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.TaskRunStatus"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -1925,7 +1953,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1.SidecarState"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.SidecarState"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -1938,17 +1966,17 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1.StepState"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.StepState"
           },
           "x-kubernetes-list-type": "atomic"
         },
         "taskSpec": {
           "description": "TaskSpec contains the Spec from the dereferenced Task definition used to instantiate this TaskRun.",
-          "$ref": "#/definitions/v1.TaskSpec"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.TaskSpec"
         }
       }
     },
-    "v1.TaskRunStatusFields": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.TaskRunStatusFields": {
       "description": "TaskRunStatusFields holds the fields of TaskRun's status.  This is defined separately and inlined so that other types can readily consume these fields via duck typing.",
       "type": "object",
       "required": [
@@ -1966,14 +1994,14 @@
         },
         "provenance": {
           "description": "Provenance contains some key authenticated metadata about how a software artifact was built (what sources, what inputs/outputs, etc.).",
-          "$ref": "#/definitions/v1.Provenance"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.Provenance"
         },
         "results": {
           "description": "Results are the list of results written out by the task's containers",
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1.TaskRunResult"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.TaskRunResult"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -1982,7 +2010,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1.TaskRunStatus"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.TaskRunStatus"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -1991,7 +2019,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1.SidecarState"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.SidecarState"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -2004,17 +2032,17 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1.StepState"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.StepState"
           },
           "x-kubernetes-list-type": "atomic"
         },
         "taskSpec": {
           "description": "TaskSpec contains the Spec from the dereferenced Task definition used to instantiate this TaskRun.",
-          "$ref": "#/definitions/v1.TaskSpec"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.TaskSpec"
         }
       }
     },
-    "v1.TaskRunStepSpec": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.TaskRunStepSpec": {
       "description": "TaskRunStepSpec is used to override the values of a Step in the corresponding Task.",
       "type": "object",
       "required": [
@@ -2034,7 +2062,7 @@
         }
       }
     },
-    "v1.TaskSpec": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.TaskSpec": {
       "description": "TaskSpec defines the desired state of Task.",
       "type": "object",
       "properties": {
@@ -2047,7 +2075,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1.ParamSpec"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.ParamSpec"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -2056,7 +2084,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1.TaskResult"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.TaskResult"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -2065,20 +2093,20 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1.Sidecar"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.Sidecar"
           },
           "x-kubernetes-list-type": "atomic"
         },
         "stepTemplate": {
           "description": "StepTemplate can be used as the basis for all step containers within the Task, so that the steps inherit settings on the base container.",
-          "$ref": "#/definitions/v1.StepTemplate"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.StepTemplate"
         },
         "steps": {
           "description": "Steps are the steps of the build; each step is run sequentially with the source mounted into /workspace.",
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1.Step"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.Step"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -2096,13 +2124,13 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1.WorkspaceDeclaration"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1.WorkspaceDeclaration"
           },
           "x-kubernetes-list-type": "atomic"
         }
       }
     },
-    "v1.TimeoutFields": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.TimeoutFields": {
       "description": "TimeoutFields allows granular specification of pipeline, task, and finally timeouts",
       "type": "object",
       "properties": {
@@ -2120,7 +2148,7 @@
         }
       }
     },
-    "v1.WhenExpression": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.WhenExpression": {
       "description": "WhenExpression allows a PipelineTask to declare expressions to be evaluated before the Task is run to determine whether the Task should be executed or skipped",
       "type": "object",
       "required": [
@@ -2150,7 +2178,7 @@
         }
       }
     },
-    "v1.WorkspaceBinding": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.WorkspaceBinding": {
       "description": "WorkspaceBinding maps a Task's declared workspace to a Volume.",
       "type": "object",
       "required": [
@@ -2196,7 +2224,7 @@
         }
       }
     },
-    "v1.WorkspaceDeclaration": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.WorkspaceDeclaration": {
       "description": "WorkspaceDeclaration is a declaration of a volume that a Task requires.",
       "type": "object",
       "required": [
@@ -2226,7 +2254,7 @@
         }
       }
     },
-    "v1.WorkspacePipelineTaskBinding": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.WorkspacePipelineTaskBinding": {
       "description": "WorkspacePipelineTaskBinding describes how a workspace passed into the pipeline should be mapped to a task's declared workspace.",
       "type": "object",
       "required": [
@@ -2248,7 +2276,7 @@
         }
       }
     },
-    "v1.WorkspaceUsage": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1.WorkspaceUsage": {
       "description": "WorkspaceUsage is used by a Step or Sidecar to declare that it wants isolated access to a Workspace defined in a Task.",
       "type": "object",
       "required": [

--- a/pkg/apis/pipeline/v1beta1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1beta1/openapi_generated.go
@@ -30,99 +30,100 @@ import (
 
 func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenAPIDefinition {
 	return map[string]common.OpenAPIDefinition{
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/pod.AffinityAssistantTemplate":           schema_pkg_apis_pipeline_pod_AffinityAssistantTemplate(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/pod.Template":                            schema_pkg_apis_pipeline_pod_Template(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.ChildStatusReference":            schema_pkg_apis_pipeline_v1beta1_ChildStatusReference(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.CloudEventDelivery":              schema_pkg_apis_pipeline_v1beta1_CloudEventDelivery(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.CloudEventDeliveryState":         schema_pkg_apis_pipeline_v1beta1_CloudEventDeliveryState(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.ClusterTask":                     schema_pkg_apis_pipeline_v1beta1_ClusterTask(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.ClusterTaskList":                 schema_pkg_apis_pipeline_v1beta1_ClusterTaskList(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.ConfigSource":                    schema_pkg_apis_pipeline_v1beta1_ConfigSource(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.CustomRun":                       schema_pkg_apis_pipeline_v1beta1_CustomRun(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.CustomRunList":                   schema_pkg_apis_pipeline_v1beta1_CustomRunList(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.CustomRunSpec":                   schema_pkg_apis_pipeline_v1beta1_CustomRunSpec(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.EmbeddedCustomRunSpec":           schema_pkg_apis_pipeline_v1beta1_EmbeddedCustomRunSpec(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.EmbeddedTask":                    schema_pkg_apis_pipeline_v1beta1_EmbeddedTask(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.InternalTaskModifier":            schema_pkg_apis_pipeline_v1beta1_InternalTaskModifier(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Matrix":                          schema_pkg_apis_pipeline_v1beta1_Matrix(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Param":                           schema_pkg_apis_pipeline_v1beta1_Param(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.ParamSpec":                       schema_pkg_apis_pipeline_v1beta1_ParamSpec(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.ParamValue":                      schema_pkg_apis_pipeline_v1beta1_ParamValue(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Pipeline":                        schema_pkg_apis_pipeline_v1beta1_Pipeline(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineDeclaredResource":        schema_pkg_apis_pipeline_v1beta1_PipelineDeclaredResource(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineList":                    schema_pkg_apis_pipeline_v1beta1_PipelineList(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineRef":                     schema_pkg_apis_pipeline_v1beta1_PipelineRef(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineResourceBinding":         schema_pkg_apis_pipeline_v1beta1_PipelineResourceBinding(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineResourceRef":             schema_pkg_apis_pipeline_v1beta1_PipelineResourceRef(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineResourceResult":          schema_pkg_apis_pipeline_v1beta1_PipelineResourceResult(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineResult":                  schema_pkg_apis_pipeline_v1beta1_PipelineResult(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineRun":                     schema_pkg_apis_pipeline_v1beta1_PipelineRun(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineRunList":                 schema_pkg_apis_pipeline_v1beta1_PipelineRunList(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineRunResult":               schema_pkg_apis_pipeline_v1beta1_PipelineRunResult(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineRunRunStatus":            schema_pkg_apis_pipeline_v1beta1_PipelineRunRunStatus(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineRunSpec":                 schema_pkg_apis_pipeline_v1beta1_PipelineRunSpec(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineRunStatus":               schema_pkg_apis_pipeline_v1beta1_PipelineRunStatus(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineRunStatusFields":         schema_pkg_apis_pipeline_v1beta1_PipelineRunStatusFields(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineRunTaskRunStatus":        schema_pkg_apis_pipeline_v1beta1_PipelineRunTaskRunStatus(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineSpec":                    schema_pkg_apis_pipeline_v1beta1_PipelineSpec(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineTask":                    schema_pkg_apis_pipeline_v1beta1_PipelineTask(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineTaskInputResource":       schema_pkg_apis_pipeline_v1beta1_PipelineTaskInputResource(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineTaskMetadata":            schema_pkg_apis_pipeline_v1beta1_PipelineTaskMetadata(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineTaskOutputResource":      schema_pkg_apis_pipeline_v1beta1_PipelineTaskOutputResource(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineTaskParam":               schema_pkg_apis_pipeline_v1beta1_PipelineTaskParam(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineTaskResources":           schema_pkg_apis_pipeline_v1beta1_PipelineTaskResources(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineTaskRun":                 schema_pkg_apis_pipeline_v1beta1_PipelineTaskRun(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineTaskRunSpec":             schema_pkg_apis_pipeline_v1beta1_PipelineTaskRunSpec(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineWorkspaceDeclaration":    schema_pkg_apis_pipeline_v1beta1_PipelineWorkspaceDeclaration(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PropertySpec":                    schema_pkg_apis_pipeline_v1beta1_PropertySpec(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Provenance":                      schema_pkg_apis_pipeline_v1beta1_Provenance(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.ResolverRef":                     schema_pkg_apis_pipeline_v1beta1_ResolverRef(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.ResultRef":                       schema_pkg_apis_pipeline_v1beta1_ResultRef(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Sidecar":                         schema_pkg_apis_pipeline_v1beta1_Sidecar(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.SidecarState":                    schema_pkg_apis_pipeline_v1beta1_SidecarState(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.SkippedTask":                     schema_pkg_apis_pipeline_v1beta1_SkippedTask(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Step":                            schema_pkg_apis_pipeline_v1beta1_Step(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.StepOutputConfig":                schema_pkg_apis_pipeline_v1beta1_StepOutputConfig(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.StepState":                       schema_pkg_apis_pipeline_v1beta1_StepState(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.StepTemplate":                    schema_pkg_apis_pipeline_v1beta1_StepTemplate(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Task":                            schema_pkg_apis_pipeline_v1beta1_Task(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskList":                        schema_pkg_apis_pipeline_v1beta1_TaskList(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskRef":                         schema_pkg_apis_pipeline_v1beta1_TaskRef(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskResource":                    schema_pkg_apis_pipeline_v1beta1_TaskResource(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskResourceBinding":             schema_pkg_apis_pipeline_v1beta1_TaskResourceBinding(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskResources":                   schema_pkg_apis_pipeline_v1beta1_TaskResources(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskResult":                      schema_pkg_apis_pipeline_v1beta1_TaskResult(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskRun":                         schema_pkg_apis_pipeline_v1beta1_TaskRun(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskRunDebug":                    schema_pkg_apis_pipeline_v1beta1_TaskRunDebug(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskRunInputs":                   schema_pkg_apis_pipeline_v1beta1_TaskRunInputs(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskRunList":                     schema_pkg_apis_pipeline_v1beta1_TaskRunList(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskRunOutputs":                  schema_pkg_apis_pipeline_v1beta1_TaskRunOutputs(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskRunResources":                schema_pkg_apis_pipeline_v1beta1_TaskRunResources(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskRunResult":                   schema_pkg_apis_pipeline_v1beta1_TaskRunResult(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskRunSidecarOverride":          schema_pkg_apis_pipeline_v1beta1_TaskRunSidecarOverride(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskRunSpec":                     schema_pkg_apis_pipeline_v1beta1_TaskRunSpec(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskRunStatus":                   schema_pkg_apis_pipeline_v1beta1_TaskRunStatus(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskRunStatusFields":             schema_pkg_apis_pipeline_v1beta1_TaskRunStatusFields(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskRunStepOverride":             schema_pkg_apis_pipeline_v1beta1_TaskRunStepOverride(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskSpec":                        schema_pkg_apis_pipeline_v1beta1_TaskSpec(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TimeoutFields":                   schema_pkg_apis_pipeline_v1beta1_TimeoutFields(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.WhenExpression":                  schema_pkg_apis_pipeline_v1beta1_WhenExpression(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.WorkspaceBinding":                schema_pkg_apis_pipeline_v1beta1_WorkspaceBinding(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.WorkspaceDeclaration":            schema_pkg_apis_pipeline_v1beta1_WorkspaceDeclaration(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.WorkspacePipelineTaskBinding":    schema_pkg_apis_pipeline_v1beta1_WorkspacePipelineTaskBinding(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.WorkspaceUsage":                  schema_pkg_apis_pipeline_v1beta1_WorkspaceUsage(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/resolution/v1beta1.ResolutionRequest":             schema_pkg_apis_resolution_v1beta1_ResolutionRequest(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/resolution/v1beta1.ResolutionRequestList":         schema_pkg_apis_resolution_v1beta1_ResolutionRequestList(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/resolution/v1beta1.ResolutionRequestSpec":         schema_pkg_apis_resolution_v1beta1_ResolutionRequestSpec(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/resolution/v1beta1.ResolutionRequestStatus":       schema_pkg_apis_resolution_v1beta1_ResolutionRequestStatus(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/resolution/v1beta1.ResolutionRequestStatusFields": schema_pkg_apis_resolution_v1beta1_ResolutionRequestStatusFields(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1.PipelineResource":               schema_pkg_apis_resource_v1alpha1_PipelineResource(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1.PipelineResourceList":           schema_pkg_apis_resource_v1alpha1_PipelineResourceList(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1.PipelineResourceSpec":           schema_pkg_apis_resource_v1alpha1_PipelineResourceSpec(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1.PipelineResourceStatus":         schema_pkg_apis_resource_v1alpha1_PipelineResourceStatus(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1.ResourceDeclaration":            schema_pkg_apis_resource_v1alpha1_ResourceDeclaration(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1.ResourceParam":                  schema_pkg_apis_resource_v1alpha1_ResourceParam(ref),
-		"github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1.SecretParam":                    schema_pkg_apis_resource_v1alpha1_SecretParam(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/pod.AffinityAssistantTemplate":           schema_pkg_apis_pipeline_pod_AffinityAssistantTemplate(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/pod.Template":                            schema_pkg_apis_pipeline_pod_Template(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.ChildStatusReference":            schema_pkg_apis_pipeline_v1beta1_ChildStatusReference(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.CloudEventDelivery":              schema_pkg_apis_pipeline_v1beta1_CloudEventDelivery(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.CloudEventDeliveryState":         schema_pkg_apis_pipeline_v1beta1_CloudEventDeliveryState(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.ClusterTask":                     schema_pkg_apis_pipeline_v1beta1_ClusterTask(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.ClusterTaskList":                 schema_pkg_apis_pipeline_v1beta1_ClusterTaskList(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.ConfigSource":                    schema_pkg_apis_pipeline_v1beta1_ConfigSource(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.CustomRun":                       schema_pkg_apis_pipeline_v1beta1_CustomRun(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.CustomRunList":                   schema_pkg_apis_pipeline_v1beta1_CustomRunList(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.CustomRunSpec":                   schema_pkg_apis_pipeline_v1beta1_CustomRunSpec(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.EmbeddedCustomRunSpec":           schema_pkg_apis_pipeline_v1beta1_EmbeddedCustomRunSpec(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.EmbeddedTask":                    schema_pkg_apis_pipeline_v1beta1_EmbeddedTask(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.InternalTaskModifier":            schema_pkg_apis_pipeline_v1beta1_InternalTaskModifier(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.Matrix":                          schema_pkg_apis_pipeline_v1beta1_Matrix(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.MatrixInclude":                   schema_pkg_apis_pipeline_v1beta1_MatrixInclude(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.Param":                           schema_pkg_apis_pipeline_v1beta1_Param(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.ParamSpec":                       schema_pkg_apis_pipeline_v1beta1_ParamSpec(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.ParamValue":                      schema_pkg_apis_pipeline_v1beta1_ParamValue(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.Pipeline":                        schema_pkg_apis_pipeline_v1beta1_Pipeline(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineDeclaredResource":        schema_pkg_apis_pipeline_v1beta1_PipelineDeclaredResource(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineList":                    schema_pkg_apis_pipeline_v1beta1_PipelineList(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineRef":                     schema_pkg_apis_pipeline_v1beta1_PipelineRef(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineResourceBinding":         schema_pkg_apis_pipeline_v1beta1_PipelineResourceBinding(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineResourceRef":             schema_pkg_apis_pipeline_v1beta1_PipelineResourceRef(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineResourceResult":          schema_pkg_apis_pipeline_v1beta1_PipelineResourceResult(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineResult":                  schema_pkg_apis_pipeline_v1beta1_PipelineResult(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineRun":                     schema_pkg_apis_pipeline_v1beta1_PipelineRun(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineRunList":                 schema_pkg_apis_pipeline_v1beta1_PipelineRunList(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineRunResult":               schema_pkg_apis_pipeline_v1beta1_PipelineRunResult(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineRunRunStatus":            schema_pkg_apis_pipeline_v1beta1_PipelineRunRunStatus(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineRunSpec":                 schema_pkg_apis_pipeline_v1beta1_PipelineRunSpec(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineRunStatus":               schema_pkg_apis_pipeline_v1beta1_PipelineRunStatus(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineRunStatusFields":         schema_pkg_apis_pipeline_v1beta1_PipelineRunStatusFields(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineRunTaskRunStatus":        schema_pkg_apis_pipeline_v1beta1_PipelineRunTaskRunStatus(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineSpec":                    schema_pkg_apis_pipeline_v1beta1_PipelineSpec(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineTask":                    schema_pkg_apis_pipeline_v1beta1_PipelineTask(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineTaskInputResource":       schema_pkg_apis_pipeline_v1beta1_PipelineTaskInputResource(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineTaskMetadata":            schema_pkg_apis_pipeline_v1beta1_PipelineTaskMetadata(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineTaskOutputResource":      schema_pkg_apis_pipeline_v1beta1_PipelineTaskOutputResource(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineTaskParam":               schema_pkg_apis_pipeline_v1beta1_PipelineTaskParam(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineTaskResources":           schema_pkg_apis_pipeline_v1beta1_PipelineTaskResources(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineTaskRun":                 schema_pkg_apis_pipeline_v1beta1_PipelineTaskRun(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineTaskRunSpec":             schema_pkg_apis_pipeline_v1beta1_PipelineTaskRunSpec(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineWorkspaceDeclaration":    schema_pkg_apis_pipeline_v1beta1_PipelineWorkspaceDeclaration(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PropertySpec":                    schema_pkg_apis_pipeline_v1beta1_PropertySpec(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.Provenance":                      schema_pkg_apis_pipeline_v1beta1_Provenance(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.ResolverRef":                     schema_pkg_apis_pipeline_v1beta1_ResolverRef(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.ResultRef":                       schema_pkg_apis_pipeline_v1beta1_ResultRef(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.Sidecar":                         schema_pkg_apis_pipeline_v1beta1_Sidecar(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.SidecarState":                    schema_pkg_apis_pipeline_v1beta1_SidecarState(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.SkippedTask":                     schema_pkg_apis_pipeline_v1beta1_SkippedTask(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.Step":                            schema_pkg_apis_pipeline_v1beta1_Step(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.StepOutputConfig":                schema_pkg_apis_pipeline_v1beta1_StepOutputConfig(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.StepState":                       schema_pkg_apis_pipeline_v1beta1_StepState(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.StepTemplate":                    schema_pkg_apis_pipeline_v1beta1_StepTemplate(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.Task":                            schema_pkg_apis_pipeline_v1beta1_Task(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskList":                        schema_pkg_apis_pipeline_v1beta1_TaskList(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskRef":                         schema_pkg_apis_pipeline_v1beta1_TaskRef(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskResource":                    schema_pkg_apis_pipeline_v1beta1_TaskResource(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskResourceBinding":             schema_pkg_apis_pipeline_v1beta1_TaskResourceBinding(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskResources":                   schema_pkg_apis_pipeline_v1beta1_TaskResources(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskResult":                      schema_pkg_apis_pipeline_v1beta1_TaskResult(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskRun":                         schema_pkg_apis_pipeline_v1beta1_TaskRun(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskRunDebug":                    schema_pkg_apis_pipeline_v1beta1_TaskRunDebug(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskRunInputs":                   schema_pkg_apis_pipeline_v1beta1_TaskRunInputs(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskRunList":                     schema_pkg_apis_pipeline_v1beta1_TaskRunList(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskRunOutputs":                  schema_pkg_apis_pipeline_v1beta1_TaskRunOutputs(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskRunResources":                schema_pkg_apis_pipeline_v1beta1_TaskRunResources(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskRunResult":                   schema_pkg_apis_pipeline_v1beta1_TaskRunResult(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskRunSidecarOverride":          schema_pkg_apis_pipeline_v1beta1_TaskRunSidecarOverride(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskRunSpec":                     schema_pkg_apis_pipeline_v1beta1_TaskRunSpec(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskRunStatus":                   schema_pkg_apis_pipeline_v1beta1_TaskRunStatus(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskRunStatusFields":             schema_pkg_apis_pipeline_v1beta1_TaskRunStatusFields(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskRunStepOverride":             schema_pkg_apis_pipeline_v1beta1_TaskRunStepOverride(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskSpec":                        schema_pkg_apis_pipeline_v1beta1_TaskSpec(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TimeoutFields":                   schema_pkg_apis_pipeline_v1beta1_TimeoutFields(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.WhenExpression":                  schema_pkg_apis_pipeline_v1beta1_WhenExpression(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.WorkspaceBinding":                schema_pkg_apis_pipeline_v1beta1_WorkspaceBinding(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.WorkspaceDeclaration":            schema_pkg_apis_pipeline_v1beta1_WorkspaceDeclaration(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.WorkspacePipelineTaskBinding":    schema_pkg_apis_pipeline_v1beta1_WorkspacePipelineTaskBinding(ref),
+		"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.WorkspaceUsage":                  schema_pkg_apis_pipeline_v1beta1_WorkspaceUsage(ref),
+		"github.com/tekton/pipeline/pkg/apis/resolution/v1beta1.ResolutionRequest":             schema_pkg_apis_resolution_v1beta1_ResolutionRequest(ref),
+		"github.com/tekton/pipeline/pkg/apis/resolution/v1beta1.ResolutionRequestList":         schema_pkg_apis_resolution_v1beta1_ResolutionRequestList(ref),
+		"github.com/tekton/pipeline/pkg/apis/resolution/v1beta1.ResolutionRequestSpec":         schema_pkg_apis_resolution_v1beta1_ResolutionRequestSpec(ref),
+		"github.com/tekton/pipeline/pkg/apis/resolution/v1beta1.ResolutionRequestStatus":       schema_pkg_apis_resolution_v1beta1_ResolutionRequestStatus(ref),
+		"github.com/tekton/pipeline/pkg/apis/resolution/v1beta1.ResolutionRequestStatusFields": schema_pkg_apis_resolution_v1beta1_ResolutionRequestStatusFields(ref),
+		"github.com/tekton/pipeline/pkg/apis/resource/v1alpha1.PipelineResource":               schema_pkg_apis_resource_v1alpha1_PipelineResource(ref),
+		"github.com/tekton/pipeline/pkg/apis/resource/v1alpha1.PipelineResourceList":           schema_pkg_apis_resource_v1alpha1_PipelineResourceList(ref),
+		"github.com/tekton/pipeline/pkg/apis/resource/v1alpha1.PipelineResourceSpec":           schema_pkg_apis_resource_v1alpha1_PipelineResourceSpec(ref),
+		"github.com/tekton/pipeline/pkg/apis/resource/v1alpha1.PipelineResourceStatus":         schema_pkg_apis_resource_v1alpha1_PipelineResourceStatus(ref),
+		"github.com/tekton/pipeline/pkg/apis/resource/v1alpha1.ResourceDeclaration":            schema_pkg_apis_resource_v1alpha1_ResourceDeclaration(ref),
+		"github.com/tekton/pipeline/pkg/apis/resource/v1alpha1.ResourceParam":                  schema_pkg_apis_resource_v1alpha1_ResourceParam(ref),
+		"github.com/tekton/pipeline/pkg/apis/resource/v1alpha1.SecretParam":                    schema_pkg_apis_resource_v1alpha1_SecretParam(ref),
 	}
 }
 
@@ -457,7 +458,7 @@ func schema_pkg_apis_pipeline_v1beta1_ChildStatusReference(ref common.ReferenceC
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.WhenExpression"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.WhenExpression"),
 									},
 								},
 							},
@@ -467,7 +468,7 @@ func schema_pkg_apis_pipeline_v1beta1_ChildStatusReference(ref common.ReferenceC
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.WhenExpression"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.WhenExpression"},
 	}
 }
 
@@ -488,14 +489,14 @@ func schema_pkg_apis_pipeline_v1beta1_CloudEventDelivery(ref common.ReferenceCal
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Default: map[string]interface{}{},
-							Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.CloudEventDeliveryState"),
+							Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.CloudEventDeliveryState"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.CloudEventDeliveryState"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.CloudEventDeliveryState"},
 	}
 }
 
@@ -575,14 +576,14 @@ func schema_pkg_apis_pipeline_v1beta1_ClusterTask(ref common.ReferenceCallback) 
 						SchemaProps: spec.SchemaProps{
 							Description: "Spec holds the desired state of the Task from the client",
 							Default:     map[string]interface{}{},
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskSpec"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskSpec"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskSpec", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskSpec", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }
 
@@ -620,7 +621,7 @@ func schema_pkg_apis_pipeline_v1beta1_ClusterTaskList(ref common.ReferenceCallba
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.ClusterTask"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.ClusterTask"),
 									},
 								},
 							},
@@ -631,7 +632,7 @@ func schema_pkg_apis_pipeline_v1beta1_ClusterTaskList(ref common.ReferenceCallba
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.ClusterTask", "k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.ClusterTask", "k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"},
 	}
 }
 
@@ -708,7 +709,7 @@ func schema_pkg_apis_pipeline_v1beta1_CustomRun(ref common.ReferenceCallback) co
 					"spec": {
 						SchemaProps: spec.SchemaProps{
 							Default: map[string]interface{}{},
-							Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.CustomRunSpec"),
+							Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.CustomRunSpec"),
 						},
 					},
 					"status": {
@@ -721,7 +722,7 @@ func schema_pkg_apis_pipeline_v1beta1_CustomRun(ref common.ReferenceCallback) co
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.CustomRunSpec", "github.com/tektoncd/pipeline/pkg/apis/run/v1beta1.CustomRunStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.CustomRunSpec", "github.com/tektoncd/pipeline/pkg/apis/run/v1beta1.CustomRunStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }
 
@@ -759,7 +760,7 @@ func schema_pkg_apis_pipeline_v1beta1_CustomRunList(ref common.ReferenceCallback
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.CustomRun"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.CustomRun"),
 									},
 								},
 							},
@@ -770,7 +771,7 @@ func schema_pkg_apis_pipeline_v1beta1_CustomRunList(ref common.ReferenceCallback
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.CustomRun", "k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.CustomRun", "k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"},
 	}
 }
 
@@ -783,13 +784,13 @@ func schema_pkg_apis_pipeline_v1beta1_CustomRunSpec(ref common.ReferenceCallback
 				Properties: map[string]spec.Schema{
 					"customRef": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskRef"),
+							Ref: ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskRef"),
 						},
 					},
 					"customSpec": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Spec is a specification of a custom task",
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.EmbeddedCustomRunSpec"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.EmbeddedCustomRunSpec"),
 						},
 					},
 					"params": {
@@ -804,7 +805,7 @@ func schema_pkg_apis_pipeline_v1beta1_CustomRunSpec(ref common.ReferenceCallback
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Param"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.Param"),
 									},
 								},
 							},
@@ -857,7 +858,7 @@ func schema_pkg_apis_pipeline_v1beta1_CustomRunSpec(ref common.ReferenceCallback
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.WorkspaceBinding"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.WorkspaceBinding"),
 									},
 								},
 							},
@@ -867,7 +868,7 @@ func schema_pkg_apis_pipeline_v1beta1_CustomRunSpec(ref common.ReferenceCallback
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.EmbeddedCustomRunSpec", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Param", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskRef", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.WorkspaceBinding", "k8s.io/apimachinery/pkg/apis/meta/v1.Duration"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.EmbeddedCustomRunSpec", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.Param", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskRef", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.WorkspaceBinding", "k8s.io/apimachinery/pkg/apis/meta/v1.Duration"},
 	}
 }
 
@@ -893,7 +894,7 @@ func schema_pkg_apis_pipeline_v1beta1_EmbeddedCustomRunSpec(ref common.Reference
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Default: map[string]interface{}{},
-							Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineTaskMetadata"),
+							Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineTaskMetadata"),
 						},
 					},
 					"spec": {
@@ -907,7 +908,7 @@ func schema_pkg_apis_pipeline_v1beta1_EmbeddedCustomRunSpec(ref common.Reference
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineTaskMetadata", "k8s.io/apimachinery/pkg/runtime.RawExtension"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineTaskMetadata", "k8s.io/apimachinery/pkg/runtime.RawExtension"},
 	}
 }
 
@@ -940,13 +941,13 @@ func schema_pkg_apis_pipeline_v1beta1_EmbeddedTask(ref common.ReferenceCallback)
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Default: map[string]interface{}{},
-							Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineTaskMetadata"),
+							Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineTaskMetadata"),
 						},
 					},
 					"resources": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Resources is a list input and output resource to run the task Resources are represented in TaskRuns as bindings to instances of PipelineResources.",
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskResources"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskResources"),
 						},
 					},
 					"params": {
@@ -962,7 +963,7 @@ func schema_pkg_apis_pipeline_v1beta1_EmbeddedTask(ref common.ReferenceCallback)
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.ParamSpec"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.ParamSpec"),
 									},
 								},
 							},
@@ -988,7 +989,7 @@ func schema_pkg_apis_pipeline_v1beta1_EmbeddedTask(ref common.ReferenceCallback)
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Step"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.Step"),
 									},
 								},
 							},
@@ -1016,7 +1017,7 @@ func schema_pkg_apis_pipeline_v1beta1_EmbeddedTask(ref common.ReferenceCallback)
 					"stepTemplate": {
 						SchemaProps: spec.SchemaProps{
 							Description: "StepTemplate can be used as the basis for all step containers within the Task, so that the steps inherit settings on the base container.",
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.StepTemplate"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.StepTemplate"),
 						},
 					},
 					"sidecars": {
@@ -1032,7 +1033,7 @@ func schema_pkg_apis_pipeline_v1beta1_EmbeddedTask(ref common.ReferenceCallback)
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Sidecar"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.Sidecar"),
 									},
 								},
 							},
@@ -1051,7 +1052,7 @@ func schema_pkg_apis_pipeline_v1beta1_EmbeddedTask(ref common.ReferenceCallback)
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.WorkspaceDeclaration"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.WorkspaceDeclaration"),
 									},
 								},
 							},
@@ -1070,7 +1071,7 @@ func schema_pkg_apis_pipeline_v1beta1_EmbeddedTask(ref common.ReferenceCallback)
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskResult"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskResult"),
 									},
 								},
 							},
@@ -1080,7 +1081,7 @@ func schema_pkg_apis_pipeline_v1beta1_EmbeddedTask(ref common.ReferenceCallback)
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.ParamSpec", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineTaskMetadata", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Sidecar", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Step", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.StepTemplate", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskResources", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskResult", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.WorkspaceDeclaration", "k8s.io/api/core/v1.Volume", "k8s.io/apimachinery/pkg/runtime.RawExtension"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.ParamSpec", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineTaskMetadata", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.Sidecar", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.Step", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.StepTemplate", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskResources", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskResult", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.WorkspaceDeclaration", "k8s.io/api/core/v1.Volume", "k8s.io/apimachinery/pkg/runtime.RawExtension"},
 	}
 }
 
@@ -1103,7 +1104,7 @@ func schema_pkg_apis_pipeline_v1beta1_InternalTaskModifier(ref common.ReferenceC
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Step"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.Step"),
 									},
 								},
 							},
@@ -1121,7 +1122,7 @@ func schema_pkg_apis_pipeline_v1beta1_InternalTaskModifier(ref common.ReferenceC
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Step"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.Step"),
 									},
 								},
 							},
@@ -1150,7 +1151,7 @@ func schema_pkg_apis_pipeline_v1beta1_InternalTaskModifier(ref common.ReferenceC
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Step", "k8s.io/api/core/v1.Volume"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.Step", "k8s.io/api/core/v1.Volume"},
 	}
 }
 
@@ -1174,7 +1175,26 @@ func schema_pkg_apis_pipeline_v1beta1_Matrix(ref common.ReferenceCallback) commo
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Param"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.Param"),
+									},
+								},
+							},
+						},
+					},
+					"include": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
+						SchemaProps: spec.SchemaProps{
+							Description: "Include is a list of MatrixInclude Note this field is in preview mode and not yet supported",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: map[string]interface{}{},
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.MatrixInclude"),
 									},
 								},
 							},
@@ -1184,7 +1204,48 @@ func schema_pkg_apis_pipeline_v1beta1_Matrix(ref common.ReferenceCallback) commo
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Param"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.MatrixInclude", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.Param"},
+	}
+}
+
+func schema_pkg_apis_pipeline_v1beta1_MatrixInclude(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "MatrixInclude allows passing in a specific combinations of Parameters into the Matrix. Note this struct is in preview mode and not yet supported",
+				Type:        []string{"object"},
+				Properties: map[string]spec.Schema{
+					"name": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Name the specified combination",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"params": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
+						SchemaProps: spec.SchemaProps{
+							Description: "Params takes only `Parameters` of type `\"string\"` The names of the `params` must match the names of the `params` in the underlying `Task`",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: map[string]interface{}{},
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.Param"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Dependencies: []string{
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.Param"},
 	}
 }
 
@@ -1205,7 +1266,7 @@ func schema_pkg_apis_pipeline_v1beta1_Param(ref common.ReferenceCallback) common
 					"value": {
 						SchemaProps: spec.SchemaProps{
 							Default: map[string]interface{}{},
-							Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.ParamValue"),
+							Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.ParamValue"),
 						},
 					},
 				},
@@ -1213,7 +1274,7 @@ func schema_pkg_apis_pipeline_v1beta1_Param(ref common.ReferenceCallback) common
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.ParamValue"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.ParamValue"},
 	}
 }
 
@@ -1255,7 +1316,7 @@ func schema_pkg_apis_pipeline_v1beta1_ParamSpec(ref common.ReferenceCallback) co
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PropertySpec"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PropertySpec"),
 									},
 								},
 							},
@@ -1264,7 +1325,7 @@ func schema_pkg_apis_pipeline_v1beta1_ParamSpec(ref common.ReferenceCallback) co
 					"default": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Default is the value a parameter takes if no input value is supplied. If default is set, a Task may be executed without a supplied value for the parameter.",
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.ParamValue"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.ParamValue"),
 						},
 					},
 				},
@@ -1272,7 +1333,7 @@ func schema_pkg_apis_pipeline_v1beta1_ParamSpec(ref common.ReferenceCallback) co
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.ParamValue", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PropertySpec"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.ParamValue", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PropertySpec"},
 	}
 }
 
@@ -1370,14 +1431,14 @@ func schema_pkg_apis_pipeline_v1beta1_Pipeline(ref common.ReferenceCallback) com
 						SchemaProps: spec.SchemaProps{
 							Description: "Spec holds the desired state of the Pipeline from the client",
 							Default:     map[string]interface{}{},
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineSpec"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineSpec"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineSpec", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineSpec", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }
 
@@ -1452,7 +1513,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineList(ref common.ReferenceCallback)
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Pipeline"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.Pipeline"),
 									},
 								},
 							},
@@ -1463,7 +1524,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineList(ref common.ReferenceCallback)
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Pipeline", "k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.Pipeline", "k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"},
 	}
 }
 
@@ -1518,7 +1579,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineResourceBinding(ref common.Referen
 					"resourceRef": {
 						SchemaProps: spec.SchemaProps{
 							Description: "ResourceRef is a reference to the instance of the actual PipelineResource that should be used",
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineResourceRef"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineResourceRef"),
 						},
 					},
 					"resourceSpec": {
@@ -1531,7 +1592,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineResourceBinding(ref common.Referen
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineResourceRef", "github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1.PipelineResourceSpec"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineResourceRef", "github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1.PipelineResourceSpec"},
 	}
 }
 
@@ -1636,7 +1697,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineResult(ref common.ReferenceCallbac
 						SchemaProps: spec.SchemaProps{
 							Description: "Value the expression used to retrieve the value",
 							Default:     map[string]interface{}{},
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.ParamValue"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.ParamValue"),
 						},
 					},
 				},
@@ -1644,7 +1705,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineResult(ref common.ReferenceCallbac
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.ParamValue"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.ParamValue"},
 	}
 }
 
@@ -1678,20 +1739,20 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineRun(ref common.ReferenceCallback) 
 					"spec": {
 						SchemaProps: spec.SchemaProps{
 							Default: map[string]interface{}{},
-							Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineRunSpec"),
+							Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineRunSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Default: map[string]interface{}{},
-							Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineRunStatus"),
+							Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineRunStatus"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineRunSpec", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineRunStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineRunSpec", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineRunStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }
 
@@ -1729,7 +1790,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineRunList(ref common.ReferenceCallba
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineRun"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineRun"),
 									},
 								},
 							},
@@ -1739,7 +1800,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineRunList(ref common.ReferenceCallba
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineRun", "k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineRun", "k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"},
 	}
 }
 
@@ -1762,7 +1823,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineRunResult(ref common.ReferenceCall
 						SchemaProps: spec.SchemaProps{
 							Description: "Value is the result returned from the execution of this PipelineRun",
 							Default:     map[string]interface{}{},
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.ParamValue"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.ParamValue"),
 						},
 					},
 				},
@@ -1770,7 +1831,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineRunResult(ref common.ReferenceCall
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.ParamValue"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.ParamValue"},
 	}
 }
 
@@ -1807,7 +1868,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineRunRunStatus(ref common.ReferenceC
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.WhenExpression"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.WhenExpression"),
 									},
 								},
 							},
@@ -1817,7 +1878,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineRunRunStatus(ref common.ReferenceC
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.WhenExpression", "github.com/tektoncd/pipeline/pkg/apis/run/v1beta1.CustomRunStatus"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.WhenExpression", "github.com/tektoncd/pipeline/pkg/apis/run/v1beta1.CustomRunStatus"},
 	}
 }
 
@@ -1830,12 +1891,12 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineRunSpec(ref common.ReferenceCallba
 				Properties: map[string]spec.Schema{
 					"pipelineRef": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineRef"),
+							Ref: ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineRef"),
 						},
 					},
 					"pipelineSpec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineSpec"),
+							Ref: ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineSpec"),
 						},
 					},
 					"resources": {
@@ -1851,7 +1912,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineRunSpec(ref common.ReferenceCallba
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineResourceBinding"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineResourceBinding"),
 									},
 								},
 							},
@@ -1870,7 +1931,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineRunSpec(ref common.ReferenceCallba
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Param"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.Param"),
 									},
 								},
 							},
@@ -1892,7 +1953,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineRunSpec(ref common.ReferenceCallba
 					"timeouts": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Time after which the Pipeline times out. Currently three keys are accepted in the map pipeline, tasks and finally with Timeouts.pipeline >= Timeouts.tasks + Timeouts.finally",
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TimeoutFields"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TimeoutFields"),
 						},
 					},
 					"timeout": {
@@ -1920,7 +1981,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineRunSpec(ref common.ReferenceCallba
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.WorkspaceBinding"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.WorkspaceBinding"),
 									},
 								},
 							},
@@ -1939,7 +2000,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineRunSpec(ref common.ReferenceCallba
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineTaskRunSpec"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineTaskRunSpec"),
 									},
 								},
 							},
@@ -1949,7 +2010,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineRunSpec(ref common.ReferenceCallba
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/pod.Template", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Param", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineRef", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineResourceBinding", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineSpec", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineTaskRunSpec", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TimeoutFields", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.WorkspaceBinding", "k8s.io/apimachinery/pkg/apis/meta/v1.Duration"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.Param", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineRef", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineResourceBinding", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineSpec", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineTaskRunSpec", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TimeoutFields", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.WorkspaceBinding", "github.com/tektoncd/pipeline/pkg/apis/pipeline/pod.Template", "k8s.io/apimachinery/pkg/apis/meta/v1.Duration"},
 	}
 }
 
@@ -2028,7 +2089,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineRunStatus(ref common.ReferenceCall
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineRunResult"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineRunResult"),
 									},
 								},
 							},
@@ -2037,7 +2098,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineRunStatus(ref common.ReferenceCall
 					"pipelineSpec": {
 						SchemaProps: spec.SchemaProps{
 							Description: "PipelineRunSpec contains the exact spec used to instantiate the run",
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineSpec"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineSpec"),
 						},
 					},
 					"skippedTasks": {
@@ -2053,7 +2114,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineRunStatus(ref common.ReferenceCall
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.SkippedTask"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.SkippedTask"),
 									},
 								},
 							},
@@ -2072,7 +2133,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineRunStatus(ref common.ReferenceCall
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.ChildStatusReference"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.ChildStatusReference"),
 									},
 								},
 							},
@@ -2087,7 +2148,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineRunStatus(ref common.ReferenceCall
 					"provenance": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Provenance contains some key authenticated metadata about how a software artifact was built (what sources, what inputs/outputs, etc.).",
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Provenance"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.Provenance"),
 						},
 					},
 					"spanContext": {
@@ -2110,7 +2171,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineRunStatus(ref common.ReferenceCall
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.ChildStatusReference", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineRunResult", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineSpec", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Provenance", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.SkippedTask", "k8s.io/apimachinery/pkg/apis/meta/v1.Time", "knative.dev/pkg/apis.Condition"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.ChildStatusReference", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineRunResult", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineSpec", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.Provenance", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.SkippedTask", "k8s.io/apimachinery/pkg/apis/meta/v1.Time", "knative.dev/pkg/apis.Condition"},
 	}
 }
 
@@ -2146,7 +2207,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineRunStatusFields(ref common.Referen
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineRunResult"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineRunResult"),
 									},
 								},
 							},
@@ -2155,7 +2216,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineRunStatusFields(ref common.Referen
 					"pipelineSpec": {
 						SchemaProps: spec.SchemaProps{
 							Description: "PipelineRunSpec contains the exact spec used to instantiate the run",
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineSpec"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineSpec"),
 						},
 					},
 					"skippedTasks": {
@@ -2171,7 +2232,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineRunStatusFields(ref common.Referen
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.SkippedTask"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.SkippedTask"),
 									},
 								},
 							},
@@ -2190,7 +2251,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineRunStatusFields(ref common.Referen
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.ChildStatusReference"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.ChildStatusReference"),
 									},
 								},
 							},
@@ -2205,7 +2266,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineRunStatusFields(ref common.Referen
 					"provenance": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Provenance contains some key authenticated metadata about how a software artifact was built (what sources, what inputs/outputs, etc.).",
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Provenance"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.Provenance"),
 						},
 					},
 					"spanContext": {
@@ -2228,7 +2289,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineRunStatusFields(ref common.Referen
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.ChildStatusReference", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineRunResult", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineSpec", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Provenance", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.SkippedTask", "k8s.io/apimachinery/pkg/apis/meta/v1.Time"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.ChildStatusReference", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineRunResult", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineSpec", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.Provenance", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.SkippedTask", "k8s.io/apimachinery/pkg/apis/meta/v1.Time"},
 	}
 }
 
@@ -2249,7 +2310,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineRunTaskRunStatus(ref common.Refere
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Status is the TaskRunStatus for the corresponding TaskRun",
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskRunStatus"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskRunStatus"),
 						},
 					},
 					"whenExpressions": {
@@ -2265,7 +2326,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineRunTaskRunStatus(ref common.Refere
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.WhenExpression"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.WhenExpression"),
 									},
 								},
 							},
@@ -2275,7 +2336,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineRunTaskRunStatus(ref common.Refere
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskRunStatus", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.WhenExpression"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskRunStatus", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.WhenExpression"},
 	}
 }
 
@@ -2306,7 +2367,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineSpec(ref common.ReferenceCallback)
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineDeclaredResource"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineDeclaredResource"),
 									},
 								},
 							},
@@ -2325,7 +2386,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineSpec(ref common.ReferenceCallback)
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineTask"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineTask"),
 									},
 								},
 							},
@@ -2344,7 +2405,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineSpec(ref common.ReferenceCallback)
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.ParamSpec"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.ParamSpec"),
 									},
 								},
 							},
@@ -2363,7 +2424,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineSpec(ref common.ReferenceCallback)
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineWorkspaceDeclaration"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineWorkspaceDeclaration"),
 									},
 								},
 							},
@@ -2382,7 +2443,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineSpec(ref common.ReferenceCallback)
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineResult"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineResult"),
 									},
 								},
 							},
@@ -2401,7 +2462,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineSpec(ref common.ReferenceCallback)
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineTask"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineTask"),
 									},
 								},
 							},
@@ -2411,7 +2472,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineSpec(ref common.ReferenceCallback)
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.ParamSpec", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineDeclaredResource", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineResult", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineTask", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineWorkspaceDeclaration"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.ParamSpec", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineDeclaredResource", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineResult", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineTask", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineWorkspaceDeclaration"},
 	}
 }
 
@@ -2432,13 +2493,13 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineTask(ref common.ReferenceCallback)
 					"taskRef": {
 						SchemaProps: spec.SchemaProps{
 							Description: "TaskRef is a reference to a task definition.",
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskRef"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskRef"),
 						},
 					},
 					"taskSpec": {
 						SchemaProps: spec.SchemaProps{
 							Description: "TaskSpec is a specification of a task",
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.EmbeddedTask"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.EmbeddedTask"),
 						},
 					},
 					"when": {
@@ -2449,7 +2510,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineTask(ref common.ReferenceCallback)
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.WhenExpression"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.WhenExpression"),
 									},
 								},
 							},
@@ -2485,7 +2546,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineTask(ref common.ReferenceCallback)
 					"resources": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Resources declares the resources given to this task as inputs and outputs.",
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineTaskResources"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineTaskResources"),
 						},
 					},
 					"params": {
@@ -2501,7 +2562,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineTask(ref common.ReferenceCallback)
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Param"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.Param"),
 									},
 								},
 							},
@@ -2510,7 +2571,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineTask(ref common.ReferenceCallback)
 					"matrix": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Matrix declares parameters used to fan out this task.",
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Matrix"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.Matrix"),
 						},
 					},
 					"workspaces": {
@@ -2526,7 +2587,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineTask(ref common.ReferenceCallback)
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.WorkspacePipelineTaskBinding"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.WorkspacePipelineTaskBinding"),
 									},
 								},
 							},
@@ -2542,7 +2603,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineTask(ref common.ReferenceCallback)
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.EmbeddedTask", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Matrix", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Param", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineTaskResources", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskRef", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.WhenExpression", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.WorkspacePipelineTaskBinding", "k8s.io/apimachinery/pkg/apis/meta/v1.Duration"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.EmbeddedTask", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.Matrix", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.Param", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineTaskResources", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskRef", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.WhenExpression", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.WorkspacePipelineTaskBinding", "k8s.io/apimachinery/pkg/apis/meta/v1.Duration"},
 	}
 }
 
@@ -2717,7 +2778,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineTaskResources(ref common.Reference
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineTaskInputResource"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineTaskInputResource"),
 									},
 								},
 							},
@@ -2736,7 +2797,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineTaskResources(ref common.Reference
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineTaskOutputResource"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineTaskOutputResource"),
 									},
 								},
 							},
@@ -2746,7 +2807,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineTaskResources(ref common.Reference
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineTaskInputResource", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineTaskOutputResource"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineTaskInputResource", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineTaskOutputResource"},
 	}
 }
 
@@ -2805,7 +2866,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineTaskRunSpec(ref common.ReferenceCa
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskRunStepOverride"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskRunStepOverride"),
 									},
 								},
 							},
@@ -2823,7 +2884,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineTaskRunSpec(ref common.ReferenceCa
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskRunSidecarOverride"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskRunSidecarOverride"),
 									},
 								},
 							},
@@ -2831,7 +2892,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineTaskRunSpec(ref common.ReferenceCa
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineTaskMetadata"),
+							Ref: ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineTaskMetadata"),
 						},
 					},
 					"computeResources": {
@@ -2844,7 +2905,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineTaskRunSpec(ref common.ReferenceCa
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/pod.Template", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineTaskMetadata", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskRunSidecarOverride", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskRunStepOverride", "k8s.io/api/core/v1.ResourceRequirements"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineTaskMetadata", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskRunSidecarOverride", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskRunStepOverride", "github.com/tektoncd/pipeline/pkg/apis/pipeline/pod.Template", "k8s.io/api/core/v1.ResourceRequirements"},
 	}
 }
 
@@ -2913,7 +2974,7 @@ func schema_pkg_apis_pipeline_v1beta1_Provenance(ref common.ReferenceCallback) c
 					"configSource": {
 						SchemaProps: spec.SchemaProps{
 							Description: "ConfigSource identifies the source where a resource came from.",
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.ConfigSource"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.ConfigSource"),
 						},
 					},
 					"featureFlags": {
@@ -2926,7 +2987,7 @@ func schema_pkg_apis_pipeline_v1beta1_Provenance(ref common.ReferenceCallback) c
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/config.FeatureFlags", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.ConfigSource"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.ConfigSource", "github.com/tektoncd/pipeline/pkg/apis/config.FeatureFlags"},
 	}
 }
 
@@ -2957,7 +3018,7 @@ func schema_pkg_apis_pipeline_v1beta1_ResolverRef(ref common.ReferenceCallback) 
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Param"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.Param"),
 									},
 								},
 							},
@@ -2967,7 +3028,7 @@ func schema_pkg_apis_pipeline_v1beta1_ResolverRef(ref common.ReferenceCallback) 
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Param"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.Param"},
 	}
 }
 
@@ -3288,7 +3349,7 @@ func schema_pkg_apis_pipeline_v1beta1_Sidecar(ref common.ReferenceCallback) comm
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.WorkspaceUsage"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.WorkspaceUsage"),
 									},
 								},
 							},
@@ -3299,7 +3360,7 @@ func schema_pkg_apis_pipeline_v1beta1_Sidecar(ref common.ReferenceCallback) comm
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.WorkspaceUsage", "k8s.io/api/core/v1.ContainerPort", "k8s.io/api/core/v1.EnvFromSource", "k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.Lifecycle", "k8s.io/api/core/v1.Probe", "k8s.io/api/core/v1.ResourceRequirements", "k8s.io/api/core/v1.SecurityContext", "k8s.io/api/core/v1.VolumeDevice", "k8s.io/api/core/v1.VolumeMount"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.WorkspaceUsage", "k8s.io/api/core/v1.ContainerPort", "k8s.io/api/core/v1.EnvFromSource", "k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.Lifecycle", "k8s.io/api/core/v1.Probe", "k8s.io/api/core/v1.ResourceRequirements", "k8s.io/api/core/v1.SecurityContext", "k8s.io/api/core/v1.VolumeDevice", "k8s.io/api/core/v1.VolumeMount"},
 	}
 }
 
@@ -3390,7 +3451,7 @@ func schema_pkg_apis_pipeline_v1beta1_SkippedTask(ref common.ReferenceCallback) 
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.WhenExpression"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.WhenExpression"),
 									},
 								},
 							},
@@ -3401,7 +3462,7 @@ func schema_pkg_apis_pipeline_v1beta1_SkippedTask(ref common.ReferenceCallback) 
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.WhenExpression"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.WhenExpression"},
 	}
 }
 
@@ -3686,7 +3747,7 @@ func schema_pkg_apis_pipeline_v1beta1_Step(ref common.ReferenceCallback) common.
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.WorkspaceUsage"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.WorkspaceUsage"),
 									},
 								},
 							},
@@ -3702,13 +3763,13 @@ func schema_pkg_apis_pipeline_v1beta1_Step(ref common.ReferenceCallback) common.
 					"stdoutConfig": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Stores configuration for the stdout stream of the step.",
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.StepOutputConfig"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.StepOutputConfig"),
 						},
 					},
 					"stderrConfig": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Stores configuration for the stderr stream of the step.",
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.StepOutputConfig"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.StepOutputConfig"),
 						},
 					},
 				},
@@ -3716,7 +3777,7 @@ func schema_pkg_apis_pipeline_v1beta1_Step(ref common.ReferenceCallback) common.
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.StepOutputConfig", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.WorkspaceUsage", "k8s.io/api/core/v1.ContainerPort", "k8s.io/api/core/v1.EnvFromSource", "k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.Lifecycle", "k8s.io/api/core/v1.Probe", "k8s.io/api/core/v1.ResourceRequirements", "k8s.io/api/core/v1.SecurityContext", "k8s.io/api/core/v1.VolumeDevice", "k8s.io/api/core/v1.VolumeMount", "k8s.io/apimachinery/pkg/apis/meta/v1.Duration"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.StepOutputConfig", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.WorkspaceUsage", "k8s.io/api/core/v1.ContainerPort", "k8s.io/api/core/v1.EnvFromSource", "k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.Lifecycle", "k8s.io/api/core/v1.Probe", "k8s.io/api/core/v1.ResourceRequirements", "k8s.io/api/core/v1.SecurityContext", "k8s.io/api/core/v1.VolumeDevice", "k8s.io/api/core/v1.VolumeMount", "k8s.io/apimachinery/pkg/apis/meta/v1.Duration"},
 	}
 }
 
@@ -4086,14 +4147,14 @@ func schema_pkg_apis_pipeline_v1beta1_Task(ref common.ReferenceCallback) common.
 						SchemaProps: spec.SchemaProps{
 							Description: "Spec holds the desired state of the Task from the client",
 							Default:     map[string]interface{}{},
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskSpec"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskSpec"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskSpec", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskSpec", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }
 
@@ -4131,7 +4192,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskList(ref common.ReferenceCallback) com
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Task"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.Task"),
 									},
 								},
 							},
@@ -4142,7 +4203,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskList(ref common.ReferenceCallback) com
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Task", "k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.Task", "k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"},
 	}
 }
 
@@ -4255,7 +4316,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskResourceBinding(ref common.ReferenceCa
 					"resourceRef": {
 						SchemaProps: spec.SchemaProps{
 							Description: "ResourceRef is a reference to the instance of the actual PipelineResource that should be used",
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineResourceRef"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineResourceRef"),
 						},
 					},
 					"resourceSpec": {
@@ -4288,7 +4349,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskResourceBinding(ref common.ReferenceCa
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineResourceRef", "github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1.PipelineResourceSpec"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineResourceRef", "github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1.PipelineResourceSpec"},
 	}
 }
 
@@ -4312,7 +4373,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskResources(ref common.ReferenceCallback
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskResource"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskResource"),
 									},
 								},
 							},
@@ -4331,7 +4392,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskResources(ref common.ReferenceCallback
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskResource"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskResource"),
 									},
 								},
 							},
@@ -4341,7 +4402,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskResources(ref common.ReferenceCallback
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskResource"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskResource"},
 	}
 }
 
@@ -4376,7 +4437,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskResult(ref common.ReferenceCallback) c
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PropertySpec"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PropertySpec"),
 									},
 								},
 							},
@@ -4394,7 +4455,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskResult(ref common.ReferenceCallback) c
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PropertySpec"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PropertySpec"},
 	}
 }
 
@@ -4428,20 +4489,20 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRun(ref common.ReferenceCallback) comm
 					"spec": {
 						SchemaProps: spec.SchemaProps{
 							Default: map[string]interface{}{},
-							Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskRunSpec"),
+							Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskRunSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Default: map[string]interface{}{},
-							Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskRunStatus"),
+							Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskRunStatus"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskRunSpec", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskRunStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskRunSpec", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskRunStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }
 
@@ -4496,7 +4557,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunInputs(ref common.ReferenceCallback
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskResourceBinding"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskResourceBinding"),
 									},
 								},
 							},
@@ -4514,7 +4575,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunInputs(ref common.ReferenceCallback
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Param"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.Param"),
 									},
 								},
 							},
@@ -4524,7 +4585,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunInputs(ref common.ReferenceCallback
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Param", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskResourceBinding"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.Param", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskResourceBinding"},
 	}
 }
 
@@ -4562,7 +4623,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunList(ref common.ReferenceCallback) 
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskRun"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskRun"),
 									},
 								},
 							},
@@ -4573,7 +4634,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunList(ref common.ReferenceCallback) 
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskRun", "k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskRun", "k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"},
 	}
 }
 
@@ -4596,7 +4657,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunOutputs(ref common.ReferenceCallbac
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskResourceBinding"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskResourceBinding"),
 									},
 								},
 							},
@@ -4606,7 +4667,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunOutputs(ref common.ReferenceCallbac
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskResourceBinding"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskResourceBinding"},
 	}
 }
 
@@ -4630,7 +4691,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunResources(ref common.ReferenceCallb
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskResourceBinding"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskResourceBinding"),
 									},
 								},
 							},
@@ -4649,7 +4710,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunResources(ref common.ReferenceCallb
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskResourceBinding"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskResourceBinding"),
 									},
 								},
 							},
@@ -4659,7 +4720,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunResources(ref common.ReferenceCallb
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskResourceBinding"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskResourceBinding"},
 	}
 }
 
@@ -4689,7 +4750,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunResult(ref common.ReferenceCallback
 						SchemaProps: spec.SchemaProps{
 							Description: "Value the given value of the result",
 							Default:     map[string]interface{}{},
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.ParamValue"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.ParamValue"),
 						},
 					},
 				},
@@ -4697,7 +4758,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunResult(ref common.ReferenceCallback
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.ParamValue"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.ParamValue"},
 	}
 }
 
@@ -4741,7 +4802,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunSpec(ref common.ReferenceCallback) 
 				Properties: map[string]spec.Schema{
 					"debug": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskRunDebug"),
+							Ref: ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskRunDebug"),
 						},
 					},
 					"params": {
@@ -4756,7 +4817,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunSpec(ref common.ReferenceCallback) 
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Param"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.Param"),
 									},
 								},
 							},
@@ -4764,7 +4825,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunSpec(ref common.ReferenceCallback) 
 					},
 					"resources": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskRunResources"),
+							Ref: ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskRunResources"),
 						},
 					},
 					"serviceAccountName": {
@@ -4777,12 +4838,12 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunSpec(ref common.ReferenceCallback) 
 					"taskRef": {
 						SchemaProps: spec.SchemaProps{
 							Description: "no more than one of the TaskRef and TaskSpec may be specified.",
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskRef"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskRef"),
 						},
 					},
 					"taskSpec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskSpec"),
+							Ref: ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskSpec"),
 						},
 					},
 					"status": {
@@ -4831,7 +4892,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunSpec(ref common.ReferenceCallback) 
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.WorkspaceBinding"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.WorkspaceBinding"),
 									},
 								},
 							},
@@ -4850,7 +4911,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunSpec(ref common.ReferenceCallback) 
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskRunStepOverride"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskRunStepOverride"),
 									},
 								},
 							},
@@ -4869,7 +4930,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunSpec(ref common.ReferenceCallback) 
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskRunSidecarOverride"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskRunSidecarOverride"),
 									},
 								},
 							},
@@ -4885,7 +4946,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunSpec(ref common.ReferenceCallback) 
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/pod.Template", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Param", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskRef", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskRunDebug", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskRunResources", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskRunSidecarOverride", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskRunStepOverride", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskSpec", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.WorkspaceBinding", "k8s.io/api/core/v1.ResourceRequirements", "k8s.io/apimachinery/pkg/apis/meta/v1.Duration"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.Param", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskRef", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskRunDebug", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskRunResources", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskRunSidecarOverride", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskRunStepOverride", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskSpec", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.WorkspaceBinding", "github.com/tektoncd/pipeline/pkg/apis/pipeline/pod.Template", "k8s.io/api/core/v1.ResourceRequirements", "k8s.io/apimachinery/pkg/apis/meta/v1.Duration"},
 	}
 }
 
@@ -4972,7 +5033,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunStatus(ref common.ReferenceCallback
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.StepState"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.StepState"),
 									},
 								},
 							},
@@ -4991,7 +5052,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunStatus(ref common.ReferenceCallback
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.CloudEventDelivery"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.CloudEventDelivery"),
 									},
 								},
 							},
@@ -5010,7 +5071,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunStatus(ref common.ReferenceCallback
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskRunStatus"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskRunStatus"),
 									},
 								},
 							},
@@ -5029,7 +5090,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunStatus(ref common.ReferenceCallback
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineResourceResult"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineResourceResult"),
 									},
 								},
 							},
@@ -5048,7 +5109,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunStatus(ref common.ReferenceCallback
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskRunResult"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskRunResult"),
 									},
 								},
 							},
@@ -5067,7 +5128,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunStatus(ref common.ReferenceCallback
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.SidecarState"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.SidecarState"),
 									},
 								},
 							},
@@ -5076,13 +5137,13 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunStatus(ref common.ReferenceCallback
 					"taskSpec": {
 						SchemaProps: spec.SchemaProps{
 							Description: "TaskSpec contains the Spec from the dereferenced Task definition used to instantiate this TaskRun.",
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskSpec"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskSpec"),
 						},
 					},
 					"provenance": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Provenance contains some key authenticated metadata about how a software artifact was built (what sources, what inputs/outputs, etc.).",
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Provenance"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.Provenance"),
 						},
 					},
 					"spanContext": {
@@ -5106,7 +5167,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunStatus(ref common.ReferenceCallback
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.CloudEventDelivery", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineResourceResult", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Provenance", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.SidecarState", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.StepState", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskRunResult", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskRunStatus", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskSpec", "k8s.io/apimachinery/pkg/apis/meta/v1.Time", "knative.dev/pkg/apis.Condition"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.CloudEventDelivery", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineResourceResult", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.Provenance", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.SidecarState", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.StepState", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskRunResult", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskRunStatus", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskSpec", "k8s.io/apimachinery/pkg/apis/meta/v1.Time", "knative.dev/pkg/apis.Condition"},
 	}
 }
 
@@ -5150,7 +5211,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunStatusFields(ref common.ReferenceCa
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.StepState"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.StepState"),
 									},
 								},
 							},
@@ -5169,7 +5230,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunStatusFields(ref common.ReferenceCa
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.CloudEventDelivery"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.CloudEventDelivery"),
 									},
 								},
 							},
@@ -5188,7 +5249,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunStatusFields(ref common.ReferenceCa
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskRunStatus"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskRunStatus"),
 									},
 								},
 							},
@@ -5207,7 +5268,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunStatusFields(ref common.ReferenceCa
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineResourceResult"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineResourceResult"),
 									},
 								},
 							},
@@ -5226,7 +5287,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunStatusFields(ref common.ReferenceCa
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskRunResult"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskRunResult"),
 									},
 								},
 							},
@@ -5245,7 +5306,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunStatusFields(ref common.ReferenceCa
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.SidecarState"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.SidecarState"),
 									},
 								},
 							},
@@ -5254,13 +5315,13 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunStatusFields(ref common.ReferenceCa
 					"taskSpec": {
 						SchemaProps: spec.SchemaProps{
 							Description: "TaskSpec contains the Spec from the dereferenced Task definition used to instantiate this TaskRun.",
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskSpec"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskSpec"),
 						},
 					},
 					"provenance": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Provenance contains some key authenticated metadata about how a software artifact was built (what sources, what inputs/outputs, etc.).",
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Provenance"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.Provenance"),
 						},
 					},
 					"spanContext": {
@@ -5284,7 +5345,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunStatusFields(ref common.ReferenceCa
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.CloudEventDelivery", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineResourceResult", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Provenance", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.SidecarState", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.StepState", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskRunResult", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskRunStatus", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskSpec", "k8s.io/apimachinery/pkg/apis/meta/v1.Time"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.CloudEventDelivery", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.PipelineResourceResult", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.Provenance", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.SidecarState", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.StepState", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskRunResult", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskRunStatus", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskSpec", "k8s.io/apimachinery/pkg/apis/meta/v1.Time"},
 	}
 }
 
@@ -5329,7 +5390,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskSpec(ref common.ReferenceCallback) com
 					"resources": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Resources is a list input and output resource to run the task Resources are represented in TaskRuns as bindings to instances of PipelineResources.",
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskResources"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskResources"),
 						},
 					},
 					"params": {
@@ -5345,7 +5406,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskSpec(ref common.ReferenceCallback) com
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.ParamSpec"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.ParamSpec"),
 									},
 								},
 							},
@@ -5371,7 +5432,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskSpec(ref common.ReferenceCallback) com
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Step"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.Step"),
 									},
 								},
 							},
@@ -5399,7 +5460,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskSpec(ref common.ReferenceCallback) com
 					"stepTemplate": {
 						SchemaProps: spec.SchemaProps{
 							Description: "StepTemplate can be used as the basis for all step containers within the Task, so that the steps inherit settings on the base container.",
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.StepTemplate"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.StepTemplate"),
 						},
 					},
 					"sidecars": {
@@ -5415,7 +5476,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskSpec(ref common.ReferenceCallback) com
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Sidecar"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.Sidecar"),
 									},
 								},
 							},
@@ -5434,7 +5495,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskSpec(ref common.ReferenceCallback) com
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.WorkspaceDeclaration"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.WorkspaceDeclaration"),
 									},
 								},
 							},
@@ -5453,7 +5514,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskSpec(ref common.ReferenceCallback) com
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskResult"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskResult"),
 									},
 								},
 							},
@@ -5463,7 +5524,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskSpec(ref common.ReferenceCallback) com
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.ParamSpec", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Sidecar", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Step", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.StepTemplate", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskResources", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskResult", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.WorkspaceDeclaration", "k8s.io/api/core/v1.Volume"},
+			"github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.ParamSpec", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.Sidecar", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.Step", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.StepTemplate", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskResources", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.TaskResult", "github.com/tekton/pipeline/pkg/apis/pipeline/v1beta1.WorkspaceDeclaration", "k8s.io/api/core/v1.Volume"},
 	}
 }
 
@@ -5770,21 +5831,21 @@ func schema_pkg_apis_resolution_v1beta1_ResolutionRequest(ref common.ReferenceCa
 						SchemaProps: spec.SchemaProps{
 							Description: "Spec holds the information for the request part of the resource request.",
 							Default:     map[string]interface{}{},
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/resolution/v1beta1.ResolutionRequestSpec"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/resolution/v1beta1.ResolutionRequestSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Status communicates the state of the request and, ultimately, the content of the resolved resource.",
 							Default:     map[string]interface{}{},
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/resolution/v1beta1.ResolutionRequestStatus"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/resolution/v1beta1.ResolutionRequestStatus"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/resolution/v1beta1.ResolutionRequestSpec", "github.com/tektoncd/pipeline/pkg/apis/resolution/v1beta1.ResolutionRequestStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"github.com/tekton/pipeline/pkg/apis/resolution/v1beta1.ResolutionRequestSpec", "github.com/tekton/pipeline/pkg/apis/resolution/v1beta1.ResolutionRequestStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }
 
@@ -5822,7 +5883,7 @@ func schema_pkg_apis_resolution_v1beta1_ResolutionRequestList(ref common.Referen
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/resolution/v1beta1.ResolutionRequest"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/resolution/v1beta1.ResolutionRequest"),
 									},
 								},
 							},
@@ -5833,7 +5894,7 @@ func schema_pkg_apis_resolution_v1beta1_ResolutionRequestList(ref common.Referen
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/resolution/v1beta1.ResolutionRequest", "k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"},
+			"github.com/tekton/pipeline/pkg/apis/resolution/v1beta1.ResolutionRequest", "k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"},
 	}
 }
 
@@ -6005,20 +6066,20 @@ func schema_pkg_apis_resource_v1alpha1_PipelineResource(ref common.ReferenceCall
 						SchemaProps: spec.SchemaProps{
 							Description: "Spec holds the desired state of the PipelineResource from the client",
 							Default:     map[string]interface{}{},
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1.PipelineResourceSpec"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/resource/v1alpha1.PipelineResourceSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Status is deprecated. It usually is used to communicate the observed state of the PipelineResource from the controller, but was unused as there is no controller for PipelineResource.",
-							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1.PipelineResourceStatus"),
+							Ref:         ref("github.com/tekton/pipeline/pkg/apis/resource/v1alpha1.PipelineResourceStatus"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1.PipelineResourceSpec", "github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1.PipelineResourceStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"github.com/tekton/pipeline/pkg/apis/resource/v1alpha1.PipelineResourceSpec", "github.com/tekton/pipeline/pkg/apis/resource/v1alpha1.PipelineResourceStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }
 
@@ -6056,7 +6117,7 @@ func schema_pkg_apis_resource_v1alpha1_PipelineResourceList(ref common.Reference
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1.PipelineResource"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/resource/v1alpha1.PipelineResource"),
 									},
 								},
 							},
@@ -6067,7 +6128,7 @@ func schema_pkg_apis_resource_v1alpha1_PipelineResourceList(ref common.Reference
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1.PipelineResource", "k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"},
+			"github.com/tekton/pipeline/pkg/apis/resource/v1alpha1.PipelineResource", "k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"},
 	}
 }
 
@@ -6104,7 +6165,7 @@ func schema_pkg_apis_resource_v1alpha1_PipelineResourceSpec(ref common.Reference
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1.ResourceParam"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/resource/v1alpha1.ResourceParam"),
 									},
 								},
 							},
@@ -6123,7 +6184,7 @@ func schema_pkg_apis_resource_v1alpha1_PipelineResourceSpec(ref common.Reference
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1.SecretParam"),
+										Ref:     ref("github.com/tekton/pipeline/pkg/apis/resource/v1alpha1.SecretParam"),
 									},
 								},
 							},
@@ -6134,7 +6195,7 @@ func schema_pkg_apis_resource_v1alpha1_PipelineResourceSpec(ref common.Reference
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1.ResourceParam", "github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1.SecretParam"},
+			"github.com/tekton/pipeline/pkg/apis/resource/v1alpha1.ResourceParam", "github.com/tekton/pipeline/pkg/apis/resource/v1alpha1.SecretParam"},
 	}
 }
 

--- a/pkg/apis/pipeline/v1beta1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types.go
@@ -170,6 +170,24 @@ type Matrix struct {
 	// The names of the `params` in the `Matrix` must match the names of the `params` in the underlying `Task` that they will be substituting.
 	// +listType=atomic
 	Params []Param `json:"params,omitempty"`
+
+	// Include is a list of MatrixInclude
+	// Note this field is in preview mode and not yet supported
+	// +optional
+	// +listType=atomic
+	Include []MatrixInclude `json:"include,omitempty"`
+}
+
+// MatrixInclude allows passing in a specific combinations of Parameters into the Matrix.
+// Note this struct is in preview mode and not yet supported
+type MatrixInclude struct {
+	// Name the specified combination
+	Name string `json:"name,omitempty"`
+
+	// Params takes only `Parameters` of type `"string"`
+	// The names of the `params` must match the names of the `params` in the underlying `Task`
+	// +listType=atomic
+	Params []Param `json:"params,omitempty"`
 }
 
 // PipelineTask defines a task in a Pipeline, passing inputs from both
@@ -305,7 +323,7 @@ func (pt PipelineTask) validateTask(ctx context.Context) (errs *apis.FieldError)
 
 // IsMatrixed return whether pipeline task is matrixed
 func (pt *PipelineTask) IsMatrixed() bool {
-	return pt.Matrix != nil && len(pt.Matrix.Params) > 0
+	return pt.Matrix != nil && (len(pt.Matrix.Params) > 0 || len(pt.Matrix.Include) > 0)
 }
 
 func (pt *PipelineTask) validateMatrix(ctx context.Context) (errs *apis.FieldError) {

--- a/pkg/apis/pipeline/v1beta1/pipeline_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types_test.go
@@ -1079,10 +1079,49 @@ func TestPipelineTask_IsMatrixed(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "matrixed",
+			name: "matrixed with params",
 			arg: arg{
 				Matrix: &Matrix{
 					Params: []Param{{Name: "platform", Value: ParamValue{ArrayVal: []string{"linux", "windows"}}}},
+				},
+			},
+			expected: true,
+		}, {
+			name: "matrixed with include",
+			arg: arg{
+				Matrix: &Matrix{
+					Include: []MatrixInclude{
+						{Name: "build-1"},
+						{Params: []Param{
+							{Name: "IMAGE", Value: ParamValue{StringVal: "image-1"}},
+							{Name: "DOCKERFILE", Value: ParamValue{StringVal: "path/to/Dockerfile1"}},
+						}},
+						{Name: "build-2"},
+						{Params: []Param{
+							{Name: "IMAGE", Value: ParamValue{StringVal: "image-2"}},
+							{Name: "DOCKERFILE", Value: ParamValue{StringVal: "path/to/Dockerfile2"}},
+						}},
+						{Name: "build-3"},
+						{Params: []Param{
+							{Name: "IMAGE", Value: ParamValue{StringVal: "image-3"}},
+							{Name: "DOCKERFILE", Value: ParamValue{StringVal: "path/to/Dockerfile3"}},
+						}},
+					},
+				},
+			},
+			expected: true,
+		}, {
+			name: "matrixed with params and include",
+			arg: arg{
+				Matrix: &Matrix{
+					Params: []Param{{Name: "GOARCH", Value: ParamValue{ArrayVal: []string{"linux/amd64", "linux/ppc64le", "linux/s390x"}}}},
+					Include: []MatrixInclude{
+						{Name: "s390x-no-race"},
+						{Params: []Param{
+							{Name: "GOARCH", Value: ParamValue{StringVal: "linux/s390x"}},
+							{Name: "flags", Value: ParamValue{StringVal: "-cover -v"}},
+						}},
+					},
 				},
 			},
 			expected: true,

--- a/pkg/apis/pipeline/v1beta1/swagger.json
+++ b/pkg/apis/pipeline/v1beta1/swagger.json
@@ -7,7 +7,7 @@
   },
   "paths": {},
   "definitions": {
-    "pod.AffinityAssistantTemplate": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.pod.AffinityAssistantTemplate": {
       "description": "AffinityAssistantTemplate holds pod specific configuration and is a subset of the generic pod Template",
       "type": "object",
       "properties": {
@@ -39,7 +39,7 @@
         }
       }
     },
-    "pod.Template": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.pod.Template": {
       "description": "Template holds pod specific configuration",
       "type": "object",
       "properties": {
@@ -151,174 +151,7 @@
         }
       }
     },
-    "v1alpha1.PipelineResource": {
-      "description": "PipelineResource describes a resource that is an input to or output from a Task.",
-      "type": "object",
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
-          "type": "string"
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "default": {},
-          "$ref": "#/definitions/v1.ObjectMeta"
-        },
-        "spec": {
-          "description": "Spec holds the desired state of the PipelineResource from the client",
-          "default": {},
-          "$ref": "#/definitions/v1alpha1.PipelineResourceSpec"
-        },
-        "status": {
-          "description": "Status is deprecated. It usually is used to communicate the observed state of the PipelineResource from the controller, but was unused as there is no controller for PipelineResource.",
-          "$ref": "#/definitions/v1alpha1.PipelineResourceStatus"
-        }
-      }
-    },
-    "v1alpha1.PipelineResourceList": {
-      "description": "PipelineResourceList contains a list of PipelineResources",
-      "type": "object",
-      "required": [
-        "items"
-      ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
-          "type": "string"
-        },
-        "items": {
-          "type": "array",
-          "items": {
-            "default": {},
-            "$ref": "#/definitions/v1alpha1.PipelineResource"
-          }
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "default": {},
-          "$ref": "#/definitions/v1.ListMeta"
-        }
-      }
-    },
-    "v1alpha1.PipelineResourceSpec": {
-      "description": "PipelineResourceSpec defines  an individual resources used in the pipeline.",
-      "type": "object",
-      "required": [
-        "type",
-        "params"
-      ],
-      "properties": {
-        "description": {
-          "description": "Description is a user-facing description of the resource that may be used to populate a UI.",
-          "type": "string"
-        },
-        "params": {
-          "type": "array",
-          "items": {
-            "default": {},
-            "$ref": "#/definitions/v1alpha1.ResourceParam"
-          },
-          "x-kubernetes-list-type": "atomic"
-        },
-        "secrets": {
-          "description": "Secrets to fetch to populate some of resource fields",
-          "type": "array",
-          "items": {
-            "default": {},
-            "$ref": "#/definitions/v1alpha1.SecretParam"
-          },
-          "x-kubernetes-list-type": "atomic"
-        },
-        "type": {
-          "type": "string",
-          "default": ""
-        }
-      }
-    },
-    "v1alpha1.PipelineResourceStatus": {
-      "description": "PipelineResourceStatus does not contain anything because PipelineResources on their own do not have a status Deprecated",
-      "type": "object"
-    },
-    "v1alpha1.ResourceDeclaration": {
-      "description": "ResourceDeclaration defines an input or output PipelineResource declared as a requirement by another type such as a Task or Condition. The Name field will be used to refer to these PipelineResources within the type's definition, and when provided as an Input, the Name will be the path to the volume mounted containing this PipelineResource as an input (e.g. an input Resource named `workspace` will be mounted at `/workspace`).",
-      "type": "object",
-      "required": [
-        "name",
-        "type"
-      ],
-      "properties": {
-        "description": {
-          "description": "Description is a user-facing description of the declared resource that may be used to populate a UI.",
-          "type": "string"
-        },
-        "name": {
-          "description": "Name declares the name by which a resource is referenced in the definition. Resources may be referenced by name in the definition of a Task's steps.",
-          "type": "string",
-          "default": ""
-        },
-        "optional": {
-          "description": "Optional declares the resource as optional. By default optional is set to false which makes a resource required. optional: true - the resource is considered optional optional: false - the resource is considered required (equivalent of not specifying it)",
-          "type": "boolean"
-        },
-        "targetPath": {
-          "description": "TargetPath is the path in workspace directory where the resource will be copied.",
-          "type": "string"
-        },
-        "type": {
-          "description": "Type is the type of this resource;",
-          "type": "string",
-          "default": ""
-        }
-      }
-    },
-    "v1alpha1.ResourceParam": {
-      "description": "ResourceParam declares a string value to use for the parameter called Name, and is used in the specific context of PipelineResources.",
-      "type": "object",
-      "required": [
-        "name",
-        "value"
-      ],
-      "properties": {
-        "name": {
-          "type": "string",
-          "default": ""
-        },
-        "value": {
-          "type": "string",
-          "default": ""
-        }
-      }
-    },
-    "v1alpha1.SecretParam": {
-      "description": "SecretParam indicates which secret can be used to populate a field of the resource",
-      "type": "object",
-      "required": [
-        "fieldName",
-        "secretKey",
-        "secretName"
-      ],
-      "properties": {
-        "fieldName": {
-          "type": "string",
-          "default": ""
-        },
-        "secretKey": {
-          "type": "string",
-          "default": ""
-        },
-        "secretName": {
-          "type": "string",
-          "default": ""
-        }
-      }
-    },
-    "v1beta1.ChildStatusReference": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.ChildStatusReference": {
       "description": "ChildStatusReference is used to point to the statuses of individual TaskRuns and Runs within this PipelineRun.",
       "type": "object",
       "properties": {
@@ -341,19 +174,19 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.WhenExpression"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.WhenExpression"
           },
           "x-kubernetes-list-type": "atomic"
         }
       }
     },
-    "v1beta1.CloudEventDelivery": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.CloudEventDelivery": {
       "description": "CloudEventDelivery is the target of a cloud event along with the state of delivery.",
       "type": "object",
       "properties": {
         "status": {
           "default": {},
-          "$ref": "#/definitions/v1beta1.CloudEventDeliveryState"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.CloudEventDeliveryState"
         },
         "target": {
           "description": "Target points to an addressable",
@@ -361,7 +194,7 @@
         }
       }
     },
-    "v1beta1.CloudEventDeliveryState": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.CloudEventDeliveryState": {
       "description": "CloudEventDeliveryState reports the state of a cloud event to be sent.",
       "type": "object",
       "required": [
@@ -390,7 +223,7 @@
         }
       }
     },
-    "v1beta1.ClusterTask": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.ClusterTask": {
       "description": "ClusterTask is a Task with a cluster scope. ClusterTasks are used to represent Tasks that should be publicly addressable from any namespace in the cluster. Deprecated: Please use the cluster resolver instead.",
       "type": "object",
       "properties": {
@@ -409,11 +242,11 @@
         "spec": {
           "description": "Spec holds the desired state of the Task from the client",
           "default": {},
-          "$ref": "#/definitions/v1beta1.TaskSpec"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.TaskSpec"
         }
       }
     },
-    "v1beta1.ClusterTaskList": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.ClusterTaskList": {
       "description": "ClusterTaskList contains a list of ClusterTask",
       "type": "object",
       "required": [
@@ -428,7 +261,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.ClusterTask"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.ClusterTask"
           }
         },
         "kind": {
@@ -441,7 +274,7 @@
         }
       }
     },
-    "v1beta1.ConfigSource": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.ConfigSource": {
       "description": "ConfigSource identifies the source where a resource came from. This can include Git repositories, Task Bundles, file checksums, or other information that allows users to identify where the resource came from and what version was used.",
       "type": "object",
       "properties": {
@@ -463,7 +296,7 @@
         }
       }
     },
-    "v1beta1.CustomRun": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.CustomRun": {
       "description": "CustomRun represents a single execution of a Custom Task.",
       "type": "object",
       "properties": {
@@ -481,7 +314,7 @@
         },
         "spec": {
           "default": {},
-          "$ref": "#/definitions/v1beta1.CustomRunSpec"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.CustomRunSpec"
         },
         "status": {
           "default": {},
@@ -489,7 +322,7 @@
         }
       }
     },
-    "v1beta1.CustomRunList": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.CustomRunList": {
       "description": "CustomRunList contains a list of CustomRun",
       "type": "object",
       "required": [
@@ -504,7 +337,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.CustomRun"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.CustomRun"
           }
         },
         "kind": {
@@ -517,22 +350,22 @@
         }
       }
     },
-    "v1beta1.CustomRunSpec": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.CustomRunSpec": {
       "description": "CustomRunSpec defines the desired state of CustomRun",
       "type": "object",
       "properties": {
         "customRef": {
-          "$ref": "#/definitions/v1beta1.TaskRef"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.TaskRef"
         },
         "customSpec": {
           "description": "Spec is a specification of a custom task",
-          "$ref": "#/definitions/v1beta1.EmbeddedCustomRunSpec"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.EmbeddedCustomRunSpec"
         },
         "params": {
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.Param"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.Param"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -562,13 +395,13 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.WorkspaceBinding"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.WorkspaceBinding"
           },
           "x-kubernetes-list-type": "atomic"
         }
       }
     },
-    "v1beta1.EmbeddedCustomRunSpec": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.EmbeddedCustomRunSpec": {
       "description": "EmbeddedCustomRunSpec allows custom task definitions to be embedded",
       "type": "object",
       "properties": {
@@ -580,7 +413,7 @@
         },
         "metadata": {
           "default": {},
-          "$ref": "#/definitions/v1beta1.PipelineTaskMetadata"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.PipelineTaskMetadata"
         },
         "spec": {
           "description": "Spec is a specification of a custom task",
@@ -589,7 +422,7 @@
         }
       }
     },
-    "v1beta1.EmbeddedTask": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.EmbeddedTask": {
       "description": "EmbeddedTask is used to define a Task inline within a Pipeline's PipelineTasks.",
       "type": "object",
       "properties": {
@@ -605,27 +438,27 @@
         },
         "metadata": {
           "default": {},
-          "$ref": "#/definitions/v1beta1.PipelineTaskMetadata"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.PipelineTaskMetadata"
         },
         "params": {
           "description": "Params is a list of input parameters required to run the task. Params must be supplied as inputs in TaskRuns unless they declare a default value.",
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.ParamSpec"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.ParamSpec"
           },
           "x-kubernetes-list-type": "atomic"
         },
         "resources": {
           "description": "Resources is a list input and output resource to run the task Resources are represented in TaskRuns as bindings to instances of PipelineResources.",
-          "$ref": "#/definitions/v1beta1.TaskResources"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.TaskResources"
         },
         "results": {
           "description": "Results are values that this Task can output",
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.TaskResult"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.TaskResult"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -634,7 +467,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.Sidecar"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.Sidecar"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -645,14 +478,14 @@
         },
         "stepTemplate": {
           "description": "StepTemplate can be used as the basis for all step containers within the Task, so that the steps inherit settings on the base container.",
-          "$ref": "#/definitions/v1beta1.StepTemplate"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.StepTemplate"
         },
         "steps": {
           "description": "Steps are the steps of the build; each step is run sequentially with the source mounted into /workspace.",
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.Step"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.Step"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -670,13 +503,13 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.WorkspaceDeclaration"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.WorkspaceDeclaration"
           },
           "x-kubernetes-list-type": "atomic"
         }
       }
     },
-    "v1beta1.InternalTaskModifier": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.InternalTaskModifier": {
       "description": "InternalTaskModifier implements TaskModifier for resources that are built-in to Tekton Pipelines.",
       "type": "object",
       "required": [
@@ -689,7 +522,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.Step"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.Step"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -697,7 +530,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.Step"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.Step"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -711,22 +544,50 @@
         }
       }
     },
-    "v1beta1.Matrix": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.Matrix": {
       "description": "Matrix is used to fan out Tasks in a Pipeline",
       "type": "object",
       "properties": {
+        "include": {
+          "description": "Include is a list of MatrixInclude Note this field is in preview mode and not yet supported",
+          "type": "array",
+          "items": {
+            "default": {},
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.MatrixInclude"
+          },
+          "x-kubernetes-list-type": "atomic"
+        },
         "params": {
           "description": "Params is a list of parameters used to fan out the pipelineTask Params takes only `Parameters` of type `\"array\"` Each array element is supplied to the `PipelineTask` by substituting `params` of type `\"string\"` in the underlying `Task`. The names of the `params` in the `Matrix` must match the names of the `params` in the underlying `Task` that they will be substituting.",
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.Param"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.Param"
           },
           "x-kubernetes-list-type": "atomic"
         }
       }
     },
-    "v1beta1.Param": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.MatrixInclude": {
+      "description": "MatrixInclude allows passing in a specific combinations of Parameters into the Matrix. Note this struct is in preview mode and not yet supported",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Name the specified combination",
+          "type": "string"
+        },
+        "params": {
+          "description": "Params takes only `Parameters` of type `\"string\"` The names of the `params` must match the names of the `params` in the underlying `Task`",
+          "type": "array",
+          "items": {
+            "default": {},
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.Param"
+          },
+          "x-kubernetes-list-type": "atomic"
+        }
+      }
+    },
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.Param": {
       "description": "Param declares an ParamValues to use for the parameter called name.",
       "type": "object",
       "required": [
@@ -740,11 +601,11 @@
         },
         "value": {
           "default": {},
-          "$ref": "#/definitions/v1beta1.ParamValue"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.ParamValue"
         }
       }
     },
-    "v1beta1.ParamSpec": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.ParamSpec": {
       "description": "ParamSpec defines arbitrary parameters needed beyond typed inputs (such as resources). Parameter values are provided by users as inputs on a TaskRun or PipelineRun.",
       "type": "object",
       "required": [
@@ -753,7 +614,7 @@
       "properties": {
         "default": {
           "description": "Default is the value a parameter takes if no input value is supplied. If default is set, a Task may be executed without a supplied value for the parameter.",
-          "$ref": "#/definitions/v1beta1.ParamValue"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.ParamValue"
         },
         "description": {
           "description": "Description is a user-facing description of the parameter that may be used to populate a UI.",
@@ -769,7 +630,7 @@
           "type": "object",
           "additionalProperties": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.PropertySpec"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.PropertySpec"
           }
         },
         "type": {
@@ -778,7 +639,7 @@
         }
       }
     },
-    "v1beta1.ParamValue": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.ParamValue": {
       "description": "ResultValue is a type alias of ParamValue",
       "type": "object",
       "required": [
@@ -814,7 +675,7 @@
         }
       }
     },
-    "v1beta1.Pipeline": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.Pipeline": {
       "description": "Pipeline describes a list of Tasks to execute. It expresses how outputs of tasks feed into inputs of subsequent tasks.",
       "type": "object",
       "properties": {
@@ -833,11 +694,11 @@
         "spec": {
           "description": "Spec holds the desired state of the Pipeline from the client",
           "default": {},
-          "$ref": "#/definitions/v1beta1.PipelineSpec"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.PipelineSpec"
         }
       }
     },
-    "v1beta1.PipelineDeclaredResource": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.PipelineDeclaredResource": {
       "description": "PipelineDeclaredResource is used by a Pipeline to declare the types of the PipelineResources that it will required to run and names which can be used to refer to these PipelineResources in PipelineTaskResourceBindings.",
       "type": "object",
       "required": [
@@ -861,7 +722,7 @@
         }
       }
     },
-    "v1beta1.PipelineList": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.PipelineList": {
       "description": "PipelineList contains a list of Pipeline",
       "type": "object",
       "required": [
@@ -876,7 +737,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.Pipeline"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.Pipeline"
           }
         },
         "kind": {
@@ -889,7 +750,7 @@
         }
       }
     },
-    "v1beta1.PipelineRef": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.PipelineRef": {
       "description": "PipelineRef can be used to refer to a specific instance of a Pipeline.",
       "type": "object",
       "properties": {
@@ -907,7 +768,7 @@
         }
       }
     },
-    "v1beta1.PipelineResourceBinding": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.PipelineResourceBinding": {
       "description": "PipelineResourceBinding connects a reference to an instance of a PipelineResource with a PipelineResource dependency that the Pipeline has declared",
       "type": "object",
       "properties": {
@@ -917,7 +778,7 @@
         },
         "resourceRef": {
           "description": "ResourceRef is a reference to the instance of the actual PipelineResource that should be used",
-          "$ref": "#/definitions/v1beta1.PipelineResourceRef"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.PipelineResourceRef"
         },
         "resourceSpec": {
           "description": "ResourceSpec is specification of a resource that should be created and consumed by the task",
@@ -925,7 +786,7 @@
         }
       }
     },
-    "v1beta1.PipelineResourceRef": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.PipelineResourceRef": {
       "description": "PipelineResourceRef can be used to refer to a specific instance of a Resource",
       "type": "object",
       "properties": {
@@ -939,7 +800,7 @@
         }
       }
     },
-    "v1beta1.PipelineResourceResult": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.PipelineResourceResult": {
       "description": "PipelineResourceResult used to export the image name and digest as json",
       "type": "object",
       "required": [
@@ -964,7 +825,7 @@
         }
       }
     },
-    "v1beta1.PipelineResult": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.PipelineResult": {
       "description": "PipelineResult used to describe the results of a pipeline",
       "type": "object",
       "required": [
@@ -989,11 +850,11 @@
         "value": {
           "description": "Value the expression used to retrieve the value",
           "default": {},
-          "$ref": "#/definitions/v1beta1.ParamValue"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.ParamValue"
         }
       }
     },
-    "v1beta1.PipelineRun": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.PipelineRun": {
       "description": "PipelineRun represents a single execution of a Pipeline. PipelineRuns are how the graph of Tasks declared in a Pipeline are executed; they specify inputs to Pipelines such as parameter values and capture operational aspects of the Tasks execution such as service account and tolerations. Creating a PipelineRun creates TaskRuns for Tasks in the referenced Pipeline.",
       "type": "object",
       "properties": {
@@ -1011,15 +872,15 @@
         },
         "spec": {
           "default": {},
-          "$ref": "#/definitions/v1beta1.PipelineRunSpec"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.PipelineRunSpec"
         },
         "status": {
           "default": {},
-          "$ref": "#/definitions/v1beta1.PipelineRunStatus"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.PipelineRunStatus"
         }
       }
     },
-    "v1beta1.PipelineRunList": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.PipelineRunList": {
       "description": "PipelineRunList contains a list of PipelineRun",
       "type": "object",
       "properties": {
@@ -1031,7 +892,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.PipelineRun"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.PipelineRun"
           }
         },
         "kind": {
@@ -1044,7 +905,7 @@
         }
       }
     },
-    "v1beta1.PipelineRunResult": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.PipelineRunResult": {
       "description": "PipelineRunResult used to describe the results of a pipeline",
       "type": "object",
       "required": [
@@ -1060,11 +921,11 @@
         "value": {
           "description": "Value is the result returned from the execution of this PipelineRun",
           "default": {},
-          "$ref": "#/definitions/v1beta1.ParamValue"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.ParamValue"
         }
       }
     },
-    "v1beta1.PipelineRunRunStatus": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.PipelineRunRunStatus": {
       "description": "PipelineRunRunStatus contains the name of the PipelineTask for this CustomRun or Run and the CustomRun or Run's Status",
       "type": "object",
       "properties": {
@@ -1081,13 +942,13 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.WhenExpression"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.WhenExpression"
           },
           "x-kubernetes-list-type": "atomic"
         }
       }
     },
-    "v1beta1.PipelineRunSpec": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.PipelineRunSpec": {
       "description": "PipelineRunSpec defines the desired state of PipelineRun",
       "type": "object",
       "properties": {
@@ -1096,15 +957,15 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.Param"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.Param"
           },
           "x-kubernetes-list-type": "atomic"
         },
         "pipelineRef": {
-          "$ref": "#/definitions/v1beta1.PipelineRef"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.PipelineRef"
         },
         "pipelineSpec": {
-          "$ref": "#/definitions/v1beta1.PipelineSpec"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.PipelineSpec"
         },
         "podTemplate": {
           "description": "PodTemplate holds pod specific configuration",
@@ -1115,7 +976,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.PipelineResourceBinding"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.PipelineResourceBinding"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -1131,7 +992,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.PipelineTaskRunSpec"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.PipelineTaskRunSpec"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -1141,20 +1002,20 @@
         },
         "timeouts": {
           "description": "Time after which the Pipeline times out. Currently three keys are accepted in the map pipeline, tasks and finally with Timeouts.pipeline \u003e= Timeouts.tasks + Timeouts.finally",
-          "$ref": "#/definitions/v1beta1.TimeoutFields"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.TimeoutFields"
         },
         "workspaces": {
           "description": "Workspaces holds a set of workspace bindings that must match names with those declared in the pipeline.",
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.WorkspaceBinding"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.WorkspaceBinding"
           },
           "x-kubernetes-list-type": "atomic"
         }
       }
     },
-    "v1beta1.PipelineRunStatus": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.PipelineRunStatus": {
       "description": "PipelineRunStatus defines the observed state of PipelineRun",
       "type": "object",
       "properties": {
@@ -1171,7 +1032,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.ChildStatusReference"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.ChildStatusReference"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -1203,24 +1064,24 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.PipelineRunResult"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.PipelineRunResult"
           },
           "x-kubernetes-list-type": "atomic"
         },
         "pipelineSpec": {
           "description": "PipelineRunSpec contains the exact spec used to instantiate the run",
-          "$ref": "#/definitions/v1beta1.PipelineSpec"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.PipelineSpec"
         },
         "provenance": {
           "description": "Provenance contains some key authenticated metadata about how a software artifact was built (what sources, what inputs/outputs, etc.).",
-          "$ref": "#/definitions/v1beta1.Provenance"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.Provenance"
         },
         "skippedTasks": {
           "description": "list of tasks that were skipped due to when expressions evaluating to false",
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.SkippedTask"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.SkippedTask"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -1238,7 +1099,7 @@
         }
       }
     },
-    "v1beta1.PipelineRunStatusFields": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.PipelineRunStatusFields": {
       "description": "PipelineRunStatusFields holds the fields of PipelineRunStatus' status. This is defined separately and inlined so that other types can readily consume these fields via duck typing.",
       "type": "object",
       "properties": {
@@ -1247,7 +1108,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.ChildStatusReference"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.ChildStatusReference"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -1264,24 +1125,24 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.PipelineRunResult"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.PipelineRunResult"
           },
           "x-kubernetes-list-type": "atomic"
         },
         "pipelineSpec": {
           "description": "PipelineRunSpec contains the exact spec used to instantiate the run",
-          "$ref": "#/definitions/v1beta1.PipelineSpec"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.PipelineSpec"
         },
         "provenance": {
           "description": "Provenance contains some key authenticated metadata about how a software artifact was built (what sources, what inputs/outputs, etc.).",
-          "$ref": "#/definitions/v1beta1.Provenance"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.Provenance"
         },
         "skippedTasks": {
           "description": "list of tasks that were skipped due to when expressions evaluating to false",
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.SkippedTask"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.SkippedTask"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -1299,7 +1160,7 @@
         }
       }
     },
-    "v1beta1.PipelineRunTaskRunStatus": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.PipelineRunTaskRunStatus": {
       "description": "PipelineRunTaskRunStatus contains the name of the PipelineTask for this TaskRun and the TaskRun's Status",
       "type": "object",
       "properties": {
@@ -1309,20 +1170,20 @@
         },
         "status": {
           "description": "Status is the TaskRunStatus for the corresponding TaskRun",
-          "$ref": "#/definitions/v1beta1.TaskRunStatus"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.TaskRunStatus"
         },
         "whenExpressions": {
           "description": "WhenExpressions is the list of checks guarding the execution of the PipelineTask",
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.WhenExpression"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.WhenExpression"
           },
           "x-kubernetes-list-type": "atomic"
         }
       }
     },
-    "v1beta1.PipelineSpec": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.PipelineSpec": {
       "description": "PipelineSpec defines the desired state of Pipeline.",
       "type": "object",
       "properties": {
@@ -1335,7 +1196,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.PipelineTask"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.PipelineTask"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -1344,7 +1205,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.ParamSpec"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.ParamSpec"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -1353,7 +1214,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.PipelineDeclaredResource"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.PipelineDeclaredResource"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -1362,7 +1223,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.PipelineResult"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.PipelineResult"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -1371,7 +1232,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.PipelineTask"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.PipelineTask"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -1380,19 +1241,19 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.PipelineWorkspaceDeclaration"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.PipelineWorkspaceDeclaration"
           },
           "x-kubernetes-list-type": "atomic"
         }
       }
     },
-    "v1beta1.PipelineTask": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.PipelineTask": {
       "description": "PipelineTask defines a task in a Pipeline, passing inputs from both Params and from the output of previous tasks.",
       "type": "object",
       "properties": {
         "matrix": {
           "description": "Matrix declares parameters used to fan out this task.",
-          "$ref": "#/definitions/v1beta1.Matrix"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.Matrix"
         },
         "name": {
           "description": "Name is the name of this task within the context of a Pipeline. Name is used as a coordinate with the `from` and `runAfter` fields to establish the execution order of tasks relative to one another.",
@@ -1403,13 +1264,13 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.Param"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.Param"
           },
           "x-kubernetes-list-type": "atomic"
         },
         "resources": {
           "description": "Resources declares the resources given to this task as inputs and outputs.",
-          "$ref": "#/definitions/v1beta1.PipelineTaskResources"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.PipelineTaskResources"
         },
         "retries": {
           "description": "Retries represents how many times this task should be retried in case of task failure: ConditionSucceeded set to False",
@@ -1427,11 +1288,11 @@
         },
         "taskRef": {
           "description": "TaskRef is a reference to a task definition.",
-          "$ref": "#/definitions/v1beta1.TaskRef"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.TaskRef"
         },
         "taskSpec": {
           "description": "TaskSpec is a specification of a task",
-          "$ref": "#/definitions/v1beta1.EmbeddedTask"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.EmbeddedTask"
         },
         "timeout": {
           "description": "Time after which the TaskRun times out. Defaults to 1 hour. Specified TaskRun timeout should be less than 24h. Refer Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration",
@@ -1442,7 +1303,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.WhenExpression"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.WhenExpression"
           }
         },
         "workspaces": {
@@ -1450,13 +1311,13 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.WorkspacePipelineTaskBinding"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.WorkspacePipelineTaskBinding"
           },
           "x-kubernetes-list-type": "atomic"
         }
       }
     },
-    "v1beta1.PipelineTaskInputResource": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.PipelineTaskInputResource": {
       "description": "PipelineTaskInputResource maps the name of a declared PipelineResource input dependency in a Task to the resource in the Pipeline's DeclaredPipelineResources that should be used. This input may come from a previous task.",
       "type": "object",
       "required": [
@@ -1485,7 +1346,7 @@
         }
       }
     },
-    "v1beta1.PipelineTaskMetadata": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.PipelineTaskMetadata": {
       "description": "PipelineTaskMetadata contains the labels or annotations for an EmbeddedTask",
       "type": "object",
       "properties": {
@@ -1505,7 +1366,7 @@
         }
       }
     },
-    "v1beta1.PipelineTaskOutputResource": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.PipelineTaskOutputResource": {
       "description": "PipelineTaskOutputResource maps the name of a declared PipelineResource output dependency in a Task to the resource in the Pipeline's DeclaredPipelineResources that should be used.",
       "type": "object",
       "required": [
@@ -1525,7 +1386,7 @@
         }
       }
     },
-    "v1beta1.PipelineTaskParam": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.PipelineTaskParam": {
       "description": "PipelineTaskParam is used to provide arbitrary string parameters to a Task.",
       "type": "object",
       "required": [
@@ -1543,7 +1404,7 @@
         }
       }
     },
-    "v1beta1.PipelineTaskResources": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.PipelineTaskResources": {
       "description": "PipelineTaskResources allows a Pipeline to declare how its DeclaredPipelineResources should be provided to a Task as its inputs and outputs.",
       "type": "object",
       "properties": {
@@ -1552,7 +1413,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.PipelineTaskInputResource"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.PipelineTaskInputResource"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -1561,13 +1422,13 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.PipelineTaskOutputResource"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.PipelineTaskOutputResource"
           },
           "x-kubernetes-list-type": "atomic"
         }
       }
     },
-    "v1beta1.PipelineTaskRun": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.PipelineTaskRun": {
       "description": "PipelineTaskRun reports the results of running a step in the Task. Each task has the potential to succeed or fail (based on the exit code) and produces logs.",
       "type": "object",
       "properties": {
@@ -1576,7 +1437,7 @@
         }
       }
     },
-    "v1beta1.PipelineTaskRunSpec": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.PipelineTaskRunSpec": {
       "description": "PipelineTaskRunSpec  can be used to configure specific specs for a concrete Task",
       "type": "object",
       "properties": {
@@ -1585,7 +1446,7 @@
           "$ref": "#/definitions/v1.ResourceRequirements"
         },
         "metadata": {
-          "$ref": "#/definitions/v1beta1.PipelineTaskMetadata"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.PipelineTaskMetadata"
         },
         "pipelineTaskName": {
           "type": "string"
@@ -1594,7 +1455,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.TaskRunSidecarOverride"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.TaskRunSidecarOverride"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -1602,7 +1463,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.TaskRunStepOverride"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.TaskRunStepOverride"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -1614,7 +1475,7 @@
         }
       }
     },
-    "v1beta1.PipelineWorkspaceDeclaration": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.PipelineWorkspaceDeclaration": {
       "description": "WorkspacePipelineDeclaration creates a named slot in a Pipeline that a PipelineRun is expected to populate with a workspace binding. Deprecated: use PipelineWorkspaceDeclaration type instead",
       "type": "object",
       "required": [
@@ -1636,7 +1497,7 @@
         }
       }
     },
-    "v1beta1.PropertySpec": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.PropertySpec": {
       "description": "PropertySpec defines the struct for object keys",
       "type": "object",
       "properties": {
@@ -1645,13 +1506,13 @@
         }
       }
     },
-    "v1beta1.Provenance": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.Provenance": {
       "description": "Provenance contains some key authenticated metadata about how a software artifact was built (what sources, what inputs/outputs, etc.). For now, it only contains the subfield `ConfigSource` that identifies the source where a build config file came from. In future, it can be expanded as needed to include more metadata about the build. This field aims to be used to carry minimum amount of the authenticated metadata in *Run status so that Tekton Chains can pick it up and record in the provenance it generates.",
       "type": "object",
       "properties": {
         "configSource": {
           "description": "ConfigSource identifies the source where a resource came from.",
-          "$ref": "#/definitions/v1beta1.ConfigSource"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.ConfigSource"
         },
         "featureFlags": {
           "description": "FeatureFlags identifies the feature flags that were used during the task/pipeline run",
@@ -1659,139 +1520,7 @@
         }
       }
     },
-    "v1beta1.ResolutionRequest": {
-      "description": "ResolutionRequest is an object for requesting the content of a Tekton resource like a pipeline.yaml.",
-      "type": "object",
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
-          "type": "string"
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "default": {},
-          "$ref": "#/definitions/v1.ObjectMeta"
-        },
-        "spec": {
-          "description": "Spec holds the information for the request part of the resource request.",
-          "default": {},
-          "$ref": "#/definitions/v1beta1.ResolutionRequestSpec"
-        },
-        "status": {
-          "description": "Status communicates the state of the request and, ultimately, the content of the resolved resource.",
-          "default": {},
-          "$ref": "#/definitions/v1beta1.ResolutionRequestStatus"
-        }
-      }
-    },
-    "v1beta1.ResolutionRequestList": {
-      "description": "ResolutionRequestList is a list of ResolutionRequests.",
-      "type": "object",
-      "required": [
-        "items"
-      ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
-          "type": "string"
-        },
-        "items": {
-          "type": "array",
-          "items": {
-            "default": {},
-            "$ref": "#/definitions/v1beta1.ResolutionRequest"
-          }
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "default": {},
-          "$ref": "#/definitions/v1.ListMeta"
-        }
-      }
-    },
-    "v1beta1.ResolutionRequestSpec": {
-      "description": "ResolutionRequestSpec are all the fields in the spec of the ResolutionRequest CRD.",
-      "type": "object",
-      "properties": {
-        "params": {
-          "description": "Parameters are the runtime attributes passed to the resolver to help it figure out how to resolve the resource being requested. For example: repo URL, commit SHA, path to file, the kind of authentication to leverage, etc.",
-          "type": "array",
-          "items": {
-            "default": {},
-            "$ref": "#/definitions/v1beta1.Param"
-          },
-          "x-kubernetes-list-type": "atomic"
-        }
-      }
-    },
-    "v1beta1.ResolutionRequestStatus": {
-      "description": "ResolutionRequestStatus are all the fields in a ResolutionRequest's status subresource.",
-      "type": "object",
-      "required": [
-        "data",
-        "source"
-      ],
-      "properties": {
-        "annotations": {
-          "description": "Annotations is additional Status fields for the Resource to save some additional State as well as convey more information to the user. This is roughly akin to Annotations on any k8s resource, just the reconciler conveying richer information outwards.",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string",
-            "default": ""
-          }
-        },
-        "conditions": {
-          "description": "Conditions the latest available observations of a resource's current state.",
-          "type": "array",
-          "items": {
-            "default": {},
-            "$ref": "#/definitions/knative.Condition"
-          },
-          "x-kubernetes-patch-merge-key": "type",
-          "x-kubernetes-patch-strategy": "merge"
-        },
-        "data": {
-          "description": "Data is a string representation of the resolved content of the requested resource in-lined into the ResolutionRequest object.",
-          "type": "string",
-          "default": ""
-        },
-        "observedGeneration": {
-          "description": "ObservedGeneration is the 'Generation' of the Service that was last processed by the controller.",
-          "type": "integer",
-          "format": "int64"
-        },
-        "source": {
-          "description": "Source is the source reference of the remote data that records the url, digest and the entrypoint.",
-          "$ref": "#/definitions/v1beta1.ConfigSource"
-        }
-      }
-    },
-    "v1beta1.ResolutionRequestStatusFields": {
-      "description": "ResolutionRequestStatusFields are the ResolutionRequest-specific fields for the status subresource.",
-      "type": "object",
-      "required": [
-        "data",
-        "source"
-      ],
-      "properties": {
-        "data": {
-          "description": "Data is a string representation of the resolved content of the requested resource in-lined into the ResolutionRequest object.",
-          "type": "string",
-          "default": ""
-        },
-        "source": {
-          "description": "Source is the source reference of the remote data that records the url, digest and the entrypoint.",
-          "$ref": "#/definitions/v1beta1.ConfigSource"
-        }
-      }
-    },
-    "v1beta1.ResolverRef": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.ResolverRef": {
       "description": "ResolverRef can be used to refer to a Pipeline or Task in a remote location like a git repo.",
       "type": "object",
       "properties": {
@@ -1800,7 +1529,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.Param"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.Param"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -1810,7 +1539,7 @@
         }
       }
     },
-    "v1beta1.ResultRef": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.ResultRef": {
       "description": "ResultRef is a type that represents a reference to a task run result",
       "type": "object",
       "required": [
@@ -1839,7 +1568,7 @@
         }
       }
     },
-    "v1beta1.Sidecar": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.Sidecar": {
       "description": "Sidecar has nearly the same data structure as Step but does not have the ability to timeout.",
       "type": "object",
       "required": [
@@ -1992,13 +1721,13 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.WorkspaceUsage"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.WorkspaceUsage"
           },
           "x-kubernetes-list-type": "atomic"
         }
       }
     },
-    "v1beta1.SidecarState": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.SidecarState": {
       "description": "SidecarState reports the results of running a sidecar in a Task.",
       "type": "object",
       "properties": {
@@ -2025,7 +1754,7 @@
         }
       }
     },
-    "v1beta1.SkippedTask": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.SkippedTask": {
       "description": "SkippedTask is used to describe the Tasks that were skipped due to their When Expressions evaluating to False. This is a struct because we are looking into including more details about the When Expressions that caused this Task to be skipped.",
       "type": "object",
       "required": [
@@ -2048,13 +1777,13 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.WhenExpression"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.WhenExpression"
           },
           "x-kubernetes-list-type": "atomic"
         }
       }
     },
-    "v1beta1.Step": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.Step": {
       "description": "Step runs a subcomponent of a Task",
       "type": "object",
       "required": [
@@ -2162,7 +1891,7 @@
         },
         "stderrConfig": {
           "description": "Stores configuration for the stderr stream of the step.",
-          "$ref": "#/definitions/v1beta1.StepOutputConfig"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.StepOutputConfig"
         },
         "stdin": {
           "description": "Deprecated. This field will be removed in a future release. Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.",
@@ -2174,7 +1903,7 @@
         },
         "stdoutConfig": {
           "description": "Stores configuration for the stdout stream of the step.",
-          "$ref": "#/definitions/v1beta1.StepOutputConfig"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.StepOutputConfig"
         },
         "terminationMessagePath": {
           "description": "Deprecated. This field will be removed in a future release and can't be meaningfully used.",
@@ -2223,13 +1952,13 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.WorkspaceUsage"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.WorkspaceUsage"
           },
           "x-kubernetes-list-type": "atomic"
         }
       }
     },
-    "v1beta1.StepOutputConfig": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.StepOutputConfig": {
       "description": "StepOutputConfig stores configuration for a step output stream.",
       "type": "object",
       "properties": {
@@ -2239,7 +1968,7 @@
         }
       }
     },
-    "v1beta1.StepState": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.StepState": {
       "description": "StepState reports the results of running a step in a Task.",
       "type": "object",
       "properties": {
@@ -2266,7 +1995,7 @@
         }
       }
     },
-    "v1beta1.StepTemplate": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.StepTemplate": {
       "description": "StepTemplate is a template for a Step",
       "type": "object",
       "required": [
@@ -2412,7 +2141,7 @@
         }
       }
     },
-    "v1beta1.Task": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.Task": {
       "description": "Task represents a collection of sequential steps that are run as part of a Pipeline using a set of inputs and producing a set of outputs. Tasks execute when TaskRuns are created that provide the input parameters and resources and output resources the Task requires.",
       "type": "object",
       "properties": {
@@ -2431,11 +2160,11 @@
         "spec": {
           "description": "Spec holds the desired state of the Task from the client",
           "default": {},
-          "$ref": "#/definitions/v1beta1.TaskSpec"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.TaskSpec"
         }
       }
     },
-    "v1beta1.TaskList": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.TaskList": {
       "description": "TaskList contains a list of Task",
       "type": "object",
       "required": [
@@ -2450,7 +2179,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.Task"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.Task"
           }
         },
         "kind": {
@@ -2463,7 +2192,7 @@
         }
       }
     },
-    "v1beta1.TaskRef": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.TaskRef": {
       "description": "TaskRef can be used to refer to a specific instance of a task.",
       "type": "object",
       "properties": {
@@ -2485,7 +2214,7 @@
         }
       }
     },
-    "v1beta1.TaskResource": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.TaskResource": {
       "description": "TaskResource defines an input or output Resource declared as a requirement by a Task. The Name field will be used to refer to these Resources within the Task definition, and when provided as an Input, the Name will be the path to the volume mounted containing this Resource as an input (e.g. an input Resource named `workspace` will be mounted at `/workspace`).",
       "type": "object",
       "required": [
@@ -2517,7 +2246,7 @@
         }
       }
     },
-    "v1beta1.TaskResourceBinding": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.TaskResourceBinding": {
       "description": "TaskResourceBinding points to the PipelineResource that will be used for the Task input or output called Name.",
       "type": "object",
       "properties": {
@@ -2536,7 +2265,7 @@
         },
         "resourceRef": {
           "description": "ResourceRef is a reference to the instance of the actual PipelineResource that should be used",
-          "$ref": "#/definitions/v1beta1.PipelineResourceRef"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.PipelineResourceRef"
         },
         "resourceSpec": {
           "description": "ResourceSpec is specification of a resource that should be created and consumed by the task",
@@ -2544,7 +2273,7 @@
         }
       }
     },
-    "v1beta1.TaskResources": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.TaskResources": {
       "description": "TaskResources allows a Pipeline to declare how its DeclaredPipelineResources should be provided to a Task as its inputs and outputs.",
       "type": "object",
       "properties": {
@@ -2553,7 +2282,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.TaskResource"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.TaskResource"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -2562,13 +2291,13 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.TaskResource"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.TaskResource"
           },
           "x-kubernetes-list-type": "atomic"
         }
       }
     },
-    "v1beta1.TaskResult": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.TaskResult": {
       "description": "TaskResult used to describe the results of a task",
       "type": "object",
       "required": [
@@ -2589,7 +2318,7 @@
           "type": "object",
           "additionalProperties": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.PropertySpec"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.PropertySpec"
           }
         },
         "type": {
@@ -2598,7 +2327,7 @@
         }
       }
     },
-    "v1beta1.TaskRun": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.TaskRun": {
       "description": "TaskRun represents a single execution of a Task. TaskRuns are how the steps specified in a Task are executed; they specify the parameters and resources used to run the steps in a Task.",
       "type": "object",
       "properties": {
@@ -2616,15 +2345,15 @@
         },
         "spec": {
           "default": {},
-          "$ref": "#/definitions/v1beta1.TaskRunSpec"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.TaskRunSpec"
         },
         "status": {
           "default": {},
-          "$ref": "#/definitions/v1beta1.TaskRunStatus"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.TaskRunStatus"
         }
       }
     },
-    "v1beta1.TaskRunDebug": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.TaskRunDebug": {
       "description": "TaskRunDebug defines the breakpoint config for a particular TaskRun",
       "type": "object",
       "properties": {
@@ -2638,7 +2367,7 @@
         }
       }
     },
-    "v1beta1.TaskRunInputs": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.TaskRunInputs": {
       "description": "TaskRunInputs holds the input values that this task was invoked with.",
       "type": "object",
       "properties": {
@@ -2646,7 +2375,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.Param"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.Param"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -2654,13 +2383,13 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.TaskResourceBinding"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.TaskResourceBinding"
           },
           "x-kubernetes-list-type": "atomic"
         }
       }
     },
-    "v1beta1.TaskRunList": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.TaskRunList": {
       "description": "TaskRunList contains a list of TaskRun",
       "type": "object",
       "required": [
@@ -2675,7 +2404,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.TaskRun"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.TaskRun"
           }
         },
         "kind": {
@@ -2688,7 +2417,7 @@
         }
       }
     },
-    "v1beta1.TaskRunOutputs": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.TaskRunOutputs": {
       "description": "TaskRunOutputs holds the output values that this task was invoked with.",
       "type": "object",
       "properties": {
@@ -2696,13 +2425,13 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.TaskResourceBinding"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.TaskResourceBinding"
           },
           "x-kubernetes-list-type": "atomic"
         }
       }
     },
-    "v1beta1.TaskRunResources": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.TaskRunResources": {
       "description": "TaskRunResources allows a TaskRun to declare inputs and outputs TaskResourceBinding",
       "type": "object",
       "properties": {
@@ -2711,7 +2440,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.TaskResourceBinding"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.TaskResourceBinding"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -2720,13 +2449,13 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.TaskResourceBinding"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.TaskResourceBinding"
           },
           "x-kubernetes-list-type": "atomic"
         }
       }
     },
-    "v1beta1.TaskRunResult": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.TaskRunResult": {
       "description": "TaskRunResult used to describe the results of a task",
       "type": "object",
       "required": [
@@ -2746,11 +2475,11 @@
         "value": {
           "description": "Value the given value of the result",
           "default": {},
-          "$ref": "#/definitions/v1beta1.ParamValue"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.ParamValue"
         }
       }
     },
-    "v1beta1.TaskRunSidecarOverride": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.TaskRunSidecarOverride": {
       "description": "TaskRunSidecarOverride is used to override the values of a Sidecar in the corresponding Task.",
       "type": "object",
       "required": [
@@ -2770,7 +2499,7 @@
         }
       }
     },
-    "v1beta1.TaskRunSpec": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.TaskRunSpec": {
       "description": "TaskRunSpec defines the desired state of TaskRun",
       "type": "object",
       "properties": {
@@ -2779,13 +2508,13 @@
           "$ref": "#/definitions/v1.ResourceRequirements"
         },
         "debug": {
-          "$ref": "#/definitions/v1beta1.TaskRunDebug"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.TaskRunDebug"
         },
         "params": {
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.Param"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.Param"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -2794,7 +2523,7 @@
           "$ref": "#/definitions/pod.Template"
         },
         "resources": {
-          "$ref": "#/definitions/v1beta1.TaskRunResources"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.TaskRunResources"
         },
         "retries": {
           "description": "Retries represents how many times this TaskRun should be retried in the event of Task failure.",
@@ -2810,7 +2539,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.TaskRunSidecarOverride"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.TaskRunSidecarOverride"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -2827,16 +2556,16 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.TaskRunStepOverride"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.TaskRunStepOverride"
           },
           "x-kubernetes-list-type": "atomic"
         },
         "taskRef": {
           "description": "no more than one of the TaskRef and TaskSpec may be specified.",
-          "$ref": "#/definitions/v1beta1.TaskRef"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.TaskRef"
         },
         "taskSpec": {
-          "$ref": "#/definitions/v1beta1.TaskSpec"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.TaskSpec"
         },
         "timeout": {
           "description": "Time after which one retry attempt times out. Defaults to 1 hour. Specified build timeout should be less than 24h. Refer Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration",
@@ -2847,13 +2576,13 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.WorkspaceBinding"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.WorkspaceBinding"
           },
           "x-kubernetes-list-type": "atomic"
         }
       }
     },
-    "v1beta1.TaskRunStatus": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.TaskRunStatus": {
       "description": "TaskRunStatus defines the observed state of TaskRun",
       "type": "object",
       "required": [
@@ -2873,7 +2602,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.CloudEventDelivery"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.CloudEventDelivery"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -2903,14 +2632,14 @@
         },
         "provenance": {
           "description": "Provenance contains some key authenticated metadata about how a software artifact was built (what sources, what inputs/outputs, etc.).",
-          "$ref": "#/definitions/v1beta1.Provenance"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.Provenance"
         },
         "resourcesResult": {
           "description": "Results from Resources built during the TaskRun. currently includes the digest of build container images",
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.PipelineResourceResult"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.PipelineResourceResult"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -2919,7 +2648,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.TaskRunStatus"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.TaskRunStatus"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -2928,7 +2657,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.SidecarState"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.SidecarState"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -2949,7 +2678,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.StepState"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.StepState"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -2958,17 +2687,17 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.TaskRunResult"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.TaskRunResult"
           },
           "x-kubernetes-list-type": "atomic"
         },
         "taskSpec": {
           "description": "TaskSpec contains the Spec from the dereferenced Task definition used to instantiate this TaskRun.",
-          "$ref": "#/definitions/v1beta1.TaskSpec"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.TaskSpec"
         }
       }
     },
-    "v1beta1.TaskRunStatusFields": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.TaskRunStatusFields": {
       "description": "TaskRunStatusFields holds the fields of TaskRun's status.  This is defined separately and inlined so that other types can readily consume these fields via duck typing.",
       "type": "object",
       "required": [
@@ -2980,7 +2709,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.CloudEventDelivery"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.CloudEventDelivery"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -2995,14 +2724,14 @@
         },
         "provenance": {
           "description": "Provenance contains some key authenticated metadata about how a software artifact was built (what sources, what inputs/outputs, etc.).",
-          "$ref": "#/definitions/v1beta1.Provenance"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.Provenance"
         },
         "resourcesResult": {
           "description": "Results from Resources built during the TaskRun. currently includes the digest of build container images",
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.PipelineResourceResult"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.PipelineResourceResult"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -3011,7 +2740,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.TaskRunStatus"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.TaskRunStatus"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -3020,7 +2749,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.SidecarState"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.SidecarState"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -3041,7 +2770,7 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.StepState"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.StepState"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -3050,17 +2779,17 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.TaskRunResult"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.TaskRunResult"
           },
           "x-kubernetes-list-type": "atomic"
         },
         "taskSpec": {
           "description": "TaskSpec contains the Spec from the dereferenced Task definition used to instantiate this TaskRun.",
-          "$ref": "#/definitions/v1beta1.TaskSpec"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.TaskSpec"
         }
       }
     },
-    "v1beta1.TaskRunStepOverride": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.TaskRunStepOverride": {
       "description": "TaskRunStepOverride is used to override the values of a Step in the corresponding Task.",
       "type": "object",
       "required": [
@@ -3080,7 +2809,7 @@
         }
       }
     },
-    "v1beta1.TaskSpec": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.TaskSpec": {
       "description": "TaskSpec defines the desired state of Task.",
       "type": "object",
       "properties": {
@@ -3093,20 +2822,20 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.ParamSpec"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.ParamSpec"
           },
           "x-kubernetes-list-type": "atomic"
         },
         "resources": {
           "description": "Resources is a list input and output resource to run the task Resources are represented in TaskRuns as bindings to instances of PipelineResources.",
-          "$ref": "#/definitions/v1beta1.TaskResources"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.TaskResources"
         },
         "results": {
           "description": "Results are values that this Task can output",
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.TaskResult"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.TaskResult"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -3115,20 +2844,20 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.Sidecar"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.Sidecar"
           },
           "x-kubernetes-list-type": "atomic"
         },
         "stepTemplate": {
           "description": "StepTemplate can be used as the basis for all step containers within the Task, so that the steps inherit settings on the base container.",
-          "$ref": "#/definitions/v1beta1.StepTemplate"
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.StepTemplate"
         },
         "steps": {
           "description": "Steps are the steps of the build; each step is run sequentially with the source mounted into /workspace.",
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.Step"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.Step"
           },
           "x-kubernetes-list-type": "atomic"
         },
@@ -3146,13 +2875,13 @@
           "type": "array",
           "items": {
             "default": {},
-            "$ref": "#/definitions/v1beta1.WorkspaceDeclaration"
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.WorkspaceDeclaration"
           },
           "x-kubernetes-list-type": "atomic"
         }
       }
     },
-    "v1beta1.TimeoutFields": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.TimeoutFields": {
       "description": "TimeoutFields allows granular specification of pipeline, task, and finally timeouts",
       "type": "object",
       "properties": {
@@ -3170,7 +2899,7 @@
         }
       }
     },
-    "v1beta1.WhenExpression": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.WhenExpression": {
       "description": "WhenExpression allows a PipelineTask to declare expressions to be evaluated before the Task is run to determine whether the Task should be executed or skipped",
       "type": "object",
       "required": [
@@ -3200,7 +2929,7 @@
         }
       }
     },
-    "v1beta1.WorkspaceBinding": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.WorkspaceBinding": {
       "description": "WorkspaceBinding maps a Task's declared workspace to a Volume.",
       "type": "object",
       "required": [
@@ -3246,7 +2975,7 @@
         }
       }
     },
-    "v1beta1.WorkspaceDeclaration": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.WorkspaceDeclaration": {
       "description": "WorkspaceDeclaration is a declaration of a volume that a Task requires.",
       "type": "object",
       "required": [
@@ -3276,7 +3005,7 @@
         }
       }
     },
-    "v1beta1.WorkspacePipelineTaskBinding": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.WorkspacePipelineTaskBinding": {
       "description": "WorkspacePipelineTaskBinding describes how a workspace passed into the pipeline should be mapped to a task's declared workspace.",
       "type": "object",
       "required": [
@@ -3298,7 +3027,7 @@
         }
       }
     },
-    "v1beta1.WorkspaceUsage": {
+    "github.com.tekton.pipeline.pkg.apis.pipeline.v1beta1.WorkspaceUsage": {
       "description": "WorkspaceUsage is used by a Step or Sidecar to declare that it wants isolated access to a Workspace defined in a Task.",
       "type": "object",
       "required": [
@@ -3313,6 +3042,305 @@
         },
         "name": {
           "description": "Name is the name of the workspace this Step or Sidecar wants access to.",
+          "type": "string",
+          "default": ""
+        }
+      }
+    },
+    "github.com.tekton.pipeline.pkg.apis.resolution.v1beta1.ResolutionRequest": {
+      "description": "ResolutionRequest is an object for requesting the content of a Tekton resource like a pipeline.yaml.",
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+          "type": "string"
+        },
+        "metadata": {
+          "default": {},
+          "$ref": "#/definitions/v1.ObjectMeta"
+        },
+        "spec": {
+          "description": "Spec holds the information for the request part of the resource request.",
+          "default": {},
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.resolution.v1beta1.ResolutionRequestSpec"
+        },
+        "status": {
+          "description": "Status communicates the state of the request and, ultimately, the content of the resolved resource.",
+          "default": {},
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.resolution.v1beta1.ResolutionRequestStatus"
+        }
+      }
+    },
+    "github.com.tekton.pipeline.pkg.apis.resolution.v1beta1.ResolutionRequestList": {
+      "description": "ResolutionRequestList is a list of ResolutionRequests.",
+      "type": "object",
+      "required": [
+        "items"
+      ],
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "type": "array",
+          "items": {
+            "default": {},
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.resolution.v1beta1.ResolutionRequest"
+          }
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+          "type": "string"
+        },
+        "metadata": {
+          "default": {},
+          "$ref": "#/definitions/v1.ListMeta"
+        }
+      }
+    },
+    "github.com.tekton.pipeline.pkg.apis.resolution.v1beta1.ResolutionRequestSpec": {
+      "description": "ResolutionRequestSpec are all the fields in the spec of the ResolutionRequest CRD.",
+      "type": "object",
+      "properties": {
+        "params": {
+          "description": "Parameters are the runtime attributes passed to the resolver to help it figure out how to resolve the resource being requested. For example: repo URL, commit SHA, path to file, the kind of authentication to leverage, etc.",
+          "type": "array",
+          "items": {
+            "default": {},
+            "$ref": "#/definitions/v1beta1.Param"
+          },
+          "x-kubernetes-list-type": "atomic"
+        }
+      }
+    },
+    "github.com.tekton.pipeline.pkg.apis.resolution.v1beta1.ResolutionRequestStatus": {
+      "description": "ResolutionRequestStatus are all the fields in a ResolutionRequest's status subresource.",
+      "type": "object",
+      "required": [
+        "data",
+        "source"
+      ],
+      "properties": {
+        "annotations": {
+          "description": "Annotations is additional Status fields for the Resource to save some additional State as well as convey more information to the user. This is roughly akin to Annotations on any k8s resource, just the reconciler conveying richer information outwards.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string",
+            "default": ""
+          }
+        },
+        "conditions": {
+          "description": "Conditions the latest available observations of a resource's current state.",
+          "type": "array",
+          "items": {
+            "default": {},
+            "$ref": "#/definitions/knative.Condition"
+          },
+          "x-kubernetes-patch-merge-key": "type",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "data": {
+          "description": "Data is a string representation of the resolved content of the requested resource in-lined into the ResolutionRequest object.",
+          "type": "string",
+          "default": ""
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the 'Generation' of the Service that was last processed by the controller.",
+          "type": "integer",
+          "format": "int64"
+        },
+        "source": {
+          "description": "Source is the source reference of the remote data that records the url, digest and the entrypoint.",
+          "$ref": "#/definitions/v1beta1.ConfigSource"
+        }
+      }
+    },
+    "github.com.tekton.pipeline.pkg.apis.resolution.v1beta1.ResolutionRequestStatusFields": {
+      "description": "ResolutionRequestStatusFields are the ResolutionRequest-specific fields for the status subresource.",
+      "type": "object",
+      "required": [
+        "data",
+        "source"
+      ],
+      "properties": {
+        "data": {
+          "description": "Data is a string representation of the resolved content of the requested resource in-lined into the ResolutionRequest object.",
+          "type": "string",
+          "default": ""
+        },
+        "source": {
+          "description": "Source is the source reference of the remote data that records the url, digest and the entrypoint.",
+          "$ref": "#/definitions/v1beta1.ConfigSource"
+        }
+      }
+    },
+    "github.com.tekton.pipeline.pkg.apis.resource.v1alpha1.PipelineResource": {
+      "description": "PipelineResource describes a resource that is an input to or output from a Task.",
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+          "type": "string"
+        },
+        "metadata": {
+          "default": {},
+          "$ref": "#/definitions/v1.ObjectMeta"
+        },
+        "spec": {
+          "description": "Spec holds the desired state of the PipelineResource from the client",
+          "default": {},
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.resource.v1alpha1.PipelineResourceSpec"
+        },
+        "status": {
+          "description": "Status is deprecated. It usually is used to communicate the observed state of the PipelineResource from the controller, but was unused as there is no controller for PipelineResource.",
+          "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.resource.v1alpha1.PipelineResourceStatus"
+        }
+      }
+    },
+    "github.com.tekton.pipeline.pkg.apis.resource.v1alpha1.PipelineResourceList": {
+      "description": "PipelineResourceList contains a list of PipelineResources",
+      "type": "object",
+      "required": [
+        "items"
+      ],
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "type": "array",
+          "items": {
+            "default": {},
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.resource.v1alpha1.PipelineResource"
+          }
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+          "type": "string"
+        },
+        "metadata": {
+          "default": {},
+          "$ref": "#/definitions/v1.ListMeta"
+        }
+      }
+    },
+    "github.com.tekton.pipeline.pkg.apis.resource.v1alpha1.PipelineResourceSpec": {
+      "description": "PipelineResourceSpec defines  an individual resources used in the pipeline.",
+      "type": "object",
+      "required": [
+        "type",
+        "params"
+      ],
+      "properties": {
+        "description": {
+          "description": "Description is a user-facing description of the resource that may be used to populate a UI.",
+          "type": "string"
+        },
+        "params": {
+          "type": "array",
+          "items": {
+            "default": {},
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.resource.v1alpha1.ResourceParam"
+          },
+          "x-kubernetes-list-type": "atomic"
+        },
+        "secrets": {
+          "description": "Secrets to fetch to populate some of resource fields",
+          "type": "array",
+          "items": {
+            "default": {},
+            "$ref": "#/definitions/github.com.tekton.pipeline.pkg.apis.resource.v1alpha1.SecretParam"
+          },
+          "x-kubernetes-list-type": "atomic"
+        },
+        "type": {
+          "type": "string",
+          "default": ""
+        }
+      }
+    },
+    "github.com.tekton.pipeline.pkg.apis.resource.v1alpha1.PipelineResourceStatus": {
+      "description": "PipelineResourceStatus does not contain anything because PipelineResources on their own do not have a status Deprecated",
+      "type": "object"
+    },
+    "github.com.tekton.pipeline.pkg.apis.resource.v1alpha1.ResourceDeclaration": {
+      "description": "ResourceDeclaration defines an input or output PipelineResource declared as a requirement by another type such as a Task or Condition. The Name field will be used to refer to these PipelineResources within the type's definition, and when provided as an Input, the Name will be the path to the volume mounted containing this PipelineResource as an input (e.g. an input Resource named `workspace` will be mounted at `/workspace`).",
+      "type": "object",
+      "required": [
+        "name",
+        "type"
+      ],
+      "properties": {
+        "description": {
+          "description": "Description is a user-facing description of the declared resource that may be used to populate a UI.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name declares the name by which a resource is referenced in the definition. Resources may be referenced by name in the definition of a Task's steps.",
+          "type": "string",
+          "default": ""
+        },
+        "optional": {
+          "description": "Optional declares the resource as optional. By default optional is set to false which makes a resource required. optional: true - the resource is considered optional optional: false - the resource is considered required (equivalent of not specifying it)",
+          "type": "boolean"
+        },
+        "targetPath": {
+          "description": "TargetPath is the path in workspace directory where the resource will be copied.",
+          "type": "string"
+        },
+        "type": {
+          "description": "Type is the type of this resource;",
+          "type": "string",
+          "default": ""
+        }
+      }
+    },
+    "github.com.tekton.pipeline.pkg.apis.resource.v1alpha1.ResourceParam": {
+      "description": "ResourceParam declares a string value to use for the parameter called Name, and is used in the specific context of PipelineResources.",
+      "type": "object",
+      "required": [
+        "name",
+        "value"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "default": ""
+        },
+        "value": {
+          "type": "string",
+          "default": ""
+        }
+      }
+    },
+    "github.com.tekton.pipeline.pkg.apis.resource.v1alpha1.SecretParam": {
+      "description": "SecretParam indicates which secret can be used to populate a field of the resource",
+      "type": "object",
+      "required": [
+        "fieldName",
+        "secretKey",
+        "secretName"
+      ],
+      "properties": {
+        "fieldName": {
+          "type": "string",
+          "default": ""
+        },
+        "secretKey": {
+          "type": "string",
+          "default": ""
+        },
+        "secretName": {
           "type": "string",
           "default": ""
         }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
[TEP-0118](https://github.com/tektoncd/community/blob/main/teps/0118-matrix-with-explicit-combinations-of-parameters.md) proposed adding include as a new field within matrix

This is the first of several PRs to add the feature to allow specify specific combinations or explicit combinations for Matrix Parameters. 

Note: This PR is to only add the new `Matrix.Include` field and update the documentation in "Preview Mode".  No functionality has been added at this time.

/kind feature

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [N/A ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
API Change: Added Matrix.Include in preview mode (Not yet functional)
```
