### PR TITLE
[TEP074] Remove PipelineResourceResultType of PipelineResourceResult Struct

### DIFF
--- a/pkg/apis/pipeline/v1beta1/resource_types.go
+++ b/pkg/apis/pipeline/v1beta1/resource_types.go
@@ -63,8 +63,6 @@ func (r *ResultType) UnmarshalJSON(data []byte) error {
 	switch asString {
 	case "TaskRunResult":
 		*r = TaskRunResultType
-	case "PipelineResourceResult":
-		*r = PipelineResourceResultType
 	case "InternalTektonResult":
 		*r = InternalTektonResultType
 	default:

--- a/pkg/apis/pipeline/v1beta1/task_types.go
+++ b/pkg/apis/pipeline/v1beta1/task_types.go
@@ -27,8 +27,9 @@ import (
 const (
 	// TaskRunResultType default task run result value
 	TaskRunResultType ResultType = 1
-	// PipelineResourceResultType default pipeline result value
-	PipelineResourceResultType = 2
+	// reserved: 2
+	// was PipelineResourceResultType
+
 	// InternalTektonResultType default internal tekton result value
 	InternalTektonResultType = 3
 	// UnknownResultType default unknown result type value

--- a/pkg/pod/status.go
+++ b/pkg/pod/status.go
@@ -290,8 +290,6 @@ func filterResultsAndResources(results []v1beta1.PipelineResourceResult, specRes
 		case v1beta1.InternalTektonResultType:
 			// Internal messages are ignored because they're not used as external result
 			continue
-		case v1beta1.PipelineResourceResultType:
-			fallthrough
 		default:
 			pipelineResourceResults = append(pipelineResourceResults, r)
 			filteredResults = append(filteredResults, r)

--- a/pkg/pod/status_test.go
+++ b/pkg/pod/status_test.go
@@ -870,7 +870,7 @@ func TestMakeTaskRunStatus(t *testing.T) {
 				Name: "step-pear",
 				State: corev1.ContainerState{
 					Terminated: &corev1.ContainerStateTerminated{
-						Message: `[{"key":"resultNameOne","value":"","type":2}, {"key":"resultNameTwo","value":"","type":3}, {"key":"resultNameThree","value":"","type":1}]`},
+						Message: `[{"key":"resultNameOne","value":"","type":3}, {"key":"resultNameThree","value":"","type":1}]`},
 				},
 			}},
 		},
@@ -880,17 +880,12 @@ func TestMakeTaskRunStatus(t *testing.T) {
 				Steps: []v1beta1.StepState{{
 					ContainerState: corev1.ContainerState{
 						Terminated: &corev1.ContainerStateTerminated{
-							Message: `[{"key":"resultNameOne","value":"","type":2},{"key":"resultNameThree","value":"","type":1}]`,
+							Message: `[{"key":"resultNameThree","value":"","type":1}]`,
 						}},
 					Name:          "pear",
 					ContainerName: "step-pear",
 				}},
 				Sidecars: []v1beta1.SidecarState{},
-				ResourcesResult: []v1beta1.PipelineResourceResult{{
-					Key:        "resultNameOne",
-					Value:      "",
-					ResultType: v1beta1.PipelineResourceResultType,
-				}},
 				TaskRunResults: []v1beta1.TaskRunResult{{
 					Name:  "resultNameThree",
 					Type:  v1beta1.ResultsTypeString,
@@ -908,7 +903,7 @@ func TestMakeTaskRunStatus(t *testing.T) {
 				Name: "step-pear",
 				State: corev1.ContainerState{
 					Terminated: &corev1.ContainerStateTerminated{
-						Message: `[{"key":"resultNameOne","value":"","type":"PipelineResourceResult"}, {"key":"resultNameTwo","value":"","type":"InternalTektonResult"}, {"key":"resultNameThree","value":"","type":"TaskRunResult"}]`,
+						Message: `[{"key":"resultNameTwo","value":"","type":"InternalTektonResult"}, {"key":"resultNameThree","value":"","type":"TaskRunResult"}]`,
 					},
 				},
 			}},
@@ -919,17 +914,12 @@ func TestMakeTaskRunStatus(t *testing.T) {
 				Steps: []v1beta1.StepState{{
 					ContainerState: corev1.ContainerState{
 						Terminated: &corev1.ContainerStateTerminated{
-							Message: `[{"key":"resultNameOne","value":"","type":2},{"key":"resultNameThree","value":"","type":1}]`,
+							Message: `[{"key":"resultNameThree","value":"","type":1}]`,
 						}},
 					Name:          "pear",
 					ContainerName: "step-pear",
 				}},
 				Sidecars: []v1beta1.SidecarState{},
-				ResourcesResult: []v1beta1.PipelineResourceResult{{
-					Key:        "resultNameOne",
-					Value:      "",
-					ResultType: v1beta1.PipelineResourceResultType,
-				}},
 				TaskRunResults: []v1beta1.TaskRunResult{{
 					Name:  "resultNameThree",
 					Type:  v1beta1.ResultsTypeString,


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
[PipelineResourceResult Struct](https://github.com/tektoncd/pipeline/blob/bffd16573facc997bea083f4426b59325cadd5ac/pkg/apis/pipeline/v1beta1/resource_types.go#L121-L169) is a blocker  for the cleanup of `PipelineResource`.

PipelineResourceResult Struct was first introduced just to write digest as results for image resources but over the time,
generalized to take in more results. But it really is just an abstraction of `TaskrunResult`, `ResourceResult` and `InternalTektonResult`. And since now the pipelineResources is going to be removed, it is no longer going to be living in the apis as in `resource_types` we would need to move it off the apis and rename it.

- It removes the `pipelineResourceResultType` since pipelineResources are
  going to be removed

Part of: https://github.com/tektoncd/pipeline/issues/6197
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
