### PR TITLE
Add CustomRun to register.go

### DIFF
--- a/pkg/apis/pipeline/register.go
+++ b/pkg/apis/pipeline/register.go
@@ -43,6 +43,9 @@ const (
 	// RunKey is used as the label identifier for a Run
 	RunKey = GroupName + "/run"
 
+	// CustomRunKey is used as the label identifier for a CustomRun
+	CustomRunKey = GroupName + "/customRun"
+
 	// MemberOfLabelKey is used as the label identifier for a PipelineTask
 	// Set to Tasks/Finally depending on the position of the PipelineTask
 	MemberOfLabelKey = GroupName + "/memberOf"
@@ -84,5 +87,11 @@ var (
 	PipelineResourceResource = schema.GroupResource{
 		Group:    GroupName,
 		Resource: "pipelineresources",
+	}
+
+	// CustomRunResource represents a Tekton CustomRun
+	CustomRunResource = schema.GroupResource{
+		Group:    GroupName,
+		Resource: "customruns",
 	}
 )


### PR DESCRIPTION
# Changes

Given CustomRun is an independent resource, I don't see a reason why it was not added to register.go.

I actually need it to not hardcode the path of the resource so that I can safely check whether it exists using RESTMapper in a client.

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
