### PR TITLE
fix weight in update-reference-docs

### DIFF
--- a/hack/update-reference-docs.sh
+++ b/hack/update-reference-docs.sh
@@ -23,4 +23,4 @@ go run github.com/ahmetb/gen-crd-api-reference-docs \
     -api-dir "github.com/tektoncd/pipeline/pkg/apis" \
     -template-dir "./hack/reference-docs-template" \
     -out-file "./docs/pipeline-api.md"
-sed -i".backup" '1s/^/<!--\n---\ntitle: Pipeline API\nlinkTitle: Pipeline API\nweight: 1000\n---\n-->\n\n/' ./docs/pipeline-api.md && rm docs/pipeline-api.md.backup
+sed -i".backup" '1s/^/<!--\n---\ntitle: Pipeline API\nlinkTitle: Pipeline API\nweight: 404\n---\n-->\n\n/' ./docs/pipeline-api.md && rm docs/pipeline-api.md.backup


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Update the weight from 1000 to 404. The weight is used to group similar docs on website. The script also needs update. This is a followup of https://github.com/tektoncd/pipeline/pull/6117

/kind documentation

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
