### PR TITLE
Revert removal of embedded TaskRun status in API.

### DIFF
--- a/docs/pipeline-api.md
+++ b/docs/pipeline-api.md
@@ -9146,6 +9146,9 @@ ParamValue
 </table>
 <h3 id="tekton.dev/v1beta1.PipelineRunRunStatus">PipelineRunRunStatus
 </h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineRunStatusFields">PipelineRunStatusFields</a>)
+</p>
 <div>
 <p>PipelineRunRunStatus contains the name of the PipelineTask for this CustomRun or Run and the CustomRun or Run&rsquo;s Status</p>
 </div>
@@ -9459,6 +9462,40 @@ Kubernetes meta/v1.Time
 </tr>
 <tr>
 <td>
+<code>taskRuns</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.PipelineRunTaskRunStatus">
+map[string]*github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineRunTaskRunStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TaskRuns is a map of PipelineRunTaskRunStatus with the taskRun name as the key.</p>
+<p>Deprecated: use ChildReferences instead. As of v0.45.0, this field is no
+longer populated and is only included for backwards compatibility with
+older server versions.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>runs</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.PipelineRunRunStatus">
+map[string]*github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineRunRunStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Runs is a map of PipelineRunRunStatus with the run name as the key</p>
+<p>Deprecated: use ChildReferences instead. As of v0.45.0, this field is no
+longer populated and is only included for backwards compatibility with
+older server versions.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>pipelineResults</code><br/>
 <em>
 <a href="#tekton.dev/v1beta1.PipelineRunResult">
@@ -9555,6 +9592,9 @@ map[string]string
 </table>
 <h3 id="tekton.dev/v1beta1.PipelineRunTaskRunStatus">PipelineRunTaskRunStatus
 </h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineRunStatusFields">PipelineRunStatusFields</a>)
+</p>
 <div>
 <p>PipelineRunTaskRunStatus contains the name of the PipelineTask for this TaskRun and the TaskRun&rsquo;s Status</p>
 </div>

--- a/pkg/apis/pipeline/v1beta1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1beta1/openapi_generated.go
@@ -1864,6 +1864,34 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineRunStatus(ref common.ReferenceCall
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
 						},
 					},
+					"taskRuns": {
+						SchemaProps: spec.SchemaProps{
+							Description: "TaskRuns is a map of PipelineRunTaskRunStatus with the taskRun name as the key.\n\nDeprecated: use ChildReferences instead. As of v0.45.0, this field is no longer populated and is only included for backwards compatibility with older server versions.",
+							Type:        []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Allows: true,
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineRunTaskRunStatus"),
+									},
+								},
+							},
+						},
+					},
+					"runs": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Runs is a map of PipelineRunRunStatus with the run name as the key\n\nDeprecated: use ChildReferences instead. As of v0.45.0, this field is no longer populated and is only included for backwards compatibility with older server versions.",
+							Type:        []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Allows: true,
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineRunRunStatus"),
+									},
+								},
+							},
+						},
+					},
 					"pipelineResults": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
@@ -1959,7 +1987,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineRunStatus(ref common.ReferenceCall
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.ChildStatusReference", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineRunResult", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineSpec", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Provenance", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.SkippedTask", "k8s.io/apimachinery/pkg/apis/meta/v1.Time", "knative.dev/pkg/apis.Condition"},
+			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.ChildStatusReference", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineRunResult", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineRunRunStatus", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineRunTaskRunStatus", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineSpec", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Provenance", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.SkippedTask", "k8s.io/apimachinery/pkg/apis/meta/v1.Time", "knative.dev/pkg/apis.Condition"},
 	}
 }
 
@@ -1982,6 +2010,34 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineRunStatusFields(ref common.Referen
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
 						},
 					},
+					"taskRuns": {
+						SchemaProps: spec.SchemaProps{
+							Description: "TaskRuns is a map of PipelineRunTaskRunStatus with the taskRun name as the key.\n\nDeprecated: use ChildReferences instead. As of v0.45.0, this field is no longer populated and is only included for backwards compatibility with older server versions.",
+							Type:        []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Allows: true,
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineRunTaskRunStatus"),
+									},
+								},
+							},
+						},
+					},
+					"runs": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Runs is a map of PipelineRunRunStatus with the run name as the key\n\nDeprecated: use ChildReferences instead. As of v0.45.0, this field is no longer populated and is only included for backwards compatibility with older server versions.",
+							Type:        []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Allows: true,
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineRunRunStatus"),
+									},
+								},
+							},
+						},
+					},
 					"pipelineResults": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
@@ -2077,7 +2133,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineRunStatusFields(ref common.Referen
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.ChildStatusReference", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineRunResult", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineSpec", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Provenance", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.SkippedTask", "k8s.io/apimachinery/pkg/apis/meta/v1.Time"},
+			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.ChildStatusReference", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineRunResult", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineRunRunStatus", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineRunTaskRunStatus", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineSpec", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Provenance", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.SkippedTask", "k8s.io/apimachinery/pkg/apis/meta/v1.Time"},
 	}
 }
 

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
@@ -413,6 +413,22 @@ type PipelineRunStatusFields struct {
 	// CompletionTime is the time the PipelineRun completed.
 	CompletionTime *metav1.Time `json:"completionTime,omitempty"`
 
+	// TaskRuns is a map of PipelineRunTaskRunStatus with the taskRun name as the key.
+	//
+	// Deprecated: use ChildReferences instead. As of v0.45.0, this field is no
+	// longer populated and is only included for backwards compatibility with
+	// older server versions.
+	// +optional
+	TaskRuns map[string]*PipelineRunTaskRunStatus `json:"taskRuns,omitempty"`
+
+	// Runs is a map of PipelineRunRunStatus with the run name as the key
+	//
+	// Deprecated: use ChildReferences instead. As of v0.45.0, this field is no
+	// longer populated and is only included for backwards compatibility with
+	// older server versions.
+	// +optional
+	Runs map[string]*PipelineRunRunStatus `json:"runs,omitempty"`
+
 	// PipelineResults are the list of results written out by the pipeline task's containers
 	// +optional
 	// +listType=atomic

--- a/pkg/apis/pipeline/v1beta1/swagger.json
+++ b/pkg/apis/pipeline/v1beta1/swagger.json
@@ -973,6 +973,13 @@
           "description": "Provenance contains some key authenticated metadata about how a software artifact was built (what sources, what inputs/outputs, etc.).",
           "$ref": "#/definitions/v1beta1.Provenance"
         },
+        "runs": {
+          "description": "Runs is a map of PipelineRunRunStatus with the run name as the key\n\nDeprecated: use ChildReferences instead. As of v0.45.0, this field is no longer populated and is only included for backwards compatibility with older server versions.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/v1beta1.PipelineRunRunStatus"
+          }
+        },
         "skippedTasks": {
           "description": "list of tasks that were skipped due to when expressions evaluating to false",
           "type": "array",
@@ -993,6 +1000,13 @@
         "startTime": {
           "description": "StartTime is the time the PipelineRun is actually started.",
           "$ref": "#/definitions/v1.Time"
+        },
+        "taskRuns": {
+          "description": "TaskRuns is a map of PipelineRunTaskRunStatus with the taskRun name as the key.\n\nDeprecated: use ChildReferences instead. As of v0.45.0, this field is no longer populated and is only included for backwards compatibility with older server versions.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/v1beta1.PipelineRunTaskRunStatus"
+          }
         }
       }
     },
@@ -1034,6 +1048,13 @@
           "description": "Provenance contains some key authenticated metadata about how a software artifact was built (what sources, what inputs/outputs, etc.).",
           "$ref": "#/definitions/v1beta1.Provenance"
         },
+        "runs": {
+          "description": "Runs is a map of PipelineRunRunStatus with the run name as the key\n\nDeprecated: use ChildReferences instead. As of v0.45.0, this field is no longer populated and is only included for backwards compatibility with older server versions.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/v1beta1.PipelineRunRunStatus"
+          }
+        },
         "skippedTasks": {
           "description": "list of tasks that were skipped due to when expressions evaluating to false",
           "type": "array",
@@ -1054,6 +1075,13 @@
         "startTime": {
           "description": "StartTime is the time the PipelineRun is actually started.",
           "$ref": "#/definitions/v1.Time"
+        },
+        "taskRuns": {
+          "description": "TaskRuns is a map of PipelineRunTaskRunStatus with the taskRun name as the key.\n\nDeprecated: use ChildReferences instead. As of v0.45.0, this field is no longer populated and is only included for backwards compatibility with older server versions.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/v1beta1.PipelineRunTaskRunStatus"
+          }
         }
       }
     },

--- a/pkg/apis/pipeline/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/pipeline/v1beta1/zz_generated.deepcopy.go
@@ -846,6 +846,36 @@ func (in *PipelineRunStatusFields) DeepCopyInto(out *PipelineRunStatusFields) {
 		in, out := &in.CompletionTime, &out.CompletionTime
 		*out = (*in).DeepCopy()
 	}
+	if in.TaskRuns != nil {
+		in, out := &in.TaskRuns, &out.TaskRuns
+		*out = make(map[string]*PipelineRunTaskRunStatus, len(*in))
+		for key, val := range *in {
+			var outVal *PipelineRunTaskRunStatus
+			if val == nil {
+				(*out)[key] = nil
+			} else {
+				in, out := &val, &outVal
+				*out = new(PipelineRunTaskRunStatus)
+				(*in).DeepCopyInto(*out)
+			}
+			(*out)[key] = outVal
+		}
+	}
+	if in.Runs != nil {
+		in, out := &in.Runs, &out.Runs
+		*out = make(map[string]*PipelineRunRunStatus, len(*in))
+		for key, val := range *in {
+			var outVal *PipelineRunRunStatus
+			if val == nil {
+				(*out)[key] = nil
+			} else {
+				in, out := &val, &outVal
+				*out = new(PipelineRunRunStatus)
+				(*in).DeepCopyInto(*out)
+			}
+			(*out)[key] = outVal
+		}
+	}
 	if in.PipelineResults != nil {
 		in, out := &in.PipelineResults, &out.PipelineResults
 		*out = make([]PipelineRunResult, len(*in))


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

This is a partial revert to undo the removal of the type from the API. Because minimal statuses were only being populated by default in v0.44.0, the removal of this field in v0.45.0 makes it difficult for clients >= v0.45 to safely communicate with older server versions (in particular LTS releases).

Only the API type is needed - newer server versions do not need to populate or support it.

Fixes https://github.com/tektoncd/chains/issues/715

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
PipelineRun Embedded TaskRun statuses reintroduced as deprecated to allow compatibility with older server versions.
```
