### PR TITLE
Fix godoc deprecated comments.

### DIFF
--- a/docs/pipeline-api.md
+++ b/docs/pipeline-api.md
@@ -2896,8 +2896,8 @@ string
 </p>
 <div>
 <p>WorkspacePipelineDeclaration creates a named slot in a Pipeline that a PipelineRun
-is expected to populate with a workspace binding.
-Deprecated: use PipelineWorkspaceDeclaration type instead</p>
+is expected to populate with a workspace binding.</p>
+<p>Deprecated: use PipelineWorkspaceDeclaration type instead</p>
 </div>
 <table>
 <thead>
@@ -6187,9 +6187,9 @@ PipelineResourceStatus
 </td>
 <td>
 <em>(Optional)</em>
-<p>Status is deprecated.
-It usually is used to communicate the observed state of the PipelineResource from
+<p>Status is used to communicate the observed state of the PipelineResource from
 the controller, but was unused as there is no controller for PipelineResource.</p>
+<p>Deprecated: Deprecated in v0.30.0.</p>
 </td>
 </tr>
 </tbody>
@@ -6721,8 +6721,8 @@ string
 </p>
 <div>
 <p>PipelineResourceStatus does not contain anything because PipelineResources on their own
-do not have a status
-Deprecated</p>
+do not have a status</p>
+<p>Deprecated: Deprecated in v0.30.0.</p>
 </div>
 <h3 id="tekton.dev/v1alpha1.ResourceDeclaration">ResourceDeclaration
 </h3>
@@ -7099,7 +7099,8 @@ Resource Types:
 <div>
 <p>ClusterTask is a Task with a cluster scope. ClusterTasks are used to
 represent Tasks that should be publicly addressable from any namespace in the
-cluster. Deprecated: Please use the cluster resolver instead.</p>
+cluster.</p>
+<p>Deprecated: Please use the cluster resolver instead.</p>
 </div>
 <table>
 <thead>
@@ -7819,9 +7820,10 @@ Kubernetes meta/v1.Duration
 </td>
 <td>
 <em>(Optional)</em>
-<p>Timeout Deprecated: use pipelineRunSpec.Timeouts.Pipeline instead
-Time after which the Pipeline times out. Defaults to never.
+<p>Timeout is the Time after which the Pipeline times out.
+Defaults to never.
 Refer to Go&rsquo;s ParseDuration documentation for expected format: <a href="https://golang.org/pkg/time/#ParseDuration">https://golang.org/pkg/time/#ParseDuration</a></p>
+<p>Deprecated: use pipelineRunSpec.Timeouts.Pipeline instead</p>
 </td>
 </tr>
 <tr>
@@ -9317,8 +9319,8 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>Bundle url reference to a Tekton Bundle.
-Deprecated: Please use ResolverRef with the bundles resolver instead.</p>
+<p>Bundle url reference to a Tekton Bundle.</p>
+<p>Deprecated: Please use ResolverRef with the bundles resolver instead.</p>
 </td>
 </tr>
 <tr>
@@ -9798,9 +9800,10 @@ Kubernetes meta/v1.Duration
 </td>
 <td>
 <em>(Optional)</em>
-<p>Timeout Deprecated: use pipelineRunSpec.Timeouts.Pipeline instead
-Time after which the Pipeline times out. Defaults to never.
+<p>Timeout is the Time after which the Pipeline times out.
+Defaults to never.
 Refer to Go&rsquo;s ParseDuration documentation for expected format: <a href="https://golang.org/pkg/time/#ParseDuration">https://golang.org/pkg/time/#ParseDuration</a></p>
+<p>Deprecated: use pipelineRunSpec.Timeouts.Pipeline instead</p>
 </td>
 </tr>
 <tr>
@@ -10741,8 +10744,8 @@ Kubernetes core/v1.ResourceRequirements
 </p>
 <div>
 <p>WorkspacePipelineDeclaration creates a named slot in a Pipeline that a PipelineRun
-is expected to populate with a workspace binding.
-Deprecated: use PipelineWorkspaceDeclaration type instead</p>
+is expected to populate with a workspace binding.</p>
+<p>Deprecated: use PipelineWorkspaceDeclaration type instead</p>
 </div>
 <table>
 <thead>
@@ -11658,14 +11661,14 @@ Cannot be updated.</p>
 </td>
 <td>
 <em>(Optional)</em>
-<p>Deprecated. This field will be removed in a future release.
-List of ports to expose from the Step&rsquo;s container. Exposing a port here gives
+<p>List of ports to expose from the Step&rsquo;s container. Exposing a port here gives
 the system additional information about the network connections a
 container uses, but is primarily informational. Not specifying a port here
 DOES NOT prevent that port from being exposed. Any port which is
 listening on the default &ldquo;0.0.0.0&rdquo; address inside a container will be
 accessible from the network.
 Cannot be updated.</p>
+<p>Deprecated: This field will be removed in a future release.</p>
 </td>
 </tr>
 <tr>
@@ -11758,11 +11761,11 @@ Kubernetes core/v1.Probe
 </td>
 <td>
 <em>(Optional)</em>
-<p>Deprecated. This field will be removed in a future release.
-Periodic probe of container liveness.
+<p>Periodic probe of container liveness.
 Step will be restarted if the probe fails.
 Cannot be updated.
 More info: <a href="https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes">https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes</a></p>
+<p>Deprecated: This field will be removed in a future release.</p>
 </td>
 </tr>
 <tr>
@@ -11776,11 +11779,11 @@ Kubernetes core/v1.Probe
 </td>
 <td>
 <em>(Optional)</em>
-<p>Deprecated. This field will be removed in a future release.
-Periodic probe of container service readiness.
+<p>Periodic probe of container service readiness.
 Step will be removed from service endpoints if the probe fails.
 Cannot be updated.
 More info: <a href="https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes">https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes</a></p>
+<p>Deprecated: This field will be removed in a future release.</p>
 </td>
 </tr>
 <tr>
@@ -11794,14 +11797,14 @@ Kubernetes core/v1.Probe
 </td>
 <td>
 <em>(Optional)</em>
-<p>Deprecated. This field will be removed in a future release.
-DeprecatedStartupProbe indicates that the Pod this Step runs in has successfully initialized.
+<p>DeprecatedStartupProbe indicates that the Pod this Step runs in has successfully initialized.
 If specified, no other probes are executed until this completes successfully.
 If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
 This can be used to provide different probe parameters at the beginning of a Pod&rsquo;s lifecycle,
 when it might take a long time to load data or warm a cache, than during steady-state operation.
 This cannot be updated.
 More info: <a href="https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes">https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes</a></p>
+<p>Deprecated: This field will be removed in a future release.</p>
 </td>
 </tr>
 <tr>
@@ -11815,9 +11818,9 @@ Kubernetes core/v1.Lifecycle
 </td>
 <td>
 <em>(Optional)</em>
-<p>Deprecated. This field will be removed in a future release.
-Actions that the management system should take in response to container lifecycle events.
+<p>Actions that the management system should take in response to container lifecycle events.
 Cannot be updated.</p>
+<p>Deprecated: This field will be removed in a future release.</p>
 </td>
 </tr>
 <tr>
@@ -11829,7 +11832,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>Deprecated. This field will be removed in a future release and can&rsquo;t be meaningfully used.</p>
+<p>Deprecated: This field will be removed in a future release and can&rsquo;t be meaningfully used.</p>
 </td>
 </tr>
 <tr>
@@ -11843,7 +11846,7 @@ Kubernetes core/v1.TerminationMessagePolicy
 </td>
 <td>
 <em>(Optional)</em>
-<p>Deprecated. This field will be removed in a future release and can&rsquo;t be meaningfully used.</p>
+<p>Deprecated: This field will be removed in a future release and can&rsquo;t be meaningfully used.</p>
 </td>
 </tr>
 <tr>
@@ -11889,10 +11892,10 @@ bool
 </td>
 <td>
 <em>(Optional)</em>
-<p>Deprecated. This field will be removed in a future release.
-Whether this container should allocate a buffer for stdin in the container runtime. If this
+<p>Whether this container should allocate a buffer for stdin in the container runtime. If this
 is not set, reads from stdin in the container will always result in EOF.
 Default is false.</p>
+<p>Deprecated: This field will be removed in a future release.</p>
 </td>
 </tr>
 <tr>
@@ -11904,14 +11907,14 @@ bool
 </td>
 <td>
 <em>(Optional)</em>
-<p>Deprecated. This field will be removed in a future release.
-Whether the container runtime should close the stdin channel after it has been opened by
+<p>Whether the container runtime should close the stdin channel after it has been opened by
 a single attach. When stdin is true the stdin stream will remain open across multiple attach
 sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
 first client attaches to stdin, and then remains open and accepts data until the client disconnects,
 at which time stdin is closed and remains closed until the container is restarted. If this
 flag is false, a container processes that reads from stdin will never receive an EOF.
 Default is false</p>
+<p>Deprecated: This field will be removed in a future release.</p>
 </td>
 </tr>
 <tr>
@@ -11923,9 +11926,9 @@ bool
 </td>
 <td>
 <em>(Optional)</em>
-<p>Deprecated. This field will be removed in a future release.
-Whether this container should allocate a DeprecatedTTY for itself, also requires &lsquo;stdin&rsquo; to be true.
+<p>Whether this container should allocate a DeprecatedTTY for itself, also requires &lsquo;stdin&rsquo; to be true.
 Default is false.</p>
+<p>Deprecated: This field will be removed in a future release.</p>
 </td>
 </tr>
 <tr>
@@ -12136,10 +12139,10 @@ string
 </em>
 </td>
 <td>
-<p>Deprecated. This field will be removed in a future release.
-Default name for each Step specified as a DNS_LABEL.
+<p>Default name for each Step specified as a DNS_LABEL.
 Each Step in a Task must have a unique name.
 Cannot be updated.</p>
+<p>Deprecated: This field will be removed in a future release.</p>
 </td>
 </tr>
 <tr>
@@ -12221,14 +12224,14 @@ Cannot be updated.</p>
 </td>
 <td>
 <em>(Optional)</em>
-<p>Deprecated. This field will be removed in a future release.
-List of ports to expose from the Step&rsquo;s container. Exposing a port here gives
+<p>List of ports to expose from the Step&rsquo;s container. Exposing a port here gives
 the system additional information about the network connections a
 container uses, but is primarily informational. Not specifying a port here
 DOES NOT prevent that port from being exposed. Any port which is
 listening on the default &ldquo;0.0.0.0&rdquo; address inside a container will be
 accessible from the network.
 Cannot be updated.</p>
+<p>Deprecated: This field will be removed in a future release.</p>
 </td>
 </tr>
 <tr>
@@ -12321,11 +12324,11 @@ Kubernetes core/v1.Probe
 </td>
 <td>
 <em>(Optional)</em>
-<p>Deprecated. This field will be removed in a future release.
-Periodic probe of container liveness.
+<p>Periodic probe of container liveness.
 Container will be restarted if the probe fails.
 Cannot be updated.
 More info: <a href="https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes">https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes</a></p>
+<p>Deprecated: This field will be removed in a future release.</p>
 </td>
 </tr>
 <tr>
@@ -12339,11 +12342,11 @@ Kubernetes core/v1.Probe
 </td>
 <td>
 <em>(Optional)</em>
-<p>Deprecated. This field will be removed in a future release.
-Periodic probe of container service readiness.
+<p>Periodic probe of container service readiness.
 Container will be removed from service endpoints if the probe fails.
 Cannot be updated.
 More info: <a href="https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes">https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes</a></p>
+<p>Deprecated: This field will be removed in a future release.</p>
 </td>
 </tr>
 <tr>
@@ -12357,14 +12360,14 @@ Kubernetes core/v1.Probe
 </td>
 <td>
 <em>(Optional)</em>
-<p>Deprecated. This field will be removed in a future release.
-DeprecatedStartupProbe indicates that the Pod has successfully initialized.
+<p>DeprecatedStartupProbe indicates that the Pod has successfully initialized.
 If specified, no other probes are executed until this completes successfully.
 If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
 This can be used to provide different probe parameters at the beginning of a Pod&rsquo;s lifecycle,
 when it might take a long time to load data or warm a cache, than during steady-state operation.
 This cannot be updated.
 More info: <a href="https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes">https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes</a></p>
+<p>Deprecated: This field will be removed in a future release.</p>
 </td>
 </tr>
 <tr>
@@ -12378,9 +12381,9 @@ Kubernetes core/v1.Lifecycle
 </td>
 <td>
 <em>(Optional)</em>
-<p>Deprecated. This field will be removed in a future release.
-Actions that the management system should take in response to container lifecycle events.
+<p>Actions that the management system should take in response to container lifecycle events.
 Cannot be updated.</p>
+<p>Deprecated: This field will be removed in a future release.</p>
 </td>
 </tr>
 <tr>
@@ -12392,7 +12395,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>Deprecated. This field will be removed in a future release and cannot be meaningfully used.</p>
+<p>Deprecated: This field will be removed in a future release and cannot be meaningfully used.</p>
 </td>
 </tr>
 <tr>
@@ -12406,7 +12409,7 @@ Kubernetes core/v1.TerminationMessagePolicy
 </td>
 <td>
 <em>(Optional)</em>
-<p>Deprecated. This field will be removed in a future release and cannot be meaningfully used.</p>
+<p>Deprecated: This field will be removed in a future release and cannot be meaningfully used.</p>
 </td>
 </tr>
 <tr>
@@ -12452,10 +12455,10 @@ bool
 </td>
 <td>
 <em>(Optional)</em>
-<p>Deprecated. This field will be removed in a future release.
-Whether this Step should allocate a buffer for stdin in the container runtime. If this
+<p>Whether this Step should allocate a buffer for stdin in the container runtime. If this
 is not set, reads from stdin in the Step will always result in EOF.
 Default is false.</p>
+<p>Deprecated: This field will be removed in a future release.</p>
 </td>
 </tr>
 <tr>
@@ -12467,14 +12470,14 @@ bool
 </td>
 <td>
 <em>(Optional)</em>
-<p>Deprecated. This field will be removed in a future release.
-Whether the container runtime should close the stdin channel after it has been opened by
+<p>Whether the container runtime should close the stdin channel after it has been opened by
 a single attach. When stdin is true the stdin stream will remain open across multiple attach
 sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
 first client attaches to stdin, and then remains open and accepts data until the client disconnects,
 at which time stdin is closed and remains closed until the container is restarted. If this
 flag is false, a container processes that reads from stdin will never receive an EOF.
 Default is false</p>
+<p>Deprecated: This field will be removed in a future release.</p>
 </td>
 </tr>
 <tr>
@@ -12486,9 +12489,9 @@ bool
 </td>
 <td>
 <em>(Optional)</em>
-<p>Deprecated. This field will be removed in a future release.
-Whether this Step should allocate a DeprecatedTTY for itself, also requires &lsquo;stdin&rsquo; to be true.
+<p>Whether this Step should allocate a DeprecatedTTY for itself, also requires &lsquo;stdin&rsquo; to be true.
 Default is false.</p>
+<p>Deprecated: This field will be removed in a future release.</p>
 </td>
 </tr>
 </tbody>
@@ -12572,8 +12575,8 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>Bundle url reference to a Tekton Bundle.
-Deprecated: Please use ResolverRef with the bundles resolver instead.</p>
+<p>Bundle url reference to a Tekton Bundle.</p>
+<p>Deprecated: Please use ResolverRef with the bundles resolver instead.</p>
 </td>
 </tr>
 <tr>
@@ -13420,9 +13423,9 @@ Kubernetes meta/v1.Time
 </td>
 <td>
 <em>(Optional)</em>
-<p>Deprecated.
-CloudEvents describe the state of each cloud event requested via a
+<p>CloudEvents describe the state of each cloud event requested via a
 CloudEventResource.</p>
+<p>Deprecated: Removed in v0.44.0.</p>
 </td>
 </tr>
 <tr>

--- a/pkg/apis/config/trusted_resources.go
+++ b/pkg/apis/config/trusted_resources.go
@@ -29,7 +29,9 @@ import (
 // TrustedResources holds the collection of configurations that we attach to contexts.
 // Configmap named with "config-trusted-resources" where cosign pub key path and
 // KMS pub key path can be configured
-// Deprecated.
+//
+// Deprecated: Use VerificationPolicy CRD instead.
+//
 // +k8s:deepcopy-gen=true
 type TrustedResources struct {
 	// Keys defines the name of the key in configmap data

--- a/pkg/apis/pipeline/v1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1/openapi_generated.go
@@ -2008,7 +2008,7 @@ func schema_pkg_apis_pipeline_v1_PipelineWorkspaceDeclaration(ref common.Referen
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "WorkspacePipelineDeclaration creates a named slot in a Pipeline that a PipelineRun is expected to populate with a workspace binding. Deprecated: use PipelineWorkspaceDeclaration type instead",
+				Description: "WorkspacePipelineDeclaration creates a named slot in a Pipeline that a PipelineRun is expected to populate with a workspace binding.\n\nDeprecated: use PipelineWorkspaceDeclaration type instead",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"name": {

--- a/pkg/apis/pipeline/v1/swagger.json
+++ b/pkg/apis/pipeline/v1/swagger.json
@@ -999,7 +999,7 @@
       }
     },
     "v1.PipelineWorkspaceDeclaration": {
-      "description": "WorkspacePipelineDeclaration creates a named slot in a Pipeline that a PipelineRun is expected to populate with a workspace binding. Deprecated: use PipelineWorkspaceDeclaration type instead",
+      "description": "WorkspacePipelineDeclaration creates a named slot in a Pipeline that a PipelineRun is expected to populate with a workspace binding.\n\nDeprecated: use PipelineWorkspaceDeclaration type instead",
       "type": "object",
       "required": [
         "name"

--- a/pkg/apis/pipeline/v1/workspace_types.go
+++ b/pkg/apis/pipeline/v1/workspace_types.go
@@ -87,6 +87,7 @@ type WorkspaceBinding struct {
 
 // WorkspacePipelineDeclaration creates a named slot in a Pipeline that a PipelineRun
 // is expected to populate with a workspace binding.
+//
 // Deprecated: use PipelineWorkspaceDeclaration type instead
 type WorkspacePipelineDeclaration = PipelineWorkspaceDeclaration
 

--- a/pkg/apis/pipeline/v1beta1/cluster_task_types.go
+++ b/pkg/apis/pipeline/v1beta1/cluster_task_types.go
@@ -31,7 +31,9 @@ import (
 
 // ClusterTask is a Task with a cluster scope. ClusterTasks are used to
 // represent Tasks that should be publicly addressable from any namespace in the
-// cluster. Deprecated: Please use the cluster resolver instead.
+// cluster.
+//
+// Deprecated: Please use the cluster resolver instead.
 type ClusterTask struct {
 	metav1.TypeMeta `json:",inline"`
 	// +optional

--- a/pkg/apis/pipeline/v1beta1/container_types.go
+++ b/pkg/apis/pipeline/v1beta1/container_types.go
@@ -42,7 +42,6 @@ type Step struct {
 	// Cannot be updated.
 	// +optional
 	WorkingDir string `json:"workingDir,omitempty" protobuf:"bytes,5,opt,name=workingDir"`
-	// Deprecated. This field will be removed in a future release.
 	// List of ports to expose from the Step's container. Exposing a port here gives
 	// the system additional information about the network connections a
 	// container uses, but is primarily informational. Not specifying a port here
@@ -50,6 +49,9 @@ type Step struct {
 	// listening on the default "0.0.0.0" address inside a container will be
 	// accessible from the network.
 	// Cannot be updated.
+	//
+	// Deprecated: This field will be removed in a future release.
+	//
 	// +optional
 	// +patchMergeKey=containerPort
 	// +patchStrategy=merge
@@ -91,21 +93,25 @@ type Step struct {
 	// +optional
 	// +listType=atomic
 	VolumeDevices []corev1.VolumeDevice `json:"volumeDevices,omitempty" patchStrategy:"merge" patchMergeKey:"devicePath" protobuf:"bytes,21,rep,name=volumeDevices"`
-	// Deprecated. This field will be removed in a future release.
 	// Periodic probe of container liveness.
 	// Step will be restarted if the probe fails.
 	// Cannot be updated.
 	// More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+	//
+	// Deprecated: This field will be removed in a future release.
+	//
 	// +optional
 	DeprecatedLivenessProbe *corev1.Probe `json:"livenessProbe,omitempty" protobuf:"bytes,10,opt,name=livenessProbe"`
-	// Deprecated. This field will be removed in a future release.
 	// Periodic probe of container service readiness.
 	// Step will be removed from service endpoints if the probe fails.
 	// Cannot be updated.
 	// More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+	//
+	// Deprecated: This field will be removed in a future release.
+	//
 	// +optional
 	DeprecatedReadinessProbe *corev1.Probe `json:"readinessProbe,omitempty" protobuf:"bytes,11,opt,name=readinessProbe"`
-	// Deprecated. This field will be removed in a future release.
+
 	// DeprecatedStartupProbe indicates that the Pod this Step runs in has successfully initialized.
 	// If specified, no other probes are executed until this completes successfully.
 	// If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
@@ -113,17 +119,22 @@ type Step struct {
 	// when it might take a long time to load data or warm a cache, than during steady-state operation.
 	// This cannot be updated.
 	// More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+	//
+	// Deprecated: This field will be removed in a future release.
+	//
 	// +optional
 	DeprecatedStartupProbe *corev1.Probe `json:"startupProbe,omitempty" protobuf:"bytes,22,opt,name=startupProbe"`
-	// Deprecated. This field will be removed in a future release.
 	// Actions that the management system should take in response to container lifecycle events.
 	// Cannot be updated.
+	//
+	// Deprecated: This field will be removed in a future release.
+	//
 	// +optional
 	DeprecatedLifecycle *corev1.Lifecycle `json:"lifecycle,omitempty" protobuf:"bytes,12,opt,name=lifecycle"`
-	// Deprecated. This field will be removed in a future release and can't be meaningfully used.
+	// Deprecated: This field will be removed in a future release and can't be meaningfully used.
 	// +optional
 	DeprecatedTerminationMessagePath string `json:"terminationMessagePath,omitempty" protobuf:"bytes,13,opt,name=terminationMessagePath"`
-	// Deprecated. This field will be removed in a future release and can't be meaningfully used.
+	// Deprecated: This field will be removed in a future release and can't be meaningfully used.
 	// +optional
 	DeprecatedTerminationMessagePolicy corev1.TerminationMessagePolicy `json:"terminationMessagePolicy,omitempty" protobuf:"bytes,20,opt,name=terminationMessagePolicy,casttype=TerminationMessagePolicy"`
 	// Image pull policy.
@@ -141,13 +152,14 @@ type Step struct {
 
 	// Variables for interactive containers, these are deprecated and should not be used.
 
-	// Deprecated. This field will be removed in a future release.
 	// Whether this container should allocate a buffer for stdin in the container runtime. If this
 	// is not set, reads from stdin in the container will always result in EOF.
 	// Default is false.
+	//
+	// Deprecated: This field will be removed in a future release.
+	//
 	// +optional
 	DeprecatedStdin bool `json:"stdin,omitempty" protobuf:"varint,16,opt,name=stdin"`
-	// Deprecated. This field will be removed in a future release.
 	// Whether the container runtime should close the stdin channel after it has been opened by
 	// a single attach. When stdin is true the stdin stream will remain open across multiple attach
 	// sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
@@ -155,11 +167,16 @@ type Step struct {
 	// at which time stdin is closed and remains closed until the container is restarted. If this
 	// flag is false, a container processes that reads from stdin will never receive an EOF.
 	// Default is false
+	//
+	// Deprecated: This field will be removed in a future release.
+	//
 	// +optional
 	DeprecatedStdinOnce bool `json:"stdinOnce,omitempty" protobuf:"varint,17,opt,name=stdinOnce"`
-	// Deprecated. This field will be removed in a future release.
 	// Whether this container should allocate a DeprecatedTTY for itself, also requires 'stdin' to be true.
 	// Default is false.
+	//
+	// Deprecated: This field will be removed in a future release.
+	//
 	// +optional
 	DeprecatedTTY bool `json:"tty,omitempty" protobuf:"varint,18,opt,name=tty"`
 
@@ -270,10 +287,12 @@ func (s *Step) SetContainerFields(c corev1.Container) {
 
 // StepTemplate is a template for a Step
 type StepTemplate struct {
-	// Deprecated. This field will be removed in a future release.
 	// Default name for each Step specified as a DNS_LABEL.
 	// Each Step in a Task must have a unique name.
 	// Cannot be updated.
+	//
+	// Deprecated: This field will be removed in a future release.
+	//
 	DeprecatedName string `json:"name" protobuf:"bytes,1,opt,name=name"`
 	// Default image name to use for each Step.
 	// More info: https://kubernetes.io/docs/concepts/containers/images
@@ -309,7 +328,6 @@ type StepTemplate struct {
 	// Cannot be updated.
 	// +optional
 	WorkingDir string `json:"workingDir,omitempty" protobuf:"bytes,5,opt,name=workingDir"`
-	// Deprecated. This field will be removed in a future release.
 	// List of ports to expose from the Step's container. Exposing a port here gives
 	// the system additional information about the network connections a
 	// container uses, but is primarily informational. Not specifying a port here
@@ -317,6 +335,9 @@ type StepTemplate struct {
 	// listening on the default "0.0.0.0" address inside a container will be
 	// accessible from the network.
 	// Cannot be updated.
+	//
+	// Deprecated: This field will be removed in a future release.
+	//
 	// +optional
 	// +patchMergeKey=containerPort
 	// +patchStrategy=merge
@@ -358,21 +379,24 @@ type StepTemplate struct {
 	// +optional
 	// +listType=atomic
 	VolumeDevices []corev1.VolumeDevice `json:"volumeDevices,omitempty" patchStrategy:"merge" patchMergeKey:"devicePath" protobuf:"bytes,21,rep,name=volumeDevices"`
-	// Deprecated. This field will be removed in a future release.
 	// Periodic probe of container liveness.
 	// Container will be restarted if the probe fails.
 	// Cannot be updated.
 	// More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+	//
+	// Deprecated: This field will be removed in a future release.
+	//
 	// +optional
 	DeprecatedLivenessProbe *corev1.Probe `json:"livenessProbe,omitempty" protobuf:"bytes,10,opt,name=livenessProbe"`
-	// Deprecated. This field will be removed in a future release.
 	// Periodic probe of container service readiness.
 	// Container will be removed from service endpoints if the probe fails.
 	// Cannot be updated.
 	// More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+	//
+	// Deprecated: This field will be removed in a future release.
+	//
 	// +optional
 	DeprecatedReadinessProbe *corev1.Probe `json:"readinessProbe,omitempty" protobuf:"bytes,11,opt,name=readinessProbe"`
-	// Deprecated. This field will be removed in a future release.
 	// DeprecatedStartupProbe indicates that the Pod has successfully initialized.
 	// If specified, no other probes are executed until this completes successfully.
 	// If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
@@ -380,17 +404,22 @@ type StepTemplate struct {
 	// when it might take a long time to load data or warm a cache, than during steady-state operation.
 	// This cannot be updated.
 	// More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+	//
+	// Deprecated: This field will be removed in a future release.
+	//
 	// +optional
 	DeprecatedStartupProbe *corev1.Probe `json:"startupProbe,omitempty" protobuf:"bytes,22,opt,name=startupProbe"`
-	// Deprecated. This field will be removed in a future release.
 	// Actions that the management system should take in response to container lifecycle events.
 	// Cannot be updated.
+	//
+	// Deprecated: This field will be removed in a future release.
+	//
 	// +optional
 	DeprecatedLifecycle *corev1.Lifecycle `json:"lifecycle,omitempty" protobuf:"bytes,12,opt,name=lifecycle"`
-	// Deprecated. This field will be removed in a future release and cannot be meaningfully used.
+	// Deprecated: This field will be removed in a future release and cannot be meaningfully used.
 	// +optional
 	DeprecatedTerminationMessagePath string `json:"terminationMessagePath,omitempty" protobuf:"bytes,13,opt,name=terminationMessagePath"`
-	// Deprecated. This field will be removed in a future release and cannot be meaningfully used.
+	// Deprecated: This field will be removed in a future release and cannot be meaningfully used.
 	// +optional
 	DeprecatedTerminationMessagePolicy corev1.TerminationMessagePolicy `json:"terminationMessagePolicy,omitempty" protobuf:"bytes,20,opt,name=terminationMessagePolicy,casttype=TerminationMessagePolicy"`
 	// Image pull policy.
@@ -408,13 +437,14 @@ type StepTemplate struct {
 
 	// Variables for interactive containers, these are deprecated and should not be used.
 
-	// Deprecated. This field will be removed in a future release.
 	// Whether this Step should allocate a buffer for stdin in the container runtime. If this
 	// is not set, reads from stdin in the Step will always result in EOF.
 	// Default is false.
+	//
+	// Deprecated: This field will be removed in a future release.
+	//
 	// +optional
 	DeprecatedStdin bool `json:"stdin,omitempty" protobuf:"varint,16,opt,name=stdin"`
-	// Deprecated. This field will be removed in a future release.
 	// Whether the container runtime should close the stdin channel after it has been opened by
 	// a single attach. When stdin is true the stdin stream will remain open across multiple attach
 	// sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
@@ -422,11 +452,16 @@ type StepTemplate struct {
 	// at which time stdin is closed and remains closed until the container is restarted. If this
 	// flag is false, a container processes that reads from stdin will never receive an EOF.
 	// Default is false
+	//
+	// Deprecated: This field will be removed in a future release.
+	//
 	// +optional
 	DeprecatedStdinOnce bool `json:"stdinOnce,omitempty" protobuf:"varint,17,opt,name=stdinOnce"`
-	// Deprecated. This field will be removed in a future release.
 	// Whether this Step should allocate a DeprecatedTTY for itself, also requires 'stdin' to be true.
 	// Default is false.
+	//
+	// Deprecated: This field will be removed in a future release.
+	//
 	// +optional
 	DeprecatedTTY bool `json:"tty,omitempty" protobuf:"varint,18,opt,name=tty"`
 }

--- a/pkg/apis/pipeline/v1beta1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1beta1/openapi_generated.go
@@ -548,7 +548,7 @@ func schema_pkg_apis_pipeline_v1beta1_ClusterTask(ref common.ReferenceCallback) 
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "ClusterTask is a Task with a cluster scope. ClusterTasks are used to represent Tasks that should be publicly addressable from any namespace in the cluster. Deprecated: Please use the cluster resolver instead.",
+				Description: "ClusterTask is a Task with a cluster scope. ClusterTasks are used to represent Tasks that should be publicly addressable from any namespace in the cluster.\n\nDeprecated: Please use the cluster resolver instead.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"kind": {
@@ -1490,7 +1490,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineRef(ref common.ReferenceCallback) 
 					},
 					"bundle": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Bundle url reference to a Tekton Bundle. Deprecated: Please use ResolverRef with the bundles resolver instead.",
+							Description: "Bundle url reference to a Tekton Bundle.\n\nDeprecated: Please use ResolverRef with the bundles resolver instead.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -1897,7 +1897,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineRunSpec(ref common.ReferenceCallba
 					},
 					"timeout": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Timeout Deprecated: use pipelineRunSpec.Timeouts.Pipeline instead Time after which the Pipeline times out. Defaults to never. Refer to Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration",
+							Description: "Timeout is the Time after which the Pipeline times out. Defaults to never. Refer to Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration\n\nDeprecated: use pipelineRunSpec.Timeouts.Pipeline instead",
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Duration"),
 						},
 					},
@@ -2852,7 +2852,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineWorkspaceDeclaration(ref common.Re
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "WorkspacePipelineDeclaration creates a named slot in a Pipeline that a PipelineRun is expected to populate with a workspace binding. Deprecated: use PipelineWorkspaceDeclaration type instead",
+				Description: "WorkspacePipelineDeclaration creates a named slot in a Pipeline that a PipelineRun is expected to populate with a workspace binding.\n\nDeprecated: use PipelineWorkspaceDeclaration type instead",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"name": {
@@ -3487,7 +3487,7 @@ func schema_pkg_apis_pipeline_v1beta1_Step(ref common.ReferenceCallback) common.
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Deprecated. This field will be removed in a future release. List of ports to expose from the Step's container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Cannot be updated.",
+							Description: "List of ports to expose from the Step's container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Cannot be updated.\n\nDeprecated: This field will be removed in a future release.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -3590,38 +3590,38 @@ func schema_pkg_apis_pipeline_v1beta1_Step(ref common.ReferenceCallback) common.
 					},
 					"livenessProbe": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Deprecated. This field will be removed in a future release. Periodic probe of container liveness. Step will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+							Description: "Periodic probe of container liveness. Step will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes\n\nDeprecated: This field will be removed in a future release.",
 							Ref:         ref("k8s.io/api/core/v1.Probe"),
 						},
 					},
 					"readinessProbe": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Deprecated. This field will be removed in a future release. Periodic probe of container service readiness. Step will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+							Description: "Periodic probe of container service readiness. Step will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes\n\nDeprecated: This field will be removed in a future release.",
 							Ref:         ref("k8s.io/api/core/v1.Probe"),
 						},
 					},
 					"startupProbe": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Deprecated. This field will be removed in a future release. DeprecatedStartupProbe indicates that the Pod this Step runs in has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+							Description: "DeprecatedStartupProbe indicates that the Pod this Step runs in has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes\n\nDeprecated: This field will be removed in a future release.",
 							Ref:         ref("k8s.io/api/core/v1.Probe"),
 						},
 					},
 					"lifecycle": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Deprecated. This field will be removed in a future release. Actions that the management system should take in response to container lifecycle events. Cannot be updated.",
+							Description: "Actions that the management system should take in response to container lifecycle events. Cannot be updated.\n\nDeprecated: This field will be removed in a future release.",
 							Ref:         ref("k8s.io/api/core/v1.Lifecycle"),
 						},
 					},
 					"terminationMessagePath": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Deprecated. This field will be removed in a future release and can't be meaningfully used.",
+							Description: "Deprecated: This field will be removed in a future release and can't be meaningfully used.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"terminationMessagePolicy": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Deprecated. This field will be removed in a future release and can't be meaningfully used.",
+							Description: "Deprecated: This field will be removed in a future release and can't be meaningfully used.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -3641,21 +3641,21 @@ func schema_pkg_apis_pipeline_v1beta1_Step(ref common.ReferenceCallback) common.
 					},
 					"stdin": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Deprecated. This field will be removed in a future release. Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.",
+							Description: "Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.\n\nDeprecated: This field will be removed in a future release.",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},
 					},
 					"stdinOnce": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Deprecated. This field will be removed in a future release. Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false",
+							Description: "Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false\n\nDeprecated: This field will be removed in a future release.",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},
 					},
 					"tty": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Deprecated. This field will be removed in a future release. Whether this container should allocate a DeprecatedTTY for itself, also requires 'stdin' to be true. Default is false.",
+							Description: "Whether this container should allocate a DeprecatedTTY for itself, also requires 'stdin' to be true. Default is false.\n\nDeprecated: This field will be removed in a future release.",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},
@@ -3800,7 +3800,7 @@ func schema_pkg_apis_pipeline_v1beta1_StepTemplate(ref common.ReferenceCallback)
 				Properties: map[string]spec.Schema{
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Deprecated. This field will be removed in a future release. Default name for each Step specified as a DNS_LABEL. Each Step in a Task must have a unique name. Cannot be updated.",
+							Description: "Default name for each Step specified as a DNS_LABEL. Each Step in a Task must have a unique name. Cannot be updated.\n\nDeprecated: This field will be removed in a future release.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -3873,7 +3873,7 @@ func schema_pkg_apis_pipeline_v1beta1_StepTemplate(ref common.ReferenceCallback)
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Deprecated. This field will be removed in a future release. List of ports to expose from the Step's container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Cannot be updated.",
+							Description: "List of ports to expose from the Step's container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Cannot be updated.\n\nDeprecated: This field will be removed in a future release.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -3976,38 +3976,38 @@ func schema_pkg_apis_pipeline_v1beta1_StepTemplate(ref common.ReferenceCallback)
 					},
 					"livenessProbe": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Deprecated. This field will be removed in a future release. Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+							Description: "Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes\n\nDeprecated: This field will be removed in a future release.",
 							Ref:         ref("k8s.io/api/core/v1.Probe"),
 						},
 					},
 					"readinessProbe": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Deprecated. This field will be removed in a future release. Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+							Description: "Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes\n\nDeprecated: This field will be removed in a future release.",
 							Ref:         ref("k8s.io/api/core/v1.Probe"),
 						},
 					},
 					"startupProbe": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Deprecated. This field will be removed in a future release. DeprecatedStartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+							Description: "DeprecatedStartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes\n\nDeprecated: This field will be removed in a future release.",
 							Ref:         ref("k8s.io/api/core/v1.Probe"),
 						},
 					},
 					"lifecycle": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Deprecated. This field will be removed in a future release. Actions that the management system should take in response to container lifecycle events. Cannot be updated.",
+							Description: "Actions that the management system should take in response to container lifecycle events. Cannot be updated.\n\nDeprecated: This field will be removed in a future release.",
 							Ref:         ref("k8s.io/api/core/v1.Lifecycle"),
 						},
 					},
 					"terminationMessagePath": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Deprecated. This field will be removed in a future release and cannot be meaningfully used.",
+							Description: "Deprecated: This field will be removed in a future release and cannot be meaningfully used.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"terminationMessagePolicy": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Deprecated. This field will be removed in a future release and cannot be meaningfully used.",
+							Description: "Deprecated: This field will be removed in a future release and cannot be meaningfully used.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -4027,21 +4027,21 @@ func schema_pkg_apis_pipeline_v1beta1_StepTemplate(ref common.ReferenceCallback)
 					},
 					"stdin": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Deprecated. This field will be removed in a future release. Whether this Step should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the Step will always result in EOF. Default is false.",
+							Description: "Whether this Step should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the Step will always result in EOF. Default is false.\n\nDeprecated: This field will be removed in a future release.",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},
 					},
 					"stdinOnce": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Deprecated. This field will be removed in a future release. Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false",
+							Description: "Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false\n\nDeprecated: This field will be removed in a future release.",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},
 					},
 					"tty": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Deprecated. This field will be removed in a future release. Whether this Step should allocate a DeprecatedTTY for itself, also requires 'stdin' to be true. Default is false.",
+							Description: "Whether this Step should allocate a DeprecatedTTY for itself, also requires 'stdin' to be true. Default is false.\n\nDeprecated: This field will be removed in a future release.",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},
@@ -4176,7 +4176,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRef(ref common.ReferenceCallback) comm
 					},
 					"bundle": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Bundle url reference to a Tekton Bundle. Deprecated: Please use ResolverRef with the bundles resolver instead.",
+							Description: "Bundle url reference to a Tekton Bundle.\n\nDeprecated: Please use ResolverRef with the bundles resolver instead.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -4985,7 +4985,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunStatus(ref common.ReferenceCallback
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Deprecated. CloudEvents describe the state of each cloud event requested via a CloudEventResource.",
+							Description: "CloudEvents describe the state of each cloud event requested via a CloudEventResource.\n\nDeprecated: Removed in v0.44.0.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -5163,7 +5163,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunStatusFields(ref common.ReferenceCa
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Deprecated. CloudEvents describe the state of each cloud event requested via a CloudEventResource.",
+							Description: "CloudEvents describe the state of each cloud event requested via a CloudEventResource.\n\nDeprecated: Removed in v0.44.0.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -6010,7 +6010,7 @@ func schema_pkg_apis_resource_v1alpha1_PipelineResource(ref common.ReferenceCall
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Status is deprecated. It usually is used to communicate the observed state of the PipelineResource from the controller, but was unused as there is no controller for PipelineResource.",
+							Description: "Status is used to communicate the observed state of the PipelineResource from the controller, but was unused as there is no controller for PipelineResource.\n\nDeprecated: Deprecated in v0.30.0.",
 							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1.PipelineResourceStatus"),
 						},
 					},
@@ -6142,7 +6142,7 @@ func schema_pkg_apis_resource_v1alpha1_PipelineResourceStatus(ref common.Referen
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "PipelineResourceStatus does not contain anything because PipelineResources on their own do not have a status Deprecated",
+				Description: "PipelineResourceStatus does not contain anything because PipelineResources on their own do not have a status\n\nDeprecated: Deprecated in v0.30.0.",
 				Type:        []string{"object"},
 			},
 		},

--- a/pkg/apis/pipeline/v1beta1/param_types.go
+++ b/pkg/apis/pipeline/v1beta1/param_types.go
@@ -138,6 +138,8 @@ type ParamValue struct {
 }
 
 // ArrayOrString is deprecated, this is to keep backward compatibility
+//
+// Deprecated: Use ParamValue instead.
 type ArrayOrString = ParamValue
 
 // UnmarshalJSON implements the json.Unmarshaller interface.

--- a/pkg/apis/pipeline/v1beta1/pipelineref_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipelineref_types.go
@@ -24,6 +24,7 @@ type PipelineRef struct {
 	// +optional
 	APIVersion string `json:"apiVersion,omitempty"`
 	// Bundle url reference to a Tekton Bundle.
+	//
 	// Deprecated: Please use ResolverRef with the bundles resolver instead.
 	// +optional
 	Bundle string `json:"bundle,omitempty"`

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
@@ -245,9 +245,12 @@ type PipelineRunSpec struct {
 	// +optional
 	Timeouts *TimeoutFields `json:"timeouts,omitempty"`
 
-	// Timeout Deprecated: use pipelineRunSpec.Timeouts.Pipeline instead
-	// Time after which the Pipeline times out. Defaults to never.
+	// Timeout is the Time after which the Pipeline times out.
+	// Defaults to never.
 	// Refer to Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration
+	//
+	// Deprecated: use pipelineRunSpec.Timeouts.Pipeline instead
+	//
 	// +optional
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
 	// PodTemplate holds pod specific configuration

--- a/pkg/apis/pipeline/v1beta1/swagger.json
+++ b/pkg/apis/pipeline/v1beta1/swagger.json
@@ -173,7 +173,7 @@
           "$ref": "#/definitions/v1alpha1.PipelineResourceSpec"
         },
         "status": {
-          "description": "Status is deprecated. It usually is used to communicate the observed state of the PipelineResource from the controller, but was unused as there is no controller for PipelineResource.",
+          "description": "Status is used to communicate the observed state of the PipelineResource from the controller, but was unused as there is no controller for PipelineResource.\n\nDeprecated: Deprecated in v0.30.0.",
           "$ref": "#/definitions/v1alpha1.PipelineResourceStatus"
         }
       }
@@ -242,7 +242,7 @@
       }
     },
     "v1alpha1.PipelineResourceStatus": {
-      "description": "PipelineResourceStatus does not contain anything because PipelineResources on their own do not have a status Deprecated",
+      "description": "PipelineResourceStatus does not contain anything because PipelineResources on their own do not have a status\n\nDeprecated: Deprecated in v0.30.0.",
       "type": "object"
     },
     "v1alpha1.ResourceDeclaration": {
@@ -391,7 +391,7 @@
       }
     },
     "v1beta1.ClusterTask": {
-      "description": "ClusterTask is a Task with a cluster scope. ClusterTasks are used to represent Tasks that should be publicly addressable from any namespace in the cluster. Deprecated: Please use the cluster resolver instead.",
+      "description": "ClusterTask is a Task with a cluster scope. ClusterTasks are used to represent Tasks that should be publicly addressable from any namespace in the cluster.\n\nDeprecated: Please use the cluster resolver instead.",
       "type": "object",
       "properties": {
         "apiVersion": {
@@ -898,7 +898,7 @@
           "type": "string"
         },
         "bundle": {
-          "description": "Bundle url reference to a Tekton Bundle. Deprecated: Please use ResolverRef with the bundles resolver instead.",
+          "description": "Bundle url reference to a Tekton Bundle.\n\nDeprecated: Please use ResolverRef with the bundles resolver instead.",
           "type": "string"
         },
         "name": {
@@ -1136,7 +1136,7 @@
           "x-kubernetes-list-type": "atomic"
         },
         "timeout": {
-          "description": "Timeout Deprecated: use pipelineRunSpec.Timeouts.Pipeline instead Time after which the Pipeline times out. Defaults to never. Refer to Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration",
+          "description": "Timeout is the Time after which the Pipeline times out. Defaults to never. Refer to Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration\n\nDeprecated: use pipelineRunSpec.Timeouts.Pipeline instead",
           "$ref": "#/definitions/v1.Duration"
         },
         "timeouts": {
@@ -1615,7 +1615,7 @@
       }
     },
     "v1beta1.PipelineWorkspaceDeclaration": {
-      "description": "WorkspacePipelineDeclaration creates a named slot in a Pipeline that a PipelineRun is expected to populate with a workspace binding. Deprecated: use PipelineWorkspaceDeclaration type instead",
+      "description": "WorkspacePipelineDeclaration creates a named slot in a Pipeline that a PipelineRun is expected to populate with a workspace binding.\n\nDeprecated: use PipelineWorkspaceDeclaration type instead",
       "type": "object",
       "required": [
         "name"
@@ -2108,11 +2108,11 @@
           "type": "string"
         },
         "lifecycle": {
-          "description": "Deprecated. This field will be removed in a future release. Actions that the management system should take in response to container lifecycle events. Cannot be updated.",
+          "description": "Actions that the management system should take in response to container lifecycle events. Cannot be updated.\n\nDeprecated: This field will be removed in a future release.",
           "$ref": "#/definitions/v1.Lifecycle"
         },
         "livenessProbe": {
-          "description": "Deprecated. This field will be removed in a future release. Periodic probe of container liveness. Step will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+          "description": "Periodic probe of container liveness. Step will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes\n\nDeprecated: This field will be removed in a future release.",
           "$ref": "#/definitions/v1.Probe"
         },
         "name": {
@@ -2125,7 +2125,7 @@
           "type": "string"
         },
         "ports": {
-          "description": "Deprecated. This field will be removed in a future release. List of ports to expose from the Step's container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Cannot be updated.",
+          "description": "List of ports to expose from the Step's container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Cannot be updated.\n\nDeprecated: This field will be removed in a future release.",
           "type": "array",
           "items": {
             "default": {},
@@ -2140,7 +2140,7 @@
           "x-kubernetes-patch-strategy": "merge"
         },
         "readinessProbe": {
-          "description": "Deprecated. This field will be removed in a future release. Periodic probe of container service readiness. Step will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+          "description": "Periodic probe of container service readiness. Step will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes\n\nDeprecated: This field will be removed in a future release.",
           "$ref": "#/definitions/v1.Probe"
         },
         "resources": {
@@ -2157,7 +2157,7 @@
           "$ref": "#/definitions/v1.SecurityContext"
         },
         "startupProbe": {
-          "description": "Deprecated. This field will be removed in a future release. DeprecatedStartupProbe indicates that the Pod this Step runs in has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+          "description": "DeprecatedStartupProbe indicates that the Pod this Step runs in has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes\n\nDeprecated: This field will be removed in a future release.",
           "$ref": "#/definitions/v1.Probe"
         },
         "stderrConfig": {
@@ -2165,11 +2165,11 @@
           "$ref": "#/definitions/v1beta1.StepOutputConfig"
         },
         "stdin": {
-          "description": "Deprecated. This field will be removed in a future release. Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.",
+          "description": "Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.\n\nDeprecated: This field will be removed in a future release.",
           "type": "boolean"
         },
         "stdinOnce": {
-          "description": "Deprecated. This field will be removed in a future release. Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false",
+          "description": "Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false\n\nDeprecated: This field will be removed in a future release.",
           "type": "boolean"
         },
         "stdoutConfig": {
@@ -2177,11 +2177,11 @@
           "$ref": "#/definitions/v1beta1.StepOutputConfig"
         },
         "terminationMessagePath": {
-          "description": "Deprecated. This field will be removed in a future release and can't be meaningfully used.",
+          "description": "Deprecated: This field will be removed in a future release and can't be meaningfully used.",
           "type": "string"
         },
         "terminationMessagePolicy": {
-          "description": "Deprecated. This field will be removed in a future release and can't be meaningfully used.",
+          "description": "Deprecated: This field will be removed in a future release and can't be meaningfully used.",
           "type": "string"
         },
         "timeout": {
@@ -2189,7 +2189,7 @@
           "$ref": "#/definitions/v1.Duration"
         },
         "tty": {
-          "description": "Deprecated. This field will be removed in a future release. Whether this container should allocate a DeprecatedTTY for itself, also requires 'stdin' to be true. Default is false.",
+          "description": "Whether this container should allocate a DeprecatedTTY for itself, also requires 'stdin' to be true. Default is false.\n\nDeprecated: This field will be removed in a future release.",
           "type": "boolean"
         },
         "volumeDevices": {
@@ -2320,20 +2320,20 @@
           "type": "string"
         },
         "lifecycle": {
-          "description": "Deprecated. This field will be removed in a future release. Actions that the management system should take in response to container lifecycle events. Cannot be updated.",
+          "description": "Actions that the management system should take in response to container lifecycle events. Cannot be updated.\n\nDeprecated: This field will be removed in a future release.",
           "$ref": "#/definitions/v1.Lifecycle"
         },
         "livenessProbe": {
-          "description": "Deprecated. This field will be removed in a future release. Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+          "description": "Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes\n\nDeprecated: This field will be removed in a future release.",
           "$ref": "#/definitions/v1.Probe"
         },
         "name": {
-          "description": "Deprecated. This field will be removed in a future release. Default name for each Step specified as a DNS_LABEL. Each Step in a Task must have a unique name. Cannot be updated.",
+          "description": "Default name for each Step specified as a DNS_LABEL. Each Step in a Task must have a unique name. Cannot be updated.\n\nDeprecated: This field will be removed in a future release.",
           "type": "string",
           "default": ""
         },
         "ports": {
-          "description": "Deprecated. This field will be removed in a future release. List of ports to expose from the Step's container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Cannot be updated.",
+          "description": "List of ports to expose from the Step's container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Cannot be updated.\n\nDeprecated: This field will be removed in a future release.",
           "type": "array",
           "items": {
             "default": {},
@@ -2348,7 +2348,7 @@
           "x-kubernetes-patch-strategy": "merge"
         },
         "readinessProbe": {
-          "description": "Deprecated. This field will be removed in a future release. Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+          "description": "Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes\n\nDeprecated: This field will be removed in a future release.",
           "$ref": "#/definitions/v1.Probe"
         },
         "resources": {
@@ -2361,27 +2361,27 @@
           "$ref": "#/definitions/v1.SecurityContext"
         },
         "startupProbe": {
-          "description": "Deprecated. This field will be removed in a future release. DeprecatedStartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+          "description": "DeprecatedStartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes\n\nDeprecated: This field will be removed in a future release.",
           "$ref": "#/definitions/v1.Probe"
         },
         "stdin": {
-          "description": "Deprecated. This field will be removed in a future release. Whether this Step should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the Step will always result in EOF. Default is false.",
+          "description": "Whether this Step should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the Step will always result in EOF. Default is false.\n\nDeprecated: This field will be removed in a future release.",
           "type": "boolean"
         },
         "stdinOnce": {
-          "description": "Deprecated. This field will be removed in a future release. Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false",
+          "description": "Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false\n\nDeprecated: This field will be removed in a future release.",
           "type": "boolean"
         },
         "terminationMessagePath": {
-          "description": "Deprecated. This field will be removed in a future release and cannot be meaningfully used.",
+          "description": "Deprecated: This field will be removed in a future release and cannot be meaningfully used.",
           "type": "string"
         },
         "terminationMessagePolicy": {
-          "description": "Deprecated. This field will be removed in a future release and cannot be meaningfully used.",
+          "description": "Deprecated: This field will be removed in a future release and cannot be meaningfully used.",
           "type": "string"
         },
         "tty": {
-          "description": "Deprecated. This field will be removed in a future release. Whether this Step should allocate a DeprecatedTTY for itself, also requires 'stdin' to be true. Default is false.",
+          "description": "Whether this Step should allocate a DeprecatedTTY for itself, also requires 'stdin' to be true. Default is false.\n\nDeprecated: This field will be removed in a future release.",
           "type": "boolean"
         },
         "volumeDevices": {
@@ -2472,7 +2472,7 @@
           "type": "string"
         },
         "bundle": {
-          "description": "Bundle url reference to a Tekton Bundle. Deprecated: Please use ResolverRef with the bundles resolver instead.",
+          "description": "Bundle url reference to a Tekton Bundle.\n\nDeprecated: Please use ResolverRef with the bundles resolver instead.",
           "type": "string"
         },
         "kind": {
@@ -2869,7 +2869,7 @@
           }
         },
         "cloudEvents": {
-          "description": "Deprecated. CloudEvents describe the state of each cloud event requested via a CloudEventResource.",
+          "description": "CloudEvents describe the state of each cloud event requested via a CloudEventResource.\n\nDeprecated: Removed in v0.44.0.",
           "type": "array",
           "items": {
             "default": {},
@@ -2976,7 +2976,7 @@
       ],
       "properties": {
         "cloudEvents": {
-          "description": "Deprecated. CloudEvents describe the state of each cloud event requested via a CloudEventResource.",
+          "description": "CloudEvents describe the state of each cloud event requested via a CloudEventResource.\n\nDeprecated: Removed in v0.44.0.",
           "type": "array",
           "items": {
             "default": {},

--- a/pkg/apis/pipeline/v1beta1/taskref_types.go
+++ b/pkg/apis/pipeline/v1beta1/taskref_types.go
@@ -26,6 +26,7 @@ type TaskRef struct {
 	// +optional
 	APIVersion string `json:"apiVersion,omitempty"`
 	// Bundle url reference to a Tekton Bundle.
+	//
 	// Deprecated: Please use ResolverRef with the bundles resolver instead.
 	// +optional
 	Bundle string `json:"bundle,omitempty"`

--- a/pkg/apis/pipeline/v1beta1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_types.go
@@ -251,9 +251,11 @@ type TaskRunStatusFields struct {
 	// +listType=atomic
 	Steps []StepState `json:"steps,omitempty"`
 
-	// Deprecated.
 	// CloudEvents describe the state of each cloud event requested via a
 	// CloudEventResource.
+	//
+	// Deprecated: Removed in v0.44.0.
+	//
 	// +optional
 	// +listType=atomic
 	CloudEvents []CloudEventDelivery `json:"cloudEvents,omitempty"`

--- a/pkg/apis/pipeline/v1beta1/workspace_types.go
+++ b/pkg/apis/pipeline/v1beta1/workspace_types.go
@@ -87,6 +87,7 @@ type WorkspaceBinding struct {
 
 // WorkspacePipelineDeclaration creates a named slot in a Pipeline that a PipelineRun
 // is expected to populate with a workspace binding.
+//
 // Deprecated: use PipelineWorkspaceDeclaration type instead
 type WorkspacePipelineDeclaration = PipelineWorkspaceDeclaration
 

--- a/pkg/apis/resource/v1alpha1/pipeline_resource_types.go
+++ b/pkg/apis/resource/v1alpha1/pipeline_resource_types.go
@@ -66,16 +66,19 @@ type PipelineResource struct {
 	// Spec holds the desired state of the PipelineResource from the client
 	Spec PipelineResourceSpec `json:"spec,omitempty"`
 
-	// Status is deprecated.
-	// It usually is used to communicate the observed state of the PipelineResource from
+	// Status is used to communicate the observed state of the PipelineResource from
 	// the controller, but was unused as there is no controller for PipelineResource.
+	//
+	// Deprecated: Deprecated in v0.30.0.
+	//
 	// +optional
 	Status *PipelineResourceStatus `json:"status,omitempty"`
 }
 
 // PipelineResourceStatus does not contain anything because PipelineResources on their own
 // do not have a status
-// Deprecated
+//
+// Deprecated: Deprecated in v0.30.0.
 type PipelineResourceStatus struct {
 }
 


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

Fix godoc deprecated comments.

From https://github.com/golang/go/wiki/Deprecated:

> To signal that an identifier should not be used, add a paragraph to its doc
> comment that begins with "Deprecated:" followed by some information about the
> deprecation, and a recommendation on what to use instead, if applicable.

This should help IDEs and pkgsite to pick up on deprecated fields.

Most changes fall into a few categories:
- "Deprecated." -> "Deprecated:"
- Added paragraph new line.
- Added deprecation description.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
