### PR TITLE
Update Tekton development processes section URLs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,11 +17,11 @@ To set up your environment and begin working on our code, see [Developing for Te
   - [Adopting good development principles](https://github.com/tektoncd/community/blob/main/standards.md#principles)
   - [Writing useful commit messages](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)
 - [Contacting other contributors](https://github.com/tektoncd/community/blob/main/contact.md)
-- [Tekton development processes](https://github.com/tektoncd/community/blob/main/process.md), including:
-  - [Finding things to work on](https://github.com/tektoncd/community/blob/main/process.md#finding-something-to-work-on)
-  - [Proposing new features](https://github.com/tektoncd/community/blob/main/process.md#proposing-features)
-  - [Performing code reviews](https://github.com/tektoncd/community/blob/main/process.md#reviews)
-  - [Becoming a code owner](https://github.com/tektoncd/community/blob/main/process.md#owners)
+- [Tekton development processes](https://github.com/tektoncd/community/tree/main/process#readme), including:
+  - [Finding things to work on](https://github.com/tektoncd/community/tree/main/process#finding-something-to-work-on)
+  - [Proposing new features](https://github.com/tektoncd/community/tree/main/process#proposing-features)
+  - [Performing code reviews](https://github.com/tektoncd/community/tree/main/process#reviews)
+  - [Becoming a community member and maintainer](https://github.com/tektoncd/community/blob/main/process/contributor-ladder.md)
 - [Making changes to the Tekton API](api_compatibility_policy.md#approving-api-changes)
 - [Understanding the Tekton automation infrastructure](https://github.com/tektoncd/plumbing)
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

- [Tekton development processes](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md?plain=1#L20-L24) links are not pointing to the right URLs.
- When accessing these links we get a `404 Page not found` error and below note
```
 The 'tektoncd/community' repository doesn't contain the 'process.md' path in 'main'.  
```
- Update the URLs under [Tekton development processes](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md?plain=1#L20-L24)  to point to the right Links.


# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
