### PR TITLE
TEP-0118: Add exported functions for validating Matrix.Include and Matrix.Params

### DIFF
--- a/pkg/apis/pipeline/v1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1/pipeline_types.go
@@ -293,7 +293,17 @@ func (pt PipelineTask) validateTask(ctx context.Context) (errs *apis.FieldError)
 
 // IsMatrixed return whether pipeline task is matrixed
 func (pt *PipelineTask) IsMatrixed() bool {
-	return pt.Matrix != nil && (len(pt.Matrix.Params) > 0 || len(pt.Matrix.Include) > 0)
+	return pt.Matrix != nil && (pt.Matrix.MatrixHasParams() || pt.Matrix.MatrixHasInclude())
+}
+
+// MatrixHasInclude return whether matrix has Include
+func (matrix *Matrix) MatrixHasInclude() bool {
+	return matrix != nil && len(matrix.Include) > 0
+}
+
+// MatrixHasParams return whether matrix has Params
+func (matrix *Matrix) MatrixHasParams() bool {
+	return matrix != nil && len(matrix.Params) > 0
 }
 
 func (pt *PipelineTask) validateMatrix(ctx context.Context) (errs *apis.FieldError) {

--- a/pkg/apis/pipeline/v1/pipeline_types_test.go
+++ b/pkg/apis/pipeline/v1/pipeline_types_test.go
@@ -903,23 +903,13 @@ func TestPipelineTask_IsMatrixed(t *testing.T) {
 			name: "matrixed with include",
 			arg: arg{
 				Matrix: &Matrix{
-					Include: []MatrixInclude{
-						{Name: "build-1"},
-						{Params: []Param{
-							{Name: "IMAGE", Value: ParamValue{StringVal: "image-1"}},
-							{Name: "DOCKERFILE", Value: ParamValue{StringVal: "path/to/Dockerfile1"}},
-						}},
-						{Name: "build-2"},
-						{Params: []Param{
-							{Name: "IMAGE", Value: ParamValue{StringVal: "image-2"}},
-							{Name: "DOCKERFILE", Value: ParamValue{StringVal: "path/to/Dockerfile2"}},
-						}},
-						{Name: "build-3"},
-						{Params: []Param{
-							{Name: "IMAGE", Value: ParamValue{StringVal: "image-3"}},
-							{Name: "DOCKERFILE", Value: ParamValue{StringVal: "path/to/Dockerfile3"}},
-						}},
-					},
+					Include: []MatrixInclude{{
+						Name: "build-1",
+						Params: []Param{{
+							Name: "IMAGE", Value: ParamValue{Type: ParamTypeString, StringVal: "image-1"},
+						}, {
+							Name: "DOCKERFILE", Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/Dockerfile1"}}},
+					}},
 				},
 			},
 			expected: true,
@@ -927,14 +917,14 @@ func TestPipelineTask_IsMatrixed(t *testing.T) {
 			name: "matrixed with params and include",
 			arg: arg{
 				Matrix: &Matrix{
-					Params: []Param{{Name: "GOARCH", Value: ParamValue{ArrayVal: []string{"linux/amd64", "linux/ppc64le", "linux/s390x"}}}},
-					Include: []MatrixInclude{
-						{Name: "s390x-no-race"},
-						{Params: []Param{
-							{Name: "GOARCH", Value: ParamValue{StringVal: "linux/s390x"}},
-							{Name: "flags", Value: ParamValue{StringVal: "-cover -v"}},
-						}},
-					},
+					Params: []Param{{
+						Name: "GOARCH", Value: ParamValue{ArrayVal: []string{"linux/amd64", "linux/ppc64le", "linux/s390x"}},
+					}},
+					Include: []MatrixInclude{{
+						Name: "common-package",
+						Params: []Param{{
+							Name: "package", Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/common/package/"}}},
+					}},
 				},
 			},
 			expected: true,
@@ -948,6 +938,150 @@ func TestPipelineTask_IsMatrixed(t *testing.T) {
 			isMatrixed := pt.IsMatrixed()
 			if isMatrixed != tc.expected {
 				t.Errorf("PipelineTask.IsMatrixed() return bool: %v, but wanted: %v", isMatrixed, tc.expected)
+			}
+		})
+	}
+}
+
+func TestPipelineTask_MatrixHasParams(t *testing.T) {
+	type arg struct {
+		*Matrix
+	}
+	testCases := []struct {
+		name     string
+		arg      arg
+		expected bool
+	}{
+		{
+			name: "nil matrix",
+			arg: arg{
+				Matrix: nil,
+			},
+			expected: false,
+		},
+		{
+			name: "empty matrix",
+			arg: arg{
+				Matrix: &Matrix{},
+			},
+			expected: false,
+		},
+		{
+			name: "matrixed with params",
+			arg: arg{
+				Matrix: &Matrix{
+					Params: []Param{{Name: "platform", Value: ParamValue{ArrayVal: []string{"linux", "windows"}}}},
+				},
+			},
+			expected: true,
+		}, {
+			name: "matrixed with include",
+			arg: arg{
+				Matrix: &Matrix{
+					Include: []MatrixInclude{{
+						Name: "build-1",
+						Params: []Param{{
+							Name: "IMAGE", Value: ParamValue{Type: ParamTypeString, StringVal: "image-1"},
+						}, {
+							Name: "DOCKERFILE", Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/Dockerfile1"}}},
+					}},
+				},
+			},
+			expected: false,
+		}, {
+			name: "matrixed with params and include",
+			arg: arg{
+				Matrix: &Matrix{
+					Params: []Param{{
+						Name: "GOARCH", Value: ParamValue{ArrayVal: []string{"linux/amd64", "linux/ppc64le", "linux/s390x"}},
+					}},
+					Include: []MatrixInclude{{
+						Name: "common-package",
+						Params: []Param{{
+							Name: "package", Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/common/package/"}}},
+					}},
+				},
+			},
+			expected: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			matrixHasParams := tc.arg.Matrix.MatrixHasParams()
+			if matrixHasParams != tc.expected {
+				t.Errorf("Matrix.MatrixHasParams() return bool: %v, but wanted: %v", matrixHasParams, tc.expected)
+			}
+		})
+	}
+}
+
+func TestPipelineTask_MatrixHasInclude(t *testing.T) {
+	type arg struct {
+		*Matrix
+	}
+	testCases := []struct {
+		name     string
+		arg      arg
+		expected bool
+	}{
+		{
+			name: "nil matrix",
+			arg: arg{
+				Matrix: nil,
+			},
+			expected: false,
+		},
+		{
+			name: "empty matrix",
+			arg: arg{
+				Matrix: &Matrix{},
+			},
+			expected: false,
+		},
+		{
+			name: "matrixed with params",
+			arg: arg{
+				Matrix: &Matrix{
+					Params: []Param{{Name: "platform", Value: ParamValue{ArrayVal: []string{"linux", "windows"}}}},
+				},
+			},
+			expected: false,
+		}, {
+			name: "matrixed with include",
+			arg: arg{
+				Matrix: &Matrix{
+					Include: []MatrixInclude{{
+						Name: "build-1",
+						Params: []Param{{
+							Name: "IMAGE", Value: ParamValue{Type: ParamTypeString, StringVal: "image-1"},
+						}, {
+							Name: "DOCKERFILE", Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/Dockerfile1"}}},
+					}},
+				},
+			},
+			expected: true,
+		}, {
+			name: "matrixed with params and include",
+			arg: arg{
+				Matrix: &Matrix{
+					Params: []Param{{
+						Name: "GOARCH", Value: ParamValue{ArrayVal: []string{"linux/amd64", "linux/ppc64le", "linux/s390x"}},
+					}},
+					Include: []MatrixInclude{{
+						Name: "common-package",
+						Params: []Param{{
+							Name: "package", Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/common/package/"}}},
+					}},
+				},
+			},
+			expected: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			matrixHasInclude := tc.arg.Matrix.MatrixHasInclude()
+			if matrixHasInclude != tc.expected {
+				t.Errorf("Matrix.MatrixHasInclude() return bool: %v, but wanted: %v", matrixHasInclude, tc.expected)
 			}
 		})
 	}

--- a/pkg/apis/pipeline/v1beta1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types.go
@@ -323,7 +323,17 @@ func (pt PipelineTask) validateTask(ctx context.Context) (errs *apis.FieldError)
 
 // IsMatrixed return whether pipeline task is matrixed
 func (pt *PipelineTask) IsMatrixed() bool {
-	return pt.Matrix != nil && (len(pt.Matrix.Params) > 0 || len(pt.Matrix.Include) > 0)
+	return pt.Matrix != nil && (pt.Matrix.MatrixHasParams() || pt.Matrix.MatrixHasInclude())
+}
+
+// MatrixHasInclude return whether matrix has Include
+func (matrix *Matrix) MatrixHasInclude() bool {
+	return matrix != nil && len(matrix.Include) > 0
+}
+
+// MatrixHasParams return whether matrix has Params
+func (matrix *Matrix) MatrixHasParams() bool {
+	return matrix != nil && len(matrix.Params) > 0
 }
 
 func (pt *PipelineTask) validateMatrix(ctx context.Context) (errs *apis.FieldError) {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
[TEP-0118](https://github.com/tektoncd/community/blob/main/teps/0118-matrix-with-explicit-combinations-of-parameters.md) proposed adding include as a new field within matrix

This commit adds functions that will be used to validate if MatrixHasInclude or MatrixHasParams(), which will be used in subsequent PRs as validation and implementation logic is built out.

/kind feature

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
