### PR TITLE
TEP-0118: Add validation for Matrix.Include.Params of type string

### DIFF
--- a/docs/matrix.md
+++ b/docs/matrix.md
@@ -154,6 +154,20 @@ spec:
 > It is still in a very early stage of development and is not yet fully functional.
 The `Include` section in the `Matrix` field exists, but is not yet functional.
 
+The `Matrix.Include` will take `Parameters` of type `"string"` only.
+
+```yaml
+    matrix:
+      include:
+        - name: s390x-no-race
+          params:
+              - name: GOARCH
+                value: "linux/s390x"
+              - name: flags
+                value: "-cover -v"
+  ...
+```
+
 ### Context Variables
 
 Similarly to the `Parameters` in the `Params` field, the `Parameters` in the `Matrix` field will accept

--- a/pkg/apis/pipeline/v1/param_types.go
+++ b/pkg/apis/pipeline/v1/param_types.go
@@ -325,11 +325,25 @@ func validatePipelineParametersVariablesInMatrixParameters(matrix []Param, prefi
 	return errs
 }
 
-func validateParametersInTaskMatrix(matrix *Matrix) (errs *apis.FieldError) {
+// validateParamTypesInMatrix validates the type of parameter
+// for Matrix.Params and Matrix.Include.Params
+// Matrix.Params must be of type array. Matrix.Include.Params must be of type string.
+func validateParamTypesInMatrix(matrix *Matrix) (errs *apis.FieldError) {
 	if matrix != nil {
-		for _, param := range matrix.Params {
-			if param.Value.Type != ParamTypeArray {
-				errs = errs.Also(apis.ErrInvalidValue("parameters of type array only are allowed in matrix", "").ViaFieldKey("matrix", param.Name))
+		if matrix.MatrixHasInclude() {
+			for _, include := range matrix.Include {
+				for _, param := range include.Params {
+					if param.Value.Type != ParamTypeString {
+						errs = errs.Also(apis.ErrInvalidValue(fmt.Sprintf("parameters of type string only are allowed, but got param type %s", string(param.Value.Type)), "").ViaFieldKey("matrix.include.params", param.Name))
+					}
+				}
+			}
+		}
+		if matrix.MatrixHasParams() {
+			for _, param := range matrix.Params {
+				if param.Value.Type != ParamTypeArray {
+					errs = errs.Also(apis.ErrInvalidValue(fmt.Sprintf("parameters of type array only are allowed, but got param type %s", string(param.Value.Type)), "").ViaFieldKey("matrix.params", param.Name))
+				}
 			}
 		}
 	}

--- a/pkg/apis/pipeline/v1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1/pipeline_types.go
@@ -314,7 +314,7 @@ func (pt *PipelineTask) validateMatrix(ctx context.Context) (errs *apis.FieldErr
 		errs = errs.Also(pt.validateMatrixCombinationsCount(ctx))
 	}
 	errs = errs.Also(validateParameterInOneOfMatrixOrParams(pt.Matrix, pt.Params))
-	errs = errs.Also(validateParametersInTaskMatrix(pt.Matrix))
+	errs = errs.Also(validateParamTypesInMatrix(pt.Matrix))
 	return errs
 }
 

--- a/pkg/apis/pipeline/v1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1/pipeline_validation_test.go
@@ -2970,8 +2970,8 @@ func Test_validateMatrix(t *testing.T) {
 				}}},
 		}},
 		wantErrs: &apis.FieldError{
-			Message: "invalid value: parameters of type array only are allowed in matrix",
-			Paths:   []string{"[0].matrix[foo]", "[0].matrix[bar]", "[1].matrix[baz]"},
+			Message: "invalid value: parameters of type array only are allowed, but got param type string",
+			Paths:   []string{"[0].matrix.params[foo]", "[0].matrix.params[bar]", "[1].matrix.params[baz]"},
 		},
 	}, {
 		name: "parameters in matrix are arrays",

--- a/pkg/apis/pipeline/v1beta1/param_types.go
+++ b/pkg/apis/pipeline/v1beta1/param_types.go
@@ -319,11 +319,25 @@ func validatePipelineParametersVariablesInMatrixParameters(matrix []Param, prefi
 	return errs
 }
 
-func validateParametersInTaskMatrix(matrix *Matrix) (errs *apis.FieldError) {
+// validateParamTypesInMatrix validates the type of parameter
+// for Matrix.Params and Matrix.Include.Params
+// Matrix.Params must be of type array. Matrix.Include.Params must be of type string.
+func validateParamTypesInMatrix(matrix *Matrix) (errs *apis.FieldError) {
 	if matrix != nil {
-		for _, param := range matrix.Params {
-			if param.Value.Type != ParamTypeArray {
-				errs = errs.Also(apis.ErrInvalidValue("parameters of type array only are allowed in matrix", "").ViaFieldKey("matrix", param.Name))
+		if matrix.MatrixHasInclude() {
+			for _, include := range matrix.Include {
+				for _, param := range include.Params {
+					if param.Value.Type != ParamTypeString {
+						errs = errs.Also(apis.ErrInvalidValue(fmt.Sprintf("parameters of type string only are allowed, but got param type %s", string(param.Value.Type)), "").ViaFieldKey("matrix.include.params", param.Name))
+					}
+				}
+			}
+		}
+		if matrix.MatrixHasParams() {
+			for _, param := range matrix.Params {
+				if param.Value.Type != ParamTypeArray {
+					errs = errs.Also(apis.ErrInvalidValue(fmt.Sprintf("parameters of type array only are allowed, but got param type %s", string(param.Value.Type)), "").ViaFieldKey("matrix.params", param.Name))
+				}
 			}
 		}
 	}

--- a/pkg/apis/pipeline/v1beta1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types.go
@@ -328,12 +328,12 @@ func (pt *PipelineTask) IsMatrixed() bool {
 
 // MatrixHasInclude return whether matrix has Include
 func (matrix *Matrix) MatrixHasInclude() bool {
-	return matrix != nil && len(matrix.Include) > 0
+	return matrix != nil && matrix.Include != nil && len(matrix.Include) > 0
 }
 
 // MatrixHasParams return whether matrix has Params
 func (matrix *Matrix) MatrixHasParams() bool {
-	return matrix != nil && len(matrix.Params) > 0
+	return matrix != nil && matrix.Params != nil && len(matrix.Params) > 0
 }
 
 func (pt *PipelineTask) validateMatrix(ctx context.Context) (errs *apis.FieldError) {
@@ -344,7 +344,7 @@ func (pt *PipelineTask) validateMatrix(ctx context.Context) (errs *apis.FieldErr
 		errs = errs.Also(pt.validateMatrixCombinationsCount(ctx))
 	}
 	errs = errs.Also(validateParameterInOneOfMatrixOrParams(pt.Matrix, pt.Params))
-	errs = errs.Also(validateParametersInTaskMatrix(pt.Matrix))
+	errs = errs.Also(validateParamTypesInMatrix(pt.Matrix))
 	return errs
 }
 

--- a/pkg/apis/pipeline/v1beta1/pipeline_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types_test.go
@@ -817,8 +817,8 @@ func TestPipelineTask_validateMatrix(t *testing.T) {
 				}}},
 		},
 		wantErrs: &apis.FieldError{
-			Message: "invalid value: parameters of type array only are allowed in matrix",
-			Paths:   []string{"matrix[foo]", "matrix[bar]"},
+			Message: "invalid value: parameters of type array only are allowed, but got param type string",
+			Paths:   []string{"matrix.params[foo]", "matrix.params[bar]"},
 		},
 	}, {
 		name: "parameters in matrix are arrays",
@@ -829,6 +829,70 @@ func TestPipelineTask_validateMatrix(t *testing.T) {
 					Name: "foobar", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"foo", "bar"}},
 				}, {
 					Name: "barfoo", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"bar", "foo"}},
+				}}},
+		},
+	}, {
+		name: "parameters in include matrix are strings",
+		pt: &PipelineTask{
+			Name: "task",
+			Matrix: &Matrix{
+				Include: []MatrixInclude{{
+					Name: "build-1",
+					Params: []Param{{
+						Name: "IMAGE", Value: ParamValue{Type: ParamTypeString, StringVal: "image-1"},
+					}, {
+						Name: "DOCKERFILE", Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/Dockerfile1"},
+					}}},
+				}},
+		},
+	}, {
+		name: "parameters in include matrix are objects",
+		pt: &PipelineTask{
+			Name: "task",
+			Matrix: &Matrix{
+				Include: []MatrixInclude{{
+					Name: "build-1",
+					Params: []Param{{
+						Name: "barfoo", Value: ParamValue{Type: ParamTypeObject, ObjectVal: map[string]string{
+							"url":    "$(params.myObject.non-exist-key)",
+							"commit": "$(params.myString)",
+						}},
+					}, {
+						Name: "foobar", Value: ParamValue{Type: ParamTypeObject, ObjectVal: map[string]string{
+							"url":    "$(params.myObject.non-exist-key)",
+							"commit": "$(params.myString)",
+						}},
+					}},
+				}}},
+		},
+		wantErrs: &apis.FieldError{
+			Message: "invalid value: parameters of type string only are allowed, but got param type object",
+			Paths:   []string{"matrix.include.params[barfoo]", "matrix.include.params[foobar]"},
+		},
+	}, {
+		name: "parameters in include matrix are arrays",
+		pt: &PipelineTask{
+			Name: "task",
+			Matrix: &Matrix{
+				Include: []MatrixInclude{{
+					Name: "build-1",
+					Params: []Param{{
+						Name: "foobar", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"foo", "bar"}},
+					}, {
+						Name: "barfoo", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"bar", "foo"}}}},
+				}}},
+		},
+		wantErrs: &apis.FieldError{
+			Message: "invalid value: parameters of type string only are allowed, but got param type array",
+			Paths:   []string{"matrix.include.params[barfoo]", "matrix.include.params[foobar]"},
+		},
+	}, {
+		name: "parameters in matrix contain results references",
+		pt: &PipelineTask{
+			Name: "task",
+			Matrix: &Matrix{
+				Params: []Param{{
+					Name: "a-param", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"$(tasks.foo-task.results.a-result)"}},
 				}}},
 		},
 	}, {

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
@@ -3414,8 +3414,8 @@ func Test_validateMatrix(t *testing.T) {
 				}}},
 		}},
 		wantErrs: &apis.FieldError{
-			Message: "invalid value: parameters of type array only are allowed in matrix",
-			Paths:   []string{"[0].matrix[foo]", "[0].matrix[bar]", "[1].matrix[baz]"},
+			Message: "invalid value: parameters of type array only are allowed, but got param type string",
+			Paths:   []string{"[0].matrix.params[foo]", "[0].matrix.params[bar]", "[1].matrix.params[baz]"},
 		},
 	}, {
 		name: "parameters in matrix are arrays",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
[TEP-0118](https://github.com/tektoncd/community/blob/main/teps/0118-matrix-with-explicit-combinations-of-parameters.md) proposed adding include as a new field within matrix

This commit validates that parameters in Matrix.Include are of type string

Note: This is still in preview mode. Other forms of validation and implementation logic will be added in subsequent commits.

/kind feature

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
