### PR TITLE
TEP-0118: Add validation for matrix combination count with matrix.include params

### DIFF
--- a/docs/matrix.md
+++ b/docs/matrix.md
@@ -50,6 +50,8 @@ The default maximum count of `TaskRuns` or `Runs` from a given `Matrix` is **256
 [config defaults](/config/config-defaults.yaml). When a `Matrix` in `PipelineTask` would generate more than the maximum
 `TaskRuns` or `Runs`, the `Pipeline` validation would fail.
 
+Note: The matrix combination count includes combinations generated from both `Matrix.Params` and `Matrix.Include.Params`.
+
 ```yaml
 apiVersion: v1
 kind: ConfigMap

--- a/pkg/apis/pipeline/v1/matrix_types_test.go
+++ b/pkg/apis/pipeline/v1/matrix_types_test.go
@@ -320,6 +320,91 @@ func TestPipelineTask_CountCombinations(t *testing.T) {
 				Name: "xyzzy", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"x", "y", "z", "z", "y"}},
 			}}},
 		want: 135,
+	}, {
+		name: "explicit combinations in the matrix",
+		matrix: &Matrix{
+			Include: []MatrixInclude{{
+				Name: "build-1",
+				Params: []Param{{
+					Name: "IMAGE", Value: ParamValue{Type: ParamTypeString, StringVal: "image-1"},
+				}, {
+					Name: "DOCKERFILE", Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/Dockerfile1"},
+				}},
+			}, {
+				Name: "build-2",
+				Params: []Param{{
+					Name: "IMAGE", Value: ParamValue{Type: ParamTypeString, StringVal: "image-2"},
+				}, {
+					Name: "DOCKERFILE", Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/Dockerfile2"},
+				}},
+			}, {
+				Name: "build-3",
+				Params: []Param{{
+					Name: "IMAGE", Value: ParamValue{Type: ParamTypeString, StringVal: "image-3"},
+				}, {
+					Name: "DOCKERFILE", Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/Dockerfile3"},
+				}},
+			}},
+		},
+		want: 3,
+	}, {
+		name: "params and include in matrix with overriding combinations params",
+		matrix: &Matrix{
+			Params: []Param{{
+				Name: "GOARCH", Value: ParamValue{ArrayVal: []string{"linux/amd64", "linux/ppc64le", "linux/s390x"}},
+			}, {
+				Name: "version", Value: ParamValue{ArrayVal: []string{"go1.17", "go1.18.1"}}},
+			},
+			Include: []MatrixInclude{{
+				Name: "common-package",
+				Params: []Param{{
+					Name: "package", Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/common/package/"}}},
+			}, {
+				Name: "s390x-no-race",
+				Params: []Param{{
+					Name: "GOARCH", Value: ParamValue{Type: ParamTypeString, StringVal: "linux/s390x"},
+				}, {
+					Name: "flags", Value: ParamValue{Type: ParamTypeString, StringVal: "-cover -v"}}},
+			}, {
+				Name: "go117-context",
+				Params: []Param{{
+					Name: "version", Value: ParamValue{Type: ParamTypeString, StringVal: "go1.17"},
+				}, {
+					Name: "context", Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/go117/context"}}},
+			}},
+		},
+		want: 6,
+	}, {
+		name: "params and include in matrix with overriding combinations params and one new combination",
+		matrix: &Matrix{
+			Params: []Param{{
+				Name: "GOARCH", Value: ParamValue{ArrayVal: []string{"linux/amd64", "linux/ppc64le", "linux/s390x"}},
+			}, {
+				Name: "version", Value: ParamValue{ArrayVal: []string{"go1.17", "go1.18.1"}}},
+			},
+			Include: []MatrixInclude{{
+				Name: "common-package",
+				Params: []Param{{
+					Name: "package", Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/common/package/"}}},
+			}, {
+				Name: "s390x-no-race",
+				Params: []Param{{
+					Name: "GOARCH", Value: ParamValue{Type: ParamTypeString, StringVal: "linux/s390x"},
+				}, {
+					Name: "flags", Value: ParamValue{Type: ParamTypeString, StringVal: "-cover -v"}}},
+			}, {
+				Name: "go117-context",
+				Params: []Param{{
+					Name: "version", Value: ParamValue{Type: ParamTypeString, StringVal: "go1.17"},
+				}, {
+					Name: "context", Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/go117/context"}}},
+			}, {
+				Name: "non-existent-arch",
+				Params: []Param{{
+					Name: "GOARCH", Value: ParamValue{Type: ParamTypeString, StringVal: "I-do-not-exist"}},
+				}},
+			}},
+		want: 7,
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/apis/pipeline/v1/param_types.go
+++ b/pkg/apis/pipeline/v1/param_types.go
@@ -134,6 +134,16 @@ func (ps Params) extractParamValuesFromParams() []string {
 	return pvs
 }
 
+// extractParamMapArrVals creates a param map with the key: param.Name and
+// val: param.Value.ArrayVal
+func (ps Params) extractParamMapArrVals() map[string][]string {
+	paramsMap := make(map[string][]string)
+	for _, p := range ps {
+		paramsMap[p.Name] = p.Value.ArrayVal
+	}
+	return paramsMap
+}
+
 // Params is a list of Param
 type Params []Param
 

--- a/pkg/apis/pipeline/v1beta1/matrix_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/matrix_types_test.go
@@ -320,6 +320,91 @@ func TestPipelineTask_CountCombinations(t *testing.T) {
 				Name: "xyzzy", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"x", "y", "z", "z", "y"}},
 			}}},
 		want: 135,
+	}, {
+		name: "explicit combinations in the matrix",
+		matrix: &Matrix{
+			Include: []MatrixInclude{{
+				Name: "build-1",
+				Params: []Param{{
+					Name: "IMAGE", Value: ParamValue{Type: ParamTypeString, StringVal: "image-1"},
+				}, {
+					Name: "DOCKERFILE", Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/Dockerfile1"},
+				}},
+			}, {
+				Name: "build-2",
+				Params: []Param{{
+					Name: "IMAGE", Value: ParamValue{Type: ParamTypeString, StringVal: "image-2"},
+				}, {
+					Name: "DOCKERFILE", Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/Dockerfile2"},
+				}},
+			}, {
+				Name: "build-3",
+				Params: []Param{{
+					Name: "IMAGE", Value: ParamValue{Type: ParamTypeString, StringVal: "image-3"},
+				}, {
+					Name: "DOCKERFILE", Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/Dockerfile3"},
+				}},
+			}},
+		},
+		want: 3,
+	}, {
+		name: "params and include in matrix with overriding combinations params",
+		matrix: &Matrix{
+			Params: []Param{{
+				Name: "GOARCH", Value: ParamValue{ArrayVal: []string{"linux/amd64", "linux/ppc64le", "linux/s390x"}},
+			}, {
+				Name: "version", Value: ParamValue{ArrayVal: []string{"go1.17", "go1.18.1"}}},
+			},
+			Include: []MatrixInclude{{
+				Name: "common-package",
+				Params: []Param{{
+					Name: "package", Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/common/package/"}}},
+			}, {
+				Name: "s390x-no-race",
+				Params: []Param{{
+					Name: "GOARCH", Value: ParamValue{Type: ParamTypeString, StringVal: "linux/s390x"},
+				}, {
+					Name: "flags", Value: ParamValue{Type: ParamTypeString, StringVal: "-cover -v"}}},
+			}, {
+				Name: "go117-context",
+				Params: []Param{{
+					Name: "version", Value: ParamValue{Type: ParamTypeString, StringVal: "go1.17"},
+				}, {
+					Name: "context", Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/go117/context"}}},
+			}},
+		},
+		want: 6,
+	}, {
+		name: "params and include in matrix with overriding combinations params and one new combination",
+		matrix: &Matrix{
+			Params: []Param{{
+				Name: "GOARCH", Value: ParamValue{ArrayVal: []string{"linux/amd64", "linux/ppc64le", "linux/s390x"}},
+			}, {
+				Name: "version", Value: ParamValue{ArrayVal: []string{"go1.17", "go1.18.1"}}},
+			},
+			Include: []MatrixInclude{{
+				Name: "common-package",
+				Params: []Param{{
+					Name: "package", Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/common/package/"}}},
+			}, {
+				Name: "s390x-no-race",
+				Params: []Param{{
+					Name: "GOARCH", Value: ParamValue{Type: ParamTypeString, StringVal: "linux/s390x"},
+				}, {
+					Name: "flags", Value: ParamValue{Type: ParamTypeString, StringVal: "-cover -v"}}},
+			}, {
+				Name: "go117-context",
+				Params: []Param{{
+					Name: "version", Value: ParamValue{Type: ParamTypeString, StringVal: "go1.17"},
+				}, {
+					Name: "context", Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/go117/context"}}},
+			}, {
+				Name: "non-existent-arch",
+				Params: []Param{{
+					Name: "GOARCH", Value: ParamValue{Type: ParamTypeString, StringVal: "I-do-not-exist"}},
+				}},
+			}},
+		want: 7,
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/apis/pipeline/v1beta1/param_types.go
+++ b/pkg/apis/pipeline/v1beta1/param_types.go
@@ -130,6 +130,16 @@ func (ps Params) extractParamValuesFromParams() []string {
 	return pvs
 }
 
+// extractParamMapArrVals creates a param map with the key: param.Name and
+// val: param.Value.ArrayVal
+func (ps Params) extractParamMapArrVals() map[string][]string {
+	paramsMap := make(map[string][]string)
+	for _, p := range ps {
+		paramsMap[p.Name] = p.Value.ArrayVal
+	}
+	return paramsMap
+}
+
 // extractParamArrayLengths extract and return the lengths of all array params
 // Example of returned value: {"a-array-params": 2,"b-array-params": 2 }
 func (ps Params) extractParamArrayLengths() map[string]int {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

[[TEP-0090: Matrix](https://github.com/tektoncd/community/blob/main/teps/0090-matrix.md)] introduced `Matrix` to the `PipelineTask` specification such that the `PipelineTask` executes a list of `TaskRuns` or `Runs` in parallel with the specified list of inputs for a `Parameter` or with different combinations of the inputs for a set of `Parameters`.

To build on this [TEP-0018 ](https://github.com/tektoncd/community/blob/main/teps/0118-matrix-with-explicit-combinations-of-parameters.md )introduced Matrix.Include, which allows passing in a specific combinations of `Parameters` into the `Matrix`.

**This PR validates that matrix combinations count including parameters in Matrix.Include does not exceed the max matrix combinations count.**

Note: This is still in preview mode. Other forms of validation and implementation logic will be added in subsequent commits.

/kind feature

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```

