### PR TITLE
TEP-0090 Matrix: Refactor Matrix FanOut() to use the Matrix Struct

### DIFF
--- a/pkg/matrix/matrix.go
+++ b/pkg/matrix/matrix.go
@@ -18,9 +18,9 @@ import (
 )
 
 // FanOut produces combinations of Parameters of type String from a slice of Parameters of type Array.
-func FanOut(params []v1beta1.Param) Combinations {
+func FanOut(matrix v1beta1.Matrix) Combinations {
 	var combinations Combinations
-	for _, parameter := range params {
+	for _, parameter := range matrix.Params {
 		combinations = combinations.fanOut(parameter)
 	}
 	return combinations

--- a/pkg/matrix/matrix_test.go
+++ b/pkg/matrix/matrix_test.go
@@ -23,14 +23,22 @@ import (
 func Test_FanOut(t *testing.T) {
 	tests := []struct {
 		name             string
-		matrix           []v1beta1.Param
+		matrix           v1beta1.Matrix
 		wantCombinations Combinations
 	}{{
+		name: "matrix with no params",
+		matrix: v1beta1.Matrix{
+			Params: []v1beta1.Param{},
+		},
+		wantCombinations: nil,
+	}, {
 		name: "single array in matrix",
-		matrix: []v1beta1.Param{{
-			Name:  "platform",
-			Value: v1beta1.ParamValue{Type: v1beta1.ParamTypeArray, ArrayVal: []string{"linux", "mac", "windows"}},
-		}},
+		matrix: v1beta1.Matrix{
+			Params: []v1beta1.Param{{
+				Name:  "platform",
+				Value: v1beta1.ParamValue{Type: v1beta1.ParamTypeArray, ArrayVal: []string{"linux", "mac", "windows"}},
+			}},
+		},
 		wantCombinations: Combinations{{
 			MatrixID: "0",
 			Params: []v1beta1.Param{{
@@ -52,13 +60,14 @@ func Test_FanOut(t *testing.T) {
 		}},
 	}, {
 		name: "multiple arrays in matrix",
-		matrix: []v1beta1.Param{{
-			Name:  "platform",
-			Value: v1beta1.ParamValue{Type: v1beta1.ParamTypeArray, ArrayVal: []string{"linux", "mac", "windows"}},
-		}, {
-			Name:  "browser",
-			Value: v1beta1.ParamValue{Type: v1beta1.ParamTypeArray, ArrayVal: []string{"chrome", "safari", "firefox"}},
-		}},
+		matrix: v1beta1.Matrix{
+			Params: []v1beta1.Param{{
+				Name:  "platform",
+				Value: v1beta1.ParamValue{Type: v1beta1.ParamTypeArray, ArrayVal: []string{"linux", "mac", "windows"}},
+			}, {
+				Name:  "browser",
+				Value: v1beta1.ParamValue{Type: v1beta1.ParamTypeArray, ArrayVal: []string{"chrome", "safari", "firefox"}},
+			}}},
 		wantCombinations: Combinations{{
 			MatrixID: "0",
 			Params: []v1beta1.Param{{

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -834,7 +834,7 @@ func (c *Reconciler) createTaskRuns(ctx context.Context, rpt *resources.Resolved
 	ctx, span := c.tracerProvider.Tracer(TracerName).Start(ctx, "createTaskRuns")
 	defer span.End()
 	var taskRuns []*v1beta1.TaskRun
-	matrixCombinations := matrix.FanOut(rpt.PipelineTask.Matrix.Params).ToMap()
+	matrixCombinations := matrix.FanOut(*rpt.PipelineTask.Matrix).ToMap()
 	for i, taskRunName := range rpt.TaskRunNames {
 		params := matrixCombinations[strconv.Itoa(i)]
 		taskRun, err := c.createTaskRun(ctx, taskRunName, params, rpt, pr, storageBasePath)
@@ -909,7 +909,7 @@ func (c *Reconciler) createRunObjects(ctx context.Context, rpt *resources.Resolv
 	var runObjects []v1beta1.RunObject
 	ctx, span := c.tracerProvider.Tracer(TracerName).Start(ctx, "createRunObjects")
 	defer span.End()
-	matrixCombinations := matrix.FanOut(rpt.PipelineTask.Matrix.Params).ToMap()
+	matrixCombinations := matrix.FanOut(*rpt.PipelineTask.Matrix).ToMap()
 	for i, runObjectName := range rpt.RunObjectNames {
 		params := matrixCombinations[strconv.Itoa(i)]
 		runObject, err := c.createRunObject(ctx, runObjectName, params, rpt, pr)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

[[TEP-0090: Matrix](https://github.com/tektoncd/community/blob/main/teps/0090-matrix.md)] introduced `Matrix` to the `PipelineTask` specification such that the `PipelineTask` executes a list of `TaskRuns` or `Runs` in parallel with the specified list of inputs for a `Parameter` or with different combinations of the inputs for a set of `Parameters`.

This PR refactors the FanOut() function to use the Matrix struct instead of the old []Params.

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```

