### PR TITLE
Hygiene: enable additional lint presets.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,7 +14,6 @@ linters-settings:
     packages-with-error-message:
     - k8s.io/apimachinery/pkg/util/clock: 'use k8s.io/utils/clock or k8s.io/utils/clock/testing'
 linters:
-  disable-all: true
   enable:
   - bodyclose
   - decorder
@@ -36,11 +35,24 @@ linters:
   - unused
   - usestdlibvars
   - whitespace
+  disable:
+  - ineffassign
+  - staticcheck
+# Enabling presets means that new linters that we automatically adopt new
+# linters that augment a preset. This also opts us in for replacement linters
+# when a linter is deprecated.
 presets:
+  - bugs
+  - comment
+  - complexity
+  - error
   - format
   - import
   - metalinter
   - module
+  - performance
+  - sql
+  - style
   - test
   - unused
 output:


### PR DESCRIPTION
# Changes

This PR opts us into remaining `golangci` presets and removes the `disable-all` configuration such that we automatically inherit new default linters.

To get here, I opted out from `staticcheck` and `ineffassign`, both of which will require us to clean up existing issues prior to enablement. That can be done in future PRs.

Context: https://github.com/tektoncd/pipeline/issues/5899

/kind cleanup

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Submitter Checklist

- [N/A] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [N/A] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
