### PR TITLE
Add conversion for remote tasks and pipelines to support v1

### DIFF
--- a/pkg/reconciler/pipelinerun/resources/pipelineref.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelineref.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/authn/k8schain"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	clientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
@@ -172,12 +173,26 @@ func resolvePipeline(ctx context.Context, resolver remote.Resolver, name string)
 
 // readRuntimeObjectAsPipeline tries to convert a generic runtime.Object
 // into a v1beta1.PipelineObject type so that its meta and spec fields
-// can be read. An error is returned if the given object is not a
+// can be read. v1 object will be converted to v1beta1 and returned.
+// An error is returned if the given object is not a
 // PipelineObject or if there is an error validating or upgrading an
 // older PipelineObject into its v1beta1 equivalent.
+// TODO(#5541): convert v1beta1 obj to v1 once we use v1 as the stored version
 func readRuntimeObjectAsPipeline(ctx context.Context, obj runtime.Object) (v1beta1.PipelineObject, error) {
-	if pipeline, ok := obj.(v1beta1.PipelineObject); ok {
-		return pipeline, nil
+	switch obj := obj.(type) {
+	case v1beta1.PipelineObject:
+		return obj, nil
+	case *v1.Pipeline:
+		t := &v1beta1.Pipeline{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Pipeline",
+				APIVersion: "tekton.dev/v1beta1",
+			},
+		}
+		if err := t.ConvertFrom(ctx, obj); err != nil {
+			return nil, err
+		}
+		return t, nil
 	}
 
 	return nil, errors.New("resource is not a pipeline")


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This commit adds conversion for remote tasks and pipelines after they are resolved by resolvers to support v1 types. Before this commit v1 tasks and pipelines are not supported in remote resolution since we use v1beta1 as the storage version and in reconciler we will convert v1 crd into v1beta. But this conversion is missing for remote resources. After we change the storage version to v1 we should update the code to support v1beta.

Closes https://github.com/tektoncd/pipeline/issues/6141

/kind bug

Signed-off-by: Yongxuan Zhang yongxuanzhang@google.com

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
V1 tasks and pipelines are supported in remote resolution
```
