### PR TITLE
Hygiene: cleanup `golangci` configuration.

### DIFF
--- a/.errcheck.txt
+++ b/.errcheck.txt
@@ -1,8 +1,0 @@
-(*github.com/tektoncd/pipeline/vendor/go.uber.org/zap.SugaredLogger).Sync
-flag.Set
-os.Setenv
-logger.Sync
-fmt.Fprintf
-fmt.Fprintln
-(io.Closer).Close
-updateConfigMap

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,18 +1,21 @@
 # Documentation: https://golangci-lint.run/usage/configuration/
 linters-settings:
   errcheck:
-    exclude: .errcheck.txt
+    exclude-functions:
+      - (*github.com/tektoncd/pipeline/vendor/go.uber.org/zap.SugaredLogger).Sync
+      - flag.Set
+      - os.Setenv
+      - logger.Sync
+      - fmt.Fprintf
+      - fmt.Fprintln
+      - (io.Closer).Close
+      - updateConfigMap
   gomodguard:
     blocked:
       modules:
         - github.com/ghodss/yaml:
             recommendations:
               - sigs.k8s.io/yaml
-  depguard:
-    list-type: denylist
-    include-go-root: false
-    packages-with-error-message:
-    - k8s.io/apimachinery/pkg/util/clock: 'use k8s.io/utils/clock or k8s.io/utils/clock/testing'
 linters:
   enable:
   - bodyclose
@@ -29,8 +32,8 @@ linters:
   - govet
   - misspell
   - revive
-  - typecheck
   - thelper
+  - typecheck
   - unconvert
   - unused
   - usestdlibvars
@@ -64,10 +67,6 @@ issues:
     - errcheck
     - gosec
   - path: test/pipelinerun_test\.go
-    linters:
-    - unused
-  - path: pkg/reconciler/pipelinerun/pipelinerun_test\.go
-    # This 11,000+ line file is too big for unused code detection.
     linters:
     - unused
   max-issues-per-linter: 0


### PR DESCRIPTION
# Changes

- Replaces deprecated `exclude` configuration for `errcheck` with replacement `exclude-functions` configuration.
- Deletes obsolete `depguard` configuration.
- Deletes obsolete skip `unused` configuration for `pipelinerun_test.go`.
- Sorts list of linters.

Context: https://github.com/tektoncd/pipeline/issues/5899

/kind cleanup

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Submitter Checklist

- [N/A] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [N/A] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
