### PR TITLE
Hygiene: enable `ineffassign` linter. 🧹🧹🧹

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,7 +36,6 @@ linters:
   - usestdlibvars
   - whitespace
   disable:
-  - ineffassign
   - staticcheck
 # Enabling presets means that new linters that we automatically adopt new
 # linters that augment a preset. This also opts us in for replacement linters
@@ -63,6 +62,7 @@ issues:
     linters:
     - errcheck
     - gosec
+    - ineffassign
   - path: test/pipelinerun_test\.go
     linters:
     - unused

--- a/pkg/pipelinerunmetrics/metrics.go
+++ b/pkg/pipelinerunmetrics/metrics.go
@@ -112,7 +112,7 @@ func viewRegister(cfg *config.Metrics) error {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 
-	prunTag := []tag.Key{}
+	var prunTag []tag.Key
 
 	switch cfg.PipelinerunLevel {
 	case config.PipelinerunLevelAtPipelinerun:

--- a/pkg/pod/status.go
+++ b/pkg/pod/status.go
@@ -266,7 +266,7 @@ func filterResultsAndResources(results []v1beta1.PipelineResourceResult, specRes
 	for _, r := range results {
 		switch r.ResultType {
 		case v1beta1.TaskRunResultType:
-			taskRunResult := v1beta1.TaskRunResult{}
+			var taskRunResult v1beta1.TaskRunResult
 			if neededTypes[r.Key] == v1beta1.ResultsTypeString {
 				taskRunResult = v1beta1.TaskRunResult{
 					Name:  r.Key,

--- a/pkg/resolution/resolver/bundle/bundle.go
+++ b/pkg/resolution/resolver/bundle/bundle.go
@@ -113,7 +113,7 @@ func GetEntry(ctx context.Context, keychain authn.Keychain, opts RequestOptions)
 			obj, err := readTarLayer(layerMap[l.Digest.String()])
 			if err != nil {
 				// This could still be a raw layer so try to read it as that instead.
-				obj, err = readRawLayer(layers[idx])
+				obj, _ = readRawLayer(layers[idx])
 			}
 			return &ResolvedResource{
 				data: obj,

--- a/pkg/resolution/resolver/bundle/resolver.go
+++ b/pkg/resolution/resolver/bundle/resolver.go
@@ -94,7 +94,7 @@ func (r *Resolver) Resolve(ctx context.Context, params []pipelinev1beta1.Param) 
 		return nil, err
 	}
 	namespace := common.RequestNamespace(ctx)
-	kc, err := k8schain.New(ctx, r.kubeClientSet, k8schain.Options{
+	kc, _ := k8schain.New(ctx, r.kubeClientSet, k8schain.Options{
 		Namespace:          namespace,
 		ServiceAccountName: opts.ServiceAccount,
 	})

--- a/pkg/taskrunmetrics/metrics.go
+++ b/pkg/taskrunmetrics/metrics.go
@@ -133,8 +133,7 @@ func viewRegister(cfg *config.Metrics) error {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 
-	prunTag := []tag.Key{}
-	trunTag := []tag.Key{}
+	var prunTag []tag.Key
 	switch cfg.PipelinerunLevel {
 	case config.PipelinerunLevelAtPipelinerun:
 		prunTag = []tag.Key{pipelineTag, pipelinerunTag}
@@ -149,6 +148,7 @@ func viewRegister(cfg *config.Metrics) error {
 		return errors.New("invalid config for PipelinerunLevel: " + cfg.PipelinerunLevel)
 	}
 
+	var trunTag []tag.Key
 	switch cfg.TaskrunLevel {
 	case config.TaskrunLevelAtTaskrun:
 		trunTag = []tag.Key{taskTag, taskrunTag}


### PR DESCRIPTION
# Changes

Enables `ineffassign` linter which identifies unused variable assignments.

- Fixes identified lint issues.
- Updated configuration to ignore ineffective assignments in unit tests.

There are no expected functional changes in this PR.

Context: https://github.com/tektoncd/pipeline/issues/5899

/kind cleanup

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Submitter Checklist

- [N/A] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [N/A] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
