### PR TITLE
fix taskrun failing with duplicate unique image found

### DIFF
--- a/pkg/pod/entrypoint_lookup_impl.go
+++ b/pkg/pod/entrypoint_lookup_impl.go
@@ -139,6 +139,11 @@ func buildCommandMap(idx v1.ImageIndex, hasArgs bool) (map[string][]string, erro
 	}
 	for _, desc := range mf.Manifests {
 		plat := desc.Platform.String()
+		// skip unknown platforms.
+		// Docker uses these to store attestation data: https://docs.docker.com/build/attestations/attestation-storage/#examples
+		if plat == "unknown/unknown" {
+			continue
+		}
 		if got, found := platToDigest[plat]; found && got != desc.Digest {
 			return nil, fmt.Errorf("duplicate unique image found for platform: %s: found %s and %s", plat, got, desc.Digest)
 		}


### PR DESCRIPTION
# Changes

fix [issue-6257](https://github.com/tektoncd/pipeline/issues/6257)

ignore unknown OS/architecture image entrypoint, because runtime.GOOS and runtime.GOARCH will not be unkonwn. all possible GOOS values are defined in [src/go/build/syslist.go](https://github.com/golang/go/blob/c054f223e7d0480a4d1d037177608c09c86c2ddd/src/go/build/syslist.go)

Signed-off-by: chengjoey <zchengjoey@gmail.com>

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
