### PR TITLE
Hygiene: enable `containedctx` linter.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,6 +19,7 @@ linters-settings:
 linters:
   enable:
   - bodyclose
+  - containedctx
   - decorder
   - depguard
   - dogsled
@@ -73,6 +74,21 @@ issues:
   - path: test/pipelinerun_test\.go
     linters:
     - unused
+  - path: pkg/apis/config/feature_flags_test.go
+    linters:
+    - containedctx
+  - path: pkg/pipelinerunmetrics/injection.go
+    linters:
+    - containedctx
+  - path: pkg/pod/creds_init_test.go
+    linters:
+    - containedctx
+  - path: pkg/taskrunmetrics/injection.go
+    linters:
+    - containedctx
+  - path: test/controller.go
+    linters:
+    - containedctx
   max-issues-per-linter: 0
   max-same-issues: 0
   include:


### PR DESCRIPTION
# Changes

Enables `containedctx` linter to identify use of antipattern use of context as a struct field. Go style is to pass the context directly instead.

To get here, I added exclusions for the existing detected use; enabling the linter will prevent additional use of the antipattern.

There are no expected functional changes in this PR.

Context: https://github.com/tektoncd/pipeline/issues/5899

/kind cleanup

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Submitter Checklist

- [N/A] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [N/A] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Release Notes

```release-note
NONE
```
