### PR TITLE
Hygiene: enable `goconst`, `dogsled` linters.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,8 +18,10 @@ linters:
   - bodyclose
   - decorder
   - depguard
+  - dogsled
   - dupword
   - errcheck
+  - goconst
   - gocritic
   - gofmt
   - goimports
@@ -61,6 +63,8 @@ issues:
   exclude-rules:
   - path: _test\.go
     linters:
+    - goconst
+    - dogsled
     - errcheck
     - gosec
   - path: test/pipelinerun_test\.go

--- a/pkg/reconciler/pipelinerun/cancel.go
+++ b/pkg/reconciler/pipelinerun/cancel.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	clientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
@@ -201,11 +200,11 @@ func getChildObjectsFromPRStatusForTaskNames(ctx context.Context, prs v1beta1.Pi
 	for _, cr := range prs.ChildReferences {
 		if taskNames.Len() == 0 || taskNames.Has(cr.PipelineTaskName) {
 			switch cr.Kind {
-			case pipeline.TaskRunControllerName:
+			case taskRun:
 				trNames = append(trNames, cr.Name)
-			case pipeline.RunControllerName:
+			case run:
 				runNames = append(runNames, cr.Name)
-			case pipeline.CustomRunControllerName:
+			case customRun:
 				customRunNames = append(customRunNames, cr.Name)
 			default:
 				unknownChildKinds[cr.Name] = cr.Kind

--- a/pkg/reconciler/pipelinerun/cancel_test.go
+++ b/pkg/reconciler/pipelinerun/cancel_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	_ "github.com/tektoncd/pipeline/pkg/pipelinerunmetrics/fake" // Make sure the pipelinerunmetrics are setup
@@ -62,7 +61,7 @@ func TestCancelPipelineRun(t *testing.T) {
 			},
 			Status: v1beta1.PipelineRunStatus{PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
 				ChildReferences: []v1beta1.ChildStatusReference{{
-					TypeMeta:         runtime.TypeMeta{Kind: "TaskRun"},
+					TypeMeta:         runtime.TypeMeta{Kind: taskRun},
 					Name:             "t1",
 					PipelineTaskName: "task-1",
 				}},
@@ -80,11 +79,11 @@ func TestCancelPipelineRun(t *testing.T) {
 			},
 			Status: v1beta1.PipelineRunStatus{PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
 				ChildReferences: []v1beta1.ChildStatusReference{{
-					TypeMeta:         runtime.TypeMeta{Kind: "TaskRun"},
+					TypeMeta:         runtime.TypeMeta{Kind: taskRun},
 					Name:             "t1",
 					PipelineTaskName: "task-1",
 				}, {
-					TypeMeta:         runtime.TypeMeta{Kind: "TaskRun"},
+					TypeMeta:         runtime.TypeMeta{Kind: taskRun},
 					Name:             "t2",
 					PipelineTaskName: "task-2",
 				}},
@@ -102,11 +101,11 @@ func TestCancelPipelineRun(t *testing.T) {
 			},
 			Status: v1beta1.PipelineRunStatus{PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
 				ChildReferences: []v1beta1.ChildStatusReference{{
-					TypeMeta:         runtime.TypeMeta{Kind: "TaskRun"},
+					TypeMeta:         runtime.TypeMeta{Kind: taskRun},
 					Name:             "t1",
 					PipelineTaskName: "task-1",
 				}, {
-					TypeMeta:         runtime.TypeMeta{Kind: "TaskRun"},
+					TypeMeta:         runtime.TypeMeta{Kind: taskRun},
 					Name:             "t2",
 					PipelineTaskName: "task-2",
 				}},
@@ -125,11 +124,11 @@ func TestCancelPipelineRun(t *testing.T) {
 			},
 			Status: v1beta1.PipelineRunStatus{PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
 				ChildReferences: []v1beta1.ChildStatusReference{{
-					TypeMeta:         runtime.TypeMeta{Kind: "CustomRun"},
+					TypeMeta:         runtime.TypeMeta{Kind: customRun},
 					Name:             "t1",
 					PipelineTaskName: "task-1",
 				}, {
-					TypeMeta:         runtime.TypeMeta{Kind: "CustomRun"},
+					TypeMeta:         runtime.TypeMeta{Kind: customRun},
 					Name:             "t2",
 					PipelineTaskName: "task-2",
 				}},
@@ -148,11 +147,11 @@ func TestCancelPipelineRun(t *testing.T) {
 			},
 			Status: v1beta1.PipelineRunStatus{PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
 				ChildReferences: []v1beta1.ChildStatusReference{{
-					TypeMeta:         runtime.TypeMeta{Kind: "CustomRun"},
+					TypeMeta:         runtime.TypeMeta{Kind: customRun},
 					Name:             "t1",
 					PipelineTaskName: "task-1",
 				}, {
-					TypeMeta:         runtime.TypeMeta{Kind: "CustomRun"},
+					TypeMeta:         runtime.TypeMeta{Kind: customRun},
 					Name:             "t2",
 					PipelineTaskName: "task-2",
 				}},
@@ -171,22 +170,22 @@ func TestCancelPipelineRun(t *testing.T) {
 			Status: v1beta1.PipelineRunStatus{PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
 				ChildReferences: []v1beta1.ChildStatusReference{
 					{
-						TypeMeta:         runtime.TypeMeta{Kind: "TaskRun"},
+						TypeMeta:         runtime.TypeMeta{Kind: taskRun},
 						Name:             "t1",
 						PipelineTaskName: "task-1",
 					},
 					{
-						TypeMeta:         runtime.TypeMeta{Kind: "TaskRun"},
+						TypeMeta:         runtime.TypeMeta{Kind: taskRun},
 						Name:             "t2",
 						PipelineTaskName: "task-2",
 					},
 					{
-						TypeMeta:         runtime.TypeMeta{Kind: pipeline.RunControllerName},
+						TypeMeta:         runtime.TypeMeta{Kind: run},
 						Name:             "r1",
 						PipelineTaskName: "run-1",
 					},
 					{
-						TypeMeta:         runtime.TypeMeta{Kind: pipeline.RunControllerName},
+						TypeMeta:         runtime.TypeMeta{Kind: run},
 						Name:             "r2",
 						PipelineTaskName: "run-2",
 					},
@@ -211,22 +210,22 @@ func TestCancelPipelineRun(t *testing.T) {
 			Status: v1beta1.PipelineRunStatus{PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
 				ChildReferences: []v1beta1.ChildStatusReference{
 					{
-						TypeMeta:         runtime.TypeMeta{Kind: "TaskRun"},
+						TypeMeta:         runtime.TypeMeta{Kind: taskRun},
 						Name:             "t1",
 						PipelineTaskName: "task-1",
 					},
 					{
-						TypeMeta:         runtime.TypeMeta{Kind: "TaskRun"},
+						TypeMeta:         runtime.TypeMeta{Kind: taskRun},
 						Name:             "t2",
 						PipelineTaskName: "task-2",
 					},
 					{
-						TypeMeta:         runtime.TypeMeta{Kind: pipeline.RunControllerName},
+						TypeMeta:         runtime.TypeMeta{Kind: run},
 						Name:             "r1",
 						PipelineTaskName: "run-1",
 					},
 					{
-						TypeMeta:         runtime.TypeMeta{Kind: pipeline.RunControllerName},
+						TypeMeta:         runtime.TypeMeta{Kind: run},
 						Name:             "r2",
 						PipelineTaskName: "run-2",
 					},
@@ -249,22 +248,22 @@ func TestCancelPipelineRun(t *testing.T) {
 			Status: v1beta1.PipelineRunStatus{PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
 				ChildReferences: []v1beta1.ChildStatusReference{
 					{
-						TypeMeta:         runtime.TypeMeta{Kind: "TaskRun"},
+						TypeMeta:         runtime.TypeMeta{Kind: taskRun},
 						Name:             "t1",
 						PipelineTaskName: "task-1",
 					},
 					{
-						TypeMeta:         runtime.TypeMeta{Kind: "TaskRun"},
+						TypeMeta:         runtime.TypeMeta{Kind: taskRun},
 						Name:             "t2",
 						PipelineTaskName: "task-2",
 					},
 					{
-						TypeMeta:         runtime.TypeMeta{Kind: pipeline.CustomRunControllerName},
+						TypeMeta:         runtime.TypeMeta{Kind: customRun},
 						Name:             "cr1",
 						PipelineTaskName: "customrun-1",
 					},
 					{
-						TypeMeta:         runtime.TypeMeta{Kind: pipeline.CustomRunControllerName},
+						TypeMeta:         runtime.TypeMeta{Kind: customRun},
 						Name:             "cr2",
 						PipelineTaskName: "customrun-2",
 					},
@@ -393,7 +392,7 @@ func TestGetChildObjectsFromPRStatusForTaskNames(t *testing.T) {
 				ChildReferences: []v1beta1.ChildStatusReference{{
 					TypeMeta: runtime.TypeMeta{
 						APIVersion: v1alpha1.SchemeGroupVersion.String(),
-						Kind:       pipeline.RunControllerName,
+						Kind:       run,
 					},
 					Name:             "r1",
 					PipelineTaskName: "run-1",
@@ -409,7 +408,7 @@ func TestGetChildObjectsFromPRStatusForTaskNames(t *testing.T) {
 				ChildReferences: []v1beta1.ChildStatusReference{{
 					TypeMeta: runtime.TypeMeta{
 						APIVersion: v1beta1.SchemeGroupVersion.String(),
-						Kind:       pipeline.CustomRunControllerName,
+						Kind:       customRun,
 					},
 					Name:             "r1",
 					PipelineTaskName: "run-1",

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -685,8 +685,8 @@ spec:
 			// This PipelineRun is in progress now and the status should reflect that
 			checkPipelineRunConditionStatusAndReason(t, reconciledRun, corev1.ConditionUnknown, v1beta1.PipelineRunReasonRunning.String())
 
-			verifyCustomRunOrRunStatusesCount(t, pipeline.RunControllerName, reconciledRun.Status, 1)
-			verifyCustomRunOrRunStatusesNames(t, pipeline.RunControllerName, reconciledRun.Status, tc.wantRun.Name)
+			verifyCustomRunOrRunStatusesCount(t, run, reconciledRun.Status, 1)
+			verifyCustomRunOrRunStatusesNames(t, run, reconciledRun.Status, tc.wantRun.Name)
 		})
 	}
 }
@@ -865,8 +865,8 @@ spec:
 			// This PipelineRun is in progress now and the status should reflect that
 			checkPipelineRunConditionStatusAndReason(t, reconciledRun, corev1.ConditionUnknown, v1beta1.PipelineRunReasonRunning.String())
 
-			verifyCustomRunOrRunStatusesCount(t, pipeline.CustomRunControllerName, reconciledRun.Status, 1)
-			verifyCustomRunOrRunStatusesNames(t, pipeline.CustomRunControllerName, reconciledRun.Status, tc.wantRun.Name)
+			verifyCustomRunOrRunStatusesCount(t, customRun, reconciledRun.Status, 1)
+			verifyCustomRunOrRunStatusesNames(t, customRun, reconciledRun.Status, tc.wantRun.Name)
 		})
 	}
 }
@@ -1528,14 +1528,14 @@ status:
 	expectedChildReferences := []v1beta1.ChildStatusReference{{
 		TypeMeta: runtime.TypeMeta{
 			APIVersion: v1beta1.SchemeGroupVersion.String(),
-			Kind:       "TaskRun",
+			Kind:       taskRun,
 		},
 		Name:             taskRunName,
 		PipelineTaskName: "hello-world-1",
 	}, {
 		TypeMeta: runtime.TypeMeta{
 			APIVersion: v1beta1.SchemeGroupVersion.String(),
-			Kind:       "Run",
+			Kind:       run,
 		},
 		Name:             runName,
 		PipelineTaskName: "hello-world-1",
@@ -2157,7 +2157,7 @@ func TestReconcileOnCancelledRunFinallyPipelineRunWithFinalTaskAndRetries(t *tes
 	prs[0].Status.ChildReferences = append(prs[0].Status.ChildReferences, v1beta1.ChildStatusReference{
 		TypeMeta: runtime.TypeMeta{
 			APIVersion: v1beta1.SchemeGroupVersion.String(),
-			Kind:       "TaskRun",
+			Kind:       taskRun,
 		},
 		Name:             "test-pipeline-run-cancelled-run-finally-hello-world",
 		PipelineTaskName: "hello-world-1",
@@ -2338,7 +2338,7 @@ status:
 			initialChildReferences: []v1beta1.ChildStatusReference{{
 				TypeMeta: runtime.TypeMeta{
 					APIVersion: v1beta1.SchemeGroupVersion.String(),
-					Kind:       "TaskRun",
+					Kind:       taskRun,
 				},
 				Name:             "test-pipeline-run-stopped-run-finally-hello-world",
 				PipelineTaskName: "hello-world-1",
@@ -2362,7 +2362,7 @@ status:
 			initialChildReferences: []v1beta1.ChildStatusReference{{
 				TypeMeta: runtime.TypeMeta{
 					APIVersion: v1beta1.SchemeGroupVersion.String(),
-					Kind:       "TaskRun",
+					Kind:       taskRun,
 				},
 				Name:             "test-pipeline-run-stopped-run-finally-hello-world",
 				PipelineTaskName: "hello-world-1",
@@ -5263,7 +5263,7 @@ status:
 		{
 			TypeMeta: runtime.TypeMeta{
 				APIVersion: v1beta1.SchemeGroupVersion.String(),
-				Kind:       "TaskRun",
+				Kind:       taskRun,
 			},
 			Name:             taskRunDone.Name,
 			PipelineTaskName: "hello-world-1",
@@ -5377,7 +5377,7 @@ status:
 	runsStatus := make(map[string]*v1beta1.PipelineRunRunStatus)
 
 	for _, cr := range reconciledRun.Status.ChildReferences {
-		if cr.Kind == "TaskRun" {
+		if cr.Kind == taskRun {
 			trStatusForPipelineRun := &v1beta1.PipelineRunTaskRunStatus{
 				PipelineTaskName: cr.PipelineTaskName,
 				WhenExpressions:  cr.WhenExpressions,
@@ -5389,7 +5389,7 @@ status:
 			}
 
 			taskRunsStatus[cr.Name] = trStatusForPipelineRun
-		} else if cr.Kind == "CustomRun" {
+		} else if cr.Kind == customRun {
 			rStatusForPipelineRun := &v1beta1.PipelineRunRunStatus{
 				PipelineTaskName: cr.PipelineTaskName,
 				WhenExpressions:  cr.WhenExpressions,
@@ -5458,10 +5458,10 @@ spec:
 		t.Fatalf("Expected 2 ChildReferences but got %d", len(reconciledRun.Status.ChildReferences))
 	}
 	for _, cr := range reconciledRun.Status.ChildReferences {
-		if cr.Kind == "TaskRun" {
+		if cr.Kind == taskRun {
 			taskRunName = cr.Name
 		}
-		if cr.Kind == "CustomRun" {
+		if cr.Kind == customRun {
 			customRunName = cr.Name
 		}
 	}
@@ -5494,8 +5494,8 @@ spec:
 	// Verify that the reconciler found the existing TaskRun and Run instead of creating new ones.
 	verifyTaskRunStatusesCount(t, reconciledRun.Status, 1)
 	verifyTaskRunStatusesNames(t, reconciledRun.Status, taskRunName)
-	verifyCustomRunOrRunStatusesCount(t, pipeline.CustomRunControllerName, reconciledRun.Status, 1)
-	verifyCustomRunOrRunStatusesNames(t, pipeline.CustomRunControllerName, reconciledRun.Status, customRunName)
+	verifyCustomRunOrRunStatusesCount(t, customRun, reconciledRun.Status, 1)
+	verifyCustomRunOrRunStatusesNames(t, customRun, reconciledRun.Status, customRunName)
 }
 
 func TestReconcilePipeline_FinalTasks(t *testing.T) {
@@ -5577,14 +5577,14 @@ func TestReconcilePipeline_FinalTasks(t *testing.T) {
 		expectedChildReferences: []v1beta1.ChildStatusReference{{
 			TypeMeta: runtime.TypeMeta{
 				APIVersion: v1beta1.SchemeGroupVersion.String(),
-				Kind:       "TaskRun",
+				Kind:       taskRun,
 			},
 			Name:             "task-run-dag-task",
 			PipelineTaskName: "dag-task-1",
 		}, {
 			TypeMeta: runtime.TypeMeta{
 				APIVersion: v1beta1.SchemeGroupVersion.String(),
-				Kind:       "TaskRun",
+				Kind:       taskRun,
 			},
 			Name:             "task-run-final-task",
 			PipelineTaskName: "final-task-1",
@@ -5656,14 +5656,14 @@ func TestReconcilePipeline_FinalTasks(t *testing.T) {
 		expectedChildReferences: []v1beta1.ChildStatusReference{{
 			TypeMeta: runtime.TypeMeta{
 				APIVersion: v1beta1.SchemeGroupVersion.String(),
-				Kind:       "TaskRun",
+				Kind:       taskRun,
 			},
 			Name:             "task-run-dag-task",
 			PipelineTaskName: "dag-task-1",
 		}, {
 			TypeMeta: runtime.TypeMeta{
 				APIVersion: v1beta1.SchemeGroupVersion.String(),
-				Kind:       "TaskRun",
+				Kind:       taskRun,
 			},
 			Name:             "task-run-final-task",
 			PipelineTaskName: "final-task-1",
@@ -5737,14 +5737,14 @@ func TestReconcilePipeline_FinalTasks(t *testing.T) {
 		expectedChildReferences: []v1beta1.ChildStatusReference{{
 			TypeMeta: runtime.TypeMeta{
 				APIVersion: v1beta1.SchemeGroupVersion.String(),
-				Kind:       "TaskRun",
+				Kind:       taskRun,
 			},
 			Name:             "task-run-dag-task",
 			PipelineTaskName: "dag-task-1",
 		}, {
 			TypeMeta: runtime.TypeMeta{
 				APIVersion: v1beta1.SchemeGroupVersion.String(),
-				Kind:       "TaskRun",
+				Kind:       taskRun,
 			},
 			Name:             "task-run-final-task",
 			PipelineTaskName: "final-task-1",
@@ -5820,14 +5820,14 @@ func TestReconcilePipeline_FinalTasks(t *testing.T) {
 		expectedChildReferences: []v1beta1.ChildStatusReference{{
 			TypeMeta: runtime.TypeMeta{
 				APIVersion: v1beta1.SchemeGroupVersion.String(),
-				Kind:       "TaskRun",
+				Kind:       taskRun,
 			},
 			Name:             "task-run-dag-task-1",
 			PipelineTaskName: "dag-task-1",
 		}, {
 			TypeMeta: runtime.TypeMeta{
 				APIVersion: v1beta1.SchemeGroupVersion.String(),
-				Kind:       "TaskRun",
+				Kind:       taskRun,
 			},
 			Name:             "task-run-dag-task-2",
 			PipelineTaskName: "dag-task-2",
@@ -5894,7 +5894,7 @@ func TestReconcilePipeline_FinalTasks(t *testing.T) {
 		expectedChildReferences: []v1beta1.ChildStatusReference{{
 			TypeMeta: runtime.TypeMeta{
 				APIVersion: v1beta1.SchemeGroupVersion.String(),
-				Kind:       "TaskRun",
+				Kind:       taskRun,
 			},
 			Name:             "task-run-dag-task-1",
 			PipelineTaskName: "dag-task-1",
@@ -5983,7 +5983,7 @@ func checkTaskRunStatusFromChildRefs(ctx context.Context, t *testing.T, namespac
 	}
 
 	for _, childRef := range childRefs {
-		if childRef.Kind != "TaskRun" {
+		if childRef.Kind != taskRun {
 			continue
 		}
 		trName := childRef.Name
@@ -6031,7 +6031,7 @@ func getPipelineRun(pr, p string, status corev1.ConditionStatus, reason string, 
 			PipelineTaskName: k,
 			Name:             v,
 			TypeMeta: runtime.TypeMeta{
-				Kind:       "TaskRun",
+				Kind:       taskRun,
 				APIVersion: "tekton.dev/v1beta1",
 			},
 		})
@@ -7298,15 +7298,15 @@ status:
 func verifyTaskRunStatusesCount(t *testing.T, prStatus v1beta1.PipelineRunStatus, taskCount int) {
 	t.Helper()
 
-	if len(filterChildRefsForKind(prStatus.ChildReferences, "TaskRun")) != taskCount {
-		t.Errorf("Expected PipelineRun status ChildReferences to have %d tasks, but was %d", taskCount, len(filterChildRefsForKind(prStatus.ChildReferences, "TaskRun")))
+	if len(filterChildRefsForKind(prStatus.ChildReferences, taskRun)) != taskCount {
+		t.Errorf("Expected PipelineRun status ChildReferences to have %d tasks, but was %d", taskCount, len(filterChildRefsForKind(prStatus.ChildReferences, taskRun)))
 	}
 }
 func verifyTaskRunStatusesNames(t *testing.T, prStatus v1beta1.PipelineRunStatus, taskNames ...string) {
 	t.Helper()
 
 	tnMap := make(map[string]struct{})
-	for _, cr := range filterChildRefsForKind(prStatus.ChildReferences, "TaskRun") {
+	for _, cr := range filterChildRefsForKind(prStatus.ChildReferences, taskRun) {
 		tnMap[cr.Name] = struct{}{}
 	}
 
@@ -10157,11 +10157,11 @@ spec:
 	var runsCount, taskrunsCount, customrunsCount int
 	for _, childRef := range pr.Status.ChildReferences {
 		switch childRef.Kind {
-		case "TaskRun":
+		case taskRun:
 			taskrunsCount++
-		case "Run":
+		case run:
 			runsCount++
-		case "CustomRun":
+		case customRun:
 			customrunsCount++
 		}
 	}

--- a/pkg/reconciler/pipelinerun/pipelinerun_updatestatus_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_updatestatus_test.go
@@ -292,7 +292,7 @@ func TestUpdatePipelineRunStatusFromChildRefs(t *testing.T) {
 			ChildReferences: []v1beta1.ChildStatusReference{{
 				TypeMeta: runtime.TypeMeta{
 					APIVersion: "tekton.dev/v1beta1",
-					Kind:       "CustomRun",
+					Kind:       customRun,
 				},
 				Name:             "pr-run-6-xxyyy",
 				PipelineTaskName: "task-6",
@@ -659,11 +659,11 @@ func TestValidateChildObjectsInPipelineRunStatus(t *testing.T) {
 				PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
 					ChildReferences: []v1beta1.ChildStatusReference{
 						{
-							TypeMeta:         runtime.TypeMeta{Kind: "TaskRun"},
+							TypeMeta:         runtime.TypeMeta{Kind: taskRun},
 							Name:             "t1",
 							PipelineTaskName: "task-1",
 						}, {
-							TypeMeta:         runtime.TypeMeta{Kind: "Run"},
+							TypeMeta:         runtime.TypeMeta{Kind: run},
 							Name:             "r1",
 							PipelineTaskName: "run-1",
 						}, {
@@ -683,11 +683,11 @@ func TestValidateChildObjectsInPipelineRunStatus(t *testing.T) {
 				PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
 					ChildReferences: []v1beta1.ChildStatusReference{
 						{
-							TypeMeta:         runtime.TypeMeta{Kind: "TaskRun"},
+							TypeMeta:         runtime.TypeMeta{Kind: taskRun},
 							Name:             "t1",
 							PipelineTaskName: "task-1",
 						}, {
-							TypeMeta:         runtime.TypeMeta{Kind: "Run"},
+							TypeMeta:         runtime.TypeMeta{Kind: run},
 							Name:             "r1",
 							PipelineTaskName: "run-1",
 						},

--- a/pkg/reconciler/pipelinerun/timeout_test.go
+++ b/pkg/reconciler/pipelinerun/timeout_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	"github.com/tektoncd/pipeline/pkg/apis/config"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	_ "github.com/tektoncd/pipeline/pkg/pipelinerunmetrics/fake" // Make sure the pipelinerunmetrics are setup
@@ -52,7 +51,7 @@ func TestTimeoutPipelineRun(t *testing.T) {
 			Spec:       v1beta1.PipelineRunSpec{},
 			Status: v1beta1.PipelineRunStatus{PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
 				ChildReferences: []v1beta1.ChildStatusReference{{
-					TypeMeta:         runtime.TypeMeta{Kind: "TaskRun"},
+					TypeMeta:         runtime.TypeMeta{Kind: taskRun},
 					Name:             "t1",
 					PipelineTaskName: "task-1",
 				}},
@@ -68,11 +67,11 @@ func TestTimeoutPipelineRun(t *testing.T) {
 			Spec:       v1beta1.PipelineRunSpec{},
 			Status: v1beta1.PipelineRunStatus{PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
 				ChildReferences: []v1beta1.ChildStatusReference{{
-					TypeMeta:         runtime.TypeMeta{Kind: "TaskRun"},
+					TypeMeta:         runtime.TypeMeta{Kind: taskRun},
 					Name:             "t1",
 					PipelineTaskName: "task-1",
 				}, {
-					TypeMeta:         runtime.TypeMeta{Kind: "TaskRun"},
+					TypeMeta:         runtime.TypeMeta{Kind: taskRun},
 					Name:             "t2",
 					PipelineTaskName: "task-2",
 				}},
@@ -89,11 +88,11 @@ func TestTimeoutPipelineRun(t *testing.T) {
 			Spec:       v1beta1.PipelineRunSpec{},
 			Status: v1beta1.PipelineRunStatus{PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
 				ChildReferences: []v1beta1.ChildStatusReference{{
-					TypeMeta:         runtime.TypeMeta{Kind: "CustomRun"},
+					TypeMeta:         runtime.TypeMeta{Kind: customRun},
 					Name:             "t1",
 					PipelineTaskName: "task-1",
 				}, {
-					TypeMeta:         runtime.TypeMeta{Kind: "CustomRun"},
+					TypeMeta:         runtime.TypeMeta{Kind: customRun},
 					Name:             "t2",
 					PipelineTaskName: "task-2",
 				}},
@@ -111,11 +110,11 @@ func TestTimeoutPipelineRun(t *testing.T) {
 			Spec:       v1beta1.PipelineRunSpec{},
 			Status: v1beta1.PipelineRunStatus{PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
 				ChildReferences: []v1beta1.ChildStatusReference{{
-					TypeMeta:         runtime.TypeMeta{Kind: "CustomRun"},
+					TypeMeta:         runtime.TypeMeta{Kind: customRun},
 					Name:             "t1",
 					PipelineTaskName: "task-1",
 				}, {
-					TypeMeta:         runtime.TypeMeta{Kind: "CustomRun"},
+					TypeMeta:         runtime.TypeMeta{Kind: customRun},
 					Name:             "t2",
 					PipelineTaskName: "task-2",
 				}},
@@ -133,19 +132,19 @@ func TestTimeoutPipelineRun(t *testing.T) {
 			Status: v1beta1.PipelineRunStatus{PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
 				ChildReferences: []v1beta1.ChildStatusReference{
 					{
-						TypeMeta:         runtime.TypeMeta{Kind: pipeline.TaskRunControllerName},
+						TypeMeta:         runtime.TypeMeta{Kind: taskRun},
 						Name:             "t1",
 						PipelineTaskName: "task-1",
 					},
 					{
-						TypeMeta:         runtime.TypeMeta{Kind: pipeline.TaskRunControllerName},
+						TypeMeta:         runtime.TypeMeta{Kind: taskRun},
 						Name:             "t2",
 						PipelineTaskName: "task-2",
 					},
 					{
 						TypeMeta: runtime.TypeMeta{
 							APIVersion: v1alpha1.SchemeGroupVersion.String(),
-							Kind:       pipeline.RunControllerName,
+							Kind:       run,
 						},
 						Name:             "r1",
 						PipelineTaskName: "run-1",
@@ -153,7 +152,7 @@ func TestTimeoutPipelineRun(t *testing.T) {
 					{
 						TypeMeta: runtime.TypeMeta{
 							APIVersion: v1alpha1.SchemeGroupVersion.String(),
-							Kind:       pipeline.RunControllerName,
+							Kind:       run,
 						},
 						Name:             "r2",
 						PipelineTaskName: "run-2",
@@ -178,19 +177,19 @@ func TestTimeoutPipelineRun(t *testing.T) {
 			Status: v1beta1.PipelineRunStatus{PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
 				ChildReferences: []v1beta1.ChildStatusReference{
 					{
-						TypeMeta:         runtime.TypeMeta{Kind: pipeline.TaskRunControllerName},
+						TypeMeta:         runtime.TypeMeta{Kind: taskRun},
 						Name:             "t1",
 						PipelineTaskName: "task-1",
 					},
 					{
-						TypeMeta:         runtime.TypeMeta{Kind: pipeline.TaskRunControllerName},
+						TypeMeta:         runtime.TypeMeta{Kind: taskRun},
 						Name:             "t2",
 						PipelineTaskName: "task-2",
 					},
 					{
 						TypeMeta: runtime.TypeMeta{
 							APIVersion: v1beta1.SchemeGroupVersion.String(),
-							Kind:       pipeline.CustomRunControllerName,
+							Kind:       customRun,
 						},
 						Name:             "r1",
 						PipelineTaskName: "run-1",
@@ -198,7 +197,7 @@ func TestTimeoutPipelineRun(t *testing.T) {
 					{
 						TypeMeta: runtime.TypeMeta{
 							APIVersion: v1beta1.SchemeGroupVersion.String(),
-							Kind:       pipeline.CustomRunControllerName,
+							Kind:       customRun,
 						},
 						Name:             "r2",
 						PipelineTaskName: "run-2",

--- a/pkg/taskrunmetrics/metrics.go
+++ b/pkg/taskrunmetrics/metrics.go
@@ -40,6 +40,8 @@ import (
 	"knative.dev/pkg/metrics"
 )
 
+const anonymous = "anonymous"
+
 var (
 	pipelinerunTag = tag.MustNewKey("pipelinerun")
 	pipelineTag    = tag.MustNewKey("pipeline")
@@ -297,7 +299,7 @@ func (r *Recorder) DurationAndCount(ctx context.Context, tr *v1beta1.TaskRun, be
 		duration = tr.Status.CompletionTime.Sub(tr.Status.StartTime.Time)
 	}
 
-	taskName := "anonymous"
+	taskName := anonymous
 	if tr.Spec.TaskRef != nil {
 		taskName = tr.Spec.TaskRef.Name
 	}
@@ -409,7 +411,7 @@ func (r *Recorder) RecordPodLatency(ctx context.Context, pod *corev1.Pod, tr *v1
 	}
 
 	latency := scheduledTime.Sub(pod.CreationTimestamp.Time)
-	taskName := "anonymous"
+	taskName := anonymous
 	if tr.Spec.TaskRef != nil {
 		taskName = tr.Spec.TaskRef.Name
 	}
@@ -438,7 +440,7 @@ func (r *Recorder) CloudEvents(ctx context.Context, tr *v1beta1.TaskRun) error {
 		return fmt.Errorf("ignoring the metrics recording for %s , failed to initialize the metrics recorder", tr.Name)
 	}
 
-	taskName := "anonymous"
+	taskName := anonymous
 	if tr.Spec.TaskRef != nil {
 		taskName = tr.Spec.TaskRef.Name
 	}


### PR DESCRIPTION
# Changes

There are no expected functional changes in this PR.

Made nominal code changes to adhere to linter standards, specifically more systematic use of
`pipeline.*RunControllerName` constants.

Context: https://github.com/tektoncd/pipeline/issues/5899

/kind cleanup

# Submitter Checklist

- [N/A] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [N/A] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Release Notes

```release-note
NONE
```
