### PR TITLE
Hygiene: enable linters for error conventions.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,6 +25,9 @@ linters:
   - dogsled
   - dupword
   - errcheck
+  - errchkjson
+  - errname
+  # errorlint TODO: cleanup the issues this linter uncovers https://github.com/tektoncd/pipeline/issues/5899
   - goconst
   - gocritic
   - gofmt
@@ -89,6 +92,9 @@ issues:
   - path: test/controller.go
     linters:
     - containedctx
+  - path: internal/sidecarlogresults/sidecarlogresults_test\.go
+    linters:
+    - errchkjson
   max-issues-per-linter: 0
   max-same-issues: 0
   include:

--- a/cmd/entrypoint/main.go
+++ b/cmd/entrypoint/main.go
@@ -98,7 +98,7 @@ func main() {
 	if err := subcommands.Process(flag.CommandLine.Args()); err != nil {
 		log.Println(err.Error())
 		switch err.(type) {
-		case subcommands.SubcommandSuccessful:
+		case subcommands.OK:
 			return
 		default:
 			os.Exit(1)

--- a/cmd/entrypoint/subcommands/subcommands_test.go
+++ b/cmd/entrypoint/subcommands/subcommands_test.go
@@ -39,7 +39,7 @@ func TestProcessSuccessfulSubcommands(t *testing.T) {
 	} {
 		t.Run(tc.command, func(t *testing.T) {
 			returnValue := Process(append([]string{tc.command}, tc.args...))
-			if _, ok := returnValue.(SubcommandSuccessful); !ok {
+			if _, ok := returnValue.(OK); !ok {
 				t.Errorf("unexpected return value from command: %v", returnValue)
 			}
 		})
@@ -49,12 +49,12 @@ func TestProcessSuccessfulSubcommands(t *testing.T) {
 		tektonRoot = tmp
 
 		returnValue := Process([]string{StepInitCommand})
-		if _, ok := returnValue.(SubcommandSuccessful); !ok {
+		if _, ok := returnValue.(OK); !ok {
 			t.Errorf("unexpected return value from step-init command: %v", returnValue)
 		}
 
 		returnValue = Process([]string{StepInitCommand, "foo", "bar"})
-		if _, ok := returnValue.(SubcommandSuccessful); !ok {
+		if _, ok := returnValue.(OK); !ok {
 			t.Errorf("unexpected return value from step-init command w/ params: %v", returnValue)
 		}
 	})

--- a/pkg/pipelinerunmetrics/metrics.go
+++ b/pkg/pipelinerunmetrics/metrics.go
@@ -81,9 +81,9 @@ type Recorder struct {
 // initializes this singleton and returns the same recorder across any
 // subsequent invocations.
 var (
-	once        sync.Once
-	r           *Recorder
-	recorderErr error
+	once           sync.Once
+	r              *Recorder
+	errRegistering error
 )
 
 // NewRecorder creates a new metrics recorder instance
@@ -98,14 +98,14 @@ func NewRecorder(ctx context.Context) (*Recorder, error) {
 		}
 
 		cfg := config.FromContextOrDefaults(ctx)
-		recorderErr = viewRegister(cfg.Metrics)
-		if recorderErr != nil {
+		errRegistering = viewRegister(cfg.Metrics)
+		if errRegistering != nil {
 			r.initialized = false
 			return
 		}
 	})
 
-	return r, recorderErr
+	return r, errRegistering
 }
 
 func viewRegister(cfg *config.Metrics) error {

--- a/pkg/pipelinerunmetrics/metrics_test.go
+++ b/pkg/pipelinerunmetrics/metrics_test.go
@@ -381,5 +381,5 @@ func unregisterMetrics() {
 	// Allow the recorder singleton to be recreated.
 	once = sync.Once{}
 	r = nil
-	recorderErr = nil
+	errRegistering = nil
 }

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -357,10 +357,10 @@ func (c *Reconciler) resolvePipelineState(
 			if tresources.IsGetTaskErrTransient(err) {
 				return nil, err
 			}
-			if errors.Is(err, remote.ErrorRequestInProgress) {
+			if errors.Is(err, remote.ErrRequestInProgress) {
 				return nil, err
 			}
-			if errors.Is(err, trustedresources.ErrorResourceVerificationFailed) {
+			if errors.Is(err, trustedresources.ErrResourceVerificationFailed) {
 				message := fmt.Sprintf("PipelineRun %s/%s referred task %s failed signature verification", pr.Namespace, pr.Name, task.Name)
 				pr.Status.MarkFailed(ReasonResourceVerificationFailed, message)
 				return nil, controller.NewPermanentError(err)
@@ -397,11 +397,11 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1beta1.PipelineRun, get
 
 	pipelineMeta, pipelineSpec, err := rprp.GetPipelineData(ctx, pr, getPipelineFunc)
 	switch {
-	case errors.Is(err, remote.ErrorRequestInProgress):
+	case errors.Is(err, remote.ErrRequestInProgress):
 		message := fmt.Sprintf("PipelineRun %s/%s awaiting remote resource", pr.Namespace, pr.Name)
 		pr.Status.MarkRunning(ReasonResolvingPipelineRef, message)
 		return nil
-	case errors.Is(err, trustedresources.ErrorResourceVerificationFailed):
+	case errors.Is(err, trustedresources.ErrResourceVerificationFailed):
 		message := fmt.Sprintf("PipelineRun %s/%s referred pipeline failed signature verification", pr.Namespace, pr.Name)
 		pr.Status.MarkFailed(ReasonResourceVerificationFailed, message)
 		return controller.NewPermanentError(err)
@@ -521,7 +521,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1beta1.PipelineRun, get
 	}
 	pipelineRunState, err := c.resolvePipelineState(ctx, tasks, pipelineMeta.ObjectMeta, pr)
 	switch {
-	case errors.Is(err, remote.ErrorRequestInProgress):
+	case errors.Is(err, remote.ErrRequestInProgress):
 		message := fmt.Sprintf("PipelineRun %s/%s awaiting remote resource", pr.Namespace, pr.Name)
 		pr.Status.MarkRunning(v1beta1.TaskRunReasonResolvingTaskRef, message)
 		return nil

--- a/pkg/reconciler/pipelinerun/resources/pipelineref.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelineref.go
@@ -122,7 +122,7 @@ func GetVerifiedPipelineFunc(ctx context.Context, k8s kubernetes.Interface, tekt
 			if err := trustedresources.VerifyPipeline(ctx, p, k8s, source, verificationpolicies); err != nil {
 				if config.CheckEnforceResourceVerificationMode(ctx) {
 					logger.Errorf("GetVerifiedPipelineFunc failed: %v", err)
-					return nil, nil, fmt.Errorf("GetVerifiedPipelineFunc failed: %w: %v", trustedresources.ErrorResourceVerificationFailed, err)
+					return nil, nil, fmt.Errorf("GetVerifiedPipelineFunc failed: %w: %v", trustedresources.ErrResourceVerificationFailed, err)
 				}
 				logger.Warnf("GetVerifiedPipelineFunc failed: %v", err)
 				return p, s, nil

--- a/pkg/reconciler/pipelinerun/resources/pipelineref_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelineref_test.go
@@ -651,13 +651,13 @@ func TestGetVerifiedPipelineFunc_VerifyError(t *testing.T) {
 			requester:                requesterUnsigned,
 			resourceVerificationMode: config.EnforceResourceVerificationMode,
 			expected:                 nil,
-			expectedErr:              trustedresources.ErrorResourceVerificationFailed,
+			expectedErr:              trustedresources.ErrResourceVerificationFailed,
 		}, {
 			name:                     "tampered pipeline with enforce policy",
 			requester:                requesterTampered,
 			resourceVerificationMode: config.EnforceResourceVerificationMode,
 			expected:                 nil,
-			expectedErr:              trustedresources.ErrorResourceVerificationFailed,
+			expectedErr:              trustedresources.ErrResourceVerificationFailed,
 		},
 	}
 	for _, tc := range testcases {

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -714,9 +714,9 @@ func resolveTask(
 			// Instead, the child TaskRun's status will be the place recording the source of individual task.
 			t, _, err = getTask(ctx, pipelineTask.TaskRef.Name)
 			switch {
-			case errors.Is(err, remote.ErrorRequestInProgress):
+			case errors.Is(err, remote.ErrRequestInProgress):
 				return v1beta1.TaskSpec{}, "", "", err
-			case errors.Is(err, trustedresources.ErrorResourceVerificationFailed):
+			case errors.Is(err, trustedresources.ErrResourceVerificationFailed):
 				return v1beta1.TaskSpec{}, "", "", err
 			case err != nil:
 				return v1beta1.TaskSpec{}, "", "", &TaskNotFoundError{

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
@@ -1963,7 +1963,7 @@ func TestResolvePipelineRun_VerificationFailed(t *testing.T) {
 		}}}
 
 	getTask := func(ctx context.Context, name string) (v1beta1.TaskObject, *v1beta1.ConfigSource, error) {
-		return nil, nil, trustedresources.ErrorResourceVerificationFailed
+		return nil, nil, trustedresources.ErrResourceVerificationFailed
 	}
 	getTaskRun := func(name string) (*v1beta1.TaskRun, error) { return nil, nil }
 	pr := v1beta1.PipelineRun{
@@ -1976,8 +1976,8 @@ func TestResolvePipelineRun_VerificationFailed(t *testing.T) {
 		if err == nil {
 			t.Errorf("expected to get err but got nil")
 		}
-		if err != trustedresources.ErrorResourceVerificationFailed {
-			t.Errorf("expected to get %v but got %v", trustedresources.ErrorResourceVerificationFailed, err)
+		if err != trustedresources.ErrResourceVerificationFailed {
+			t.Errorf("expected to get %v but got %v", trustedresources.ErrResourceVerificationFailed, err)
 		}
 	}
 }

--- a/pkg/reconciler/taskrun/resources/taskref.go
+++ b/pkg/reconciler/taskrun/resources/taskref.go
@@ -100,7 +100,7 @@ func GetVerifiedTaskFunc(ctx context.Context, k8s kubernetes.Interface, tekton c
 			if err := trustedresources.VerifyTask(ctx, t, k8s, source, verificationpolicies); err != nil {
 				if config.CheckEnforceResourceVerificationMode(ctx) {
 					logger.Errorf("GetVerifiedTaskFunc failed: %v", err)
-					return nil, nil, fmt.Errorf("GetVerifiedTaskFunc failed: %w: %v", trustedresources.ErrorResourceVerificationFailed, err)
+					return nil, nil, fmt.Errorf("GetVerifiedTaskFunc failed: %w: %v", trustedresources.ErrResourceVerificationFailed, err)
 				}
 				logger.Warnf("GetVerifiedTaskFunc failed: %v", err)
 				return t, s, nil

--- a/pkg/reconciler/taskrun/resources/taskref_test.go
+++ b/pkg/reconciler/taskrun/resources/taskref_test.go
@@ -857,13 +857,13 @@ func TestGetVerifiedTaskFunc_VerifyError(t *testing.T) {
 		requester:                requesterUnsigned,
 		resourceVerificationMode: config.EnforceResourceVerificationMode,
 		expected:                 nil,
-		expectedErr:              trustedresources.ErrorResourceVerificationFailed,
+		expectedErr:              trustedresources.ErrResourceVerificationFailed,
 	}, {
 		name:                     "tampered task with enforce policy",
 		requester:                requesterTampered,
 		resourceVerificationMode: config.EnforceResourceVerificationMode,
 		expected:                 nil,
-		expectedErr:              trustedresources.ErrorResourceVerificationFailed,
+		expectedErr:              trustedresources.ErrResourceVerificationFailed,
 	},
 	}
 	for _, tc := range testcases {

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -345,11 +345,11 @@ func (c *Reconciler) prepare(ctx context.Context, tr *v1beta1.TaskRun) (*v1beta1
 
 	taskMeta, taskSpec, err := resources.GetTaskData(ctx, tr, getTaskfunc)
 	switch {
-	case errors.Is(err, remote.ErrorRequestInProgress):
+	case errors.Is(err, remote.ErrRequestInProgress):
 		message := fmt.Sprintf("TaskRun %s/%s awaiting remote resource", tr.Namespace, tr.Name)
 		tr.Status.MarkResourceOngoing(v1beta1.TaskRunReasonResolvingTaskRef, message)
 		return nil, nil, err
-	case errors.Is(err, trustedresources.ErrorResourceVerificationFailed):
+	case errors.Is(err, trustedresources.ErrResourceVerificationFailed):
 		logger.Errorf("TaskRun %s/%s referred task failed signature verification", tr.Namespace, tr.Name)
 		tr.Status.MarkResourceFailed(podconvert.ReasonResourceVerificationFailed, err)
 		return nil, nil, controller.NewPermanentError(err)

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -4974,12 +4974,12 @@ status:
 		{
 			name:          "unsigned task fails verification",
 			task:          []*v1beta1.Task{ts},
-			expectedError: trustedresources.ErrorResourceVerificationFailed,
+			expectedError: trustedresources.ErrResourceVerificationFailed,
 		},
 		{
 			name:          "modified task fails verification",
 			task:          []*v1beta1.Task{tamperedTask},
-			expectedError: trustedresources.ErrorResourceVerificationFailed,
+			expectedError: trustedresources.ErrResourceVerificationFailed,
 		},
 	}
 

--- a/pkg/remote/errors.go
+++ b/pkg/remote/errors.go
@@ -17,7 +17,15 @@ package remote
 
 import "errors"
 
-// ErrorRequestInProgress is a sentinel value that indicates
-// resolving a remote file like a pipeline in a bundle or
-// a task in git hasn't completed yet.
-var ErrorRequestInProgress = errors.New("resource request in progress")
+var (
+	// ErrRequestInProgress is a sentinel value that indicates
+	// resolving a remote file like a pipeline in a bundle or
+	// a task in git hasn't completed yet.
+	ErrRequestInProgress = errors.New("resource request in progress")
+
+	// ErrorRequestInProgress is an alias for ErrRequestInProgress and will be
+	// removed in a future release..
+	//
+	// Deprecated: use ErrRequestInProgress instead
+	ErrorRequestInProgress = ErrRequestInProgress
+)

--- a/pkg/remote/resolution/error.go
+++ b/pkg/remote/resolution/error.go
@@ -21,55 +21,79 @@ import (
 	"fmt"
 )
 
-// ErrorRequestedResourceIsNil is returned when remote resolution
-// appears to have succeeded but the resolved resource is nil.
-var ErrorRequestedResourceIsNil = errors.New("unknown error occurred: requested resource is nil")
+var (
+	// ErrNilResource is returned when remote resolution
+	// appears to have succeeded but the resolved resource is nil.
+	ErrNilResource = errors.New("unknown error occurred: requested resource is nil")
 
-// ErrorInvalidRuntimeObject is returned when remote resolution
+	// ErrorRequestedResourceIsNil is a deprecated alias for ErrNilResource and will
+	// be removed in a future release.
+	//
+	// Deprecated: use ErrNilResource instead.
+	ErrorRequestedResourceIsNil = ErrNilResource
+)
+
+// InvalidRuntimeObjectError is returned when remote resolution
 // succeeded but the returned data is not a valid runtime.Object.
-type ErrorInvalidRuntimeObject struct {
+type InvalidRuntimeObjectError struct {
 	original error
 }
 
-var _ error = &ErrorInvalidRuntimeObject{}
+// ErrorInvalidRuntimeObject is an alias to InvalidRuntimeObjectError.
+//
+// Deprecated: use InvalidRuntimeObjectError instead.
+type ErrorInvalidRuntimeObject = InvalidRuntimeObjectError
+
+var (
+	_ error = &InvalidRuntimeObjectError{}
+	_ error = &ErrorInvalidRuntimeObject{}
+)
 
 // Error returns the string representation of this error.
-func (e *ErrorInvalidRuntimeObject) Error() string {
+func (e *InvalidRuntimeObjectError) Error() string {
 	return fmt.Sprintf("invalid runtime object: %v", e.original)
 }
 
 // Unwrap returns the underlying original error.
-func (e *ErrorInvalidRuntimeObject) Unwrap() error {
+func (e *InvalidRuntimeObjectError) Unwrap() error {
 	return e.original
 }
 
 // Is returns true if the given error coerces into an error of this type.
-func (*ErrorInvalidRuntimeObject) Is(e error) bool {
-	_, ok := e.(*ErrorInvalidRuntimeObject)
+func (*InvalidRuntimeObjectError) Is(e error) bool {
+	_, ok := e.(*InvalidRuntimeObjectError)
 	return ok
 }
 
-// ErrorAccessingData is returned when remote resolution succeeded but
+// DataAccessError is returned when remote resolution succeeded but
 // attempting to access the resolved data failed. An example of this
 // type of error would be if a ResolutionRequest contained malformed base64.
-type ErrorAccessingData struct {
+type DataAccessError struct {
 	original error
 }
 
-var _ error = &ErrorAccessingData{}
+// ErrorAccessingData is an alias to DataAccessError
+//
+// Deprecated: use DataAccessError instead.
+type ErrorAccessingData = DataAccessError
+
+var (
+	_ error = &DataAccessError{}
+	_ error = &ErrorAccessingData{}
+)
 
 // Error returns the string representation of this error.
-func (e *ErrorAccessingData) Error() string {
+func (e *DataAccessError) Error() string {
 	return fmt.Sprintf("error accessing data from remote resource: %v", e.original)
 }
 
 // Unwrap returns the underlying original error.
-func (e *ErrorAccessingData) Unwrap() error {
+func (e *DataAccessError) Unwrap() error {
 	return e.original
 }
 
 // Is returns true if the given error coerces into an error of this type.
-func (*ErrorAccessingData) Is(e error) bool {
-	_, ok := e.(*ErrorAccessingData)
+func (*DataAccessError) Is(e error) bool {
+	_, ok := e.(*DataAccessError)
 	return ok
 }

--- a/pkg/remote/resolution/resolver.go
+++ b/pkg/remote/resolution/resolver.go
@@ -64,21 +64,21 @@ func (resolver *Resolver) Get(ctx context.Context, _, _ string) (runtime.Object,
 	}
 	resolved, err := resolver.requester.Submit(ctx, resolverName, req)
 	switch {
-	case errors.Is(err, resolutioncommon.ErrorRequestInProgress):
-		return nil, nil, remote.ErrorRequestInProgress
+	case errors.Is(err, resolutioncommon.ErrRequestInProgress):
+		return nil, nil, remote.ErrRequestInProgress
 	case err != nil:
 		return nil, nil, fmt.Errorf("error requesting remote resource: %w", err)
 	case resolved == nil:
-		return nil, nil, ErrorRequestedResourceIsNil
+		return nil, nil, ErrNilResource
 	default:
 	}
 	data, err := resolved.Data()
 	if err != nil {
-		return nil, nil, &ErrorAccessingData{original: err}
+		return nil, nil, &DataAccessError{original: err}
 	}
 	obj, _, err := scheme.Codecs.UniversalDeserializer().Decode(data, nil, nil)
 	if err != nil {
-		return nil, nil, &ErrorInvalidRuntimeObject{original: err}
+		return nil, nil, &InvalidRuntimeObjectError{original: err}
 	}
 	return obj, resolved.Source(), nil
 }

--- a/pkg/remote/resolution/resolver_test.go
+++ b/pkg/remote/resolution/resolver_test.go
@@ -90,12 +90,12 @@ func TestGet_Errors(t *testing.T) {
 		expectedGetErr   error
 		resolvedResource remoteresource.ResolvedResource
 	}{{
-		submitErr:        resolutioncommon.ErrorRequestInProgress,
-		expectedGetErr:   remote.ErrorRequestInProgress,
+		submitErr:        resolutioncommon.ErrRequestInProgress,
+		expectedGetErr:   remote.ErrRequestInProgress,
 		resolvedResource: nil,
 	}, {
 		submitErr:        nil,
-		expectedGetErr:   ErrorRequestedResourceIsNil,
+		expectedGetErr:   ErrNilResource,
 		resolvedResource: nil,
 	}, {
 		submitErr:        genericError,
@@ -103,11 +103,11 @@ func TestGet_Errors(t *testing.T) {
 		resolvedResource: nil,
 	}, {
 		submitErr:        nil,
-		expectedGetErr:   &ErrorInvalidRuntimeObject{},
+		expectedGetErr:   &InvalidRuntimeObjectError{},
 		resolvedResource: notARuntimeObject,
 	}, {
 		submitErr:        nil,
-		expectedGetErr:   &ErrorAccessingData{},
+		expectedGetErr:   &DataAccessError{},
 		resolvedResource: invalidDataResource,
 	}} {
 		ctx := context.Background()

--- a/pkg/resolution/common/errors.go
+++ b/pkg/resolution/common/errors.go
@@ -51,77 +51,102 @@ func NewError(reason string, err error) *Error {
 }
 
 var (
-	// ErrorRequestInProgress is a sentinel value to indicate that
+	// ErrRequestInProgress is a sentinel value to indicate that
 	// a resource request is still in progress.
-	ErrorRequestInProgress = NewError("RequestInProgress", errors.New("Resource request is still in-progress"))
+	ErrRequestInProgress = NewError("RequestInProgress", errors.New("Resource request is still in-progress"))
+
+	// ErrorRequestInProgress is an alias to ErrRequestInProgress
+	//
+	// Deprecated: use ErrRequestInProgress instead.
+	ErrorRequestInProgress = ErrRequestInProgress
 )
 
-// ErrorInvalidResourceKey indicates that a string key given to the
+// InvalidResourceKeyError indicates that a string key given to the
 // Reconcile function does not match the expected "name" or "namespace/name"
 // format.
-type ErrorInvalidResourceKey struct {
+type InvalidResourceKeyError struct {
 	Key      string
 	Original error
 }
 
-var _ error = &ErrorInvalidResourceKey{}
+// ErrorInvalidResourceKey is an alias to type InvalidResourceKeyError.
+//
+// Deprecated: use type InvalidResourceKeyError instead.
+type ErrorInvalidResourceKey = InvalidResourceKeyError
 
-func (e *ErrorInvalidResourceKey) Error() string {
+var _ error = &InvalidResourceKeyError{}
+
+func (e *InvalidResourceKeyError) Error() string {
 	return fmt.Sprintf("invalid resource key %q: %v", e.Key, e.Original)
 }
 
-func (e *ErrorInvalidResourceKey) Unwrap() error {
+func (e *InvalidResourceKeyError) Unwrap() error {
 	return e.Original
 }
 
-// ErrorInvalidRequest is an error received when a
+// InvalidRequestError is an error received when a
 // resource request is badly formed for some reason: either the
 // parameters don't match the resolver's expectations or there is some
 // other structural issue.
-type ErrorInvalidRequest struct {
+type InvalidRequestError struct {
 	ResolutionRequestKey string
 	Message              string
 }
 
-var _ error = &ErrorInvalidRequest{}
+// ErrorInvalidRequest is an alias to type InvalidRequestError.
+//
+// Deprecated: use type InvalidRequestError instead.
+type ErrorInvalidRequest = InvalidRequestError
 
-func (e *ErrorInvalidRequest) Error() string {
+var _ error = &InvalidRequestError{}
+
+func (e *InvalidRequestError) Error() string {
 	return fmt.Sprintf("invalid resource request %q: %s", e.ResolutionRequestKey, e.Message)
 }
 
-// ErrorGettingResource is an error received during what should
+// GetResourceError is an error received during what should
 // otherwise have been a successful resource request.
-type ErrorGettingResource struct {
+type GetResourceError struct {
 	ResolverName string
 	Key          string
 	Original     error
 }
 
-var _ error = &ErrorGettingResource{}
+// ErrorGettingResource is an alias to type GetResourceError.
+//
+// Deprecated: use type GetResourceError instead.
+type ErrorGettingResource = GetResourceError
 
-func (e *ErrorGettingResource) Error() string {
+var _ error = &GetResourceError{}
+
+func (e *GetResourceError) Error() string {
 	return fmt.Sprintf("error getting %q %q: %v", e.ResolverName, e.Key, e.Original)
 }
 
-func (e *ErrorGettingResource) Unwrap() error {
+func (e *GetResourceError) Unwrap() error {
 	return e.Original
 }
 
-// ErrorUpdatingRequest is an error during any part of the update
+// UpdatingRequestError is an error during any part of the update
 // process for a ResolutionRequest, e.g. when attempting to patch the
 // ResolutionRequest with resolved data.
-type ErrorUpdatingRequest struct {
+type UpdatingRequestError struct {
 	ResolutionRequestKey string
 	Original             error
 }
 
-var _ error = &ErrorUpdatingRequest{}
+// ErrorUpdatingRequest is an alias to UpdatingRequestError
+//
+// Deprecated: use UpdatingRequestError instead.
+type ErrorUpdatingRequest = UpdatingRequestError
 
-func (e *ErrorUpdatingRequest) Error() string {
+var _ error = &UpdatingRequestError{}
+
+func (e *UpdatingRequestError) Error() string {
 	return fmt.Sprintf("error updating resource request %q with data: %v", e.ResolutionRequestKey, e.Original)
 }
 
-func (e *ErrorUpdatingRequest) Unwrap() error {
+func (e *UpdatingRequestError) Unwrap() error {
 	return e.Original
 }
 

--- a/pkg/resolution/resolver/bundle/resolver_test.go
+++ b/pkg/resolution/resolver/bundle/resolver_test.go
@@ -493,7 +493,7 @@ func createRequest(p *params) *v1beta1.ResolutionRequest {
 }
 
 func createError(image, msg string) error {
-	return &resolutioncommon.ErrorGettingResource{
+	return &resolutioncommon.GetResourceError{
 		ResolverName: BundleResolverName,
 		Key:          "foo/rr",
 		Original:     fmt.Errorf("invalid tekton bundle %s, error: %s", image, msg),

--- a/pkg/resolution/resolver/cluster/resolver_test.go
+++ b/pkg/resolution/resolver/cluster/resolver_test.go
@@ -326,7 +326,7 @@ func TestResolve(t *testing.T) {
 			resourceName:   exampleTask.Name,
 			namespace:      "other-ns",
 			expectedStatus: internal.CreateResolutionRequestFailureStatus(),
-			expectedErr: &resolutioncommon.ErrorGettingResource{
+			expectedErr: &resolutioncommon.GetResourceError{
 				ResolverName: ClusterResolverName,
 				Key:          "foo/rr",
 				Original:     errors.New(`tasks.tekton.dev "example-task" not found`),
@@ -338,7 +338,7 @@ func TestResolve(t *testing.T) {
 			namespace:         "other-ns",
 			allowedNamespaces: "foo,bar",
 			expectedStatus:    internal.CreateResolutionRequestFailureStatus(),
-			expectedErr: &resolutioncommon.ErrorInvalidRequest{
+			expectedErr: &resolutioncommon.InvalidRequestError{
 				ResolutionRequestKey: "foo/rr",
 				Message:              "access to specified namespace other-ns is not allowed",
 			},
@@ -349,7 +349,7 @@ func TestResolve(t *testing.T) {
 			namespace:         "other-ns",
 			blockedNamespaces: "foo,other-ns,bar",
 			expectedStatus:    internal.CreateResolutionRequestFailureStatus(),
-			expectedErr: &resolutioncommon.ErrorInvalidRequest{
+			expectedErr: &resolutioncommon.InvalidRequestError{
 				ResolutionRequestKey: "foo/rr",
 				Message:              "access to specified namespace other-ns is blocked",
 			},

--- a/pkg/resolution/resolver/framework/controller.go
+++ b/pkg/resolution/resolver/framework/controller.go
@@ -142,17 +142,24 @@ func leaderAwareFuncs(lister rrlister.ResolutionRequestLister) reconciler.Leader
 	}
 }
 
-// ErrorMissingTypeSelector is returned when a resolver does not return
-// a selector with a type label from its GetSelector method.
-var ErrorMissingTypeSelector = fmt.Errorf("invalid resolver: minimum selector must include %q", common.LabelKeyResolverType)
+var (
+	// ErrMissingTypeSelector is returned when a resolver does not return
+	// a selector with a type label from its GetSelector method.
+	ErrMissingTypeSelector = fmt.Errorf("invalid resolver: minimum selector must include %q", common.LabelKeyResolverType)
+
+	// ErrorMissingTypeSelector is an alias to ErrMissingTypeSelector
+	//
+	// Deprecated: use ErrMissingTypeSelector instead.
+	ErrorMissingTypeSelector = ErrMissingTypeSelector
+)
 
 func validateResolver(ctx context.Context, r Resolver) error {
 	sel := r.GetSelector(ctx)
 	if sel == nil {
-		return ErrorMissingTypeSelector
+		return ErrMissingTypeSelector
 	}
 	if sel[common.LabelKeyResolverType] == "" {
-		return ErrorMissingTypeSelector
+		return ErrMissingTypeSelector
 	}
 	return nil
 }

--- a/pkg/resolution/resolver/git/resolver_test.go
+++ b/pkg/resolution/resolver/git/resolver_test.go
@@ -743,7 +743,7 @@ func resolverDisabledContext() context.Context {
 }
 
 func createError(msg string) error {
-	return &resolutioncommon.ErrorGettingResource{
+	return &resolutioncommon.GetResourceError{
 		ResolverName: gitResolverName,
 		Key:          "foo/rr",
 		Original:     errors.New(msg),

--- a/pkg/resolution/resource/crd_resource.go
+++ b/pkg/resolution/resource/crd_resource.go
@@ -57,7 +57,7 @@ func (r *CRDRequester) Submit(ctx context.Context, resolver ResolverName, req Re
 		if err := r.createResolutionRequest(ctx, resolver, req); err != nil {
 			return nil, err
 		}
-		return nil, resolutioncommon.ErrorRequestInProgress
+		return nil, resolutioncommon.ErrRequestInProgress
 	}
 
 	if rr.Status.GetCondition(apis.ConditionSucceeded).IsUnknown() {
@@ -66,7 +66,7 @@ func (r *CRDRequester) Submit(ctx context.Context, resolver ResolverName, req Re
 		// that it doesn't get deleted until the caller is done
 		// with it. Use appendOwnerReference and then submit
 		// update to ResolutionRequest.
-		return nil, resolutioncommon.ErrorRequestInProgress
+		return nil, resolutioncommon.ErrRequestInProgress
 	}
 
 	if rr.Status.GetCondition(apis.ConditionSucceeded).IsTrue() {

--- a/pkg/taskrunmetrics/metrics.go
+++ b/pkg/taskrunmetrics/metrics.go
@@ -103,9 +103,9 @@ type Recorder struct {
 // initializes this singleton and returns the same recorder across any
 // subsequent invocations.
 var (
-	once        sync.Once
-	r           *Recorder
-	recorderErr error
+	once           sync.Once
+	r              *Recorder
+	errRegistering error
 )
 
 // NewRecorder creates a new metrics recorder instance
@@ -121,14 +121,14 @@ func NewRecorder(ctx context.Context) (*Recorder, error) {
 
 		cfg := config.FromContextOrDefaults(ctx)
 
-		recorderErr = viewRegister(cfg.Metrics)
-		if recorderErr != nil {
+		errRegistering = viewRegister(cfg.Metrics)
+		if errRegistering != nil {
 			r.initialized = false
 			return
 		}
 	})
 
-	return r, recorderErr
+	return r, errRegistering
 }
 
 func viewRegister(cfg *config.Metrics) error {

--- a/pkg/taskrunmetrics/metrics_test.go
+++ b/pkg/taskrunmetrics/metrics_test.go
@@ -690,5 +690,5 @@ func unregisterMetrics() {
 	// Allow the recorder singleton to be recreated.
 	once = sync.Once{}
 	r = nil
-	recorderErr = nil
+	errRegistering = nil
 }

--- a/pkg/termination/write.go
+++ b/pkg/termination/write.go
@@ -49,7 +49,7 @@ func WriteMessage(path string, pro []v1beta1.PipelineResourceResult) error {
 	}
 
 	if len(jsonOutput) > MaxContainerTerminationMessageLength {
-		return aboveMax
+		return errTooLong
 	}
 
 	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE, 0666)
@@ -68,7 +68,7 @@ func WriteMessage(path string, pro []v1beta1.PipelineResourceResult) error {
 type MessageLengthError string
 
 const (
-	aboveMax MessageLengthError = "Termination message is above max allowed size 4096, caused by large task result."
+	errTooLong MessageLengthError = "Termination message is above max allowed size 4096, caused by large task result."
 )
 
 func (e MessageLengthError) Error() string {

--- a/pkg/termination/write_test.go
+++ b/pkg/termination/write_test.go
@@ -82,7 +82,7 @@ func TestMaxSizeFile(t *testing.T) {
 		Value: value,
 	}}
 
-	if err := WriteMessage(tmpFile.Name(), output); !errors.Is(err, aboveMax) {
+	if err := WriteMessage(tmpFile.Name(), output); !errors.Is(err, errTooLong) {
 		t.Fatalf("Expected MessageLengthError, received: %v", err)
 	}
 }

--- a/pkg/trustedresources/errors.go
+++ b/pkg/trustedresources/errors.go
@@ -18,14 +18,14 @@ package trustedresources
 import "errors"
 
 var (
-	// ErrorResourceVerificationFailed is returned when trusted resources fails verification.
-	ErrorResourceVerificationFailed = errors.New("resource verification failed")
-	// ErrorEmptyVerificationConfig is returned when no VerificationPolicy is founded
-	ErrorEmptyVerificationConfig = errors.New("no policies founded for verification")
-	// ErrorNoMatchedPolicies is returned when no policies are matched
-	ErrorNoMatchedPolicies = errors.New("no policies are matched")
-	// ErrorRegexMatch is returned when regex match returns error
-	ErrorRegexMatch = errors.New("regex failed to match")
-	// ErrorSignatureMissing is returned when signature is missing in resource
-	ErrorSignatureMissing = errors.New("signature is missing")
+	// ErrResourceVerificationFailed is returned when trusted resources fails verification.
+	ErrResourceVerificationFailed = errors.New("resource verification failed")
+	// ErrEmptyVerificationConfig is returned when no VerificationPolicy is found
+	ErrEmptyVerificationConfig = errors.New("no policies founded for verification")
+	// ErrNoMatchedPolicies is returned when no policies are matched
+	ErrNoMatchedPolicies = errors.New("no policies are matched")
+	// ErrRegexMatch is returned when regex match returns error
+	ErrRegexMatch = errors.New("regex failed to match")
+	// ErrSignatureMissing is returned when signature is missing in resource
+	ErrSignatureMissing = errors.New("signature is missing")
 )

--- a/pkg/trustedresources/verifier/errors.go
+++ b/pkg/trustedresources/verifier/errors.go
@@ -18,24 +18,24 @@ package verifier
 import "errors"
 
 var (
-	// ErrorFailedLoadKeyFile is returned the key file cannot be read
-	ErrorFailedLoadKeyFile = errors.New("the key file cannot be read")
-	// ErrorDecodeKey is returned when the key cannot be decoded
-	ErrorDecodeKey = errors.New("key cannot be decoded")
-	// ErrorEmptyPublicKeys is returned when no public keys are founded
-	ErrorEmptyPublicKeys = errors.New("no public keys are founded")
-	// ErrorEmptySecretData is returned secret data is empty
-	ErrorEmptySecretData = errors.New("secret data is empty")
-	// ErrorSecretNotFound is returned when the secret is not found
-	ErrorSecretNotFound = errors.New("secret not found")
-	// ErrorMultipleSecretData is returned secret contains multiple data
-	ErrorMultipleSecretData = errors.New("secret contains multiple data")
-	// ErrorEmptyKey is returned when the key doesn't contain data or keyRef
-	ErrorEmptyKey = errors.New("key doesn't contain data or keyRef")
-	// ErrorK8sSpecificationInvalid is returned when kubernetes specification format is invalid
-	ErrorK8sSpecificationInvalid = errors.New("kubernetes specification should be in the format k8s://<namespace>/<secret>")
-	// ErrorLoadVerifier is returned when verifier cannot be loaded from the key
-	ErrorLoadVerifier = errors.New("verifier cannot to be loaded")
-	// ErrorAlgorithmInvalid is returned the hash algorithm is not supported
-	ErrorAlgorithmInvalid = errors.New("unknown digest algorithm")
+	// ErrFailedLoadKeyFile is returned the key file cannot be read
+	ErrFailedLoadKeyFile = errors.New("the key file cannot be read")
+	// ErrDecodeKey is returned when the key cannot be decoded
+	ErrDecodeKey = errors.New("key cannot be decoded")
+	// ErrEmptyPublicKeys is returned when no public keys are founded
+	ErrEmptyPublicKeys = errors.New("no public keys are founded")
+	// ErrEmptySecretData is returned secret data is empty
+	ErrEmptySecretData = errors.New("secret data is empty")
+	// ErrSecretNotFound is returned when the secret is not found
+	ErrSecretNotFound = errors.New("secret not found")
+	// ErrMultipleSecretData is returned secret contains multiple data
+	ErrMultipleSecretData = errors.New("secret contains multiple data")
+	// ErrEmptyKey is returned when the key doesn't contain data or keyRef
+	ErrEmptyKey = errors.New("key doesn't contain data or keyRef")
+	// ErrK8sSpecificationInvalid is returned when kubernetes specification format is invalid
+	ErrK8sSpecificationInvalid = errors.New("kubernetes specification should be in the format k8s://<namespace>/<secret>")
+	// ErrLoadVerifier is returned when verifier cannot be loaded from the key
+	ErrLoadVerifier = errors.New("verifier cannot to be loaded")
+	// ErrAlgorithmInvalid is returned the hash algorithm is not supported
+	ErrAlgorithmInvalid = errors.New("unknown digest algorithm")
 )

--- a/pkg/trustedresources/verifier/verifier_test.go
+++ b/pkg/trustedresources/verifier/verifier_test.go
@@ -151,7 +151,7 @@ func TestFromPolicy_Error(t *testing.T) {
 				},
 			},
 		},
-		expectedError: ErrorAlgorithmInvalid,
+		expectedError: ErrAlgorithmInvalid,
 	}, {
 		name: "key is empty",
 		policy: &v1alpha1.VerificationPolicy{
@@ -163,7 +163,7 @@ func TestFromPolicy_Error(t *testing.T) {
 				},
 			},
 		},
-		expectedError: ErrorEmptyKey,
+		expectedError: ErrEmptyKey,
 	}, {
 		name: "authority is empty",
 		policy: &v1alpha1.VerificationPolicy{
@@ -171,7 +171,7 @@ func TestFromPolicy_Error(t *testing.T) {
 				Authorities: []v1alpha1.Authority{},
 			},
 		},
-		expectedError: ErrorEmptyPublicKeys,
+		expectedError: ErrEmptyPublicKeys,
 	}, {
 		name: "from data error",
 		policy: &v1alpha1.VerificationPolicy{
@@ -186,7 +186,7 @@ func TestFromPolicy_Error(t *testing.T) {
 				},
 			},
 		},
-		expectedError: ErrorDecodeKey,
+		expectedError: ErrDecodeKey,
 	}, {
 		name: "from secret error",
 		policy: &v1alpha1.VerificationPolicy{
@@ -203,7 +203,7 @@ func TestFromPolicy_Error(t *testing.T) {
 				},
 			},
 		},
-		expectedError: ErrorSecretNotFound,
+		expectedError: ErrSecretNotFound,
 	}, {
 		name: "from kms error",
 		policy: &v1alpha1.VerificationPolicy{
@@ -283,17 +283,17 @@ func TestFromKeyRef_Error(t *testing.T) {
 		name:          "failed to read file",
 		keyref:        "wrongPath",
 		algorithm:     crypto.SHA256,
-		expectedError: ErrorFailedLoadKeyFile,
+		expectedError: ErrFailedLoadKeyFile,
 	}, {
 		name:          "failed to read from secret",
 		keyref:        fmt.Sprintf("k8s://%s/not-exist-secret", namespace),
 		algorithm:     crypto.SHA256,
-		expectedError: ErrorSecretNotFound,
+		expectedError: ErrSecretNotFound,
 	}, {
 		name:          "failed to read from data",
 		keyref:        keypath,
 		algorithm:     crypto.BLAKE2b_256,
-		expectedError: ErrorLoadVerifier,
+		expectedError: ErrLoadVerifier,
 	}}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
@@ -358,27 +358,27 @@ func TestFromSecret_Error(t *testing.T) {
 	}{{
 		name:          "no data in secret",
 		secretref:     fmt.Sprintf("k8s://%s/empty-secret", namespace),
-		expectedError: ErrorEmptySecretData,
+		expectedError: ErrEmptySecretData,
 	}, {
 		name:          "multiple data in secret",
 		secretref:     fmt.Sprintf("k8s://%s/multiple-data-secret", namespace),
-		expectedError: ErrorMultipleSecretData,
+		expectedError: ErrMultipleSecretData,
 	}, {
 		name:          "invalid data in secret",
 		secretref:     fmt.Sprintf("k8s://%s/invalid-data-secret", namespace),
-		expectedError: ErrorDecodeKey,
+		expectedError: ErrDecodeKey,
 	}, {
 		name:          "invalid secretref",
 		secretref:     "invalid-secretref",
-		expectedError: ErrorK8sSpecificationInvalid,
+		expectedError: ErrK8sSpecificationInvalid,
 	}, {
 		name:          "secretref has k8s prefix but contains invalid data",
 		secretref:     "k8s://ns/name/foo",
-		expectedError: ErrorK8sSpecificationInvalid,
+		expectedError: ErrK8sSpecificationInvalid,
 	}, {
 		name:          "secret doesn't exist",
 		secretref:     fmt.Sprintf("k8s://%s/not-exist-secret", namespace),
-		expectedError: ErrorSecretNotFound,
+		expectedError: ErrSecretNotFound,
 	}}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
@@ -404,12 +404,12 @@ func TestFromData_Error(t *testing.T) {
 		name:          "data in cannot be decoded",
 		data:          []byte("wrong key"),
 		algorithm:     crypto.SHA256,
-		expectedError: ErrorDecodeKey,
+		expectedError: ErrDecodeKey,
 	}, {
 		name:          "verifier cannot be loaded due to wrong algorithm",
 		data:          pub,
 		algorithm:     crypto.BLAKE2b_256,
-		expectedError: ErrorLoadVerifier,
+		expectedError: ErrLoadVerifier,
 	}}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
@@ -454,8 +454,8 @@ func TestMatchHashAlgorithm_Success(t *testing.T) {
 
 func TestHashAlgorithm_Error(t *testing.T) {
 	_, err := matchHashAlgorithm("SHA1")
-	if !errors.Is(err, ErrorAlgorithmInvalid) {
-		t.Errorf("hashAlgorithm got: %v, want: %v", err, ErrorAlgorithmInvalid)
+	if !errors.Is(err, ErrAlgorithmInvalid) {
+		t.Errorf("hashAlgorithm got: %v, want: %v", err, ErrAlgorithmInvalid)
 	}
 }
 

--- a/pkg/trustedresources/verify_test.go
+++ b/pkg/trustedresources/verify_test.go
@@ -92,15 +92,15 @@ func TestVerifyInterface_Task_Error(t *testing.T) {
 	}{{
 		name:          "Unsigned Task Fail Verification",
 		task:          unsignedTask,
-		expectedError: ErrorResourceVerificationFailed,
+		expectedError: ErrResourceVerificationFailed,
 	}, {
 		name:          "Empty task Fail Verification",
 		task:          nil,
-		expectedError: ErrorResourceVerificationFailed,
+		expectedError: ErrResourceVerificationFailed,
 	}, {
 		name:          "Tampered task Fail Verification",
 		task:          tamperedTask,
-		expectedError: ErrorResourceVerificationFailed,
+		expectedError: ErrResourceVerificationFailed,
 	}}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
@@ -227,19 +227,19 @@ func TestVerifyTask_VerificationPolicy_Error(t *testing.T) {
 		task:               tamperedTask,
 		source:             "git+https://github.com/tektoncd/catalog.git",
 		verificationPolicy: vps,
-		expectedError:      ErrorResourceVerificationFailed,
+		expectedError:      ErrResourceVerificationFailed,
 	}, {
 		name:               "task not matching pattern fails verification",
 		task:               signedTask,
 		source:             "wrong source",
 		verificationPolicy: vps,
-		expectedError:      ErrorNoMatchedPolicies,
+		expectedError:      ErrNoMatchedPolicies,
 	}, {
 		name:               "verification fails with empty policy",
 		task:               tamperedTask,
 		source:             "git+https://github.com/tektoncd/catalog.git",
 		verificationPolicy: []*v1alpha1.VerificationPolicy{},
-		expectedError:      ErrorEmptyVerificationConfig,
+		expectedError:      ErrEmptyVerificationConfig,
 	}, {
 		name:   "Verification fails with regex error",
 		task:   signedTask,
@@ -256,7 +256,7 @@ func TestVerifyTask_VerificationPolicy_Error(t *testing.T) {
 				},
 			},
 		},
-		expectedError: ErrorRegexMatch,
+		expectedError: ErrRegexMatch,
 	}, {
 		name:   "Verification fails with error from policy",
 		task:   signedTask,
@@ -281,7 +281,7 @@ func TestVerifyTask_VerificationPolicy_Error(t *testing.T) {
 				},
 			},
 		},
-		expectedError: verifier.ErrorDecodeKey,
+		expectedError: verifier.ErrDecodeKey,
 	}}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
# Changes

There are no expected functional changes in this PR.

Made non-functional code changes to adhere to linter standards.

Context: https://github.com/tektoncd/pipeline/issues/5899

See related style docs:
- [Error naming](https://github.com/golang/go/wiki/Errors#naming)
- [Concision](https://google.github.io/styleguide/go/guide#concision)
- [Error handling](https://go.dev/blog/errors-are-values)

/kind cleanup

# Submitter Checklist

- [N/A] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [N/A] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note

action required: 

- `resolution.ErrorRequestedResourceIsNil` is deprecated; change references to `resolution.ErrNilResource`.
- `remote.ErrorRequestInProgress` is deprecated; change references to `remote.ErrRequestInProgress`.
- in package `cmd/entrypoint/subcommands`, `SubcommandSuccessful` type is deprecated, use type `OK`.
- in package `resolution/common`, `ErrorRequestInProgress` is deprecated; change references to `ErrRequestInProgress`.
- in package `resolution/common`, all errors of type `Error*` have been renamed to type `*Error`.
- in package `resolution/framework`, `ErrorMissingTypeSelector` is deprecated; change references to `ErrMissingTypeSelector`

Trusted Resources are in alpha; the following breaking changes are included in this PR:

- in package `trustedresources`:
  - `ErrorResourceVerificationFailed` is replaced by `ErrResourceVerificationFailed`
  - `ErrorEmptyVerificationConfig` is replaced by `ErrEmptyVerificationConfig`
  - `ErrorNoMatchedPolicies` is replaced by `ErrNoMatchedPolicies`
  - `ErrorRegexMatch` is replaced by `ErrRegexMatch`
  - `ErrorSignatureMissing` is replaced by `ErrSignatureMissing`
- in package `trustedresources/verifier`:
  - `ErrorFailedLoadKeyFile` is replaced by `ErrFailedLoadKeyFile`
  - `ErrorDecodeKey` is replaced by `ErrDecodeKey`
  - `ErrorEmptyPublicKeys` is replaced by `ErrEmptyPublicKeys`
  - `ErrorEmptySecretData` is replaced by `ErrEmptySecretData`
  - `ErrorSecretNotFound` is replaced by `ErrSecretNotFound`
  - `ErrorMultipleSecretData` is replaced by `ErrMultipleSecretData`
  - `ErrorEmptyKey` is replaced by `ErrEmptyKey`
  - `ErrorK8sSpecificationInvalid` is replaced by `ErrK8sSpecificationInvalid`
  - `ErrorLoadVerifier` is replaced by `ErrLoadVerifier`
  - `ErrorAlgorithmInvalid` is replaced by `ErrAlgorithmInvalid`
```
