### PR TITLE
Update EOL releases

### DIFF
--- a/releases.md
+++ b/releases.md
@@ -58,7 +58,7 @@ Further documentation available:
 ### v0.43
 
 - **Latest Release**: [v0.43.2][v0-43-2] (2023-01-10) ([docs][v0-43-2-docs], [examples][v0-43-2-examples])
-- **Initial Release**: [v0.43.0][v0-43-0] (2023-12-22)
+- **Initial Release**: [v0.43.0][v0-43-0] (2022-12-22)
 - **End of Life**: 2023-04-22
 - **Patch Releases**: [v0.43.0][v0-43-0], [v0.43.1][v0-43-1], [v0.43.2][v0-43-2]
  
@@ -76,6 +76,8 @@ Further documentation available:
 - **End of Life**: 2023-10-30
 - **Patch Releases**: [v0.41.0][v0-41-0], [v0.41.1][v0-41-1]
 
+## End of Life Releases
+
 ### v0.40
 
 - **Latest Release**: [v0.40.2][v0-40-2] (2022-10-03) ([docs][v0-40-2-docs], [examples][v0-40-2-examples])
@@ -89,8 +91,6 @@ Further documentation available:
 - **Initial Release**: [v0.39.0][v0-39-0] (2022-08-18)
 - **End of Life**: 2022-12-17
 - **Patch Releases**: [v0.39.0][v0-39-0]
-
-## End of Life Releases
 
 ### v0.38
 


### PR DESCRIPTION
# Changes

v0.39.x and v0.40.x are end of life, so move them to the EOL section.

Also fixed the initial date for v0.43 (marked as 2023 instead of 2022)

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Move v0.39 and v0.40 releases to the end-of-life section.
```

/kind documentation