### PR TITLE
Add exact comparison for events

### DIFF
--- a/pkg/reconciler/events/k8sevent/event_test.go
+++ b/pkg/reconciler/events/k8sevent/event_test.go
@@ -134,6 +134,42 @@ func TestEmitK8sEventsOnConditions(t *testing.T) {
 			Status: corev1.ConditionFalse,
 		},
 		wantEvents: []string{"Warning Failed "},
+	}, {
+		name:   "match wildcard events through escaping",
+		before: nil,
+		after: &apis.Condition{
+			Type:    apis.ConditionSucceeded,
+			Status:  corev1.ConditionFalse,
+			Message: "contains a * character",
+		},
+		wantEvents: []string{"Warning Failed contains a \\* character"},
+	}, {
+		name:   "match wildcard events literally",
+		before: nil,
+		after: &apis.Condition{
+			Type:    apis.ConditionSucceeded,
+			Status:  corev1.ConditionFalse,
+			Message: "contains a * character",
+		},
+		wantEvents: []string{"Warning Failed contains a * character"},
+	}, {
+		name:   "match contains parenthesis events through escaping",
+		before: nil,
+		after: &apis.Condition{
+			Type:    apis.ConditionSucceeded,
+			Status:  corev1.ConditionFalse,
+			Message: "contains (parenthesis)",
+		},
+		wantEvents: []string{"Warning Failed contains \\(parenthesis\\)"},
+	}, {
+		name:   "match contains parenthesis events through literally",
+		before: nil,
+		after: &apis.Condition{
+			Type:    apis.ConditionSucceeded,
+			Status:  corev1.ConditionFalse,
+			Message: "contains (parenthesis)",
+		},
+		wantEvents: []string{"Warning Failed contains (parenthesis)"},
 	}}
 
 	for _, ts := range testcases {

--- a/pkg/reconciler/events/k8sevent/events.go
+++ b/pkg/reconciler/events/k8sevent/events.go
@@ -54,6 +54,11 @@ func eventsFromChannel(c chan string, wantEvents []string) error {
 		case event := <-c:
 			foundEvents = append(foundEvents, event)
 			wantEvent := wantEvents[ii]
+			// If the event is an exact match, there is no need to use regular expressions for matching.
+			// This can avoid the need to escape special characters, such as *, in the event to match.
+			if wantEvent == event {
+				continue
+			}
 			matching, err := regexp.MatchString(wantEvent, event)
 			if err == nil {
 				if !matching {


### PR DESCRIPTION
fix #6306

For those who are writing unit tests for the first time, they may instinctively copy the event information from the error message.
However, if the error message contains special characters that are not properly escaped, the unit test will fail.
This requires the user to examine the source code to understand the reason for the failure.
With this optimization, it could be more beginner-friendly.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
