### PR TITLE
[TEP074] Tombstone ResourceResult field with the removal of PipelineResources

### DIFF
--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -54,3 +54,5 @@ See [TEP-0074](https://github.com/tektoncd/community/blob/main/teps/0074-depreca
 - The artifacts bucket/pvc setup by the `pkg/artifacts` package related with Storage PipelineResources
 
 - The generic pipelineResources functions including inputs and outputs resources and the `from` type
+
+- [TaskRun.Status.ResourcesResult is deprecated and tombstoned #6301](https://github.com/tektoncd/pipeline/issues/6325)

--- a/docs/pipeline-api.md
+++ b/docs/pipeline-api.md
@@ -13973,8 +13973,9 @@ All TaskRunStatus stored in RetriesStatus will have no date within the RetriesSt
 </td>
 <td>
 <em>(Optional)</em>
-<p>Results from Resources built during the TaskRun. currently includes
-the digest of build container images</p>
+<p>Results from Resources built during the TaskRun.
+This is tomb-stoned along with the removal of pipelineResources
+Deprecated: this field is not populated and is preserved only for backwards compatibility</p>
 </td>
 </tr>
 <tr>

--- a/pkg/apis/pipeline/v1beta1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1beta1/openapi_generated.go
@@ -5213,7 +5213,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunStatus(ref common.ReferenceCallback
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Results from Resources built during the TaskRun. currently includes the digest of build container images",
+							Description: "Results from Resources built during the TaskRun. This is tomb-stoned along with the removal of pipelineResources Deprecated: this field is not populated and is preserved only for backwards compatibility",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -5391,7 +5391,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunStatusFields(ref common.ReferenceCa
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Results from Resources built during the TaskRun. currently includes the digest of build container images",
+							Description: "Results from Resources built during the TaskRun. This is tomb-stoned along with the removal of pipelineResources Deprecated: this field is not populated and is preserved only for backwards compatibility",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_conversion_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_conversion_test.go
@@ -97,11 +97,6 @@ var (
 					ImageID:       "image-id",
 					ContainerName: "sidecar-error",
 				}},
-				ResourcesResult: []v1beta1.RunResult{{
-					Key:          "digest",
-					Value:        "sha256:1234",
-					ResourceName: "source-image",
-				}},
 			},
 		},
 		WhenExpressions: v1beta1.WhenExpressions{{

--- a/pkg/apis/pipeline/v1beta1/swagger.json
+++ b/pkg/apis/pipeline/v1beta1/swagger.json
@@ -2849,7 +2849,7 @@
           "$ref": "#/definitions/v1beta1.Provenance"
         },
         "resourcesResult": {
-          "description": "Results from Resources built during the TaskRun. currently includes the digest of build container images",
+          "description": "Results from Resources built during the TaskRun. This is tomb-stoned along with the removal of pipelineResources Deprecated: this field is not populated and is preserved only for backwards compatibility",
           "type": "array",
           "items": {
             "default": {},
@@ -2941,7 +2941,7 @@
           "$ref": "#/definitions/v1beta1.Provenance"
         },
         "resourcesResult": {
-          "description": "Results from Resources built during the TaskRun. currently includes the digest of build container images",
+          "description": "Results from Resources built during the TaskRun. This is tomb-stoned along with the removal of pipelineResources Deprecated: this field is not populated and is preserved only for backwards compatibility",
           "type": "array",
           "items": {
             "default": {},

--- a/pkg/apis/pipeline/v1beta1/taskrun_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_conversion.go
@@ -44,9 +44,6 @@ func (tr *TaskRun) ConvertTo(ctx context.Context, to apis.Convertible) error {
 		if err := serializeTaskRunCloudEvents(&sink.ObjectMeta, &tr.Status); err != nil {
 			return err
 		}
-		if err := serializeTaskRunResourcesResult(&sink.ObjectMeta, &tr.Status); err != nil {
-			return err
-		}
 		if err := tr.Status.ConvertTo(ctx, &sink.Status); err != nil {
 			return err
 		}
@@ -116,9 +113,6 @@ func (tr *TaskRun) ConvertFrom(ctx context.Context, from apis.Convertible) error
 	case *v1.TaskRun:
 		tr.ObjectMeta = source.ObjectMeta
 		if err := deserializeTaskRunCloudEvents(&tr.ObjectMeta, &tr.Status); err != nil {
-			return err
-		}
-		if err := deserializeTaskRunResourcesResult(&tr.ObjectMeta, &tr.Status); err != nil {
 			return err
 		}
 		if err := tr.Status.ConvertFrom(ctx, source.Status); err != nil {
@@ -369,25 +363,6 @@ func deserializeTaskRunCloudEvents(meta *metav1.ObjectMeta, status *TaskRunStatu
 	}
 	if len(cloudEvents) != 0 {
 		status.CloudEvents = cloudEvents
-	}
-	return nil
-}
-
-func serializeTaskRunResourcesResult(meta *metav1.ObjectMeta, status *TaskRunStatus) error {
-	if status.ResourcesResult == nil {
-		return nil
-	}
-	return version.SerializeToMetadata(meta, status.ResourcesResult, resourcesResultAnnotationKey)
-}
-
-func deserializeTaskRunResourcesResult(meta *metav1.ObjectMeta, status *TaskRunStatus) error {
-	resourcesResult := []RunResult{}
-	err := version.DeserializeFromMetadata(meta, &resourcesResult, resourcesResultAnnotationKey)
-	if err != nil {
-		return err
-	}
-	if len(resourcesResult) != 0 {
-		status.ResourcesResult = resourcesResult
 	}
 	return nil
 }

--- a/pkg/apis/pipeline/v1beta1/taskrun_conversion_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_conversion_test.go
@@ -377,56 +377,6 @@ func TestTaskRunConversionFromDeprecated(t *testing.T) {
 				},
 			},
 		},
-	}, {
-		name: "resourcesResult",
-		in: &v1beta1.TaskRun{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "foo",
-				Namespace: "bar",
-			},
-			Spec: v1beta1.TaskRunSpec{
-				TaskRef: &v1beta1.TaskRef{
-					Name: "test-resources-result",
-				},
-			},
-			Status: v1beta1.TaskRunStatus{
-				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
-					ResourcesResult: []v1beta1.RunResult{{
-						Key:          "digest",
-						Value:        "sha256:1234",
-						ResourceName: "source-image",
-					}, {
-						Key:          "digest-11",
-						Value:        "sha256:1234",
-						ResourceName: "source-image",
-					}},
-				},
-			},
-		},
-		want: &v1beta1.TaskRun{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "foo",
-				Namespace: "bar",
-			},
-			Spec: v1beta1.TaskRunSpec{
-				TaskRef: &v1beta1.TaskRef{
-					Name: "test-resources-result",
-				},
-			},
-			Status: v1beta1.TaskRunStatus{
-				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
-					ResourcesResult: []v1beta1.RunResult{{
-						Key:          "digest",
-						Value:        "sha256:1234",
-						ResourceName: "source-image",
-					}, {
-						Key:          "digest-11",
-						Value:        "sha256:1234",
-						ResourceName: "source-image",
-					}},
-				},
-			},
-		},
 	}}
 	for _, test := range tests {
 		versions := []apis.Convertible{&v1.TaskRun{}}

--- a/pkg/apis/pipeline/v1beta1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_types.go
@@ -250,8 +250,9 @@ type TaskRunStatusFields struct {
 	// +listType=atomic
 	RetriesStatus []TaskRunStatus `json:"retriesStatus,omitempty"`
 
-	// Results from Resources built during the TaskRun. currently includes
-	// the digest of build container images
+	// Results from Resources built during the TaskRun.
+	// This is tomb-stoned along with the removal of pipelineResources
+	// Deprecated: this field is not populated and is preserved only for backwards compatibility
 	// +optional
 	// +listType=atomic
 	ResourcesResult []RunResult `json:"resourcesResult,omitempty"`

--- a/pkg/pod/status_test.go
+++ b/pkg/pod/status_test.go
@@ -647,7 +647,7 @@ func TestMakeTaskRunStatus(t *testing.T) {
 			},
 		},
 	}, {
-		desc: "image resource updated",
+		desc: "image resource that should not populate resourcesResult",
 		podStatus: corev1.PodStatus{
 			Phase: corev1.PodSucceeded,
 			ContainerStatuses: []corev1.ContainerStatus{{
@@ -671,11 +671,6 @@ func TestMakeTaskRunStatus(t *testing.T) {
 					ContainerName: "step-foo",
 				}},
 				Sidecars: []v1beta1.SidecarState{},
-				ResourcesResult: []v1beta1.RunResult{{
-					Key:          "digest",
-					Value:        "sha256:12345",
-					ResourceName: "source-image",
-				}},
 				// We don't actually care about the time, just that it's not nil
 				CompletionTime: &metav1.Time{Time: time.Now()},
 			},
@@ -705,11 +700,6 @@ func TestMakeTaskRunStatus(t *testing.T) {
 					ContainerName: "step-bar",
 				}},
 				Sidecars: []v1beta1.SidecarState{},
-				ResourcesResult: []v1beta1.RunResult{{
-					Key:          "digest",
-					Value:        "sha256:1234",
-					ResourceName: "source-image",
-				}},
 				TaskRunResults: []v1beta1.TaskRunResult{{
 					Name:  "resultName",
 					Type:  v1beta1.ResultsTypeString,
@@ -744,11 +734,6 @@ func TestMakeTaskRunStatus(t *testing.T) {
 					ContainerName: "step-banana",
 				}},
 				Sidecars: []v1beta1.SidecarState{},
-				ResourcesResult: []v1beta1.RunResult{{
-					Key:          "digest",
-					Value:        "sha256:1234",
-					ResourceName: "source-image",
-				}},
 				TaskRunResults: []v1beta1.TaskRunResult{{
 					Name:  "resultName",
 					Type:  v1beta1.ResultsTypeString,
@@ -1297,11 +1282,6 @@ func TestMakeTaskRunStatusAlpha(t *testing.T) {
 					ContainerName: "step-bar",
 				}},
 				Sidecars: []v1beta1.SidecarState{},
-				ResourcesResult: []v1beta1.RunResult{{
-					Key:          "digest",
-					Value:        "sha256:1234",
-					ResourceName: "source-image",
-				}},
 				TaskRunResults: []v1beta1.TaskRunResult{{
 					Name:  "resultName",
 					Type:  v1beta1.ResultsTypeString,
@@ -1344,11 +1324,6 @@ func TestMakeTaskRunStatusAlpha(t *testing.T) {
 					ContainerName: "step-bar",
 				}},
 				Sidecars: []v1beta1.SidecarState{},
-				ResourcesResult: []v1beta1.RunResult{{
-					Key:          "digest",
-					Value:        "sha256:1234",
-					ResourceName: "source-image",
-				}},
 				TaskRunResults: []v1beta1.TaskRunResult{{
 					Name:  "resultName",
 					Type:  v1beta1.ResultsTypeString,
@@ -1391,11 +1366,6 @@ func TestMakeTaskRunStatusAlpha(t *testing.T) {
 					ContainerName: "step-bar",
 				}},
 				Sidecars: []v1beta1.SidecarState{},
-				ResourcesResult: []v1beta1.RunResult{{
-					Key:          "digest",
-					Value:        "sha256:1234",
-					ResourceName: "source-image",
-				}},
 				TaskRunResults: []v1beta1.TaskRunResult{{
 					Name:  "resultName",
 					Type:  v1beta1.ResultsTypeArray,
@@ -1438,11 +1408,6 @@ func TestMakeTaskRunStatusAlpha(t *testing.T) {
 					ContainerName: "step-bar",
 				}},
 				Sidecars: []v1beta1.SidecarState{},
-				ResourcesResult: []v1beta1.RunResult{{
-					Key:          "digest",
-					Value:        "sha256:1234",
-					ResourceName: "source-image",
-				}},
 				TaskRunResults: []v1beta1.TaskRunResult{{
 					Name:  "resultName",
 					Type:  v1beta1.ResultsTypeObject,


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This commit tombstones the `resourcesResult` field of TaskRun along with the removal of `pipelineResources`.
It aims to cleanup `pkg/pod/status` as the prerequisites swapping to v1 as storage version.

It is tombstoned due to following reasons:
- `ResourceResult`, according its description, was 'Results from Resources built during the TaskRun. currently includes the digest of build container images', now since image resources are removed, it was left meaningless.
- `ResourceResult` highly relies on PipelineResourcesResult type, where previously PipelineResourceResult is being written to it, now that PipelineResources is being removed, there is no usage for resourcesResult
- `ResourceResult` has not been moved to v1, when we swap the storage versions, there will not be a suitable place to write to `PipelineResourceResult` any more

The migration of PipelineResourceResult is broken down into:
- Stop populating resourceName in git-init image https://github.com/tektoncd/pipeline/pull/6310
- removing `PipelineResourceResultType` of `PipelineResourceResult` Struct (https://github.com/tektoncd/pipeline/pull/6198)
- tombstoning of deprecated field `resourcesResult` (https://github.com/tektoncd/pipeline/pull/6301)

/kind misc
part of https://github.com/tektoncd/pipeline/issues/6197

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
