### PR TITLE
[TEP046] Remove Deprecated PipelineRun Timeout Field

### DIFF
--- a/docs/pipeline-api.md
+++ b/docs/pipeline-api.md
@@ -7490,7 +7490,8 @@ Kubernetes meta/v1.Duration
 <p>Timeout is the Time after which the Pipeline times out.
 Defaults to never.
 Refer to Go&rsquo;s ParseDuration documentation for expected format: <a href="https://golang.org/pkg/time/#ParseDuration">https://golang.org/pkg/time/#ParseDuration</a></p>
-<p>Deprecated: use pipelineRunSpec.Timeouts.Pipeline instead</p>
+<p>Deprecated: use pipelineRunSpec.Timeouts.Pipeline instead. It is only kept
+for backwards compatibility with older server versions.</p>
 </td>
 </tr>
 <tr>
@@ -9348,7 +9349,8 @@ Kubernetes meta/v1.Duration
 <p>Timeout is the Time after which the Pipeline times out.
 Defaults to never.
 Refer to Go&rsquo;s ParseDuration documentation for expected format: <a href="https://golang.org/pkg/time/#ParseDuration">https://golang.org/pkg/time/#ParseDuration</a></p>
-<p>Deprecated: use pipelineRunSpec.Timeouts.Pipeline instead</p>
+<p>Deprecated: use pipelineRunSpec.Timeouts.Pipeline instead. It is only kept
+for backwards compatibility with older server versions.</p>
 </td>
 </tr>
 <tr>

--- a/examples/v1beta1/pipelineruns/alpha/isolated-workspaces.yaml
+++ b/examples/v1beta1/pipelineruns/alpha/isolated-workspaces.yaml
@@ -17,7 +17,8 @@ apiVersion: tekton.dev/v1beta1
 metadata:
   generateName: isolated-workspaces-
 spec:
-  timeout: 60s
+  timeouts:
+    pipeline: 60s
   workspaces:
   - name: ssh-credentials
     secret:

--- a/examples/v1beta1/pipelineruns/no-ci/pipeline-timeout.yaml
+++ b/examples/v1beta1/pipelineruns/no-ci/pipeline-timeout.yaml
@@ -22,7 +22,8 @@ metadata:
   name: pipelinerun-timeout
 spec:
   # 1 hour and half timeout
-  timeout: 1h30m
+  timeouts:
+    pipeline: 1h30m
   pipelineSpec:
     params:
       - name: MORNING_GREETINGS

--- a/pkg/apis/pipeline/v1beta1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1beta1/openapi_generated.go
@@ -1745,7 +1745,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineRunSpec(ref common.ReferenceCallba
 					},
 					"timeout": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Timeout is the Time after which the Pipeline times out. Defaults to never. Refer to Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration\n\nDeprecated: use pipelineRunSpec.Timeouts.Pipeline instead",
+							Description: "Timeout is the Time after which the Pipeline times out. Defaults to never. Refer to Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration\n\nDeprecated: use pipelineRunSpec.Timeouts.Pipeline instead. It is only kept for backwards compatibility with older server versions.",
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Duration"),
 						},
 					},

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_conversion.go
@@ -67,10 +67,6 @@ func (prs PipelineRunSpec) ConvertTo(ctx context.Context, sink *v1.PipelineRunSp
 		sink.Timeouts = &v1.TimeoutFields{}
 		prs.Timeouts.convertTo(ctx, sink.Timeouts)
 	}
-	if prs.Timeout != nil {
-		sink.Timeouts = &v1.TimeoutFields{}
-		sink.Timeouts.Pipeline = prs.Timeout
-	}
 	sink.TaskRunTemplate = v1.PipelineTaskRunTemplate{}
 	sink.TaskRunTemplate.PodTemplate = prs.PodTemplate
 	sink.TaskRunTemplate.ServiceAccountName = prs.ServiceAccountName

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_conversion_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_conversion_test.go
@@ -354,28 +354,6 @@ func TestPipelineRunConversionFromDeprecated(t *testing.T) {
 		in   *v1beta1.PipelineRun
 		want *v1beta1.PipelineRun
 	}{{
-		name: "timeout to timeouts",
-		in: &v1beta1.PipelineRun{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "foo",
-				Namespace: "bar",
-			},
-			Spec: v1beta1.PipelineRunSpec{
-				Timeout: &metav1.Duration{Duration: 5 * time.Minute},
-			},
-		},
-		want: &v1beta1.PipelineRun{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "foo",
-				Namespace: "bar",
-			},
-			Spec: v1beta1.PipelineRunSpec{
-				Timeouts: &v1beta1.TimeoutFields{
-					Pipeline: &metav1.Duration{Duration: 5 * time.Minute},
-				},
-			},
-		},
-	}, {
 		name: "bundle",
 		in: &v1beta1.PipelineRun{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_defaults.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_defaults.go
@@ -36,11 +36,11 @@ func (pr *PipelineRun) SetDefaults(ctx context.Context) {
 // SetDefaults implements apis.Defaultable
 func (prs *PipelineRunSpec) SetDefaults(ctx context.Context) {
 	cfg := config.FromContextOrDefaults(ctx)
-	if prs.Timeout == nil && prs.Timeouts == nil {
-		prs.Timeout = &metav1.Duration{Duration: time.Duration(cfg.Defaults.DefaultTimeoutMinutes) * time.Minute}
+	if prs.Timeouts == nil {
+		prs.Timeouts = &TimeoutFields{}
 	}
 
-	if prs.Timeouts != nil && prs.Timeouts.Pipeline == nil {
+	if prs.Timeouts.Pipeline == nil {
 		prs.Timeouts.Pipeline = &metav1.Duration{Duration: time.Duration(cfg.Defaults.DefaultTimeoutMinutes) * time.Minute}
 	}
 

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_defaults_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_defaults_test.go
@@ -43,17 +43,21 @@ func TestPipelineRunSpec_SetDefaults(t *testing.T) {
 			prs:  &v1beta1.PipelineRunSpec{},
 			want: &v1beta1.PipelineRunSpec{
 				ServiceAccountName: config.DefaultServiceAccountValue,
-				Timeout:            &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
+				Timeouts: &v1beta1.TimeoutFields{
+					Pipeline: &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
+				},
 			},
 		},
 		{
-			desc: "timeout is not nil",
+			desc: "timeouts is not nil",
 			prs: &v1beta1.PipelineRunSpec{
-				Timeout: &metav1.Duration{Duration: 500 * time.Millisecond},
+				Timeouts: &v1beta1.TimeoutFields{},
 			},
 			want: &v1beta1.PipelineRunSpec{
 				ServiceAccountName: config.DefaultServiceAccountValue,
-				Timeout:            &metav1.Duration{Duration: 500 * time.Millisecond},
+				Timeouts: &v1beta1.TimeoutFields{
+					Pipeline: &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
+				},
 			},
 		},
 		{
@@ -61,7 +65,9 @@ func TestPipelineRunSpec_SetDefaults(t *testing.T) {
 			prs:  &v1beta1.PipelineRunSpec{},
 			want: &v1beta1.PipelineRunSpec{
 				ServiceAccountName: config.DefaultServiceAccountValue,
-				Timeout:            &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
+				Timeouts: &v1beta1.TimeoutFields{
+					Pipeline: &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
+				},
 			},
 		},
 		{
@@ -75,11 +81,13 @@ func TestPipelineRunSpec_SetDefaults(t *testing.T) {
 			},
 			want: &v1beta1.PipelineRunSpec{
 				ServiceAccountName: config.DefaultServiceAccountValue,
-				Timeout:            &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
 				PodTemplate: &pod.Template{
 					NodeSelector: map[string]string{
 						"label": "value",
 					},
+				},
+				Timeouts: &v1beta1.TimeoutFields{
+					Pipeline: &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
 				},
 			},
 		},
@@ -117,7 +125,9 @@ func TestPipelineRunDefaulting(t *testing.T) {
 		want: &v1beta1.PipelineRun{
 			Spec: v1beta1.PipelineRunSpec{
 				ServiceAccountName: config.DefaultServiceAccountValue,
-				Timeout:            &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
+				Timeouts: &v1beta1.TimeoutFields{
+					Pipeline: &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
+				},
 			},
 		},
 	}, {
@@ -128,6 +138,9 @@ func TestPipelineRunDefaulting(t *testing.T) {
 					Params: []v1beta1.ParamSpec{{
 						Name: "foo",
 					}},
+				},
+				Timeouts: &v1beta1.TimeoutFields{
+					Pipeline: &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
 				},
 			},
 		},
@@ -140,7 +153,9 @@ func TestPipelineRunDefaulting(t *testing.T) {
 					}},
 				},
 				ServiceAccountName: config.DefaultServiceAccountValue,
-				Timeout:            &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
+				Timeouts: &v1beta1.TimeoutFields{
+					Pipeline: &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
+				},
 			},
 		},
 	}, {
@@ -154,7 +169,9 @@ func TestPipelineRunDefaulting(t *testing.T) {
 			Spec: v1beta1.PipelineRunSpec{
 				PipelineRef:        &v1beta1.PipelineRef{Name: "foo"},
 				ServiceAccountName: config.DefaultServiceAccountValue,
-				Timeout:            &metav1.Duration{Duration: 5 * time.Minute},
+				Timeouts: &v1beta1.TimeoutFields{
+					Pipeline: &metav1.Duration{Duration: 5 * time.Minute},
+				},
 			},
 		},
 		wc: func(ctx context.Context) context.Context {
@@ -179,8 +196,10 @@ func TestPipelineRunDefaulting(t *testing.T) {
 		want: &v1beta1.PipelineRun{
 			Spec: v1beta1.PipelineRunSpec{
 				PipelineRef:        &v1beta1.PipelineRef{Name: "foo"},
-				Timeout:            &metav1.Duration{Duration: 5 * time.Minute},
 				ServiceAccountName: "tekton",
+				Timeouts: &v1beta1.TimeoutFields{
+					Pipeline: &metav1.Duration{Duration: 5 * time.Minute},
+				},
 			},
 		},
 		wc: func(ctx context.Context) context.Context {
@@ -206,12 +225,14 @@ func TestPipelineRunDefaulting(t *testing.T) {
 		want: &v1beta1.PipelineRun{
 			Spec: v1beta1.PipelineRunSpec{
 				PipelineRef:        &v1beta1.PipelineRef{Name: "foo"},
-				Timeout:            &metav1.Duration{Duration: 5 * time.Minute},
 				ServiceAccountName: "tekton",
 				PodTemplate: &pod.Template{
 					NodeSelector: map[string]string{
 						"label": "value",
 					},
+				},
+				Timeouts: &v1beta1.TimeoutFields{
+					Pipeline: &metav1.Duration{Duration: 5 * time.Minute},
 				},
 			},
 		},
@@ -244,12 +265,14 @@ func TestPipelineRunDefaulting(t *testing.T) {
 		want: &v1beta1.PipelineRun{
 			Spec: v1beta1.PipelineRunSpec{
 				PipelineRef:        &v1beta1.PipelineRef{Name: "foo"},
-				Timeout:            &metav1.Duration{Duration: 5 * time.Minute},
 				ServiceAccountName: "tekton",
 				PodTemplate: &pod.Template{
 					NodeSelector: map[string]string{
 						"label2": "value2",
 					},
+				},
+				Timeouts: &v1beta1.TimeoutFields{
+					Pipeline: &metav1.Duration{Duration: 5 * time.Minute},
 				},
 			},
 		},
@@ -286,7 +309,6 @@ func TestPipelineRunDefaulting(t *testing.T) {
 		want: &v1beta1.PipelineRun{
 			Spec: v1beta1.PipelineRunSpec{
 				PipelineRef:        &v1beta1.PipelineRef{Name: "foo"},
-				Timeout:            &metav1.Duration{Duration: 5 * time.Minute},
 				ServiceAccountName: "tekton",
 				PodTemplate: &pod.Template{
 					NodeSelector: map[string]string{
@@ -296,6 +318,9 @@ func TestPipelineRunDefaulting(t *testing.T) {
 						RunAsNonRoot: &ttrue,
 					},
 					HostNetwork: true,
+				},
+				Timeouts: &v1beta1.TimeoutFields{
+					Pipeline: &metav1.Duration{Duration: 5 * time.Minute},
 				},
 			},
 		},

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
@@ -98,9 +98,6 @@ func (pr *PipelineRun) IsGracefullyStopped() bool {
 
 // PipelineTimeout returns the applicable timeout for the PipelineRun
 func (pr *PipelineRun) PipelineTimeout(ctx context.Context) time.Duration {
-	if pr.Spec.Timeout != nil {
-		return pr.Spec.Timeout.Duration
-	}
 	if pr.Spec.Timeouts != nil && pr.Spec.Timeouts.Pipeline != nil {
 		return pr.Spec.Timeouts.Pipeline.Duration
 	}
@@ -243,8 +240,8 @@ type PipelineRunSpec struct {
 	// Defaults to never.
 	// Refer to Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration
 	//
-	// Deprecated: use pipelineRunSpec.Timeouts.Pipeline instead
-	//
+	// Deprecated: use pipelineRunSpec.Timeouts.Pipeline instead. It is only kept
+	// for backwards compatibility with older server versions.
 	// +optional
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
 	// PodTemplate holds pod specific configuration

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_types_test.go
@@ -241,20 +241,6 @@ func TestPipelineRunHasTimedOut(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		t.Run("pipeline.timeout "+tc.name, func(t *testing.T) {
-			pr := &v1beta1.PipelineRun{
-				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
-				Spec: v1beta1.PipelineRunSpec{
-					Timeout: &metav1.Duration{Duration: tc.timeout},
-				},
-				Status: v1beta1.PipelineRunStatus{PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
-					StartTime: &metav1.Time{Time: tc.starttime},
-				}},
-			}
-			if pr.HasTimedOut(context.Background(), testClock) != tc.expected {
-				t.Errorf("Expected HasTimedOut to be %t when using pipeline.timeout", tc.expected)
-			}
-		})
 		t.Run("pipeline.timeouts.pipeline "+tc.name, func(t *testing.T) {
 			pr := &v1beta1.PipelineRun{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo"},

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_validation.go
@@ -84,18 +84,10 @@ func (ps *PipelineRunSpec) Validate(ctx context.Context) (errs *apis.FieldError)
 	errs = errs.Also(ps.validatePropagatedWorkspaces(ctx))
 
 	if ps.Timeout != nil {
-		// timeout should be a valid duration of at least 0.
-		if ps.Timeout.Duration < 0 {
-			errs = errs.Also(apis.ErrInvalidValue(fmt.Sprintf("%s should be >= 0", ps.Timeout.Duration.String()), "timeout"))
-		}
+		errs = errs.Also(apis.ErrDisallowedUpdateDeprecatedFields("timeout"))
 	}
 
 	if ps.Timeouts != nil {
-		if ps.Timeout != nil {
-			// can't have both at the same time
-			errs = errs.Also(apis.ErrDisallowedFields("timeout", "timeouts"))
-		}
-
 		// tasks timeout should be a valid duration of at least 0.
 		errs = errs.Also(validateTimeoutDuration("tasks", ps.Timeouts.Tasks))
 

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_validation_test.go
@@ -87,20 +87,6 @@ func TestPipelineRun_Invalid(t *testing.T) {
 			Paths:   []string{"metadata.name"},
 		},
 	}, {
-		name: "negative pipeline timeout",
-		pr: v1beta1.PipelineRun{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "pipelinelinename",
-			},
-			Spec: v1beta1.PipelineRunSpec{
-				PipelineRef: &v1beta1.PipelineRef{
-					Name: "prname",
-				},
-				Timeout: &metav1.Duration{Duration: -48 * time.Hour},
-			},
-		},
-		want: apis.ErrInvalidValue("-48h0m0s should be >= 0", "spec.timeout"),
-	}, {
 		name: "wrong pipelinerun cancel",
 		pr: v1beta1.PipelineRun{
 			ObjectMeta: metav1.ObjectMeta{
@@ -527,19 +513,6 @@ func TestPipelineRun_Validate(t *testing.T) {
 				PipelineRef: &v1beta1.PipelineRef{
 					Name: "prname",
 				},
-			},
-		},
-	}, {
-		name: "no timeout",
-		pr: v1beta1.PipelineRun{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "pipelinename",
-			},
-			Spec: v1beta1.PipelineRunSpec{
-				PipelineRef: &v1beta1.PipelineRef{
-					Name: "prname",
-				},
-				Timeout: &metav1.Duration{Duration: 0},
 			},
 		},
 	}, {
@@ -1424,23 +1397,6 @@ func TestPipelineRun_InvalidTimeouts(t *testing.T) {
 			},
 		},
 		want: apis.ErrInvalidValue(`0s (no timeout) should be <= pipeline duration`, "spec.timeouts.finally"),
-	}, {
-		name: "Timeout and Timeouts both are set",
-		pr: v1beta1.PipelineRun{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "pipelinelinename",
-			},
-			Spec: v1beta1.PipelineRunSpec{
-				PipelineRef: &v1beta1.PipelineRef{
-					Name: "prname",
-				},
-				Timeout: &metav1.Duration{Duration: 10 * time.Minute},
-				Timeouts: &v1beta1.TimeoutFields{
-					Pipeline: &metav1.Duration{Duration: 10 * time.Minute},
-				},
-			},
-		},
-		want: apis.ErrDisallowedFields("spec.timeout", "spec.timeouts"),
 	}}
 
 	for _, tc := range tests {

--- a/pkg/apis/pipeline/v1beta1/swagger.json
+++ b/pkg/apis/pipeline/v1beta1/swagger.json
@@ -893,7 +893,7 @@
           "x-kubernetes-list-type": "atomic"
         },
         "timeout": {
-          "description": "Timeout is the Time after which the Pipeline times out. Defaults to never. Refer to Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration\n\nDeprecated: use pipelineRunSpec.Timeouts.Pipeline instead",
+          "description": "Timeout is the Time after which the Pipeline times out. Defaults to never. Refer to Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration\n\nDeprecated: use pipelineRunSpec.Timeouts.Pipeline instead. It is only kept for backwards compatibility with older server versions.",
           "$ref": "#/definitions/v1.Duration"
         },
         "timeouts": {

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
@@ -2089,37 +2089,6 @@ func TestGetPipelineConditionStatus_WithFinalTasks(t *testing.T) {
 	}
 }
 
-// pipeline should result in timeout if its runtime exceeds its spec.Timeout based on its status.Timeout
-func TestGetPipelineConditionStatus_PipelineTimeoutDeprecated(t *testing.T) {
-	d, err := dagFromState(oneFinishedState)
-	if err != nil {
-		t.Fatalf("Unexpected error while building DAG for state %v: %v", oneFinishedState, err)
-	}
-	pr := &v1beta1.PipelineRun{
-		ObjectMeta: metav1.ObjectMeta{Name: "pipelinerun-no-tasks-started"},
-		Spec: v1beta1.PipelineRunSpec{
-			Timeout: &metav1.Duration{Duration: 1 * time.Minute},
-		},
-		Status: v1beta1.PipelineRunStatus{
-			PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
-				StartTime: &metav1.Time{Time: now.Add(-2 * time.Minute)},
-			},
-		},
-	}
-	facts := PipelineRunFacts{
-		State:           oneFinishedState,
-		TasksGraph:      d,
-		FinalTasksGraph: &dag.Graph{},
-		TimeoutsState: PipelineRunTimeoutsState{
-			Clock: testClock,
-		},
-	}
-	c := facts.GetPipelineConditionStatus(context.Background(), pr, zap.NewNop().Sugar(), testClock)
-	if c.Status != corev1.ConditionFalse && c.Reason != v1beta1.PipelineRunReasonTimedOut.String() {
-		t.Fatalf("Expected to get status %s but got %s for state %v", corev1.ConditionFalse, c.Status, oneFinishedState)
-	}
-}
-
 // pipeline should result in timeout if its runtime exceeds its spec.Timeouts.Pipeline based on its status.Timeout
 func TestGetPipelineConditionStatus_PipelineTimeouts(t *testing.T) {
 	d, err := dagFromState(oneFinishedState)

--- a/test/conversion_test.go
+++ b/test/conversion_test.go
@@ -525,7 +525,8 @@ spec:
   - name: password-vault
     secret:
       secretName: secret-password
-  timeout: 60s
+  timeouts:
+    pipeline: 60s
   pipelineSpec:
     tasks:
     - name: fetch-secure-data

--- a/test/custom_task_test.go
+++ b/test/custom_task_test.go
@@ -296,7 +296,8 @@ metadata:
 spec:
   pipelineRef:
     name: %s
-  timeout: 5s
+  timeouts: 
+    pipeline: 5s
 `, helpers.ObjectNameForTest(t), namespace, pipeline.Name))
 	if _, err := c.V1beta1PipelineClient.Create(ctx, pipeline, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Pipeline `%s`: %s", pipeline.Name, err)
@@ -766,7 +767,9 @@ func TestWaitCustomTask_PipelineRun(t *testing.T) {
 					PipelineRef: &v1beta1.PipelineRef{
 						Name: p.Name,
 					},
-					Timeout: tc.prTimeout,
+					Timeouts: &v1beta1.TimeoutFields{
+						Pipeline: tc.prTimeout,
+					},
 				},
 			}
 			if _, err := c.V1beta1PipelineClient.Create(ctx, p, metav1.CreateOptions{}); err != nil {
@@ -799,7 +802,9 @@ func TestWaitCustomTask_PipelineRun(t *testing.T) {
 				Spec: v1beta1.PipelineRunSpec{
 					ServiceAccountName: "default",
 					PipelineRef:        &v1beta1.PipelineRef{Name: p.Name},
-					Timeout:            tc.prTimeout,
+					Timeouts: &v1beta1.TimeoutFields{
+						Pipeline: tc.prTimeout,
+					},
 				},
 				Status: v1beta1.PipelineRunStatus{
 					Status: duckv1.Status{
@@ -1054,7 +1059,9 @@ func TestWaitCustomTask_V1Beta1_PipelineRun(t *testing.T) {
 					PipelineRef: &v1beta1.PipelineRef{
 						Name: p.Name,
 					},
-					Timeout: tc.prTimeout,
+					Timeouts: &v1beta1.TimeoutFields{
+						Pipeline: tc.prTimeout,
+					},
 				},
 			}
 			if _, err := c.V1beta1PipelineClient.Create(ctx, p, metav1.CreateOptions{}); err != nil {
@@ -1087,7 +1094,9 @@ func TestWaitCustomTask_V1Beta1_PipelineRun(t *testing.T) {
 				Spec: v1beta1.PipelineRunSpec{
 					ServiceAccountName: "default",
 					PipelineRef:        &v1beta1.PipelineRef{Name: p.Name},
-					Timeout:            tc.prTimeout,
+					Timeouts: &v1beta1.TimeoutFields{
+						Pipeline: tc.prTimeout,
+					},
 				},
 				Status: v1beta1.PipelineRunStatus{
 					Status: duckv1.Status{

--- a/test/larger_results_sidecar_logs_test.go
+++ b/test/larger_results_sidecar_logs_test.go
@@ -171,7 +171,8 @@ metadata:
   namespace: %s
 spec:
   serviceAccountName: default
-  timeout: 1h
+  timeouts:
+    pipeline: 1h
   pipelineSpec:
     tasks:
       - name: task1

--- a/test/propagated_params_test.go
+++ b/test/propagated_params_test.go
@@ -169,7 +169,8 @@ metadata:
   name: propagated-parameters-fully
   namespace: %s
 spec:
-  timeout: 1h
+  timeouts: 
+    pipeline: 1h
   params:
   - name: HELLO
     value: "Hello World!"
@@ -279,7 +280,8 @@ metadata:
   name: propagated-parameters-task-level
   namespace: %s
 spec:
-  timeout: 1h
+  timeouts:
+    pipeline: 1h
   params:
   - name: HELLO
     value: "Pipeline Hello World!"
@@ -363,7 +365,8 @@ metadata:
   name: propagated-parameters-default-task-level
   namespace: %s
 spec:
-  timeout: 1h
+  timeouts: 
+    pipeline: 1h
   params:
   - name: HELLO
     value: "Hello World!"

--- a/test/timeout_test.go
+++ b/test/timeout_test.go
@@ -82,7 +82,8 @@ metadata:
 spec:
   pipelineRef:
     name: %s
-  timeout: 5s
+  timeouts: 
+    pipeline: 5s
 `, helpers.ObjectNameForTest(t), namespace, pipeline.Name))
 	if _, err := c.V1beta1PipelineClient.Create(ctx, pipeline, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Pipeline `%s`: %s", pipeline.Name, err)


### PR DESCRIPTION


# Changes
This commit removes the `pipelineRun.spec.timeout` field which has been deprecated.  It tombstones the field and add the invalid error message for the validation if specified by users since it has just been the earliest date for removal.

It conforms to [api compatibility policy](https://github.com/tektoncd/pipeline/blob/main/api_compatibility_policy.md) and follows the timeline according to [deprecation.md](https://github.com/tektoncd/pipeline/blob/main/docs/deprecations.md).

/kind misc

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
action required: please migrate off `pipelineRun.spec.timeout` since it has been deprecated and is removed in v0.46
please use `pipelineRun.spec.timeouts.pipeline` instead
```
