### PR TITLE
validate matrix for duplicate params

### DIFF
--- a/docs/matrix.md
+++ b/docs/matrix.md
@@ -71,7 +71,9 @@ For more information, see [installation customizations](install.md#customizing-b
 The `Matrix` will take `Parameters` of type `"array"` only, which will be supplied to the
 `PipelineTask` by substituting `Parameters` of type `"string"` in the underlying `Task`.
 The names of the `Parameters` in the `Matrix` must match the names of the `Parameters`
-in the underlying `Task` that they will be substituting.
+in the underlying `Task` that they will be substituting. The names of the `Parameters`
+in the `Matrix` must be unique. Specifying the same parameter multiple times will result
+in a validation error.
 
 In the example below, the *test* `Task` takes *browser* and *platform* `Parameters` of type
 `"string"`. A `Pipeline` used to fan out the `Task` using `Matrix` would have two `Parameters`

--- a/pkg/apis/pipeline/v1/matrix_types.go
+++ b/pkg/apis/pipeline/v1/matrix_types.go
@@ -163,13 +163,16 @@ func (m *Matrix) validateCombinationsCount(ctx context.Context) (errs *apis.Fiel
 	return errs
 }
 
-// validateParamTypes validates the type of parameter
+// validateParams validates the type of parameter
 // for Matrix.Params and Matrix.Include.Params
 // Matrix.Params must be of type array. Matrix.Include.Params must be of type string.
-func (m *Matrix) validateParamTypes() (errs *apis.FieldError) {
+// validateParams also validates Matrix.Params for a unique list of params
+// and a unique list of params in each Matrix.Include.Params specification
+func (m *Matrix) validateParams() (errs *apis.FieldError) {
 	if m != nil {
 		if m.hasInclude() {
-			for _, include := range m.Include {
+			for i, include := range m.Include {
+				errs = errs.Also(include.Params.validateDuplicateParameters().ViaField(fmt.Sprintf("matrix.include[%d].params", i)))
 				for _, param := range include.Params {
 					if param.Value.Type != ParamTypeString {
 						errs = errs.Also(apis.ErrInvalidValue(fmt.Sprintf("parameters of type string only are allowed, but got param type %s", string(param.Value.Type)), "").ViaFieldKey("matrix.include.params", param.Name))
@@ -178,6 +181,7 @@ func (m *Matrix) validateParamTypes() (errs *apis.FieldError) {
 			}
 		}
 		if m.hasParams() {
+			errs = errs.Also(m.Params.validateDuplicateParameters().ViaField("matrix.params"))
 			for _, param := range m.Params {
 				if param.Value.Type != ParamTypeArray {
 					errs = errs.Also(apis.ErrInvalidValue(fmt.Sprintf("parameters of type array only are allowed, but got param type %s", string(param.Value.Type)), "").ViaFieldKey("matrix.params", param.Name))

--- a/pkg/apis/pipeline/v1/param_types.go
+++ b/pkg/apis/pipeline/v1/param_types.go
@@ -157,6 +157,19 @@ func (ps Params) extractParamArrayLengths() map[string]int {
 	return arrayParamsLengths
 }
 
+// validateDuplicateParameters checks if a parameter with the same name is defined more than once
+func (ps Params) validateDuplicateParameters() (errs *apis.FieldError) {
+	taskParamNames := sets.NewString()
+	for i, param := range ps {
+		if taskParamNames.Has(param.Name) {
+			errs = errs.Also(apis.ErrGeneric(fmt.Sprintf("parameter names must be unique,"+
+				" the parameter \"%s\" is also defined at", param.Name), fmt.Sprintf("[%d].name", i)))
+		}
+		taskParamNames.Insert(param.Name)
+	}
+	return errs
+}
+
 // extractParamArrayLengths extract and return the lengths of all array params
 // Example of returned value: {"a-array-params": 2,"b-array-params": 2 }
 func (ps ParamSpecs) extractParamArrayLengths() map[string]int {
@@ -510,12 +523,9 @@ func ArrayReference(a string) string {
 
 // validatePipelineParametersVariablesInTaskParameters validates param value that
 // may contain the reference(s) to other params to make sure those references are used appropriately.
-func validatePipelineParametersVariablesInTaskParameters(params []Param, prefix string, paramNames sets.String, arrayParamNames sets.String, objectParamNameKeys map[string][]string) (errs *apis.FieldError) {
-	taskParamNames := sets.NewString()
-	for i, param := range params {
-		if taskParamNames.Has(param.Name) {
-			errs = errs.Also(apis.ErrGeneric(fmt.Sprintf("params names must be unique, the same param: %s is defined multiple times at", param.Name), fmt.Sprintf("params[%d].name", i)))
-		}
+func validatePipelineParametersVariablesInTaskParameters(params Params, prefix string, paramNames sets.String, arrayParamNames sets.String, objectParamNameKeys map[string][]string) (errs *apis.FieldError) {
+	errs = errs.Also(params.validateDuplicateParameters()).ViaField("params")
+	for _, param := range params {
 		switch param.Value.Type {
 		case ParamTypeArray:
 			for idx, arrayElement := range param.Value.ArrayVal {
@@ -528,7 +538,6 @@ func validatePipelineParametersVariablesInTaskParameters(params []Param, prefix 
 		default:
 			errs = errs.Also(validateParamStringValue(param, prefix, paramNames, arrayParamNames, objectParamNameKeys))
 		}
-		taskParamNames.Insert(param.Name)
 	}
 	return errs
 }

--- a/pkg/apis/pipeline/v1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1/pipeline_types.go
@@ -275,7 +275,7 @@ func (pt *PipelineTask) validateMatrix(ctx context.Context) (errs *apis.FieldErr
 		errs = errs.Also(pt.Matrix.validateCombinationsCount(ctx))
 	}
 	errs = errs.Also(pt.Matrix.validateParameterInOneOfMatrixOrParams(pt.Params))
-	errs = errs.Also(pt.Matrix.validateParamTypes())
+	errs = errs.Also(pt.Matrix.validateParams())
 	return errs
 }
 

--- a/pkg/apis/pipeline/v1/pipeline_types_test.go
+++ b/pkg/apis/pipeline/v1/pipeline_types_test.go
@@ -607,6 +607,21 @@ func TestPipelineTask_validateMatrix(t *testing.T) {
 		},
 		wantErrs: apis.ErrMultipleOneOf("matrix[foobar]", "params[foobar]"),
 	}, {
+		name: "duplicate parameters in matrix.params",
+		pt: &PipelineTask{
+			Name: "task",
+			Matrix: &Matrix{
+				Params: []Param{{
+					Name: "foobar", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"foo", "bar"}},
+				}, {
+					Name: "foobar", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"foo-1", "bar-1"}},
+				}}},
+		},
+		wantErrs: &apis.FieldError{
+			Message: `parameter names must be unique, the parameter "foobar" is also defined at`,
+			Paths:   []string{"matrix.params[1].name"},
+		},
+	}, {
 		name: "parameters unique in matrix and params",
 		pt: &PipelineTask{
 			Name: "task",
@@ -617,6 +632,24 @@ func TestPipelineTask_validateMatrix(t *testing.T) {
 			Params: []Param{{
 				Name: "barfoo", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"bar", "foo"}},
 			}},
+		},
+	}, {
+		name: "duplicate parameters in matrix.include.params",
+		pt: &PipelineTask{
+			Name: "task",
+			Matrix: &Matrix{
+				Include: []MatrixInclude{{
+					Name: "invalid-include",
+					Params: Params{{
+						Name: "foobar", Value: ParamValue{Type: ParamTypeString, StringVal: "foo"},
+					}, {
+						Name: "foobar", Value: ParamValue{Type: ParamTypeString, StringVal: "foo-1"},
+					}}},
+				}},
+		},
+		wantErrs: &apis.FieldError{
+			Message: `parameter names must be unique, the parameter "foobar" is also defined at`,
+			Paths:   []string{"matrix.include[0].params[1].name"},
 		},
 	}, {
 		name: "parameters in matrix are strings",

--- a/pkg/apis/pipeline/v1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1/pipeline_validation_test.go
@@ -1782,8 +1782,8 @@ func TestValidatePipelineParameterVariables_Failure(t *testing.T) {
 			}},
 		}},
 		expectedError: apis.FieldError{
-			Message: `params names must be unique, the same param: duplicate-param is defined multiple times at`,
-			Paths:   []string{"[0].params[1].name", "[0].params[2].name"},
+			Message: `parameter names must be unique, the parameter "duplicate-param" is also defined at`,
+			Paths:   []string{"[0].params[1].name, [0].params[2].name"},
 		},
 	}}
 	for _, tt := range tests {

--- a/pkg/apis/pipeline/v1beta1/matrix_types.go
+++ b/pkg/apis/pipeline/v1beta1/matrix_types.go
@@ -163,13 +163,16 @@ func (m *Matrix) validateCombinationsCount(ctx context.Context) (errs *apis.Fiel
 	return errs
 }
 
-// validateParamTypes validates the type of parameter
+// validateParams validates the type of parameter
 // for Matrix.Params and Matrix.Include.Params
 // Matrix.Params must be of type array. Matrix.Include.Params must be of type string.
-func (m *Matrix) validateParamTypes() (errs *apis.FieldError) {
+// validateParams also validates Matrix.Params for a unique list of params
+// and a unique list of params in each Matrix.Include.Params specification
+func (m *Matrix) validateParams() (errs *apis.FieldError) {
 	if m != nil {
 		if m.hasInclude() {
-			for _, include := range m.Include {
+			for i, include := range m.Include {
+				errs = errs.Also(include.Params.validateDuplicateParameters().ViaField(fmt.Sprintf("matrix.include[%d].params", i)))
 				for _, param := range include.Params {
 					if param.Value.Type != ParamTypeString {
 						errs = errs.Also(apis.ErrInvalidValue(fmt.Sprintf("parameters of type string only are allowed, but got param type %s", string(param.Value.Type)), "").ViaFieldKey("matrix.include.params", param.Name))
@@ -178,6 +181,7 @@ func (m *Matrix) validateParamTypes() (errs *apis.FieldError) {
 			}
 		}
 		if m.hasParams() {
+			errs = errs.Also(m.Params.validateDuplicateParameters().ViaField("matrix.params"))
 			for _, param := range m.Params {
 				if param.Value.Type != ParamTypeArray {
 					errs = errs.Also(apis.ErrInvalidValue(fmt.Sprintf("parameters of type array only are allowed, but got param type %s", string(param.Value.Type)), "").ViaFieldKey("matrix.params", param.Name))

--- a/pkg/apis/pipeline/v1beta1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types.go
@@ -291,7 +291,7 @@ func (pt *PipelineTask) validateMatrix(ctx context.Context) (errs *apis.FieldErr
 		errs = errs.Also(pt.Matrix.validateCombinationsCount(ctx))
 	}
 	errs = errs.Also(pt.Matrix.validateParameterInOneOfMatrixOrParams(pt.Params))
-	errs = errs.Also(pt.Matrix.validateParamTypes())
+	errs = errs.Also(pt.Matrix.validateParams())
 	return errs
 }
 

--- a/pkg/apis/pipeline/v1beta1/pipeline_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types_test.go
@@ -581,6 +581,21 @@ func TestPipelineTask_validateMatrix(t *testing.T) {
 		},
 		wantErrs: apis.ErrMultipleOneOf("matrix[foobar]", "params[foobar]"),
 	}, {
+		name: "duplicate parameters in matrix.params",
+		pt: &PipelineTask{
+			Name: "task",
+			Matrix: &Matrix{
+				Params: []Param{{
+					Name: "foobar", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"foo", "bar"}},
+				}, {
+					Name: "foobar", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"foo-1", "bar-1"}},
+				}}},
+		},
+		wantErrs: &apis.FieldError{
+			Message: `parameter names must be unique, the parameter "foobar" is also defined at`,
+			Paths:   []string{"matrix.params[1].name"},
+		},
+	}, {
 		name: "parameters unique in matrix and params",
 		pt: &PipelineTask{
 			Name: "task",
@@ -617,6 +632,24 @@ func TestPipelineTask_validateMatrix(t *testing.T) {
 				}, {
 					Name: "barfoo", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"bar", "foo"}},
 				}}},
+		},
+	}, {
+		name: "duplicate parameters in matrix.include.params",
+		pt: &PipelineTask{
+			Name: "task",
+			Matrix: &Matrix{
+				Include: []MatrixInclude{{
+					Name: "invalid-include",
+					Params: Params{{
+						Name: "foobar", Value: ParamValue{Type: ParamTypeString, StringVal: "foo"},
+					}, {
+						Name: "foobar", Value: ParamValue{Type: ParamTypeString, StringVal: "foo-1"},
+					}}},
+				}},
+		},
+		wantErrs: &apis.FieldError{
+			Message: `parameter names must be unique, the parameter "foobar" is also defined at`,
+			Paths:   []string{"matrix.include[0].params[1].name"},
 		},
 	}, {
 		name: "parameters in include matrix are strings",

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
@@ -1784,8 +1784,8 @@ func TestValidatePipelineParameterVariables_Failure(t *testing.T) {
 			}},
 		}},
 		expectedError: apis.FieldError{
-			Message: `params names must be unique, the same param: duplicate-param is defined multiple times at`,
-			Paths:   []string{"[0].params[1].name", "[0].params[2].name"},
+			Message: `parameter names must be unique, the parameter "duplicate-param" is also defined at`,
+			Paths:   []string{"[0].params[1].name, [0].params[2].name"},
 		},
 	}}
 	for _, tt := range tests {


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

In case of task/pipeline params, the validation we have in place catches duplicate params i.e. parameters defined multiple times with the same name results in a validation error. The same validation was missing from `matrix.params` and `matrix.Include.params`. This PR is implementing such validation. `matrix.params` and `matrix.include.params.` also specifies a list of array parameters where a user could define the same parameter twice by mistake.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Validate matrix.params and matrix.include.params such that specifying duplicate parameters is caught by the validation.
```
