### PR TITLE
Stop populating resourceName in git-init image

### DIFF
--- a/cmd/git-init/main.go
+++ b/cmd/git-init/main.go
@@ -17,7 +17,6 @@ package main
 
 import (
 	"flag"
-	"os"
 
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/git"
@@ -58,17 +57,14 @@ func main() {
 	if err != nil {
 		logger.Fatalf("Error parsing revision %s of git repository: %s", fetchSpec.Revision, err)
 	}
-	resourceName := os.Getenv("TEKTON_RESOURCE_NAME")
 	output := []v1beta1.PipelineResourceResult{
 		{
-			Key:          "commit",
-			Value:        commit,
-			ResourceName: resourceName,
+			Key:   "commit",
+			Value: commit,
 		},
 		{
-			Key:          "url",
-			Value:        fetchSpec.URL,
-			ResourceName: resourceName,
+			Key:   "url",
+			Value: fetchSpec.URL,
 		},
 	}
 

--- a/pkg/apis/pipeline/v1beta1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1beta1/openapi_generated.go
@@ -1433,7 +1433,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineResourceResult(ref common.Referenc
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "PipelineResourceResult used to export the image name and digest as json",
+				Description: "PipelineResourceResult is used to write key/value pairs to TaskRun pod termination messages. The key/value pairs may come from the entrypoint binary, or represent a TaskRunResult. If they represent a TaskRunResult, the key is the name of the result and the value is the JSON-serialized value of the result.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"key": {
@@ -1452,8 +1452,9 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineResourceResult(ref common.Referenc
 					},
 					"resourceName": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "ResourceName may be used in tests, but it is not populated in termination messages. It is preserved here for backwards compatibility and will not be ported to v1.",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"type": {

--- a/pkg/apis/pipeline/v1beta1/resource_types.go
+++ b/pkg/apis/pipeline/v1beta1/resource_types.go
@@ -23,10 +23,16 @@ import (
 	"github.com/hashicorp/go-multierror"
 )
 
-// PipelineResourceResult used to export the image name and digest as json
+// PipelineResourceResult is used to write key/value pairs to TaskRun pod termination messages.
+// The key/value pairs may come from the entrypoint binary, or represent a TaskRunResult.
+// If they represent a TaskRunResult, the key is the name of the result and the value is the
+// JSON-serialized value of the result.
+// TODO(#6197): Rename this struct
 type PipelineResourceResult struct {
-	Key          string     `json:"key"`
-	Value        string     `json:"value"`
+	Key   string `json:"key"`
+	Value string `json:"value"`
+	// ResourceName may be used in tests, but it is not populated in termination messages.
+	// It is preserved here for backwards compatibility and will not be ported to v1.
 	ResourceName string     `json:"resourceName,omitempty"`
 	ResultType   ResultType `json:"type,omitempty"`
 }

--- a/pkg/apis/pipeline/v1beta1/swagger.json
+++ b/pkg/apis/pipeline/v1beta1/swagger.json
@@ -706,7 +706,7 @@
       }
     },
     "v1beta1.PipelineResourceResult": {
-      "description": "PipelineResourceResult used to export the image name and digest as json",
+      "description": "PipelineResourceResult is used to write key/value pairs to TaskRun pod termination messages. The key/value pairs may come from the entrypoint binary, or represent a TaskRunResult. If they represent a TaskRunResult, the key is the name of the result and the value is the JSON-serialized value of the result.",
       "type": "object",
       "required": [
         "key",
@@ -718,6 +718,7 @@
           "default": ""
         },
         "resourceName": {
+          "description": "ResourceName may be used in tests, but it is not populated in termination messages. It is preserved here for backwards compatibility and will not be ported to v1.",
           "type": "string"
         },
         "type": {


### PR DESCRIPTION
The git-init image writes a git commit SHA and URL to a pod's termination message. Prior to this commit, if these values came from the output of a PipelineResource, it would also write the name of that PipelineResource to the pod's termination message.

Since PipelineResources have been removed, the environment variable TEKTON_RESOURCE_NAME is never populated, and the PipelineResource name is never written to termination messages. This commit removes the check for this environment variable and stops writing this value to the termination message. The termination message will still be parseable by other code.

Removing this functionality will make it easier to migrate to v1, by allowing us to remove fields not relevant to our v1 API. Refactoring/renaming PipelineResourceResult will happen in a separate commit.

Part of #6197 

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- n/a Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- n/a Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- n/a Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- n/a Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
