### PR TITLE
dependabot: do not update k8s.io/* major/minor updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,9 @@ updates:
     - "dependencies"
     - "release-note-none"
     - "kind/misc"
+    ignore:
+    - dependency-name: "k8s.io/*"
+      update-types: ["version-update:semver-major", "version-update:semver-minor]
   - package-ecosystem: "gomod"
     directory: "/tools"
     schedule:


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This makes dependabot ignore major and minor updates to k8s.io/*
modules. It will still update patch release though (0.25.1 to 0.25.2).

The reason to ignore those (major/minor) is because they are usually
tied to `knative/pkg` and this means, we usually only want to update
those *when* `knative/pkg` dependencies are updated as well.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

This will reduce the number of pull request for k8s.io dependencies
update that we usually close

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
