### PR TITLE
[TEP-0091] change feature flag resource-verification-mode to trusted-resources-verification-no-match-policy

### DIFF
--- a/config/config-feature-flags.yaml
+++ b/config/config-feature-flags.yaml
@@ -76,10 +76,11 @@ data:
   # Setting this flag to "true" enables CloudEvents for CustomRuns and Runs, as long as a
   # CloudEvents sink is configured in the config-defaults config map
   send-cloudevents-for-runs: "false"
-  # Setting this flag to "enforce" will enforce verification of tasks/pipeline. Failing to verify
-  # will fail the taskrun/pipelinerun. "warn" will only log the err message and "skip"
-  # will skip the whole verification
-  resource-verification-mode: "skip"
+  # This flag affects the behavior of taskruns and pipelineruns in cases where no VerificationPolicies match them.
+  # If it is set to "fail", TaskRuns and PipelineRuns will fail verification if no matching policies are found.
+  # If it is set to "warn", TaskRuns and PipelineRuns will run to completion if no matching policies are found, and an error will be logged.
+  # If it is set to "ignore", TaskRuns and PipelineRuns will run to completion if no matching policies are found, and no error will be logged.
+  trusted-resources-verification-no-match-policy: "ignore"
   # Setting this flag to "true" enables populating the "provenance" field in TaskRun
   # and PipelineRun status. This field contains metadata about resources used
   # in the TaskRun/PipelineRun such as the source from where a remote Task/Pipeline

--- a/docs/additional-configs.md
+++ b/docs/additional-configs.md
@@ -2,12 +2,12 @@
 ---
 title: "Additional Configuration Options"
 linkTitle: "Additional Configuration Options"
-weight: 109 
+weight: 109
 description: >
   Additional configurations when installing Tekton Pipelines
 ---
 -->
-  
+
 This document describes additional options to configure your Tekton Pipelines
 installation.
 
@@ -98,7 +98,7 @@ Environment variables can be configured in the following ways, mentioned in orde
 3. Environment variables specified via a `default` `PodTemplate`.
 4. Environment variables specified via a `PodTemplate`.
 
-The environment variables specified by a `PodTemplate` supercedes all other ways of specifying environment variables. However, there exists a configuration i.e. `default-forbidden-env`, the environment variable specified in this list cannot be updated via a `PodTemplate`. 
+The environment variables specified by a `PodTemplate` supercedes all other ways of specifying environment variables. However, there exists a configuration i.e. `default-forbidden-env`, the environment variable specified in this list cannot be updated via a `PodTemplate`.
 
 For example:
 
@@ -238,7 +238,9 @@ The default is `false`. For more information, see the [associated issue](https:/
 most stable features to be used. Set it to "alpha" to allow [alpha
 features](#alpha-features) to be used.
 
-- `resource-verification-mode`: Setting this flag to "enforce" will enforce verification of tasks/pipeline. Failing to verify will fail the taskrun/pipelinerun. "warn" will only log the err message and "skip" will skip the whole verification.
+- `trusted-resources-verification-no-match-policy`: Setting this flag to `fail` will fail the taskrun/pipelinerun if no matching policies found. Setting to `warn` will skip verification and log a warning if no matching policies are found, but not fail the taskrun/pipelinerun. Setting to `ignore` will skip verification if no matching policies found.
+Defaults to "ignore".
+
 - `results-from`: set this flag to "termination-message" to use the container's termination message to fetch results from. This is the default method of extracting results. Set it to "sidecar-logs" to enable use of a results sidecar logs to extract results instead of termination message.
 
 - `enable-provenance-in-status`: set this flag to "true" to enable recording
@@ -285,7 +287,7 @@ Features currently in "alpha" are:
 | [Matrix](./matrix.md)                                                                               | [TEP-0090](https://github.com/tektoncd/community/blob/main/teps/0090-matrix.md)                                            | [v0.38.0](https://github.com/tektoncd/pipeline/releases/tag/v0.38.0) |                               |
 | [Task-level Resource Requirements](compute-resources.md#task-level-compute-resources-configuration) | [TEP-0104](https://github.com/tektoncd/community/blob/main/teps/0104-tasklevel-resource-requirements.md)                   | [v0.39.0](https://github.com/tektoncd/pipeline/releases/tag/v0.39.0) |                               |
 | [Object Params and Results](pipelineruns.md#specifying-parameters)                                  | [TEP-0075](https://github.com/tektoncd/community/blob/main/teps/0075-object-param-and-result-types.md)                     | [v0.38.0](https://github.com/tektoncd/pipeline/releases/tag/v0.38.0) |                               |                             |
-| [Trusted Resources](./trusted-resources.md)                                                         | [TEP-0091](https://github.com/tektoncd/community/blob/main/teps/0091-trusted-resources.md)                                 | N/A                                                                  | `resource-verification-mode`  |
+| [Trusted Resources](./trusted-resources.md)                                                         | [TEP-0091](https://github.com/tektoncd/community/blob/main/teps/0091-trusted-resources.md)                                 | N/A                                                                  | `trusted-resources-verification-no-match-policy`  |
 | [`Provenance` field in Status](pipeline-api.md#provenance)                                          | [issue#5550](https://github.com/tektoncd/pipeline/issues/5550)                                                             | N/A                                                                  | `enable-provenance-in-status` |
 | [Larger Results via Sidecar Logs](#enabling-larger-results-using-sidecar-logs)                      | [TEP-0127](https://github.com/tektoncd/community/blob/main/teps/0127-larger-results-via-sidecar-logs.md)                   | [v0.43.0](https://github.com/tektoncd/pipeline/releases/tag/v0.43.0) | `results-from`                |
 
@@ -313,7 +315,7 @@ To exceed this limit of 4096 bytes, you can enable larger results using sidecar 
 
 **Note**: to enable this feature, you need to grant `get` access to all `pods/log` to the `Tekton pipeline controller`. This means that the tekton pipeline controller has the ability to access the pod logs.
 
-1. Create a cluster role and rolebinding by applying the following spec to provide log access to `tekton-pipelines-controller`. 
+1. Create a cluster role and rolebinding by applying the following spec to provide log access to `tekton-pipelines-controller`.
 
 ```
 kubectl apply -f optional_config/enable-log-access-to-controller/
@@ -326,7 +328,7 @@ kubectl patch cm feature-flags -n tekton-pipelines -p '{"data":{"results-from":"
 ```
 
 3. If you want the size per result to be something other than 4096 bytes, you can set the `max-result-size` feature flag in bytes by setting `max-result-size: 8192(whatever you need here)`. **Note:** The value you can set here cannot exceed the size of the CRD limit of 1.5 MB.
- 
+
 ```
 kubectl patch cm feature-flags -n tekton-pipelines -p '{"data":{"max-result-size":"<VALUE-IN-BYTES>"}}'
 ```

--- a/docs/trusted-resources.md
+++ b/docs/trusted-resources.md
@@ -54,19 +54,21 @@ metadata:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
 data:
-  resource-verification-mode: "enforce"
+  trusted-resources-verification-no-match-policy: "fail"
 ```
 
-**Note:** `resource-verification-mode` needs to be set as `enforce` or `warn` to enable resource verification.
+`trusted-resources-verification-no-match-policy` configurations:
+ * `ignore`: if no matching policies are found, skip the verification, don't log, and don't fail the taskrun/pipelinerun
+ * `warn`:  if no matching policies are found, skip the verification, log a warning, and don't fail the taskrun/pipelinerun
+ * `fail`: Fail the taskrun/pipelinerun if no matching policies are found.
 
-`resource-verification-mode` configurations:
- * `enforce`: Failing verification will mark the taskruns/pipelineruns as failed.
- * `warn`: Log warning but don't fail the taskruns/pipelineruns.
- * `skip`: Directly skip the verification.
+ **Notes:**
+ * To skip the verification: make sure no policies exist and `trusted-resources-verification-no-match-policy` is set to `warn` or `ignore`.
+ * To enable the verification: install [VerificationPolicy](#config-key-at-verificationpolicy) to match the resources.
 
 Or patch the new values:
 ```bash
-kubectl patch configmap feature-flags -n tekton-pipelines -p='{"data":{"resource-verification-mode":"enforce"}}
+kubectl patch configmap feature-flags -n tekton-pipelines -p='{"data":{"trusted-resources-verification-no-match-policy":"fail"}}
 ```
 
 #### Config key at VerificationPolicy

--- a/pkg/apis/config/feature_flags_test.go
+++ b/pkg/apis/config/feature_flags_test.go
@@ -42,16 +42,16 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 				RunningInEnvWithInjectedSidecars: true,
 				RequireGitSSHSecretKnownHosts:    false,
 
-				DisableCredsInit:         config.DefaultDisableCredsInit,
-				AwaitSidecarReadiness:    config.DefaultAwaitSidecarReadiness,
-				EnableTektonOCIBundles:   config.DefaultEnableTektonOciBundles,
-				EnableAPIFields:          config.DefaultEnableAPIFields,
-				SendCloudEventsForRuns:   config.DefaultSendCloudEventsForRuns,
-				ResourceVerificationMode: config.DefaultResourceVerificationMode,
-				EnableProvenanceInStatus: config.DefaultEnableProvenanceInStatus,
-				ResultExtractionMethod:   config.DefaultResultExtractionMethod,
-				MaxResultSize:            config.DefaultMaxResultSize,
-				CustomTaskVersion:        config.DefaultCustomTaskVersion,
+				DisableCredsInit:          config.DefaultDisableCredsInit,
+				AwaitSidecarReadiness:     config.DefaultAwaitSidecarReadiness,
+				EnableTektonOCIBundles:    config.DefaultEnableTektonOciBundles,
+				EnableAPIFields:           config.DefaultEnableAPIFields,
+				SendCloudEventsForRuns:    config.DefaultSendCloudEventsForRuns,
+				VerificationNoMatchPolicy: config.DefaultNoMatchPolicyConfig,
+				EnableProvenanceInStatus:  config.DefaultEnableProvenanceInStatus,
+				ResultExtractionMethod:    config.DefaultResultExtractionMethod,
+				MaxResultSize:             config.DefaultMaxResultSize,
+				CustomTaskVersion:         config.DefaultCustomTaskVersion,
 			},
 			fileName: config.GetFeatureFlagsConfigName(),
 		},
@@ -65,7 +65,7 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 				EnableAPIFields:                  "alpha",
 				SendCloudEventsForRuns:           true,
 				EnforceNonfalsifiability:         "spire",
-				ResourceVerificationMode:         "enforce",
+				VerificationNoMatchPolicy:        config.FailNoMatchPolicy,
 				EnableProvenanceInStatus:         true,
 				ResultExtractionMethod:           "termination-message",
 				MaxResultSize:                    4096,
@@ -86,7 +86,7 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 				AwaitSidecarReadiness:            config.DefaultAwaitSidecarReadiness,
 				RequireGitSSHSecretKnownHosts:    config.DefaultRequireGitSSHSecretKnownHosts,
 				SendCloudEventsForRuns:           config.DefaultSendCloudEventsForRuns,
-				ResourceVerificationMode:         config.DefaultResourceVerificationMode,
+				VerificationNoMatchPolicy:        config.DefaultNoMatchPolicyConfig,
 				ResultExtractionMethod:           config.DefaultResultExtractionMethod,
 				MaxResultSize:                    config.DefaultMaxResultSize,
 				CustomTaskVersion:                config.DefaultCustomTaskVersion,
@@ -104,7 +104,7 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 				AwaitSidecarReadiness:            config.DefaultAwaitSidecarReadiness,
 				RequireGitSSHSecretKnownHosts:    config.DefaultRequireGitSSHSecretKnownHosts,
 				SendCloudEventsForRuns:           config.DefaultSendCloudEventsForRuns,
-				ResourceVerificationMode:         config.DefaultResourceVerificationMode,
+				VerificationNoMatchPolicy:        config.DefaultNoMatchPolicyConfig,
 				ResultExtractionMethod:           config.DefaultResultExtractionMethod,
 				MaxResultSize:                    config.DefaultMaxResultSize,
 				CustomTaskVersion:                config.DefaultCustomTaskVersion,
@@ -122,7 +122,7 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 				AwaitSidecarReadiness:            config.DefaultAwaitSidecarReadiness,
 				RequireGitSSHSecretKnownHosts:    config.DefaultRequireGitSSHSecretKnownHosts,
 				SendCloudEventsForRuns:           config.DefaultSendCloudEventsForRuns,
-				ResourceVerificationMode:         config.DefaultResourceVerificationMode,
+				VerificationNoMatchPolicy:        config.DefaultNoMatchPolicyConfig,
 				ResultExtractionMethod:           config.DefaultResultExtractionMethod,
 				MaxResultSize:                    config.DefaultMaxResultSize,
 				CustomTaskVersion:                config.DefaultCustomTaskVersion,
@@ -134,7 +134,7 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 				EnableAPIFields:                  "alpha",
 				EnforceNonfalsifiability:         "spire",
 				EnableTektonOCIBundles:           true,
-				ResourceVerificationMode:         config.DefaultResourceVerificationMode,
+				VerificationNoMatchPolicy:        config.DefaultNoMatchPolicyConfig,
 				RunningInEnvWithInjectedSidecars: config.DefaultRunningInEnvWithInjectedSidecars,
 				AwaitSidecarReadiness:            config.DefaultAwaitSidecarReadiness,
 				ResultExtractionMethod:           config.DefaultResultExtractionMethod,
@@ -146,7 +146,7 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 		{
 			expectedConfig: &config.FeatureFlags{
 				EnableAPIFields:                  "stable",
-				ResourceVerificationMode:         config.DefaultResourceVerificationMode,
+				VerificationNoMatchPolicy:        config.DefaultNoMatchPolicyConfig,
 				RunningInEnvWithInjectedSidecars: config.DefaultRunningInEnvWithInjectedSidecars,
 				AwaitSidecarReadiness:            config.DefaultAwaitSidecarReadiness,
 				ResultExtractionMethod:           config.ResultExtractionMethodSidecarLogs,
@@ -178,7 +178,7 @@ func TestNewFeatureFlagsFromEmptyConfigMap(t *testing.T) {
 		EnableAPIFields:                  config.DefaultEnableAPIFields,
 		SendCloudEventsForRuns:           config.DefaultSendCloudEventsForRuns,
 		EnforceNonfalsifiability:         config.DefaultEnforceNonfalsifiability,
-		ResourceVerificationMode:         config.DefaultResourceVerificationMode,
+		VerificationNoMatchPolicy:        config.DefaultNoMatchPolicyConfig,
 		EnableProvenanceInStatus:         config.DefaultEnableProvenanceInStatus,
 		ResultExtractionMethod:           config.DefaultResultExtractionMethod,
 		MaxResultSize:                    config.DefaultMaxResultSize,
@@ -222,7 +222,7 @@ func TestNewFeatureFlagsConfigMapErrors(t *testing.T) {
 	}, {
 		fileName: "feature-flags-invalid-enable-api-fields",
 	}, {
-		fileName: "feature-flags-invalid-resource-verification-mode",
+		fileName: "feature-flags-invalid-trusted-resources-verification-no-match-policy",
 	}, {
 		fileName: "feature-flags-invalid-results-from",
 	}, {
@@ -245,45 +245,42 @@ func TestNewFeatureFlagsConfigMapErrors(t *testing.T) {
 	}
 }
 
-func TestCheckEnforceResourceVerificationMode(t *testing.T) {
+func TestGetVerificationNoMatchPolicy(t *testing.T) {
 	ctx := context.Background()
-	if config.CheckEnforceResourceVerificationMode(ctx) {
-		t.Errorf("CheckCheckEnforceResourceVerificationMode got true but expected to be false")
-	}
-	store := config.NewStore(logging.FromContext(ctx).Named("config-store"))
-	featureflags := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "feature-flags",
-		},
-		Data: map[string]string{
-			"resource-verification-mode": config.EnforceResourceVerificationMode,
-		},
-	}
-	store.OnConfigChanged(featureflags)
-	ctx = store.ToContext(ctx)
-	if !config.CheckEnforceResourceVerificationMode(ctx) {
-		t.Errorf("CheckCheckEnforceResourceVerificationMode got false but expected to be true")
-	}
-}
+	tcs := []struct {
+		name, noMatchPolicy, expected string
+	}{{
+		name:          "ignore no match policy",
+		noMatchPolicy: config.IgnoreNoMatchPolicy,
+		expected:      config.IgnoreNoMatchPolicy,
+	}, {
+		name:          "warn no match policy",
+		noMatchPolicy: config.WarnNoMatchPolicy,
+		expected:      config.WarnNoMatchPolicy,
+	}, {
+		name:          "fail no match policy",
+		noMatchPolicy: config.FailNoMatchPolicy,
+		expected:      config.FailNoMatchPolicy,
+	}}
 
-func TestCheckWarnResourceVerificationMode(t *testing.T) {
-	ctx := context.Background()
-	if config.CheckWarnResourceVerificationMode(ctx) {
-		t.Errorf("CheckWarnResourceVerificationMode got true but expected to be false")
-	}
-	store := config.NewStore(logging.FromContext(ctx).Named("config-store"))
-	featureflags := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "feature-flags",
-		},
-		Data: map[string]string{
-			"resource-verification-mode": config.WarnResourceVerificationMode,
-		},
-	}
-	store.OnConfigChanged(featureflags)
-	ctx = store.ToContext(ctx)
-	if !config.CheckWarnResourceVerificationMode(ctx) {
-		t.Errorf("CheckWarnResourceVerificationMode got false but expected to be true")
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			store := config.NewStore(logging.FromContext(ctx).Named("config-store"))
+			featureflags := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "feature-flags",
+				},
+				Data: map[string]string{
+					"trusted-resources-verification-no-match-policy": tc.noMatchPolicy,
+				},
+			}
+			store.OnConfigChanged(featureflags)
+			ctx = store.ToContext(ctx)
+			got := config.GetVerificationNoMatchPolicy(ctx)
+			if d := cmp.Diff(tc.expected, got); d != "" {
+				t.Errorf("Unexpected feature flag config: %s", diff.PrintWantGot(d))
+			}
+		})
 	}
 }
 

--- a/pkg/apis/config/testdata/feature-flags-all-flags-set.yaml
+++ b/pkg/apis/config/testdata/feature-flags-all-flags-set.yaml
@@ -27,6 +27,6 @@ data:
   enable-api-fields: "alpha"
   send-cloudevents-for-runs: "true"
   enforce-nonfalsifiability: "spire"
-  resource-verification-mode: "enforce"
+  trusted-resources-verification-no-match-policy: "fail"
   enable-provenance-in-status: "true"
   custom-task-version: "v1beta1"

--- a/pkg/apis/config/testdata/feature-flags-invalid-trusted-resources-verification-no-match-policy.yaml
+++ b/pkg/apis/config/testdata/feature-flags-invalid-trusted-resources-verification-no-match-policy.yaml
@@ -18,4 +18,4 @@ metadata:
   name: feature-flags
   namespace: tekton-pipelines
 data:
-  resource-verification-mode: "wrong mode"
+  trusted-resources-verification-no-match-policy: "wrong value"

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_conversion_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_conversion_test.go
@@ -314,7 +314,7 @@ func TestPipelineRunConversion(t *testing.T) {
 							RunningInEnvWithInjectedSidecars: config.DefaultRunningInEnvWithInjectedSidecars,
 							EnableAPIFields:                  config.DefaultEnableAPIFields,
 							AwaitSidecarReadiness:            config.DefaultAwaitSidecarReadiness,
-							ResourceVerificationMode:         config.DefaultResourceVerificationMode,
+							VerificationNoMatchPolicy:        config.DefaultNoMatchPolicyConfig,
 							ResultExtractionMethod:           config.DefaultResultExtractionMethod,
 							MaxResultSize:                    config.DefaultMaxResultSize,
 							CustomTaskVersion:                config.DefaultCustomTaskVersion,

--- a/pkg/apis/pipeline/v1beta1/taskrun_conversion_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_conversion_test.go
@@ -241,7 +241,7 @@ func TestTaskRunConversion(t *testing.T) {
 							RunningInEnvWithInjectedSidecars: config.DefaultRunningInEnvWithInjectedSidecars,
 							EnableAPIFields:                  config.DefaultEnableAPIFields,
 							AwaitSidecarReadiness:            config.DefaultAwaitSidecarReadiness,
-							ResourceVerificationMode:         config.DefaultResourceVerificationMode,
+							VerificationNoMatchPolicy:        config.DefaultNoMatchPolicyConfig,
 							ResultExtractionMethod:           config.DefaultResultExtractionMethod,
 							MaxResultSize:                    config.DefaultMaxResultSize,
 							CustomTaskVersion:                config.DefaultCustomTaskVersion,

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -55,6 +55,7 @@ import (
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -199,7 +200,8 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pr *v1beta1.PipelineRun)
 		before = pr.Status.GetCondition(apis.ConditionSucceeded)
 	}
 
-	vp, err := getVerificationPolicies(ctx, c.verificationPolicyLister, pr.Namespace)
+	// list VerificationPolicies for trusted resources
+	vp, err := c.verificationPolicyLister.VerificationPolicies(pr.Namespace).List(labels.Everything())
 	if err != nil {
 		return fmt.Errorf("failed to list VerificationPolicies from namespace %s with error %v", pr.Namespace, err)
 	}
@@ -309,11 +311,11 @@ func (c *Reconciler) resolvePipelineState(
 		// in the TaskRun reconciler.
 		trName := resources.GetTaskRunName(pr.Status.ChildReferences, task.Name, pr.Name)
 
-		vp, err := getVerificationPolicies(ctx, c.verificationPolicyLister, pr.Namespace)
+		// list VerificationPolicies for trusted resources
+		vp, err := c.verificationPolicyLister.VerificationPolicies(pr.Namespace).List(labels.Everything())
 		if err != nil {
 			return nil, fmt.Errorf("failed to list VerificationPolicies from namespace %s with error %v", pr.Namespace, err)
 		}
-
 		fn := tresources.GetVerifiedTaskFunc(ctx, c.KubeClientSet, c.PipelineClientSet, c.resolutionRequester, pr, task.TaskRef, trName, pr.Namespace, pr.Spec.ServiceAccountName, vp)
 
 		getRunObjectFunc := func(name string) (v1beta1.RunObject, error) {
@@ -1427,17 +1429,4 @@ func updatePipelineRunStatusFromChildRefs(logger *zap.SugaredLogger, pr *v1beta1
 		newChildRefs = append(newChildRefs, *childRefByName[k])
 	}
 	pr.Status.ChildReferences = newChildRefs
-}
-
-// getVerificationPolicies lists the verificationPolicies from given namespace
-func getVerificationPolicies(ctx context.Context, verificationPolicyLister alpha1listers.VerificationPolicyLister, namespace string) ([]*v1alpha1.VerificationPolicy, error) {
-	var verificationpolicies []*v1alpha1.VerificationPolicy
-	if config.CheckEnforceResourceVerificationMode(ctx) || config.CheckWarnResourceVerificationMode(ctx) {
-		var err error
-		verificationpolicies, err = verificationPolicyLister.VerificationPolicies(namespace).List(k8slabels.Everything())
-		if err != nil {
-			return nil, fmt.Errorf("failed to list VerificationPolicies: %w", err)
-		}
-	}
-	return verificationpolicies, nil
 }

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -2511,7 +2511,7 @@ status:
 		mustParseTaskRunWithObjectMeta(t, taskRunObjectMeta("test-pipeline-run-with-timeout-finaltask-1", "foo", "test-pipeline-run-with-timeout",
 			"test-pipeline", "finaltask-1", false), `
 spec:
-  
+
   serviceAccountName: test-sa
   taskRef:
     name: hello-world
@@ -4792,7 +4792,7 @@ metadata:
 					RunningInEnvWithInjectedSidecars: config.DefaultRunningInEnvWithInjectedSidecars,
 					EnableAPIFields:                  config.DefaultEnableAPIFields,
 					AwaitSidecarReadiness:            config.DefaultAwaitSidecarReadiness,
-					ResourceVerificationMode:         config.DefaultResourceVerificationMode,
+					VerificationNoMatchPolicy:        config.DefaultNoMatchPolicyConfig,
 					EnableProvenanceInStatus:         true,
 					ResultExtractionMethod:           config.DefaultResultExtractionMethod,
 					MaxResultSize:                    config.DefaultMaxResultSize,
@@ -9895,21 +9895,10 @@ spec:
 		t.Fatal("fail to sign pipeline", err)
 	}
 
-	cms := []*corev1.ConfigMap{
-		{
-			ObjectMeta: metav1.ObjectMeta{Name: config.GetFeatureFlagsConfigName(), Namespace: system.Namespace()},
-			Data: map[string]string{
-				"resource-verification-mode": "enforce",
-			},
-		},
-	}
-	t.Logf("config maps: %s", cms)
-
 	d := test.Data{
 		PipelineRuns:         []*v1beta1.PipelineRun{prs},
 		Pipelines:            []*v1beta1.Pipeline{signedPipeline},
 		Tasks:                []*v1beta1.Task{signedTask},
-		ConfigMaps:           cms,
 		VerificationPolicies: vps,
 	}
 	prt := newPipelineRunTest(t, d)
@@ -9981,16 +9970,6 @@ spec:
 	}
 	tamperedPipeline.Annotations["random"] = "attack"
 
-	cms := []*corev1.ConfigMap{
-		{
-			ObjectMeta: metav1.ObjectMeta{Name: config.GetFeatureFlagsConfigName(), Namespace: system.Namespace()},
-			Data: map[string]string{
-				"resource-verification-mode": "enforce",
-			},
-		},
-	}
-	t.Logf("config maps: %s", cms)
-
 	testCases := []struct {
 		name        string
 		pipelinerun []*v1beta1.PipelineRun
@@ -10028,7 +10007,6 @@ spec:
 				PipelineRuns:         tc.pipelinerun,
 				Pipelines:            tc.pipeline,
 				Tasks:                tc.task,
-				ConfigMaps:           cms,
 				VerificationPolicies: vps,
 			}
 			prt := newPipelineRunTest(t, d)

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -3762,7 +3762,7 @@ spec:
 					RunningInEnvWithInjectedSidecars: config.DefaultRunningInEnvWithInjectedSidecars,
 					EnableAPIFields:                  config.DefaultEnableAPIFields,
 					AwaitSidecarReadiness:            config.DefaultAwaitSidecarReadiness,
-					ResourceVerificationMode:         config.DefaultResourceVerificationMode,
+					VerificationNoMatchPolicy:        config.DefaultNoMatchPolicyConfig,
 					EnableProvenanceInStatus:         true,
 					ResultExtractionMethod:           config.DefaultResultExtractionMethod,
 					MaxResultSize:                    config.DefaultMaxResultSize,
@@ -4889,7 +4889,7 @@ status:
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: config.GetFeatureFlagsConfigName(), Namespace: system.Namespace()},
 			Data: map[string]string{
-				"resource-verification-mode": "enforce",
+				"trusted-resources-verification-no-match-policy": config.FailNoMatchPolicy,
 			},
 		},
 	}
@@ -4960,7 +4960,7 @@ status:
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: config.GetFeatureFlagsConfigName(), Namespace: system.Namespace()},
 			Data: map[string]string{
-				"resource-verification-mode": "enforce",
+				"trusted-resources-verification-no-match-policy": config.FailNoMatchPolicy,
 			},
 		},
 	}

--- a/pkg/trustedresources/errors.go
+++ b/pkg/trustedresources/errors.go
@@ -20,8 +20,6 @@ import "errors"
 var (
 	// ErrResourceVerificationFailed is returned when trusted resources fails verification.
 	ErrResourceVerificationFailed = errors.New("resource verification failed")
-	// ErrEmptyVerificationConfig is returned when no VerificationPolicy is found
-	ErrEmptyVerificationConfig = errors.New("no policies founded for verification")
 	// ErrNoMatchedPolicies is returned when no policies are matched
 	ErrNoMatchedPolicies = errors.New("no policies are matched")
 	// ErrRegexMatch is returned when regex match returns error

--- a/test/trusted_resources_test.go
+++ b/test/trusted_resources_test.go
@@ -268,7 +268,7 @@ func setSecretAndConfig(ctx context.Context, t *testing.T, client kubernetes.Int
 	// Note that this may not work if we run e2e tests in parallel since this feature flag require all tasks and pipelines
 	// to be signed and unsigned resources will fail. i.e. Don't add t.Parallel() for this test.
 	configMapData := map[string]string{
-		"resource-verification-mode": config.EnforceResourceVerificationMode,
+		"trusted-resources-verification-no-match-policy": config.FailNoMatchPolicy,
 	}
 	if err := updateConfigMap(ctx, client, system.Namespace(), config.GetFeatureFlagsConfigName(), configMapData); err != nil {
 		t.Fatal(err)
@@ -304,7 +304,7 @@ func removeResourceVerificationConfig(ctx context.Context, t *testing.T, c *clie
 func resetSecretAndConfig(ctx context.Context, t *testing.T, client kubernetes.Interface, secretName, namespace string) {
 	t.Helper()
 	configMapData := map[string]string{
-		"resource-verification-mode": config.SkipResourceVerificationMode,
+		"trusted-resources-verification-no-match-policy": config.IgnoreNoMatchPolicy,
 	}
 	if err := updateConfigMap(ctx, client, system.Namespace(), config.GetFeatureFlagsConfigName(), configMapData); err != nil {
 		t.Fatal(err)

--- a/test/trustedresources.go
+++ b/test/trustedresources.go
@@ -95,8 +95,8 @@ func GetUnsignedPipeline(name string) *v1beta1.Pipeline {
 	}
 }
 
-// SetupTrustedResourceConfig config the resource-verification-mode feature flag by given mode for testing
-func SetupTrustedResourceConfig(ctx context.Context, resourceVerificationMode string) context.Context {
+// SetupTrustedResourceConfig configures the trusted-resources-verification-no-match-policy feature flag with the given mode for testing
+func SetupTrustedResourceConfig(ctx context.Context, verificationNoMatchPolicy string) context.Context {
 	store := config.NewStore(logging.FromContext(ctx).Named("config-store"))
 	featureflags := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -104,7 +104,7 @@ func SetupTrustedResourceConfig(ctx context.Context, resourceVerificationMode st
 			Name:      "feature-flags",
 		},
 		Data: map[string]string{
-			"resource-verification-mode": resourceVerificationMode,
+			"trusted-resources-verification-no-match-policy": verificationNoMatchPolicy,
 		},
 	}
 	store.OnConfigChanged(featureflags)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

🚨BREAKING CHANGES🚨

This commits changes trusted resources feature flag from resource-verification-mode to verification-no-match-policy. This is a backward incompatiable change as discussed in [TEP-0091](https://github.com/tektoncd/community/blob/main/teps/0091-trusted-resources.md). Before this commit the feature flag is used to skip/enforce the verification. This commit changes this to check the existence of matched VerificationPolicy. So to enable the verification, users just need to apply VerificationPolicy to match the resources. To disable the verification, users need to remove the policies and set the verification-no-match-policy to ignore (by default).

Part of https://github.com/tektoncd/pipeline/issues/6356

/kind feature

Signed-off-by: Yongxuan Zhang yongxuanzhang@google.com

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
[action required] for trusted resources users, please change feature flag resource-verification-mode to trusted-resources-verification-no-match-policy, please refer to https://github.com/tektoncd/pipeline/blob/main/docs/trusted-resources.md#enable-trusted-resources to learn how to config the new  trusted-resources-verification-no-match-policy feature flag
```
