### PR TITLE
[TEP-0091] Add mode for VerificationPolicy

### DIFF
--- a/docs/pipeline-api.md
+++ b/docs/pipeline-api.md
@@ -6161,6 +6161,22 @@ Then the ResourcesPattern should be valid regex. E.g. If using gitresolver, and 
 <p>Authorities defines the rules for validating signatures.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>mode</code><br/>
+<em>
+<a href="#tekton.dev/v1alpha1.ModeType">
+ModeType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Mode controls whether a failing policy will fail the taskrun/pipelinerun, or only log the warnings
+enforce - fail the taskrun/pipelinerun if verification fails (default)
+warn - don&rsquo;t fail the taskrun/pipelinerun if verification fails but log warnings</p>
+</td>
+</tr>
 </table>
 </td>
 </tr>
@@ -6362,6 +6378,14 @@ HashAlgorithm
 </tr>
 </tbody>
 </table>
+<h3 id="tekton.dev/v1alpha1.ModeType">ModeType
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1alpha1.VerificationPolicySpec">VerificationPolicySpec</a>)
+</p>
+<div>
+<p>ModeType indicates the type of a mode for VerificationPolicy</p>
+</div>
 <h3 id="tekton.dev/v1alpha1.ResourcePattern">ResourcePattern
 </h3>
 <p>
@@ -6615,6 +6639,22 @@ Then the ResourcesPattern should be valid regex. E.g. If using gitresolver, and 
 </td>
 <td>
 <p>Authorities defines the rules for validating signatures.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>mode</code><br/>
+<em>
+<a href="#tekton.dev/v1alpha1.ModeType">
+ModeType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Mode controls whether a failing policy will fail the taskrun/pipelinerun, or only log the warnings
+enforce - fail the taskrun/pipelinerun if verification fails (default)
+warn - don&rsquo;t fail the taskrun/pipelinerun if verification fails but log warnings</p>
 </td>
 </tr>
 </tbody>

--- a/pkg/apis/pipeline/v1alpha1/verificationpolicy_types.go
+++ b/pkg/apis/pipeline/v1alpha1/verificationpolicy_types.go
@@ -62,6 +62,11 @@ type VerificationPolicySpec struct {
 	Resources []ResourcePattern `json:"resources"`
 	// Authorities defines the rules for validating signatures.
 	Authorities []Authority `json:"authorities"`
+	// Mode controls whether a failing policy will fail the taskrun/pipelinerun, or only log the warnings
+	// enforce - fail the taskrun/pipelinerun if verification fails (default)
+	// warn - don't fail the taskrun/pipelinerun if verification fails but log warnings
+	// +optional
+	Mode ModeType `json:"mode,omitempty"`
 }
 
 // ResourcePattern defines the pattern of the resource source
@@ -81,6 +86,15 @@ type Authority struct {
 	// Key contains the public key to validate the resource.
 	Key *KeyRef `json:"key,omitempty"`
 }
+
+// ModeType indicates the type of a mode for VerificationPolicy
+type ModeType string
+
+// Valid ModeType:
+const (
+	ModeWarn    ModeType = "warn"
+	ModeEnforce ModeType = "enforce"
+)
 
 // KeyRef defines the reference to a public key
 type KeyRef struct {

--- a/pkg/apis/pipeline/v1alpha1/verificationpolicy_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/verificationpolicy_validation.go
@@ -55,6 +55,9 @@ func (vs *VerificationPolicySpec) Validate(ctx context.Context) (errs *apis.Fiel
 			errs = errs.Also(a.Key.Validate(ctx).ViaFieldIndex("key", i))
 		}
 	}
+	if vs.Mode != "" && vs.Mode != ModeEnforce && vs.Mode != ModeWarn {
+		errs = errs.Also(apis.ErrInvalidValue(fmt.Sprintf("available values are: %s, %s, but got: %s", ModeEnforce, ModeWarn, vs.Mode), "mode"))
+	}
 	return errs
 }
 

--- a/pkg/apis/pipeline/v1alpha1/verificationpolicy_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/verificationpolicy_validation_test.go
@@ -80,6 +80,26 @@ func TestVerificationPolicy_Invalid(t *testing.T) {
 		},
 		want: apis.ErrMissingField("authorities"),
 	}, {
+		name: "wrong mode",
+		verificationPolicy: &v1alpha1.VerificationPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "vp",
+			},
+			Spec: v1alpha1.VerificationPolicySpec{
+				Resources: []v1alpha1.ResourcePattern{{".*"}},
+				Authorities: []v1alpha1.Authority{
+					{
+						Name: "foo",
+						Key: &v1alpha1.KeyRef{
+							Data: "inlinekey",
+						},
+					},
+				},
+				Mode: "wrongMode",
+			},
+		},
+		want: apis.ErrInvalidValue(fmt.Sprintf("available values are: %s, %s, but got: %s", v1alpha1.ModeEnforce, v1alpha1.ModeWarn, "wrongMode"), "mode"),
+	}, {
 		name: "missing Authority key",
 		verificationPolicy: &v1alpha1.VerificationPolicy{
 			ObjectMeta: metav1.ObjectMeta{
@@ -277,6 +297,44 @@ func TestVerificationPolicy_Valid(t *testing.T) {
 							},
 						},
 					},
+				},
+			},
+		}, {
+			name: "enforce mode",
+			verificationPolicy: &v1alpha1.VerificationPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "vp",
+				},
+				Spec: v1alpha1.VerificationPolicySpec{
+					Resources: []v1alpha1.ResourcePattern{{".*"}},
+					Authorities: []v1alpha1.Authority{
+						{
+							Name: "foo",
+							Key: &v1alpha1.KeyRef{
+								KMS: "kms://key/path",
+							},
+						},
+					},
+					Mode: v1alpha1.ModeEnforce,
+				},
+			},
+		}, {
+			name: "warn mode",
+			verificationPolicy: &v1alpha1.VerificationPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "vp",
+				},
+				Spec: v1alpha1.VerificationPolicySpec{
+					Resources: []v1alpha1.ResourcePattern{{".*"}},
+					Authorities: []v1alpha1.Authority{
+						{
+							Name: "foo",
+							Key: &v1alpha1.KeyRef{
+								KMS: "kms://key/path",
+							},
+						},
+					},
+					Mode: v1alpha1.ModeWarn,
 				},
 			},
 		}}

--- a/test/trusted_resources_test.go
+++ b/test/trusted_resources_test.go
@@ -77,6 +77,7 @@ spec:
         secretRef:
           name:  %s
           namespace: %s
+  mode: enforce
 `, helpers.ObjectNameForTest(t), namespace, secretName, namespace))
 
 	if _, err := c.V1alpha1VerificationPolicyClient.Create(ctx, vp, metav1.CreateOptions{}); err != nil {
@@ -175,6 +176,7 @@ spec:
         secretRef:
           name:  %s
           namespace: %s
+  mode: enforce
 `, helpers.ObjectNameForTest(t), namespace, secretName, namespace))
 
 	if _, err := c.V1alpha1VerificationPolicyClient.Create(ctx, vp, metav1.CreateOptions{}); err != nil {

--- a/test/trustedresources.go
+++ b/test/trustedresources.go
@@ -363,6 +363,7 @@ func getVerificationPolicy(name, namespace string, patterns []v1alpha1.ResourceP
 		Spec: v1alpha1.VerificationPolicySpec{
 			Resources:   patterns,
 			Authorities: authorities,
+			Mode:        v1alpha1.ModeEnforce,
 		},
 	}
 }


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This commit adds the mode field into VerificationPolicy. Mode can be set to `enforce` or `warn`. It controls whether a failing policy will fail the taskrun/pipelinerun or only log the warning. When set to `enforce`, the run will fail. When set to `warn`, the run won't fail and only log warning.

/kind feature

Part of https://github.com/tektoncd/pipeline/issues/6356

Signed-off-by: Yongxuan Zhang yongxuanzhang@google.com

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Add mode field into VerificationPolicy to controls whether fail taskrun/pipelinerun or not when fails verification
```
