### PR TITLE
Migrate git-init image off PipelineResourceResult

### DIFF
--- a/cmd/git-init/main.go
+++ b/cmd/git-init/main.go
@@ -57,14 +57,18 @@ func main() {
 	if err != nil {
 		logger.Fatalf("Error parsing revision %s of git repository: %s", fetchSpec.Revision, err)
 	}
-	output := []v1beta1.PipelineResourceResult{
+	output := []v1beta1.TaskRunResult{
 		{
-			Key:   "commit",
-			Value: commit,
+			Name: "commit",
+			Value: v1beta1.ParamValue{
+				StringVal: commit,
+			},
 		},
 		{
-			Key:   "url",
-			Value: fetchSpec.URL,
+			Name: "url",
+			Value: v1beta1.ParamValue{
+				StringVal: fetchSpec.URL,
+			},
 		},
 	}
 

--- a/pkg/termination/write.go
+++ b/pkg/termination/write.go
@@ -30,12 +30,12 @@ const (
 )
 
 // WriteMessage writes the results to the termination message path.
-func WriteMessage(path string, pro []v1beta1.PipelineResourceResult) error {
+func WriteMessage[T v1beta1.TaskRunResult | v1beta1.PipelineResourceResult](path string, pro []T) error {
 	// if the file at path exists, concatenate the new values otherwise create it
 	// file at path already exists
 	fileContents, err := os.ReadFile(path)
 	if err == nil {
-		var existingEntries []v1beta1.PipelineResourceResult
+		var existingEntries []T
 		if err := json.Unmarshal(fileContents, &existingEntries); err == nil {
 			// append new entries to existing entries
 			pro = append(existingEntries, pro...)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This commit makes introduces the generics of PipelineResourceResult and TaskrunResult in termination package and migrates the git-init image off from using PipelineResourceResult.

/kind misc
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
