### PR TITLE
Check generated API docs during CI

### DIFF
--- a/docs/pipeline-api.md
+++ b/docs/pipeline-api.md
@@ -1323,12 +1323,12 @@ string
 <h3 id="tekton.dev/v1.Combination">Combination
 (<code>map[string]string</code> alias)</h3>
 <div>
-<p>Combination holds a single combination from a Matrix with key as param.Name and value as param.Value</p>
+<p>Combination is a map, mainly defined to hold a single combination from a Matrix with key as param.Name and value as param.Value</p>
 </div>
 <h3 id="tekton.dev/v1.Combinations">Combinations
 (<code>[]github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Combination</code> alias)</h3>
 <div>
-<p>Combinations holds a list of combination for a given Matrix</p>
+<p>Combinations is a list of combinations</p>
 </div>
 <h3 id="tekton.dev/v1.ConfigSource">ConfigSource
 </h3>
@@ -8189,12 +8189,12 @@ int32
 <h3 id="tekton.dev/v1beta1.Combination">Combination
 (<code>map[string]string</code> alias)</h3>
 <div>
-<p>Combination holds a single combination from a Matrix with key as param.Name and value as param.Value</p>
+<p>Combination is a map, mainly defined to hold a single combination from a Matrix with key as param.Name and value as param.Value</p>
 </div>
 <h3 id="tekton.dev/v1beta1.Combinations">Combinations
 (<code>[]github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Combination</code> alias)</h3>
 <div>
-<p>Combinations holds a list of combination for a given Matrix</p>
+<p>Combinations is a list of combination</p>
 </div>
 <h3 id="tekton.dev/v1beta1.ConfigSource">ConfigSource
 </h3>
@@ -8968,7 +8968,11 @@ feature gate is enabled.</p>
 (<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskRunStatusFields">TaskRunStatusFields</a>)
 </p>
 <div>
-<p>PipelineResourceResult used to export the image name and digest as json</p>
+<p>PipelineResourceResult is used to write key/value pairs to TaskRun pod termination messages.
+The key/value pairs may come from the entrypoint binary, or represent a TaskRunResult.
+If they represent a TaskRunResult, the key is the name of the result and the value is the
+JSON-serialized value of the result.
+TODO(#6197): Rename this struct</p>
 </div>
 <table>
 <thead>
@@ -9006,6 +9010,8 @@ string
 </em>
 </td>
 <td>
+<p>ResourceName may be used in tests, but it is not populated in termination messages.
+It is preserved here for backwards compatibility and will not be ported to v1.</p>
 </td>
 </tr>
 <tr>

--- a/hack/verify-codegen.sh
+++ b/hack/verify-codegen.sh
@@ -37,15 +37,20 @@ cp -aR "${REPO_ROOT_DIR}/pkg" "${TMP_DIFFROOT}"
 mkdir -p "${TMP_DIFFROOT}/vendor"
 cp -aR "${REPO_ROOT_DIR}/vendor" "${TMP_DIFFROOT}"
 
+mkdir -p "${TMP_DIFFROOT}/docs"
+cp -aR "${REPO_ROOT_DIR}/docs" "${TMP_DIFFROOT}"
+
 "${REPO_ROOT_DIR}/hack/update-codegen.sh"
 echo "Diffing ${REPO_ROOT_DIR} against freshly generated codegen"
 ret=0
 diff -Naupr "${REPO_ROOT_DIR}/pkg" "${TMP_DIFFROOT}/pkg" || ret=1
 diff -Naupr "${REPO_ROOT_DIR}/vendor" "${TMP_DIFFROOT}/vendor" || ret=1
+diff -Naupr "${REPO_ROOT_DIR}/docs/pipeline-api.md" "${TMP_DIFFROOT}/docs/pipeline-api.md" || ret=1
 
 # Restore working tree state
 rm -fr "${REPO_ROOT_DIR}/pkg"
 rm -fr "${REPO_ROOT_DIR}/vendor"
+rm -fr "${REPO_ROOT_DIR}/docs"
 cp -aR "${TMP_DIFFROOT}"/* "${REPO_ROOT_DIR}"
 
 if [[ $ret -eq 0 ]]


### PR DESCRIPTION
This commit updates hack/verify-codegen.sh to verify that the generated API reference docs match any changes to the API and its documentation, and re-runs reference doc generation. It does not verify that licenses have been updated (this will be a separate commit).

Partially addresses https://github.com/tektoncd/pipeline/issues/6210

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- n/a Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- n/a Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- n/a Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- n/a Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
