### PR TITLE
[TEP-0133] Refactor set default test helper

### DIFF
--- a/pkg/apis/config/testing/defaults.go
+++ b/pkg/apis/config/testing/defaults.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2023 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tektoncd/pipeline/pkg/apis/config"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	logtesting "knative.dev/pkg/logging/testing"
+)
+
+// SetDefaults sets the default ConfigMap values in an existing context (for use in testing)
+func SetDefaults(ctx context.Context, t *testing.T, data map[string]string) context.Context {
+	t.Helper()
+	s := config.NewStore(logtesting.TestLogger(t))
+	s.OnConfigChanged(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: config.GetDefaultsConfigName(),
+		},
+		Data: data,
+	})
+	return s.ToContext(ctx)
+}

--- a/pkg/apis/pipeline/v1beta1/taskrun_defaults_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_defaults_test.go
@@ -23,12 +23,12 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
+	cfgtesting "github.com/tektoncd/pipeline/pkg/apis/config/testing"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/test/diff"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	logtesting "knative.dev/pkg/logging/testing"
 )
 
 var (
@@ -132,10 +132,10 @@ func TestTaskRunSpec_SetDefaults(t *testing.T) {
 
 func TestTaskRunDefaulting(t *testing.T) {
 	tests := []struct {
-		name string
-		in   *v1beta1.TaskRun
-		want *v1beta1.TaskRun
-		wc   func(context.Context) context.Context
+		name     string
+		in       *v1beta1.TaskRun
+		want     *v1beta1.TaskRun
+		defaults map[string]string
 	}{{
 		name: "empty no context",
 		in:   &v1beta1.TaskRun{},
@@ -182,17 +182,8 @@ func TestTaskRunDefaulting(t *testing.T) {
 				Timeout:            &metav1.Duration{Duration: 5 * time.Minute},
 			},
 		},
-		wc: func(ctx context.Context) context.Context {
-			s := config.NewStore(logtesting.TestLogger(t))
-			s.OnConfigChanged(&corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: config.GetDefaultsConfigName(),
-				},
-				Data: map[string]string{
-					"default-timeout-minutes": "5",
-				},
-			})
-			return s.ToContext(ctx)
+		defaults: map[string]string{
+			"default-timeout-minutes": "5",
 		},
 	}, {
 		name: "TaskRef default config context with SA",
@@ -211,18 +202,9 @@ func TestTaskRunDefaulting(t *testing.T) {
 				ServiceAccountName: "tekton",
 			},
 		},
-		wc: func(ctx context.Context) context.Context {
-			s := config.NewStore(logtesting.TestLogger(t))
-			s.OnConfigChanged(&corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: config.GetDefaultsConfigName(),
-				},
-				Data: map[string]string{
-					"default-timeout-minutes": "5",
-					"default-service-account": "tekton",
-				},
-			})
-			return s.ToContext(ctx)
+		defaults: map[string]string{
+			"default-timeout-minutes": "5",
+			"default-service-account": "tekton",
 		},
 	}, {
 		name: "TaskRun managed-by set in config",
@@ -241,18 +223,9 @@ func TestTaskRunDefaulting(t *testing.T) {
 				Timeout:            &metav1.Duration{Duration: 5 * time.Minute},
 			},
 		},
-		wc: func(ctx context.Context) context.Context {
-			s := config.NewStore(logtesting.TestLogger(t))
-			s.OnConfigChanged(&corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: config.GetDefaultsConfigName(),
-				},
-				Data: map[string]string{
-					"default-timeout-minutes":        "5",
-					"default-managed-by-label-value": "something-else",
-				},
-			})
-			return s.ToContext(ctx)
+		defaults: map[string]string{
+			"default-timeout-minutes":        "5",
+			"default-managed-by-label-value": "something-else",
 		},
 	}, {
 		name: "TaskRun managed-by set in request and config (request wins)",
@@ -274,18 +247,9 @@ func TestTaskRunDefaulting(t *testing.T) {
 				Timeout:            &metav1.Duration{Duration: 5 * time.Minute},
 			},
 		},
-		wc: func(ctx context.Context) context.Context {
-			s := config.NewStore(logtesting.TestLogger(t))
-			s.OnConfigChanged(&corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: config.GetDefaultsConfigName(),
-				},
-				Data: map[string]string{
-					"default-timeout-minutes":        "5",
-					"default-managed-by-label-value": "something-else",
-				},
-			})
-			return s.ToContext(ctx)
+		defaults: map[string]string{
+			"default-timeout-minutes":        "5",
+			"default-managed-by-label-value": "something-else",
 		},
 	}, {
 		name: "TaskRef pod template is coming from default config pod template",
@@ -309,19 +273,10 @@ func TestTaskRunDefaulting(t *testing.T) {
 				},
 			},
 		},
-		wc: func(ctx context.Context) context.Context {
-			s := config.NewStore(logtesting.TestLogger(t))
-			s.OnConfigChanged(&corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: config.GetDefaultsConfigName(),
-				},
-				Data: map[string]string{
-					"default-timeout-minutes": "5",
-					"default-service-account": "tekton",
-					"default-pod-template":    "nodeSelector: { 'label': 'value' }",
-				},
-			})
-			return s.ToContext(ctx)
+		defaults: map[string]string{
+			"default-timeout-minutes": "5",
+			"default-service-account": "tekton",
+			"default-pod-template":    "nodeSelector: { 'label': 'value' }",
 		},
 	}, {
 		name: "TaskRef pod template NodeSelector takes precedence over default config pod template NodeSelector",
@@ -350,19 +305,10 @@ func TestTaskRunDefaulting(t *testing.T) {
 				},
 			},
 		},
-		wc: func(ctx context.Context) context.Context {
-			s := config.NewStore(logtesting.TestLogger(t))
-			s.OnConfigChanged(&corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: config.GetDefaultsConfigName(),
-				},
-				Data: map[string]string{
-					"default-timeout-minutes": "5",
-					"default-service-account": "tekton",
-					"default-pod-template":    "nodeSelector: { 'label': 'value' }",
-				},
-			})
-			return s.ToContext(ctx)
+		defaults: map[string]string{
+			"default-timeout-minutes": "5",
+			"default-service-account": "tekton",
+			"default-pod-template":    "nodeSelector: { 'label': 'value' }",
 		},
 	}, {
 		name: "TaskRef pod template merges non competing fields with default config pod template",
@@ -394,28 +340,16 @@ func TestTaskRunDefaulting(t *testing.T) {
 				},
 			},
 		},
-		wc: func(ctx context.Context) context.Context {
-			s := config.NewStore(logtesting.TestLogger(t))
-			s.OnConfigChanged(&corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: config.GetDefaultsConfigName(),
-				},
-				Data: map[string]string{
-					"default-timeout-minutes": "5",
-					"default-service-account": "tekton",
-					"default-pod-template":    "nodeSelector: { 'label': 'value' }",
-				},
-			})
-			return s.ToContext(ctx)
+		defaults: map[string]string{
+			"default-timeout-minutes": "5",
+			"default-service-account": "tekton",
+			"default-pod-template":    "nodeSelector: { 'label': 'value' }",
 		},
 	}}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			ctx := cfgtesting.SetDefaults(context.Background(), t, tc.defaults)
 			got := tc.in
-			ctx := context.Background()
-			if tc.wc != nil {
-				ctx = tc.wc(ctx)
-			}
 			got.SetDefaults(ctx)
 			if !cmp.Equal(got, tc.want, ignoreUnexportedResources) {
 				d := cmp.Diff(got, tc.want, ignoreUnexportedResources)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Prior to this change, unit tests in `pipelinerun_defaults_test.go` and `taskrun_defaults_test.go` use deplicated `withContext()` functions to overwrite default values in `config-defaults` ConfigMap

This commit adds a `SetDefaults` helper function in a separate file to refactors the duplicate code.

There is no functionality change in this commit.

/kind cleanup
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
