### PR TITLE
Hygiene: enable `errorlint`.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,7 +27,7 @@ linters:
   - errcheck
   - errchkjson
   - errname
-  # errorlint TODO: cleanup the issues this linter uncovers https://github.com/tektoncd/pipeline/issues/5899
+  - errorlint
   - goconst
   - gocritic
   - gofmt

--- a/cmd/entrypoint/main.go
+++ b/cmd/entrypoint/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -97,12 +98,11 @@ func main() {
 	}
 	if err := subcommands.Process(flag.CommandLine.Args()); err != nil {
 		log.Println(err.Error())
-		switch err.(type) {
-		case subcommands.OK:
+		var ok subcommands.OK
+		if errors.As(err, &ok) {
 			return
-		default:
-			os.Exit(1)
 		}
+		os.Exit(1)
 	}
 
 	// Copy credentials we're expecting from the legacy credentials helper (creds-init)
@@ -174,7 +174,7 @@ func main() {
 
 	if err := e.Go(); err != nil {
 		breakpointExitPostFile := e.PostFile + breakpointExitSuffix
-		switch t := err.(type) {
+		switch t := err.(type) { // nolint -- checking for multiple types with errors.As is ugly.
 		case skipError:
 			log.Print("Skipping step because a previous step failed")
 			os.Exit(1)

--- a/cmd/entrypoint/namespaces_test.go
+++ b/cmd/entrypoint/namespaces_test.go
@@ -20,6 +20,7 @@ limitations under the License.
 package main
 
 import (
+	"errors"
 	"os/exec"
 	"testing"
 
@@ -60,7 +61,7 @@ func TestDropNetworking(t *testing.T) {
 
 		b1, err1 := withNetworking.CombinedOutput()
 		b2, err2 := withoutNetworking.CombinedOutput()
-		if err1 != err2 {
+		if !errors.Is(err1, err2) {
 			t.Errorf("Expected no errors, got %v %v", err1, err2)
 		}
 		if diff := cmp.Diff(string(b1), string(b2)); diff != "" {

--- a/cmd/entrypoint/runner.go
+++ b/cmd/entrypoint/runner.go
@@ -20,6 +20,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -116,7 +117,7 @@ func (rr *realRunner) Run(ctx context.Context, args ...string) error {
 
 	// Start defined command
 	if err := cmd.Start(); err != nil {
-		if ctx.Err() == context.DeadlineExceeded {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return context.DeadlineExceeded
 		}
 		return err
@@ -134,7 +135,7 @@ func (rr *realRunner) Run(ctx context.Context, args ...string) error {
 
 	// Wait for command to exit
 	if err := cmd.Wait(); err != nil {
-		if ctx.Err() == context.DeadlineExceeded {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return context.DeadlineExceeded
 		}
 		return err

--- a/cmd/entrypoint/runner_test.go
+++ b/cmd/entrypoint/runner_test.go
@@ -165,8 +165,9 @@ func TestRealRunnerTimeout(t *testing.T) {
 	timeout := time.Millisecond
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
+
 	if err := rr.Run(ctx, "sleep", "0.01"); err != nil {
-		if err != context.DeadlineExceeded {
+		if !errors.Is(err, context.DeadlineExceeded) {
 			t.Fatalf("unexpected error received: %v", err)
 		}
 	} else {

--- a/cmd/entrypoint/subcommands/subcommands_test.go
+++ b/cmd/entrypoint/subcommands/subcommands_test.go
@@ -1,6 +1,7 @@
 package subcommands
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -24,6 +25,8 @@ func TestProcessSuccessfulSubcommands(t *testing.T) {
 		t.Fatalf("error writing source file: %v", err)
 	}
 
+	var ok OK
+
 	for _, tc := range []struct {
 		command string
 		args    []string
@@ -39,7 +42,7 @@ func TestProcessSuccessfulSubcommands(t *testing.T) {
 	} {
 		t.Run(tc.command, func(t *testing.T) {
 			returnValue := Process(append([]string{tc.command}, tc.args...))
-			if _, ok := returnValue.(OK); !ok {
+			if !errors.As(returnValue, &ok) {
 				t.Errorf("unexpected return value from command: %v", returnValue)
 			}
 		})
@@ -49,12 +52,12 @@ func TestProcessSuccessfulSubcommands(t *testing.T) {
 		tektonRoot = tmp
 
 		returnValue := Process([]string{StepInitCommand})
-		if _, ok := returnValue.(OK); !ok {
+		if !errors.As(returnValue, &ok) {
 			t.Errorf("unexpected return value from step-init command: %v", returnValue)
 		}
 
 		returnValue = Process([]string{StepInitCommand, "foo", "bar"})
-		if _, ok := returnValue.(OK); !ok {
+		if !errors.As(returnValue, &ok) {
 			t.Errorf("unexpected return value from step-init command w/ params: %v", returnValue)
 		}
 	})

--- a/cmd/entrypoint/waiter_test.go
+++ b/cmd/entrypoint/waiter_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"errors"
 	"os"
 	"strings"
 	"testing"
@@ -149,11 +150,11 @@ func TestRealWaiterWaitWithErrorWaitfile(t *testing.T) {
 		if err == nil {
 			t.Errorf("expected skipError upon encounter error waitfile")
 		}
-		switch typ := err.(type) {
-		case skipError:
+		var skipErr skipError
+		if errors.As(err, &skipErr) {
 			close(doneCh)
-		default:
-			t.Errorf("unexpected error type %T", typ)
+		} else {
+			t.Errorf("unexpected error type %T", err)
 		}
 	}()
 	delay := time.NewTimer(2 * testWaitPollingInterval)

--- a/internal/sidecarlogresults/sidecarlogresults_test.go
+++ b/internal/sidecarlogresults/sidecarlogresults_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -181,7 +182,7 @@ func TestExtractResultsFromLogs_Failure(t *testing.T) {
 	logs := strings.NewReader(podLogs)
 
 	_, err := extractResultsFromLogs(logs, []v1beta1.PipelineResourceResult{}, 4096)
-	if err != ErrSizeExceeded {
+	if !errors.Is(err, ErrSizeExceeded) {
 		t.Fatalf("Expected error %v but got %v", ErrSizeExceeded, err)
 	}
 }

--- a/pkg/apis/config/feature_flags.go
+++ b/pkg/apis/config/feature_flags.go
@@ -157,7 +157,7 @@ func NewFeatureFlagsFromMap(cfgMap map[string]string) (*FeatureFlags, error) {
 		if cfg, ok := cfgMap[key]; ok {
 			value, err := strconv.ParseBool(cfg)
 			if err != nil {
-				return fmt.Errorf("failed parsing feature flags config %q: %v", cfg, err)
+				return fmt.Errorf("failed parsing feature flags config %q: %w", cfg, err)
 			}
 			*feature = value
 			return nil

--- a/pkg/apis/config/resolver/feature_flags.go
+++ b/pkg/apis/config/resolver/feature_flags.go
@@ -68,7 +68,7 @@ func NewFeatureFlagsFromMap(cfgMap map[string]string) (*FeatureFlags, error) {
 		if cfg, ok := cfgMap[key]; ok {
 			value, err := strconv.ParseBool(cfg)
 			if err != nil {
-				return fmt.Errorf("failed parsing feature flags config %q: %v", cfg, err)
+				return fmt.Errorf("failed parsing feature flags config %q: %w", cfg, err)
 			}
 			*feature = value
 			return nil

--- a/pkg/apis/pipeline/v1beta1/resource_types.go
+++ b/pkg/apis/pipeline/v1beta1/resource_types.go
@@ -63,7 +63,7 @@ func (r *ResultType) UnmarshalJSON(data []byte) error {
 	var asString string
 
 	if err := json.Unmarshal(data, &asString); err != nil {
-		return fmt.Errorf("unsupported value type, neither int nor string: %v", multierror.Append(intErr, err).ErrorOrNil())
+		return fmt.Errorf("unsupported value type, neither int nor string: %w", multierror.Append(intErr, err).ErrorOrNil())
 	}
 
 	switch asString {

--- a/pkg/apis/version/conversion.go
+++ b/pkg/apis/version/conversion.go
@@ -28,7 +28,7 @@ import (
 func SerializeToMetadata(meta *metav1.ObjectMeta, field interface{}, key string) error {
 	bytes, err := json.Marshal(field)
 	if err != nil {
-		return fmt.Errorf("error serializing field: %s", err)
+		return fmt.Errorf("error serializing field: %w", err)
 	}
 	if meta.Annotations == nil {
 		meta.Annotations = make(map[string]string)
@@ -46,7 +46,7 @@ func DeserializeFromMetadata(meta *metav1.ObjectMeta, to interface{}, key string
 	}
 	if str, ok := meta.Annotations[key]; ok {
 		if err := json.Unmarshal([]byte(str), to); err != nil {
-			return fmt.Errorf("error deserializing key %s from metadata: %s", key, err)
+			return fmt.Errorf("error deserializing key %s from metadata: %w", key, err)
 		}
 		delete(meta.Annotations, key)
 		if len(meta.Annotations) == 0 {

--- a/pkg/entrypoint/entrypointer.go
+++ b/pkg/entrypoint/entrypointer.go
@@ -157,7 +157,7 @@ func (e Entrypointer) Go() error {
 			defer cancel()
 		}
 		err = e.Runner.Run(ctx, e.Command...)
-		if err == context.DeadlineExceeded {
+		if errors.Is(err, context.DeadlineExceeded) {
 			output = append(output, v1beta1.PipelineResourceResult{
 				Key:        "Reason",
 				Value:      "TimeoutExceeded",

--- a/pkg/pipelinerunmetrics/metrics.go
+++ b/pkg/pipelinerunmetrics/metrics.go
@@ -268,7 +268,7 @@ func (r *Recorder) RunningPipelineRuns(lister listers.PipelineRunLister) error {
 
 	prs, err := lister.List(labels.Everything())
 	if err != nil {
-		return fmt.Errorf("failed to list pipelineruns while generating metrics : %v", err)
+		return fmt.Errorf("failed to list pipelineruns while generating metrics : %w", err)
 	}
 
 	var runningPRs int

--- a/pkg/pod/entrypoint_lookup_impl.go
+++ b/pkg/pod/entrypoint_lookup_impl.go
@@ -76,7 +76,7 @@ func (e *entrypointCache) get(ctx context.Context, ref name.Reference, namespace
 		ImagePullSecrets:   pullSecretsNames,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("error creating k8schain: %v", err)
+		return nil, fmt.Errorf("error creating k8schain: %w", err)
 	}
 
 	desc, err := remote.Get(ref, remote.WithAuthFromKeychain(kc))

--- a/pkg/reconciler/events/k8sevent/events.go
+++ b/pkg/reconciler/events/k8sevent/events.go
@@ -30,7 +30,7 @@ func CheckEventsOrdered(t *testing.T, eventChan chan string, testName string, wa
 	t.Helper()
 	err := eventsFromChannel(eventChan, wantEvents)
 	if err != nil {
-		return fmt.Errorf("error in test %s: %v", testName, err)
+		return fmt.Errorf("error in test %s: %w", testName, err)
 	}
 	return nil
 }
@@ -65,7 +65,7 @@ func eventsFromChannel(c chan string, wantEvents []string) error {
 					return fmt.Errorf("expected event \"%s\" but got \"%s\" instead", wantEvent, event)
 				}
 			} else {
-				return fmt.Errorf("something went wrong matching the event: %s", err)
+				return fmt.Errorf("something went wrong matching the event: %w", err)
 			}
 		case <-timer:
 			return fmt.Errorf("received %d events but %d expected. Found events: %#v", len(foundEvents), len(wantEvents), foundEvents)

--- a/pkg/reconciler/pipelinerun/affinity_assistant.go
+++ b/pkg/reconciler/pipelinerun/affinity_assistant.go
@@ -63,13 +63,13 @@ func (c *Reconciler) createAffinityAssistants(ctx context.Context, wb []v1beta1.
 				affinityAssistantStatefulSet := affinityAssistantStatefulSet(affinityAssistantName, pr, claimName, c.Images.NopImage, cfg.Defaults.DefaultAAPodTemplate)
 				_, err := c.KubeClientSet.AppsV1().StatefulSets(namespace).Create(ctx, affinityAssistantStatefulSet, metav1.CreateOptions{})
 				if err != nil {
-					errs = append(errs, fmt.Errorf("failed to create StatefulSet %s: %s", affinityAssistantName, err))
+					errs = append(errs, fmt.Errorf("failed to create StatefulSet %s: %w", affinityAssistantName, err))
 				}
 				if err == nil {
 					logger.Infof("Created StatefulSet %s in namespace %s", affinityAssistantName, namespace)
 				}
 			case err != nil:
-				errs = append(errs, fmt.Errorf("failed to retrieve StatefulSet %s: %s", affinityAssistantName, err))
+				errs = append(errs, fmt.Errorf("failed to retrieve StatefulSet %s: %w", affinityAssistantName, err))
 			}
 		}
 	}
@@ -97,7 +97,7 @@ func (c *Reconciler) cleanupAffinityAssistants(ctx context.Context, pr *v1beta1.
 		if w.PersistentVolumeClaim != nil || w.VolumeClaimTemplate != nil {
 			affinityAssistantStsName := getAffinityAssistantName(w.Name, pr.Name)
 			if err := c.KubeClientSet.AppsV1().StatefulSets(pr.Namespace).Delete(ctx, affinityAssistantStsName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
-				errs = append(errs, fmt.Errorf("failed to delete StatefulSet %s: %s", affinityAssistantStsName, err))
+				errs = append(errs, fmt.Errorf("failed to delete StatefulSet %s: %w", affinityAssistantStsName, err))
 			}
 		}
 	}

--- a/pkg/reconciler/pipelinerun/cancel.go
+++ b/pkg/reconciler/pipelinerun/cancel.go
@@ -163,7 +163,7 @@ func cancelPipelineTaskRunsForTaskNames(ctx context.Context, logger *zap.Sugared
 		logger.Infof("cancelling TaskRun %s", taskRunName)
 
 		if err := cancelTaskRun(ctx, taskRunName, pr.Namespace, clientSet); err != nil {
-			errs = append(errs, fmt.Errorf("Failed to patch TaskRun `%s` with cancellation: %s", taskRunName, err).Error())
+			errs = append(errs, fmt.Errorf("Failed to patch TaskRun `%s` with cancellation: %w", taskRunName, err).Error())
 			continue
 		}
 	}
@@ -172,7 +172,7 @@ func cancelPipelineTaskRunsForTaskNames(ctx context.Context, logger *zap.Sugared
 		logger.Infof("cancelling CustomRun %s", runName)
 
 		if err := cancelCustomRun(ctx, runName, pr.Namespace, clientSet); err != nil {
-			errs = append(errs, fmt.Errorf("Failed to patch CustomRun `%s` with cancellation: %s", runName, err).Error())
+			errs = append(errs, fmt.Errorf("Failed to patch CustomRun `%s` with cancellation: %w", runName, err).Error())
 			continue
 		}
 	}
@@ -181,7 +181,7 @@ func cancelPipelineTaskRunsForTaskNames(ctx context.Context, logger *zap.Sugared
 		logger.Infof("cancelling Run %s", runName)
 
 		if err := cancelRun(ctx, runName, pr.Namespace, clientSet); err != nil {
-			errs = append(errs, fmt.Errorf("Failed to patch Run `%s` with cancellation: %s", runName, err).Error())
+			errs = append(errs, fmt.Errorf("Failed to patch Run `%s` with cancellation: %w", runName, err).Error())
 			continue
 		}
 	}

--- a/pkg/reconciler/pipelinerun/resources/pipelineref_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelineref_test.go
@@ -817,7 +817,7 @@ func TestGetVerifiedPipelineFunc_GetFuncError(t *testing.T) {
 			name:        "get error when remote resolution return error",
 			requester:   requesterUnsigned,
 			pipelinerun: *prResolutionError,
-			expectedErr: fmt.Errorf("failed to get pipeline: error accessing data from remote resource: %v", resolvedUnsigned.DataErr),
+			expectedErr: fmt.Errorf("failed to get pipeline: error accessing data from remote resource: %w", resolvedUnsigned.DataErr),
 		},
 	}
 	for _, tc := range testcases {

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
@@ -1934,13 +1934,14 @@ func TestResolvePipelineRun_TaskDoesntExist(t *testing.T) {
 	}
 	for _, pt := range pts {
 		_, err := ResolvePipelineTask(context.Background(), pr, getTask, getTaskRun, nopGetRun, pt)
-		switch err := err.(type) {
-		case nil:
-			t.Fatalf("Expected error getting non-existent Tasks for Pipeline %s but got none", p.Name)
-		case *TaskNotFoundError:
+		var tnf *TaskNotFoundError
+		switch {
+		case err == nil:
+			t.Fatalf("Pipeline %s: want error, got nil", p.Name)
+		case errors.As(err, &tnf):
 			// expected error
 		default:
-			t.Fatalf("Expected specific error type returned by func for non-existent Task for Pipeline %s but got %s", p.Name, err)
+			t.Fatalf("Pipeline %s: Want %T, got %s of type %T", p.Name, tnf, err, err)
 		}
 	}
 }
@@ -1976,7 +1977,7 @@ func TestResolvePipelineRun_VerificationFailed(t *testing.T) {
 		if err == nil {
 			t.Errorf("expected to get err but got nil")
 		}
-		if err != trustedresources.ErrResourceVerificationFailed {
+		if !errors.Is(err, trustedresources.ErrResourceVerificationFailed) {
 			t.Errorf("expected to get %v but got %v", trustedresources.ErrResourceVerificationFailed, err)
 		}
 	}

--- a/pkg/reconciler/pipelinerun/resources/validate_dependencies.go
+++ b/pkg/reconciler/pipelinerun/resources/validate_dependencies.go
@@ -32,7 +32,7 @@ func ValidatePipelineTaskResults(state PipelineRunState) error {
 	for _, rpt := range state {
 		for _, ref := range v1beta1.PipelineTaskResultRefs(rpt.PipelineTask) {
 			if err := validateResultRef(ref, ptMap); err != nil {
-				return fmt.Errorf("invalid result reference in pipeline task %q: %s", rpt.PipelineTask.Name, err)
+				return fmt.Errorf("invalid result reference in pipeline task %q: %w", rpt.PipelineTask.Name, err)
 			}
 		}
 	}
@@ -50,7 +50,7 @@ func ValidatePipelineResults(ps *v1beta1.PipelineSpec, state PipelineRunState) e
 		refs := v1beta1.NewResultRefs(expressions)
 		for _, ref := range refs {
 			if err := validateResultRef(ref, ptMap); err != nil {
-				return fmt.Errorf("invalid pipeline result %q: %s", result.Name, err)
+				return fmt.Errorf("invalid pipeline result %q: %w", result.Name, err)
 			}
 		}
 	}

--- a/pkg/reconciler/pipelinerun/timeout.go
+++ b/pkg/reconciler/pipelinerun/timeout.go
@@ -139,7 +139,7 @@ func timeoutPipelineTasksForTaskNames(ctx context.Context, logger *zap.SugaredLo
 		logger.Infof("cancelling TaskRun %s for timeout", taskRunName)
 
 		if _, err := clientSet.TektonV1beta1().TaskRuns(pr.Namespace).Patch(ctx, taskRunName, types.JSONPatchType, timeoutTaskRunPatchBytes, metav1.PatchOptions{}, ""); err != nil {
-			errs = append(errs, fmt.Errorf("Failed to patch TaskRun `%s` with cancellation: %s", taskRunName, err).Error())
+			errs = append(errs, fmt.Errorf("Failed to patch TaskRun `%s` with cancellation: %w", taskRunName, err).Error())
 			continue
 		}
 	}
@@ -148,7 +148,7 @@ func timeoutPipelineTasksForTaskNames(ctx context.Context, logger *zap.SugaredLo
 		logger.Infof("cancelling CustomRun %s for timeout", custonRunName)
 
 		if err := timeoutCustomRun(ctx, custonRunName, pr.Namespace, clientSet); err != nil {
-			errs = append(errs, fmt.Errorf("Failed to patch CustomRun `%s` with cancellation: %s", custonRunName, err).Error())
+			errs = append(errs, fmt.Errorf("Failed to patch CustomRun `%s` with cancellation: %w", custonRunName, err).Error())
 			continue
 		}
 	}
@@ -157,7 +157,7 @@ func timeoutPipelineTasksForTaskNames(ctx context.Context, logger *zap.SugaredLo
 		logger.Infof("cancelling Run %s for timeout", runName)
 
 		if err := timeoutRun(ctx, runName, pr.Namespace, clientSet); err != nil {
-			errs = append(errs, fmt.Errorf("Failed to patch Run `%s` with cancellation: %s", runName, err).Error())
+			errs = append(errs, fmt.Errorf("Failed to patch Run `%s` with cancellation: %w", runName, err).Error())
 			continue
 		}
 	}

--- a/pkg/reconciler/taskrun/resources/taskref_test.go
+++ b/pkg/reconciler/taskrun/resources/taskref_test.go
@@ -1022,7 +1022,7 @@ func TestGetVerifiedTaskFunc_GetFuncError(t *testing.T) {
 			name:        "get error when remote resolution return error",
 			requester:   requesterUnsigned,
 			taskrun:     *trResolutionError,
-			expectedErr: fmt.Errorf("failed to get task: error accessing data from remote resource: %v", resolvedUnsigned.DataErr),
+			expectedErr: fmt.Errorf("failed to get task: error accessing data from remote resource: %w", resolvedUnsigned.DataErr),
 		},
 	}
 	for _, tc := range testcases {

--- a/pkg/reconciler/volumeclaim/pvchandler.go
+++ b/pkg/reconciler/volumeclaim/pvchandler.go
@@ -63,7 +63,7 @@ func (c *defaultPVCHandler) CreatePersistentVolumeClaimsForWorkspaces(ctx contex
 		case apierrors.IsNotFound(err):
 			_, err := c.clientset.CoreV1().PersistentVolumeClaims(claim.Namespace).Create(ctx, claim, metav1.CreateOptions{})
 			if err != nil && !apierrors.IsAlreadyExists(err) {
-				errs = append(errs, fmt.Errorf("failed to create PVC %s: %s", claim.Name, err))
+				errs = append(errs, fmt.Errorf("failed to create PVC %s: %w", claim.Name, err))
 			}
 
 			if apierrors.IsAlreadyExists(err) {
@@ -75,7 +75,7 @@ func (c *defaultPVCHandler) CreatePersistentVolumeClaimsForWorkspaces(ctx contex
 				c.logger.Infof("Created PersistentVolumeClaim %s in namespace %s", claim.Name, claim.Namespace)
 			}
 		case err != nil:
-			errs = append(errs, fmt.Errorf("failed to retrieve PVC %s: %s", claim.Name, err))
+			errs = append(errs, fmt.Errorf("failed to retrieve PVC %s: %w", claim.Name, err))
 		}
 	}
 	return errorutils.NewAggregate(errs)

--- a/pkg/remote/oci/resolver.go
+++ b/pkg/remote/oci/resolver.go
@@ -19,6 +19,7 @@ package oci
 import (
 	"archive/tar"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -192,7 +193,7 @@ func readTarLayer(layer v1.Layer) (runtime.Object, error) {
 	}
 
 	contents := make([]byte, header.Size)
-	if _, err := treader.Read(contents); err != nil && err != io.EOF {
+	if _, err := treader.Read(contents); err != nil && !errors.Is(err, io.EOF) {
 		// We only allow 1 resource per layer so this tar bundle should have one and only one file.
 		return nil, fmt.Errorf("failed to read tar bundle: %w", err)
 	}

--- a/pkg/remote/resolution/error.go
+++ b/pkg/remote/resolution/error.go
@@ -60,9 +60,8 @@ func (e *InvalidRuntimeObjectError) Unwrap() error {
 }
 
 // Is returns true if the given error coerces into an error of this type.
-func (*InvalidRuntimeObjectError) Is(e error) bool {
-	_, ok := e.(*InvalidRuntimeObjectError)
-	return ok
+func (e *InvalidRuntimeObjectError) Is(that error) bool {
+	return errors.As(that, &e)
 }
 
 // DataAccessError is returned when remote resolution succeeded but
@@ -93,7 +92,6 @@ func (e *DataAccessError) Unwrap() error {
 }
 
 // Is returns true if the given error coerces into an error of this type.
-func (*DataAccessError) Is(e error) bool {
-	_, ok := e.(*DataAccessError)
-	return ok
+func (e *DataAccessError) Is(that error) bool {
+	return errors.As(that, &e)
 }

--- a/pkg/resolution/common/errors.go
+++ b/pkg/resolution/common/errors.go
@@ -157,7 +157,8 @@ func ReasonError(err error) (string, error) {
 	reason := ReasonResolutionFailed
 	resolutionError := err
 
-	if e, ok := err.(*Error); ok {
+	var e *Error
+	if errors.As(err, &e) {
 		reason = e.Reason
 		resolutionError = e.Unwrap()
 	}

--- a/pkg/resolution/resolver/bundle/bundle.go
+++ b/pkg/resolution/resolver/bundle/bundle.go
@@ -16,6 +16,7 @@ package bundle
 import (
 	"archive/tar"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -193,7 +194,7 @@ func readTarLayer(layer v1.Layer) ([]byte, error) {
 	}
 
 	contents := make([]byte, header.Size)
-	if _, err := treader.Read(contents); err != nil && err != io.EOF {
+	if _, err := treader.Read(contents); err != nil && !errors.Is(err, io.EOF) {
 		// We only allow 1 resource per layer so this tar bundle should have one and only one file.
 		return nil, fmt.Errorf("failed to read tar bundle: %w", err)
 	}

--- a/pkg/resolution/resolver/git/resolver.go
+++ b/pkg/resolution/resolver/git/resolver.go
@@ -227,38 +227,38 @@ func (r *Resolver) resolveAnonymousGit(ctx context.Context, params map[string]st
 	if err != nil {
 		var fetchErr git.NoMatchingRefSpecError
 		if !errors.As(err, &fetchErr) {
-			return nil, fmt.Errorf("unexpected fetch error: %v", err)
+			return nil, fmt.Errorf("unexpected fetch error: %w", err)
 		}
 	}
 
 	w, err := repository.Worktree()
 	if err != nil {
-		return nil, fmt.Errorf("worktree error: %v", err)
+		return nil, fmt.Errorf("worktree error: %w", err)
 	}
 
 	h, err := repository.ResolveRevision(plumbing.Revision(revision))
 	if err != nil {
-		return nil, fmt.Errorf("revision error: %v", err)
+		return nil, fmt.Errorf("revision error: %w", err)
 	}
 
 	err = w.Checkout(&git.CheckoutOptions{
 		Hash: *h,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("checkout error: %v", err)
+		return nil, fmt.Errorf("checkout error: %w", err)
 	}
 
 	path := params[pathParam]
 
 	f, err := filesystem.Open(path)
 	if err != nil {
-		return nil, fmt.Errorf("error opening file %q: %v", path, err)
+		return nil, fmt.Errorf("error opening file %q: %w", path, err)
 	}
 
 	buf := &bytes.Buffer{}
 	_, err = io.Copy(buf, f)
 	if err != nil {
-		return nil, fmt.Errorf("error reading file %q: %v", path, err)
+		return nil, fmt.Errorf("error reading file %q: %w", path, err)
 	}
 
 	return &resolvedGitResource{

--- a/pkg/resolution/resolver/hub/resolver.go
+++ b/pkg/resolution/resolver/hub/resolver.go
@@ -82,10 +82,10 @@ func (r *Resolver) ValidateParams(ctx context.Context, params []pipelinev1beta1.
 
 	paramsMap, err := populateDefaultParams(ctx, params)
 	if err != nil {
-		return fmt.Errorf("failed to populate default params: %v", err)
+		return fmt.Errorf("failed to populate default params: %w", err)
 	}
 	if err := r.validateParams(ctx, paramsMap); err != nil {
-		return fmt.Errorf("failed to validate params: %v", err)
+		return fmt.Errorf("failed to validate params: %w", err)
 	}
 
 	return nil
@@ -115,10 +115,10 @@ func (r *Resolver) Resolve(ctx context.Context, params []pipelinev1beta1.Param) 
 
 	paramsMap, err := populateDefaultParams(ctx, params)
 	if err != nil {
-		return nil, fmt.Errorf("failed to populate default params: %v", err)
+		return nil, fmt.Errorf("failed to populate default params: %w", err)
 	}
 	if err := r.validateParams(ctx, paramsMap); err != nil {
-		return nil, fmt.Errorf("failed to validate params: %v", err)
+		return nil, fmt.Errorf("failed to validate params: %w", err)
 	}
 
 	resVer, err := resolveVersion(paramsMap[ParamVersion], paramsMap[ParamType])
@@ -133,7 +133,7 @@ func (r *Resolver) Resolve(ctx context.Context, params []pipelinev1beta1.Param) 
 		url := fmt.Sprintf(r.ArtifactHubURL, paramsMap[ParamKind], paramsMap[ParamCatalog], paramsMap[ParamName], paramsMap[ParamVersion])
 		resp := artifactHubResponse{}
 		if err := fetchHubResource(url, &resp); err != nil {
-			return nil, fmt.Errorf("fail to fetch Artifact Hub resource: %v", err)
+			return nil, fmt.Errorf("fail to fetch Artifact Hub resource: %w", err)
 		}
 		return &ResolvedHubResource{
 			URL:     url,
@@ -143,7 +143,7 @@ func (r *Resolver) Resolve(ctx context.Context, params []pipelinev1beta1.Param) 
 		url := fmt.Sprintf(r.TektonHubURL, paramsMap[ParamCatalog], paramsMap[ParamKind], paramsMap[ParamName], paramsMap[ParamVersion])
 		resp := tektonHubResponse{}
 		if err := fetchHubResource(url, &resp); err != nil {
-			return nil, fmt.Errorf("fail to fetch Tekton Hub resource: %v", err)
+			return nil, fmt.Errorf("fail to fetch Tekton Hub resource: %w", err)
 		}
 		return &ResolvedHubResource{
 			URL:     url,

--- a/pkg/substitution/substitution.go
+++ b/pkg/substitution/substitution.go
@@ -276,7 +276,7 @@ func extractEntireVariablesFromString(s, prefix string) ([]string, error) {
 	pattern := fmt.Sprintf(braceMatchingRegex, prefix, parameterSubstitution, parameterSubstitution, parameterSubstitution)
 	re, err := regexp.Compile(pattern)
 	if err != nil {
-		return nil, fmt.Errorf("Fail to parse regex pattern: %v", err)
+		return nil, fmt.Errorf("Fail to parse regex pattern: %w", err)
 	}
 
 	matches := re.FindAllStringSubmatch(s, -1)

--- a/pkg/termination/parse.go
+++ b/pkg/termination/parse.go
@@ -36,7 +36,7 @@ func ParseMessage(logger *zap.SugaredLogger, msg string) ([]v1beta1.PipelineReso
 
 	var r []v1beta1.PipelineResourceResult
 	if err := json.Unmarshal([]byte(msg), &r); err != nil {
-		return nil, fmt.Errorf("parsing message json: %v, msg: %s", err, msg)
+		return nil, fmt.Errorf("parsing message json: %w, msg: %s", err, msg)
 	}
 
 	for i, rr := range r {

--- a/pkg/trustedresources/verifier/verifier.go
+++ b/pkg/trustedresources/verifier/verifier.go
@@ -97,7 +97,7 @@ func fromKeyRef(ctx context.Context, keyRef string, hashAlgorithm crypto.Hash, k
 	}
 	raw, err := os.ReadFile(filepath.Clean(keyRef))
 	if err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrFailedLoadKeyFile, err)
+		return nil, fmt.Errorf("%w: %v", ErrFailedLoadKeyFile, err) // nolint -- needs errorlint cleanup
 	}
 	v, err := fromData(raw, hashAlgorithm)
 	if err != nil {
@@ -136,11 +136,11 @@ func fromSecret(ctx context.Context, secretRef string, hashAlgorithm crypto.Hash
 func fromData(raw []byte, hashAlgorithm crypto.Hash) (signature.Verifier, error) {
 	pubKey, err := cryptoutils.UnmarshalPEMToPublicKey(raw)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrDecodeKey, err)
+		return nil, fmt.Errorf("%w: %v", ErrDecodeKey, err) // nolint -- needs errorlint cleanup
 	}
 	v, err := signature.LoadVerifier(pubKey, hashAlgorithm)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrLoadVerifier, err)
+		return nil, fmt.Errorf("%w: %v", ErrLoadVerifier, err) // nolint -- needs errorlint cleanup
 	}
 	return v, nil
 }
@@ -156,7 +156,7 @@ func getKeyPairSecret(ctx context.Context, k8sRef string, k8s kubernetes.Interfa
 
 	s, err := k8s.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrSecretNotFound, err)
+		return nil, fmt.Errorf("%w: %v", ErrSecretNotFound, err) // nolint -- needs errorlint cleanup
 	}
 
 	return s, nil

--- a/pkg/trustedresources/verify.go
+++ b/pkg/trustedresources/verify.go
@@ -119,7 +119,7 @@ func getMatchedPolicies(resourceName string, source string, policies []*v1alpha1
 		for _, r := range p.Spec.Resources {
 			matching, err := regexp.MatchString(r.Pattern, source)
 			if err != nil {
-				return matchedPolicies, fmt.Errorf("%v: %w", err, ErrRegexMatch)
+				return matchedPolicies, fmt.Errorf("%v: %w", err, ErrRegexMatch) // nolint -- needs errorlint cleanup
 			}
 			if matching {
 				matchedPolicies = append(matchedPolicies, p)
@@ -177,7 +177,7 @@ func verifyInterface(obj interface{}, verifier signature.Verifier, signature []b
 	h.Write(ts)
 
 	if err := verifier.VerifySignature(bytes.NewReader(signature), bytes.NewReader(h.Sum(nil))); err != nil {
-		return fmt.Errorf("%w:%v", ErrResourceVerificationFailed, err.Error())
+		return fmt.Errorf("%w:%v", ErrResourceVerificationFailed, err.Error()) // nolint -- needs errorlint cleanup
 	}
 
 	return nil

--- a/pkg/workspace/validate.go
+++ b/pkg/workspace/validate.go
@@ -31,7 +31,7 @@ func ValidateBindings(ctx context.Context, decls []v1beta1.WorkspaceDeclaration,
 	// reason we'll invoke the same validation here.
 	for _, b := range binds {
 		if err := b.Validate(ctx); err != nil {
-			return fmt.Errorf("binding %q is invalid: %v", b.Name, err)
+			return fmt.Errorf("binding %q is invalid: %w", b.Name, err)
 		}
 	}
 

--- a/test/init_test.go
+++ b/test/init_test.go
@@ -293,7 +293,7 @@ func getCRDYaml(ctx context.Context, cs *clients, ns string) ([]byte, error) {
 
 	v1alpha1Runs, err := cs.V1alpha1RunClient.List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("could not get v1alpha1 runs: %v", err)
+		return nil, fmt.Errorf("could not get v1alpha1 runs: %w", err)
 	}
 	for _, i := range v1alpha1Runs.Items {
 		i.SetManagedFields(nil)
@@ -302,7 +302,7 @@ func getCRDYaml(ctx context.Context, cs *clients, ns string) ([]byte, error) {
 
 	v1beta1CustomRuns, err := cs.V1beta1CustomRunClient.List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("could not get v1beta1 customruns: %v", err)
+		return nil, fmt.Errorf("could not get v1beta1 customruns: %w", err)
 	}
 	for _, i := range v1beta1CustomRuns.Items {
 		i.SetManagedFields(nil)

--- a/test/remote_test.go
+++ b/test/remote_test.go
@@ -18,6 +18,7 @@ package test
 
 import (
 	"archive/tar"
+	"errors"
 	"io"
 	"net/http/httptest"
 	"net/url"
@@ -94,7 +95,7 @@ metadata:
 	}
 
 	actual := make([]byte, header.Size)
-	if _, err := reader.Read(actual); err != nil && err != io.EOF {
+	if _, err := reader.Read(actual); err != nil && !errors.Is(err, io.EOF) {
 		t.Errorf("failed to read contents of tar bundle: %v", err)
 	}
 


### PR DESCRIPTION
There are no expected functional changes in this PR.

Made non-functional code changes to adhere to Golang error standards.

Added `// nolint` pragmas in 4 files that violate existing Golang error conventions; @Yongxuanzhang is fixing those issues separately.

Context: https://github.com/tektoncd/pipeline/issues/5899

See related style docs:
- https://pkg.go.dev/errors
- https://go.dev/blog/go1.13-errors
- https://go.dev/blog/errors-are-values

/kind cleanup

- [N/A] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [N/A] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [N/A] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [N/A] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

```release-note
NONE
```
