### PR TITLE
TEP-0118: Implement Fanning Out logic to support Matrix Include Parameters in a Task Run

### DIFF
--- a/docs/pipeline-api.md
+++ b/docs/pipeline-api.md
@@ -1481,8 +1481,7 @@ TaskSpec
 <h3 id="tekton.dev/v1.IncludeParams">IncludeParams
 </h3>
 <div>
-<p>IncludeParams allows passing in a specific combinations of Parameters into the Matrix.
-Note this struct is in preview mode and not yet supported</p>
+<p>IncludeParams allows passing in a specific combinations of Parameters into the Matrix.</p>
 </div>
 <table>
 <thead>
@@ -1562,8 +1561,7 @@ IncludeParamsList
 </td>
 <td>
 <em>(Optional)</em>
-<p>Include is a list of IncludeParams which allows passing in specific combinations of Parameters into the Matrix.
-Note that Include is in preview mode and not yet supported.</p>
+<p>Include is a list of IncludeParams which allows passing in specific combinations of Parameters into the Matrix.</p>
 </td>
 </tr>
 </tbody>
@@ -8614,8 +8612,7 @@ TaskSpec
 <h3 id="tekton.dev/v1beta1.IncludeParams">IncludeParams
 </h3>
 <div>
-<p>IncludeParams allows passing in a specific combinations of Parameters into the Matrix.
-Note this struct is in preview mode and not yet supported</p>
+<p>IncludeParams allows passing in a specific combinations of Parameters into the Matrix.</p>
 </div>
 <table>
 <thead>
@@ -8695,8 +8692,7 @@ IncludeParamsList
 </td>
 <td>
 <em>(Optional)</em>
-<p>Include is a list of IncludeParams which allows passing in specific combinations of Parameters into the Matrix.
-Note that Include is in preview mode and not yet supported.</p>
+<p>Include is a list of IncludeParams which allows passing in specific combinations of Parameters into the Matrix.</p>
 </td>
 </tr>
 </tbody>

--- a/examples/v1beta1/pipelineruns/alpha/pipelinerun-with-matrix-include-explicit.yaml
+++ b/examples/v1beta1/pipelineruns/alpha/pipelinerun-with-matrix-include-explicit.yaml
@@ -1,0 +1,48 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: mytask
+  annotations:
+    description: |
+      A task that echoes image and dockerfile
+spec:
+  params:
+    - name: IMAGE
+    - name: DOCKERFILE
+  steps:
+    - name: echo
+      image: alpine
+      script: |
+        echo "$(params.IMAGE) and $(params.DOCKERFILE)"
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: explicit-combos
+spec:
+  serviceAccountName: 'default'
+  pipelineSpec:
+    tasks:
+      - name: matrix-include
+        matrix:
+          include:
+            - name: build-1
+              params:
+                - name: IMAGE
+                  value: image-1
+                - name: DOCKERFILE
+                  value: path/to/Dockerfile1
+            - name: build-2
+              params:
+                - name: IMAGE
+                  value: image-2
+                - name: DOCKERFILE
+                  value: path/to/Dockerfile2
+            - name: build-3
+              params:
+                - name: IMAGE
+                  value: image-3
+                - name: DOCKERFILE
+                  value: path/to/Dockerfile3
+        taskRef:
+          name: mytask

--- a/examples/v1beta1/pipelineruns/alpha/pipelinerun-with-matrix-include.yaml
+++ b/examples/v1beta1/pipelineruns/alpha/pipelinerun-with-matrix-include.yaml
@@ -1,0 +1,68 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: mytask
+  annotations:
+    description: |
+      A task that does something cool with GOARCH and version
+spec:
+  params:
+    - name: GOARCH
+      default: ''
+    - name: version
+      default: ''
+    - name: flags
+      default: ''
+    - name: context
+      default: ''
+    - name: package
+      default: ''
+  steps:
+    - name: echo
+      image: alpine
+      script: |
+        echo $(params.GOARCH) and $(params.version) flags? $(params.flags) context? $(params.context) package? $(params.package)
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: matrixed-include-pr
+spec:
+  serviceAccountName: default
+  pipelineSpec:
+    tasks:
+      - name: matrix-include
+        matrix:
+          params:
+            - name: GOARCH
+              value:
+                - linux/amd64
+                - linux/ppc64le
+                - linux/s390x
+            - name: version
+              value:
+                - go1.17
+                - go1.18.1
+          include:
+            - name: common-package
+              params:
+                - name: package
+                  value: path/to/common/package/
+            - name: s390x-no-race
+              params:
+                - name: GOARCH
+                  value: linux/s390x
+                - name: flags
+                  value: '-cover -v'
+            - name: go117-context
+              params:
+                - name: version
+                  value: go1.17
+                - name: context
+                  value: path/to/go117/context
+            - name: non-existent-arch
+              params:
+                - name: GOARCH
+                  value: I-do-not-exist
+        taskRef:
+          name: mytask

--- a/pkg/apis/pipeline/v1/matrix_types_test.go
+++ b/pkg/apis/pipeline/v1/matrix_types_test.go
@@ -114,7 +114,474 @@ func TestMatrix_FanOut(t *testing.T) {
 				Value: ParamValue{Type: ParamTypeString, StringVal: "go1.18.1"},
 			},
 		}},
-	}}
+	}, {
+		name: "Fan out explicit combinations, no matrix params",
+		matrix: Matrix{
+			Include: IncludeParamsList{{
+				Name: "build-1",
+				Params: []Param{{
+					Name: "IMAGE", Value: ParamValue{Type: ParamTypeString, StringVal: "image-1"},
+				}, {
+					Name: "DOCKERFILE", Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/Dockerfile1"}}},
+			}, {
+				Name: "build-2",
+				Params: []Param{{
+					Name: "IMAGE", Value: ParamValue{Type: ParamTypeString, StringVal: "image-2"},
+				}, {
+					Name: "DOCKERFILE", Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/Dockerfile2"}}},
+			}, {
+				Name: "build-3",
+				Params: []Param{{
+					Name: "IMAGE", Value: ParamValue{Type: ParamTypeString, StringVal: "image-3"},
+				}, {
+					Name: "DOCKERFILE", Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/Dockerfile3"}}},
+			}},
+		},
+		want: []Params{{
+			{
+				Name:  "DOCKERFILE",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/Dockerfile1"},
+			}, {
+				Name:  "IMAGE",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "image-1"},
+			},
+		}, {
+			{
+				Name:  "DOCKERFILE",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/Dockerfile2"},
+			}, {
+				Name:  "IMAGE",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "image-2"},
+			},
+		}, {
+			{
+				Name:  "DOCKERFILE",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/Dockerfile3"},
+			}, {
+				Name:  "IMAGE",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "image-3"},
+			},
+		}},
+	}, {
+		name: "matrix include unknown param name, append to all combinations",
+		matrix: Matrix{
+			Params: Params{{
+				Name: "GOARCH", Value: ParamValue{ArrayVal: []string{"linux/amd64", "linux/ppc64le", "linux/s390x"}},
+			}, {
+				Name: "version", Value: ParamValue{ArrayVal: []string{"go1.17", "go1.18.1"}}},
+			},
+			Include: IncludeParamsList{{
+				Name: "common-package",
+				Params: Params{{
+					Name: "package", Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/common/package/"}}},
+			}},
+		},
+		want: []Params{{
+			{
+				Name:  "GOARCH",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "linux/amd64"},
+			}, {
+				Name:  "package",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/common/package/"},
+			}, {
+				Name:  "version",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "go1.17"},
+			},
+		}, {
+			{
+				Name:  "GOARCH",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "linux/ppc64le"},
+			}, {
+				Name:  "package",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/common/package/"},
+			}, {
+				Name:  "version",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "go1.17"},
+			},
+		}, {
+			{
+				Name:  "GOARCH",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "linux/s390x"},
+			}, {
+				Name:  "package",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/common/package/"},
+			}, {
+				Name:  "version",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "go1.17"},
+			},
+		}, {
+			{
+				Name:  "GOARCH",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "linux/amd64"},
+			}, {
+				Name:  "package",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/common/package/"},
+			}, {
+				Name:  "version",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "go1.18.1"},
+			},
+		}, {
+			{
+				Name:  "GOARCH",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "linux/ppc64le"},
+			}, {
+				Name:  "package",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/common/package/"},
+			}, {
+				Name:  "version",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "go1.18.1"},
+			},
+		}, {
+			{
+				Name:  "GOARCH",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "linux/s390x"},
+			}, {
+				Name:  "package",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/common/package/"},
+			}, {
+				Name:  "version",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "go1.18.1"},
+			},
+		}},
+	}, {
+		name: "matrix include param value does not exist, generate a new combination",
+		matrix: Matrix{
+			Params: Params{{
+				Name: "GOARCH", Value: ParamValue{ArrayVal: []string{"linux/amd64", "linux/ppc64le", "linux/s390x"}},
+			}, {
+				Name: "version", Value: ParamValue{ArrayVal: []string{"go1.17", "go1.18.1"}}},
+			},
+			Include: IncludeParamsList{{
+				Name: "non-existent-arch",
+				Params: Params{{
+					Name: "GOARCH", Value: ParamValue{Type: ParamTypeString, StringVal: "I-do-not-exist"}}},
+			}},
+		},
+		want: []Params{{
+			{
+				Name:  "GOARCH",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "linux/amd64"},
+			}, {
+				Name:  "version",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "go1.17"},
+			},
+		}, {
+			{
+				Name:  "GOARCH",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "linux/ppc64le"},
+			}, {
+				Name:  "version",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "go1.17"},
+			},
+		}, {
+			{
+				Name:  "GOARCH",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "linux/s390x"},
+			}, {
+				Name:  "version",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "go1.17"},
+			},
+		}, {
+			{
+				Name:  "GOARCH",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "linux/amd64"},
+			}, {
+				Name:  "version",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "go1.18.1"},
+			},
+		}, {
+			{
+				Name:  "GOARCH",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "linux/ppc64le"},
+			}, {
+				Name:  "version",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "go1.18.1"},
+			},
+		}, {
+			{
+				Name:  "GOARCH",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "linux/s390x"},
+			}, {
+				Name:  "version",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "go1.18.1"},
+			},
+		}, {
+			{
+				Name:  "GOARCH",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "I-do-not-exist"},
+			},
+		}},
+	}, {
+		name: "Matrix include filters single parameter and appends missing values",
+		matrix: Matrix{
+			Params: Params{{
+				Name: "GOARCH", Value: ParamValue{ArrayVal: []string{"linux/amd64", "linux/ppc64le", "linux/s390x"}},
+			}, {
+				Name: "version", Value: ParamValue{ArrayVal: []string{"go1.17", "go1.18.1"}}},
+			},
+			Include: IncludeParamsList{{
+				Name: "s390x-no-race",
+				Params: []Param{{
+					Name: "GOARCH", Value: ParamValue{Type: ParamTypeString, StringVal: "linux/s390x"},
+				}, {
+					Name: "flags", Value: ParamValue{Type: ParamTypeString, StringVal: "-cover -v"}}},
+			}},
+		},
+		want: []Params{{
+			{
+				Name:  "GOARCH",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "linux/amd64"},
+			}, {
+				Name:  "version",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "go1.17"},
+			},
+		}, {
+			{
+				Name:  "GOARCH",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "linux/ppc64le"},
+			}, {
+				Name:  "version",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "go1.17"},
+			},
+		}, {
+
+			{
+				Name:  "GOARCH",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "linux/s390x"},
+			}, {
+				Name:  "flags",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "-cover -v"},
+			}, {
+				Name:  "version",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "go1.17"},
+			},
+		}, {
+			{
+				Name:  "GOARCH",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "linux/amd64"},
+			}, {
+				Name:  "version",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "go1.18.1"},
+			},
+		}, {
+			{
+				Name:  "GOARCH",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "linux/ppc64le"},
+			}, {
+				Name:  "version",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "go1.18.1"},
+			},
+		}, {
+			{
+				Name:  "GOARCH",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "linux/s390x"},
+			}, {
+				Name:  "flags",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "-cover -v"},
+			}, {
+				Name:  "version",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "go1.18.1"},
+			},
+		}},
+	},
+		{
+			name: "Matrix include filters multiple parameters and append new parameters",
+			matrix: Matrix{
+				Params: Params{{
+					Name: "GOARCH", Value: ParamValue{ArrayVal: []string{"linux/amd64", "linux/ppc64le", "linux/s390x"}},
+				}, {
+					Name: "version", Value: ParamValue{ArrayVal: []string{"go1.17", "go1.18.1"}}},
+				},
+				Include: IncludeParamsList{
+					{
+						Name: "390x-no-race",
+						Params: Params{{
+							Name: "GOARCH", Value: ParamValue{Type: ParamTypeString, StringVal: "linux/s390x"}}, {
+							Name: "flags", Value: ParamValue{Type: ParamTypeString, StringVal: "-cover -v"}}, {
+							Name: "version", Value: ParamValue{Type: ParamTypeString, StringVal: "go1.18.1"}}},
+					},
+					{
+						Name: "amd64-no-race",
+						Params: Params{{
+							Name: "GOARCH", Value: ParamValue{Type: ParamTypeString, StringVal: "linux/amd64"}}, {
+							Name: "flags", Value: ParamValue{Type: ParamTypeString, StringVal: "-cover -v"}}, {
+							Name: "version", Value: ParamValue{Type: ParamTypeString, StringVal: "go1.17"}}},
+					},
+				},
+			},
+			want: []Params{{
+				{
+					Name:  "GOARCH",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "linux/amd64"},
+				}, {
+					Name:  "flags",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "-cover -v"},
+				}, {
+					Name:  "version",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "go1.17"},
+				},
+			}, {
+				{
+					Name:  "GOARCH",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "linux/ppc64le"},
+				}, {
+					Name:  "version",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "go1.17"},
+				},
+			}, {
+				{
+					Name:  "GOARCH",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "linux/s390x"},
+				}, {
+					Name:  "version",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "go1.17"},
+				},
+			}, {
+				{
+					Name:  "GOARCH",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "linux/amd64"},
+				}, {
+					Name:  "version",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "go1.18.1"},
+				},
+			}, {
+				{
+					Name:  "GOARCH",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "linux/ppc64le"},
+				}, {
+					Name:  "version",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "go1.18.1"},
+				},
+			}, {
+				{
+					Name:  "GOARCH",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "linux/s390x"},
+				}, {
+					Name:  "flags",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "-cover -v"},
+				}, {
+					Name:  "version",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "go1.18.1"},
+				},
+			}},
+		}, {
+			name: "Matrix params and include params handles filter, appending, and generating new combinations at once",
+			matrix: Matrix{
+				Params: Params{{
+					Name: "GOARCH", Value: ParamValue{ArrayVal: []string{"linux/amd64", "linux/ppc64le", "linux/s390x"}},
+				}, {
+					Name: "version", Value: ParamValue{ArrayVal: []string{"go1.17", "go1.18.1"}}},
+				},
+				Include: IncludeParamsList{{
+					Name: "common-package",
+					Params: []Param{{
+						Name: "package", Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/common/package/"}}},
+				}, {
+					Name: "s390x-no-race",
+					Params: []Param{{
+						Name: "GOARCH", Value: ParamValue{Type: ParamTypeString, StringVal: "linux/s390x"},
+					}, {
+						Name: "flags", Value: ParamValue{Type: ParamTypeString, StringVal: "-cover -v"}}},
+				}, {
+					Name: "go117-context",
+					Params: []Param{{
+						Name: "version", Value: ParamValue{Type: ParamTypeString, StringVal: "go1.17"},
+					}, {
+						Name: "context", Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/go117/context"}}},
+				}, {
+					Name: "non-existent-arch",
+					Params: []Param{{
+						Name: "GOARCH", Value: ParamValue{Type: ParamTypeString, StringVal: "I-do-not-exist"}},
+					},
+				}},
+			},
+			want: []Params{{
+				{
+					Name:  "GOARCH",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "linux/amd64"},
+				}, {
+					Name:  "context",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/go117/context"},
+				}, {
+					Name:  "package",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/common/package/"},
+				}, {
+					Name:  "version",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "go1.17"},
+				},
+			}, {
+				{
+					Name:  "GOARCH",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "linux/ppc64le"},
+				}, {
+					Name:  "context",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/go117/context"},
+				}, {
+					Name:  "package",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/common/package/"},
+				}, {
+					Name:  "version",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "go1.17"},
+				},
+			}, {
+				{
+					Name:  "GOARCH",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "linux/s390x"},
+				}, {
+					Name:  "context",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/go117/context"},
+				}, {
+					Name:  "flags",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "-cover -v"},
+				}, {
+					Name:  "package",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/common/package/"},
+				}, {
+					Name:  "version",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "go1.17"},
+				},
+			}, {
+				{
+					Name:  "GOARCH",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "linux/amd64"},
+				}, {
+					Name:  "package",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/common/package/"}}, {
+					Name:  "version",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "go1.18.1"},
+				},
+			}, {
+				{
+					Name:  "GOARCH",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "linux/ppc64le"},
+				}, {
+					Name:  "package",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/common/package/"},
+				}, {
+					Name:  "version",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "go1.18.1"},
+				},
+			}, {
+				{
+					Name:  "GOARCH",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "linux/s390x"},
+				}, {
+					Name:  "flags",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "-cover -v"},
+				}, {
+					Name:  "package",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/common/package/"},
+				}, {
+					Name:  "version",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "go1.18.1"},
+				},
+			}, {
+				{
+					Name:  "GOARCH",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "I-do-not-exist"},
+				},
+			}},
+		}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if d := cmp.Diff(tt.want, tt.matrix.FanOut()); d != "" {

--- a/pkg/apis/pipeline/v1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1/openapi_generated.go
@@ -654,7 +654,7 @@ func schema_pkg_apis_pipeline_v1_IncludeParams(ref common.ReferenceCallback) com
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "IncludeParams allows passing in a specific combinations of Parameters into the Matrix. Note this struct is in preview mode and not yet supported",
+				Description: "IncludeParams allows passing in a specific combinations of Parameters into the Matrix.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"name": {
@@ -724,7 +724,7 @@ func schema_pkg_apis_pipeline_v1_Matrix(ref common.ReferenceCallback) common.Ope
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Include is a list of IncludeParams which allows passing in specific combinations of Parameters into the Matrix. Note that Include is in preview mode and not yet supported.",
+							Description: "Include is a list of IncludeParams which allows passing in specific combinations of Parameters into the Matrix.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{

--- a/pkg/apis/pipeline/v1/swagger.json
+++ b/pkg/apis/pipeline/v1/swagger.json
@@ -286,7 +286,7 @@
       }
     },
     "v1.IncludeParams": {
-      "description": "IncludeParams allows passing in a specific combinations of Parameters into the Matrix. Note this struct is in preview mode and not yet supported",
+      "description": "IncludeParams allows passing in a specific combinations of Parameters into the Matrix.",
       "type": "object",
       "properties": {
         "name": {
@@ -309,7 +309,7 @@
       "type": "object",
       "properties": {
         "include": {
-          "description": "Include is a list of IncludeParams which allows passing in specific combinations of Parameters into the Matrix. Note that Include is in preview mode and not yet supported.",
+          "description": "Include is a list of IncludeParams which allows passing in specific combinations of Parameters into the Matrix.",
           "type": "array",
           "items": {
             "default": {},

--- a/pkg/apis/pipeline/v1beta1/matrix_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/matrix_types_test.go
@@ -114,7 +114,474 @@ func TestMatrix_FanOut(t *testing.T) {
 				Value: ParamValue{Type: ParamTypeString, StringVal: "go1.18.1"},
 			},
 		}},
-	}}
+	}, {
+		name: "Fan out explicit combinations, no matrix params",
+		matrix: Matrix{
+			Include: IncludeParamsList{{
+				Name: "build-1",
+				Params: Params{{
+					Name: "IMAGE", Value: ParamValue{Type: ParamTypeString, StringVal: "image-1"},
+				}, {
+					Name: "DOCKERFILE", Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/Dockerfile1"}}},
+			}, {
+				Name: "build-2",
+				Params: Params{{
+					Name: "IMAGE", Value: ParamValue{Type: ParamTypeString, StringVal: "image-2"},
+				}, {
+					Name: "DOCKERFILE", Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/Dockerfile2"}}},
+			}, {
+				Name: "build-3",
+				Params: Params{{
+					Name: "IMAGE", Value: ParamValue{Type: ParamTypeString, StringVal: "image-3"},
+				}, {
+					Name: "DOCKERFILE", Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/Dockerfile3"}}},
+			}},
+		},
+		want: []Params{{
+			{
+				Name:  "DOCKERFILE",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/Dockerfile1"},
+			}, {
+				Name:  "IMAGE",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "image-1"},
+			},
+		}, {
+			{
+				Name:  "DOCKERFILE",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/Dockerfile2"},
+			}, {
+				Name:  "IMAGE",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "image-2"},
+			},
+		}, {
+			{
+				Name:  "DOCKERFILE",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/Dockerfile3"},
+			}, {
+				Name:  "IMAGE",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "image-3"},
+			},
+		}},
+	}, {
+		name: "matrix include unknown param name, append to all combinations",
+		matrix: Matrix{
+			Params: Params{{
+				Name: "GOARCH", Value: ParamValue{ArrayVal: []string{"linux/amd64", "linux/ppc64le", "linux/s390x"}},
+			}, {
+				Name: "version", Value: ParamValue{ArrayVal: []string{"go1.17", "go1.18.1"}}},
+			},
+			Include: IncludeParamsList{{
+				Name: "common-package",
+				Params: Params{{
+					Name: "package", Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/common/package/"}}},
+			}},
+		},
+		want: []Params{{
+			{
+				Name:  "GOARCH",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "linux/amd64"},
+			}, {
+				Name:  "package",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/common/package/"},
+			}, {
+				Name:  "version",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "go1.17"},
+			},
+		}, {
+			{
+				Name:  "GOARCH",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "linux/ppc64le"},
+			}, {
+				Name:  "package",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/common/package/"},
+			}, {
+				Name:  "version",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "go1.17"},
+			},
+		}, {
+			{
+				Name:  "GOARCH",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "linux/s390x"},
+			}, {
+				Name:  "package",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/common/package/"},
+			}, {
+				Name:  "version",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "go1.17"},
+			},
+		}, {
+			{
+				Name:  "GOARCH",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "linux/amd64"},
+			}, {
+				Name:  "package",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/common/package/"},
+			}, {
+				Name:  "version",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "go1.18.1"},
+			},
+		}, {
+			{
+				Name:  "GOARCH",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "linux/ppc64le"},
+			}, {
+				Name:  "package",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/common/package/"},
+			}, {
+				Name:  "version",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "go1.18.1"},
+			},
+		}, {
+			{
+				Name:  "GOARCH",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "linux/s390x"},
+			}, {
+				Name:  "package",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/common/package/"},
+			}, {
+				Name:  "version",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "go1.18.1"},
+			},
+		}},
+	}, {
+		name: "matrix include param value does not exist, generate a new combination",
+		matrix: Matrix{
+			Params: Params{{
+				Name: "GOARCH", Value: ParamValue{ArrayVal: []string{"linux/amd64", "linux/ppc64le", "linux/s390x"}},
+			}, {
+				Name: "version", Value: ParamValue{ArrayVal: []string{"go1.17", "go1.18.1"}}},
+			},
+			Include: IncludeParamsList{{
+				Name: "non-existent-arch",
+				Params: Params{{
+					Name: "GOARCH", Value: ParamValue{Type: ParamTypeString, StringVal: "I-do-not-exist"}}},
+			}},
+		},
+		want: []Params{{
+			{
+				Name:  "GOARCH",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "linux/amd64"},
+			}, {
+				Name:  "version",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "go1.17"},
+			},
+		}, {
+			{
+				Name:  "GOARCH",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "linux/ppc64le"},
+			}, {
+				Name:  "version",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "go1.17"},
+			},
+		}, {
+			{
+				Name:  "GOARCH",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "linux/s390x"},
+			}, {
+				Name:  "version",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "go1.17"},
+			},
+		}, {
+			{
+				Name:  "GOARCH",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "linux/amd64"},
+			}, {
+				Name:  "version",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "go1.18.1"},
+			},
+		}, {
+			{
+				Name:  "GOARCH",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "linux/ppc64le"},
+			}, {
+				Name:  "version",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "go1.18.1"},
+			},
+		}, {
+			{
+				Name:  "GOARCH",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "linux/s390x"},
+			}, {
+				Name:  "version",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "go1.18.1"},
+			},
+		}, {
+			{
+				Name:  "GOARCH",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "I-do-not-exist"},
+			},
+		}},
+	}, {
+		name: "Matrix include filters single parameter and appends missing values",
+		matrix: Matrix{
+			Params: Params{{
+				Name: "GOARCH", Value: ParamValue{ArrayVal: []string{"linux/amd64", "linux/ppc64le", "linux/s390x"}},
+			}, {
+				Name: "version", Value: ParamValue{ArrayVal: []string{"go1.17", "go1.18.1"}}},
+			},
+			Include: IncludeParamsList{{
+				Name: "s390x-no-race",
+				Params: Params{{
+					Name: "GOARCH", Value: ParamValue{Type: ParamTypeString, StringVal: "linux/s390x"},
+				}, {
+					Name: "flags", Value: ParamValue{Type: ParamTypeString, StringVal: "-cover -v"}}},
+			}},
+		},
+		want: []Params{{
+			{
+				Name:  "GOARCH",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "linux/amd64"},
+			}, {
+				Name:  "version",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "go1.17"},
+			},
+		}, {
+			{
+				Name:  "GOARCH",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "linux/ppc64le"},
+			}, {
+				Name:  "version",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "go1.17"},
+			},
+		}, {
+
+			{
+				Name:  "GOARCH",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "linux/s390x"},
+			}, {
+				Name:  "flags",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "-cover -v"},
+			}, {
+				Name:  "version",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "go1.17"},
+			},
+		}, {
+			{
+				Name:  "GOARCH",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "linux/amd64"},
+			}, {
+				Name:  "version",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "go1.18.1"},
+			},
+		}, {
+			{
+				Name:  "GOARCH",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "linux/ppc64le"},
+			}, {
+				Name:  "version",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "go1.18.1"},
+			},
+		}, {
+			{
+				Name:  "GOARCH",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "linux/s390x"},
+			}, {
+				Name:  "flags",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "-cover -v"},
+			}, {
+				Name:  "version",
+				Value: ParamValue{Type: ParamTypeString, StringVal: "go1.18.1"},
+			},
+		}},
+	},
+		{
+			name: "Matrix include filters multiple parameters and append new parameters",
+			matrix: Matrix{
+				Params: Params{{
+					Name: "GOARCH", Value: ParamValue{ArrayVal: []string{"linux/amd64", "linux/ppc64le", "linux/s390x"}},
+				}, {
+					Name: "version", Value: ParamValue{ArrayVal: []string{"go1.17", "go1.18.1"}}},
+				},
+				Include: IncludeParamsList{
+					{
+						Name: "390x-no-race",
+						Params: Params{{
+							Name: "GOARCH", Value: ParamValue{Type: ParamTypeString, StringVal: "linux/s390x"}}, {
+							Name: "flags", Value: ParamValue{Type: ParamTypeString, StringVal: "-cover -v"}}, {
+							Name: "version", Value: ParamValue{Type: ParamTypeString, StringVal: "go1.18.1"}}},
+					},
+					{
+						Name: "amd64-no-race",
+						Params: Params{{
+							Name: "GOARCH", Value: ParamValue{Type: ParamTypeString, StringVal: "linux/amd64"}}, {
+							Name: "flags", Value: ParamValue{Type: ParamTypeString, StringVal: "-cover -v"}}, {
+							Name: "version", Value: ParamValue{Type: ParamTypeString, StringVal: "go1.17"}}},
+					},
+				},
+			},
+			want: []Params{{
+				{
+					Name:  "GOARCH",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "linux/amd64"},
+				}, {
+					Name:  "flags",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "-cover -v"},
+				}, {
+					Name:  "version",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "go1.17"},
+				},
+			}, {
+				{
+					Name:  "GOARCH",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "linux/ppc64le"},
+				}, {
+					Name:  "version",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "go1.17"},
+				},
+			}, {
+				{
+					Name:  "GOARCH",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "linux/s390x"},
+				}, {
+					Name:  "version",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "go1.17"},
+				},
+			}, {
+				{
+					Name:  "GOARCH",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "linux/amd64"},
+				}, {
+					Name:  "version",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "go1.18.1"},
+				},
+			}, {
+				{
+					Name:  "GOARCH",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "linux/ppc64le"},
+				}, {
+					Name:  "version",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "go1.18.1"},
+				},
+			}, {
+				{
+					Name:  "GOARCH",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "linux/s390x"},
+				}, {
+					Name:  "flags",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "-cover -v"},
+				}, {
+					Name:  "version",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "go1.18.1"},
+				},
+			}},
+		}, {
+			name: "Matrix params and include params handles filter, appending, and generating new combinations at once",
+			matrix: Matrix{
+				Params: Params{{
+					Name: "GOARCH", Value: ParamValue{ArrayVal: []string{"linux/amd64", "linux/ppc64le", "linux/s390x"}},
+				}, {
+					Name: "version", Value: ParamValue{ArrayVal: []string{"go1.17", "go1.18.1"}}},
+				},
+				Include: IncludeParamsList{{
+					Name: "common-package",
+					Params: Params{{
+						Name: "package", Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/common/package/"}}},
+				}, {
+					Name: "s390x-no-race",
+					Params: Params{{
+						Name: "GOARCH", Value: ParamValue{Type: ParamTypeString, StringVal: "linux/s390x"},
+					}, {
+						Name: "flags", Value: ParamValue{Type: ParamTypeString, StringVal: "-cover -v"}}},
+				}, {
+					Name: "go117-context",
+					Params: Params{{
+						Name: "version", Value: ParamValue{Type: ParamTypeString, StringVal: "go1.17"},
+					}, {
+						Name: "context", Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/go117/context"}}},
+				}, {
+					Name: "non-existent-arch",
+					Params: Params{{
+						Name: "GOARCH", Value: ParamValue{Type: ParamTypeString, StringVal: "I-do-not-exist"}},
+					},
+				}},
+			},
+			want: []Params{{
+				{
+					Name:  "GOARCH",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "linux/amd64"},
+				}, {
+					Name:  "context",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/go117/context"},
+				}, {
+					Name:  "package",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/common/package/"},
+				}, {
+					Name:  "version",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "go1.17"},
+				},
+			}, {
+				{
+					Name:  "GOARCH",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "linux/ppc64le"},
+				}, {
+					Name:  "context",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/go117/context"},
+				}, {
+					Name:  "package",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/common/package/"},
+				}, {
+					Name:  "version",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "go1.17"},
+				},
+			}, {
+				{
+					Name:  "GOARCH",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "linux/s390x"},
+				}, {
+					Name:  "context",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/go117/context"},
+				}, {
+					Name:  "flags",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "-cover -v"},
+				}, {
+					Name:  "package",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/common/package/"},
+				}, {
+					Name:  "version",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "go1.17"},
+				},
+			}, {
+				{
+					Name:  "GOARCH",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "linux/amd64"},
+				}, {
+					Name:  "package",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/common/package/"}}, {
+					Name:  "version",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "go1.18.1"},
+				},
+			}, {
+				{
+					Name:  "GOARCH",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "linux/ppc64le"},
+				}, {
+					Name:  "package",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/common/package/"},
+				}, {
+					Name:  "version",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "go1.18.1"},
+				},
+			}, {
+				{
+					Name:  "GOARCH",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "linux/s390x"},
+				}, {
+					Name:  "flags",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "-cover -v"},
+				}, {
+					Name:  "package",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/common/package/"},
+				}, {
+					Name:  "version",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "go1.18.1"},
+				},
+			}, {
+				{
+					Name:  "GOARCH",
+					Value: ParamValue{Type: ParamTypeString, StringVal: "I-do-not-exist"},
+				},
+			}},
+		}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if d := cmp.Diff(tt.want, tt.matrix.FanOut()); d != "" {

--- a/pkg/apis/pipeline/v1beta1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1beta1/openapi_generated.go
@@ -1063,7 +1063,7 @@ func schema_pkg_apis_pipeline_v1beta1_IncludeParams(ref common.ReferenceCallback
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "IncludeParams allows passing in a specific combinations of Parameters into the Matrix. Note this struct is in preview mode and not yet supported",
+				Description: "IncludeParams allows passing in a specific combinations of Parameters into the Matrix.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"name": {
@@ -1133,7 +1133,7 @@ func schema_pkg_apis_pipeline_v1beta1_Matrix(ref common.ReferenceCallback) commo
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Include is a list of IncludeParams which allows passing in specific combinations of Parameters into the Matrix. Note that Include is in preview mode and not yet supported.",
+							Description: "Include is a list of IncludeParams which allows passing in specific combinations of Parameters into the Matrix.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{

--- a/pkg/apis/pipeline/v1beta1/swagger.json
+++ b/pkg/apis/pipeline/v1beta1/swagger.json
@@ -506,7 +506,7 @@
       }
     },
     "v1beta1.IncludeParams": {
-      "description": "IncludeParams allows passing in a specific combinations of Parameters into the Matrix. Note this struct is in preview mode and not yet supported",
+      "description": "IncludeParams allows passing in a specific combinations of Parameters into the Matrix.",
       "type": "object",
       "properties": {
         "name": {
@@ -529,7 +529,7 @@
       "type": "object",
       "properties": {
         "include": {
-          "description": "Include is a list of IncludeParams which allows passing in specific combinations of Parameters into the Matrix. Note that Include is in preview mode and not yet supported.",
+          "description": "Include is a list of IncludeParams which allows passing in specific combinations of Parameters into the Matrix.",
           "type": "array",
           "items": {
             "default": {},

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -7991,6 +7991,766 @@ spec:
 		})
 	}
 }
+func TestReconciler_PipelineTaskIncludeParams(t *testing.T) {
+	names.TestingSeed()
+
+	task := parse.MustParseV1beta1Task(t, `
+metadata:
+  name: mytask
+  namespace: foo
+spec:
+  params:
+    - name: GOARCH
+    - name: version
+    - name: flags
+      default: ""
+    - name: context
+      default: ""
+    - name: package
+      default: ""
+  steps:
+    - name: echo
+      image: alpine
+      script: |
+        echo "$(params.GOARCH) and $(params.version)"
+`)
+
+	expectedTaskRuns := []*v1beta1.TaskRun{
+		mustParseTaskRunWithObjectMeta(t,
+			taskRunObjectMeta("pr-matrix-include-0", "foo",
+				"pr", "p", "matrix-include", false),
+			`
+spec:
+  params:
+  - name: GOARCH
+    value: linux/amd64
+  - name: context
+    value: path/to/go117/context
+  - name: package
+    value: path/to/common/package/
+  - name: version
+    value: go1.17
+  serviceAccountName: test-sa
+  taskRef:
+    name: mytask
+    kind: Task
+`),
+		mustParseTaskRunWithObjectMeta(t,
+			taskRunObjectMeta("pr-matrix-include-1", "foo",
+				"pr", "p", "matrix-include", false),
+			`
+spec:
+  params:
+  - name: GOARCH
+    value: linux/ppc64le
+  - name: context
+    value: path/to/go117/context
+  - name: package
+    value: path/to/common/package/
+  - name: version
+    value: go1.17
+  serviceAccountName: test-sa
+  taskRef:
+    name: mytask
+    kind: Task
+`),
+		mustParseTaskRunWithObjectMeta(t,
+			taskRunObjectMeta("pr-matrix-include-2", "foo",
+				"pr", "p", "matrix-include", false),
+			`
+spec:
+  params:
+  - name: GOARCH
+    value: linux/s390x
+  - name: context
+    value: path/to/go117/context
+  - name: flags
+    value: -cover -v
+  - name: package
+    value: path/to/common/package/
+  - name: version
+    value: go1.17
+  serviceAccountName: test-sa
+  taskRef:
+    name: mytask
+    kind: Task
+`),
+		mustParseTaskRunWithObjectMeta(t,
+			taskRunObjectMeta("pr-matrix-include-3", "foo",
+				"pr", "p", "matrix-include", false),
+			`
+spec:
+  params:
+  - name: GOARCH
+    value: linux/amd64
+  - name: package
+    value: path/to/common/package/
+  - name: version
+    value: go1.18.1
+  serviceAccountName: test-sa
+  taskRef:
+    name: mytask
+    kind: Task
+`),
+		mustParseTaskRunWithObjectMeta(t,
+			taskRunObjectMeta("pr-matrix-include-4", "foo",
+				"pr", "p", "matrix-include", false),
+			`
+spec:
+  params:
+  - name: GOARCH
+    value: linux/ppc64le
+  - name: package
+    value: path/to/common/package/
+  - name: version
+    value: go1.18.1
+  serviceAccountName: test-sa
+  taskRef:
+    name: mytask
+    kind: Task
+`),
+		mustParseTaskRunWithObjectMeta(t,
+			taskRunObjectMeta("pr-matrix-include-5", "foo",
+				"pr", "p", "matrix-include", false),
+			`
+spec:
+  params:
+  - name: GOARCH
+    value: linux/s390x
+  - name: flags
+    value: -cover -v
+  - name: package
+    value: path/to/common/package/
+  - name: version
+    value: go1.18.1
+  serviceAccountName: test-sa
+  taskRef:
+    name: mytask
+    kind: Task
+`),
+		mustParseTaskRunWithObjectMeta(t,
+			taskRunObjectMeta("pr-matrix-include-6", "foo",
+				"pr", "p", "matrix-include", false),
+			`
+spec:
+  params:
+  - name: GOARCH
+    value: I-do-not-exist
+  serviceAccountName: test-sa
+  taskRef:
+    name: mytask
+    kind: Task
+`),
+	}
+	cms := []*corev1.ConfigMap{withEnabledAlphaAPIFields(newFeatureFlagsConfigMap())}
+	cms = append(cms, withMaxMatrixCombinationsCount(newDefaultsConfigMap(), 10))
+
+	tests := []struct {
+		name                string
+		memberOf            string
+		p                   *v1beta1.Pipeline
+		tr                  *v1beta1.TaskRun
+		expectedPipelineRun *v1beta1.PipelineRun
+	}{{
+		name:     "p-dag",
+		memberOf: "tasks",
+		p: parse.MustParseV1beta1Pipeline(t, fmt.Sprintf(`
+metadata:
+  name: %s
+  namespace: foo
+spec:
+  tasks:
+    - name: matrix-include
+      taskRef:
+        name: mytask
+      matrix:
+        params:
+          - name: GOARCH
+            value:
+              - linux/amd64
+              - linux/ppc64le
+              - linux/s390x
+          - name: version
+            value:
+              - go1.17
+              - go1.18.1
+        include:
+         - name: common-package
+           params:
+            - name: package
+              value: path/to/common/package/
+         - name: s390x-no-race
+           params:
+           - name: GOARCH
+             value: linux/s390x
+           - name: flags
+             value: '-cover -v'
+         - name: go117-context
+           params:
+            - name: version
+              value: go1.17
+            - name: context
+              value: path/to/go117/context
+         - name: non-existent-arch
+           params:
+            - name: GOARCH
+              value: I-do-not-exist
+`, "p-dag")),
+		expectedPipelineRun: parse.MustParseV1beta1PipelineRun(t, `
+metadata:
+  name: pr
+  namespace: foo
+  annotations: {}
+  labels:
+    tekton.dev/pipeline: p-dag
+spec:
+  serviceAccountName: test-sa
+  pipelineRef:
+    name: p-dag
+status:
+  pipelineSpec:
+    tasks:
+    - name: matrix-include
+      taskRef:
+        name: mytask
+        kind: Task
+      matrix:
+        params:
+          - name: GOARCH
+            value:
+              - linux/amd64
+              - linux/ppc64le
+              - linux/s390x
+          - name: version
+            value:
+              - go1.17
+              - go1.18.1
+        include:
+         - name: common-package
+           params:
+            - name: package
+              value: path/to/common/package/
+         - name: s390x-no-race
+           params:
+           - name: GOARCH
+             value: linux/s390x
+           - name: flags
+             value: '-cover -v'
+         - name: go117-context
+           params:
+            - name: version
+              value: go1.17
+            - name: context
+              value: path/to/go117/context
+         - name: non-existent-arch
+           params:
+            - name: GOARCH
+              value: I-do-not-exist
+  conditions:
+  - type: Succeeded
+    status: "Unknown"
+    reason: "Running"
+    message: "Tasks Completed: 0 (Failed: 0, Cancelled 0), Incomplete: 1, Skipped: 0"
+  childReferences:
+  - apiVersion: tekton.dev/v1beta1
+    kind: TaskRun
+    name: pr-matrix-include-0
+    pipelineTaskName: matrix-include
+  - apiVersion: tekton.dev/v1beta1
+    kind: TaskRun
+    name: pr-matrix-include-1
+    pipelineTaskName: matrix-include
+  - apiVersion: tekton.dev/v1beta1
+    kind: TaskRun
+    name: pr-matrix-include-2
+    pipelineTaskName: matrix-include
+  - apiVersion: tekton.dev/v1beta1
+    kind: TaskRun
+    name: pr-matrix-include-3
+    pipelineTaskName: matrix-include
+  - apiVersion: tekton.dev/v1beta1
+    kind: TaskRun
+    name: pr-matrix-include-4
+    pipelineTaskName: matrix-include
+  - apiVersion: tekton.dev/v1beta1
+    kind: TaskRun
+    name: pr-matrix-include-5
+    pipelineTaskName: matrix-include
+  - apiVersion: tekton.dev/v1beta1
+    kind: TaskRun
+    name: pr-matrix-include-6
+    pipelineTaskName: matrix-include
+`),
+	}, {
+		name:     "p-finally",
+		memberOf: "finally",
+		p: parse.MustParseV1beta1Pipeline(t, fmt.Sprintf(`
+metadata:
+  name: %s
+  namespace: foo
+spec:
+  tasks:
+    - name: unmatrixed-pt
+      params:
+      - name: GOARCH
+        value: "test"
+      - name: version
+        value: "test"
+      - name: flags
+        value: "test"
+      - name: context
+        value: "test"
+      - name: package
+        value: "test"
+      taskRef:
+        name: mytask
+  finally:
+    - name: matrix-include
+      taskRef:
+        name: mytask
+      matrix:
+        params:
+          - name: GOARCH
+            value:
+              - linux/amd64
+              - linux/ppc64le
+              - linux/s390x
+          - name: version
+            value:
+              - go1.17
+              - go1.18.1
+        include:
+         - name: common-package
+           params:
+            - name: package
+              value: path/to/common/package/
+         - name: s390x-no-race
+           params:
+           - name: GOARCH
+             value: linux/s390x
+           - name: flags
+             value: '-cover -v'
+         - name: go117-context
+           params:
+            - name: version
+              value: go1.17
+            - name: context
+              value: path/to/go117/context
+         - name: non-existent-arch
+           params:
+            - name: GOARCH
+              value: I-do-not-exist
+`, "p-finally")),
+		tr: mustParseTaskRunWithObjectMeta(t,
+			taskRunObjectMeta("pr-unmatrixed-pt", "foo",
+				"pr", "p-finally", "unmatrixed-pt", false),
+			`
+spec:
+  params:
+  - name: GOARCH
+    value: "test"
+  - name: version
+    value: "test"
+  - name: flags
+    value: "test"
+  - name: context
+    value: "test"
+  - name: package
+    value: "test"
+  serviceAccountName: test-sa
+  taskRef:
+    name: mytask
+    kind: Task
+status:
+ conditions:
+  - type: Succeeded
+    status: "True"
+    reason: Succeeded
+    message: All Tasks have completed executing
+`),
+		expectedPipelineRun: parse.MustParseV1beta1PipelineRun(t, `
+metadata:
+  name: pr
+  namespace: foo
+  annotations: {}
+  labels:
+    tekton.dev/pipeline: p-finally
+spec:
+  serviceAccountName: test-sa
+  pipelineRef:
+    name: p-finally
+status:
+  pipelineSpec:
+    tasks:
+    - name: unmatrixed-pt
+      params:
+       - name: GOARCH
+         value: "test"
+       - name: version
+         value: "test"
+       - name: flags
+         value: "test"
+       - name: context
+         value: "test"
+       - name: package
+         value: "test"
+      taskRef:
+        name: mytask
+        kind: Task
+    finally:
+    - name: matrix-include
+      taskRef:
+        name: mytask
+        kind: Task
+      matrix:
+        params:
+          - name: GOARCH
+            value:
+              - linux/amd64
+              - linux/ppc64le
+              - linux/s390x
+          - name: version
+            value:
+              - go1.17
+              - go1.18.1
+        include:
+         - name: common-package
+           params:
+            - name: package
+              value: path/to/common/package/
+         - name: s390x-no-race
+           params:
+           - name: GOARCH
+             value: linux/s390x
+           - name: flags
+             value: '-cover -v'
+         - name: go117-context
+           params:
+            - name: version
+              value: go1.17
+            - name: context
+              value: path/to/go117/context
+         - name: non-existent-arch
+           params:
+            - name: GOARCH
+              value: I-do-not-exist
+  conditions:
+  - type: Succeeded
+    status: "Unknown"
+    reason: "Running"
+    message: "Tasks Completed: 1 (Failed: 0, Cancelled 0), Incomplete: 1, Skipped: 0"
+  childReferences:
+  - apiVersion: tekton.dev/v1beta1
+    kind: TaskRun
+    name: pr-unmatrixed-pt
+    pipelineTaskName: unmatrixed-pt
+  - apiVersion: tekton.dev/v1beta1
+    kind: TaskRun
+    name: pr-matrix-include-0
+    pipelineTaskName: matrix-include
+  - apiVersion: tekton.dev/v1beta1
+    kind: TaskRun
+    name: pr-matrix-include-1
+    pipelineTaskName: matrix-include
+  - apiVersion: tekton.dev/v1beta1
+    kind: TaskRun
+    name: pr-matrix-include-2
+    pipelineTaskName: matrix-include
+  - apiVersion: tekton.dev/v1beta1
+    kind: TaskRun
+    name: pr-matrix-include-3
+    pipelineTaskName: matrix-include
+  - apiVersion: tekton.dev/v1beta1
+    kind: TaskRun
+    name: pr-matrix-include-4
+    pipelineTaskName: matrix-include
+  - apiVersion: tekton.dev/v1beta1
+    kind: TaskRun
+    name: pr-matrix-include-5
+    pipelineTaskName: matrix-include
+  - apiVersion: tekton.dev/v1beta1
+    kind: TaskRun
+    name: pr-matrix-include-6
+    pipelineTaskName: matrix-include
+`),
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pr := parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
+metadata:
+  name: pr
+  namespace: foo
+spec:
+  serviceAccountName: test-sa
+  pipelineRef:
+    name: %s
+`, tt.name))
+			d := test.Data{
+				PipelineRuns: []*v1beta1.PipelineRun{pr},
+				Pipelines:    []*v1beta1.Pipeline{tt.p},
+				Tasks:        []*v1beta1.Task{task},
+				ConfigMaps:   cms,
+			}
+			if tt.tr != nil {
+				d.TaskRuns = []*v1beta1.TaskRun{tt.tr}
+			}
+			prt := newPipelineRunTest(t, d)
+			defer prt.Cancel()
+
+			_, clients := prt.reconcileRun("foo", "pr", []string{}, false)
+			taskRuns, err := clients.Pipeline.TektonV1beta1().TaskRuns("foo").List(prt.TestAssets.Ctx, metav1.ListOptions{
+				LabelSelector: fmt.Sprintf("tekton.dev/pipelineRun=pr,tekton.dev/pipeline=%s,tekton.dev/pipelineTask=matrix-include", tt.name),
+				Limit:         1,
+			})
+			if err != nil {
+				t.Fatalf("Failure to list TaskRun's %s", err)
+			}
+
+			if len(taskRuns.Items) != 7 {
+				t.Fatalf("Expected 7 TaskRuns got %d", len(taskRuns.Items))
+			}
+
+			for i := range taskRuns.Items {
+				expectedTaskRun := expectedTaskRuns[i]
+				expectedTaskRun.Labels["tekton.dev/pipeline"] = tt.name
+				expectedTaskRun.Labels["tekton.dev/memberOf"] = tt.memberOf
+				if d := cmp.Diff(expectedTaskRun, &taskRuns.Items[i], ignoreResourceVersion, ignoreTypeMeta); d != "" {
+					t.Errorf("expected to see TaskRun %v created. Diff %s", expectedTaskRuns[i].Name, diff.PrintWantGot(d))
+				}
+			}
+
+			pipelineRun, err := clients.Pipeline.TektonV1beta1().PipelineRuns("foo").Get(prt.TestAssets.Ctx, "pr", metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("Got an error getting reconciled run out of fake client: %s", err)
+			}
+			if d := cmp.Diff(tt.expectedPipelineRun, pipelineRun, ignoreResourceVersion, ignoreTypeMeta, ignoreLastTransitionTime, ignoreStartTime, ignoreFinallyStartTime, cmpopts.EquateEmpty()); d != "" {
+				t.Errorf("expected PipelineRun was not created. Diff %s", diff.PrintWantGot(d))
+			}
+		})
+	}
+}
+
+func TestReconciler_PipelineTaskExplicitCombos(t *testing.T) {
+	names.TestingSeed()
+
+	task := parse.MustParseV1beta1Task(t, `
+metadata:
+  name: mytask
+  namespace: foo
+spec:
+  params:
+    - name: IMAGE
+    - name: DOCKERFILE
+  steps:
+    - name: echo
+      image: alpine
+      script: |
+        echo "$(params.IMAGE) and $(params.DOCKERFILE)"
+`)
+
+	expectedTaskRuns := []*v1beta1.TaskRun{
+		mustParseTaskRunWithObjectMeta(t,
+			taskRunObjectMeta("pr-matrix-include-0", "foo",
+				"pr", "p", "matrix-include", false),
+			`
+spec:
+  params:
+  - name: DOCKERFILE
+    value: path/to/Dockerfile1
+  - name: IMAGE
+    value: image-1
+  serviceAccountName: test-sa
+  taskRef:
+    name: mytask
+    kind: Task
+`),
+		mustParseTaskRunWithObjectMeta(t,
+			taskRunObjectMeta("pr-matrix-include-1", "foo",
+				"pr", "p", "matrix-include", false),
+			`
+spec:
+  params:
+  - name: DOCKERFILE
+    value: path/to/Dockerfile2
+  - name: IMAGE
+    value: image-2
+  serviceAccountName: test-sa
+  taskRef:
+    name: mytask
+    kind: Task
+`),
+		mustParseTaskRunWithObjectMeta(t,
+			taskRunObjectMeta("pr-matrix-include-2", "foo",
+				"pr", "p", "matrix-include", false),
+			`
+spec:
+  params:
+  - name: DOCKERFILE
+    value: path/to/Dockerfile3
+  - name: IMAGE
+    value: image-3
+  serviceAccountName: test-sa
+  taskRef:
+    name: mytask
+    kind: Task
+`),
+	}
+	cms := []*corev1.ConfigMap{withEnabledAlphaAPIFields(newFeatureFlagsConfigMap())}
+	cms = append(cms, withMaxMatrixCombinationsCount(newDefaultsConfigMap(), 10))
+
+	tests := []struct {
+		name                string
+		memberOf            string
+		p                   *v1beta1.Pipeline
+		tr                  *v1beta1.TaskRun
+		expectedPipelineRun *v1beta1.PipelineRun
+	}{{
+		name:     "p-dag",
+		memberOf: "tasks",
+		p: parse.MustParseV1beta1Pipeline(t, fmt.Sprintf(`
+metadata:
+  name: %s
+  namespace: foo
+spec:
+  tasks:
+    - name: matrix-include
+      taskRef:
+        name: mytask
+      matrix:
+        include:
+         - name: build-1
+           params:
+            - name: IMAGE
+              value: image-1
+            - name: DOCKERFILE
+              value: path/to/Dockerfile1
+         - name: build-2
+           params:
+            - name: IMAGE
+              value: image-2
+            - name: DOCKERFILE
+              value: path/to/Dockerfile2
+         - name: build-3
+           params:
+            - name: IMAGE
+              value: image-3
+            - name: DOCKERFILE
+              value: path/to/Dockerfile3
+`, "p-dag")),
+		expectedPipelineRun: parse.MustParseV1beta1PipelineRun(t, `
+metadata:
+  name: pr
+  namespace: foo
+  annotations: {}
+  labels:
+    tekton.dev/pipeline: p-dag
+spec:
+  serviceAccountName: test-sa
+  pipelineRef:
+    name: p-dag
+status:
+  pipelineSpec:
+    tasks:
+      - name: matrix-include
+        taskRef:
+          name: mytask
+          kind: Task
+        matrix:
+          include:
+           - name: build-1
+             params:
+              - name: IMAGE
+                value: image-1
+              - name: DOCKERFILE
+                value: path/to/Dockerfile1
+           - name: build-2
+             params:
+              - name: IMAGE
+                value: image-2
+              - name: DOCKERFILE
+                value: path/to/Dockerfile2
+           - name: build-3
+             params:
+              - name: IMAGE
+                value: image-3
+              - name: DOCKERFILE
+                value: path/to/Dockerfile3
+  conditions:
+  - type: Succeeded
+    status: "Unknown"
+    reason: "Running"
+    message: "Tasks Completed: 0 (Failed: 0, Cancelled 0), Incomplete: 1, Skipped: 0"
+  childReferences:
+  - apiVersion: tekton.dev/v1beta1
+    kind: TaskRun
+    name: pr-matrix-include-0
+    pipelineTaskName: matrix-include
+  - apiVersion: tekton.dev/v1beta1
+    kind: TaskRun
+    name: pr-matrix-include-1
+    pipelineTaskName: matrix-include
+  - apiVersion: tekton.dev/v1beta1
+    kind: TaskRun
+    name: pr-matrix-include-2
+    pipelineTaskName: matrix-include
+`),
+	},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pr := parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
+metadata:
+  name: pr
+  namespace: foo
+spec:
+  serviceAccountName: test-sa
+  pipelineRef:
+    name: %s
+`, tt.name))
+			d := test.Data{
+				PipelineRuns: []*v1beta1.PipelineRun{pr},
+				Pipelines:    []*v1beta1.Pipeline{tt.p},
+				Tasks:        []*v1beta1.Task{task},
+				ConfigMaps:   cms,
+			}
+			if tt.tr != nil {
+				d.TaskRuns = []*v1beta1.TaskRun{tt.tr}
+			}
+			prt := newPipelineRunTest(t, d)
+			defer prt.Cancel()
+
+			_, clients := prt.reconcileRun("foo", "pr", []string{}, false)
+			taskRuns, err := clients.Pipeline.TektonV1beta1().TaskRuns("foo").List(prt.TestAssets.Ctx, metav1.ListOptions{
+				LabelSelector: fmt.Sprintf("tekton.dev/pipelineRun=pr,tekton.dev/pipeline=%s,tekton.dev/pipelineTask=matrix-include", tt.name),
+				Limit:         1,
+			})
+			if err != nil {
+				t.Fatalf("Failure to list TaskRun's %s", err)
+			}
+
+			if len(taskRuns.Items) != 3 {
+				t.Fatalf("Expected 3 TaskRuns got %d", len(taskRuns.Items))
+			}
+
+			for i := range taskRuns.Items {
+				expectedTaskRun := expectedTaskRuns[i]
+				expectedTaskRun.Labels["tekton.dev/pipeline"] = tt.name
+				expectedTaskRun.Labels["tekton.dev/memberOf"] = tt.memberOf
+				if d := cmp.Diff(expectedTaskRun, &taskRuns.Items[i], ignoreResourceVersion, ignoreTypeMeta); d != "" {
+					t.Errorf("expected to see TaskRun %v created. Diff %s", expectedTaskRuns[i].Name, diff.PrintWantGot(d))
+				}
+			}
+
+			pipelineRun, err := clients.Pipeline.TektonV1beta1().PipelineRuns("foo").Get(prt.TestAssets.Ctx, "pr", metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("Got an error getting reconciled run out of fake client: %s", err)
+			}
+			if d := cmp.Diff(tt.expectedPipelineRun, pipelineRun, ignoreResourceVersion, ignoreTypeMeta, ignoreLastTransitionTime, ignoreStartTime, ignoreFinallyStartTime, cmpopts.EquateEmpty()); d != "" {
+				t.Errorf("expected PipelineRun was not created. Diff %s", diff.PrintWantGot(d))
+			}
+		})
+	}
+}
 
 func TestReconciler_PipelineTaskMatrixWithResults(t *testing.T) {
 	names.TestingSeed()


### PR DESCRIPTION
[TEP-0090: Matrix] introduced `Matrix` to the `PipelineTask` specification such that the `PipelineTask` executes a list of `TaskRuns` or `Runs` in parallel with the specified list of inputs for a `Parameter` or with different combinations of the inputs for a set of `Parameters`.

To build on this, Tep-0018 introduced Matrix.Include, which allows passing in a specific combinations of `Parameters` into the `Matrix`. 

**This PR  addresses issue #5267  by adding implementation logic and testing for fanning out the Matrix Include Parameters in a Task Run to allow users to generate explicit combinations and support adding a specific combination of input values for Matrix Parameters**

Note: this feature is still in preview mode 

/kind feature

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Users can now specify a`PipelineTask` with `Matrix Include Parameters` to generate explicit combinations or add 
a specific combination of input values for Matrix Parameters. 
```
