### PR TITLE
TEP-0118: Update Pipeline Conversion for Matrix Include Parameters

### DIFF
--- a/pkg/apis/pipeline/v1beta1/pipeline_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_conversion.go
@@ -259,6 +259,14 @@ func (m *Matrix) convertTo(ctx context.Context, sink *v1.Matrix) {
 		param.convertTo(ctx, &new)
 		sink.Params = append(sink.Params, new)
 	}
+	for i, include := range m.Include {
+		sink.Include = append(sink.Include, v1.MatrixInclude{Name: include.Name})
+		for _, param := range include.Params {
+			newIncludeParam := v1.Param{}
+			param.convertTo(ctx, &newIncludeParam)
+			sink.Include[i].Params = append(sink.Include[i].Params, newIncludeParam)
+		}
+	}
 }
 
 func (m *Matrix) convertFrom(ctx context.Context, source v1.Matrix) {
@@ -266,6 +274,15 @@ func (m *Matrix) convertFrom(ctx context.Context, source v1.Matrix) {
 		new := Param{}
 		new.convertFrom(ctx, param)
 		m.Params = append(m.Params, new)
+	}
+
+	for i, include := range source.Include {
+		m.Include = append(m.Include, MatrixInclude{Name: include.Name})
+		for _, p := range include.Params {
+			new := Param{}
+			new.convertFrom(ctx, p)
+			m.Include[i].Params = append(m.Include[i].Params, new)
+		}
 	}
 }
 

--- a/pkg/apis/pipeline/v1beta1/pipeline_conversion_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_conversion_test.go
@@ -108,13 +108,21 @@ func TestPipelineConversion(t *testing.T) {
 						},
 					}},
 					Matrix: &v1beta1.Matrix{
-						Params: []v1beta1.Param{{
+						Params: v1beta1.Params{{
 							Name: "a-param",
 							Value: v1beta1.ParamValue{
 								Type:     v1beta1.ParamTypeArray,
 								ArrayVal: []string{"$(params.baz)", "and", "$(params.foo-is-baz)"},
 							},
-						}}},
+						}},
+						Include: []v1beta1.MatrixInclude{{
+							Name: "baz",
+							Params: v1beta1.Params{{
+								Name: "a-param", Value: v1beta1.ParamValue{Type: v1beta1.ParamTypeString, StringVal: "$(params.baz)"},
+							}, {
+								Name: "flags", Value: v1beta1.ParamValue{Type: v1beta1.ParamTypeString, StringVal: "-cover -v"}}},
+						}},
+					},
 					Workspaces: []v1beta1.WorkspacePipelineTaskBinding{{
 						Name:      "my-task-workspace",
 						Workspace: "source",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

[[TEP-0090: Matrix](https://github.com/tektoncd/community/blob/main/teps/0090-matrix.md)] introduced `Matrix` to the `PipelineTask` specification such that the `PipelineTask` executes a list of `TaskRuns` or `Runs` in parallel with the specified list of inputs for a `Parameter` or with different combinations of the inputs for a set of `Parameters`.

To build on this [TEP-0018 ](https://github.com/tektoncd/community/blob/main/teps/0118-matrix-with-explicit-combinations-of-parameters.md )introduced Matrix.Include, which allows passing in a specific combinations of `Parameters` into the `Matrix`.

**This PR updates Pipeline Conversion to convert Matrix Include Parameters.**

Note: This feature is still in preview mode.

/kind feature

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
