### PR TITLE
TEP-0118: Validate Matrix Include Parameters are unique in Matrix and Pipeline Task Parameters

### DIFF
--- a/pkg/apis/pipeline/v1/param_types.go
+++ b/pkg/apis/pipeline/v1/param_types.go
@@ -116,7 +116,15 @@ type Param struct {
 	Value ParamValue `json:"value"`
 }
 
-func (ps Params) extractParamValues() []string {
+func (ps Params) extractNames() []string {
+	names := []string{}
+	for _, p := range ps {
+		names = append(names, p.Name)
+	}
+	return names
+}
+
+func (ps Params) extractValues() []string {
 	pvs := []string{}
 	for i := range ps {
 		pvs = append(pvs, ps[i].Value.StringVal)

--- a/pkg/apis/pipeline/v1/pipeline_types_test.go
+++ b/pkg/apis/pipeline/v1/pipeline_types_test.go
@@ -594,7 +594,7 @@ func TestPipelineTask_validateMatrix(t *testing.T) {
 		pt       *PipelineTask
 		wantErrs *apis.FieldError
 	}{{
-		name: "parameter duplicated in matrix and params",
+		name: "parameter duplicated in matrix.params and pipelinetask.params",
 		pt: &PipelineTask{
 			Name: "task",
 			Matrix: &Matrix{
@@ -606,6 +606,22 @@ func TestPipelineTask_validateMatrix(t *testing.T) {
 			}},
 		},
 		wantErrs: apis.ErrMultipleOneOf("matrix[foobar]", "params[foobar]"),
+	}, {
+		name: "parameter duplicated in matrix.include.params and pipelinetask.params",
+		pt: &PipelineTask{
+			Name: "task",
+			Matrix: &Matrix{
+				Include: []MatrixInclude{{
+					Name: "duplicate-param",
+					Params: Params{{
+						Name: "duplicate", Value: ParamValue{Type: ParamTypeString, StringVal: "foo"},
+					}}},
+				}},
+			Params: []Param{{
+				Name: "duplicate", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"foo", "bar"}},
+			}},
+		},
+		wantErrs: apis.ErrMultipleOneOf("matrix[duplicate]", "params[duplicate]"),
 	}, {
 		name: "duplicate parameters in matrix.params",
 		pt: &PipelineTask{

--- a/pkg/apis/pipeline/v1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1/pipeline_validation.go
@@ -183,7 +183,7 @@ func validatePipelineContextVariables(tasks []PipelineTask) *apis.FieldError {
 	)
 	var paramValues []string
 	for _, task := range tasks {
-		paramValues = task.extractAllParams().extractParamValues()
+		paramValues = task.extractAllParams().extractValues()
 	}
 	errs := validatePipelineContextVariablesInParamValues(paramValues, "context\\.pipelineRun", pipelineRunContextNames).
 		Also(validatePipelineContextVariablesInParamValues(paramValues, "context\\.pipeline", pipelineContextNames)).
@@ -422,9 +422,9 @@ func (ps *PipelineSpec) ValidateParamArrayIndex(ctx context.Context, params Para
 
 	paramsRefs := []string{}
 	for i := range ps.Tasks {
-		paramsRefs = append(paramsRefs, ps.Tasks[i].Params.extractParamValues()...)
+		paramsRefs = append(paramsRefs, ps.Tasks[i].Params.extractValues()...)
 		if ps.Tasks[i].IsMatrixed() {
-			paramsRefs = append(paramsRefs, ps.Tasks[i].Matrix.Params.extractParamValues()...)
+			paramsRefs = append(paramsRefs, ps.Tasks[i].Matrix.Params.extractValues()...)
 		}
 		for j := range ps.Tasks[i].Workspaces {
 			paramsRefs = append(paramsRefs, ps.Tasks[i].Workspaces[j].SubPath)
@@ -436,9 +436,9 @@ func (ps *PipelineSpec) ValidateParamArrayIndex(ctx context.Context, params Para
 	}
 
 	for i := range ps.Finally {
-		paramsRefs = append(paramsRefs, ps.Finally[i].Params.extractParamValues()...)
+		paramsRefs = append(paramsRefs, ps.Finally[i].Params.extractValues()...)
 		if ps.Finally[i].IsMatrixed() {
-			paramsRefs = append(paramsRefs, ps.Finally[i].Matrix.Params.extractParamValues()...)
+			paramsRefs = append(paramsRefs, ps.Finally[i].Matrix.Params.extractValues()...)
 		}
 		for _, wes := range ps.Finally[i].When {
 			paramsRefs = append(paramsRefs, wes.Values...)

--- a/pkg/apis/pipeline/v1beta1/param_types.go
+++ b/pkg/apis/pipeline/v1beta1/param_types.go
@@ -112,7 +112,15 @@ type Param struct {
 // Params is a list of Param
 type Params []Param
 
-func (ps Params) extractParamValues() []string {
+func (ps Params) extractNames() []string {
+	names := []string{}
+	for _, p := range ps {
+		names = append(names, p.Name)
+	}
+	return names
+}
+
+func (ps Params) extractValues() []string {
 	pvs := []string{}
 	for i := range ps {
 		pvs = append(pvs, ps[i].Value.StringVal)

--- a/pkg/apis/pipeline/v1beta1/pipeline_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types_test.go
@@ -568,7 +568,7 @@ func TestPipelineTask_validateMatrix(t *testing.T) {
 		pt       *PipelineTask
 		wantErrs *apis.FieldError
 	}{{
-		name: "parameter duplicated in matrix and params",
+		name: "parameter duplicated in matrix.params and pipelinetask.params",
 		pt: &PipelineTask{
 			Name: "task",
 			Matrix: &Matrix{
@@ -580,6 +580,22 @@ func TestPipelineTask_validateMatrix(t *testing.T) {
 			}},
 		},
 		wantErrs: apis.ErrMultipleOneOf("matrix[foobar]", "params[foobar]"),
+	}, {
+		name: "parameter duplicated in matrix.include.params and pipelinetask.params",
+		pt: &PipelineTask{
+			Name: "task",
+			Matrix: &Matrix{
+				Include: []MatrixInclude{{
+					Name: "duplicate-param",
+					Params: Params{{
+						Name: "duplicate", Value: ParamValue{Type: ParamTypeString, StringVal: "foo"},
+					}}},
+				}},
+			Params: []Param{{
+				Name: "duplicate", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"foo", "bar"}},
+			}},
+		},
+		wantErrs: apis.ErrMultipleOneOf("matrix[duplicate]", "params[duplicate]"),
 	}, {
 		name: "duplicate parameters in matrix.params",
 		pt: &PipelineTask{

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation.go
@@ -183,7 +183,7 @@ func validatePipelineContextVariables(tasks []PipelineTask) *apis.FieldError {
 	)
 	var paramValues []string
 	for _, task := range tasks {
-		paramValues = task.extractAllParams().extractParamValues()
+		paramValues = task.extractAllParams().extractValues()
 	}
 	errs := validatePipelineContextVariablesInParamValues(paramValues, "context\\.pipelineRun", pipelineRunContextNames).
 		Also(validatePipelineContextVariablesInParamValues(paramValues, "context\\.pipeline", pipelineContextNames)).
@@ -423,9 +423,9 @@ func (ps *PipelineSpec) ValidateParamArrayIndex(ctx context.Context, params Para
 
 	paramsRefs := []string{}
 	for i := range ps.Tasks {
-		paramsRefs = append(paramsRefs, ps.Tasks[i].Params.extractParamValues()...)
+		paramsRefs = append(paramsRefs, ps.Tasks[i].Params.extractValues()...)
 		if ps.Tasks[i].IsMatrixed() {
-			paramsRefs = append(paramsRefs, ps.Tasks[i].Matrix.Params.extractParamValues()...)
+			paramsRefs = append(paramsRefs, ps.Tasks[i].Matrix.Params.extractValues()...)
 		}
 		for j := range ps.Tasks[i].Workspaces {
 			paramsRefs = append(paramsRefs, ps.Tasks[i].Workspaces[j].SubPath)
@@ -437,9 +437,9 @@ func (ps *PipelineSpec) ValidateParamArrayIndex(ctx context.Context, params Para
 	}
 
 	for i := range ps.Finally {
-		paramsRefs = append(paramsRefs, ps.Finally[i].Params.extractParamValues()...)
+		paramsRefs = append(paramsRefs, ps.Finally[i].Params.extractValues()...)
 		if ps.Finally[i].IsMatrixed() {
-			paramsRefs = append(paramsRefs, ps.Finally[i].Matrix.Params.extractParamValues()...)
+			paramsRefs = append(paramsRefs, ps.Finally[i].Matrix.Params.extractValues()...)
 		}
 		for _, wes := range ps.Finally[i].WhenExpressions {
 			paramsRefs = append(paramsRefs, wes.Values...)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
[TEP-0090: Matrix] introduced `Matrix` to the `PipelineTask` specification such that the `PipelineTask` executes a list of `TaskRuns` or `Runs` in parallel with the specified list of inputs for a `Parameter` or with different combinations of the inputs for a set of `Parameters`.

To build on this, [Tep-0018](https://github.com/tektoncd/community/blob/main/teps/0118-matrix-with-explicit-combinations-of-parameters.md) introduced Matrix.Include, which allows passing in a specific combinations of `Parameters` into the `Matrix`.

**This commit validates that a matrix include parameter is unique to both pipeline task parameters and matrix parameters.**

/kind feature

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```

