### PR TITLE
TEP-0118: Apply PipelineTask Context Replacements in Matrix Include

### DIFF
--- a/pkg/reconciler/pipelinerun/resources/apply.go
+++ b/pkg/reconciler/pipelinerun/resources/apply.go
@@ -161,6 +161,9 @@ func ApplyPipelineTaskContexts(pt *v1beta1.PipelineTask) *v1beta1.PipelineTask {
 	pt.Params = replaceParamValues(pt.Params, replacements, map[string][]string{}, map[string]map[string]string{})
 	if pt.IsMatrixed() {
 		pt.Matrix.Params = replaceParamValues(pt.Matrix.Params, replacements, map[string][]string{}, map[string]map[string]string{})
+		for i := range pt.Matrix.Include {
+			pt.Matrix.Include[i].Params = replaceParamValues(pt.Matrix.Include[i].Params, replacements, map[string][]string{}, map[string]map[string]string{})
+		}
 	}
 	return pt
 }

--- a/pkg/reconciler/pipelinerun/resources/apply_test.go
+++ b/pkg/reconciler/pipelinerun/resources/apply_test.go
@@ -3260,7 +3260,15 @@ func TestApplyPipelineTaskContexts(t *testing.T) {
 				Params: []v1beta1.Param{{
 					Name:  "retries",
 					Value: *v1beta1.NewStructuredValues("$(context.pipelineTask.retries)"),
-				}}},
+				}},
+				Include: []v1beta1.MatrixInclude{{
+					Name: "build-1",
+					Params: []v1beta1.Param{{
+						Name:  "retries",
+						Value: *v1beta1.NewStructuredValues("$(context.pipelineTask.retries)"),
+					}},
+				}},
+			},
 		},
 		want: v1beta1.PipelineTask{
 			Retries: 5,
@@ -3272,7 +3280,15 @@ func TestApplyPipelineTaskContexts(t *testing.T) {
 				Params: []v1beta1.Param{{
 					Name:  "retries",
 					Value: *v1beta1.NewStructuredValues("5"),
-				}}},
+				}},
+				Include: []v1beta1.MatrixInclude{{
+					Name: "build-1",
+					Params: []v1beta1.Param{{
+						Name:  "retries",
+						Value: *v1beta1.NewStructuredValues("5"),
+					}},
+				}},
+			},
 		},
 	}, {
 		description: "context retries replacement with no defined retries",
@@ -3285,7 +3301,15 @@ func TestApplyPipelineTaskContexts(t *testing.T) {
 				Params: []v1beta1.Param{{
 					Name:  "retries",
 					Value: *v1beta1.NewStructuredValues("$(context.pipelineTask.retries)"),
-				}}},
+				}},
+				Include: []v1beta1.MatrixInclude{{
+					Name: "build-1",
+					Params: []v1beta1.Param{{
+						Name:  "retries",
+						Value: *v1beta1.NewStructuredValues("$(context.pipelineTask.retries)"),
+					}},
+				}},
+			},
 		},
 		want: v1beta1.PipelineTask{
 			Params: []v1beta1.Param{{
@@ -3296,7 +3320,15 @@ func TestApplyPipelineTaskContexts(t *testing.T) {
 				Params: []v1beta1.Param{{
 					Name:  "retries",
 					Value: *v1beta1.NewStructuredValues("0"),
-				}}},
+				}},
+				Include: []v1beta1.MatrixInclude{{
+					Name: "build-1",
+					Params: []v1beta1.Param{{
+						Name:  "retries",
+						Value: *v1beta1.NewStructuredValues("0"),
+					}},
+				}},
+			},
 		},
 	}} {
 		t.Run(tc.description, func(t *testing.T) {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
[TEP-0090: Matrix] introduced `Matrix` to the `PipelineTask` specification such that the `PipelineTask` executes a list of `TaskRuns` or `Runs` in parallel with the specified list of inputs for a `Parameter` or with different combinations of the inputs for a set of `Parameters`.

To build on this, Tep-0018 introduced Matrix.Include, which allows passing in a specific combinations of `Parameters` into the `Matrix`.

**This PR  updates replacement functionality for substituting context.pipelineTask with the specified values for matrix include parameters.

Note: This feature is still in preview mode..**

/kind feature

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
