### PR TITLE
Update min k8s version in development.md to 1.23

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -266,7 +266,7 @@ as follows.
 
 The recommended minimum development configuration is:
 
-- Kubernetes version 1.22 or later
+- Kubernetes version 1.23 or later
 - 4 (virtual) CPU nodes
   - 8 GB of (actual or virtualized) platform memory
 - Node autoscaling, up to 3 nodes
@@ -324,7 +324,7 @@ optional: As a convenience, the [Tekton plumbing project](https://github.com/tek
      --region=us-central1 \
      --machine-type=e2-standard-4 \
      --num-nodes=1 \
-     --cluster-version=1.22
+     --cluster-version=1.23
     ```
 
     > **Note**: The recommended [GCE machine type](https://cloud.google.com/compute/docs/machine-types) is `'e2-standard-4'`.


### PR DESCRIPTION
# Changes

As of the [0.41 release](https://github.com/tektoncd/pipeline/releases/tag/v0.41.0) the minimum version of k8s required is 1.23

/kind documentation

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [n/a] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
