### PR TITLE
drop git-init from the list of published images

### DIFF
--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -11,7 +11,7 @@ spec:
       default: github.com/tektoncd/pipeline
     - name: images
       description: List of cmd/* paths to be published as images
-      default: "controller webhook entrypoint nop git-init workingdirinit resolvers sidecarlogresults"
+      default: "controller webhook entrypoint nop workingdirinit resolvers sidecarlogresults"
     - name: versionTag
       description: The vX.Y.Z version that the artifacts should be tagged with (including `v`)
     - name: imageRegistry
@@ -109,9 +109,6 @@ spec:
         $(params.package)/cmd/entrypoint: ${COMBINED_BASE_IMAGE}
         $(params.package)/cmd/nop: ${COMBINED_BASE_IMAGE}
         $(params.package)/cmd/workingdirinit: ${COMBINED_BASE_IMAGE}
-
-        # This matches values configured in .ko.yaml
-        $(params.package)/cmd/git-init: cgr.dev/chainguard/git
       EOF
 
       cat /workspace/.ko.yaml


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

The recent release creation failed with:

Expected images did not match: Images ['gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.46.0'] were expected but missing.

We no longer create git-init image in a seperate commit - https://github.com/tektoncd/pipeline/commit/81876e6bc928b8b444fa020eead5d2a3cd080900

Updating the image publish task to not publish git-init image.

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
