### PR TITLE
add an extra check for the release manager

### DIFF
--- a/tekton/release-cheat-sheet.md
+++ b/tekton/release-cheat-sheet.md
@@ -19,6 +19,8 @@ the pipelines repo, a terminal window and a text editor.
     ```bash
     kustomize build tekton | kubectl --context dogfooding replace -f -
     ```
+1. Ensure the `pipeline` and `task` definitions are up-to-date in the
+   [pipelines](https://github.com/tektoncd/pipeline/tree/main/tekton) repo.
 
 1. Create environment variables for bash scripts in later steps.
 


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

We have started incorporating git resolver in our release pipeline which resolves a task definition from the pipelines repo based on the specified commit at the run time.

Adding an extra check to verify for the release manager while creating a release. We might be able to discard the previous step verifying the resources on the cluster after updating the pipelineRun creation using remote resolver.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
