### PR TITLE
[TEP-0091] use verification mode in trusted resources

### DIFF
--- a/docs/trusted-resources.md
+++ b/docs/trusted-resources.md
@@ -78,7 +78,8 @@ How does VerificationPolicy work?
 You can create multiple `VerificationPolicy` and apply them to the cluster.
 1. Trusted resources will look up policies from the resource namespace (usually this is the same as taskrun/pipelinerun namespace).
 2. If multiple policies are found. For each policy we will check if the resource url is matching any of the `patterns` in the `resources` list. If matched then this policy will be used for verification.
-3. If multiple policies are matched, the resource needs to pass all of them to pass verification.
+3. If multiple policies are matched, the resource must pass all the "enforce" mode policies. If the resource only matches policies in "warn" mode and fails to pass the "warn" policy, it will not fail the taskrun or pipelinerun, but log a warning instead.
+
 4. To pass one policy, the resource can pass any public keys in the policy.
 
 Take the following `VerificationPolicies` for example, a resource from "https://github.com/tektoncd/catalog.git", needs to pass both `verification-policy-a` and `verification-policy-b`, to pass `verification-policy-a` the resource needs to pass either `key1` or `key2`.
@@ -109,6 +110,8 @@ spec:
       key:
         # data stores the inline public key data
         data: "STRING_ENCODED_PUBLIC_KEY"
+  # mode can be set to "enforce" (default) or "warn".
+  mode: enforce
 ```
 
 ```yaml
@@ -141,6 +144,9 @@ To learn more about `ConfigSource` please refer to resolvers doc for more contex
 
 `hashAlgorithm` is the algorithm for the public key, by default is `sha256`. It also supports `SHA224`, `SHA384`, `SHA512`.
 
+`mode` controls whether a failing policy will fail the taskrun/pipelinerun, or only log the a warning
+ * enforce (default) - fail the taskrun/pipelinerun if verification fails
+ * warn - don't fail the taskrun/pipelinerun if verification fails but log a warning
 
 #### Migrate Config key at configmap to VerificationPolicy
 **Note:** key configuration in configmap is deprecated,

--- a/pkg/trustedresources/errors.go
+++ b/pkg/trustedresources/errors.go
@@ -24,6 +24,4 @@ var (
 	ErrNoMatchedPolicies = errors.New("no policies are matched")
 	// ErrRegexMatch is returned when regex match returns error
 	ErrRegexMatch = errors.New("regex failed to match")
-	// ErrSignatureMissing is returned when signature is missing in resource
-	ErrSignatureMissing = errors.New("signature is missing")
 )


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This commit uses verification policy's mode field in trusted resources. The mode can be set to "warn" or "enforce". The policy will use "enforce" mode if the `mode` is not set. If the mode is set `warn`, then fails to verify this policy will only log a warning and not fail the taskruns or pipelineruns. "enforce" mode policy will fail the taskruns or pipelineruns if fails to verify.

This PR is part of https://github.com/tektoncd/pipeline/issues/6356

/kind feature

Signed-off-by: Yongxuan Zhang yongxuanzhang@google.com

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
The mode of VerificationPolicy determines how failing policies for trusted resources are handled. When set to warn, failing policies will log a warning but not fail the taskrun/pipelinerun. When set to enforce, failing policies will cause the taskrun/pipelinerun to fail if the policy cannot be verified.
```
