### PR TITLE
increase timer for TestRealRunnerTimeout

### DIFF
--- a/cmd/entrypoint/runner_test.go
+++ b/cmd/entrypoint/runner_test.go
@@ -119,13 +119,13 @@ func TestRealRunnerStdoutPathWithSignal(t *testing.T) {
 	}
 }
 
-// TestRealRunnerTimeout tests whether cmd is killed after a millisecond even though it's supposed to sleep for 10 milliseconds.
+// TestRealRunnerTimeout tests whether cmd is killed after 1 millisecond even though it's supposed to sleep for 200 milliseconds.
 func TestRealRunnerTimeout(t *testing.T) {
 	rr := realRunner{}
 	timeout := time.Millisecond
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
-	if err := rr.Run(ctx, "sleep", "0.01"); err != nil {
+	if err := rr.Run(ctx, "sleep", "0.2"); err != nil {
 		if err != context.DeadlineExceeded {
 			t.Fatalf("unexpected error received: %v", err)
 		}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This commit increase the timer for TestRealRunnerTimeout and hope this could mitigate/fix the flake of #4643.

Some thoughts about why #4643 happened. The flaky test got "step didn't timeout", which means that the rr.Run doesn't return any errors, including the DeadlineExceeded error. It could be that the context timeout is accidentally larger than the sleep time and the Run finishes without context timeout (This could be the sleep time decreases, or the ctx timeout increases). 
If we look at those failed reports:
https://prow.tekton.dev/view/gs/tekton-prow/pr-logs/pull/tektoncd_pipeline/5666/pull-tekton-pipeline-unit-tests/1584556112152104960
https://prow.tekton.dev/view/gs/tekton-prow/pr-logs/pull/tektoncd_pipeline/5666/pull-tekton-pipeline-unit-tests/1584676793351147520
https://prow.tekton.dev/view/gs/tekton-prow/pr-logs/pull/tektoncd_pipeline/5465/pull-tekton-pipeline-unit-tests/1570762197682884608
https://prow.tekton.dev/view/gs/tekton-prow/pr-logs/pull/tektoncd_pipeline/6120/pull-tekton-pipeline-unit-tests/1623358151954796544

TestRealRunnerTimeout took either 0.09s or 0.08s but the passed case should take less time than that (includes code run time and ctx timeout time, sleep time if the process started, if we look at passed reports most of them should be less than 0.02s). So I suspect it may be the case where ctx timeout took much longer time, and the test finished (code run time+process sleep time) less than ctx timeout. And I think we may increase the sleep time to 0.2s to leave more room and may avoid this flake. 


/kind flake

Signed-off-by: Yongxuan Zhang yongxuanzhang@google.com

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
