### PR TITLE
Ignore k8s.io/* major/minor version in test/* go.mod

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,9 @@ updates:
     - "dependencies"
     - "release-note-none"
     - "kind/misc"
+    ignore:
+    - dependency-name: "k8s.io/*"
+      update-types: ["version-update:semver-major", "version-update:semver-minor"]
   - package-ecosystem: "gomod"
     directory: "/test/custom-task-ctrls/wait-task-alpha"
     schedule:
@@ -30,6 +33,9 @@ updates:
     - "dependencies"
     - "release-note-none"
     - "kind/misc"
+    ignore:
+    - dependency-name: "k8s.io/*"
+      update-types: ["version-update:semver-major", "version-update:semver-minor"]
   - package-ecosystem: "gomod"
     directory: "/test/custom-task-ctrls/wait-task-beta"
     schedule:
@@ -39,3 +45,6 @@ updates:
     - "dependencies"
     - "release-note-none"
     - "kind/misc"
+    ignore:
+    - dependency-name: "k8s.io/*"
+      update-types: ["version-update:semver-major", "version-update:semver-minor"]


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Similar to the main `go.mod`, we should probably ignore those bumps as
we handle those when bumping knative/pkg manually.

/kind misc

Signed-off-by: Vincent Demeester <vincent@sbr.pm>

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
