### PR TITLE
fix:inconsistent 'retries' document example fields in customrun

### DIFF
--- a/docs/customruns.md
+++ b/docs/customruns.md
@@ -240,7 +240,7 @@ spec:
   params:
     - name: searching
       value: the purpose of my existence
-  ref:
+  customRef:
     apiVersion: custom.tekton.dev/v1alpha1
     kind: Example
     name: exampleName
@@ -250,7 +250,7 @@ Supporting retries is optional but recommended.
 
 #### Developer guide for custom controllers supporting `retries`
 
-1. Teton controller only depends on `ConditionSucceeded` to determine the 
+1. Tekton controller only depends on `ConditionSucceeded` to determine the 
    termination status of a `CustomRun`, therefore Custom task implementors
    MUST NOT set `ConditionSucceeded` to `False` until all retries are exhausted.
 2. Those custom tasks who do not wish to support retry, can simply ignore it.


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The customrun example docs do not match.

```
  params:
    - name: searching
      value: the purpose of my existence
  #  customRef
  ref:
    apiVersion: custom.tekton.dev/v1alpha1
```

/kind documentation

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```