### PR TITLE
[TEP-0091] add condition for trusted resources

### DIFF
--- a/docs/trusted-resources.md
+++ b/docs/trusted-resources.md
@@ -65,6 +65,7 @@ data:
  **Notes:**
  * To skip the verification: make sure no policies exist and `trusted-resources-verification-no-match-policy` is set to `warn` or `ignore`.
  * To enable the verification: install [VerificationPolicy](#config-key-at-verificationpolicy) to match the resources.
+ * Setting the feature flag will have impact on the [condition].(#taskrun-and-pipelinerun-status-update)
 
 Or patch the new values:
 ```bash
@@ -147,6 +148,55 @@ To learn more about `ConfigSource` please refer to resolvers doc for more contex
 `mode` controls whether a failing policy will fail the taskrun/pipelinerun, or only log the a warning
  * enforce (default) - fail the taskrun/pipelinerun if verification fails
  * warn - don't fail the taskrun/pipelinerun if verification fails but log a warning
+
+#### TaskRun and PipelineRun status update
+
+Trusted resources will update the taskrun/pipelinerun’s [condition](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties) to indicate if it passes verification or not.
+
+The following tables illustrate how the conditions are impacted by feature flag and verification result. Note that if not `true` or `false` means this case doesn't update the corresponding condition.
+
+**No Matching Policies:**
+
+|                             | `Conditions.TrustedResourcesVerified` | `Conditions.Succeeded` |
+|-----------------------------|---------------------------------------|------------------------|
+| `no-match-policy`: "ignore" |                                       |                        |
+| `no-match-policy`: "warn"   | False                                 |                        |
+| `no-match-policy`: "fail"   | False                                 | False                  |
+
+**Matching Policies(no matter what `trusted-resources-verification-no-match-policy` value is):**
+
+|                          | `Conditions.TrustedResourcesVerified` | `Conditions.Succeeded` |
+|--------------------------|---------------------------------------|------------------------|
+| all policies pass        | True                                  |                        |
+| any enforce policy fails | False                                 | False                  |
+| only warn policies fail  | False                                 |                        |
+
+A successful sample `TrustedResourcesVerified` condition is:
+```yaml
+status:
+  conditions:
+  - lastTransitionTime: "2023-03-01T18:17:05Z"
+    message: Trusted resource verification passed
+    reason: ResourceVerificationSucceeded
+    status: "True"
+    type: TrustedResourcesVerified
+```
+
+Failed sample `TrustedResourcesVerified` and `Succeeded` conditions are:
+```yaml
+status:
+  conditions:
+  - lastTransitionTime: "2023-03-01T18:17:05Z"
+    message: Trusted resource verification failed # This will be filled with detailed error message.
+    reason: ResourceVerificationFailed
+    status: "False"
+    type: TrustedResourcesVerified
+  - lastTransitionTime: "2023-03-01T18:17:10Z"
+    message: resource verification failed
+    reason: ResourceVerificationFailed
+    status: "False"
+    type: Succeeded
+```
 
 #### Migrate Config key at configmap to VerificationPolicy
 **Note:** key configuration in configmap is deprecated,

--- a/pkg/reconciler/pipelinerun/pipelinespec/pipelinespec_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinespec/pipelinespec_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	cfgtesting "github.com/tektoncd/pipeline/pkg/apis/config/testing"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/pkg/trustedresources"
 	"github.com/tektoncd/pipeline/test/diff"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -302,6 +303,26 @@ func TestGetPipelineData_ResolvedNilPipeline(t *testing.T) {
 	}
 	ctx := context.Background()
 	_, _, err := GetPipelineData(ctx, pr, getPipeline)
+	if err == nil {
+		t.Fatalf("Expected error when unable to find referenced Pipeline but got none")
+	}
+}
+
+func TestGetPipelineSpec_VerificationError(t *testing.T) {
+	tr := &v1beta1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "mypipelinerun",
+		},
+		Spec: v1beta1.PipelineRunSpec{
+			PipelineRef: &v1beta1.PipelineRef{
+				Name: "orchestrate",
+			},
+		},
+	}
+	gt := func(ctx context.Context, n string) (*v1beta1.Pipeline, *v1beta1.RefSource, error) {
+		return nil, nil, &trustedresources.VerificationError{}
+	}
+	_, _, err := GetPipelineData(context.Background(), tr, gt)
 	if err == nil {
 		t.Fatalf("Expected error when unable to find referenced Pipeline but got none")
 	}

--- a/pkg/reconciler/pipelinerun/resources/pipelineref.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelineref.go
@@ -117,7 +117,10 @@ func GetVerifiedPipelineFunc(ctx context.Context, k8s kubernetes.Interface, tekt
 			refSource = s.URI
 		}
 		if err := trustedresources.VerifyPipeline(ctx, p, k8s, refSource, verificationpolicies); err != nil {
-			return nil, nil, fmt.Errorf("GetVerifiedPipelineFunc failed: %w: %v", trustedresources.ErrResourceVerificationFailed, err)
+			if trustedresources.IsVerificationResultError(err) {
+				return nil, nil, err
+			}
+			return p, s, err
 		}
 		return p, s, nil
 	}

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
@@ -2035,7 +2035,7 @@ func TestResolvePipelineRun_VerificationFailed(t *testing.T) {
 		}}}
 
 	getTask := func(ctx context.Context, name string) (*v1beta1.Task, *v1beta1.RefSource, error) {
-		return nil, nil, trustedresources.ErrResourceVerificationFailed
+		return nil, nil, &trustedresources.VerificationError{}
 	}
 	getTaskRun := func(name string) (*v1beta1.TaskRun, error) { return nil, nil }
 	pr := v1beta1.PipelineRun{
@@ -2047,9 +2047,6 @@ func TestResolvePipelineRun_VerificationFailed(t *testing.T) {
 		_, err := ResolvePipelineTask(context.Background(), pr, getTask, getTaskRun, nopGetRun, pt)
 		if err == nil {
 			t.Errorf("expected to get err but got nil")
-		}
-		if !errors.Is(err, trustedresources.ErrResourceVerificationFailed) {
-			t.Errorf("expected to get %v but got %v", trustedresources.ErrResourceVerificationFailed, err)
 		}
 	}
 }

--- a/pkg/reconciler/taskrun/resources/taskref.go
+++ b/pkg/reconciler/taskrun/resources/taskref.go
@@ -94,8 +94,12 @@ func GetVerifiedTaskFunc(ctx context.Context, k8s kubernetes.Interface, tekton c
 		if s != nil {
 			refSource = s.URI
 		}
-		if err := trustedresources.VerifyTask(ctx, t, k8s, refSource, verificationpolicies); err != nil {
-			return nil, nil, fmt.Errorf("GetVerifiedTaskFunc failed: %w: %v", trustedresources.ErrResourceVerificationFailed, err)
+		err = trustedresources.VerifyTask(ctx, t, k8s, refSource, verificationpolicies)
+		if err != nil {
+			if trustedresources.IsVerificationResultError(err) {
+				return nil, nil, err
+			}
+			return t, s, err
 		}
 		return t, s, nil
 	}

--- a/pkg/reconciler/taskrun/resources/taskref_test.go
+++ b/pkg/reconciler/taskrun/resources/taskref_test.go
@@ -838,8 +838,7 @@ func TestGetVerifiedTaskFunc_Success(t *testing.T) {
 			fn := resources.GetVerifiedTaskFunc(ctx, k8sclient, tektonclient, tc.requester, tr, tr.Spec.TaskRef, "", "default", "default", tc.policies)
 
 			resolvedTask, refSource, err := fn(ctx, taskRef.Name)
-
-			if err != nil {
+			if err != nil && trustedresources.IsVerificationResultError(err) {
 				t.Fatalf("Received unexpected error ( %#v )", err)
 			}
 
@@ -952,7 +951,7 @@ func TestGetVerifiedTaskFunc_VerifyError(t *testing.T) {
 		requester:                 requesterUnmatched,
 		verificationNoMatchPolicy: config.FailNoMatchPolicy,
 		expected:                  nil,
-		expectedErr:               trustedresources.ErrResourceVerificationFailed,
+		expectedErr:               trustedresources.ErrNoMatchedPolicies,
 	},
 	}
 	for _, tc := range testcases {
@@ -968,8 +967,7 @@ func TestGetVerifiedTaskFunc_VerifyError(t *testing.T) {
 			fn := resources.GetVerifiedTaskFunc(ctx, k8sclient, tektonclient, tc.requester, tr, tr.Spec.TaskRef, "", "default", "default", vps)
 
 			resolvedTask, resolvedRefSource, err := fn(ctx, taskRef.Name)
-
-			if !errors.Is(err, tc.expectedErr) {
+			if !errors.Is(errors.Unwrap(err), tc.expectedErr) {
 				t.Errorf("GetVerifiedTaskFunc got %v but want %v", err, tc.expectedErr)
 			}
 

--- a/pkg/reconciler/taskrun/resources/taskspec_test.go
+++ b/pkg/reconciler/taskrun/resources/taskspec_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/reconciler/taskrun/resources"
+	"github.com/tektoncd/pipeline/pkg/trustedresources"
 	"github.com/tektoncd/pipeline/test/diff"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -238,6 +239,26 @@ func TestGetTaskData_ResolvedNilTask(t *testing.T) {
 	}
 	ctx := context.Background()
 	_, _, err := resources.GetTaskData(ctx, tr, getTask)
+	if err == nil {
+		t.Fatalf("Expected error when unable to find referenced Task but got none")
+	}
+}
+
+func TestGetTaskSpec_VerificationError(t *testing.T) {
+	tr := &v1beta1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "mytaskrun",
+		},
+		Spec: v1beta1.TaskRunSpec{
+			TaskRef: &v1beta1.TaskRef{
+				Name: "orchestrate",
+			},
+		},
+	}
+	gt := func(ctx context.Context, n string) (*v1beta1.Task, *v1beta1.RefSource, error) {
+		return nil, nil, &trustedresources.VerificationError{}
+	}
+	_, _, err := resources.GetTaskData(context.Background(), tr, gt)
 	if err == nil {
 		t.Fatalf("Expected error when unable to find referenced Task but got none")
 	}

--- a/pkg/trustedresources/errors.go
+++ b/pkg/trustedresources/errors.go
@@ -15,7 +15,9 @@ limitations under the License.
 */
 package trustedresources
 
-import "errors"
+import (
+	"errors"
+)
 
 var (
 	// ErrResourceVerificationFailed is returned when trusted resources fails verification.
@@ -25,3 +27,47 @@ var (
 	// ErrRegexMatch is returned when regex match returns error
 	ErrRegexMatch = errors.New("regex failed to match")
 )
+
+type verificationResultType int
+
+const (
+	verificationResultError = iota
+	verificationResultWarn
+	verificationResultPass
+)
+
+// VerificationError wraps the verification result with the error
+type VerificationError struct {
+	// err wraps the verification error
+	err error
+	// resultType indicates if the verification is of error, warn or pass.
+	resultType verificationResultType
+}
+
+// Error returns the error message
+func (e *VerificationError) Error() string {
+	return e.err.Error()
+}
+
+// Unwrap returns the error
+func (e *VerificationError) Unwrap() error {
+	return e.err
+}
+
+// IsVerificationResultError checks if the resultType is verificationResultError
+func IsVerificationResultError(err error) bool {
+	var verr *VerificationError
+	if errors.As(err, &verr) {
+		return verr.resultType == verificationResultError
+	}
+	return false
+}
+
+// IsVerificationResultPass checks if the resultType is verificationResultPass
+func IsVerificationResultPass(err error) bool {
+	var verr *VerificationError
+	if errors.As(err, &verr) {
+		return verr.resultType == verificationResultPass
+	}
+	return false
+}

--- a/pkg/trustedresources/errors_test.go
+++ b/pkg/trustedresources/errors_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2022 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package trustedresources
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestError(t *testing.T) {
+	err := fmt.Errorf("some error")
+	verificationErr := VerificationError{err: err, resultType: verificationResultError}
+	if verificationErr.Error() != err.Error() {
+		t.Errorf("VerificationError Error() want %s got %s", err.Error(), verificationErr.Error())
+	}
+}
+
+func TestUnwrap(t *testing.T) {
+	err := ErrResourceVerificationFailed
+	verificationErr := VerificationError{err: err, resultType: verificationResultError}
+	unwrap := errors.Unwrap(&verificationErr)
+	if !errors.Is(unwrap, err) {
+		t.Errorf("VerificationError Unwrap() want %s got %s", err, unwrap)
+	}
+}
+
+func TestIsVerificationResultError(t *testing.T) {
+	tcs := []struct {
+		name            string
+		verificationErr error
+		want            bool
+	}{{
+		name:            "verificationResultError is verificationResultError",
+		verificationErr: &VerificationError{resultType: verificationResultError},
+		want:            true,
+	}, {
+		name:            "verificationResultWarn is not verificationResultError",
+		verificationErr: &VerificationError{resultType: verificationResultWarn},
+		want:            false,
+	}, {
+		name:            "verificationResultPass is not verificationResultError",
+		verificationErr: &VerificationError{resultType: verificationResultPass},
+		want:            false,
+	}, {
+		name:            "other error is not verificationResultError",
+		verificationErr: fmt.Errorf("random error"),
+		want:            false,
+	}}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			got := IsVerificationResultError(tc.verificationErr)
+			if got != tc.want {
+				t.Errorf("IsVerificationResultError want:%v got:%v,", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestIsVerificationResultPass(t *testing.T) {
+	tcs := []struct {
+		name            string
+		verificationErr error
+		want            bool
+	}{{
+		name:            "verificationResultError is not verificationResultPass",
+		verificationErr: &VerificationError{resultType: verificationResultError},
+		want:            false,
+	}, {
+		name:            "verificationResultWarn is not verificationResultPass",
+		verificationErr: &VerificationError{resultType: verificationResultWarn},
+		want:            false,
+	}, {
+		name:            "verificationResultPass is not verificationResultPass",
+		verificationErr: &VerificationError{resultType: verificationResultPass},
+		want:            true,
+	}, {
+		name:            "other error is not verificationResultError",
+		verificationErr: fmt.Errorf("random error"),
+		want:            false,
+	}}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			got := IsVerificationResultPass(tc.verificationErr)
+			if got != tc.want {
+				t.Errorf("IsVerificationResultPass want:%v got:%v,", tc.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This commit adds the `ConditionTrustedResourcesVerified` for trusted
resources into pipelinerun/taskrun status to show if the resources passes verification. Failing
to verify will add a false condition to the taskrun/pipelinerun
status and passing the verification will add a true status condition.

/kind feature

Signed-off-by: Yongxuan Zhang yongxuanzhang@google.com

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Add ConditionTrustedResourcesVerified condition to pipelinerun/taskrun status indicate whether trusted resources fails verification or not.
```
