### PR TITLE
Cleanup Resolution import path

### DIFF
--- a/pkg/resolution/resolver/cluster/resolver.go
+++ b/pkg/resolution/resolver/cluster/resolver.go
@@ -25,7 +25,6 @@ import (
 	"strings"
 
 	resolverconfig "github.com/tektoncd/pipeline/pkg/apis/config/resolver"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	pipelinev1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	clientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	pipelineclient "github.com/tektoncd/pipeline/pkg/client/injection/client"
@@ -215,7 +214,7 @@ func (r ResolvedClusterResource) Source() *pipelinev1beta1.ConfigSource {
 	h.Write(r.Spec)
 	sha256CheckSum := hex.EncodeToString(h.Sum(nil))
 
-	return &v1beta1.ConfigSource{
+	return &pipelinev1beta1.ConfigSource{
 		URI: r.Identifier,
 		Digest: map[string]string{
 			"sha256": sha256CheckSum,

--- a/test/resolution.go
+++ b/test/resolution.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	pipelinev1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	resolution "github.com/tektoncd/pipeline/pkg/resolution/resource"
 	"github.com/tektoncd/pipeline/test/diff"
@@ -28,7 +27,7 @@ func NewRequester(resource resolution.ResolvedResource, err error) *Requester {
 // NewResolvedResource creates a mock resolved resource that is
 // populated with the given data and annotations or returns the given
 // error from its Data() method.
-func NewResolvedResource(data []byte, annotations map[string]string, source *v1beta1.ConfigSource, dataErr error) *ResolvedResource {
+func NewResolvedResource(data []byte, annotations map[string]string, source *pipelinev1beta1.ConfigSource, dataErr error) *ResolvedResource {
 	return &ResolvedResource{
 		ResolvedData:        data,
 		ResolvedAnnotations: annotations,


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This commit cleans up the duplicate import path for resolution. No functional changes.
Cleanup as one of the prerequisites for v1 storage version swap.

/kind cleanup

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [n/a] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [n/a] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [n/a] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
