### PR TITLE
Ignore tekton reserved annotations

### DIFF
--- a/pkg/apis/pipeline/constant.go
+++ b/pkg/apis/pipeline/constant.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2023 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pipeline
+
+const (
+	// TektonReservedAnnotationExpr is the expression we use to filter out reserved key in annotation
+	TektonReservedAnnotationExpr = "(results.tekton.dev|chains.tekton.dev)/.*"
+)

--- a/pkg/apis/pipeline/v1/pipelinerun_defaults_test.go
+++ b/pkg/apis/pipeline/v1/pipelinerun_defaults_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/tektoncd/pipeline/test/diff"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
 )
 
 func TestPipelineRunSpec_SetDefaults(t *testing.T) {
@@ -314,15 +315,16 @@ func TestPipelineRunDefaulting(t *testing.T) {
 		in: &v1.PipelineRun{
 			Spec: v1.PipelineRunSpec{
 				PipelineRef: &v1.PipelineRef{Name: "foo"},
-				TaskRunTemplate: v1.PipelineTaskRunTemplate{PodTemplate: &pod.Template{
-					NodeSelector: map[string]string{
-						"label2": "value2",
+				TaskRunTemplate: v1.PipelineTaskRunTemplate{
+					PodTemplate: &pod.Template{
+						NodeSelector: map[string]string{
+							"label2": "value2",
+						},
+						SecurityContext: &corev1.PodSecurityContext{
+							RunAsNonRoot: &ttrue,
+						},
+						HostNetwork: false,
 					},
-					SecurityContext: &corev1.PodSecurityContext{
-						RunAsNonRoot: &ttrue,
-					},
-					HostNetwork: false,
-				},
 				},
 			},
 		},
@@ -401,10 +403,86 @@ func TestPipelineRunDefaulting(t *testing.T) {
 		defaults: map[string]string{
 			"default-resolver-type": "git",
 		},
+	}, {
+		name: "Reserved Tekton annotations are not filtered on update",
+		in: &v1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{"chains.tekton.dev/signed": "true", "foo": "bar"},
+			},
+			Spec: v1.PipelineRunSpec{
+				PipelineRef: &v1.PipelineRef{
+					Name: "foo",
+				},
+			},
+		},
+		want: &v1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{"chains.tekton.dev/signed": "true", "foo": "bar"},
+			},
+			Spec: v1.PipelineRunSpec{
+				TaskRunTemplate: v1.PipelineTaskRunTemplate{
+					ServiceAccountName: config.DefaultServiceAccountValue,
+				},
+				Timeouts: &v1.TimeoutFields{
+					Pipeline: &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
+				},
+				PipelineRef: &v1.PipelineRef{
+					Name: "foo",
+				},
+			},
+		},
 	}}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := cfgtesting.SetDefaults(context.Background(), t, tc.defaults)
+			got := tc.in
+			got.SetDefaults(ctx)
+			if !cmp.Equal(got, tc.want, ignoreUnexportedResources) {
+				d := cmp.Diff(got, tc.want, ignoreUnexportedResources)
+				t.Errorf("SetDefaults %s", diff.PrintWantGot(d))
+			}
+		})
+	}
+}
+
+func TestPipelineRunDefaultingOnCreate(t *testing.T) {
+	tests := []struct {
+		name     string
+		in       *v1.PipelineRun
+		want     *v1.PipelineRun
+		defaults map[string]string
+	}{{
+		name: "Reserved Tekton annotations are filtered on create",
+		in: &v1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{"chains.tekton.dev/signed": "true", "results.tekton.dev/hello": "world", "tekton.dev/foo": "bar", "foo": "bar"},
+			},
+			Spec: v1.PipelineRunSpec{
+				PipelineRef: &v1.PipelineRef{
+					Name: "foo",
+				},
+			},
+		},
+		want: &v1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{"tekton.dev/foo": "bar", "foo": "bar"},
+			},
+			Spec: v1.PipelineRunSpec{
+				TaskRunTemplate: v1.PipelineTaskRunTemplate{
+					ServiceAccountName: config.DefaultServiceAccountValue,
+				},
+				Timeouts: &v1.TimeoutFields{
+					Pipeline: &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
+				},
+				PipelineRef: &v1.PipelineRef{
+					Name: "foo",
+				},
+			},
+		},
+	}}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := apis.WithinCreate(cfgtesting.SetDefaults(context.Background(), t, tc.defaults))
 			got := tc.in
 			got.SetDefaults(ctx)
 			if !cmp.Equal(got, tc.want, ignoreUnexportedResources) {

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_defaults.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_defaults.go
@@ -18,19 +18,32 @@ package v1beta1
 
 import (
 	"context"
+	"regexp"
 	"time"
 
 	"github.com/tektoncd/pipeline/pkg/apis/config"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	pod "github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
+	"knative.dev/pkg/kmap"
 )
 
-var _ apis.Defaultable = (*PipelineRun)(nil)
+var (
+	_                              apis.Defaultable = (*PipelineRun)(nil)
+	filterReservedAnnotationRegexp                  = regexp.MustCompile(pipeline.TektonReservedAnnotationExpr)
+)
 
 // SetDefaults implements apis.Defaultable
 func (pr *PipelineRun) SetDefaults(ctx context.Context) {
 	pr.Spec.SetDefaults(ctx)
+
+	// Silently filtering out Tekton Reserved annotations at creation
+	if apis.IsInCreate(ctx) {
+		pr.ObjectMeta.Annotations = kmap.Filter(pr.ObjectMeta.Annotations, func(s string) bool {
+			return filterReservedAnnotationRegexp.MatchString(s)
+		})
+	}
 }
 
 // SetDefaults implements apis.Defaultable

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_defaults_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_defaults_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/tektoncd/pipeline/test/diff"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
 )
 
 func TestPipelineRunSpec_SetDefaults(t *testing.T) {
@@ -55,7 +56,8 @@ func TestPipelineRunSpec_SetDefaults(t *testing.T) {
 				ServiceAccountName: config.DefaultServiceAccountValue,
 				Timeout:            &metav1.Duration{Duration: 500 * time.Millisecond},
 			},
-		}, {
+		},
+		{
 			desc: "timeouts is nil",
 			prs:  &v1beta1.PipelineRunSpec{},
 			want: &v1beta1.PipelineRunSpec{
@@ -88,7 +90,8 @@ func TestPipelineRunSpec_SetDefaults(t *testing.T) {
 					Pipeline: &metav1.Duration{Duration: (config.DefaultTimeoutMinutes + 1) * time.Minute},
 				},
 			},
-		}, {
+		},
+		{
 			desc: "timeouts.pipeline is nil with timeouts.tasks and timeouts.finally",
 			prs: &v1beta1.PipelineRunSpec{
 				Timeouts: &v1beta1.TimeoutFields{
@@ -359,10 +362,78 @@ func TestPipelineRunDefaulting(t *testing.T) {
 		defaults: map[string]string{
 			"default-resolver-type": "git",
 		},
+	}, {
+		name: "Reserved Tekton annotations are not filtered on update",
+		in: &v1beta1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{"chains.tekton.dev/signed": "true", "foo": "bar"},
+			},
+			Spec: v1beta1.PipelineRunSpec{
+				PipelineRef: &v1beta1.PipelineRef{
+					Name: "foo",
+				},
+			},
+		},
+		want: &v1beta1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{"chains.tekton.dev/signed": "true", "foo": "bar"},
+			},
+			Spec: v1beta1.PipelineRunSpec{
+				ServiceAccountName: config.DefaultServiceAccountValue,
+				Timeout:            &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
+				PipelineRef: &v1beta1.PipelineRef{
+					Name: "foo",
+				},
+			},
+		},
 	}}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := cfgtesting.SetDefaults(context.Background(), t, tc.defaults)
+			got := tc.in
+			got.SetDefaults(ctx)
+			if !cmp.Equal(got, tc.want, ignoreUnexportedResources) {
+				d := cmp.Diff(got, tc.want, ignoreUnexportedResources)
+				t.Errorf("SetDefaults %s", diff.PrintWantGot(d))
+			}
+		})
+	}
+}
+
+func TestPipelineRunDefaultingOnCreate(t *testing.T) {
+	tests := []struct {
+		name     string
+		in       *v1beta1.PipelineRun
+		want     *v1beta1.PipelineRun
+		defaults map[string]string
+	}{{
+		name: "Reserved Tekton annotations are filtered on create",
+		in: &v1beta1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{"chains.tekton.dev/signed": "true", "results.tekton.dev/hello": "world", "tekton.dev/foo": "bar", "foo": "bar"},
+			},
+			Spec: v1beta1.PipelineRunSpec{
+				PipelineRef: &v1beta1.PipelineRef{
+					Name: "foo",
+				},
+			},
+		},
+		want: &v1beta1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{"tekton.dev/foo": "bar", "foo": "bar"},
+			},
+			Spec: v1beta1.PipelineRunSpec{
+				ServiceAccountName: config.DefaultServiceAccountValue,
+				Timeout:            &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
+				PipelineRef: &v1beta1.PipelineRef{
+					Name: "foo",
+				},
+			},
+		},
+	}}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := apis.WithinCreate(cfgtesting.SetDefaults(context.Background(), t, tc.defaults))
 			got := tc.in
 			got.SetDefaults(ctx)
 			if !cmp.Equal(got, tc.want, ignoreUnexportedResources) {

--- a/pkg/apis/pipeline/v1beta1/taskrun_defaults_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_defaults_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/tektoncd/pipeline/test/diff"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
 )
 
 var (
@@ -403,6 +404,52 @@ func TestTaskRunDefaulting(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := cfgtesting.SetDefaults(context.Background(), t, tc.defaults)
+			got := tc.in
+			got.SetDefaults(ctx)
+			if !cmp.Equal(got, tc.want, ignoreUnexportedResources) {
+				d := cmp.Diff(got, tc.want, ignoreUnexportedResources)
+				t.Errorf("SetDefaults %s", diff.PrintWantGot(d))
+			}
+		})
+	}
+}
+
+func TestTaskRunDefaultingOnCreate(t *testing.T) {
+	tests := []struct {
+		name     string
+		in       *v1beta1.TaskRun
+		want     *v1beta1.TaskRun
+		defaults map[string]string
+	}{{
+		name: "Reserved Tekton annotations are filtered on create",
+		in: &v1beta1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{"chains.tekton.dev/signed": "true", "results.tekton.dev/hello": "world", "tekton.dev/foo": "bar", "foo": "bar"},
+			},
+			Spec: v1beta1.TaskRunSpec{
+				TaskRef: &v1beta1.TaskRef{
+					Name: "foo",
+				},
+			},
+		},
+		want: &v1beta1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels:      map[string]string{"app.kubernetes.io/managed-by": "tekton-pipelines"},
+				Annotations: map[string]string{"tekton.dev/foo": "bar", "foo": "bar"},
+			},
+			Spec: v1beta1.TaskRunSpec{
+				TaskRef: &v1beta1.TaskRef{
+					Kind: "Task",
+					Name: "foo",
+				},
+				Timeout:            &metav1.Duration{Duration: time.Hour},
+				ServiceAccountName: "default",
+			},
+		},
+	}}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := apis.WithinCreate(cfgtesting.SetDefaults(context.Background(), t, tc.defaults))
 			got := tc.in
 			got.SetDefaults(ctx)
 			if !cmp.Equal(got, tc.want, ignoreUnexportedResources) {

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -888,7 +888,7 @@ func storeTaskSpecAndMergeMeta(ctx context.Context, tr *v1.TaskRun, ts *v1.TaskS
 		}
 
 		// Propagate annotations from Task to TaskRun. TaskRun annotations take precedences over Task.
-		tr.ObjectMeta.Annotations = kmap.Union(kmap.ExcludeKeys(meta.Annotations, "kubectl.kubernetes.io/last-applied-configuration"), tr.ObjectMeta.Annotations)
+		tr.ObjectMeta.Annotations = kmap.Union(kmap.ExcludeKeys(meta.Annotations, tknreconciler.KubectlLastAppliedAnnotationKey), tr.ObjectMeta.Annotations)
 		// Propagate labels from Task to TaskRun. TaskRun labels take precedences over Task.
 		tr.ObjectMeta.Labels = kmap.Union(meta.Labels, tr.ObjectMeta.Labels)
 		if tr.Spec.TaskRef != nil {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This "filters" out annotation that looks like `*.tekton.dev/*` at creation for `PipelineRun` and `TaskRun`, as well as not propagating this annotation from `PipelineRun` to `TaskRun`.

Closes #6435 

**Why is this required ?**

This is a little bit explained in https://github.com/tektoncd/pipeline/issues/6435. But in a nutshell, if a client has a re-run feature and copies all annotations from one `PipelineRun` to a new one, it might end up copying some "reserved" annotations, like `chains.tekton.dev/*` — which can be a problem. For chains, having those will make chains ignore the `PipelineRun` or `TaskRun` and not handle it at all. For results, it could be marking a `PipelineRun` or `TaskRun` as taken care of even if it is not, …

cc @lcarva 
@tektoncd/core-maintainers I would suggest to cherry-pick this fix to all LTS as well as this "affects" all versions 🙏🏼 

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Reserved annotations (`results.tekton.dev/*` and `chains.tekton.dev/*`) are now filter at creation (and not passed from PipelineRun to TaskRun).
```
