### PR TITLE
Clarify ParamValue syntax

### DIFF
--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -14,13 +14,13 @@
 - [Status Signalling](#status-signalling)
 - [Listing Resources](#listing-resources)
 - [Detailed Resource Types - v1beta1](#detailed-resource-types---v1beta1)
-  * [`ParamValue`](#paramvalue)
   * [`ContainerStateRunning`](#containerstaterunning)
   * [`ContainerStateWaiting`](#containerstatewaiting)
   * [`ContainerStateTerminated`](#containerstateterminated)
   * [`EnvVar`](#envvar)
   * [`Param`](#param)
   * [`ParamSpec`](#paramspec)
+  * [`ParamValue`](#paramvalue)
   * [`Step`](#step)
   * [`StepState`](#stepstate)
   * [`TaskResult`](#taskresult)
@@ -186,15 +186,6 @@ List responses have the following fields (based on [`meta.v1/ListMeta`](https://
 
 ## Detailed Resource Types - v1beta1
 
-### `ParamValue`
-
-| Field Name  | Field Type | Requirement |
-|-------------|------------|-------------|
-| `type`      | Enum:<br>- `"string"` (default)<br>- `"array"` <br>- `"object"` | REQUIRED |
-| `stringVal` | string     | REQUIRED    |
-| `arrayVal`  | []string   | REQUIRED    |
-| `objectVal` | map<string,string>   | REQUIRED    |
-
 ### `ContainerStateRunning`
 
 | Field Name   | Field Type | Requirement |
@@ -236,7 +227,7 @@ List responses have the following fields (based on [`meta.v1/ListMeta`](https://
 | Field Name | Field Type      | Requirement |
 |------------|-----------------|-------------|
 | `name`     | string          | REQUIRED    |
-| `value`    | `ParamValue` | REQUIRED    |
+| `value`    | `ParamValue`    | REQUIRED    |
 
 ### `ParamSpec`
 
@@ -247,6 +238,10 @@ List responses have the following fields (based on [`meta.v1/ListMeta`](https://
 | `type`      | Enum:<br>- `"string"` (default)<br>- `"array"` <br>- `"object"` | REQUIRED (The values `string` and `array` for this field are REQUIRED, and the value `object` is RECOMMENDED.) |
 | `properties`  | map<string,PropertySpec> |RECOMMENDED <br><br>note: `PropertySpec` is a type that defines the spec of an individual key. See how to define the `properties` section in the [example](../examples/v1beta1/taskruns/alpha/object-param-result.yaml).|
 | `default`     | `ParamValue` | REQUIRED |
+
+### `ParamValue`
+
+A `ParamValue` may be a string, a list of string, or a map of string to string.
 
 ### `Step`
 

--- a/docs/pipeline-api.md
+++ b/docs/pipeline-api.md
@@ -1788,7 +1788,7 @@ Used to distinguish between a single string and an array of strings.</p>
 <tbody>
 <tr>
 <td>
-<code>type</code><br/>
+<code>Type</code><br/>
 <em>
 <a href="#tekton.dev/v1.ParamType">
 ParamType
@@ -1800,7 +1800,7 @@ ParamType
 </tr>
 <tr>
 <td>
-<code>stringVal</code><br/>
+<code>StringVal</code><br/>
 <em>
 string
 </em>
@@ -1811,7 +1811,7 @@ string
 </tr>
 <tr>
 <td>
-<code>arrayVal</code><br/>
+<code>ArrayVal</code><br/>
 <em>
 []string
 </em>
@@ -1821,7 +1821,7 @@ string
 </tr>
 <tr>
 <td>
-<code>objectVal</code><br/>
+<code>ObjectVal</code><br/>
 <em>
 map[string]string
 </em>
@@ -9501,7 +9501,7 @@ Used to distinguish between a single string and an array of strings.</p>
 <tbody>
 <tr>
 <td>
-<code>type</code><br/>
+<code>Type</code><br/>
 <em>
 <a href="#tekton.dev/v1beta1.ParamType">
 ParamType
@@ -9513,7 +9513,7 @@ ParamType
 </tr>
 <tr>
 <td>
-<code>stringVal</code><br/>
+<code>StringVal</code><br/>
 <em>
 string
 </em>
@@ -9524,7 +9524,7 @@ string
 </tr>
 <tr>
 <td>
-<code>arrayVal</code><br/>
+<code>ArrayVal</code><br/>
 <em>
 []string
 </em>
@@ -9534,7 +9534,7 @@ string
 </tr>
 <tr>
 <td>
-<code>objectVal</code><br/>
+<code>ObjectVal</code><br/>
 <em>
 map[string]string
 </em>

--- a/hack/ignored-openapi-violations.list
+++ b/hack/ignored-openapi-violations.list
@@ -7,6 +7,14 @@ API rule violation: names_match,github.com/tektoncd/pipeline/pkg/apis/pipeline/v
 API rule violation: names_match,github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1,SidecarState,ContainerName
 API rule violation: names_match,github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1,StepState,ContainerName
 API rule violation: names_match,github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1,TaskRunStatusFields,TaskRunResults
+API rule violation: names_match,github.com/tektoncd/pipeline/pkg/apis/pipeline/v1,ParamValue,ArrayVal
+API rule violation: names_match,github.com/tektoncd/pipeline/pkg/apis/pipeline/v1,ParamValue,ObjectVal
+API rule violation: names_match,github.com/tektoncd/pipeline/pkg/apis/pipeline/v1,ParamValue,StringVal
+API rule violation: names_match,github.com/tektoncd/pipeline/pkg/apis/pipeline/v1,ParamValue,Type
+API rule violation: names_match,github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1,ParamValue,ArrayVal
+API rule violation: names_match,github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1,ParamValue,ObjectVal
+API rule violation: names_match,github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1,ParamValue,StringVal
+API rule violation: names_match,github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1,ParamValue,Type
 API rule violation: names_match,github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1,PipelineResourceSpec,SecretParams
 API rule violation: names_match,github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1,Step,DeprecatedLifecycle
 API rule violation: names_match,github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1,Step,DeprecatedLivenessProbe

--- a/pkg/apis/pipeline/v1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1/openapi_generated.go
@@ -846,14 +846,14 @@ func schema_pkg_apis_pipeline_v1_ParamValue(ref common.ReferenceCallback) common
 				Description: "ResultValue is a type alias of ParamValue",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
-					"type": {
+					"Type": {
 						SchemaProps: spec.SchemaProps{
 							Default: "",
 							Type:    []string{"string"},
 							Format:  "",
 						},
 					},
-					"stringVal": {
+					"StringVal": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Represents the stored type of ParamValues.",
 							Default:     "",
@@ -861,7 +861,7 @@ func schema_pkg_apis_pipeline_v1_ParamValue(ref common.ReferenceCallback) common
 							Format:      "",
 						},
 					},
-					"arrayVal": {
+					"ArrayVal": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
 								"x-kubernetes-list-type": "atomic",
@@ -880,7 +880,7 @@ func schema_pkg_apis_pipeline_v1_ParamValue(ref common.ReferenceCallback) common
 							},
 						},
 					},
-					"objectVal": {
+					"ObjectVal": {
 						SchemaProps: spec.SchemaProps{
 							Type: []string{"object"},
 							AdditionalProperties: &spec.SchemaOrBool{
@@ -896,7 +896,7 @@ func schema_pkg_apis_pipeline_v1_ParamValue(ref common.ReferenceCallback) common
 						},
 					},
 				},
-				Required: []string{"type", "stringVal", "arrayVal", "objectVal"},
+				Required: []string{"Type", "StringVal", "ArrayVal", "ObjectVal"},
 			},
 		},
 	}

--- a/pkg/apis/pipeline/v1/param_types.go
+++ b/pkg/apis/pipeline/v1/param_types.go
@@ -377,11 +377,11 @@ var AllParamTypes = []ParamType{ParamTypeString, ParamTypeArray, ParamTypeObject
 // Used in JSON unmarshalling so that a single JSON field can accept
 // either an individual string or an array of strings.
 type ParamValue struct {
-	Type      ParamType `json:"type"` // Represents the stored type of ParamValues.
-	StringVal string    `json:"stringVal"`
+	Type      ParamType // Represents the stored type of ParamValues.
+	StringVal string
 	// +listType=atomic
-	ArrayVal  []string          `json:"arrayVal"`
-	ObjectVal map[string]string `json:"objectVal"`
+	ArrayVal  []string
+	ObjectVal map[string]string
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface.

--- a/pkg/apis/pipeline/v1/swagger.json
+++ b/pkg/apis/pipeline/v1/swagger.json
@@ -388,13 +388,13 @@
       "description": "ResultValue is a type alias of ParamValue",
       "type": "object",
       "required": [
-        "type",
-        "stringVal",
-        "arrayVal",
-        "objectVal"
+        "Type",
+        "StringVal",
+        "ArrayVal",
+        "ObjectVal"
       ],
       "properties": {
-        "arrayVal": {
+        "ArrayVal": {
           "type": "array",
           "items": {
             "type": "string",
@@ -402,19 +402,19 @@
           },
           "x-kubernetes-list-type": "atomic"
         },
-        "objectVal": {
+        "ObjectVal": {
           "type": "object",
           "additionalProperties": {
             "type": "string",
             "default": ""
           }
         },
-        "stringVal": {
+        "StringVal": {
           "description": "Represents the stored type of ParamValues.",
           "type": "string",
           "default": ""
         },
-        "type": {
+        "Type": {
           "type": "string",
           "default": ""
         }

--- a/pkg/apis/pipeline/v1beta1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1beta1/openapi_generated.go
@@ -1344,14 +1344,14 @@ func schema_pkg_apis_pipeline_v1beta1_ParamValue(ref common.ReferenceCallback) c
 				Description: "ResultValue is a type alias of ParamValue",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
-					"type": {
+					"Type": {
 						SchemaProps: spec.SchemaProps{
 							Default: "",
 							Type:    []string{"string"},
 							Format:  "",
 						},
 					},
-					"stringVal": {
+					"StringVal": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Represents the stored type of ParamValues.",
 							Default:     "",
@@ -1359,7 +1359,7 @@ func schema_pkg_apis_pipeline_v1beta1_ParamValue(ref common.ReferenceCallback) c
 							Format:      "",
 						},
 					},
-					"arrayVal": {
+					"ArrayVal": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
 								"x-kubernetes-list-type": "atomic",
@@ -1378,7 +1378,7 @@ func schema_pkg_apis_pipeline_v1beta1_ParamValue(ref common.ReferenceCallback) c
 							},
 						},
 					},
-					"objectVal": {
+					"ObjectVal": {
 						SchemaProps: spec.SchemaProps{
 							Type: []string{"object"},
 							AdditionalProperties: &spec.SchemaOrBool{
@@ -1394,7 +1394,7 @@ func schema_pkg_apis_pipeline_v1beta1_ParamValue(ref common.ReferenceCallback) c
 						},
 					},
 				},
-				Required: []string{"type", "stringVal", "arrayVal", "objectVal"},
+				Required: []string{"Type", "StringVal", "ArrayVal", "ObjectVal"},
 			},
 		},
 	}

--- a/pkg/apis/pipeline/v1beta1/param_types.go
+++ b/pkg/apis/pipeline/v1beta1/param_types.go
@@ -370,11 +370,11 @@ var AllParamTypes = []ParamType{ParamTypeString, ParamTypeArray, ParamTypeObject
 // Used in JSON unmarshalling so that a single JSON field can accept
 // either an individual string or an array of strings.
 type ParamValue struct {
-	Type      ParamType `json:"type"` // Represents the stored type of ParamValues.
-	StringVal string    `json:"stringVal"`
+	Type      ParamType // Represents the stored type of ParamValues.
+	StringVal string
 	// +listType=atomic
-	ArrayVal  []string          `json:"arrayVal"`
-	ObjectVal map[string]string `json:"objectVal"`
+	ArrayVal  []string
+	ObjectVal map[string]string
 }
 
 // ArrayOrString is deprecated, this is to keep backward compatibility

--- a/pkg/apis/pipeline/v1beta1/swagger.json
+++ b/pkg/apis/pipeline/v1beta1/swagger.json
@@ -647,13 +647,13 @@
       "description": "ResultValue is a type alias of ParamValue",
       "type": "object",
       "required": [
-        "type",
-        "stringVal",
-        "arrayVal",
-        "objectVal"
+        "Type",
+        "StringVal",
+        "ArrayVal",
+        "ObjectVal"
       ],
       "properties": {
-        "arrayVal": {
+        "ArrayVal": {
           "type": "array",
           "items": {
             "type": "string",
@@ -661,19 +661,19 @@
           },
           "x-kubernetes-list-type": "atomic"
         },
-        "objectVal": {
+        "ObjectVal": {
           "type": "object",
           "additionalProperties": {
             "type": "string",
             "default": ""
           }
         },
-        "stringVal": {
+        "StringVal": {
           "description": "Represents the stored type of ParamValues.",
           "type": "string",
           "default": ""
         },
-        "type": {
+        "Type": {
           "type": "string",
           "default": ""
         }


### PR DESCRIPTION
This commit updates the API spec docs to clarify that ParamValues can be strings, lists of strings, and maps of string to string. Since we use a custom unmarshaling function, the user-specified syntax doesn't actually contain the fields "type", "stringVal", "arrayVal", and "objectVal".

This commit also removes the JSON struct tags for this field, which serve no functional purpose. This helps clarify that param values undergo custom unmarshalling.

More investigation is needed to determine how to correctly display this field in autogenerated OpenAPI docs. This will happen in a later commit.

Partially addresses https://github.com/tektoncd/pipeline/issues/6365
/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- n/a Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- n/a Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- n/a Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
