### PR TITLE
Clean Up: Update `[]Param` to the new `Params` type

### DIFF
--- a/docs/pipeline-api.md
+++ b/docs/pipeline-api.md
@@ -713,8 +713,8 @@ PipelineSpec
 <td>
 <code>params</code><br/>
 <em>
-<a href="#tekton.dev/v1.Param">
-[]Param
+<a href="#tekton.dev/v1.Params">
+Params
 </a>
 </em>
 </td>
@@ -1071,8 +1071,8 @@ TaskRunDebug
 <td>
 <code>params</code><br/>
 <em>
-<a href="#tekton.dev/v1.Param">
-[]Param
+<a href="#tekton.dev/v1.Params">
+Params
 </a>
 </em>
 </td>
@@ -1591,9 +1591,6 @@ IncludeParamsList
 </table>
 <h3 id="tekton.dev/v1.Param">Param
 </h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineRunSpec">PipelineRunSpec</a>, <a href="#tekton.dev/v1.ResolverRef">ResolverRef</a>, <a href="#tekton.dev/v1.TaskRunInputs">TaskRunInputs</a>, <a href="#tekton.dev/v1.TaskRunSpec">TaskRunSpec</a>)
-</p>
 <div>
 <p>Param declares an ParamValues to use for the parameter called name.</p>
 </div>
@@ -1811,7 +1808,7 @@ map[string]string
 <h3 id="tekton.dev/v1.Params">Params
 (<code>[]github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Param</code> alias)</h3>
 <p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.IncludeParams">IncludeParams</a>, <a href="#tekton.dev/v1.Matrix">Matrix</a>, <a href="#tekton.dev/v1.PipelineTask">PipelineTask</a>)
+(<em>Appears on:</em><a href="#tekton.dev/v1.IncludeParams">IncludeParams</a>, <a href="#tekton.dev/v1.Matrix">Matrix</a>, <a href="#tekton.dev/v1.PipelineRunSpec">PipelineRunSpec</a>, <a href="#tekton.dev/v1.PipelineTask">PipelineTask</a>, <a href="#tekton.dev/v1.ResolverRef">ResolverRef</a>, <a href="#tekton.dev/v1.TaskRunInputs">TaskRunInputs</a>, <a href="#tekton.dev/v1.TaskRunSpec">TaskRunSpec</a>)
 </p>
 <div>
 <p>Params is a list of Param</p>
@@ -2136,8 +2133,8 @@ PipelineSpec
 <td>
 <code>params</code><br/>
 <em>
-<a href="#tekton.dev/v1.Param">
-[]Param
+<a href="#tekton.dev/v1.Params">
+Params
 </a>
 </em>
 </td>
@@ -3157,8 +3154,8 @@ resolution of the referenced Tekton resource, such as &ldquo;git&rdquo;.</p>
 <td>
 <code>params</code><br/>
 <em>
-<a href="#tekton.dev/v1.Param">
-[]Param
+<a href="#tekton.dev/v1.Params">
+Params
 </a>
 </em>
 </td>
@@ -4634,8 +4631,8 @@ string
 <td>
 <code>params</code><br/>
 <em>
-<a href="#tekton.dev/v1.Param">
-[]Param
+<a href="#tekton.dev/v1.Params">
+Params
 </a>
 </em>
 </td>
@@ -4820,8 +4817,8 @@ TaskRunDebug
 <td>
 <code>params</code><br/>
 <em>
-<a href="#tekton.dev/v1.Param">
-[]Param
+<a href="#tekton.dev/v1.Params">
+Params
 </a>
 </em>
 </td>
@@ -5945,8 +5942,8 @@ EmbeddedRunSpec
 <td>
 <code>params</code><br/>
 <em>
-<a href="#tekton.dev/v1beta1.Param">
-[]Param
+<a href="#tekton.dev/v1beta1.Params">
+Params
 </a>
 </em>
 </td>
@@ -6470,8 +6467,8 @@ EmbeddedRunSpec
 <td>
 <code>params</code><br/>
 <em>
-<a href="#tekton.dev/v1beta1.Param">
-[]Param
+<a href="#tekton.dev/v1beta1.Params">
+Params
 </a>
 </em>
 </td>
@@ -7120,8 +7117,8 @@ EmbeddedCustomRunSpec
 <td>
 <code>params</code><br/>
 <em>
-<a href="#tekton.dev/v1beta1.Param">
-[]Param
+<a href="#tekton.dev/v1beta1.Params">
+Params
 </a>
 </em>
 </td>
@@ -7470,8 +7467,8 @@ PipelineSpec
 <td>
 <code>params</code><br/>
 <em>
-<a href="#tekton.dev/v1beta1.Param">
-[]Param
+<a href="#tekton.dev/v1beta1.Params">
+Params
 </a>
 </em>
 </td>
@@ -7855,8 +7852,8 @@ TaskRunDebug
 <td>
 <code>params</code><br/>
 <em>
-<a href="#tekton.dev/v1beta1.Param">
-[]Param
+<a href="#tekton.dev/v1beta1.Params">
+Params
 </a>
 </em>
 </td>
@@ -8343,8 +8340,8 @@ EmbeddedCustomRunSpec
 <td>
 <code>params</code><br/>
 <em>
-<a href="#tekton.dev/v1beta1.Param">
-[]Param
+<a href="#tekton.dev/v1beta1.Params">
+Params
 </a>
 </em>
 </td>
@@ -8708,7 +8705,7 @@ IncludeParamsList
 <h3 id="tekton.dev/v1beta1.Param">Param
 </h3>
 <p>
-(<em>Appears on:</em><a href="#tekton.dev/v1alpha1.RunSpec">RunSpec</a>, <a href="#tekton.dev/v1beta1.CustomRunSpec">CustomRunSpec</a>, <a href="#tekton.dev/v1beta1.PipelineRunSpec">PipelineRunSpec</a>, <a href="#tekton.dev/v1beta1.ResolverRef">ResolverRef</a>, <a href="#tekton.dev/v1beta1.TaskRunSpec">TaskRunSpec</a>, <a href="#resolution.tekton.dev/v1beta1.ResolutionRequestSpec">ResolutionRequestSpec</a>)
+(<em>Appears on:</em><a href="#resolution.tekton.dev/v1beta1.ResolutionRequestSpec">ResolutionRequestSpec</a>)
 </p>
 <div>
 <p>Param declares an ParamValues to use for the parameter called name.</p>
@@ -8912,7 +8909,7 @@ map[string]string
 <h3 id="tekton.dev/v1beta1.Params">Params
 (<code>[]github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Param</code> alias)</h3>
 <p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.IncludeParams">IncludeParams</a>, <a href="#tekton.dev/v1beta1.Matrix">Matrix</a>, <a href="#tekton.dev/v1beta1.PipelineTask">PipelineTask</a>)
+(<em>Appears on:</em><a href="#tekton.dev/v1alpha1.RunSpec">RunSpec</a>, <a href="#tekton.dev/v1beta1.CustomRunSpec">CustomRunSpec</a>, <a href="#tekton.dev/v1beta1.IncludeParams">IncludeParams</a>, <a href="#tekton.dev/v1beta1.Matrix">Matrix</a>, <a href="#tekton.dev/v1beta1.PipelineRunSpec">PipelineRunSpec</a>, <a href="#tekton.dev/v1beta1.PipelineTask">PipelineTask</a>, <a href="#tekton.dev/v1beta1.ResolverRef">ResolverRef</a>, <a href="#tekton.dev/v1beta1.TaskRunSpec">TaskRunSpec</a>)
 </p>
 <div>
 <p>Params is a list of Param</p>
@@ -9277,8 +9274,8 @@ PipelineSpec
 <td>
 <code>params</code><br/>
 <em>
-<a href="#tekton.dev/v1beta1.Param">
-[]Param
+<a href="#tekton.dev/v1beta1.Params">
+Params
 </a>
 </em>
 </td>
@@ -10319,8 +10316,8 @@ resolution of the referenced Tekton resource, such as &ldquo;git&rdquo;.</p>
 <td>
 <code>params</code><br/>
 <em>
-<a href="#tekton.dev/v1beta1.Param">
-[]Param
+<a href="#tekton.dev/v1beta1.Params">
+Params
 </a>
 </em>
 </td>
@@ -12239,8 +12236,8 @@ TaskRunDebug
 <td>
 <code>params</code><br/>
 <em>
-<a href="#tekton.dev/v1beta1.Param">
-[]Param
+<a href="#tekton.dev/v1beta1.Params">
+Params
 </a>
 </em>
 </td>

--- a/pkg/apis/pipeline/v1/matrix_types_test.go
+++ b/pkg/apis/pipeline/v1/matrix_types_test.go
@@ -119,19 +119,19 @@ func TestMatrix_FanOut(t *testing.T) {
 		matrix: Matrix{
 			Include: IncludeParamsList{{
 				Name: "build-1",
-				Params: []Param{{
+				Params: Params{{
 					Name: "IMAGE", Value: ParamValue{Type: ParamTypeString, StringVal: "image-1"},
 				}, {
 					Name: "DOCKERFILE", Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/Dockerfile1"}}},
 			}, {
 				Name: "build-2",
-				Params: []Param{{
+				Params: Params{{
 					Name: "IMAGE", Value: ParamValue{Type: ParamTypeString, StringVal: "image-2"},
 				}, {
 					Name: "DOCKERFILE", Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/Dockerfile2"}}},
 			}, {
 				Name: "build-3",
-				Params: []Param{{
+				Params: Params{{
 					Name: "IMAGE", Value: ParamValue{Type: ParamTypeString, StringVal: "image-3"},
 				}, {
 					Name: "DOCKERFILE", Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/Dockerfile3"}}},
@@ -321,7 +321,7 @@ func TestMatrix_FanOut(t *testing.T) {
 			},
 			Include: IncludeParamsList{{
 				Name: "s390x-no-race",
-				Params: []Param{{
+				Params: Params{{
 					Name: "GOARCH", Value: ParamValue{Type: ParamTypeString, StringVal: "linux/s390x"},
 				}, {
 					Name: "flags", Value: ParamValue{Type: ParamTypeString, StringVal: "-cover -v"}}},
@@ -474,23 +474,23 @@ func TestMatrix_FanOut(t *testing.T) {
 				},
 				Include: IncludeParamsList{{
 					Name: "common-package",
-					Params: []Param{{
+					Params: Params{{
 						Name: "package", Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/common/package/"}}},
 				}, {
 					Name: "s390x-no-race",
-					Params: []Param{{
+					Params: Params{{
 						Name: "GOARCH", Value: ParamValue{Type: ParamTypeString, StringVal: "linux/s390x"},
 					}, {
 						Name: "flags", Value: ParamValue{Type: ParamTypeString, StringVal: "-cover -v"}}},
 				}, {
 					Name: "go117-context",
-					Params: []Param{{
+					Params: Params{{
 						Name: "version", Value: ParamValue{Type: ParamTypeString, StringVal: "go1.17"},
 					}, {
 						Name: "context", Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/go117/context"}}},
 				}, {
 					Name: "non-existent-arch",
-					Params: []Param{{
+					Params: Params{{
 						Name: "GOARCH", Value: ParamValue{Type: ParamTypeString, StringVal: "I-do-not-exist"}},
 					},
 				}},
@@ -610,7 +610,7 @@ func TestMatrix_HasParams(t *testing.T) {
 		{
 			name: "matrixed with params",
 			matrix: &Matrix{
-				Params: []Param{{Name: "platform", Value: ParamValue{ArrayVal: []string{"linux", "windows"}}}},
+				Params: Params{{Name: "platform", Value: ParamValue{ArrayVal: []string{"linux", "windows"}}}},
 			},
 			want: true,
 		}, {
@@ -618,7 +618,7 @@ func TestMatrix_HasParams(t *testing.T) {
 			matrix: &Matrix{
 				Include: IncludeParamsList{{
 					Name: "build-1",
-					Params: []Param{{
+					Params: Params{{
 						Name: "IMAGE", Value: ParamValue{Type: ParamTypeString, StringVal: "image-1"},
 					}, {
 						Name: "DOCKERFILE", Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/Dockerfile1"}}},
@@ -834,21 +834,21 @@ func TestPipelineTask_CountCombinations(t *testing.T) {
 		matrix: &Matrix{
 			Include: IncludeParamsList{{
 				Name: "build-1",
-				Params: []Param{{
+				Params: Params{{
 					Name: "IMAGE", Value: ParamValue{Type: ParamTypeString, StringVal: "image-1"},
 				}, {
 					Name: "DOCKERFILE", Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/Dockerfile1"},
 				}},
 			}, {
 				Name: "build-2",
-				Params: []Param{{
+				Params: Params{{
 					Name: "IMAGE", Value: ParamValue{Type: ParamTypeString, StringVal: "image-2"},
 				}, {
 					Name: "DOCKERFILE", Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/Dockerfile2"},
 				}},
 			}, {
 				Name: "build-3",
-				Params: []Param{{
+				Params: Params{{
 					Name: "IMAGE", Value: ParamValue{Type: ParamTypeString, StringVal: "image-3"},
 				}, {
 					Name: "DOCKERFILE", Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/Dockerfile3"},
@@ -859,24 +859,24 @@ func TestPipelineTask_CountCombinations(t *testing.T) {
 	}, {
 		name: "params and include in matrix with overriding combinations params",
 		matrix: &Matrix{
-			Params: []Param{{
+			Params: Params{{
 				Name: "GOARCH", Value: ParamValue{ArrayVal: []string{"linux/amd64", "linux/ppc64le", "linux/s390x"}},
 			}, {
 				Name: "version", Value: ParamValue{ArrayVal: []string{"go1.17", "go1.18.1"}}},
 			},
 			Include: IncludeParamsList{{
 				Name: "common-package",
-				Params: []Param{{
+				Params: Params{{
 					Name: "package", Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/common/package/"}}},
 			}, {
 				Name: "s390x-no-race",
-				Params: []Param{{
+				Params: Params{{
 					Name: "GOARCH", Value: ParamValue{Type: ParamTypeString, StringVal: "linux/s390x"},
 				}, {
 					Name: "flags", Value: ParamValue{Type: ParamTypeString, StringVal: "-cover -v"}}},
 			}, {
 				Name: "go117-context",
-				Params: []Param{{
+				Params: Params{{
 					Name: "version", Value: ParamValue{Type: ParamTypeString, StringVal: "go1.17"},
 				}, {
 					Name: "context", Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/go117/context"}}},
@@ -886,30 +886,30 @@ func TestPipelineTask_CountCombinations(t *testing.T) {
 	}, {
 		name: "params and include in matrix with overriding combinations params and one new combination",
 		matrix: &Matrix{
-			Params: []Param{{
+			Params: Params{{
 				Name: "GOARCH", Value: ParamValue{ArrayVal: []string{"linux/amd64", "linux/ppc64le", "linux/s390x"}},
 			}, {
 				Name: "version", Value: ParamValue{ArrayVal: []string{"go1.17", "go1.18.1"}}},
 			},
 			Include: IncludeParamsList{{
 				Name: "common-package",
-				Params: []Param{{
+				Params: Params{{
 					Name: "package", Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/common/package/"}}},
 			}, {
 				Name: "s390x-no-race",
-				Params: []Param{{
+				Params: Params{{
 					Name: "GOARCH", Value: ParamValue{Type: ParamTypeString, StringVal: "linux/s390x"},
 				}, {
 					Name: "flags", Value: ParamValue{Type: ParamTypeString, StringVal: "-cover -v"}}},
 			}, {
 				Name: "go117-context",
-				Params: []Param{{
+				Params: Params{{
 					Name: "version", Value: ParamValue{Type: ParamTypeString, StringVal: "go1.17"},
 				}, {
 					Name: "context", Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/go117/context"}}},
 			}, {
 				Name: "non-existent-arch",
-				Params: []Param{{
+				Params: Params{{
 					Name: "GOARCH", Value: ParamValue{Type: ParamTypeString, StringVal: "I-do-not-exist"}},
 				}},
 			}},

--- a/pkg/apis/pipeline/v1/pipeline_types_test.go
+++ b/pkg/apis/pipeline/v1/pipeline_types_test.go
@@ -217,7 +217,7 @@ func TestPipelineTask_ValidateRegularTask_Success(t *testing.T) {
 	}, {
 		name: "pipeline task - use of resolver params with the feature flag set",
 		tasks: PipelineTask{
-			TaskRef: &TaskRef{Name: "boo", ResolverRef: ResolverRef{Params: []Param{{}}}},
+			TaskRef: &TaskRef{Name: "boo", ResolverRef: ResolverRef{Params: Params{{}}}},
 		},
 		enableBetaAPIFields: true,
 	}}
@@ -286,7 +286,7 @@ func TestPipelineTask_ValidateRegularTask_Failure(t *testing.T) {
 	}, {
 		name: "pipeline task - use of resolver params without the feature flag set",
 		task: PipelineTask{
-			TaskRef: &TaskRef{Name: "boo", ResolverRef: ResolverRef{Params: []Param{{}}}},
+			TaskRef: &TaskRef{Name: "boo", ResolverRef: ResolverRef{Params: Params{{}}}},
 		},
 		expectedError: *apis.ErrDisallowedFields("taskref.params"),
 	}}
@@ -380,7 +380,7 @@ func TestPipelineTaskList_Deps(t *testing.T) {
 			Name: "task-1",
 		}, {
 			Name: "task-2",
-			Params: []Param{{
+			Params: Params{{
 				Value: ParamValue{
 					Type:      "string",
 					StringVal: "$(tasks.task-1.results.result)",
@@ -397,7 +397,7 @@ func TestPipelineTaskList_Deps(t *testing.T) {
 		}, {
 			Name: "task-2",
 			Matrix: &Matrix{
-				Params: []Param{{
+				Params: Params{{
 					Value: ParamValue{
 						Type: ParamTypeArray,
 						ArrayVal: []string{
@@ -437,7 +437,7 @@ func TestPipelineTaskList_Deps(t *testing.T) {
 		}, {
 			Name:     "task-4",
 			RunAfter: []string{"task-1"},
-			Params: []Param{{
+			Params: Params{{
 				Value: ParamValue{
 					Type:      "string",
 					StringVal: "$(tasks.task-3.results.result)",
@@ -455,7 +455,7 @@ func TestPipelineTaskList_Deps(t *testing.T) {
 			Name:     "task-6",
 			RunAfter: []string{"task-1"},
 			Matrix: &Matrix{
-				Params: []Param{{
+				Params: Params{{
 					Value: ParamValue{
 						Type: ParamTypeArray,
 						ArrayVal: []string{
@@ -485,7 +485,7 @@ func TestPipelineTaskList_Deps(t *testing.T) {
 		}, {
 			Name:     "task-4",
 			RunAfter: []string{"task-1", "task-3"},
-			Params: []Param{{
+			Params: Params{{
 				Value: ParamValue{
 					Type:      "string",
 					StringVal: "$(tasks.task-2.results.result)",
@@ -498,7 +498,7 @@ func TestPipelineTaskList_Deps(t *testing.T) {
 		}, {
 			Name:     "task-5",
 			RunAfter: []string{"task-1", "task-2", "task-3", "task-4"},
-			Params: []Param{{
+			Params: Params{{
 				Value: ParamValue{
 					Type:      "string",
 					StringVal: "$(tasks.task-4.results.result)",
@@ -516,7 +516,7 @@ func TestPipelineTaskList_Deps(t *testing.T) {
 		}, {
 			Name:     "task-6",
 			RunAfter: []string{"task-1", "task-2", "task-3", "task-4", "task-5"},
-			Params: []Param{{
+			Params: Params{{
 				Value: ParamValue{
 					Type:      "string",
 					StringVal: "$(tasks.task-4.results.result)",
@@ -532,7 +532,7 @@ func TestPipelineTaskList_Deps(t *testing.T) {
 				Values:   []string{"foo"},
 			}},
 			Matrix: &Matrix{
-				Params: []Param{{
+				Params: Params{{
 					Value: ParamValue{
 						Type: ParamTypeArray,
 						ArrayVal: []string{
@@ -554,7 +554,7 @@ func TestPipelineTaskList_Deps(t *testing.T) {
 			}},
 		}, {
 			Name: "task-8",
-			Params: []Param{{
+			Params: Params{{
 				Value: ParamValue{
 					Type:      "string",
 					StringVal: "$(tasks.task-4.results.result1)",
@@ -918,7 +918,7 @@ func TestPipelineTask_IsMatrixed(t *testing.T) {
 			name: "matrixed with params",
 			arg: arg{
 				Matrix: &Matrix{
-					Params: []Param{{Name: "platform", Value: ParamValue{ArrayVal: []string{"linux", "windows"}}}},
+					Params: Params{{Name: "platform", Value: ParamValue{ArrayVal: []string{"linux", "windows"}}}},
 				},
 			},
 			expected: true,
@@ -928,7 +928,7 @@ func TestPipelineTask_IsMatrixed(t *testing.T) {
 				Matrix: &Matrix{
 					Include: IncludeParamsList{{
 						Name: "build-1",
-						Params: []Param{{
+						Params: Params{{
 							Name: "IMAGE", Value: ParamValue{Type: ParamTypeString, StringVal: "image-1"},
 						}, {
 							Name: "DOCKERFILE", Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/Dockerfile1"}}},
@@ -940,12 +940,12 @@ func TestPipelineTask_IsMatrixed(t *testing.T) {
 			name: "matrixed with params and include",
 			arg: arg{
 				Matrix: &Matrix{
-					Params: []Param{{
+					Params: Params{{
 						Name: "GOARCH", Value: ParamValue{ArrayVal: []string{"linux/amd64", "linux/ppc64le", "linux/s390x"}},
 					}},
 					Include: IncludeParamsList{{
 						Name: "common-package",
-						Params: []Param{{
+						Params: Params{{
 							Name: "package", Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/common/package/"}}},
 					}},
 				},

--- a/pkg/apis/pipeline/v1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1/pipeline_validation_test.go
@@ -3346,7 +3346,7 @@ func TestValidateParamArrayIndex_valid(t *testing.T) {
 	for _, tt := range []struct {
 		name     string
 		original PipelineSpec
-		params   []Param
+		params   Params
 	}{{
 		name: "single parameter",
 		original: PipelineSpec{
@@ -3355,7 +3355,7 @@ func TestValidateParamArrayIndex_valid(t *testing.T) {
 				{Name: "second-param", Type: ParamTypeString},
 			},
 			Tasks: []PipelineTask{{
-				Params: []Param{
+				Params: Params{
 					{Name: "first-task-first-param", Value: *NewStructuredValues("$(params.first-param[1])")},
 					{Name: "first-task-second-param", Value: *NewStructuredValues("$(params.second-param[0])")},
 					{Name: "first-task-third-param", Value: *NewStructuredValues("static value")},
@@ -3387,7 +3387,7 @@ func TestValidateParamArrayIndex_valid(t *testing.T) {
 				{Name: "second-param", Type: ParamTypeArray, Default: NewStructuredValues("default-value", "default-value-again")},
 			},
 			Tasks: []PipelineTask{{
-				Params: []Param{
+				Params: Params{
 					{Name: "first-task-first-param", Value: *NewStructuredValues("$(input.workspace.$(params.first-param[0]))")},
 					{Name: "first-task-second-param", Value: *NewStructuredValues("$(input.workspace.$(params.second-param[1]))")},
 				},
@@ -3402,13 +3402,13 @@ func TestValidateParamArrayIndex_valid(t *testing.T) {
 				{Name: "second-param", Type: ParamTypeArray},
 			},
 			Tasks: []PipelineTask{{
-				Params: []Param{
+				Params: Params{
 					{Name: "first-task-first-param", Value: *NewStructuredValues("firstelement", "$(params.first-param)")},
 					{Name: "first-task-second-param", Value: *NewStructuredValues("firstelement", "$(params.second-param[0])")},
 				},
 			}},
 		},
-		params: []Param{
+		params: Params{
 			{Name: "second-param", Value: *NewStructuredValues("second-value", "array")},
 		},
 	}, {
@@ -3419,7 +3419,7 @@ func TestValidateParamArrayIndex_valid(t *testing.T) {
 				{Name: "second-param", Type: ParamTypeArray},
 			},
 			Finally: []PipelineTask{{
-				Params: []Param{
+				Params: Params{
 					{Name: "final-task-first-param", Value: *NewStructuredValues("$(params.first-param[0])")},
 					{Name: "final-task-second-param", Value: *NewStructuredValues("$(params.second-param[1])")},
 				},
@@ -3439,13 +3439,13 @@ func TestValidateParamArrayIndex_valid(t *testing.T) {
 				{Name: "second-param", Type: ParamTypeArray},
 			},
 			Tasks: []PipelineTask{{
-				Params: []Param{
+				Params: Params{
 					{Name: "final-task-first-param", Value: *NewStructuredValues("$(params.first-param[0])")},
 					{Name: "final-task-second-param", Value: *NewStructuredValues("$(params.second-param[1])")},
 				},
 			}},
 			Finally: []PipelineTask{{
-				Params: []Param{
+				Params: Params{
 					{Name: "final-task-first-param", Value: *NewStructuredValues("$(params.first-param[0])")},
 					{Name: "final-task-second-param", Value: *NewStructuredValues("$(params.second-param[1])")},
 				},
@@ -3467,7 +3467,7 @@ func TestValidateParamArrayIndex_valid(t *testing.T) {
 				{Name: "fourth/param", Type: ParamTypeArray},
 			},
 			Tasks: []PipelineTask{{
-				Params: []Param{
+				Params: Params{
 					{Name: "first-task-first-param", Value: *NewStructuredValues(`$(params["first.param"][0])`)},
 					{Name: "first-task-second-param", Value: *NewStructuredValues(`$(params["second/param"][0])`)},
 					{Name: "first-task-third-param", Value: *NewStructuredValues(`$(params['third.param'][1])`)},
@@ -3476,7 +3476,7 @@ func TestValidateParamArrayIndex_valid(t *testing.T) {
 				},
 			}},
 		},
-		params: []Param{
+		params: Params{
 			{Name: "second/param", Value: *NewStructuredValues("second-value", "second-value-again")},
 			{Name: "fourth/param", Value: *NewStructuredValues("fourth-value", "fourth-value-again")},
 		},
@@ -3488,7 +3488,7 @@ func TestValidateParamArrayIndex_valid(t *testing.T) {
 				{Name: "second-param", Type: ParamTypeArray},
 			},
 			Tasks: []PipelineTask{{
-				Params: []Param{
+				Params: Params{
 					{Name: "first-task-first-param", Value: *NewStructuredValues("$(params.first-param[0])")},
 					{Name: "first-task-second-param", Value: *NewStructuredValues("static value")},
 				},
@@ -3523,7 +3523,7 @@ func TestValidateParamArrayIndex_invalid(t *testing.T) {
 	for _, tt := range []struct {
 		name     string
 		original PipelineSpec
-		params   []Param
+		params   Params
 		expected error
 	}{{
 		name: "single parameter reference out of bound",
@@ -3533,7 +3533,7 @@ func TestValidateParamArrayIndex_invalid(t *testing.T) {
 				{Name: "second-param", Type: ParamTypeString},
 			},
 			Tasks: []PipelineTask{{
-				Params: []Param{
+				Params: Params{
 					{Name: "first-task-first-param", Value: *NewStructuredValues("$(params.first-param[2])")},
 					{Name: "first-task-second-param", Value: *NewStructuredValues("$(params.second-param[2])")},
 					{Name: "first-task-third-param", Value: *NewStructuredValues("static value")},
@@ -3567,7 +3567,7 @@ func TestValidateParamArrayIndex_invalid(t *testing.T) {
 				{Name: "second-param", Type: ParamTypeArray, Default: NewStructuredValues("default-value", "default-value-again")},
 			},
 			Tasks: []PipelineTask{{
-				Params: []Param{
+				Params: Params{
 					{Name: "first-task-first-param", Value: *NewStructuredValues("$(input.workspace.$(params.first-param[2]))")},
 					{Name: "first-task-second-param", Value: *NewStructuredValues("$(input.workspace.$(params.second-param[2]))")},
 				},
@@ -3583,13 +3583,13 @@ func TestValidateParamArrayIndex_invalid(t *testing.T) {
 				{Name: "second-param", Type: ParamTypeArray},
 			},
 			Tasks: []PipelineTask{{
-				Params: []Param{
+				Params: Params{
 					{Name: "first-task-first-param", Value: *NewStructuredValues("firstelement", "$(params.first-param[3])")},
 					{Name: "first-task-second-param", Value: *NewStructuredValues("firstelement", "$(params.second-param[4])")},
 				},
 			}},
 		},
-		params: []Param{
+		params: Params{
 			{Name: "second-param", Value: *NewStructuredValues("second-value", "array")},
 		},
 		expected: fmt.Errorf("non-existent param references:[$(params.first-param[3]) $(params.second-param[4])]"),
@@ -3601,7 +3601,7 @@ func TestValidateParamArrayIndex_invalid(t *testing.T) {
 				{Name: "second-param", Type: ParamTypeArray},
 			},
 			Tasks: []PipelineTask{{
-				Params: []Param{
+				Params: Params{
 					{Name: "first-task-first-param", Value: *NewObject(map[string]string{
 						"val1": "$(params.first-param[4])",
 						"val2": "$(params.second-param[4])",
@@ -3609,7 +3609,7 @@ func TestValidateParamArrayIndex_invalid(t *testing.T) {
 				},
 			}},
 		},
-		params: []Param{
+		params: Params{
 			{Name: "second-param", Value: *NewStructuredValues("second-value", "array")},
 		},
 		expected: fmt.Errorf("non-existent param references:[$(params.first-param[4]) $(params.second-param[4])]"),
@@ -3621,7 +3621,7 @@ func TestValidateParamArrayIndex_invalid(t *testing.T) {
 				{Name: "second-param", Type: ParamTypeArray},
 			},
 			Finally: []PipelineTask{{
-				Params: []Param{
+				Params: Params{
 					{Name: "final-task-first-param", Value: *NewStructuredValues("$(params.first-param[2])")},
 					{Name: "final-task-second-param", Value: *NewStructuredValues("$(params.second-param[2])")},
 				},
@@ -3642,13 +3642,13 @@ func TestValidateParamArrayIndex_invalid(t *testing.T) {
 				{Name: "second-param", Type: ParamTypeArray},
 			},
 			Tasks: []PipelineTask{{
-				Params: []Param{
+				Params: Params{
 					{Name: "final-task-first-param", Value: *NewStructuredValues("$(params.first-param[2])")},
 					{Name: "final-task-second-param", Value: *NewStructuredValues("$(params.second-param[2])")},
 				},
 			}},
 			Finally: []PipelineTask{{
-				Params: []Param{
+				Params: Params{
 					{Name: "final-task-first-param", Value: *NewStructuredValues("$(params.first-param[3])")},
 					{Name: "final-task-second-param", Value: *NewStructuredValues("$(params.second-param[3])")},
 				},
@@ -3658,7 +3658,7 @@ func TestValidateParamArrayIndex_invalid(t *testing.T) {
 					Values:   []string{"$(params.second-param[2])"},
 				}},
 				Matrix: &Matrix{
-					Params: []Param{
+					Params: Params{
 						{Name: "final-task-first-param", Value: *NewStructuredValues("$(params.first-param[4])")},
 						{Name: "final-task-second-param", Value: *NewStructuredValues("$(params.second-param[4])")},
 					}},
@@ -3675,7 +3675,7 @@ func TestValidateParamArrayIndex_invalid(t *testing.T) {
 			},
 			Tasks: []PipelineTask{{
 				Matrix: &Matrix{
-					Params: []Param{
+					Params: Params{
 						{Name: "first-task-first-param", Value: *NewStructuredValues("$(params.first-param[2])")},
 						{Name: "first-task-second-param", Value: *NewStructuredValues("static value")},
 					},
@@ -3694,7 +3694,7 @@ func TestValidateParamArrayIndex_invalid(t *testing.T) {
 				{Name: "fourth/param", Type: ParamTypeArray},
 			},
 			Tasks: []PipelineTask{{
-				Params: []Param{
+				Params: Params{
 					{Name: "first-task-first-param", Value: *NewStructuredValues(`$(params["first.param"][2])`)},
 					{Name: "first-task-second-param", Value: *NewStructuredValues(`$(params["second/param"][2])`)},
 					{Name: "first-task-third-param", Value: *NewStructuredValues(`$(params['third.param'][2])`)},
@@ -3703,7 +3703,7 @@ func TestValidateParamArrayIndex_invalid(t *testing.T) {
 				},
 			}},
 		},
-		params: []Param{
+		params: Params{
 			{Name: "second/param", Value: *NewStructuredValues("second-value", "second-value-again")},
 			{Name: "fourth/param", Value: *NewStructuredValues("fourth-value", "fourth-value-again")},
 		},
@@ -3716,7 +3716,7 @@ func TestValidateParamArrayIndex_invalid(t *testing.T) {
 				{Name: "second-param", Type: ParamTypeArray},
 			},
 			Tasks: []PipelineTask{{
-				Params: []Param{
+				Params: Params{
 					{Name: "first-task-first-param", Value: *NewStructuredValues("$(params.first-param[2])")},
 					{Name: "first-task-second-param", Value: *NewStructuredValues("static value")},
 				},

--- a/pkg/apis/pipeline/v1/pipelineref_validation_test.go
+++ b/pkg/apis/pipeline/v1/pipelineref_validation_test.go
@@ -49,7 +49,7 @@ func TestPipelineRef_Invalid(t *testing.T) {
 		name: "pipelineref params disallowed without beta feature gate",
 		ref: &v1.PipelineRef{
 			ResolverRef: v1.ResolverRef{
-				Params: []v1.Param{},
+				Params: v1.Params{},
 			},
 		},
 		wantErr: apis.ErrMissingField("resolver").Also(apis.ErrGeneric("resolver params requires \"enable-api-fields\" feature gate to be \"alpha\" or \"beta\" but it is \"stable\"")),
@@ -57,7 +57,7 @@ func TestPipelineRef_Invalid(t *testing.T) {
 		name: "pipelineref params disallowed without resolver",
 		ref: &v1.PipelineRef{
 			ResolverRef: v1.ResolverRef{
-				Params: []v1.Param{},
+				Params: v1.Params{},
 			},
 		},
 		wantErr:     apis.ErrMissingField("resolver"),
@@ -77,7 +77,7 @@ func TestPipelineRef_Invalid(t *testing.T) {
 		ref: &v1.PipelineRef{
 			Name: "bar",
 			ResolverRef: v1.ResolverRef{
-				Params: []v1.Param{{
+				Params: v1.Params{{
 					Name: "foo",
 					Value: v1.ParamValue{
 						Type:      v1.ParamTypeString,
@@ -93,7 +93,7 @@ func TestPipelineRef_Invalid(t *testing.T) {
 		ref: &v1.PipelineRef{
 			ResolverRef: v1.ResolverRef{
 				Resolver: "some-resolver",
-				Params: []v1.Param{{
+				Params: v1.Params{{
 					Name: "foo",
 					Value: v1.ParamValue{
 						Type:      v1.ParamTypeObject,
@@ -140,7 +140,7 @@ func TestPipelineRef_Valid(t *testing.T) {
 		wc:   config.EnableAlphaAPIFields,
 	}, {
 		name: "alpha feature: valid resolver with params",
-		ref: &v1.PipelineRef{ResolverRef: v1.ResolverRef{Resolver: "git", Params: []v1.Param{{
+		ref: &v1.PipelineRef{ResolverRef: v1.ResolverRef{Resolver: "git", Params: v1.Params{{
 			Name: "repo",
 			Value: v1.ParamValue{
 				Type:      v1.ParamTypeString,

--- a/pkg/apis/pipeline/v1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1/pipelinerun_types.go
@@ -223,7 +223,7 @@ type PipelineRunSpec struct {
 	PipelineSpec *PipelineSpec `json:"pipelineSpec,omitempty"`
 	// Params is a list of parameter names and values.
 	// +listType=atomic
-	Params []Param `json:"params,omitempty"`
+	Params Params `json:"params,omitempty"`
 
 	// Used for cancelling a pipelinerun (and maybe more later on)
 	// +optional

--- a/pkg/apis/pipeline/v1/pipelinerun_validation.go
+++ b/pkg/apis/pipeline/v1/pipelinerun_validation.go
@@ -190,7 +190,7 @@ func appendParamSpec(paramSpec []ParamSpec, params []ParamSpec) []ParamSpec {
 	return paramSpec
 }
 
-func appendParam(paramSpec []ParamSpec, params []Param) []ParamSpec {
+func appendParam(paramSpec []ParamSpec, params Params) []ParamSpec {
 	for _, p := range params {
 		skip := false
 		for _, ps := range paramSpec {

--- a/pkg/apis/pipeline/v1/pipelinerun_validation_test.go
+++ b/pkg/apis/pipeline/v1/pipelinerun_validation_test.go
@@ -162,7 +162,7 @@ func TestPipelineRun_Validate(t *testing.T) {
 					}},
 					Tasks: []v1.PipelineTask{{
 						Name: "echoit",
-						Params: []v1.Param{{
+						Params: v1.Params{{
 							Name: "task-words",
 							Value: v1.ParamValue{
 								ArrayVal: []string{"$(params.pipeline-words)"},

--- a/pkg/apis/pipeline/v1/resolver_types.go
+++ b/pkg/apis/pipeline/v1/resolver_types.go
@@ -34,5 +34,5 @@ type ResolverRef struct {
 	// the chosen resolver.
 	// +optional
 	// +listType=atomic
-	Params []Param `json:"params,omitempty"`
+	Params Params `json:"params,omitempty"`
 }

--- a/pkg/apis/pipeline/v1/resultref_test.go
+++ b/pkg/apis/pipeline/v1/resultref_test.go
@@ -626,7 +626,7 @@ func TestLooksLikeResultRefWhenExpressionFalse(t *testing.T) {
 // returns them all in the expected order.
 func TestPipelineTaskResultRefs(t *testing.T) {
 	pt := v1.PipelineTask{
-		Params: []v1.Param{{
+		Params: v1.Params{{
 			Value: *v1.NewStructuredValues("$(tasks.pt1.results.r1)"),
 		}, {
 			Value: *v1.NewStructuredValues("$(tasks.pt2.results.r2)"),
@@ -641,11 +641,11 @@ func TestPipelineTaskResultRefs(t *testing.T) {
 		Matrix: &v1.Matrix{
 			Include: v1.IncludeParamsList{{
 				Name: "build-1",
-				Params: []v1.Param{{
+				Params: v1.Params{{
 					Name: "a-param", Value: *v1.NewStructuredValues("$(tasks.pt9.results.r9)"),
 				}},
 			}},
-			Params: []v1.Param{{
+			Params: v1.Params{{
 				Value: *v1.NewStructuredValues("$(tasks.pt5.results.r5)", "$(tasks.pt6.results.r6)"),
 			}, {
 				Value: *v1.NewStructuredValues("$(tasks.pt7.results.r7)", "$(tasks.pt8.results.r8)"),

--- a/pkg/apis/pipeline/v1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1/task_validation_test.go
@@ -1743,12 +1743,12 @@ func TestValidateParamArrayIndex(t *testing.T) {
 
 	tcs := []struct {
 		name          string
-		params        []v1.Param
+		params        v1.Params
 		taskspec      *v1.TaskSpec
 		expectedError error
 	}{{
 		name: "steps reference invalid",
-		params: []v1.Param{{
+		params: v1.Params{{
 			Name:  "array-params",
 			Value: *v1.NewStructuredValues("bar", "foo"),
 		}},
@@ -1804,7 +1804,7 @@ func TestValidateParamArrayIndex(t *testing.T) {
 		expectedError: fmt.Errorf("non-existent param references:[%v]", strings.Join(stepsInvalidReferences, " ")),
 	}, {
 		name: "stepTemplate reference invalid",
-		params: []v1.Param{{
+		params: v1.Params{{
 			Name:  "array-params",
 			Value: *v1.NewStructuredValues("bar", "foo"),
 		}},
@@ -1820,7 +1820,7 @@ func TestValidateParamArrayIndex(t *testing.T) {
 		expectedError: fmt.Errorf("non-existent param references:[%v]", "$(params.array-params[3])"),
 	}, {
 		name: "volumes reference invalid",
-		params: []v1.Param{{
+		params: v1.Params{{
 			Name:  "array-params",
 			Value: *v1.NewStructuredValues("bar", "foo"),
 		}},
@@ -1882,7 +1882,7 @@ func TestValidateParamArrayIndex(t *testing.T) {
 		expectedError: fmt.Errorf("non-existent param references:[%v]", strings.Join(volumesInvalidReferences, " ")),
 	}, {
 		name: "workspaces reference invalid",
-		params: []v1.Param{{
+		params: v1.Params{{
 			Name:  "array-params",
 			Value: *v1.NewStructuredValues("bar", "foo"),
 		}},
@@ -1898,7 +1898,7 @@ func TestValidateParamArrayIndex(t *testing.T) {
 		expectedError: fmt.Errorf("non-existent param references:[%v]", "$(params.array-params[3])"),
 	}, {
 		name: "sidecar reference invalid",
-		params: []v1.Param{{
+		params: v1.Params{{
 			Name:  "array-params",
 			Value: *v1.NewStructuredValues("bar", "foo"),
 		}},

--- a/pkg/apis/pipeline/v1/taskref_validation_test.go
+++ b/pkg/apis/pipeline/v1/taskref_validation_test.go
@@ -47,7 +47,7 @@ func TestTaskRef_Valid(t *testing.T) {
 		wc:      config.EnableAlphaAPIFields,
 	}, {
 		name: "beta feature: valid resolver with params",
-		taskRef: &v1.TaskRef{ResolverRef: v1.ResolverRef{Resolver: "git", Params: []v1.Param{{
+		taskRef: &v1.TaskRef{ResolverRef: v1.ResolverRef{Resolver: "git", Params: v1.Params{{
 			Name: "repo",
 			Value: v1.ParamValue{
 				Type:      v1.ParamTypeString,
@@ -97,7 +97,7 @@ func TestTaskRef_Invalid(t *testing.T) {
 		name: "taskref params disallowed without beta feature gate",
 		taskRef: &v1.TaskRef{
 			ResolverRef: v1.ResolverRef{
-				Params: []v1.Param{},
+				Params: v1.Params{},
 			},
 		},
 		wantErr: apis.ErrMissingField("resolver").Also(apis.ErrGeneric("resolver params requires \"enable-api-fields\" feature gate to be \"alpha\" or \"beta\" but it is \"stable\"")),
@@ -105,7 +105,7 @@ func TestTaskRef_Invalid(t *testing.T) {
 		name: "taskref params disallowed without resolver",
 		taskRef: &v1.TaskRef{
 			ResolverRef: v1.ResolverRef{
-				Params: []v1.Param{},
+				Params: v1.Params{},
 			},
 		},
 		wantErr: apis.ErrMissingField("resolver"),
@@ -125,7 +125,7 @@ func TestTaskRef_Invalid(t *testing.T) {
 		taskRef: &v1.TaskRef{
 			Name: "bar",
 			ResolverRef: v1.ResolverRef{
-				Params: []v1.Param{{
+				Params: v1.Params{{
 					Name: "foo",
 					Value: v1.ParamValue{
 						Type:      v1.ParamTypeString,
@@ -141,7 +141,7 @@ func TestTaskRef_Invalid(t *testing.T) {
 		taskRef: &v1.TaskRef{
 			ResolverRef: v1.ResolverRef{
 				Resolver: "some-resolver",
-				Params: []v1.Param{{
+				Params: v1.Params{{
 					Name: "foo",
 					Value: v1.ParamValue{
 						Type:      v1.ParamTypeObject,

--- a/pkg/apis/pipeline/v1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1/taskrun_types.go
@@ -37,7 +37,7 @@ type TaskRunSpec struct {
 	Debug *TaskRunDebug `json:"debug,omitempty"`
 	// +optional
 	// +listType=atomic
-	Params []Param `json:"params,omitempty"`
+	Params Params `json:"params,omitempty"`
 	// +optional
 	ServiceAccountName string `json:"serviceAccountName"`
 	// no more than one of the TaskRef and TaskSpec may be specified.
@@ -114,7 +114,7 @@ type TaskRunDebug struct {
 type TaskRunInputs struct {
 	// +optional
 	// +listType=atomic
-	Params []Param `json:"params,omitempty"`
+	Params Params `json:"params,omitempty"`
 }
 
 var taskRunCondSet = apis.NewBatchConditionSet()

--- a/pkg/apis/pipeline/v1/taskrun_validation.go
+++ b/pkg/apis/pipeline/v1/taskrun_validation.go
@@ -238,7 +238,7 @@ func ValidateWorkspaceBindings(ctx context.Context, wb []WorkspaceBinding) (errs
 }
 
 // ValidateParameters makes sure the params for the Task are valid.
-func ValidateParameters(ctx context.Context, params []Param) (errs *apis.FieldError) {
+func ValidateParameters(ctx context.Context, params Params) (errs *apis.FieldError) {
 	var names []string
 	for _, p := range params {
 		if p.Value.Type == ParamTypeObject {

--- a/pkg/apis/pipeline/v1/taskrun_validation_test.go
+++ b/pkg/apis/pipeline/v1/taskrun_validation_test.go
@@ -89,7 +89,7 @@ func TestTaskRun_Invalidate(t *testing.T) {
 		taskRun: &v1.TaskRun{
 			ObjectMeta: metav1.ObjectMeta{Name: "tr"},
 			Spec: v1.TaskRunSpec{
-				Params: []v1.Param{{
+				Params: v1.Params{{
 					Name: "task-words",
 					Value: v1.ParamValue{
 						Type:      v1.ParamTypeObject,
@@ -144,7 +144,7 @@ func TestTaskRun_Validate(t *testing.T) {
 		taskRun: &v1.TaskRun{
 			ObjectMeta: metav1.ObjectMeta{Name: "tr"},
 			Spec: v1.TaskRunSpec{
-				Params: []v1.Param{{
+				Params: v1.Params{{
 					Name: "task-words",
 					Value: v1.ParamValue{
 						Type:     v1.ParamTypeArray,
@@ -167,7 +167,7 @@ func TestTaskRun_Validate(t *testing.T) {
 		taskRun: &v1.TaskRun{
 			ObjectMeta: metav1.ObjectMeta{Name: "tr"},
 			Spec: v1.TaskRunSpec{
-				Params: []v1.Param{{
+				Params: v1.Params{{
 					Name: "task-words",
 					Value: v1.ParamValue{
 						Type:      v1.ParamTypeObject,
@@ -190,7 +190,7 @@ func TestTaskRun_Validate(t *testing.T) {
 		taskRun: &v1.TaskRun{
 			ObjectMeta: metav1.ObjectMeta{Name: "tr"},
 			Spec: v1.TaskRunSpec{
-				Params: []v1.Param{{
+				Params: v1.Params{{
 					Name: "task-words",
 					Value: v1.ParamValue{
 						Type: v1.ParamTypeObject,
@@ -223,7 +223,7 @@ func TestTaskRun_Validate(t *testing.T) {
 		taskRun: &v1.TaskRun{
 			ObjectMeta: metav1.ObjectMeta{Name: "tr"},
 			Spec: v1.TaskRunSpec{
-				Params: []v1.Param{{
+				Params: v1.Params{{
 					Name: "task-words",
 					Value: v1.ParamValue{
 						Type:     v1.ParamTypeArray,
@@ -255,7 +255,7 @@ func TestTaskRun_Validate(t *testing.T) {
 		taskRun: &v1.TaskRun{
 			ObjectMeta: metav1.ObjectMeta{Name: "tr"},
 			Spec: v1.TaskRunSpec{
-				Params: []v1.Param{{
+				Params: v1.Params{{
 					Name: "task-words",
 					Value: v1.ParamValue{
 						Type:      v1.ParamTypeObject,
@@ -289,7 +289,7 @@ func TestTaskRun_Validate(t *testing.T) {
 		taskRun: &v1.TaskRun{
 			ObjectMeta: metav1.ObjectMeta{Name: "tr"},
 			Spec: v1.TaskRunSpec{
-				Params: []v1.Param{{
+				Params: v1.Params{{
 					Name: "task-words",
 					Value: v1.ParamValue{
 						Type:     v1.ParamTypeArray,
@@ -324,7 +324,7 @@ func TestTaskRun_Validate(t *testing.T) {
 		taskRun: &v1.TaskRun{
 			ObjectMeta: metav1.ObjectMeta{Name: "tr"},
 			Spec: v1.TaskRunSpec{
-				Params: []v1.Param{{
+				Params: v1.Params{{
 					Name: "task-words",
 					Value: v1.ParamValue{
 						Type:      v1.ParamTypeObject,
@@ -359,7 +359,7 @@ func TestTaskRun_Validate(t *testing.T) {
 		taskRun: &v1.TaskRun{
 			ObjectMeta: metav1.ObjectMeta{Name: "tr"},
 			Spec: v1.TaskRunSpec{
-				Params: []v1.Param{{
+				Params: v1.Params{{
 					Name: "task-words",
 					Value: v1.ParamValue{
 						Type:     v1.ParamTypeArray,
@@ -386,7 +386,7 @@ func TestTaskRun_Validate(t *testing.T) {
 		taskRun: &v1.TaskRun{
 			ObjectMeta: metav1.ObjectMeta{Name: "tr"},
 			Spec: v1.TaskRunSpec{
-				Params: []v1.Param{{
+				Params: v1.Params{{
 					Name: "task-words",
 					Value: v1.ParamValue{
 						Type:      v1.ParamTypeObject,
@@ -593,7 +593,7 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 	}, {
 		name: "invalid params - exactly same names",
 		spec: v1.TaskRunSpec{
-			Params: []v1.Param{{
+			Params: v1.Params{{
 				Name:  "myname",
 				Value: *v1.NewStructuredValues("value"),
 			}, {
@@ -606,7 +606,7 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 	}, {
 		name: "invalid params - same names but different case",
 		spec: v1.TaskRunSpec{
-			Params: []v1.Param{{
+			Params: v1.Params{{
 				Name:  "FOO",
 				Value: *v1.NewStructuredValues("value"),
 			}, {
@@ -619,7 +619,7 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 	}, {
 		name: "invalid params (object type) - same names but different case",
 		spec: v1.TaskRunSpec{
-			Params: []v1.Param{{
+			Params: v1.Params{{
 				Name:  "MYOBJECTPARAM",
 				Value: *v1.NewObject(map[string]string{"key1": "val1", "key2": "val2"}),
 			}, {
@@ -823,7 +823,7 @@ func TestTaskRunSpec_Validate(t *testing.T) {
 		name: "parameters",
 		spec: v1.TaskRunSpec{
 			Timeout: &metav1.Duration{Duration: 0},
-			Params: []v1.Param{{
+			Params: v1.Params{{
 				Name:  "name",
 				Value: *v1.NewStructuredValues("value"),
 			}},

--- a/pkg/apis/pipeline/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/pipeline/v1/zz_generated.deepcopy.go
@@ -554,7 +554,7 @@ func (in *PipelineRunSpec) DeepCopyInto(out *PipelineRunSpec) {
 	}
 	if in.Params != nil {
 		in, out := &in.Params, &out.Params
-		*out = make([]Param, len(*in))
+		*out = make(Params, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
@@ -1026,7 +1026,7 @@ func (in *ResolverRef) DeepCopyInto(out *ResolverRef) {
 	*out = *in
 	if in.Params != nil {
 		in, out := &in.Params, &out.Params
-		*out = make([]Param, len(*in))
+		*out = make(Params, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
@@ -1511,7 +1511,7 @@ func (in *TaskRunInputs) DeepCopyInto(out *TaskRunInputs) {
 	*out = *in
 	if in.Params != nil {
 		in, out := &in.Params, &out.Params
-		*out = make([]Param, len(*in))
+		*out = make(Params, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
@@ -1606,7 +1606,7 @@ func (in *TaskRunSpec) DeepCopyInto(out *TaskRunSpec) {
 	}
 	if in.Params != nil {
 		in, out := &in.Params, &out.Params
-		*out = make([]Param, len(*in))
+		*out = make(Params, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}

--- a/pkg/apis/pipeline/v1alpha1/run_types.go
+++ b/pkg/apis/pipeline/v1alpha1/run_types.go
@@ -55,7 +55,7 @@ type RunSpec struct {
 	Spec *EmbeddedRunSpec `json:"spec,omitempty"`
 
 	// +optional
-	Params []v1beta1.Param `json:"params,omitempty"`
+	Params v1beta1.Params `json:"params,omitempty"`
 
 	// Used for cancelling a run (and maybe more later on)
 	// +optional

--- a/pkg/apis/pipeline/v1alpha1/run_types_test.go
+++ b/pkg/apis/pipeline/v1alpha1/run_types_test.go
@@ -51,7 +51,7 @@ func TestGetParams(t *testing.T) {
 	}, {
 		desc: "found",
 		spec: v1alpha1.RunSpec{
-			Params: []v1beta1.Param{{
+			Params: v1beta1.Params{{
 				Name:  "first",
 				Value: *v1beta1.NewStructuredValues("blah"),
 			}, {
@@ -67,7 +67,7 @@ func TestGetParams(t *testing.T) {
 	}, {
 		desc: "not found",
 		spec: v1alpha1.RunSpec{
-			Params: []v1beta1.Param{{
+			Params: v1beta1.Params{{
 				Name:  "first",
 				Value: *v1beta1.NewStructuredValues("blah"),
 			}, {
@@ -83,7 +83,7 @@ func TestGetParams(t *testing.T) {
 		// the specified name.
 		desc: "multiple with same name",
 		spec: v1alpha1.RunSpec{
-			Params: []v1beta1.Param{{
+			Params: v1beta1.Params{{
 				Name:  "first",
 				Value: *v1beta1.NewStructuredValues("blah"),
 			}, {

--- a/pkg/apis/pipeline/v1alpha1/run_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/run_validation_test.go
@@ -171,7 +171,7 @@ func TestRun_Invalid(t *testing.T) {
 					APIVersion: "blah",
 					Kind:       "blah",
 				},
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name:  "foo",
 					Value: *v1beta1.NewStructuredValues("foo"),
 				}, {
@@ -263,7 +263,7 @@ func TestRun_Valid(t *testing.T) {
 					APIVersion: "blah",
 					Kind:       "blah",
 				},
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name:  "foo",
 					Value: *v1beta1.NewStructuredValues("foo"),
 				}, {

--- a/pkg/apis/pipeline/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/pipeline/v1alpha1/zz_generated.deepcopy.go
@@ -182,7 +182,7 @@ func (in *RunSpec) DeepCopyInto(out *RunSpec) {
 	}
 	if in.Params != nil {
 		in, out := &in.Params, &out.Params
-		*out = make([]v1beta1.Param, len(*in))
+		*out = make(v1beta1.Params, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}

--- a/pkg/apis/pipeline/v1beta1/customrun_types.go
+++ b/pkg/apis/pipeline/v1beta1/customrun_types.go
@@ -54,7 +54,7 @@ type CustomRunSpec struct {
 
 	// +optional
 	// +listType=atomic
-	Params []Param `json:"params,omitempty"`
+	Params Params `json:"params,omitempty"`
 
 	// Used for cancelling a customrun (and maybe more later on)
 	// +optional

--- a/pkg/apis/pipeline/v1beta1/customrun_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/customrun_types_test.go
@@ -46,7 +46,7 @@ func TestGetParams(t *testing.T) {
 	}, {
 		desc: "found",
 		spec: v1beta1.CustomRunSpec{
-			Params: []v1beta1.Param{{
+			Params: v1beta1.Params{{
 				Name:  "first",
 				Value: *v1beta1.NewStructuredValues("blah"),
 			}, {
@@ -62,7 +62,7 @@ func TestGetParams(t *testing.T) {
 	}, {
 		desc: "not found",
 		spec: v1beta1.CustomRunSpec{
-			Params: []v1beta1.Param{{
+			Params: v1beta1.Params{{
 				Name:  "first",
 				Value: *v1beta1.NewStructuredValues("blah"),
 			}, {
@@ -78,7 +78,7 @@ func TestGetParams(t *testing.T) {
 		// the specified name.
 		desc: "multiple with same name",
 		spec: v1beta1.CustomRunSpec{
-			Params: []v1beta1.Param{{
+			Params: v1beta1.Params{{
 				Name:  "first",
 				Value: *v1beta1.NewStructuredValues("blah"),
 			}, {

--- a/pkg/apis/pipeline/v1beta1/customrun_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/customrun_validation_test.go
@@ -170,7 +170,7 @@ func TestCustomRun_Invalid(t *testing.T) {
 					APIVersion: "blah",
 					Kind:       "blah",
 				},
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name:  "foo",
 					Value: *v1beta1.NewStructuredValues("foo"),
 				}, {
@@ -262,7 +262,7 @@ func TestRun_Valid(t *testing.T) {
 					APIVersion: "blah",
 					Kind:       "blah",
 				},
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name:  "foo",
 					Value: *v1beta1.NewStructuredValues("foo"),
 				}, {

--- a/pkg/apis/pipeline/v1beta1/matrix_types.go
+++ b/pkg/apis/pipeline/v1beta1/matrix_types.go
@@ -356,7 +356,7 @@ func (m *Matrix) validatePipelineParametersVariablesInMatrixParameters(prefix st
 	return errs
 }
 
-func (m *Matrix) validateParameterInOneOfMatrixOrParams(params []Param) (errs *apis.FieldError) {
+func (m *Matrix) validateParameterInOneOfMatrixOrParams(params Params) (errs *apis.FieldError) {
 	matrixParamNames := m.GetAllParams().ExtractNames()
 	for _, param := range params {
 		if matrixParamNames.Has(param.Name) {

--- a/pkg/apis/pipeline/v1beta1/matrix_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/matrix_types_test.go
@@ -610,7 +610,7 @@ func TestMatrix_HasParams(t *testing.T) {
 		{
 			name: "matrixed with params",
 			matrix: &Matrix{
-				Params: []Param{{Name: "platform", Value: ParamValue{ArrayVal: []string{"linux", "windows"}}}},
+				Params: Params{{Name: "platform", Value: ParamValue{ArrayVal: []string{"linux", "windows"}}}},
 			},
 			want: true,
 		}, {
@@ -618,7 +618,7 @@ func TestMatrix_HasParams(t *testing.T) {
 			matrix: &Matrix{
 				Include: IncludeParamsList{{
 					Name: "build-1",
-					Params: []Param{{
+					Params: Params{{
 						Name: "IMAGE", Value: ParamValue{Type: ParamTypeString, StringVal: "image-1"},
 					}, {
 						Name: "DOCKERFILE", Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/Dockerfile1"}}},
@@ -834,21 +834,21 @@ func TestPipelineTask_CountCombinations(t *testing.T) {
 		matrix: &Matrix{
 			Include: IncludeParamsList{{
 				Name: "build-1",
-				Params: []Param{{
+				Params: Params{{
 					Name: "IMAGE", Value: ParamValue{Type: ParamTypeString, StringVal: "image-1"},
 				}, {
 					Name: "DOCKERFILE", Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/Dockerfile1"},
 				}},
 			}, {
 				Name: "build-2",
-				Params: []Param{{
+				Params: Params{{
 					Name: "IMAGE", Value: ParamValue{Type: ParamTypeString, StringVal: "image-2"},
 				}, {
 					Name: "DOCKERFILE", Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/Dockerfile2"},
 				}},
 			}, {
 				Name: "build-3",
-				Params: []Param{{
+				Params: Params{{
 					Name: "IMAGE", Value: ParamValue{Type: ParamTypeString, StringVal: "image-3"},
 				}, {
 					Name: "DOCKERFILE", Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/Dockerfile3"},
@@ -859,24 +859,24 @@ func TestPipelineTask_CountCombinations(t *testing.T) {
 	}, {
 		name: "params and include in matrix with overriding combinations params",
 		matrix: &Matrix{
-			Params: []Param{{
+			Params: Params{{
 				Name: "GOARCH", Value: ParamValue{ArrayVal: []string{"linux/amd64", "linux/ppc64le", "linux/s390x"}},
 			}, {
 				Name: "version", Value: ParamValue{ArrayVal: []string{"go1.17", "go1.18.1"}}},
 			},
 			Include: IncludeParamsList{{
 				Name: "common-package",
-				Params: []Param{{
+				Params: Params{{
 					Name: "package", Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/common/package/"}}},
 			}, {
 				Name: "s390x-no-race",
-				Params: []Param{{
+				Params: Params{{
 					Name: "GOARCH", Value: ParamValue{Type: ParamTypeString, StringVal: "linux/s390x"},
 				}, {
 					Name: "flags", Value: ParamValue{Type: ParamTypeString, StringVal: "-cover -v"}}},
 			}, {
 				Name: "go117-context",
-				Params: []Param{{
+				Params: Params{{
 					Name: "version", Value: ParamValue{Type: ParamTypeString, StringVal: "go1.17"},
 				}, {
 					Name: "context", Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/go117/context"}}},
@@ -886,30 +886,30 @@ func TestPipelineTask_CountCombinations(t *testing.T) {
 	}, {
 		name: "params and include in matrix with overriding combinations params and one new combination",
 		matrix: &Matrix{
-			Params: []Param{{
+			Params: Params{{
 				Name: "GOARCH", Value: ParamValue{ArrayVal: []string{"linux/amd64", "linux/ppc64le", "linux/s390x"}},
 			}, {
 				Name: "version", Value: ParamValue{ArrayVal: []string{"go1.17", "go1.18.1"}}},
 			},
 			Include: IncludeParamsList{{
 				Name: "common-package",
-				Params: []Param{{
+				Params: Params{{
 					Name: "package", Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/common/package/"}}},
 			}, {
 				Name: "s390x-no-race",
-				Params: []Param{{
+				Params: Params{{
 					Name: "GOARCH", Value: ParamValue{Type: ParamTypeString, StringVal: "linux/s390x"},
 				}, {
 					Name: "flags", Value: ParamValue{Type: ParamTypeString, StringVal: "-cover -v"}}},
 			}, {
 				Name: "go117-context",
-				Params: []Param{{
+				Params: Params{{
 					Name: "version", Value: ParamValue{Type: ParamTypeString, StringVal: "go1.17"},
 				}, {
 					Name: "context", Value: ParamValue{Type: ParamTypeString, StringVal: "path/to/go117/context"}}},
 			}, {
 				Name: "non-existent-arch",
-				Params: []Param{{
+				Params: Params{{
 					Name: "GOARCH", Value: ParamValue{Type: ParamTypeString, StringVal: "I-do-not-exist"}},
 				}},
 			}},

--- a/pkg/apis/pipeline/v1beta1/pipeline_conversion_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_conversion_test.go
@@ -100,7 +100,7 @@ func TestPipelineConversion(t *testing.T) {
 					}},
 					Retries:  1,
 					RunAfter: []string{"task-1"},
-					Params: []v1beta1.Param{{
+					Params: v1beta1.Params{{
 						Name: "param-task-1",
 						Value: v1beta1.ParamValue{
 							ArrayVal: []string{"value-task-1"},

--- a/pkg/apis/pipeline/v1beta1/pipeline_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types_test.go
@@ -243,7 +243,7 @@ func TestPipelineTask_ValidateRegularTask_Success(t *testing.T) {
 	}, {
 		name: "pipeline task - use of params",
 		tasks: PipelineTask{
-			TaskRef: &TaskRef{Name: "boo", ResolverRef: ResolverRef{Params: []Param{}}},
+			TaskRef: &TaskRef{Name: "boo", ResolverRef: ResolverRef{Params: Params{}}},
 		},
 	}, {
 		name: "pipeline task - use of bundle with the feature flag set",

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
@@ -3365,7 +3365,7 @@ func TestValidateParamArrayIndex_valid(t *testing.T) {
 	for _, tt := range []struct {
 		name     string
 		original PipelineSpec
-		params   []Param
+		params   Params
 	}{{
 		name: "single parameter",
 		original: PipelineSpec{
@@ -3374,7 +3374,7 @@ func TestValidateParamArrayIndex_valid(t *testing.T) {
 				{Name: "second-param", Type: ParamTypeString},
 			},
 			Tasks: []PipelineTask{{
-				Params: []Param{
+				Params: Params{
 					{Name: "first-task-first-param", Value: *NewStructuredValues("$(params.first-param[1])")},
 					{Name: "first-task-second-param", Value: *NewStructuredValues("$(params.second-param[0])")},
 					{Name: "first-task-third-param", Value: *NewStructuredValues("static value")},
@@ -3406,7 +3406,7 @@ func TestValidateParamArrayIndex_valid(t *testing.T) {
 				{Name: "second-param", Type: ParamTypeArray, Default: NewStructuredValues("default-value", "default-value-again")},
 			},
 			Tasks: []PipelineTask{{
-				Params: []Param{
+				Params: Params{
 					{Name: "first-task-first-param", Value: *NewStructuredValues("$(input.workspace.$(params.first-param[0]))")},
 					{Name: "first-task-second-param", Value: *NewStructuredValues("$(input.workspace.$(params.second-param[1]))")},
 				},
@@ -3421,13 +3421,13 @@ func TestValidateParamArrayIndex_valid(t *testing.T) {
 				{Name: "second-param", Type: ParamTypeArray},
 			},
 			Tasks: []PipelineTask{{
-				Params: []Param{
+				Params: Params{
 					{Name: "first-task-first-param", Value: *NewStructuredValues("firstelement", "$(params.first-param)")},
 					{Name: "first-task-second-param", Value: *NewStructuredValues("firstelement", "$(params.second-param[0])")},
 				},
 			}},
 		},
-		params: []Param{
+		params: Params{
 			{Name: "second-param", Value: *NewStructuredValues("second-value", "array")},
 		},
 	}, {
@@ -3438,7 +3438,7 @@ func TestValidateParamArrayIndex_valid(t *testing.T) {
 				{Name: "second-param", Type: ParamTypeArray},
 			},
 			Finally: []PipelineTask{{
-				Params: []Param{
+				Params: Params{
 					{Name: "final-task-first-param", Value: *NewStructuredValues("$(params.first-param[0])")},
 					{Name: "final-task-second-param", Value: *NewStructuredValues("$(params.second-param[1])")},
 				},
@@ -3458,13 +3458,13 @@ func TestValidateParamArrayIndex_valid(t *testing.T) {
 				{Name: "second-param", Type: ParamTypeArray},
 			},
 			Tasks: []PipelineTask{{
-				Params: []Param{
+				Params: Params{
 					{Name: "final-task-first-param", Value: *NewStructuredValues("$(params.first-param[0])")},
 					{Name: "final-task-second-param", Value: *NewStructuredValues("$(params.second-param[1])")},
 				},
 			}},
 			Finally: []PipelineTask{{
-				Params: []Param{
+				Params: Params{
 					{Name: "final-task-first-param", Value: *NewStructuredValues("$(params.first-param[0])")},
 					{Name: "final-task-second-param", Value: *NewStructuredValues("$(params.second-param[1])")},
 				},
@@ -3486,7 +3486,7 @@ func TestValidateParamArrayIndex_valid(t *testing.T) {
 				{Name: "fourth/param", Type: ParamTypeArray},
 			},
 			Tasks: []PipelineTask{{
-				Params: []Param{
+				Params: Params{
 					{Name: "first-task-first-param", Value: *NewStructuredValues(`$(params["first.param"][0])`)},
 					{Name: "first-task-second-param", Value: *NewStructuredValues(`$(params["second/param"][0])`)},
 					{Name: "first-task-third-param", Value: *NewStructuredValues(`$(params['third.param'][1])`)},
@@ -3495,7 +3495,7 @@ func TestValidateParamArrayIndex_valid(t *testing.T) {
 				},
 			}},
 		},
-		params: []Param{
+		params: Params{
 			{Name: "second/param", Value: *NewStructuredValues("second-value", "second-value-again")},
 			{Name: "fourth/param", Value: *NewStructuredValues("fourth-value", "fourth-value-again")},
 		},
@@ -3507,7 +3507,7 @@ func TestValidateParamArrayIndex_valid(t *testing.T) {
 				{Name: "second-param", Type: ParamTypeArray},
 			},
 			Tasks: []PipelineTask{{
-				Params: []Param{
+				Params: Params{
 					{Name: "first-task-first-param", Value: *NewStructuredValues("$(params.first-param[0])")},
 					{Name: "first-task-second-param", Value: *NewStructuredValues("static value")},
 				},
@@ -3542,7 +3542,7 @@ func TestValidateParamArrayIndex_invalid(t *testing.T) {
 	for _, tt := range []struct {
 		name     string
 		original PipelineSpec
-		params   []Param
+		params   Params
 		expected error
 	}{{
 		name: "single parameter reference out of bound",
@@ -3552,7 +3552,7 @@ func TestValidateParamArrayIndex_invalid(t *testing.T) {
 				{Name: "second-param", Type: ParamTypeString},
 			},
 			Tasks: []PipelineTask{{
-				Params: []Param{
+				Params: Params{
 					{Name: "first-task-first-param", Value: *NewStructuredValues("$(params.first-param[2])")},
 					{Name: "first-task-second-param", Value: *NewStructuredValues("$(params.second-param[2])")},
 					{Name: "first-task-third-param", Value: *NewStructuredValues("static value")},
@@ -3586,7 +3586,7 @@ func TestValidateParamArrayIndex_invalid(t *testing.T) {
 				{Name: "second-param", Type: ParamTypeArray, Default: NewStructuredValues("default-value", "default-value-again")},
 			},
 			Tasks: []PipelineTask{{
-				Params: []Param{
+				Params: Params{
 					{Name: "first-task-first-param", Value: *NewStructuredValues("$(input.workspace.$(params.first-param[2]))")},
 					{Name: "first-task-second-param", Value: *NewStructuredValues("$(input.workspace.$(params.second-param[2]))")},
 				},
@@ -3602,13 +3602,13 @@ func TestValidateParamArrayIndex_invalid(t *testing.T) {
 				{Name: "second-param", Type: ParamTypeArray},
 			},
 			Tasks: []PipelineTask{{
-				Params: []Param{
+				Params: Params{
 					{Name: "first-task-first-param", Value: *NewStructuredValues("firstelement", "$(params.first-param[3])")},
 					{Name: "first-task-second-param", Value: *NewStructuredValues("firstelement", "$(params.second-param[4])")},
 				},
 			}},
 		},
-		params: []Param{
+		params: Params{
 			{Name: "second-param", Value: *NewStructuredValues("second-value", "array")},
 		},
 		expected: fmt.Errorf("non-existent param references:[$(params.first-param[3]) $(params.second-param[4])]"),
@@ -3620,7 +3620,7 @@ func TestValidateParamArrayIndex_invalid(t *testing.T) {
 				{Name: "second-param", Type: ParamTypeArray},
 			},
 			Tasks: []PipelineTask{{
-				Params: []Param{
+				Params: Params{
 					{Name: "first-task-first-param", Value: *NewObject(map[string]string{
 						"val1": "$(params.first-param[4])",
 						"val2": "$(params.second-param[4])",
@@ -3628,7 +3628,7 @@ func TestValidateParamArrayIndex_invalid(t *testing.T) {
 				},
 			}},
 		},
-		params: []Param{
+		params: Params{
 			{Name: "second-param", Value: *NewStructuredValues("second-value", "array")},
 		},
 		expected: fmt.Errorf("non-existent param references:[$(params.first-param[4]) $(params.second-param[4])]"),
@@ -3640,7 +3640,7 @@ func TestValidateParamArrayIndex_invalid(t *testing.T) {
 				{Name: "second-param", Type: ParamTypeArray},
 			},
 			Finally: []PipelineTask{{
-				Params: []Param{
+				Params: Params{
 					{Name: "final-task-first-param", Value: *NewStructuredValues("$(params.first-param[2])")},
 					{Name: "final-task-second-param", Value: *NewStructuredValues("$(params.second-param[2])")},
 				},
@@ -3661,13 +3661,13 @@ func TestValidateParamArrayIndex_invalid(t *testing.T) {
 				{Name: "second-param", Type: ParamTypeArray},
 			},
 			Tasks: []PipelineTask{{
-				Params: []Param{
+				Params: Params{
 					{Name: "final-task-first-param", Value: *NewStructuredValues("$(params.first-param[2])")},
 					{Name: "final-task-second-param", Value: *NewStructuredValues("$(params.second-param[2])")},
 				},
 			}},
 			Finally: []PipelineTask{{
-				Params: []Param{
+				Params: Params{
 					{Name: "final-task-first-param", Value: *NewStructuredValues("$(params.first-param[3])")},
 					{Name: "final-task-second-param", Value: *NewStructuredValues("$(params.second-param[3])")},
 				},
@@ -3677,7 +3677,7 @@ func TestValidateParamArrayIndex_invalid(t *testing.T) {
 					Values:   []string{"$(params.second-param[2])"},
 				}},
 				Matrix: &Matrix{
-					Params: []Param{
+					Params: Params{
 						{Name: "final-task-first-param", Value: *NewStructuredValues("$(params.first-param[4])")},
 						{Name: "final-task-second-param", Value: *NewStructuredValues("$(params.second-param[4])")},
 					}},
@@ -3694,7 +3694,7 @@ func TestValidateParamArrayIndex_invalid(t *testing.T) {
 			},
 			Tasks: []PipelineTask{{
 				Matrix: &Matrix{
-					Params: []Param{
+					Params: Params{
 						{Name: "first-task-first-param", Value: *NewStructuredValues("$(params.first-param[2])")},
 						{Name: "first-task-second-param", Value: *NewStructuredValues("static value")},
 					},
@@ -3713,7 +3713,7 @@ func TestValidateParamArrayIndex_invalid(t *testing.T) {
 				{Name: "fourth/param", Type: ParamTypeArray},
 			},
 			Tasks: []PipelineTask{{
-				Params: []Param{
+				Params: Params{
 					{Name: "first-task-first-param", Value: *NewStructuredValues(`$(params["first.param"][2])`)},
 					{Name: "first-task-second-param", Value: *NewStructuredValues(`$(params["second/param"][2])`)},
 					{Name: "first-task-third-param", Value: *NewStructuredValues(`$(params['third.param'][2])`)},
@@ -3722,7 +3722,7 @@ func TestValidateParamArrayIndex_invalid(t *testing.T) {
 				},
 			}},
 		},
-		params: []Param{
+		params: Params{
 			{Name: "second/param", Value: *NewStructuredValues("second-value", "second-value-again")},
 			{Name: "fourth/param", Value: *NewStructuredValues("fourth-value", "fourth-value-again")},
 		},
@@ -3735,7 +3735,7 @@ func TestValidateParamArrayIndex_invalid(t *testing.T) {
 				{Name: "second-param", Type: ParamTypeArray},
 			},
 			Tasks: []PipelineTask{{
-				Params: []Param{
+				Params: Params{
 					{Name: "first-task-first-param", Value: *NewStructuredValues("$(params.first-param[2])")},
 					{Name: "first-task-second-param", Value: *NewStructuredValues("static value")},
 				},

--- a/pkg/apis/pipeline/v1beta1/pipelineref_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/pipelineref_conversion.go
@@ -32,7 +32,7 @@ func (pr PipelineRef) convertBundleToResolver(sink *v1.PipelineRef) {
 	if pr.Bundle != "" {
 		sink.ResolverRef = v1.ResolverRef{
 			Resolver: "bundles",
-			Params: []v1.Param{{
+			Params: v1.Params{{
 				Name:  "bundle",
 				Value: v1.ParamValue{StringVal: pr.Bundle, Type: v1.ParamTypeString},
 			}, {

--- a/pkg/apis/pipeline/v1beta1/pipelineref_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelineref_validation_test.go
@@ -66,7 +66,7 @@ func TestPipelineRef_Invalid(t *testing.T) {
 		name: "pipelineref params disallowed without resolver",
 		ref: &v1beta1.PipelineRef{
 			ResolverRef: v1beta1.ResolverRef{
-				Params: []v1beta1.Param{},
+				Params: v1beta1.Params{},
 			},
 		},
 		wantErr: apis.ErrMissingField("resolver"),
@@ -94,7 +94,7 @@ func TestPipelineRef_Invalid(t *testing.T) {
 		ref: &v1beta1.PipelineRef{
 			Name: "bar",
 			ResolverRef: v1beta1.ResolverRef{
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name: "foo",
 					Value: v1beta1.ParamValue{
 						Type:      v1beta1.ParamTypeString,
@@ -109,7 +109,7 @@ func TestPipelineRef_Invalid(t *testing.T) {
 		ref: &v1beta1.PipelineRef{
 			Bundle: "bar",
 			ResolverRef: v1beta1.ResolverRef{
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name: "foo",
 					Value: v1beta1.ParamValue{
 						Type:      v1beta1.ParamTypeString,
@@ -125,7 +125,7 @@ func TestPipelineRef_Invalid(t *testing.T) {
 		ref: &v1beta1.PipelineRef{
 			ResolverRef: v1beta1.ResolverRef{
 				Resolver: "some-resolver",
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name: "foo",
 					Value: v1beta1.ParamValue{
 						Type:      v1beta1.ParamTypeObject,
@@ -164,7 +164,7 @@ func TestPipelineRef_Valid(t *testing.T) {
 		ref:  &v1beta1.PipelineRef{ResolverRef: v1beta1.ResolverRef{Resolver: "git"}},
 	}, {
 		name: "valid resolver with params",
-		ref: &v1beta1.PipelineRef{ResolverRef: v1beta1.ResolverRef{Resolver: "git", Params: []v1beta1.Param{{
+		ref: &v1beta1.PipelineRef{ResolverRef: v1beta1.ResolverRef{Resolver: "git", Params: v1beta1.Params{{
 			Name: "repo",
 			Value: v1beta1.ParamValue{
 				Type:      v1beta1.ParamTypeString,

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_conversion_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_conversion_test.go
@@ -171,7 +171,7 @@ func TestPipelineRunConversion(t *testing.T) {
 						Type: "string",
 					}},
 				},
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name:  "foo",
 					Value: *v1beta1.NewStructuredValues("value"),
 				}, {
@@ -398,7 +398,7 @@ func TestPipelineRunConversionFromDeprecated(t *testing.T) {
 				PipelineRef: &v1beta1.PipelineRef{
 					ResolverRef: v1beta1.ResolverRef{
 						Resolver: "bundles",
-						Params: []v1beta1.Param{
+						Params: v1beta1.Params{
 							{Name: "bundle", Value: v1beta1.ParamValue{StringVal: "test-bundle", Type: "string"}},
 							{Name: "name", Value: v1beta1.ParamValue{StringVal: "test-bundle-name", Type: "string"}},
 							{Name: "kind", Value: v1beta1.ParamValue{StringVal: "Task", Type: "string"}},

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
@@ -225,7 +225,7 @@ type PipelineRunSpec struct {
 	PipelineSpec *PipelineSpec `json:"pipelineSpec,omitempty"`
 	// Params is a list of parameter names and values.
 	// +listType=atomic
-	Params []Param `json:"params,omitempty"`
+	Params Params `json:"params,omitempty"`
 	// +optional
 	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_validation.go
@@ -239,7 +239,7 @@ func (ps *PipelineRunSpec) validateInlineParameters(ctx context.Context) (errs *
 	return errs
 }
 
-func appendPipelineTaskParams(paramSpecForValidation map[string]ParamSpec, params []Param) map[string]ParamSpec {
+func appendPipelineTaskParams(paramSpecForValidation map[string]ParamSpec, params Params) map[string]ParamSpec {
 	for _, p := range params {
 		if pSpec, ok := paramSpecForValidation[p.Name]; ok {
 			if p.Value.ObjectVal != nil {

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_validation_test.go
@@ -147,7 +147,7 @@ func TestPipelineRun_Invalid(t *testing.T) {
 				Name: "pipelinelinename",
 			},
 			Spec: v1beta1.PipelineRunSpec{
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name: "pipeline-words",
 					Value: v1beta1.ParamValue{
 						Type:      v1beta1.ParamTypeObject,
@@ -221,7 +221,7 @@ func TestPipelineRun_Invalid(t *testing.T) {
 			Spec: v1beta1.PipelineRunSpec{
 				PipelineSpec: &v1beta1.PipelineSpec{
 					Tasks: []v1beta1.PipelineTask{{
-						Params: []v1beta1.Param{{
+						Params: v1beta1.Params{{
 							Name: "pipeline-words",
 							Value: v1beta1.ParamValue{
 								Type:      v1beta1.ParamTypeObject,
@@ -264,7 +264,7 @@ func TestPipelineRun_Invalid(t *testing.T) {
 				Name: "pipelinename",
 			},
 			Spec: v1beta1.PipelineRunSpec{
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name: "pipeline-words",
 					Value: v1beta1.ArrayOrString{
 						Type:     v1beta1.ParamTypeArray,
@@ -297,7 +297,7 @@ func TestPipelineRun_Invalid(t *testing.T) {
 				Name: "objectpipelinename",
 			},
 			Spec: v1beta1.PipelineRunSpec{
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name: "pipeline-words",
 					Value: v1beta1.ParamValue{
 						Type:      v1beta1.ParamTypeObject,
@@ -318,7 +318,7 @@ func TestPipelineRun_Invalid(t *testing.T) {
 					}},
 					Tasks: []v1beta1.PipelineTask{{
 						Name: "echoit",
-						Params: []v1beta1.Param{{
+						Params: v1beta1.Params{{
 							Name: "pipeline-words",
 							Value: v1beta1.ParamValue{
 								Type:      v1beta1.ParamTypeObject,
@@ -360,7 +360,7 @@ func TestPipelineRun_Invalid(t *testing.T) {
 				Name: "pipelinelinename",
 			},
 			Spec: v1beta1.PipelineRunSpec{
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name: "some-param",
 					Value: v1beta1.ArrayOrString{
 						ArrayVal: []string{"hello", "pipeline"},
@@ -387,7 +387,7 @@ func TestPipelineRun_Invalid(t *testing.T) {
 				Name: "pipelinelinename",
 			},
 			Spec: v1beta1.PipelineRunSpec{
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name: "some-param",
 					Value: v1beta1.ArrayOrString{
 						StringVal: "$(tasks.some-task.results.foo)",
@@ -410,7 +410,7 @@ func TestPipelineRun_Invalid(t *testing.T) {
 				Name: "pipelinelinename",
 			},
 			Spec: v1beta1.PipelineRunSpec{
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name: "some-param",
 					Value: v1beta1.ArrayOrString{
 						ArrayVal: []string{"$(tasks.some-task.results.foo)"},
@@ -433,7 +433,7 @@ func TestPipelineRun_Invalid(t *testing.T) {
 				Name: "pipelinelinename",
 			},
 			Spec: v1beta1.PipelineRunSpec{
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name: "pipeline-words",
 					Value: v1beta1.ArrayOrString{
 						Type:     v1beta1.ParamTypeArray,
@@ -447,7 +447,7 @@ func TestPipelineRun_Invalid(t *testing.T) {
 					}},
 					Tasks: []v1beta1.PipelineTask{{
 						Name: "echoit",
-						Params: []v1beta1.Param{{
+						Params: v1beta1.Params{{
 							Name: "pipeline-words",
 							Value: v1beta1.ArrayOrString{
 								Type:     v1beta1.ParamTypeArray,
@@ -549,7 +549,7 @@ func TestPipelineRun_Validate(t *testing.T) {
 				Name: "pipelinelinename",
 			},
 			Spec: v1beta1.PipelineRunSpec{
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name: "pipeline-words",
 					Value: v1beta1.ArrayOrString{
 						Type:     v1beta1.ParamTypeArray,
@@ -563,7 +563,7 @@ func TestPipelineRun_Validate(t *testing.T) {
 					}},
 					Tasks: []v1beta1.PipelineTask{{
 						Name: "echoit",
-						Params: []v1beta1.Param{{
+						Params: v1beta1.Params{{
 							Name: "task-words",
 							Value: v1beta1.ParamValue{
 								Type:     v1beta1.ParamTypeArray,
@@ -609,7 +609,7 @@ func TestPipelineRun_Validate(t *testing.T) {
 				Name: "pipelinelinename",
 			},
 			Spec: v1beta1.PipelineRunSpec{
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name: "pipeline-words",
 					Value: v1beta1.ArrayOrString{
 						Type:     v1beta1.ParamTypeArray,
@@ -639,7 +639,7 @@ func TestPipelineRun_Validate(t *testing.T) {
 				Name: "pipelinelinename",
 			},
 			Spec: v1beta1.PipelineRunSpec{
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name: "pipeline-words",
 					Value: v1beta1.ParamValue{
 						Type:      v1beta1.ParamTypeObject,
@@ -669,7 +669,7 @@ func TestPipelineRun_Validate(t *testing.T) {
 				Name: "pipelinelinename",
 			},
 			Spec: v1beta1.PipelineRunSpec{
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name: "pipeline-words",
 					Value: v1beta1.ParamValue{
 						Type: v1beta1.ParamTypeObject,
@@ -709,7 +709,7 @@ func TestPipelineRun_Validate(t *testing.T) {
 				Name: "pipelinelinename",
 			},
 			Spec: v1beta1.PipelineRunSpec{
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name: "pipeline-words",
 					Value: v1beta1.ParamValue{
 						Type:      v1beta1.ParamTypeObject,

--- a/pkg/apis/pipeline/v1beta1/resolver_types.go
+++ b/pkg/apis/pipeline/v1beta1/resolver_types.go
@@ -33,5 +33,5 @@ type ResolverRef struct {
 	// the chosen resolver.
 	// +optional
 	// +listType=atomic
-	Params []Param `json:"params,omitempty"`
+	Params Params `json:"params,omitempty"`
 }

--- a/pkg/apis/pipeline/v1beta1/resultref_test.go
+++ b/pkg/apis/pipeline/v1beta1/resultref_test.go
@@ -626,7 +626,7 @@ func TestLooksLikeResultRefWhenExpressionFalse(t *testing.T) {
 // returns them all in the expected order.
 func TestPipelineTaskResultRefs(t *testing.T) {
 	pt := v1beta1.PipelineTask{
-		Params: []v1beta1.Param{{
+		Params: v1beta1.Params{{
 			Value: *v1beta1.NewStructuredValues("$(tasks.pt1.results.r1)"),
 		}, {
 			Value: *v1beta1.NewStructuredValues("$(tasks.pt2.results.r2)"),
@@ -641,11 +641,11 @@ func TestPipelineTaskResultRefs(t *testing.T) {
 		Matrix: &v1beta1.Matrix{
 			Include: []v1beta1.IncludeParams{{
 				Name: "build-1",
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name: "a-param", Value: *v1beta1.NewStructuredValues("$(tasks.pt9.results.r9)"),
 				}},
 			}},
-			Params: []v1beta1.Param{{
+			Params: v1beta1.Params{{
 				Value: *v1beta1.NewStructuredValues("$(tasks.pt5.results.r5)", "$(tasks.pt6.results.r6)"),
 			}, {
 				Value: *v1beta1.NewStructuredValues("$(tasks.pt7.results.r7)", "$(tasks.pt8.results.r8)"),

--- a/pkg/apis/pipeline/v1beta1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation_test.go
@@ -1746,12 +1746,12 @@ func TestValidateParamArrayIndex(t *testing.T) {
 
 	tcs := []struct {
 		name          string
-		params        []v1beta1.Param
+		params        v1beta1.Params
 		taskspec      *v1beta1.TaskSpec
 		expectedError error
 	}{{
 		name: "steps reference invalid",
-		params: []v1beta1.Param{{
+		params: v1beta1.Params{{
 			Name:  "array-params",
 			Value: *v1beta1.NewStructuredValues("bar", "foo"),
 		}},
@@ -1807,7 +1807,7 @@ func TestValidateParamArrayIndex(t *testing.T) {
 		expectedError: fmt.Errorf("non-existent param references:[%v]", strings.Join(stepsInvalidReferences, " ")),
 	}, {
 		name: "stepTemplate reference invalid",
-		params: []v1beta1.Param{{
+		params: v1beta1.Params{{
 			Name:  "array-params",
 			Value: *v1beta1.NewStructuredValues("bar", "foo"),
 		}},
@@ -1823,7 +1823,7 @@ func TestValidateParamArrayIndex(t *testing.T) {
 		expectedError: fmt.Errorf("non-existent param references:[%v]", "$(params.array-params[3])"),
 	}, {
 		name: "volumes reference invalid",
-		params: []v1beta1.Param{{
+		params: v1beta1.Params{{
 			Name:  "array-params",
 			Value: *v1beta1.NewStructuredValues("bar", "foo"),
 		}},
@@ -1885,7 +1885,7 @@ func TestValidateParamArrayIndex(t *testing.T) {
 		expectedError: fmt.Errorf("non-existent param references:[%v]", strings.Join(volumesInvalidReferences, " ")),
 	}, {
 		name: "workspaces reference invalid",
-		params: []v1beta1.Param{{
+		params: v1beta1.Params{{
 			Name:  "array-params",
 			Value: *v1beta1.NewStructuredValues("bar", "foo"),
 		}},
@@ -1901,7 +1901,7 @@ func TestValidateParamArrayIndex(t *testing.T) {
 		expectedError: fmt.Errorf("non-existent param references:[%v]", "$(params.array-params[3])"),
 	}, {
 		name: "sidecar reference invalid",
-		params: []v1beta1.Param{{
+		params: v1beta1.Params{{
 			Name:  "array-params",
 			Value: *v1beta1.NewStructuredValues("bar", "foo"),
 		}},

--- a/pkg/apis/pipeline/v1beta1/taskref_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/taskref_conversion.go
@@ -34,7 +34,7 @@ func (tr TaskRef) convertBundleToResolver(sink *v1.TaskRef) {
 	if tr.Bundle != "" {
 		sink.ResolverRef = v1.ResolverRef{
 			Resolver: "bundles",
-			Params: []v1.Param{{
+			Params: v1.Params{{
 				Name:  "bundle",
 				Value: v1.ParamValue{StringVal: tr.Bundle, Type: v1.ParamTypeString},
 			}, {

--- a/pkg/apis/pipeline/v1beta1/taskref_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskref_validation_test.go
@@ -41,7 +41,7 @@ func TestTaskRef_Valid(t *testing.T) {
 		taskRef: &v1beta1.TaskRef{ResolverRef: v1beta1.ResolverRef{Resolver: "git"}},
 	}, {
 		name: "valid resolver with params",
-		taskRef: &v1beta1.TaskRef{ResolverRef: v1beta1.ResolverRef{Resolver: "git", Params: []v1beta1.Param{{
+		taskRef: &v1beta1.TaskRef{ResolverRef: v1beta1.ResolverRef{Resolver: "git", Params: v1beta1.Params{{
 			Name: "repo",
 			Value: v1beta1.ParamValue{
 				Type:      v1beta1.ParamTypeString,
@@ -110,7 +110,7 @@ func TestTaskRef_Invalid(t *testing.T) {
 		name: "taskref params disallowed without resolver",
 		taskRef: &v1beta1.TaskRef{
 			ResolverRef: v1beta1.ResolverRef{
-				Params: []v1beta1.Param{},
+				Params: v1beta1.Params{},
 			},
 		},
 		wantErr: apis.ErrMissingField("resolver"),
@@ -138,7 +138,7 @@ func TestTaskRef_Invalid(t *testing.T) {
 		taskRef: &v1beta1.TaskRef{
 			Name: "bar",
 			ResolverRef: v1beta1.ResolverRef{
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name: "foo",
 					Value: v1beta1.ParamValue{
 						Type:      v1beta1.ParamTypeString,
@@ -153,7 +153,7 @@ func TestTaskRef_Invalid(t *testing.T) {
 		taskRef: &v1beta1.TaskRef{
 			Bundle: "bar",
 			ResolverRef: v1beta1.ResolverRef{
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name: "foo",
 					Value: v1beta1.ParamValue{
 						Type:      v1beta1.ParamTypeString,
@@ -169,7 +169,7 @@ func TestTaskRef_Invalid(t *testing.T) {
 		taskRef: &v1beta1.TaskRef{
 			ResolverRef: v1beta1.ResolverRef{
 				Resolver: "some-resolver",
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name: "foo",
 					Value: v1beta1.ParamValue{
 						Type:      v1beta1.ParamTypeObject,

--- a/pkg/apis/pipeline/v1beta1/taskrun_conversion_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_conversion_test.go
@@ -76,7 +76,7 @@ func TestTaskRunConversion(t *testing.T) {
 				Debug: &v1beta1.TaskRunDebug{
 					Breakpoint: []string{breakpointOnFailure},
 				},
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name: "param-task-1",
 					Value: v1beta1.ParamValue{
 						ArrayVal: []string{"value-task-1"},
@@ -302,7 +302,7 @@ func TestTaskRunConversionFromDeprecated(t *testing.T) {
 				TaskRef: &v1beta1.TaskRef{
 					ResolverRef: v1beta1.ResolverRef{
 						Resolver: "bundles",
-						Params: []v1beta1.Param{
+						Params: v1beta1.Params{
 							{Name: "bundle", Value: v1beta1.ParamValue{StringVal: "test-bundle", Type: "string"}},
 							{Name: "name", Value: v1beta1.ParamValue{StringVal: "test-bundle-name", Type: "string"}},
 							{Name: "kind", Value: v1beta1.ParamValue{StringVal: "Task", Type: "string"}},
@@ -464,7 +464,7 @@ func TestTaskRunConvertTo(t *testing.T) {
 			},
 			Spec: v1beta1.TaskRunSpec{
 				Retries: 1,
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name: "param-task-0",
 					Value: v1beta1.ParamValue{
 						StringVal: "param-value-string",
@@ -493,7 +493,7 @@ func TestTaskRunConvertTo(t *testing.T) {
 			},
 			Spec: v1.TaskRunSpec{
 				Retries: 1,
-				Params: []v1.Param{{
+				Params: v1.Params{{
 					Name: "param-task-0",
 					Value: v1.ParamValue{
 						StringVal: "param-value-string",
@@ -547,7 +547,7 @@ func TestTaskRunConvertFrom(t *testing.T) {
 			},
 			Spec: v1.TaskRunSpec{
 				Retries: 1,
-				Params: []v1.Param{{
+				Params: v1.Params{{
 					Name: "param-task-1",
 					Value: v1.ParamValue{
 						ArrayVal: []string{"value-task-1"},
@@ -567,7 +567,7 @@ func TestTaskRunConvertFrom(t *testing.T) {
 			},
 			Spec: v1beta1.TaskRunSpec{
 				Retries: 1,
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name: "param-task-1",
 					Value: v1beta1.ParamValue{
 						ArrayVal: []string{"value-task-1"},

--- a/pkg/apis/pipeline/v1beta1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_types.go
@@ -40,7 +40,7 @@ type TaskRunSpec struct {
 	Debug *TaskRunDebug `json:"debug,omitempty"`
 	// +optional
 	// +listType=atomic
-	Params []Param `json:"params,omitempty"`
+	Params Params `json:"params,omitempty"`
 	// +optional
 	ServiceAccountName string `json:"serviceAccountName"`
 	// no more than one of the TaskRef and TaskSpec may be specified.

--- a/pkg/apis/pipeline/v1beta1/taskrun_validation.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_validation.go
@@ -237,7 +237,7 @@ func ValidateWorkspaceBindings(ctx context.Context, wb []WorkspaceBinding) (errs
 }
 
 // ValidateParameters makes sure the params for the Task are valid.
-func ValidateParameters(ctx context.Context, params []Param) (errs *apis.FieldError) {
+func ValidateParameters(ctx context.Context, params Params) (errs *apis.FieldError) {
 	var names []string
 	for _, p := range params {
 		if p.Value.Type == ParamTypeObject {

--- a/pkg/apis/pipeline/v1beta1/taskrun_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_validation_test.go
@@ -114,7 +114,7 @@ func TestTaskRun_Invalidate(t *testing.T) {
 		taskRun: &v1beta1.TaskRun{
 			ObjectMeta: metav1.ObjectMeta{Name: "tr"},
 			Spec: v1beta1.TaskRunSpec{
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name: "task-words",
 					Value: v1beta1.ParamValue{
 						Type:      v1beta1.ParamTypeObject,
@@ -169,7 +169,7 @@ func TestTaskRun_Validate(t *testing.T) {
 		taskRun: &v1beta1.TaskRun{
 			ObjectMeta: metav1.ObjectMeta{Name: "tr"},
 			Spec: v1beta1.TaskRunSpec{
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name: "task-words",
 					Value: v1beta1.ParamValue{
 						Type:     v1beta1.ParamTypeArray,
@@ -191,7 +191,7 @@ func TestTaskRun_Validate(t *testing.T) {
 		taskRun: &v1beta1.TaskRun{
 			ObjectMeta: metav1.ObjectMeta{Name: "tr"},
 			Spec: v1beta1.TaskRunSpec{
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name: "task-words",
 					Value: v1beta1.ParamValue{
 						Type:      v1beta1.ParamTypeObject,
@@ -214,7 +214,7 @@ func TestTaskRun_Validate(t *testing.T) {
 		taskRun: &v1beta1.TaskRun{
 			ObjectMeta: metav1.ObjectMeta{Name: "tr"},
 			Spec: v1beta1.TaskRunSpec{
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name: "task-words",
 					Value: v1beta1.ParamValue{
 						Type: v1beta1.ParamTypeObject,
@@ -247,7 +247,7 @@ func TestTaskRun_Validate(t *testing.T) {
 		taskRun: &v1beta1.TaskRun{
 			ObjectMeta: metav1.ObjectMeta{Name: "tr"},
 			Spec: v1beta1.TaskRunSpec{
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name: "task-words",
 					Value: v1beta1.ParamValue{
 						Type:     v1beta1.ParamTypeArray,
@@ -278,7 +278,7 @@ func TestTaskRun_Validate(t *testing.T) {
 		taskRun: &v1beta1.TaskRun{
 			ObjectMeta: metav1.ObjectMeta{Name: "tr"},
 			Spec: v1beta1.TaskRunSpec{
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name: "task-words",
 					Value: v1beta1.ParamValue{
 						Type:      v1beta1.ParamTypeObject,
@@ -312,7 +312,7 @@ func TestTaskRun_Validate(t *testing.T) {
 		taskRun: &v1beta1.TaskRun{
 			ObjectMeta: metav1.ObjectMeta{Name: "tr"},
 			Spec: v1beta1.TaskRunSpec{
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name: "task-words",
 					Value: v1beta1.ParamValue{
 						Type:     v1beta1.ParamTypeArray,
@@ -346,7 +346,7 @@ func TestTaskRun_Validate(t *testing.T) {
 		taskRun: &v1beta1.TaskRun{
 			ObjectMeta: metav1.ObjectMeta{Name: "tr"},
 			Spec: v1beta1.TaskRunSpec{
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name: "task-words",
 					Value: v1beta1.ParamValue{
 						Type:      v1beta1.ParamTypeObject,
@@ -381,7 +381,7 @@ func TestTaskRun_Validate(t *testing.T) {
 		taskRun: &v1beta1.TaskRun{
 			ObjectMeta: metav1.ObjectMeta{Name: "tr"},
 			Spec: v1beta1.TaskRunSpec{
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name: "task-words",
 					Value: v1beta1.ParamValue{
 						Type:     v1beta1.ParamTypeArray,
@@ -407,7 +407,7 @@ func TestTaskRun_Validate(t *testing.T) {
 		taskRun: &v1beta1.TaskRun{
 			ObjectMeta: metav1.ObjectMeta{Name: "tr"},
 			Spec: v1beta1.TaskRunSpec{
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name: "task-words",
 					Value: v1beta1.ParamValue{
 						Type:      v1beta1.ParamTypeObject,
@@ -589,7 +589,7 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 	}, {
 		name: "invalid params - exactly same names",
 		spec: v1beta1.TaskRunSpec{
-			Params: []v1beta1.Param{{
+			Params: v1beta1.Params{{
 				Name:  "myname",
 				Value: *v1beta1.NewStructuredValues("value"),
 			}, {
@@ -602,7 +602,7 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 	}, {
 		name: "invalid params - same names but different case",
 		spec: v1beta1.TaskRunSpec{
-			Params: []v1beta1.Param{{
+			Params: v1beta1.Params{{
 				Name:  "FOO",
 				Value: *v1beta1.NewStructuredValues("value"),
 			}, {
@@ -615,7 +615,7 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 	}, {
 		name: "invalid params (object type) - same names but different case",
 		spec: v1beta1.TaskRunSpec{
-			Params: []v1beta1.Param{{
+			Params: v1beta1.Params{{
 				Name:  "MYOBJECTPARAM",
 				Value: *v1beta1.NewObject(map[string]string{"key1": "val1", "key2": "val2"}),
 			}, {
@@ -819,7 +819,7 @@ func TestTaskRunSpec_Validate(t *testing.T) {
 		name: "parameters",
 		spec: v1beta1.TaskRunSpec{
 			Timeout: &metav1.Duration{Duration: 0},
-			Params: []v1beta1.Param{{
+			Params: v1beta1.Params{{
 				Name:  "name",
 				Value: *v1beta1.NewStructuredValues("value"),
 			}},

--- a/pkg/apis/pipeline/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/pipeline/v1beta1/zz_generated.deepcopy.go
@@ -300,7 +300,7 @@ func (in *CustomRunSpec) DeepCopyInto(out *CustomRunSpec) {
 	}
 	if in.Params != nil {
 		in, out := &in.Params, &out.Params
-		*out = make([]Param, len(*in))
+		*out = make(Params, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
@@ -792,7 +792,7 @@ func (in *PipelineRunSpec) DeepCopyInto(out *PipelineRunSpec) {
 	}
 	if in.Params != nil {
 		in, out := &in.Params, &out.Params
-		*out = make([]Param, len(*in))
+		*out = make(Params, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
@@ -1282,7 +1282,7 @@ func (in *ResolverRef) DeepCopyInto(out *ResolverRef) {
 	*out = *in
 	if in.Params != nil {
 		in, out := &in.Params, &out.Params
-		*out = make([]Param, len(*in))
+		*out = make(Params, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
@@ -1889,7 +1889,7 @@ func (in *TaskRunSpec) DeepCopyInto(out *TaskRunSpec) {
 	}
 	if in.Params != nil {
 		in, out := &in.Params, &out.Params
-		*out = make([]Param, len(*in))
+		*out = make(Params, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}

--- a/pkg/reconciler/pipeline/dag/dag_test.go
+++ b/pkg/reconciler/pipeline/dag/dag_test.go
@@ -172,7 +172,7 @@ func TestBuild_JoinMultipleRoots(t *testing.T) {
 	}
 	xDependsOnA := v1beta1.PipelineTask{
 		Name: "x",
-		Params: []v1beta1.Param{
+		Params: v1beta1.Params{
 			{
 				Value: *v1beta1.NewStructuredValues("$(tasks.a.results.result)"),
 			},
@@ -181,7 +181,7 @@ func TestBuild_JoinMultipleRoots(t *testing.T) {
 	yDependsOnARunsAfterB := v1beta1.PipelineTask{
 		Name:     "y",
 		RunAfter: []string{"b"},
-		Params: []v1beta1.Param{
+		Params: v1beta1.Params{
 			{
 				Value: *v1beta1.NewStructuredValues("$(tasks.a.results.result)"),
 			},
@@ -250,7 +250,7 @@ func TestBuild_FanInFanOut(t *testing.T) {
 				Name: "resultFromD",
 			}},
 		}},
-		Params: []v1beta1.Param{{
+		Params: v1beta1.Params{{
 			Value: *v1beta1.NewStructuredValues("$(tasks.a.results.result)"),
 		}},
 	}
@@ -261,13 +261,13 @@ func TestBuild_FanInFanOut(t *testing.T) {
 				Name: "resultFromE",
 			}},
 		}},
-		Params: []v1beta1.Param{{
+		Params: v1beta1.Params{{
 			Value: *v1beta1.NewStructuredValues("$(tasks.a.results.result)"),
 		}},
 	}
 	fDependsOnDAndE := v1beta1.PipelineTask{
 		Name: "f",
-		Params: []v1beta1.Param{{
+		Params: v1beta1.Params{{
 			Value: *v1beta1.NewStructuredValues("$(tasks.d.results.resultFromD)"),
 		}, {
 			Value: *v1beta1.NewStructuredValues("$(tasks.e.results.resultFromE)"),
@@ -333,7 +333,7 @@ func TestBuild_TaskParamsFromTaskResults(t *testing.T) {
 	f := v1beta1.PipelineTask{Name: "f"}
 	xDependsOnA := v1beta1.PipelineTask{
 		Name: "x",
-		Params: []v1beta1.Param{{
+		Params: v1beta1.Params{{
 			Name:  "paramX",
 			Value: *v1beta1.NewStructuredValues("$(tasks.a.results.resultA)"),
 		}},
@@ -341,21 +341,21 @@ func TestBuild_TaskParamsFromTaskResults(t *testing.T) {
 	yDependsOnBRunsAfterC := v1beta1.PipelineTask{
 		Name:     "y",
 		RunAfter: []string{"c"},
-		Params: []v1beta1.Param{{
+		Params: v1beta1.Params{{
 			Name:  "paramB",
 			Value: *v1beta1.NewStructuredValues("$(tasks.b.results.resultB)"),
 		}},
 	}
 	zDependsOnDAndE := v1beta1.PipelineTask{
 		Name: "z",
-		Params: []v1beta1.Param{{
+		Params: v1beta1.Params{{
 			Name:  "paramZ",
 			Value: *v1beta1.NewStructuredValues("$(tasks.d.results.resultD) $(tasks.e.results.resultE)"),
 		}},
 	}
 	wDependsOnF := v1beta1.PipelineTask{
 		Name: "w",
-		Params: []v1beta1.Param{{
+		Params: v1beta1.Params{{
 			Name:  "paramw",
 			Value: *v1beta1.NewStructuredValues("$(tasks.f.results.resultF[*])"),
 		}},
@@ -430,7 +430,7 @@ func TestBuild_InvalidDAG(t *testing.T) {
 				Name: "resultX",
 			}},
 		}},
-		Params: []v1beta1.Param{{
+		Params: v1beta1.Params{{
 			Value: *v1beta1.NewStructuredValues("$(tasks.a.results.result)"),
 		}},
 	}
@@ -441,13 +441,13 @@ func TestBuild_InvalidDAG(t *testing.T) {
 				Name: "resultZ",
 			}},
 		}},
-		Params: []v1beta1.Param{{
+		Params: v1beta1.Params{{
 			Value: *v1beta1.NewStructuredValues("$(tasks.x.results.resultX)"),
 		}},
 	}
 	aDependsOnZ := v1beta1.PipelineTask{
 		Name: "a",
-		Params: []v1beta1.Param{{
+		Params: v1beta1.Params{{
 			Value: *v1beta1.NewStructuredValues("$(tasks.z.results.resultZ)"),
 		}},
 	}
@@ -470,13 +470,13 @@ func TestBuild_InvalidDAG(t *testing.T) {
 				Name: "result",
 			}},
 		}},
-		Params: []v1beta1.Param{{
+		Params: v1beta1.Params{{
 			Value: *v1beta1.NewStructuredValues("$(tasks.a.results.result)"),
 		}},
 	}
 	invalidTaskResult := v1beta1.PipelineTask{
 		Name: "a",
-		Params: []v1beta1.Param{{
+		Params: v1beta1.Params{{
 			Value: *v1beta1.NewStructuredValues("$(tasks.invalid.results.none)"),
 		}},
 	}
@@ -499,7 +499,7 @@ func TestBuild_InvalidDAG(t *testing.T) {
 	}
 	bDependsOnA := v1beta1.PipelineTask{
 		Name: "b",
-		Params: []v1beta1.Param{{
+		Params: v1beta1.Params{{
 			Value: *v1beta1.NewStructuredValues("$(tasks.a.results.result)"),
 		}},
 		TaskSpec: &v1beta1.EmbeddedTask{TaskSpec: v1beta1.TaskSpec{
@@ -510,7 +510,7 @@ func TestBuild_InvalidDAG(t *testing.T) {
 	}
 	cDependsOnA := v1beta1.PipelineTask{
 		Name: "c",
-		Params: []v1beta1.Param{{
+		Params: v1beta1.Params{{
 			Value: *v1beta1.NewStructuredValues("$(tasks.a.results.result)"),
 		}},
 		TaskSpec: &v1beta1.EmbeddedTask{TaskSpec: v1beta1.TaskSpec{
@@ -521,7 +521,7 @@ func TestBuild_InvalidDAG(t *testing.T) {
 	}
 	dDependsOnBAndC := v1beta1.PipelineTask{
 		Name: "d",
-		Params: []v1beta1.Param{{
+		Params: v1beta1.Params{{
 			Value: *v1beta1.NewStructuredValues("$(tasks.b.results.resultb)"),
 		}, {
 			Value: *v1beta1.NewStructuredValues("$(tasks.c.results.resultc)"),
@@ -715,7 +715,7 @@ func testGraph(t *testing.T) *dag.Graph {
 		Name: "b",
 	}, {
 		Name: "w",
-		Params: []v1beta1.Param{{
+		Params: v1beta1.Params{{
 			Name:  "foo",
 			Value: *v1beta1.NewStructuredValues("$(tasks.y.results.bar)"),
 		}},

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -826,7 +826,7 @@ func (c *Reconciler) createTaskRuns(ctx context.Context, rpt *resources.Resolved
 	return taskRuns, nil
 }
 
-func (c *Reconciler) createTaskRun(ctx context.Context, taskRunName string, params []v1beta1.Param, rpt *resources.ResolvedPipelineTask, pr *v1beta1.PipelineRun) (*v1beta1.TaskRun, error) {
+func (c *Reconciler) createTaskRun(ctx context.Context, taskRunName string, params v1beta1.Params, rpt *resources.ResolvedPipelineTask, pr *v1beta1.PipelineRun) (*v1beta1.TaskRun, error) {
 	ctx, span := c.tracerProvider.Tracer(TracerName).Start(ctx, "createTaskRun")
 	defer span.End()
 	logger := logging.FromContext(ctx)
@@ -900,7 +900,7 @@ func (c *Reconciler) createRunObjects(ctx context.Context, rpt *resources.Resolv
 	return runObjects, nil
 }
 
-func (c *Reconciler) createRunObject(ctx context.Context, runName string, params []v1beta1.Param, rpt *resources.ResolvedPipelineTask, pr *v1beta1.PipelineRun) (v1beta1.RunObject, error) {
+func (c *Reconciler) createRunObject(ctx context.Context, runName string, params v1beta1.Params, rpt *resources.ResolvedPipelineTask, pr *v1beta1.PipelineRun) (v1beta1.RunObject, error) {
 	ctx, span := c.tracerProvider.Tracer(TracerName).Start(ctx, "createRunObject")
 	defer span.End()
 	logger := logging.FromContext(ctx)

--- a/pkg/reconciler/pipelinerun/resources/apply.go
+++ b/pkg/reconciler/pipelinerun/resources/apply.go
@@ -317,7 +317,7 @@ func propagateParams(t v1beta1.PipelineTask, stringReplacements map[string]strin
 	return t
 }
 
-func replaceParamValues(params []v1beta1.Param, stringReplacements map[string]string, arrayReplacements map[string][]string, objectReplacements map[string]map[string]string) []v1beta1.Param {
+func replaceParamValues(params v1beta1.Params, stringReplacements map[string]string, arrayReplacements map[string][]string, objectReplacements map[string]map[string]string) v1beta1.Params {
 	for i := range params {
 		params[i].Value.ApplyReplacements(stringReplacements, arrayReplacements, objectReplacements)
 	}

--- a/pkg/reconciler/pipelinerun/resources/apply_test.go
+++ b/pkg/reconciler/pipelinerun/resources/apply_test.go
@@ -33,7 +33,7 @@ func TestApplyParameters(t *testing.T) {
 	for _, tt := range []struct {
 		name     string
 		original v1beta1.PipelineSpec
-		params   []v1beta1.Param
+		params   v1beta1.Params
 		expected v1beta1.PipelineSpec
 		wc       func(context.Context) context.Context
 	}{{
@@ -44,21 +44,21 @@ func TestApplyParameters(t *testing.T) {
 				{Name: "second-param", Type: v1beta1.ParamTypeString},
 			},
 			Tasks: []v1beta1.PipelineTask{{
-				Params: []v1beta1.Param{
+				Params: v1beta1.Params{
 					{Name: "first-task-first-param", Value: *v1beta1.NewStructuredValues("$(params.first-param)")},
 					{Name: "first-task-second-param", Value: *v1beta1.NewStructuredValues("$(params.second-param)")},
 					{Name: "first-task-third-param", Value: *v1beta1.NewStructuredValues("static value")},
 				},
 			}},
 		},
-		params: []v1beta1.Param{{Name: "second-param", Value: *v1beta1.NewStructuredValues("second-value")}},
+		params: v1beta1.Params{{Name: "second-param", Value: *v1beta1.NewStructuredValues("second-value")}},
 		expected: v1beta1.PipelineSpec{
 			Params: []v1beta1.ParamSpec{
 				{Name: "first-param", Type: v1beta1.ParamTypeString, Default: v1beta1.NewStructuredValues("default-value")},
 				{Name: "second-param", Type: v1beta1.ParamTypeString},
 			},
 			Tasks: []v1beta1.PipelineTask{{
-				Params: []v1beta1.Param{
+				Params: v1beta1.Params{
 					{Name: "first-task-first-param", Value: *v1beta1.NewStructuredValues("default-value")},
 					{Name: "first-task-second-param", Value: *v1beta1.NewStructuredValues("second-value")},
 					{Name: "first-task-third-param", Value: *v1beta1.NewStructuredValues("static value")},
@@ -80,7 +80,7 @@ func TestApplyParameters(t *testing.T) {
 				},
 			}},
 		},
-		params: []v1beta1.Param{{Name: "HELLO", Value: *v1beta1.NewStructuredValues("hello param!")}},
+		params: v1beta1.Params{{Name: "HELLO", Value: *v1beta1.NewStructuredValues("hello param!")}},
 		expected: v1beta1.PipelineSpec{
 			Tasks: []v1beta1.PipelineTask{{
 				TaskSpec: &v1beta1.EmbeddedTask{
@@ -109,7 +109,7 @@ func TestApplyParameters(t *testing.T) {
 				},
 			}},
 		},
-		params: []v1beta1.Param{{Name: "HELLO", Value: *v1beta1.NewStructuredValues("hello param!")}},
+		params: v1beta1.Params{{Name: "HELLO", Value: *v1beta1.NewStructuredValues("hello param!")}},
 		expected: v1beta1.PipelineSpec{
 			Finally: []v1beta1.PipelineTask{{
 				TaskSpec: &v1beta1.EmbeddedTask{
@@ -138,7 +138,7 @@ func TestApplyParameters(t *testing.T) {
 				},
 			}},
 		},
-		params: []v1beta1.Param{{Name: "HELLO", Value: *v1beta1.NewStructuredValues("hello", "param", "!!!")}},
+		params: v1beta1.Params{{Name: "HELLO", Value: *v1beta1.NewStructuredValues("hello", "param", "!!!")}},
 		expected: v1beta1.PipelineSpec{
 			Tasks: []v1beta1.PipelineTask{{
 				TaskSpec: &v1beta1.EmbeddedTask{
@@ -167,7 +167,7 @@ func TestApplyParameters(t *testing.T) {
 				},
 			}},
 		},
-		params: []v1beta1.Param{{Name: "HELLO", Value: *v1beta1.NewStructuredValues("hello", "param", "!!!")}},
+		params: v1beta1.Params{{Name: "HELLO", Value: *v1beta1.NewStructuredValues("hello", "param", "!!!")}},
 		expected: v1beta1.PipelineSpec{
 			Finally: []v1beta1.PipelineTask{{
 				TaskSpec: &v1beta1.EmbeddedTask{
@@ -196,7 +196,7 @@ func TestApplyParameters(t *testing.T) {
 				},
 			}},
 		},
-		params: []v1beta1.Param{{Name: "myObject", Value: *v1beta1.NewObject(map[string]string{"key1": "hello", "key2": "world!"})}},
+		params: v1beta1.Params{{Name: "myObject", Value: *v1beta1.NewObject(map[string]string{"key1": "hello", "key2": "world!"})}},
 		expected: v1beta1.PipelineSpec{
 			Tasks: []v1beta1.PipelineTask{{
 				TaskSpec: &v1beta1.EmbeddedTask{
@@ -226,7 +226,7 @@ func TestApplyParameters(t *testing.T) {
 				},
 			}},
 		},
-		params: []v1beta1.Param{{Name: "myObject", Value: *v1beta1.NewObject(map[string]string{"key1": "hello", "key2": "world!"})}},
+		params: v1beta1.Params{{Name: "myObject", Value: *v1beta1.NewObject(map[string]string{"key1": "hello", "key2": "world!"})}},
 		expected: v1beta1.PipelineSpec{
 			Finally: []v1beta1.PipelineTask{{
 				TaskSpec: &v1beta1.EmbeddedTask{
@@ -260,7 +260,7 @@ func TestApplyParameters(t *testing.T) {
 				},
 			}},
 		},
-		params: []v1beta1.Param{{Name: "HELLO", Value: *v1beta1.NewStructuredValues("pipeline param!")}},
+		params: v1beta1.Params{{Name: "HELLO", Value: *v1beta1.NewStructuredValues("pipeline param!")}},
 		expected: v1beta1.PipelineSpec{
 			Tasks: []v1beta1.PipelineTask{{
 				TaskSpec: &v1beta1.EmbeddedTask{
@@ -297,7 +297,7 @@ func TestApplyParameters(t *testing.T) {
 				},
 			}},
 		},
-		params: []v1beta1.Param{{Name: "HELLO", Value: *v1beta1.NewStructuredValues("pipeline param!")}},
+		params: v1beta1.Params{{Name: "HELLO", Value: *v1beta1.NewStructuredValues("pipeline param!")}},
 		expected: v1beta1.PipelineSpec{
 			Finally: []v1beta1.PipelineTask{{
 				TaskSpec: &v1beta1.EmbeddedTask{
@@ -334,7 +334,7 @@ func TestApplyParameters(t *testing.T) {
 				},
 			}},
 		},
-		params: []v1beta1.Param{{Name: "HELLO", Value: *v1beta1.NewStructuredValues("pipeline", "param!")}},
+		params: v1beta1.Params{{Name: "HELLO", Value: *v1beta1.NewStructuredValues("pipeline", "param!")}},
 		expected: v1beta1.PipelineSpec{
 			Tasks: []v1beta1.PipelineTask{{
 				TaskSpec: &v1beta1.EmbeddedTask{
@@ -371,7 +371,7 @@ func TestApplyParameters(t *testing.T) {
 				},
 			}},
 		},
-		params: []v1beta1.Param{{Name: "HELLO", Value: *v1beta1.NewStructuredValues("pipeline", "param!")}},
+		params: v1beta1.Params{{Name: "HELLO", Value: *v1beta1.NewStructuredValues("pipeline", "param!")}},
 		expected: v1beta1.PipelineSpec{
 			Finally: []v1beta1.PipelineTask{{
 				TaskSpec: &v1beta1.EmbeddedTask{
@@ -393,7 +393,7 @@ func TestApplyParameters(t *testing.T) {
 		name: "parameter propagation array with task default and task winner task",
 		original: v1beta1.PipelineSpec{
 			Tasks: []v1beta1.PipelineTask{{
-				Params: []v1beta1.Param{
+				Params: v1beta1.Params{
 					{Name: "HELLO", Value: *v1beta1.NewStructuredValues("task", "param!")},
 				},
 				TaskSpec: &v1beta1.EmbeddedTask{
@@ -411,10 +411,10 @@ func TestApplyParameters(t *testing.T) {
 				},
 			}},
 		},
-		params: []v1beta1.Param{{Name: "HELLO", Value: *v1beta1.NewStructuredValues("pipeline", "param!")}},
+		params: v1beta1.Params{{Name: "HELLO", Value: *v1beta1.NewStructuredValues("pipeline", "param!")}},
 		expected: v1beta1.PipelineSpec{
 			Tasks: []v1beta1.PipelineTask{{
-				Params: []v1beta1.Param{
+				Params: v1beta1.Params{
 					{Name: "HELLO", Value: *v1beta1.NewStructuredValues("task", "param!")},
 				},
 				TaskSpec: &v1beta1.EmbeddedTask{
@@ -436,7 +436,7 @@ func TestApplyParameters(t *testing.T) {
 		name: "Finally task parameter propagation array with task default and task winner task",
 		original: v1beta1.PipelineSpec{
 			Finally: []v1beta1.PipelineTask{{
-				Params: []v1beta1.Param{
+				Params: v1beta1.Params{
 					{Name: "HELLO", Value: *v1beta1.NewStructuredValues("task", "param!")},
 				},
 				TaskSpec: &v1beta1.EmbeddedTask{
@@ -454,10 +454,10 @@ func TestApplyParameters(t *testing.T) {
 				},
 			}},
 		},
-		params: []v1beta1.Param{{Name: "HELLO", Value: *v1beta1.NewStructuredValues("pipeline", "param!")}},
+		params: v1beta1.Params{{Name: "HELLO", Value: *v1beta1.NewStructuredValues("pipeline", "param!")}},
 		expected: v1beta1.PipelineSpec{
 			Finally: []v1beta1.PipelineTask{{
-				Params: []v1beta1.Param{
+				Params: v1beta1.Params{
 					{Name: "HELLO", Value: *v1beta1.NewStructuredValues("task", "param!")},
 				},
 				TaskSpec: &v1beta1.EmbeddedTask{
@@ -479,7 +479,7 @@ func TestApplyParameters(t *testing.T) {
 		name: "parameter propagation with task default and task winner task",
 		original: v1beta1.PipelineSpec{
 			Tasks: []v1beta1.PipelineTask{{
-				Params: []v1beta1.Param{
+				Params: v1beta1.Params{
 					{Name: "HELLO", Value: *v1beta1.NewStructuredValues("task param!")},
 				},
 				TaskSpec: &v1beta1.EmbeddedTask{
@@ -497,10 +497,10 @@ func TestApplyParameters(t *testing.T) {
 				},
 			}},
 		},
-		params: []v1beta1.Param{{Name: "HELLO", Value: *v1beta1.NewStructuredValues("pipeline param!")}},
+		params: v1beta1.Params{{Name: "HELLO", Value: *v1beta1.NewStructuredValues("pipeline param!")}},
 		expected: v1beta1.PipelineSpec{
 			Tasks: []v1beta1.PipelineTask{{
-				Params: []v1beta1.Param{
+				Params: v1beta1.Params{
 					{Name: "HELLO", Value: *v1beta1.NewStructuredValues("task param!")},
 				},
 				TaskSpec: &v1beta1.EmbeddedTask{
@@ -522,7 +522,7 @@ func TestApplyParameters(t *testing.T) {
 		name: "Finally task parameter propagation with task default and task winner task",
 		original: v1beta1.PipelineSpec{
 			Finally: []v1beta1.PipelineTask{{
-				Params: []v1beta1.Param{
+				Params: v1beta1.Params{
 					{Name: "HELLO", Value: *v1beta1.NewStructuredValues("task param!")},
 				},
 				TaskSpec: &v1beta1.EmbeddedTask{
@@ -540,10 +540,10 @@ func TestApplyParameters(t *testing.T) {
 				},
 			}},
 		},
-		params: []v1beta1.Param{{Name: "HELLO", Value: *v1beta1.NewStructuredValues("pipeline param!")}},
+		params: v1beta1.Params{{Name: "HELLO", Value: *v1beta1.NewStructuredValues("pipeline param!")}},
 		expected: v1beta1.PipelineSpec{
 			Finally: []v1beta1.PipelineTask{{
-				Params: []v1beta1.Param{
+				Params: v1beta1.Params{
 					{Name: "HELLO", Value: *v1beta1.NewStructuredValues("task param!")},
 				},
 				TaskSpec: &v1beta1.EmbeddedTask{
@@ -587,7 +587,7 @@ func TestApplyParameters(t *testing.T) {
 				},
 			}},
 		},
-		params: []v1beta1.Param{{Name: "myobject", Value: *v1beta1.NewObject(map[string]string{
+		params: v1beta1.Params{{Name: "myobject", Value: *v1beta1.NewObject(map[string]string{
 			"key1": "pipeline",
 			"key2": "param!!",
 		})}},
@@ -642,7 +642,7 @@ func TestApplyParameters(t *testing.T) {
 				},
 			}},
 		},
-		params: []v1beta1.Param{{Name: "myobject", Value: *v1beta1.NewObject(map[string]string{
+		params: v1beta1.Params{{Name: "myobject", Value: *v1beta1.NewObject(map[string]string{
 			"key1": "pipeline",
 			"key2": "param!!",
 		})}},
@@ -675,7 +675,7 @@ func TestApplyParameters(t *testing.T) {
 		name: "parameter propagation object with task default and task winner task",
 		original: v1beta1.PipelineSpec{
 			Tasks: []v1beta1.PipelineTask{{
-				Params: []v1beta1.Param{
+				Params: v1beta1.Params{
 					{Name: "myobject", Value: *v1beta1.NewObject(map[string]string{
 						"key1": "task",
 						"key2": "param!",
@@ -703,10 +703,10 @@ func TestApplyParameters(t *testing.T) {
 				},
 			}},
 		},
-		params: []v1beta1.Param{{Name: "myobject", Value: *v1beta1.NewObject(map[string]string{"key1": "pipeline", "key2": "param!!!"})}},
+		params: v1beta1.Params{{Name: "myobject", Value: *v1beta1.NewObject(map[string]string{"key1": "pipeline", "key2": "param!!!"})}},
 		expected: v1beta1.PipelineSpec{
 			Tasks: []v1beta1.PipelineTask{{
-				Params: []v1beta1.Param{
+				Params: v1beta1.Params{
 					{Name: "myobject", Value: *v1beta1.NewObject(map[string]string{
 						"key1": "task",
 						"key2": "param!",
@@ -739,7 +739,7 @@ func TestApplyParameters(t *testing.T) {
 		name: "Finally task parameter propagation object with task default and task winner task",
 		original: v1beta1.PipelineSpec{
 			Finally: []v1beta1.PipelineTask{{
-				Params: []v1beta1.Param{
+				Params: v1beta1.Params{
 					{Name: "myobject", Value: *v1beta1.NewObject(map[string]string{
 						"key1": "task",
 						"key2": "param!",
@@ -767,10 +767,10 @@ func TestApplyParameters(t *testing.T) {
 				},
 			}},
 		},
-		params: []v1beta1.Param{{Name: "myobject", Value: *v1beta1.NewObject(map[string]string{"key1": "pipeline", "key2": "param!!!"})}},
+		params: v1beta1.Params{{Name: "myobject", Value: *v1beta1.NewObject(map[string]string{"key1": "pipeline", "key2": "param!!!"})}},
 		expected: v1beta1.PipelineSpec{
 			Finally: []v1beta1.PipelineTask{{
-				Params: []v1beta1.Param{
+				Params: v1beta1.Params{
 					{Name: "myobject", Value: *v1beta1.NewObject(map[string]string{
 						"key1": "task",
 						"key2": "param!",
@@ -814,7 +814,7 @@ func TestApplyParameters(t *testing.T) {
 				}},
 			}},
 		},
-		params: []v1beta1.Param{{Name: "second-param", Value: *v1beta1.NewStructuredValues("second-value")}},
+		params: v1beta1.Params{{Name: "second-param", Value: *v1beta1.NewStructuredValues("second-value")}},
 		expected: v1beta1.PipelineSpec{
 			Params: []v1beta1.ParamSpec{
 				{Name: "first-param", Type: v1beta1.ParamTypeString, Default: v1beta1.NewStructuredValues("default-value")},
@@ -855,7 +855,7 @@ func TestApplyParameters(t *testing.T) {
 				}},
 			}},
 		},
-		params: []v1beta1.Param{{Name: "myobject", Value: *v1beta1.NewObject(map[string]string{
+		params: v1beta1.Params{{Name: "myobject", Value: *v1beta1.NewObject(map[string]string{
 			"key1": "val1",
 			"key2": "val2",
 			"key3": "val1",
@@ -893,7 +893,7 @@ func TestApplyParameters(t *testing.T) {
 				{Name: "second-param", Type: v1beta1.ParamTypeString, Default: v1beta1.NewStructuredValues("default-value")},
 			},
 			Tasks: []v1beta1.PipelineTask{{
-				Params: []v1beta1.Param{
+				Params: v1beta1.Params{
 					{Name: "first-task-first-param", Value: *v1beta1.NewStructuredValues("$(input.workspace.$(params.first-param))")},
 					{Name: "first-task-second-param", Value: *v1beta1.NewStructuredValues("$(input.workspace.$(params.second-param))")},
 				},
@@ -906,7 +906,7 @@ func TestApplyParameters(t *testing.T) {
 				{Name: "second-param", Type: v1beta1.ParamTypeString, Default: v1beta1.NewStructuredValues("default-value")},
 			},
 			Tasks: []v1beta1.PipelineTask{{
-				Params: []v1beta1.Param{
+				Params: v1beta1.Params{
 					{Name: "first-task-first-param", Value: *v1beta1.NewStructuredValues("$(input.workspace.default-value)")},
 					{Name: "first-task-second-param", Value: *v1beta1.NewStructuredValues("$(input.workspace.default-value)")},
 				},
@@ -920,13 +920,13 @@ func TestApplyParameters(t *testing.T) {
 				{Name: "second-param", Type: v1beta1.ParamTypeArray},
 			},
 			Tasks: []v1beta1.PipelineTask{{
-				Params: []v1beta1.Param{
+				Params: v1beta1.Params{
 					{Name: "first-task-first-param", Value: *v1beta1.NewStructuredValues("firstelement", "$(params.first-param)")},
 					{Name: "first-task-second-param", Value: *v1beta1.NewStructuredValues("firstelement", "$(params.second-param)")},
 				},
 			}},
 		},
-		params: []v1beta1.Param{
+		params: v1beta1.Params{
 			{Name: "second-param", Value: *v1beta1.NewStructuredValues("second-value", "array")},
 		},
 		expected: v1beta1.PipelineSpec{
@@ -935,7 +935,7 @@ func TestApplyParameters(t *testing.T) {
 				{Name: "second-param", Type: v1beta1.ParamTypeArray},
 			},
 			Tasks: []v1beta1.PipelineTask{{
-				Params: []v1beta1.Param{
+				Params: v1beta1.Params{
 					{Name: "first-task-first-param", Value: *v1beta1.NewStructuredValues("firstelement", "default", "array", "value")},
 					{Name: "first-task-second-param", Value: *v1beta1.NewStructuredValues("firstelement", "second-value", "array")},
 				},
@@ -959,7 +959,7 @@ func TestApplyParameters(t *testing.T) {
 				},
 			},
 			Tasks: []v1beta1.PipelineTask{{
-				Params: []v1beta1.Param{
+				Params: v1beta1.Params{
 					{Name: "first-task-first-param", Value: *v1beta1.NewStructuredValues("$(input.workspace.$(params.myobject.key1))")},
 					{Name: "first-task-second-param", Value: *v1beta1.NewStructuredValues("$(input.workspace.$(params.myobject.key2))")},
 				},
@@ -982,7 +982,7 @@ func TestApplyParameters(t *testing.T) {
 				},
 			},
 			Tasks: []v1beta1.PipelineTask{{
-				Params: []v1beta1.Param{
+				Params: v1beta1.Params{
 					{Name: "first-task-first-param", Value: *v1beta1.NewStructuredValues("$(input.workspace.val1)")},
 					{Name: "first-task-second-param", Value: *v1beta1.NewStructuredValues("$(input.workspace.val2)")},
 				},
@@ -996,7 +996,7 @@ func TestApplyParameters(t *testing.T) {
 				{Name: "second-param", Type: v1beta1.ParamTypeString},
 			},
 			Finally: []v1beta1.PipelineTask{{
-				Params: []v1beta1.Param{
+				Params: v1beta1.Params{
 					{Name: "final-task-first-param", Value: *v1beta1.NewStructuredValues("$(params.first-param)")},
 					{Name: "final-task-second-param", Value: *v1beta1.NewStructuredValues("$(params.second-param)")},
 				},
@@ -1007,14 +1007,14 @@ func TestApplyParameters(t *testing.T) {
 				}},
 			}},
 		},
-		params: []v1beta1.Param{{Name: "second-param", Value: *v1beta1.NewStructuredValues("second-value")}},
+		params: v1beta1.Params{{Name: "second-param", Value: *v1beta1.NewStructuredValues("second-value")}},
 		expected: v1beta1.PipelineSpec{
 			Params: []v1beta1.ParamSpec{
 				{Name: "first-param", Type: v1beta1.ParamTypeString, Default: v1beta1.NewStructuredValues("default-value")},
 				{Name: "second-param", Type: v1beta1.ParamTypeString},
 			},
 			Finally: []v1beta1.PipelineTask{{
-				Params: []v1beta1.Param{
+				Params: v1beta1.Params{
 					{Name: "final-task-first-param", Value: *v1beta1.NewStructuredValues("default-value")},
 					{Name: "final-task-second-param", Value: *v1beta1.NewStructuredValues("second-value")},
 				},
@@ -1033,13 +1033,13 @@ func TestApplyParameters(t *testing.T) {
 				{Name: "second-param", Type: v1beta1.ParamTypeString},
 			},
 			Tasks: []v1beta1.PipelineTask{{
-				Params: []v1beta1.Param{
+				Params: v1beta1.Params{
 					{Name: "final-task-first-param", Value: *v1beta1.NewStructuredValues("$(params.first-param)")},
 					{Name: "final-task-second-param", Value: *v1beta1.NewStructuredValues("$(params.second-param)")},
 				},
 			}},
 			Finally: []v1beta1.PipelineTask{{
-				Params: []v1beta1.Param{
+				Params: v1beta1.Params{
 					{Name: "final-task-first-param", Value: *v1beta1.NewStructuredValues("$(params.first-param)")},
 					{Name: "final-task-second-param", Value: *v1beta1.NewStructuredValues("$(params.second-param)")},
 				},
@@ -1050,20 +1050,20 @@ func TestApplyParameters(t *testing.T) {
 				}},
 			}},
 		},
-		params: []v1beta1.Param{{Name: "second-param", Value: *v1beta1.NewStructuredValues("second-value")}},
+		params: v1beta1.Params{{Name: "second-param", Value: *v1beta1.NewStructuredValues("second-value")}},
 		expected: v1beta1.PipelineSpec{
 			Params: []v1beta1.ParamSpec{
 				{Name: "first-param", Type: v1beta1.ParamTypeString, Default: v1beta1.NewStructuredValues("default-value")},
 				{Name: "second-param", Type: v1beta1.ParamTypeString},
 			},
 			Tasks: []v1beta1.PipelineTask{{
-				Params: []v1beta1.Param{
+				Params: v1beta1.Params{
 					{Name: "final-task-first-param", Value: *v1beta1.NewStructuredValues("default-value")},
 					{Name: "final-task-second-param", Value: *v1beta1.NewStructuredValues("second-value")},
 				},
 			}},
 			Finally: []v1beta1.PipelineTask{{
-				Params: []v1beta1.Param{
+				Params: v1beta1.Params{
 					{Name: "final-task-first-param", Value: *v1beta1.NewStructuredValues("default-value")},
 					{Name: "final-task-second-param", Value: *v1beta1.NewStructuredValues("second-value")},
 				},
@@ -1092,13 +1092,13 @@ func TestApplyParameters(t *testing.T) {
 				},
 			},
 			Tasks: []v1beta1.PipelineTask{{
-				Params: []v1beta1.Param{
+				Params: v1beta1.Params{
 					{Name: "final-task-first-param", Value: *v1beta1.NewStructuredValues("$(params.myobject.key1)")},
 					{Name: "final-task-second-param", Value: *v1beta1.NewStructuredValues("$(params.myobject.key2)")},
 				},
 			}},
 			Finally: []v1beta1.PipelineTask{{
-				Params: []v1beta1.Param{
+				Params: v1beta1.Params{
 					{Name: "final-task-first-param", Value: *v1beta1.NewStructuredValues("$(params.myobject.key1)")},
 					{Name: "final-task-second-param", Value: *v1beta1.NewStructuredValues("$(params.myobject.key2)")},
 				},
@@ -1109,7 +1109,7 @@ func TestApplyParameters(t *testing.T) {
 				}},
 			}},
 		},
-		params: []v1beta1.Param{{Name: "myobject", Value: *v1beta1.NewObject(map[string]string{
+		params: v1beta1.Params{{Name: "myobject", Value: *v1beta1.NewObject(map[string]string{
 			"key1": "foo",
 			"key2": "bar",
 		})}},
@@ -1129,13 +1129,13 @@ func TestApplyParameters(t *testing.T) {
 				},
 			},
 			Tasks: []v1beta1.PipelineTask{{
-				Params: []v1beta1.Param{
+				Params: v1beta1.Params{
 					{Name: "final-task-first-param", Value: *v1beta1.NewStructuredValues("foo")},
 					{Name: "final-task-second-param", Value: *v1beta1.NewStructuredValues("bar")},
 				},
 			}},
 			Finally: []v1beta1.PipelineTask{{
-				Params: []v1beta1.Param{
+				Params: v1beta1.Params{
 					{Name: "final-task-first-param", Value: *v1beta1.NewStructuredValues("foo")},
 					{Name: "final-task-second-param", Value: *v1beta1.NewStructuredValues("bar")},
 				},
@@ -1156,7 +1156,7 @@ func TestApplyParameters(t *testing.T) {
 				{Name: "fourth/param", Type: v1beta1.ParamTypeString},
 			},
 			Tasks: []v1beta1.PipelineTask{{
-				Params: []v1beta1.Param{
+				Params: v1beta1.Params{
 					{Name: "first-task-first-param", Value: *v1beta1.NewStructuredValues(`$(params["first.param"])`)},
 					{Name: "first-task-second-param", Value: *v1beta1.NewStructuredValues(`$(params["second/param"])`)},
 					{Name: "first-task-third-param", Value: *v1beta1.NewStructuredValues(`$(params['third.param'])`)},
@@ -1165,7 +1165,7 @@ func TestApplyParameters(t *testing.T) {
 				},
 			}},
 		},
-		params: []v1beta1.Param{
+		params: v1beta1.Params{
 			{Name: "second/param", Value: *v1beta1.NewStructuredValues("second-value")},
 			{Name: "fourth/param", Value: *v1beta1.NewStructuredValues("fourth-value")},
 		},
@@ -1177,7 +1177,7 @@ func TestApplyParameters(t *testing.T) {
 				{Name: "fourth/param", Type: v1beta1.ParamTypeString},
 			},
 			Tasks: []v1beta1.PipelineTask{{
-				Params: []v1beta1.Param{
+				Params: v1beta1.Params{
 					{Name: "first-task-first-param", Value: *v1beta1.NewStructuredValues("default-value")},
 					{Name: "first-task-second-param", Value: *v1beta1.NewStructuredValues("second-value")},
 					{Name: "first-task-third-param", Value: *v1beta1.NewStructuredValues("default-value")},
@@ -1194,7 +1194,7 @@ func TestApplyParameters(t *testing.T) {
 				{Name: "second-param", Type: v1beta1.ParamTypeString},
 			},
 			Tasks: []v1beta1.PipelineTask{{
-				Params: []v1beta1.Param{
+				Params: v1beta1.Params{
 					{Name: "first-task-first-param", Value: *v1beta1.NewStructuredValues("$(params.first-param)")},
 					{Name: "first-task-second-param", Value: *v1beta1.NewStructuredValues("static value")},
 				},
@@ -1207,14 +1207,14 @@ func TestApplyParameters(t *testing.T) {
 				},
 			}},
 		},
-		params: []v1beta1.Param{{Name: "second-param", Value: *v1beta1.NewStructuredValues("second-value")}},
+		params: v1beta1.Params{{Name: "second-param", Value: *v1beta1.NewStructuredValues("second-value")}},
 		expected: v1beta1.PipelineSpec{
 			Params: []v1beta1.ParamSpec{
 				{Name: "first-param", Type: v1beta1.ParamTypeString, Default: v1beta1.NewStructuredValues("default-value")},
 				{Name: "second-param", Type: v1beta1.ParamTypeString},
 			},
 			Tasks: []v1beta1.PipelineTask{{
-				Params: []v1beta1.Param{
+				Params: v1beta1.Params{
 					{Name: "first-task-first-param", Value: *v1beta1.NewStructuredValues("default-value")},
 					{Name: "first-task-second-param", Value: *v1beta1.NewStructuredValues("static value")},
 				},
@@ -1245,7 +1245,7 @@ func TestApplyParameters(t *testing.T) {
 				},
 			},
 			Tasks: []v1beta1.PipelineTask{{
-				Params: []v1beta1.Param{
+				Params: v1beta1.Params{
 					{Name: "first-task-first-param", Value: *v1beta1.NewStructuredValues("$(params.myobject.key1)")},
 					{Name: "first-task-second-param", Value: *v1beta1.NewStructuredValues("static value")},
 				},
@@ -1258,7 +1258,7 @@ func TestApplyParameters(t *testing.T) {
 				},
 			}},
 		},
-		params: []v1beta1.Param{{Name: "myobject", Value: *v1beta1.NewObject(map[string]string{
+		params: v1beta1.Params{{Name: "myobject", Value: *v1beta1.NewObject(map[string]string{
 			"key1": "foo",
 			"key2": "bar",
 		})}},
@@ -1278,7 +1278,7 @@ func TestApplyParameters(t *testing.T) {
 				},
 			},
 			Tasks: []v1beta1.PipelineTask{{
-				Params: []v1beta1.Param{
+				Params: v1beta1.Params{
 					{Name: "first-task-first-param", Value: *v1beta1.NewStructuredValues("foo")},
 					{Name: "first-task-second-param", Value: *v1beta1.NewStructuredValues("static value")},
 				},
@@ -1301,7 +1301,7 @@ func TestApplyParameters(t *testing.T) {
 			Tasks: []v1beta1.PipelineTask{{
 				TaskRef: &v1beta1.TaskRef{
 					ResolverRef: v1beta1.ResolverRef{
-						Params: []v1beta1.Param{{
+						Params: v1beta1.Params{{
 							Name:  "first-resolver-param",
 							Value: *v1beta1.NewArrayOrString("$(params.first-param)"),
 						}, {
@@ -1312,7 +1312,7 @@ func TestApplyParameters(t *testing.T) {
 				},
 			}},
 		},
-		params: []v1beta1.Param{{Name: "second-param", Value: *v1beta1.NewArrayOrString("second-value")}},
+		params: v1beta1.Params{{Name: "second-param", Value: *v1beta1.NewArrayOrString("second-value")}},
 		expected: v1beta1.PipelineSpec{
 			Params: []v1beta1.ParamSpec{
 				{Name: "first-param", Type: v1beta1.ParamTypeString, Default: v1beta1.NewArrayOrString("default-value")},
@@ -1321,7 +1321,7 @@ func TestApplyParameters(t *testing.T) {
 			Tasks: []v1beta1.PipelineTask{{
 				TaskRef: &v1beta1.TaskRef{
 					ResolverRef: v1beta1.ResolverRef{
-						Params: []v1beta1.Param{{
+						Params: v1beta1.Params{{
 							Name:  "first-resolver-param",
 							Value: *v1beta1.NewArrayOrString("default-value"),
 						}, {
@@ -1354,7 +1354,7 @@ func TestApplyParameters(t *testing.T) {
 			Tasks: []v1beta1.PipelineTask{{
 				TaskRef: &v1beta1.TaskRef{
 					ResolverRef: v1beta1.ResolverRef{
-						Params: []v1beta1.Param{{
+						Params: v1beta1.Params{{
 							Name:  "first-resolver-param",
 							Value: *v1beta1.NewArrayOrString("$(params.myobject.key1)"),
 						}, {
@@ -1368,7 +1368,7 @@ func TestApplyParameters(t *testing.T) {
 				},
 			}},
 		},
-		params: []v1beta1.Param{{Name: "myobject", Value: *v1beta1.NewObject(map[string]string{
+		params: v1beta1.Params{{Name: "myobject", Value: *v1beta1.NewObject(map[string]string{
 			"key1": "val1",
 			"key2": "val2",
 			"key3": "val1",
@@ -1393,7 +1393,7 @@ func TestApplyParameters(t *testing.T) {
 			Tasks: []v1beta1.PipelineTask{{
 				TaskRef: &v1beta1.TaskRef{
 					ResolverRef: v1beta1.ResolverRef{
-						Params: []v1beta1.Param{{
+						Params: v1beta1.Params{{
 							Name:  "first-resolver-param",
 							Value: *v1beta1.NewArrayOrString("val1"),
 						}, {
@@ -1416,7 +1416,7 @@ func TestApplyParameters(t *testing.T) {
 				{Name: "second-param", Type: v1beta1.ParamTypeString},
 			},
 			Finally: []v1beta1.PipelineTask{{
-				Params: []v1beta1.Param{
+				Params: v1beta1.Params{
 					{Name: "first-task-first-param", Value: *v1beta1.NewStructuredValues("$(params.first-param)")},
 					{Name: "first-task-second-param", Value: *v1beta1.NewStructuredValues("static value")},
 				},
@@ -1429,14 +1429,14 @@ func TestApplyParameters(t *testing.T) {
 				},
 			}},
 		},
-		params: []v1beta1.Param{{Name: "second-param", Value: *v1beta1.NewStructuredValues("second-value")}},
+		params: v1beta1.Params{{Name: "second-param", Value: *v1beta1.NewStructuredValues("second-value")}},
 		expected: v1beta1.PipelineSpec{
 			Params: []v1beta1.ParamSpec{
 				{Name: "first-param", Type: v1beta1.ParamTypeString, Default: v1beta1.NewStructuredValues("default-value")},
 				{Name: "second-param", Type: v1beta1.ParamTypeString},
 			},
 			Finally: []v1beta1.PipelineTask{{
-				Params: []v1beta1.Param{
+				Params: v1beta1.Params{
 					{Name: "first-task-first-param", Value: *v1beta1.NewStructuredValues("default-value")},
 					{Name: "first-task-second-param", Value: *v1beta1.NewStructuredValues("static value")},
 				},
@@ -1479,7 +1479,7 @@ func TestApplyParameters(t *testing.T) {
 								},
 							},
 						},
-						Params: []v1beta1.Param{
+						Params: v1beta1.Params{
 							{
 								Name: "param1",
 								Value: v1beta1.ParamValue{
@@ -1501,7 +1501,7 @@ func TestApplyParameters(t *testing.T) {
 								},
 							},
 						},
-						Params: []v1beta1.Param{
+						Params: v1beta1.Params{
 							{
 								Name: "param1",
 								Value: v1beta1.ParamValue{
@@ -1540,7 +1540,7 @@ func TestApplyParameters(t *testing.T) {
 								},
 							},
 						},
-						Params: []v1beta1.Param{
+						Params: v1beta1.Params{
 							{
 								Name: "param1",
 								Value: v1beta1.ParamValue{
@@ -1562,7 +1562,7 @@ func TestApplyParameters(t *testing.T) {
 								},
 							},
 						},
-						Params: []v1beta1.Param{
+						Params: v1beta1.Params{
 							{
 								Name: "param1",
 								Value: v1beta1.ParamValue{
@@ -1606,7 +1606,7 @@ func TestApplyParameters(t *testing.T) {
 								},
 							},
 						},
-						Params: []v1beta1.Param{
+						Params: v1beta1.Params{
 							{
 								Name: "param1",
 								Value: v1beta1.ParamValue{
@@ -1628,7 +1628,7 @@ func TestApplyParameters(t *testing.T) {
 								},
 							},
 						},
-						Params: []v1beta1.Param{
+						Params: v1beta1.Params{
 							{
 								Name: "param1",
 								Value: v1beta1.ParamValue{
@@ -1669,7 +1669,7 @@ func TestApplyParameters(t *testing.T) {
 								},
 							},
 						},
-						Params: []v1beta1.Param{
+						Params: v1beta1.Params{
 							{
 								Name: "param1",
 								Value: v1beta1.ParamValue{
@@ -1691,7 +1691,7 @@ func TestApplyParameters(t *testing.T) {
 								},
 							},
 						},
-						Params: []v1beta1.Param{
+						Params: v1beta1.Params{
 							{
 								Name: "param1",
 								Value: v1beta1.ParamValue{
@@ -1733,7 +1733,7 @@ func TestApplyParameters_ArrayIndexing(t *testing.T) {
 	for _, tt := range []struct {
 		name     string
 		original v1beta1.PipelineSpec
-		params   []v1beta1.Param
+		params   v1beta1.Params
 		expected v1beta1.PipelineSpec
 	}{{
 		name: "single parameter",
@@ -1743,21 +1743,21 @@ func TestApplyParameters_ArrayIndexing(t *testing.T) {
 				{Name: "second-param", Type: v1beta1.ParamTypeString},
 			},
 			Tasks: []v1beta1.PipelineTask{{
-				Params: []v1beta1.Param{
+				Params: v1beta1.Params{
 					{Name: "first-task-first-param", Value: *v1beta1.NewStructuredValues("$(params.first-param[1])")},
 					{Name: "first-task-second-param", Value: *v1beta1.NewStructuredValues("$(params.second-param[0])")},
 					{Name: "first-task-third-param", Value: *v1beta1.NewStructuredValues("static value")},
 				},
 			}},
 		},
-		params: []v1beta1.Param{{Name: "second-param", Value: *v1beta1.NewStructuredValues("second-value", "second-value-again")}},
+		params: v1beta1.Params{{Name: "second-param", Value: *v1beta1.NewStructuredValues("second-value", "second-value-again")}},
 		expected: v1beta1.PipelineSpec{
 			Params: []v1beta1.ParamSpec{
 				{Name: "first-param", Type: v1beta1.ParamTypeArray, Default: v1beta1.NewStructuredValues("default-value", "default-value-again")},
 				{Name: "second-param", Type: v1beta1.ParamTypeString},
 			},
 			Tasks: []v1beta1.PipelineTask{{
-				Params: []v1beta1.Param{
+				Params: v1beta1.Params{
 					{Name: "first-task-first-param", Value: *v1beta1.NewStructuredValues("default-value-again")},
 					{Name: "first-task-second-param", Value: *v1beta1.NewStructuredValues("second-value")},
 					{Name: "first-task-third-param", Value: *v1beta1.NewStructuredValues("static value")},
@@ -1779,7 +1779,7 @@ func TestApplyParameters_ArrayIndexing(t *testing.T) {
 				}},
 			}},
 		},
-		params: []v1beta1.Param{{Name: "second-param", Value: *v1beta1.NewStructuredValues("second-value", "second-value-again")}},
+		params: v1beta1.Params{{Name: "second-param", Value: *v1beta1.NewStructuredValues("second-value", "second-value-again")}},
 		expected: v1beta1.PipelineSpec{
 			Params: []v1beta1.ParamSpec{
 				{Name: "first-param", Type: v1beta1.ParamTypeArray, Default: v1beta1.NewStructuredValues("default-value", "default-value-again")},
@@ -1801,7 +1801,7 @@ func TestApplyParameters_ArrayIndexing(t *testing.T) {
 				{Name: "second-param", Type: v1beta1.ParamTypeArray, Default: v1beta1.NewStructuredValues("default-value", "default-value-again")},
 			},
 			Tasks: []v1beta1.PipelineTask{{
-				Params: []v1beta1.Param{
+				Params: v1beta1.Params{
 					{Name: "first-task-first-param", Value: *v1beta1.NewStructuredValues("$(input.workspace.$(params.first-param[0]))")},
 					{Name: "first-task-second-param", Value: *v1beta1.NewStructuredValues("$(input.workspace.$(params.second-param[1]))")},
 				},
@@ -1814,7 +1814,7 @@ func TestApplyParameters_ArrayIndexing(t *testing.T) {
 				{Name: "second-param", Type: v1beta1.ParamTypeArray, Default: v1beta1.NewStructuredValues("default-value", "default-value-again")},
 			},
 			Tasks: []v1beta1.PipelineTask{{
-				Params: []v1beta1.Param{
+				Params: v1beta1.Params{
 					{Name: "first-task-first-param", Value: *v1beta1.NewStructuredValues("$(input.workspace.default-value)")},
 					{Name: "first-task-second-param", Value: *v1beta1.NewStructuredValues("$(input.workspace.default-value-again)")},
 				},
@@ -1828,13 +1828,13 @@ func TestApplyParameters_ArrayIndexing(t *testing.T) {
 				{Name: "second-param", Type: v1beta1.ParamTypeArray},
 			},
 			Tasks: []v1beta1.PipelineTask{{
-				Params: []v1beta1.Param{
+				Params: v1beta1.Params{
 					{Name: "first-task-first-param", Value: *v1beta1.NewStructuredValues("firstelement", "$(params.first-param)")},
 					{Name: "first-task-second-param", Value: *v1beta1.NewStructuredValues("firstelement", "$(params.second-param[0])")},
 				},
 			}},
 		},
-		params: []v1beta1.Param{
+		params: v1beta1.Params{
 			{Name: "second-param", Value: *v1beta1.NewStructuredValues("second-value", "array")},
 		},
 		expected: v1beta1.PipelineSpec{
@@ -1843,7 +1843,7 @@ func TestApplyParameters_ArrayIndexing(t *testing.T) {
 				{Name: "second-param", Type: v1beta1.ParamTypeArray},
 			},
 			Tasks: []v1beta1.PipelineTask{{
-				Params: []v1beta1.Param{
+				Params: v1beta1.Params{
 					{Name: "first-task-first-param", Value: *v1beta1.NewStructuredValues("firstelement", "default", "array", "value")},
 					{Name: "first-task-second-param", Value: *v1beta1.NewStructuredValues("firstelement", "second-value")},
 				},
@@ -1857,7 +1857,7 @@ func TestApplyParameters_ArrayIndexing(t *testing.T) {
 				{Name: "second-param", Type: v1beta1.ParamTypeArray},
 			},
 			Finally: []v1beta1.PipelineTask{{
-				Params: []v1beta1.Param{
+				Params: v1beta1.Params{
 					{Name: "final-task-first-param", Value: *v1beta1.NewStructuredValues("$(params.first-param[0])")},
 					{Name: "final-task-second-param", Value: *v1beta1.NewStructuredValues("$(params.second-param[1])")},
 				},
@@ -1868,14 +1868,14 @@ func TestApplyParameters_ArrayIndexing(t *testing.T) {
 				}},
 			}},
 		},
-		params: []v1beta1.Param{{Name: "second-param", Value: *v1beta1.NewStructuredValues("second-value", "second-value-again")}},
+		params: v1beta1.Params{{Name: "second-param", Value: *v1beta1.NewStructuredValues("second-value", "second-value-again")}},
 		expected: v1beta1.PipelineSpec{
 			Params: []v1beta1.ParamSpec{
 				{Name: "first-param", Type: v1beta1.ParamTypeArray, Default: v1beta1.NewStructuredValues("default-value", "default-value-again")},
 				{Name: "second-param", Type: v1beta1.ParamTypeArray},
 			},
 			Finally: []v1beta1.PipelineTask{{
-				Params: []v1beta1.Param{
+				Params: v1beta1.Params{
 					{Name: "final-task-first-param", Value: *v1beta1.NewStructuredValues("default-value")},
 					{Name: "final-task-second-param", Value: *v1beta1.NewStructuredValues("second-value-again")},
 				},
@@ -1894,13 +1894,13 @@ func TestApplyParameters_ArrayIndexing(t *testing.T) {
 				{Name: "second-param", Type: v1beta1.ParamTypeArray},
 			},
 			Tasks: []v1beta1.PipelineTask{{
-				Params: []v1beta1.Param{
+				Params: v1beta1.Params{
 					{Name: "final-task-first-param", Value: *v1beta1.NewStructuredValues("$(params.first-param[0])")},
 					{Name: "final-task-second-param", Value: *v1beta1.NewStructuredValues("$(params.second-param[1])")},
 				},
 			}},
 			Finally: []v1beta1.PipelineTask{{
-				Params: []v1beta1.Param{
+				Params: v1beta1.Params{
 					{Name: "final-task-first-param", Value: *v1beta1.NewStructuredValues("$(params.first-param[0])")},
 					{Name: "final-task-second-param", Value: *v1beta1.NewStructuredValues("$(params.second-param[1])")},
 				},
@@ -1911,20 +1911,20 @@ func TestApplyParameters_ArrayIndexing(t *testing.T) {
 				}},
 			}},
 		},
-		params: []v1beta1.Param{{Name: "second-param", Value: *v1beta1.NewStructuredValues("second-value", "second-value-again")}},
+		params: v1beta1.Params{{Name: "second-param", Value: *v1beta1.NewStructuredValues("second-value", "second-value-again")}},
 		expected: v1beta1.PipelineSpec{
 			Params: []v1beta1.ParamSpec{
 				{Name: "first-param", Type: v1beta1.ParamTypeArray, Default: v1beta1.NewStructuredValues("default-value", "default-value-again")},
 				{Name: "second-param", Type: v1beta1.ParamTypeArray},
 			},
 			Tasks: []v1beta1.PipelineTask{{
-				Params: []v1beta1.Param{
+				Params: v1beta1.Params{
 					{Name: "final-task-first-param", Value: *v1beta1.NewStructuredValues("default-value")},
 					{Name: "final-task-second-param", Value: *v1beta1.NewStructuredValues("second-value-again")},
 				},
 			}},
 			Finally: []v1beta1.PipelineTask{{
-				Params: []v1beta1.Param{
+				Params: v1beta1.Params{
 					{Name: "final-task-first-param", Value: *v1beta1.NewStructuredValues("default-value")},
 					{Name: "final-task-second-param", Value: *v1beta1.NewStructuredValues("second-value-again")},
 				},
@@ -1945,7 +1945,7 @@ func TestApplyParameters_ArrayIndexing(t *testing.T) {
 				{Name: "fourth/param", Type: v1beta1.ParamTypeArray},
 			},
 			Tasks: []v1beta1.PipelineTask{{
-				Params: []v1beta1.Param{
+				Params: v1beta1.Params{
 					{Name: "first-task-first-param", Value: *v1beta1.NewStructuredValues(`$(params["first.param"][0])`)},
 					{Name: "first-task-second-param", Value: *v1beta1.NewStructuredValues(`$(params["second/param"][0])`)},
 					{Name: "first-task-third-param", Value: *v1beta1.NewStructuredValues(`$(params['third.param'][1])`)},
@@ -1954,7 +1954,7 @@ func TestApplyParameters_ArrayIndexing(t *testing.T) {
 				},
 			}},
 		},
-		params: []v1beta1.Param{
+		params: v1beta1.Params{
 			{Name: "second/param", Value: *v1beta1.NewStructuredValues("second-value", "second-value-again")},
 			{Name: "fourth/param", Value: *v1beta1.NewStructuredValues("fourth-value", "fourth-value-again")},
 		},
@@ -1966,7 +1966,7 @@ func TestApplyParameters_ArrayIndexing(t *testing.T) {
 				{Name: "fourth/param", Type: v1beta1.ParamTypeArray},
 			},
 			Tasks: []v1beta1.PipelineTask{{
-				Params: []v1beta1.Param{
+				Params: v1beta1.Params{
 					{Name: "first-task-first-param", Value: *v1beta1.NewStructuredValues("default-value")},
 					{Name: "first-task-second-param", Value: *v1beta1.NewStructuredValues("second-value")},
 					{Name: "first-task-third-param", Value: *v1beta1.NewStructuredValues("default-value-again")},
@@ -1983,7 +1983,7 @@ func TestApplyParameters_ArrayIndexing(t *testing.T) {
 				{Name: "second-param", Type: v1beta1.ParamTypeArray},
 			},
 			Tasks: []v1beta1.PipelineTask{{
-				Params: []v1beta1.Param{
+				Params: v1beta1.Params{
 					{Name: "first-task-first-param", Value: *v1beta1.NewStructuredValues("$(params.first-param[0])")},
 					{Name: "first-task-second-param", Value: *v1beta1.NewStructuredValues("static value")},
 				},
@@ -1996,14 +1996,14 @@ func TestApplyParameters_ArrayIndexing(t *testing.T) {
 				},
 			}},
 		},
-		params: []v1beta1.Param{{Name: "second-param", Value: *v1beta1.NewStructuredValues("second-value", "second-value-again")}},
+		params: v1beta1.Params{{Name: "second-param", Value: *v1beta1.NewStructuredValues("second-value", "second-value-again")}},
 		expected: v1beta1.PipelineSpec{
 			Params: []v1beta1.ParamSpec{
 				{Name: "first-param", Type: v1beta1.ParamTypeArray, Default: v1beta1.NewStructuredValues("default-value", "default-value-again")},
 				{Name: "second-param", Type: v1beta1.ParamTypeArray},
 			},
 			Tasks: []v1beta1.PipelineTask{{
-				Params: []v1beta1.Param{
+				Params: v1beta1.Params{
 					{Name: "first-task-first-param", Value: *v1beta1.NewStructuredValues("default-value")},
 					{Name: "first-task-second-param", Value: *v1beta1.NewStructuredValues("static value")},
 				},
@@ -2042,7 +2042,7 @@ func TestApplyReplacementsMatrix(t *testing.T) {
 	for _, tt := range []struct {
 		name     string
 		original v1beta1.PipelineSpec
-		params   []v1beta1.Param
+		params   v1beta1.Params
 		expected v1beta1.PipelineSpec
 	}{{
 		name: "matrix params replacements",
@@ -2056,7 +2056,7 @@ func TestApplyReplacementsMatrix(t *testing.T) {
 			}},
 			Tasks: []v1beta1.PipelineTask{{
 				Matrix: &v1beta1.Matrix{
-					Params: []v1beta1.Param{{
+					Params: v1beta1.Params{{
 						// string replacements from string param, array param and object param
 						Name: "first-param", Value: *v1beta1.NewStructuredValues("$(params.foo)", "$(params.bar[0])", "$(params.rad.key1)"),
 					}, {
@@ -2066,7 +2066,7 @@ func TestApplyReplacementsMatrix(t *testing.T) {
 				},
 			}},
 		},
-		params: []v1beta1.Param{
+		params: v1beta1.Params{
 			{Name: "foo", Value: *v1beta1.NewStructuredValues("foo")},
 			{Name: "bar", Value: *v1beta1.NewStructuredValues("b", "a", "r")},
 			{Name: "rad", Value: *v1beta1.NewObject(map[string]string{
@@ -2085,7 +2085,7 @@ func TestApplyReplacementsMatrix(t *testing.T) {
 			}},
 			Tasks: []v1beta1.PipelineTask{{
 				Matrix: &v1beta1.Matrix{
-					Params: []v1beta1.Param{{
+					Params: v1beta1.Params{{
 						// string replacements from string param, array param and object param
 						Name: "first-param", Value: *v1beta1.NewStructuredValues("foo", "b", "r"),
 					}, {
@@ -2123,7 +2123,7 @@ func TestApplyReplacementsMatrix(t *testing.T) {
 				},
 			}},
 		},
-		params: []v1beta1.Param{
+		params: v1beta1.Params{
 			{Name: "foo", Value: *v1beta1.NewStructuredValues("foo")},
 			{Name: "bar", Value: *v1beta1.NewStructuredValues("b", "a", "r")},
 			{Name: "rad", Value: *v1beta1.NewObject(map[string]string{
@@ -2144,7 +2144,7 @@ func TestApplyReplacementsMatrix(t *testing.T) {
 				Matrix: &v1beta1.Matrix{
 					Include: []v1beta1.IncludeParams{{
 						Name: "build-1",
-						Params: []v1beta1.Param{{
+						Params: v1beta1.Params{{
 							// string replacements from string param
 							Name: "first-param", Value: *v1beta1.NewStructuredValues("foo"),
 						}, {
@@ -2170,7 +2170,7 @@ func TestApplyReplacementsMatrix(t *testing.T) {
 			}},
 			Finally: []v1beta1.PipelineTask{{
 				Matrix: &v1beta1.Matrix{
-					Params: []v1beta1.Param{{
+					Params: v1beta1.Params{{
 						// string replacements from string param, array param and object param
 						Name: "first-param", Value: *v1beta1.NewStructuredValues("$(params.foo)", "$(params.bar[0])", "$(params.rad.key1)"),
 					}, {
@@ -2180,7 +2180,7 @@ func TestApplyReplacementsMatrix(t *testing.T) {
 				},
 			}},
 		},
-		params: []v1beta1.Param{
+		params: v1beta1.Params{
 			{Name: "foo", Value: *v1beta1.NewStructuredValues("foo")},
 			{Name: "bar", Value: *v1beta1.NewStructuredValues("b", "a", "r")},
 			{Name: "rad", Value: *v1beta1.NewObject(map[string]string{
@@ -2199,7 +2199,7 @@ func TestApplyReplacementsMatrix(t *testing.T) {
 			}},
 			Finally: []v1beta1.PipelineTask{{
 				Matrix: &v1beta1.Matrix{
-					Params: []v1beta1.Param{{
+					Params: v1beta1.Params{{
 						// string replacements from string param, array param and object param
 						Name: "first-param", Value: *v1beta1.NewStructuredValues("foo", "b", "r"),
 					}, {
@@ -2237,7 +2237,7 @@ func TestApplyReplacementsMatrix(t *testing.T) {
 				},
 			}},
 		},
-		params: []v1beta1.Param{
+		params: v1beta1.Params{
 			{Name: "foo", Value: *v1beta1.NewStructuredValues("foo")},
 			{Name: "bar", Value: *v1beta1.NewStructuredValues("b", "a", "r")},
 			{Name: "rad", Value: *v1beta1.NewObject(map[string]string{
@@ -2258,7 +2258,7 @@ func TestApplyReplacementsMatrix(t *testing.T) {
 				Matrix: &v1beta1.Matrix{
 					Include: []v1beta1.IncludeParams{{
 						Name: "build-1",
-						Params: []v1beta1.Param{{
+						Params: v1beta1.Params{{
 							// string replacements from string param
 							Name: "first-param", Value: *v1beta1.NewStructuredValues("foo"),
 						}, {
@@ -2310,7 +2310,7 @@ func TestApplyTaskResults_MinimalExpression(t *testing.T) {
 			PipelineTask: &v1beta1.PipelineTask{
 				Name:    "bTask",
 				TaskRef: &v1beta1.TaskRef{Name: "bTask"},
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name:  "bParam",
 					Value: *v1beta1.NewStructuredValues(`$(tasks.aTask.results["a.Result"])`),
 				}},
@@ -2320,7 +2320,7 @@ func TestApplyTaskResults_MinimalExpression(t *testing.T) {
 			PipelineTask: &v1beta1.PipelineTask{
 				Name:    "bTask",
 				TaskRef: &v1beta1.TaskRef{Name: "bTask"},
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name:  "bParam",
 					Value: *v1beta1.NewStructuredValues("aResultValue"),
 				}},
@@ -2340,7 +2340,7 @@ func TestApplyTaskResults_MinimalExpression(t *testing.T) {
 			PipelineTask: &v1beta1.PipelineTask{
 				Name:    "bTask",
 				TaskRef: &v1beta1.TaskRef{Name: "bTask"},
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name:  "bParam",
 					Value: *v1beta1.NewStructuredValues(`$(tasks.aTask.results["a.Result"][1])`),
 				}},
@@ -2350,7 +2350,7 @@ func TestApplyTaskResults_MinimalExpression(t *testing.T) {
 			PipelineTask: &v1beta1.PipelineTask{
 				Name:    "bTask",
 				TaskRef: &v1beta1.TaskRef{Name: "bTask"},
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name:  "bParam",
 					Value: *v1beta1.NewStructuredValues("arrayResultValueTwo"),
 				}},
@@ -2370,7 +2370,7 @@ func TestApplyTaskResults_MinimalExpression(t *testing.T) {
 			PipelineTask: &v1beta1.PipelineTask{
 				Name:    "bTask",
 				TaskRef: &v1beta1.TaskRef{Name: "bTask"},
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name:  "bParam",
 					Value: *v1beta1.NewStructuredValues(`$(tasks.aTask.results["a.Result"][3])`),
 				}},
@@ -2380,7 +2380,7 @@ func TestApplyTaskResults_MinimalExpression(t *testing.T) {
 			PipelineTask: &v1beta1.PipelineTask{
 				Name:    "bTask",
 				TaskRef: &v1beta1.TaskRef{Name: "bTask"},
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name: "bParam",
 					// index validation is done in ResolveResultRefs() before ApplyTaskResults()
 					Value: *v1beta1.NewStructuredValues(`$(tasks.aTask.results["a.Result"][3])`),
@@ -2401,7 +2401,7 @@ func TestApplyTaskResults_MinimalExpression(t *testing.T) {
 			PipelineTask: &v1beta1.PipelineTask{
 				Name:    "bTask",
 				TaskRef: &v1beta1.TaskRef{Name: "bTask"},
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name: "bParam",
 					Value: v1beta1.ParamValue{Type: v1beta1.ParamTypeArray,
 						ArrayVal: []string{`$(tasks.aTask.results["a.Result"][*])`},
@@ -2413,7 +2413,7 @@ func TestApplyTaskResults_MinimalExpression(t *testing.T) {
 			PipelineTask: &v1beta1.PipelineTask{
 				Name:    "bTask",
 				TaskRef: &v1beta1.TaskRef{Name: "bTask"},
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name:  "bParam",
 					Value: *v1beta1.NewStructuredValues("arrayResultValueOne", "arrayResultValueTwo"),
 				}},
@@ -2436,7 +2436,7 @@ func TestApplyTaskResults_MinimalExpression(t *testing.T) {
 			PipelineTask: &v1beta1.PipelineTask{
 				Name:    "bTask",
 				TaskRef: &v1beta1.TaskRef{Name: "bTask"},
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name:  "bParam",
 					Value: *v1beta1.NewStructuredValues(`$(tasks.aTask.results.resultName[*])`),
 				}},
@@ -2446,7 +2446,7 @@ func TestApplyTaskResults_MinimalExpression(t *testing.T) {
 			PipelineTask: &v1beta1.PipelineTask{
 				Name:    "bTask",
 				TaskRef: &v1beta1.TaskRef{Name: "bTask"},
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name: "bParam",
 					// index validation is done in ResolveResultRefs() before ApplyTaskResults()
 					Value: *v1beta1.NewObject(map[string]string{
@@ -2473,7 +2473,7 @@ func TestApplyTaskResults_MinimalExpression(t *testing.T) {
 			PipelineTask: &v1beta1.PipelineTask{
 				Name:    "bTask",
 				TaskRef: &v1beta1.TaskRef{Name: "bTask"},
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name:  "bParam",
 					Value: *v1beta1.NewStructuredValues(`$(tasks.aTask.results.resultName.key1)`),
 				}},
@@ -2483,7 +2483,7 @@ func TestApplyTaskResults_MinimalExpression(t *testing.T) {
 			PipelineTask: &v1beta1.PipelineTask{
 				Name:    "bTask",
 				TaskRef: &v1beta1.TaskRef{Name: "bTask"},
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name: "bParam",
 					// index validation is done in ResolveResultRefs() before ApplyTaskResults()
 					Value: *v1beta1.NewStructuredValues("val1"),
@@ -2505,7 +2505,7 @@ func TestApplyTaskResults_MinimalExpression(t *testing.T) {
 				Name:    "bTask",
 				TaskRef: &v1beta1.TaskRef{Name: "bTask"},
 				Matrix: &v1beta1.Matrix{
-					Params: []v1beta1.Param{{
+					Params: v1beta1.Params{{
 						Name:  "bParam",
 						Value: *v1beta1.NewStructuredValues(`$(tasks.aTask.results["a.Result"])`),
 					}}},
@@ -2516,7 +2516,7 @@ func TestApplyTaskResults_MinimalExpression(t *testing.T) {
 				Name:    "bTask",
 				TaskRef: &v1beta1.TaskRef{Name: "bTask"},
 				Matrix: &v1beta1.Matrix{
-					Params: []v1beta1.Param{{
+					Params: v1beta1.Params{{
 						Name:  "bParam",
 						Value: *v1beta1.NewStructuredValues("aResultValue"),
 					}}},
@@ -2537,7 +2537,7 @@ func TestApplyTaskResults_MinimalExpression(t *testing.T) {
 				Name:    "bTask",
 				TaskRef: &v1beta1.TaskRef{Name: "bTask"},
 				Matrix: &v1beta1.Matrix{
-					Params: []v1beta1.Param{{
+					Params: v1beta1.Params{{
 						Name:  "bParam",
 						Value: *v1beta1.NewStructuredValues(`$(tasks.aTask.results["a.Result"][1])`),
 					}}},
@@ -2548,7 +2548,7 @@ func TestApplyTaskResults_MinimalExpression(t *testing.T) {
 				Name:    "bTask",
 				TaskRef: &v1beta1.TaskRef{Name: "bTask"},
 				Matrix: &v1beta1.Matrix{
-					Params: []v1beta1.Param{{
+					Params: v1beta1.Params{{
 						Name:  "bParam",
 						Value: *v1beta1.NewStructuredValues("arrayResultValueTwo"),
 					}}},
@@ -2569,7 +2569,7 @@ func TestApplyTaskResults_MinimalExpression(t *testing.T) {
 				Name:    "bTask",
 				TaskRef: &v1beta1.TaskRef{Name: "bTask"},
 				Matrix: &v1beta1.Matrix{
-					Params: []v1beta1.Param{{
+					Params: v1beta1.Params{{
 						Name:  "bParam",
 						Value: *v1beta1.NewStructuredValues(`$(tasks.aTask.results["a.Result"][3])`),
 					}}},
@@ -2580,7 +2580,7 @@ func TestApplyTaskResults_MinimalExpression(t *testing.T) {
 				Name:    "bTask",
 				TaskRef: &v1beta1.TaskRef{Name: "bTask"},
 				Matrix: &v1beta1.Matrix{
-					Params: []v1beta1.Param{{
+					Params: v1beta1.Params{{
 						Name:  "bParam",
 						Value: *v1beta1.NewStructuredValues(`$(tasks.aTask.results["a.Result"][3])`),
 					}}},
@@ -2697,7 +2697,7 @@ func TestApplyTaskResults_MinimalExpression(t *testing.T) {
 			PipelineTask: &v1beta1.PipelineTask{
 				TaskRef: &v1beta1.TaskRef{
 					ResolverRef: v1beta1.ResolverRef{
-						Params: []v1beta1.Param{{
+						Params: v1beta1.Params{{
 							Name: "bParam",
 							Value: v1beta1.ArrayOrString{Type: v1beta1.ParamTypeArray,
 								ArrayVal: []string{`$(tasks.aTask.results["aResult"][*])`},
@@ -2711,7 +2711,7 @@ func TestApplyTaskResults_MinimalExpression(t *testing.T) {
 			PipelineTask: &v1beta1.PipelineTask{
 				TaskRef: &v1beta1.TaskRef{
 					ResolverRef: v1beta1.ResolverRef{
-						Params: []v1beta1.Param{{
+						Params: v1beta1.Params{{
 							Name: "bParam",
 							Value: v1beta1.ArrayOrString{Type: v1beta1.ParamTypeArray,
 								ArrayVal: []string{"arrayResultValueOne", "arrayResultValueTwo"},
@@ -2735,7 +2735,7 @@ func TestApplyTaskResults_MinimalExpression(t *testing.T) {
 			PipelineTask: &v1beta1.PipelineTask{
 				TaskRef: &v1beta1.TaskRef{
 					ResolverRef: v1beta1.ResolverRef{
-						Params: []v1beta1.Param{{
+						Params: v1beta1.Params{{
 							Name:  "bParam",
 							Value: *v1beta1.NewArrayOrString("$(tasks.aTask.results.aResult)"),
 						}},
@@ -2747,7 +2747,7 @@ func TestApplyTaskResults_MinimalExpression(t *testing.T) {
 			PipelineTask: &v1beta1.PipelineTask{
 				TaskRef: &v1beta1.TaskRef{
 					ResolverRef: v1beta1.ResolverRef{
-						Params: []v1beta1.Param{{
+						Params: v1beta1.Params{{
 							Name:  "bParam",
 							Value: *v1beta1.NewArrayOrString("aResultValue"),
 						}},
@@ -2769,7 +2769,7 @@ func TestApplyTaskResults_MinimalExpression(t *testing.T) {
 			PipelineTask: &v1beta1.PipelineTask{
 				TaskRef: &v1beta1.TaskRef{
 					ResolverRef: v1beta1.ResolverRef{
-						Params: []v1beta1.Param{{
+						Params: v1beta1.Params{{
 							Name:  "bParam",
 							Value: *v1beta1.NewArrayOrString("$(tasks.aTask.results.aResult[0])"),
 						}, {
@@ -2784,7 +2784,7 @@ func TestApplyTaskResults_MinimalExpression(t *testing.T) {
 			PipelineTask: &v1beta1.PipelineTask{
 				TaskRef: &v1beta1.TaskRef{
 					ResolverRef: v1beta1.ResolverRef{
-						Params: []v1beta1.Param{{
+						Params: v1beta1.Params{{
 							Name:  "bParam",
 							Value: *v1beta1.NewArrayOrString("arrayResultValueOne"),
 						}, {
@@ -2825,7 +2825,7 @@ func TestApplyTaskResults_EmbeddedExpression(t *testing.T) {
 			PipelineTask: &v1beta1.PipelineTask{
 				Name:    "bTask",
 				TaskRef: &v1beta1.TaskRef{Name: "bTask"},
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name:  "bParam",
 					Value: *v1beta1.NewStructuredValues("Result value --> $(tasks.aTask.results.aResult)"),
 				}},
@@ -2835,7 +2835,7 @@ func TestApplyTaskResults_EmbeddedExpression(t *testing.T) {
 			PipelineTask: &v1beta1.PipelineTask{
 				Name:    "bTask",
 				TaskRef: &v1beta1.TaskRef{Name: "bTask"},
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name:  "bParam",
 					Value: *v1beta1.NewStructuredValues("Result value --> aResultValue"),
 				}},
@@ -2855,7 +2855,7 @@ func TestApplyTaskResults_EmbeddedExpression(t *testing.T) {
 			PipelineTask: &v1beta1.PipelineTask{
 				Name:    "bTask",
 				TaskRef: &v1beta1.TaskRef{Name: "bTask"},
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name:  "bParam",
 					Value: *v1beta1.NewStructuredValues("Result value --> $(tasks.aTask.results.aResult[0])"),
 				}},
@@ -2865,7 +2865,7 @@ func TestApplyTaskResults_EmbeddedExpression(t *testing.T) {
 			PipelineTask: &v1beta1.PipelineTask{
 				Name:    "bTask",
 				TaskRef: &v1beta1.TaskRef{Name: "bTask"},
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name:  "bParam",
 					Value: *v1beta1.NewStructuredValues("Result value --> arrayResultValueOne"),
 				}},
@@ -2886,7 +2886,7 @@ func TestApplyTaskResults_EmbeddedExpression(t *testing.T) {
 				Name:    "bTask",
 				TaskRef: &v1beta1.TaskRef{Name: "bTask"},
 				Matrix: &v1beta1.Matrix{
-					Params: []v1beta1.Param{{
+					Params: v1beta1.Params{{
 						Name:  "bParam",
 						Value: *v1beta1.NewStructuredValues("Result value --> $(tasks.aTask.results.aResult)"),
 					}}},
@@ -2897,7 +2897,7 @@ func TestApplyTaskResults_EmbeddedExpression(t *testing.T) {
 				Name:    "bTask",
 				TaskRef: &v1beta1.TaskRef{Name: "bTask"},
 				Matrix: &v1beta1.Matrix{
-					Params: []v1beta1.Param{{
+					Params: v1beta1.Params{{
 						Name:  "bParam",
 						Value: *v1beta1.NewStructuredValues("Result value --> aResultValue"),
 					}}},
@@ -2936,7 +2936,7 @@ func TestApplyTaskResults_EmbeddedExpression(t *testing.T) {
 				Name:    "bTask",
 				TaskRef: &v1beta1.TaskRef{Name: "bTask"},
 				Matrix: &v1beta1.Matrix{
-					Params: []v1beta1.Param{{
+					Params: v1beta1.Params{{
 						// string replacements from string param, array param and object results
 						Name: "first-param", Value: *v1beta1.NewStructuredValues("$(tasks.aTask.results.foo)", "$(tasks.aTask.results.bar[0])", "$(tasks.aTask.results.rad.key1)"),
 					}},
@@ -3005,7 +3005,7 @@ func TestApplyTaskResults_EmbeddedExpression(t *testing.T) {
 				Matrix: &v1beta1.Matrix{
 					Include: []v1beta1.IncludeParams{{
 						Name: "build-1",
-						Params: []v1beta1.Param{{
+						Params: v1beta1.Params{{
 							// string replacements from string results, array results and object results
 							Name: "first-param", Value: *v1beta1.NewStructuredValues("foo", "b", "r"),
 						}},
@@ -3095,7 +3095,7 @@ func TestApplyTaskResults_EmbeddedExpression(t *testing.T) {
 			PipelineTask: &v1beta1.PipelineTask{
 				TaskRef: &v1beta1.TaskRef{
 					ResolverRef: v1beta1.ResolverRef{
-						Params: []v1beta1.Param{{
+						Params: v1beta1.Params{{
 							Name:  "bParam",
 							Value: *v1beta1.NewArrayOrString("Result value --> $(tasks.aTask.results.aResult)"),
 						}},
@@ -3107,7 +3107,7 @@ func TestApplyTaskResults_EmbeddedExpression(t *testing.T) {
 			PipelineTask: &v1beta1.PipelineTask{
 				TaskRef: &v1beta1.TaskRef{
 					ResolverRef: v1beta1.ResolverRef{
-						Params: []v1beta1.Param{{
+						Params: v1beta1.Params{{
 							Name:  "bParam",
 							Value: *v1beta1.NewArrayOrString("Result value --> aResultValue"),
 						}},
@@ -3129,7 +3129,7 @@ func TestApplyTaskResults_EmbeddedExpression(t *testing.T) {
 			PipelineTask: &v1beta1.PipelineTask{
 				TaskRef: &v1beta1.TaskRef{
 					ResolverRef: v1beta1.ResolverRef{
-						Params: []v1beta1.Param{{
+						Params: v1beta1.Params{{
 							Name:  "bParam",
 							Value: *v1beta1.NewArrayOrString("Result value --> $(tasks.aTask.results.aResult[0])"),
 						}, {
@@ -3144,7 +3144,7 @@ func TestApplyTaskResults_EmbeddedExpression(t *testing.T) {
 			PipelineTask: &v1beta1.PipelineTask{
 				TaskRef: &v1beta1.TaskRef{
 					ResolverRef: v1beta1.ResolverRef{
-						Params: []v1beta1.Param{{
+						Params: v1beta1.Params{{
 							Name:  "bParam",
 							Value: *v1beta1.NewArrayOrString("Result value --> arrayResultValueOne"),
 						}, {
@@ -3226,9 +3226,9 @@ func TestContext(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "test-pipeline"},
 				Spec: v1beta1.PipelineSpec{
 					Tasks: []v1beta1.PipelineTask{{
-						Params: []v1beta1.Param{tc.original},
+						Params: v1beta1.Params{tc.original},
 						Matrix: &v1beta1.Matrix{
-							Params: []v1beta1.Param{tc.original},
+							Params: v1beta1.Params{tc.original},
 						}}},
 				},
 			}
@@ -3252,18 +3252,18 @@ func TestApplyPipelineTaskContexts(t *testing.T) {
 		description: "context retries replacement",
 		pt: v1beta1.PipelineTask{
 			Retries: 5,
-			Params: []v1beta1.Param{{
+			Params: v1beta1.Params{{
 				Name:  "retries",
 				Value: *v1beta1.NewStructuredValues("$(context.pipelineTask.retries)"),
 			}},
 			Matrix: &v1beta1.Matrix{
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name:  "retries",
 					Value: *v1beta1.NewStructuredValues("$(context.pipelineTask.retries)"),
 				}},
 				Include: []v1beta1.IncludeParams{{
 					Name: "build-1",
-					Params: []v1beta1.Param{{
+					Params: v1beta1.Params{{
 						Name:  "retries",
 						Value: *v1beta1.NewStructuredValues("$(context.pipelineTask.retries)"),
 					}},
@@ -3272,18 +3272,18 @@ func TestApplyPipelineTaskContexts(t *testing.T) {
 		},
 		want: v1beta1.PipelineTask{
 			Retries: 5,
-			Params: []v1beta1.Param{{
+			Params: v1beta1.Params{{
 				Name:  "retries",
 				Value: *v1beta1.NewStructuredValues("5"),
 			}},
 			Matrix: &v1beta1.Matrix{
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name:  "retries",
 					Value: *v1beta1.NewStructuredValues("5"),
 				}},
 				Include: []v1beta1.IncludeParams{{
 					Name: "build-1",
-					Params: []v1beta1.Param{{
+					Params: v1beta1.Params{{
 						Name:  "retries",
 						Value: *v1beta1.NewStructuredValues("5"),
 					}},
@@ -3293,18 +3293,18 @@ func TestApplyPipelineTaskContexts(t *testing.T) {
 	}, {
 		description: "context retries replacement with no defined retries",
 		pt: v1beta1.PipelineTask{
-			Params: []v1beta1.Param{{
+			Params: v1beta1.Params{{
 				Name:  "retries",
 				Value: *v1beta1.NewStructuredValues("$(context.pipelineTask.retries)"),
 			}},
 			Matrix: &v1beta1.Matrix{
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name:  "retries",
 					Value: *v1beta1.NewStructuredValues("$(context.pipelineTask.retries)"),
 				}},
 				Include: []v1beta1.IncludeParams{{
 					Name: "build-1",
-					Params: []v1beta1.Param{{
+					Params: v1beta1.Params{{
 						Name:  "retries",
 						Value: *v1beta1.NewStructuredValues("$(context.pipelineTask.retries)"),
 					}},
@@ -3312,18 +3312,18 @@ func TestApplyPipelineTaskContexts(t *testing.T) {
 			},
 		},
 		want: v1beta1.PipelineTask{
-			Params: []v1beta1.Param{{
+			Params: v1beta1.Params{{
 				Name:  "retries",
 				Value: *v1beta1.NewStructuredValues("0"),
 			}},
 			Matrix: &v1beta1.Matrix{
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name:  "retries",
 					Value: *v1beta1.NewStructuredValues("0"),
 				}},
 				Include: []v1beta1.IncludeParams{{
 					Name: "build-1",
-					Params: []v1beta1.Param{{
+					Params: v1beta1.Params{{
 						Name:  "retries",
 						Value: *v1beta1.NewStructuredValues("0"),
 					}},
@@ -3370,7 +3370,7 @@ func TestApplyWorkspaces(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			p1 := v1beta1.PipelineSpec{
 				Tasks: []v1beta1.PipelineTask{{
-					Params: []v1beta1.Param{{Value: *v1beta1.NewStructuredValues(tc.variableUsage)}},
+					Params: v1beta1.Params{{Value: *v1beta1.NewStructuredValues(tc.variableUsage)}},
 				}},
 				Workspaces: tc.declarations,
 			}
@@ -4035,7 +4035,7 @@ func TestApplyTaskRunContext(t *testing.T) {
 		PipelineTask: &v1beta1.PipelineTask{
 			Name:    "task4",
 			TaskRef: &v1beta1.TaskRef{Name: "task"},
-			Params: []v1beta1.Param{{
+			Params: v1beta1.Params{{
 				Name:  "task1",
 				Value: *v1beta1.NewStructuredValues("$(tasks.task1.status)"),
 			}, {
@@ -4053,7 +4053,7 @@ func TestApplyTaskRunContext(t *testing.T) {
 		PipelineTask: &v1beta1.PipelineTask{
 			Name:    "task4",
 			TaskRef: &v1beta1.TaskRef{Name: "task"},
-			Params: []v1beta1.Param{{
+			Params: v1beta1.Params{{
 				Name:  "task1",
 				Value: *v1beta1.NewStructuredValues("succeeded"),
 			}, {

--- a/pkg/reconciler/pipelinerun/resources/pipelineref_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelineref_test.go
@@ -348,7 +348,7 @@ func TestGetPipelineFunc_RemoteResolution_ReplacedParams(t *testing.T) {
 	pipelineRef := &v1beta1.PipelineRef{
 		ResolverRef: v1beta1.ResolverRef{
 			Resolver: "git",
-			Params: []v1beta1.Param{{
+			Params: v1beta1.Params{{
 				Name:  "foo",
 				Value: *v1beta1.NewStructuredValues("$(params.resolver-param)"),
 			}, {
@@ -366,7 +366,7 @@ func TestGetPipelineFunc_RemoteResolution_ReplacedParams(t *testing.T) {
 	resolved := test.NewResolvedResource([]byte(pipelineYAML), nil, sampleConfigSource.DeepCopy(), nil)
 	requester := &test.Requester{
 		ResolvedResource: resolved,
-		Params: []v1beta1.Param{{
+		Params: v1beta1.Params{{
 			Name:  "foo",
 			Value: *v1beta1.NewStructuredValues("bar"),
 		}, {
@@ -382,7 +382,7 @@ func TestGetPipelineFunc_RemoteResolution_ReplacedParams(t *testing.T) {
 		Spec: v1beta1.PipelineRunSpec{
 			PipelineRef:        pipelineRef,
 			ServiceAccountName: "default",
-			Params: []v1beta1.Param{{
+			Params: v1beta1.Params{{
 				Name:  "resolver-param",
 				Value: *v1beta1.NewStructuredValues("bar"),
 			}},
@@ -405,7 +405,7 @@ func TestGetPipelineFunc_RemoteResolution_ReplacedParams(t *testing.T) {
 	pipelineRefNotMatching := &v1beta1.PipelineRef{
 		ResolverRef: v1beta1.ResolverRef{
 			Resolver: "git",
-			Params: []v1beta1.Param{{
+			Params: v1beta1.Params{{
 				Name:  "foo",
 				Value: *v1beta1.NewStructuredValues("$(params.resolver-param)"),
 			}, {
@@ -423,7 +423,7 @@ func TestGetPipelineFunc_RemoteResolution_ReplacedParams(t *testing.T) {
 		Spec: v1beta1.PipelineRunSpec{
 			PipelineRef:        pipelineRefNotMatching,
 			ServiceAccountName: "default",
-			Params: []v1beta1.Param{{
+			Params: v1beta1.Params{{
 				Name:  "resolver-param",
 				Value: *v1beta1.NewStructuredValues("banana"),
 			}},

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -814,7 +814,7 @@ func resolvePipelineTaskResources(pt v1beta1.PipelineTask, ts *v1beta1.TaskSpec,
 }
 
 func (t *ResolvedPipelineTask) hasResultReferences() bool {
-	var matrixParams []v1beta1.Param
+	var matrixParams v1beta1.Params
 	if t.PipelineTask.IsMatrixed() {
 		matrixParams = t.PipelineTask.Params
 	}

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
@@ -120,18 +120,18 @@ var pts = []v1beta1.PipelineTask{{
 }, {
 	Name:    "mytask15",
 	TaskRef: &v1beta1.TaskRef{Name: "taskWithReferenceToTaskResult"},
-	Params:  []v1beta1.Param{{Name: "param1", Value: *v1beta1.NewStructuredValues("$(tasks.mytask1.results.result1)")}},
+	Params:  v1beta1.Params{{Name: "param1", Value: *v1beta1.NewStructuredValues("$(tasks.mytask1.results.result1)")}},
 }, {
 	Name: "mytask16",
 	Matrix: &v1beta1.Matrix{
-		Params: []v1beta1.Param{{
+		Params: v1beta1.Params{{
 			Name:  "browser",
 			Value: v1beta1.ParamValue{ArrayVal: []string{"safari", "chrome"}},
 		}}},
 }, {
 	Name: "mytask17",
 	Matrix: &v1beta1.Matrix{
-		Params: []v1beta1.Param{{
+		Params: v1beta1.Params{{
 			Name:  "browser",
 			Value: v1beta1.ParamValue{ArrayVal: []string{"safari", "chrome"}},
 		}}},
@@ -140,7 +140,7 @@ var pts = []v1beta1.PipelineTask{{
 	TaskRef: &v1beta1.TaskRef{Name: "task"},
 	Retries: 1,
 	Matrix: &v1beta1.Matrix{
-		Params: []v1beta1.Param{{
+		Params: v1beta1.Params{{
 			Name:  "browser",
 			Value: v1beta1.ParamValue{ArrayVal: []string{"safari", "chrome"}},
 		}}},
@@ -148,7 +148,7 @@ var pts = []v1beta1.PipelineTask{{
 	Name:    "mytask19",
 	TaskRef: &v1beta1.TaskRef{APIVersion: "example.dev/v0", Kind: "Example", Name: "customtask"},
 	Matrix: &v1beta1.Matrix{
-		Params: []v1beta1.Param{{
+		Params: v1beta1.Params{{
 			Name:  "browser",
 			Value: v1beta1.ParamValue{ArrayVal: []string{"safari", "chrome"}},
 		}}},
@@ -156,7 +156,7 @@ var pts = []v1beta1.PipelineTask{{
 	Name:    "mytask20",
 	TaskRef: &v1beta1.TaskRef{APIVersion: "example.dev/v0", Kind: "Example", Name: "customtask"},
 	Matrix: &v1beta1.Matrix{
-		Params: []v1beta1.Param{{
+		Params: v1beta1.Params{{
 			Name:  "browser",
 			Value: v1beta1.ParamValue{ArrayVal: []string{"safari", "chrome"}},
 		}}},
@@ -165,7 +165,7 @@ var pts = []v1beta1.PipelineTask{{
 	TaskRef: &v1beta1.TaskRef{Name: "task"},
 	Retries: 2,
 	Matrix: &v1beta1.Matrix{
-		Params: []v1beta1.Param{{
+		Params: v1beta1.Params{{
 			Name:  "browser",
 			Value: v1beta1.ParamValue{ArrayVal: []string{"safari", "chrome"}},
 		}}},
@@ -243,7 +243,7 @@ var v1alpha1Runs = []v1alpha1.Run{{
 var matrixedPipelineTask = &v1beta1.PipelineTask{
 	Name: "task",
 	Matrix: &v1beta1.Matrix{
-		Params: []v1beta1.Param{{
+		Params: v1beta1.Params{{
 			Name:  "browser",
 			Value: v1beta1.ParamValue{ArrayVal: []string{"safari", "chrome"}},
 		}}},
@@ -1061,7 +1061,7 @@ func TestIsSkipped(t *testing.T) {
 			PipelineTask: &v1beta1.PipelineTask{
 				Name:    "mytask20",
 				TaskRef: &v1beta1.TaskRef{Name: "task"},
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name:  "commit",
 					Value: *v1beta1.NewStructuredValues("$(tasks.mytask11.results.missingResult)"),
 				}},
@@ -1911,7 +1911,7 @@ func TestResolvePipelineRun_TaskDoesntExist(t *testing.T) {
 		Name:    "mytask2",
 		TaskRef: &v1beta1.TaskRef{Name: "task"},
 		Matrix: &v1beta1.Matrix{
-			Params: []v1beta1.Param{{
+			Params: v1beta1.Params{{
 				Name:  "foo",
 				Value: *v1beta1.NewStructuredValues("f", "o", "o"),
 			}, {
@@ -1953,7 +1953,7 @@ func TestResolvePipelineRun_VerificationFailed(t *testing.T) {
 		Name:    "mytask2",
 		TaskRef: &v1beta1.TaskRef{Name: "task"},
 		Matrix: &v1beta1.Matrix{
-			Params: []v1beta1.Param{{
+			Params: v1beta1.Params{{
 				Name:  "foo",
 				Value: *v1beta1.NewStructuredValues("f", "o", "o"),
 			}, {
@@ -2382,7 +2382,7 @@ func TestResolvedPipelineRunTask_IsFinallySkipped(t *testing.T) {
 		PipelineTask: &v1beta1.PipelineTask{
 			Name:    "final-task-1",
 			TaskRef: &v1beta1.TaskRef{Name: "task"},
-			Params: []v1beta1.Param{{
+			Params: v1beta1.Params{{
 				Name:  "commit",
 				Value: *v1beta1.NewStructuredValues("$(tasks.dag-task.results.commit)"),
 			}},
@@ -2391,7 +2391,7 @@ func TestResolvedPipelineRunTask_IsFinallySkipped(t *testing.T) {
 		PipelineTask: &v1beta1.PipelineTask{
 			Name:    "final-task-2",
 			TaskRef: &v1beta1.TaskRef{Name: "task"},
-			Params: []v1beta1.Param{{
+			Params: v1beta1.Params{{
 				Name:  "commit",
 				Value: *v1beta1.NewStructuredValues("$(tasks.dag-task.results.missingResult)"),
 			}},
@@ -2727,7 +2727,7 @@ func TestResolvedPipelineRunTask_IsFinalTask(t *testing.T) {
 		PipelineTask: &v1beta1.PipelineTask{
 			Name:    "final-task",
 			TaskRef: &v1beta1.TaskRef{Name: "task"},
-			Params: []v1beta1.Param{{
+			Params: v1beta1.Params{{
 				Name:  "commit",
 				Value: *v1beta1.NewStructuredValues("$(tasks.dag-task.results.commit)"),
 			}},
@@ -3017,7 +3017,7 @@ func TestIsMatrixed(t *testing.T) {
 				Kind:       "Sample",
 			},
 			Matrix: &v1beta1.Matrix{
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name:  "platform",
 					Value: v1beta1.ParamValue{Type: v1beta1.ParamTypeArray, ArrayVal: []string{"linux", "mac", "windows"}},
 				}}},
@@ -3039,7 +3039,7 @@ func TestIsMatrixed(t *testing.T) {
 				Name: "my-task",
 			},
 			Matrix: &v1beta1.Matrix{
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name:  "platform",
 					Value: v1beta1.ParamValue{Type: v1beta1.ParamTypeArray, ArrayVal: []string{"linux", "mac", "windows"}},
 				}}},
@@ -3107,7 +3107,7 @@ func TestResolvePipelineRunTask_WithMatrix(t *testing.T) {
 			Name: "my-task",
 		},
 		Matrix: &v1beta1.Matrix{
-			Params: []v1beta1.Param{{
+			Params: v1beta1.Params{{
 				Name:  "platform",
 				Value: v1beta1.ParamValue{Type: v1beta1.ParamTypeArray, ArrayVal: []string{"linux", "mac", "windows"}},
 			}}},
@@ -3117,7 +3117,7 @@ func TestResolvePipelineRunTask_WithMatrix(t *testing.T) {
 			Name: "my-task",
 		},
 		Matrix: &v1beta1.Matrix{
-			Params: []v1beta1.Param{{
+			Params: v1beta1.Params{{
 				Name:  "platform",
 				Value: v1beta1.ParamValue{Type: v1beta1.ParamTypeArray, ArrayVal: []string{"linux", "mac", "windows"}},
 			}, {
@@ -3216,7 +3216,7 @@ func TestResolvePipelineRunTask_WithMatrixedCustomTask(t *testing.T) {
 			Name:       "my-task",
 		},
 		Matrix: &v1beta1.Matrix{
-			Params: []v1beta1.Param{{
+			Params: v1beta1.Params{{
 				Name:  "platform",
 				Value: v1beta1.ParamValue{Type: v1beta1.ParamTypeArray, ArrayVal: []string{"linux", "mac", "windows"}},
 			}}},
@@ -3228,7 +3228,7 @@ func TestResolvePipelineRunTask_WithMatrixedCustomTask(t *testing.T) {
 			Name:       "my-task",
 		},
 		Matrix: &v1beta1.Matrix{
-			Params: []v1beta1.Param{{
+			Params: v1beta1.Params{{
 				Name:  "platform",
 				Value: v1beta1.ParamValue{Type: v1beta1.ParamTypeArray, ArrayVal: []string{"linux", "mac", "windows"}},
 			}, {

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
@@ -1423,7 +1423,7 @@ func buildPipelineStateWithLargeDependencyGraph(t *testing.T) PipelineRunState {
 				dependFrom = i - (i % 10)
 			}
 		}
-		params := []v1beta1.Param{}
+		params := v1beta1.Params{}
 		var alpha byte
 		for alpha = 'a'; alpha <= 'j'; alpha++ {
 			params = append(params, v1beta1.Param{
@@ -1474,7 +1474,7 @@ func buildPipelineStateWithMultipleTaskResults(t *testing.T, includeWhen bool) P
 		},
 	}}
 	for i := 2; i < 400; i++ {
-		var params []v1beta1.Param
+		var params v1beta1.Params
 		whenExpressions := v1beta1.WhenExpressions{}
 		var alpha byte
 		// the task has a reference to multiple task results (a through j) from each parent task - causing a redundant references
@@ -2720,7 +2720,7 @@ func TestPipelineRunState_GetResultsFuncs(t *testing.T) {
 				APIVersion: "v1beta1",
 			},
 			Matrix: &v1beta1.Matrix{
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name:  "foobar",
 					Value: v1beta1.ParamValue{Type: v1beta1.ParamTypeArray, ArrayVal: []string{"foo", "bar"}},
 				}, {
@@ -2783,7 +2783,7 @@ func TestPipelineRunState_GetResultsFuncs(t *testing.T) {
 				APIVersion: "example.dev/v0",
 			},
 			Matrix: &v1beta1.Matrix{
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name:  "foobar",
 					Value: v1beta1.ParamValue{Type: v1beta1.ParamTypeArray, ArrayVal: []string{"foo", "bar"}},
 				}, {
@@ -3080,7 +3080,7 @@ func TestPipelineRunState_GetChildReferences(t *testing.T) {
 						Values:   []string{"foo", "bar"},
 					}},
 					Matrix: &v1beta1.Matrix{
-						Params: []v1beta1.Param{{
+						Params: v1beta1.Params{{
 							Name:  "foobar",
 							Value: v1beta1.ParamValue{Type: v1beta1.ParamTypeArray, ArrayVal: []string{"foo", "bar"}},
 						}, {
@@ -3109,7 +3109,7 @@ func TestPipelineRunState_GetChildReferences(t *testing.T) {
 						Values:   []string{"foo", "bar"},
 					}},
 					Matrix: &v1beta1.Matrix{
-						Params: []v1beta1.Param{{
+						Params: v1beta1.Params{{
 							Name:  "foobar",
 							Value: v1beta1.ParamValue{Type: v1beta1.ParamTypeArray, ArrayVal: []string{"foo", "bar"}},
 						}, {
@@ -3196,7 +3196,7 @@ func TestPipelineRunState_GetChildReferences(t *testing.T) {
 						Values:   []string{"foo", "bar"},
 					}},
 					Matrix: &v1beta1.Matrix{
-						Params: []v1beta1.Param{{
+						Params: v1beta1.Params{{
 							Name:  "foobar",
 							Value: v1beta1.ParamValue{Type: v1beta1.ParamTypeArray, ArrayVal: []string{"foo", "bar"}},
 						}, {
@@ -3223,7 +3223,7 @@ func TestPipelineRunState_GetChildReferences(t *testing.T) {
 						Values:   []string{"foo", "bar"},
 					}},
 					Matrix: &v1beta1.Matrix{
-						Params: []v1beta1.Param{{
+						Params: v1beta1.Params{{
 							Name:  "foobar",
 							Value: v1beta1.ParamValue{Type: v1beta1.ParamTypeArray, ArrayVal: []string{"foo", "bar"}},
 						}, {

--- a/pkg/reconciler/pipelinerun/resources/resultrefresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/resultrefresolution_test.go
@@ -54,7 +54,7 @@ var pipelineRunState = PipelineRunState{{
 	PipelineTask: &v1beta1.PipelineTask{
 		Name:    "bTask",
 		TaskRef: &v1beta1.TaskRef{Name: "bTask"},
-		Params: []v1beta1.Param{{
+		Params: v1beta1.Params{{
 			Name:  "bParam",
 			Value: *v1beta1.NewStructuredValues("$(tasks.aTask.results.aResult)"),
 		}},
@@ -83,7 +83,7 @@ var pipelineRunState = PipelineRunState{{
 	PipelineTask: &v1beta1.PipelineTask{
 		Name:    "bTask",
 		TaskRef: &v1beta1.TaskRef{Name: "bTask"},
-		Params: []v1beta1.Param{{
+		Params: v1beta1.Params{{
 			Name:  "bParam",
 			Value: *v1beta1.NewStructuredValues("$(tasks.aTask.results.missingResult)"),
 		}},
@@ -113,7 +113,7 @@ var pipelineRunState = PipelineRunState{{
 	PipelineTask: &v1beta1.PipelineTask{
 		Name:    "bTask",
 		TaskRef: &v1beta1.TaskRef{Name: "bTask"},
-		Params: []v1beta1.Param{{
+		Params: v1beta1.Params{{
 			Name:  "bParam",
 			Value: *v1beta1.NewStructuredValues("$(tasks.aCustomPipelineTask.results.aResult)"),
 		}},
@@ -139,7 +139,7 @@ var pipelineRunState = PipelineRunState{{
 	PipelineTask: &v1beta1.PipelineTask{
 		Name:    "cTask",
 		TaskRef: &v1beta1.TaskRef{Name: "cTask"},
-		Params: []v1beta1.Param{{
+		Params: v1beta1.Params{{
 			Name:  "cParam",
 			Value: *v1beta1.NewStructuredValues("$(tasks.cTask.results.cResult[1])"),
 		}},
@@ -165,7 +165,7 @@ var pipelineRunState = PipelineRunState{{
 	PipelineTask: &v1beta1.PipelineTask{
 		Name:    "dTask",
 		TaskRef: &v1beta1.TaskRef{Name: "dTask"},
-		Params: []v1beta1.Param{{
+		Params: v1beta1.Params{{
 			Name:  "dParam",
 			Value: *v1beta1.NewStructuredValues("$(tasks.dTask.results.dResult[3])"),
 		}},

--- a/pkg/reconciler/pipelinerun/resources/validate_dependencies_test.go
+++ b/pkg/reconciler/pipelinerun/resources/validate_dependencies_test.go
@@ -36,7 +36,7 @@ func TestValidatePipelineTaskResults_ValidStates(t *testing.T) {
 		state: PipelineRunState{{
 			PipelineTask: &v1beta1.PipelineTask{
 				Name: "pt1",
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name:  "p1",
 					Value: *v1beta1.NewStructuredValues("foo"),
 				}},
@@ -59,7 +59,7 @@ func TestValidatePipelineTaskResults_ValidStates(t *testing.T) {
 		}, {
 			PipelineTask: &v1beta1.PipelineTask{
 				Name: "pt2",
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name:  "p",
 					Value: *v1beta1.NewStructuredValues("$(tasks.pt1.results.result)"),
 				}},
@@ -83,7 +83,7 @@ func TestValidatePipelineTaskResults_ValidStates(t *testing.T) {
 			PipelineTask: &v1beta1.PipelineTask{
 				Name: "pt2",
 				Matrix: &v1beta1.Matrix{
-					Params: []v1beta1.Param{{
+					Params: v1beta1.Params{{
 						Name:  "p",
 						Value: *v1beta1.NewStructuredValues("$(tasks.pt1.results.result)", "foo"),
 					}}},
@@ -100,7 +100,7 @@ func TestValidatePipelineTaskResults_ValidStates(t *testing.T) {
 		}, {
 			PipelineTask: &v1beta1.PipelineTask{
 				Name: "pt2",
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name:  "p",
 					Value: *v1beta1.NewStructuredValues("$(tasks.pt1.results.a-dynamic-custom-task-result)"),
 				}},
@@ -127,7 +127,7 @@ func TestValidatePipelineTaskResults_IncorrectTaskName(t *testing.T) {
 		state: PipelineRunState{{
 			PipelineTask: &v1beta1.PipelineTask{
 				Name: "pt1",
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name:  "p1",
 					Value: *v1beta1.NewStructuredValues(missingPipelineTaskVariable),
 				}},
@@ -138,7 +138,7 @@ func TestValidatePipelineTaskResults_IncorrectTaskName(t *testing.T) {
 		state: PipelineRunState{{
 			PipelineTask: &v1beta1.PipelineTask{
 				Name: "pt1",
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name:  "p1",
 					Value: *v1beta1.NewStructuredValues(missingPipelineTaskVariable, "foo"),
 				}},
@@ -192,7 +192,7 @@ func TestValidatePipelineTaskResults_IncorrectResultName(t *testing.T) {
 		state: PipelineRunState{pt1, {
 			PipelineTask: &v1beta1.PipelineTask{
 				Name: "pt2",
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name:  "p1",
 					Value: *v1beta1.NewStructuredValues("$(tasks.pt1.results.result1)"),
 				}},
@@ -204,7 +204,7 @@ func TestValidatePipelineTaskResults_IncorrectResultName(t *testing.T) {
 			PipelineTask: &v1beta1.PipelineTask{
 				Name: "pt2",
 				Matrix: &v1beta1.Matrix{
-					Params: []v1beta1.Param{{
+					Params: v1beta1.Params{{
 						Name:  "p1",
 						Value: *v1beta1.NewStructuredValues("$(tasks.pt1.results.result1)", "$(tasks.pt1.results.result2)"),
 					}}},
@@ -249,7 +249,7 @@ func TestValidatePipelineTaskResults_MissingTaskSpec(t *testing.T) {
 	state := PipelineRunState{pt1, {
 		PipelineTask: &v1beta1.PipelineTask{
 			Name: "pt2",
-			Params: []v1beta1.Param{{
+			Params: v1beta1.Params{{
 				Name:  "p1",
 				Value: *v1beta1.NewStructuredValues("$(tasks.pt1.results.result1)"),
 			}},
@@ -258,7 +258,7 @@ func TestValidatePipelineTaskResults_MissingTaskSpec(t *testing.T) {
 		PipelineTask: &v1beta1.PipelineTask{
 			Name: "pt3",
 			Matrix: &v1beta1.Matrix{
-				Params: []v1beta1.Param{{
+				Params: v1beta1.Params{{
 					Name:  "p1",
 					Value: *v1beta1.NewStructuredValues("$(tasks.pt1.results.result1)", "$(tasks.pt1.results.result2)"),
 				}}},

--- a/pkg/reconciler/pipelinerun/resources/validate_params.go
+++ b/pkg/reconciler/pipelinerun/resources/validate_params.go
@@ -51,7 +51,7 @@ func ValidateParamTypesMatching(p *v1beta1.PipelineSpec, pr *v1beta1.PipelineRun
 
 // ValidateRequiredParametersProvided validates that all the parameters expected by the Pipeline are provided by the PipelineRun.
 // Extra Parameters are allowed, the Pipeline will use the Parameters it needs and ignore the other Parameters.
-func ValidateRequiredParametersProvided(pipelineParameters *v1beta1.ParamSpecs, pipelineRunParameters *[]v1beta1.Param) error {
+func ValidateRequiredParametersProvided(pipelineParameters *v1beta1.ParamSpecs, pipelineRunParameters *v1beta1.Params) error {
 	// Build a list of parameter names declared in pr.
 	var providedParams []string
 	for _, param := range *pipelineRunParameters {
@@ -76,7 +76,7 @@ func ValidateRequiredParametersProvided(pipelineParameters *v1beta1.ParamSpecs, 
 }
 
 // ValidateObjectParamRequiredKeys validates that the required keys of all the object parameters expected by the Pipeline are provided by the PipelineRun.
-func ValidateObjectParamRequiredKeys(pipelineParameters []v1beta1.ParamSpec, pipelineRunParameters []v1beta1.Param) error {
+func ValidateObjectParamRequiredKeys(pipelineParameters []v1beta1.ParamSpec, pipelineRunParameters v1beta1.Params) error {
 	missings := taskrun.MissingKeysObjectParamNames(pipelineParameters, pipelineRunParameters)
 	if len(missings) != 0 {
 		return fmt.Errorf("PipelineRun missing object keys for parameters: %v", missings)

--- a/pkg/reconciler/pipelinerun/resources/validate_params_test.go
+++ b/pkg/reconciler/pipelinerun/resources/validate_params_test.go
@@ -31,21 +31,21 @@ func TestValidateParamTypesMatching_Valid(t *testing.T) {
 		name        string
 		description string
 		pp          []v1beta1.ParamSpec
-		prp         []v1beta1.Param
+		prp         v1beta1.Params
 	}{{
 		name: "proper param types",
 		pp: []v1beta1.ParamSpec{
 			{Name: "correct-type-1", Type: v1beta1.ParamTypeString},
 			{Name: "correct-type-2", Type: v1beta1.ParamTypeArray},
 		},
-		prp: []v1beta1.Param{
+		prp: v1beta1.Params{
 			{Name: "correct-type-1", Value: stringValue},
 			{Name: "correct-type-2", Value: arrayValue},
 		},
 	}, {
 		name: "no params to get wrong",
 		pp:   []v1beta1.ParamSpec{},
-		prp:  []v1beta1.Param{},
+		prp:  v1beta1.Params{},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			ps := &v1beta1.PipelineSpec{Params: tc.pp}
@@ -69,7 +69,7 @@ func TestValidateParamTypesMatching_Invalid(t *testing.T) {
 		name        string
 		description string
 		pp          []v1beta1.ParamSpec
-		prp         []v1beta1.Param
+		prp         v1beta1.Params
 	}{{
 		name: "string-array mismatch",
 		pp: []v1beta1.ParamSpec{
@@ -77,7 +77,7 @@ func TestValidateParamTypesMatching_Invalid(t *testing.T) {
 			{Name: "correct-type-2", Type: v1beta1.ParamTypeArray},
 			{Name: "incorrect-type", Type: v1beta1.ParamTypeString},
 		},
-		prp: []v1beta1.Param{
+		prp: v1beta1.Params{
 			{Name: "correct-type-1", Value: stringValue},
 			{Name: "correct-type-2", Value: arrayValue},
 			{Name: "incorrect-type", Value: arrayValue},
@@ -89,7 +89,7 @@ func TestValidateParamTypesMatching_Invalid(t *testing.T) {
 			{Name: "correct-type-2", Type: v1beta1.ParamTypeArray},
 			{Name: "incorrect-type", Type: v1beta1.ParamTypeArray},
 		},
-		prp: []v1beta1.Param{
+		prp: v1beta1.Params{
 			{Name: "correct-type-1", Value: stringValue},
 			{Name: "correct-type-2", Value: arrayValue},
 			{Name: "incorrect-type", Value: stringValue},
@@ -117,13 +117,13 @@ func TestValidateRequiredParametersProvided_Valid(t *testing.T) {
 		name        string
 		description string
 		pp          v1beta1.ParamSpecs
-		prp         []v1beta1.Param
+		prp         v1beta1.Params
 	}{{
 		name: "required string params provided",
 		pp: []v1beta1.ParamSpec{
 			{Name: "required-string-param", Type: v1beta1.ParamTypeString},
 		},
-		prp: []v1beta1.Param{
+		prp: v1beta1.Params{
 			{Name: "required-string-param", Value: stringValue},
 		},
 	}, {
@@ -131,7 +131,7 @@ func TestValidateRequiredParametersProvided_Valid(t *testing.T) {
 		pp: []v1beta1.ParamSpec{
 			{Name: "required-array-param", Type: v1beta1.ParamTypeArray},
 		},
-		prp: []v1beta1.Param{
+		prp: v1beta1.Params{
 			{Name: "required-array-param", Value: arrayValue},
 		},
 	}, {
@@ -139,7 +139,7 @@ func TestValidateRequiredParametersProvided_Valid(t *testing.T) {
 		pp: []v1beta1.ParamSpec{
 			{Name: "string-param", Type: v1beta1.ParamTypeString, Default: &stringValue},
 		},
-		prp: []v1beta1.Param{
+		prp: v1beta1.Params{
 			{Name: "another-string-param", Value: stringValue},
 		},
 	}} {
@@ -159,13 +159,13 @@ func TestValidateRequiredParametersProvided_Invalid(t *testing.T) {
 		name        string
 		description string
 		pp          v1beta1.ParamSpecs
-		prp         []v1beta1.Param
+		prp         v1beta1.Params
 	}{{
 		name: "required string param missing",
 		pp: []v1beta1.ParamSpec{
 			{Name: "required-string-param", Type: v1beta1.ParamTypeString},
 		},
-		prp: []v1beta1.Param{
+		prp: v1beta1.Params{
 			{Name: "another-string-param", Value: stringValue},
 		},
 	}, {
@@ -173,7 +173,7 @@ func TestValidateRequiredParametersProvided_Invalid(t *testing.T) {
 		pp: []v1beta1.ParamSpec{
 			{Name: "required-array-param", Type: v1beta1.ParamTypeArray},
 		},
-		prp: []v1beta1.Param{
+		prp: v1beta1.Params{
 			{Name: "another-array-param", Value: arrayValue},
 		},
 	}} {
@@ -189,7 +189,7 @@ func TestValidateObjectParamRequiredKeys_Invalid(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		pp   []v1beta1.ParamSpec
-		prp  []v1beta1.Param
+		prp  v1beta1.Params
 	}{{
 		name: "miss all required keys",
 		pp: []v1beta1.ParamSpec{
@@ -202,7 +202,7 @@ func TestValidateObjectParamRequiredKeys_Invalid(t *testing.T) {
 				},
 			},
 		},
-		prp: []v1beta1.Param{
+		prp: v1beta1.Params{
 			{
 				Name: "an-object-param",
 				Value: *v1beta1.NewObject(map[string]string{
@@ -221,7 +221,7 @@ func TestValidateObjectParamRequiredKeys_Invalid(t *testing.T) {
 				},
 			},
 		},
-		prp: []v1beta1.Param{
+		prp: v1beta1.Params{
 			{
 				Name: "an-object-param",
 				Value: *v1beta1.NewObject(map[string]string{
@@ -241,7 +241,7 @@ func TestValidateObjectParamRequiredKeys_Valid(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		pp   []v1beta1.ParamSpec
-		prp  []v1beta1.Param
+		prp  v1beta1.Params
 	}{{
 		name: "some keys are provided by default, and the rest are provided in value",
 		pp: []v1beta1.ParamSpec{
@@ -260,7 +260,7 @@ func TestValidateObjectParamRequiredKeys_Valid(t *testing.T) {
 				},
 			},
 		},
-		prp: []v1beta1.Param{
+		prp: v1beta1.Params{
 			{
 				Name: "an-object-param",
 				Value: *v1beta1.NewObject(map[string]string{
@@ -279,7 +279,7 @@ func TestValidateObjectParamRequiredKeys_Valid(t *testing.T) {
 				},
 			},
 		},
-		prp: []v1beta1.Param{
+		prp: v1beta1.Params{
 			{
 				Name: "an-object-param",
 				Value: *v1beta1.NewObject(map[string]string{
@@ -299,7 +299,7 @@ func TestValidateObjectParamRequiredKeys_Valid(t *testing.T) {
 				},
 			},
 		},
-		prp: []v1beta1.Param{
+		prp: v1beta1.Params{
 			{
 				Name: "an-object-param",
 				Value: *v1beta1.NewObject(map[string]string{

--- a/pkg/reconciler/taskrun/resources/apply_test.go
+++ b/pkg/reconciler/taskrun/resources/apply_test.go
@@ -514,7 +514,7 @@ var (
 
 	arrayTaskRun0Elements = &v1beta1.TaskRun{
 		Spec: v1beta1.TaskRunSpec{
-			Params: []v1beta1.Param{{
+			Params: v1beta1.Params{{
 				Name: "array-param",
 				Value: v1beta1.ParamValue{
 					Type:     v1beta1.ParamTypeArray,
@@ -526,7 +526,7 @@ var (
 
 	arrayTaskRun1Elements = &v1beta1.TaskRun{
 		Spec: v1beta1.TaskRunSpec{
-			Params: []v1beta1.Param{{
+			Params: v1beta1.Params{{
 				Name:  "array-param",
 				Value: *v1beta1.NewStructuredValues("foo"),
 			}},
@@ -535,7 +535,7 @@ var (
 
 	arrayTaskRun3Elements = &v1beta1.TaskRun{
 		Spec: v1beta1.TaskRunSpec{
-			Params: []v1beta1.Param{{
+			Params: v1beta1.Params{{
 				Name:  "array-param",
 				Value: *v1beta1.NewStructuredValues("foo", "bar", "third"),
 			}},
@@ -544,7 +544,7 @@ var (
 
 	arrayTaskRunMultipleArrays = &v1beta1.TaskRun{
 		Spec: v1beta1.TaskRunSpec{
-			Params: []v1beta1.Param{{
+			Params: v1beta1.Params{{
 				Name:  "array-param",
 				Value: *v1beta1.NewStructuredValues("foo", "bar", "third"),
 			}, {
@@ -556,7 +556,7 @@ var (
 
 	arrayTaskRunWith1StringParam = &v1beta1.TaskRun{
 		Spec: v1beta1.TaskRunSpec{
-			Params: []v1beta1.Param{{
+			Params: v1beta1.Params{{
 				Name:  "array-param",
 				Value: *v1beta1.NewStructuredValues("middlefirst", "middlesecond"),
 			}, {
@@ -568,7 +568,7 @@ var (
 
 	arrayTaskRunWith1ObjectParam = &v1beta1.TaskRun{
 		Spec: v1beta1.TaskRunSpec{
-			Params: []v1beta1.Param{{
+			Params: v1beta1.Params{{
 				Name:  "array-param",
 				Value: *v1beta1.NewStructuredValues("middlefirst", "middlesecond"),
 			}, {
@@ -583,7 +583,7 @@ var (
 
 	arrayTaskRunMultipleArraysAndStrings = &v1beta1.TaskRun{
 		Spec: v1beta1.TaskRunSpec{
-			Params: []v1beta1.Param{{
+			Params: v1beta1.Params{{
 				Name:  "array-param1",
 				Value: *v1beta1.NewStructuredValues("1-param1", "2-param1", "3-param1", "4-param1"),
 			}, {
@@ -601,7 +601,7 @@ var (
 
 	arrayTaskRunMultipleArraysAndObject = &v1beta1.TaskRun{
 		Spec: v1beta1.TaskRunSpec{
-			Params: []v1beta1.Param{{
+			Params: v1beta1.Params{{
 				Name:  "array-param1",
 				Value: *v1beta1.NewStructuredValues("1-param1", "2-param1", "3-param1", "4-param1"),
 			}, {
@@ -738,7 +738,7 @@ func TestApplyArrayParameters(t *testing.T) {
 func TestApplyParameters(t *testing.T) {
 	tr := &v1beta1.TaskRun{
 		Spec: v1beta1.TaskRunSpec{
-			Params: []v1beta1.Param{{
+			Params: v1beta1.Params{{
 				Name:  "myimage",
 				Value: *v1beta1.NewStructuredValues("bar"),
 			}, {
@@ -805,7 +805,7 @@ func TestApplyParameters(t *testing.T) {
 func TestApplyParameters_ArrayIndexing(t *testing.T) {
 	tr := &v1beta1.TaskRun{
 		Spec: v1beta1.TaskRunSpec{
-			Params: []v1beta1.Param{{
+			Params: v1beta1.Params{{
 				Name:  "myimage",
 				Value: *v1beta1.NewStructuredValues("bar", "foo"),
 			}, {
@@ -876,7 +876,7 @@ func TestApplyObjectParameters(t *testing.T) {
 	// define the taskrun to test values provided by taskrun can overwrite the values provided in spec's default
 	tr := &v1beta1.TaskRun{
 		Spec: v1beta1.TaskRunSpec{
-			Params: []v1beta1.Param{{
+			Params: v1beta1.Params{{
 				Name: "myObject",
 				Value: *v1beta1.NewObject(map[string]string{
 					"key1": "taskrun-value-for-key1",

--- a/pkg/reconciler/taskrun/resources/taskref.go
+++ b/pkg/reconciler/taskrun/resources/taskref.go
@@ -134,7 +134,7 @@ func GetTaskFunc(ctx context.Context, k8s kubernetes.Interface, tekton clientset
 		// Return an inline function that implements GetTask by calling Resolver.Get with the specified task type and
 		// casting it to a TaskObject.
 		return func(ctx context.Context, name string) (v1beta1.TaskObject, *v1beta1.ConfigSource, error) {
-			var replacedParams []v1beta1.Param
+			var replacedParams v1beta1.Params
 			if ownerAsTR, ok := owner.(*v1beta1.TaskRun); ok {
 				stringReplacements, arrayReplacements := paramsFromTaskRun(ctx, ownerAsTR)
 				for k, v := range getContextReplacements("", ownerAsTR) {

--- a/pkg/reconciler/taskrun/resources/taskref_test.go
+++ b/pkg/reconciler/taskrun/resources/taskref_test.go
@@ -593,7 +593,7 @@ func TestGetTaskFunc_RemoteResolution_ReplacedParams(t *testing.T) {
 	taskRef := &v1beta1.TaskRef{
 		ResolverRef: v1beta1.ResolverRef{
 			Resolver: "git",
-			Params: []v1beta1.Param{{
+			Params: v1beta1.Params{{
 				Name:  "foo",
 				Value: *v1beta1.NewStructuredValues("$(params.resolver-param)"),
 			}, {
@@ -611,7 +611,7 @@ func TestGetTaskFunc_RemoteResolution_ReplacedParams(t *testing.T) {
 	resolved := test.NewResolvedResource([]byte(taskYAML), nil, sampleConfigSource.DeepCopy(), nil)
 	requester := &test.Requester{
 		ResolvedResource: resolved,
-		Params: []v1beta1.Param{{
+		Params: v1beta1.Params{{
 			Name:  "foo",
 			Value: *v1beta1.NewStructuredValues("bar"),
 		}, {
@@ -627,7 +627,7 @@ func TestGetTaskFunc_RemoteResolution_ReplacedParams(t *testing.T) {
 		Spec: v1beta1.TaskRunSpec{
 			TaskRef:            taskRef,
 			ServiceAccountName: "default",
-			Params: []v1beta1.Param{{
+			Params: v1beta1.Params{{
 				Name:  "resolver-param",
 				Value: *v1beta1.NewStructuredValues("bar"),
 			}},
@@ -651,7 +651,7 @@ func TestGetTaskFunc_RemoteResolution_ReplacedParams(t *testing.T) {
 	taskRefNotMatching := &v1beta1.TaskRef{
 		ResolverRef: v1beta1.ResolverRef{
 			Resolver: "git",
-			Params: []v1beta1.Param{{
+			Params: v1beta1.Params{{
 				Name:  "foo",
 				Value: *v1beta1.NewStructuredValues("$(params.resolver-param)"),
 			}, {
@@ -669,7 +669,7 @@ func TestGetTaskFunc_RemoteResolution_ReplacedParams(t *testing.T) {
 		Spec: v1beta1.TaskRunSpec{
 			TaskRef:            taskRefNotMatching,
 			ServiceAccountName: "default",
-			Params: []v1beta1.Param{{
+			Params: v1beta1.Params{{
 				Name:  "resolver-param",
 				Value: *v1beta1.NewStructuredValues("banana"),
 			}},

--- a/pkg/reconciler/taskrun/resources/taskspec_test.go
+++ b/pkg/reconciler/taskrun/resources/taskspec_test.go
@@ -160,7 +160,7 @@ func TestGetTaskData_ResolutionSuccess(t *testing.T) {
 			TaskRef: &v1beta1.TaskRef{
 				ResolverRef: v1beta1.ResolverRef{
 					Resolver: "foo",
-					Params: []v1beta1.Param{{
+					Params: v1beta1.Params{{
 						Name: "bar",
 						Value: v1beta1.ParamValue{
 							Type:      v1beta1.ParamTypeString,

--- a/pkg/reconciler/taskrun/validate_taskrun.go
+++ b/pkg/reconciler/taskrun/validate_taskrun.go
@@ -72,7 +72,7 @@ func missingParamsNames(neededParams sets.String, providedParams sets.String, pa
 	}
 	return missingParamsNamesWithNoDefaults
 }
-func wrongTypeParamsNames(params []v1beta1.Param, matrix []v1beta1.Param, neededParamsTypes map[string]v1beta1.ParamType) []string {
+func wrongTypeParamsNames(params []v1beta1.Param, matrix v1beta1.Params, neededParamsTypes map[string]v1beta1.ParamType) []string {
 	// TODO(#4723): validate that $(task.taskname.result.resultname) is invalid for array and object type.
 	// It should be used to refer string and need to add [*] to refer to array or object.
 	var wrongTypeParamNames []string
@@ -107,7 +107,7 @@ func wrongTypeParamsNames(params []v1beta1.Param, matrix []v1beta1.Param, needed
 }
 
 // MissingKeysObjectParamNames checks if all required keys of object type param definitions are provided in params or param definitions' defaults.
-func MissingKeysObjectParamNames(paramSpecs []v1beta1.ParamSpec, params []v1beta1.Param) map[string][]string {
+func MissingKeysObjectParamNames(paramSpecs []v1beta1.ParamSpec, params v1beta1.Params) map[string][]string {
 	neededKeys := make(map[string][]string)
 	providedKeys := make(map[string][]string)
 
@@ -159,7 +159,7 @@ func findMissingKeys(neededKeys, providedKeys map[string][]string) map[string][]
 // ValidateResolvedTask validates that all parameters declared in the TaskSpec are present in the taskrun
 // It also validates that all parameters have values, parameter types match the specified type and
 // object params have all the keys required
-func ValidateResolvedTask(ctx context.Context, params []v1beta1.Param, matrix *v1beta1.Matrix, rtr *resources.ResolvedTask) error {
+func ValidateResolvedTask(ctx context.Context, params v1beta1.Params, matrix *v1beta1.Matrix, rtr *resources.ResolvedTask) error {
 	if err := validateParams(ctx, rtr.TaskSpec.Params, params, matrix.GetAllParams()); err != nil {
 		return fmt.Errorf("invalid input params for task %s: %w", rtr.TaskName, err)
 	}

--- a/pkg/reconciler/taskrun/validate_taskrun_test.go
+++ b/pkg/reconciler/taskrun/validate_taskrun_test.go
@@ -107,7 +107,7 @@ func TestValidateResolvedTask_ValidParams(t *testing.T) {
 		}),
 	}}
 	m := &v1beta1.Matrix{
-		Params: []v1beta1.Param{{
+		Params: v1beta1.Params{{
 			Name:  "zoo",
 			Value: *v1beta1.NewStructuredValues("a", "b", "c"),
 		}},
@@ -127,7 +127,7 @@ func TestValidateResolvedTask_ExtraValidParams(t *testing.T) {
 	tcs := []struct {
 		name   string
 		task   v1beta1.Task
-		params []v1beta1.Param
+		params v1beta1.Params
 		matrix *v1beta1.Matrix
 	}{{
 		name: "extra-str-param",
@@ -199,7 +199,7 @@ func TestValidateResolvedTask_ExtraValidParams(t *testing.T) {
 		},
 		params: v1beta1.Params{{}},
 		matrix: &v1beta1.Matrix{
-			Params: []v1beta1.Param{{
+			Params: v1beta1.Params{{
 				Name:  "extraArr",
 				Value: *v1beta1.NewStructuredValues("extra", "arr"),
 			}},
@@ -228,7 +228,7 @@ func TestValidateResolvedTask_InvalidParams(t *testing.T) {
 	tcs := []struct {
 		name    string
 		task    v1beta1.Task
-		params  []v1beta1.Param
+		params  v1beta1.Params
 		matrix  *v1beta1.Matrix
 		wantErr string
 	}{{

--- a/pkg/remote/resolution/resolver.go
+++ b/pkg/remote/resolution/resolver.go
@@ -35,7 +35,7 @@ type Resolver struct {
 	requester       remoteresource.Requester
 	owner           kmeta.OwnerRefable
 	resolverName    string
-	params          []v1beta1.Param
+	params          v1beta1.Params
 	targetName      string
 	targetNamespace string
 }
@@ -44,7 +44,7 @@ var _ remote.Resolver = &Resolver{}
 
 // NewResolver returns an implementation of remote.Resolver capable
 // of performing asynchronous remote resolution.
-func NewResolver(requester remoteresource.Requester, owner kmeta.OwnerRefable, resolverName string, targetName string, targetNamespace string, params []v1beta1.Param) remote.Resolver {
+func NewResolver(requester remoteresource.Requester, owner kmeta.OwnerRefable, resolverName string, targetName string, targetNamespace string, params v1beta1.Params) remote.Resolver {
 	return &Resolver{
 		requester:       requester,
 		owner:           owner,
@@ -88,7 +88,7 @@ func (resolver *Resolver) List(_ context.Context) ([]remote.ResolvedObject, erro
 	return nil, nil
 }
 
-func buildRequest(resolverName string, owner kmeta.OwnerRefable, name string, namespace string, params []v1beta1.Param) (*resolutionRequest, error) {
+func buildRequest(resolverName string, owner kmeta.OwnerRefable, name string, namespace string, params v1beta1.Params) (*resolutionRequest, error) {
 	if name == "" {
 		name = owner.GetObjectMeta().GetName()
 		namespace = owner.GetObjectMeta().GetNamespace()

--- a/pkg/resolution/resource/name.go
+++ b/pkg/resolution/resource/name.go
@@ -35,13 +35,13 @@ func nameHasher() hash.Hash {
 // will have the format {prefix}-{hash} where {prefix} is
 // given and {hash} is nameHasher(base) + nameHasher(param1) +
 // nameHasher(param2) + ...
-func GenerateDeterministicName(prefix, base string, params []v1beta1.Param) (string, error) {
+func GenerateDeterministicName(prefix, base string, params v1beta1.Params) (string, error) {
 	hasher := nameHasher()
 	if _, err := hasher.Write([]byte(base)); err != nil {
 		return "", err
 	}
 
-	sortedParams := make([]v1beta1.Param, len(params))
+	sortedParams := make(v1beta1.Params, len(params))
 	sort.SliceStable(sortedParams, func(i, j int) bool {
 		return sortedParams[i].Name < sortedParams[j].Name
 	})

--- a/pkg/resolution/resource/request.go
+++ b/pkg/resolution/resource/request.go
@@ -24,12 +24,12 @@ var _ Request = &BasicRequest{}
 type BasicRequest struct {
 	name      string
 	namespace string
-	params    []v1beta1.Param
+	params    v1beta1.Params
 }
 
 // NewRequest returns an instance of a BasicRequest with the given name,
 // namespace and params.
-func NewRequest(name, namespace string, params []v1beta1.Param) Request {
+func NewRequest(name, namespace string, params v1beta1.Params) Request {
 	return &BasicRequest{name, namespace, params}
 }
 
@@ -46,6 +46,6 @@ func (req *BasicRequest) Namespace() string {
 }
 
 // Params are the map of parameters associated with this request
-func (req *BasicRequest) Params() []v1beta1.Param {
+func (req *BasicRequest) Params() v1beta1.Params {
 	return req.params
 }

--- a/pkg/resolution/resource/resource.go
+++ b/pkg/resolution/resource/resource.go
@@ -44,7 +44,7 @@ type Requester interface {
 type Request interface {
 	Name() string
 	Namespace() string
-	Params() []pipelinev1beta1.Param
+	Params() pipelinev1beta1.Params
 }
 
 // OwnedRequest is implemented by any type implementing Request that also needs

--- a/test/custom_task_test.go
+++ b/test/custom_task_test.go
@@ -223,7 +223,7 @@ spec:
 	}
 
 	// Validate the task's result reference to the custom task's result was resolved.
-	expectedTaskRunParams := []v1beta1.Param{{
+	expectedTaskRunParams := v1beta1.Params{{
 		Name: "input-result-from-custom-task-ref", Value: *v1beta1.NewStructuredValues("aResultValue"),
 	}, {
 		Name: "input-result-from-custom-task-spec", Value: *v1beta1.NewStructuredValues("aResultValue"),
@@ -523,7 +523,7 @@ func TestWaitCustomTask_Run(t *testing.T) {
 						APIVersion: apiVersion,
 						Kind:       kind,
 					},
-					Params: []v1beta1.Param{{Name: "duration", Value: v1beta1.ParamValue{Type: "string", StringVal: tc.duration}}},
+					Params: v1beta1.Params{{Name: "duration", Value: v1beta1.ParamValue{Type: "string", StringVal: tc.duration}}},
 				},
 			}
 
@@ -560,7 +560,7 @@ func TestWaitCustomTask_Run(t *testing.T) {
 						APIVersion: apiVersion,
 						Kind:       kind,
 					},
-					Params:             []v1beta1.Param{{Name: "duration", Value: v1beta1.ParamValue{Type: "string", StringVal: tc.duration}}},
+					Params:             v1beta1.Params{{Name: "duration", Value: v1beta1.ParamValue{Type: "string", StringVal: tc.duration}}},
 					ServiceAccountName: "default",
 				},
 				Status: v1alpha1.RunStatus{
@@ -753,7 +753,7 @@ func TestWaitCustomTask_PipelineRun(t *testing.T) {
 							APIVersion: apiVersion,
 							Kind:       kind,
 						},
-						Params: []v1beta1.Param{{Name: "duration", Value: v1beta1.ParamValue{Type: "string", StringVal: tc.runDuration}}},
+						Params: v1beta1.Params{{Name: "duration", Value: v1beta1.ParamValue{Type: "string", StringVal: tc.runDuration}}},
 					}},
 				},
 			}
@@ -818,7 +818,7 @@ func TestWaitCustomTask_PipelineRun(t *testing.T) {
 										APIVersion: apiVersion,
 										Kind:       kind,
 									},
-									Params: []v1beta1.Param{{
+									Params: v1beta1.Params{{
 										Name:  "duration",
 										Value: v1beta1.ParamValue{Type: "string", StringVal: tc.runDuration},
 									}},
@@ -1041,7 +1041,7 @@ func TestWaitCustomTask_V1Beta1_PipelineRun(t *testing.T) {
 							APIVersion: betaAPIVersion,
 							Kind:       kind,
 						},
-						Params: []v1beta1.Param{{Name: "duration", Value: v1beta1.ParamValue{Type: "string", StringVal: tc.customRunDuration}}},
+						Params: v1beta1.Params{{Name: "duration", Value: v1beta1.ParamValue{Type: "string", StringVal: tc.customRunDuration}}},
 					}},
 				},
 			}
@@ -1106,7 +1106,7 @@ func TestWaitCustomTask_V1Beta1_PipelineRun(t *testing.T) {
 										APIVersion: betaAPIVersion,
 										Kind:       kind,
 									},
-									Params: []v1beta1.Param{{
+									Params: v1beta1.Params{{
 										Name:  "duration",
 										Value: v1beta1.ParamValue{Type: "string", StringVal: tc.customRunDuration},
 									}},


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

This PR updates `[]Param` to the new `Params` type everywhere in the code base. This is a follow up to PR #6180 where the type `type Params []Param` was introduced to allow member functions. This change will make it easier to make changes related to the type.

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [N/A] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [N/A] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [N/A] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [N/A] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
