### PR TITLE
Split up and refactor `isCustomTask`

### DIFF
--- a/docs/pipeline-api.md
+++ b/docs/pipeline-api.md
@@ -4547,7 +4547,9 @@ TaskKind
 </em>
 </td>
 <td>
-<p>TaskKind indicates the kind of the task, namespaced or cluster scoped.</p>
+<p>TaskKind indicates the Kind of the Task:
+1. Namespaced Task when Kind is set to &ldquo;Task&rdquo;. If Kind is &ldquo;&rdquo;, it defaults to &ldquo;Task&rdquo;.
+2. Custom Task when Kind is non-empty and APIVersion is non-empty</p>
 </td>
 </tr>
 <tr>
@@ -4559,7 +4561,8 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>API version of the referent</p>
+<p>API version of the referent
+Note: A Task with non-empty APIVersion and Kind is considered a Custom Task</p>
 </td>
 </tr>
 <tr>
@@ -12102,7 +12105,10 @@ TaskKind
 </em>
 </td>
 <td>
-<p>TaskKind indicates the kind of the task, namespaced or cluster scoped.</p>
+<p>TaskKind indicates the Kind of the Task:
+1. Namespaced Task when Kind is set to &ldquo;Task&rdquo;. If Kind is &ldquo;&rdquo;, it defaults to &ldquo;Task&rdquo;.
+2. Cluster-Scoped Task when Kind is set to &ldquo;ClusterTask&rdquo;
+3. Custom Task when Kind is non-empty and APIVersion is non-empty</p>
 </td>
 </tr>
 <tr>
@@ -12114,7 +12120,8 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>API version of the referent</p>
+<p>API version of the referent
+Note: A Task with non-empty APIVersion and Kind is considered a Custom Task</p>
 </td>
 </tr>
 <tr>

--- a/pkg/apis/pipeline/v1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1/openapi_generated.go
@@ -3262,14 +3262,14 @@ func schema_pkg_apis_pipeline_v1_TaskRef(ref common.ReferenceCallback) common.Op
 					},
 					"kind": {
 						SchemaProps: spec.SchemaProps{
-							Description: "TaskKind indicates the kind of the task, namespaced or cluster scoped.",
+							Description: "TaskKind indicates the Kind of the Task: 1. Namespaced Task when Kind is set to \"Task\". If Kind is \"\", it defaults to \"Task\". 2. Custom Task when Kind is non-empty and APIVersion is non-empty",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"apiVersion": {
 						SchemaProps: spec.SchemaProps{
-							Description: "API version of the referent",
+							Description: "API version of the referent Note: A Task with non-empty APIVersion and Kind is considered a Custom Task",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/apis/pipeline/v1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1/pipeline_types.go
@@ -217,6 +217,13 @@ type PipelineTask struct {
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
 }
 
+// IsCustomTask checks whether an embedded TaskSpec is a Custom Task
+func (et *EmbeddedTask) IsCustomTask() bool {
+	// Note that if `apiVersion` is set to `"tekton.dev/v1beta1"` and `kind` is set to `"Task"`,
+	// the reference will be considered a Custom Task - https://github.com/tektoncd/pipeline/issues/6457
+	return et != nil && et.APIVersion != "" && et.Kind != ""
+}
+
 // validateRefOrSpec validates at least one of taskRef or taskSpec is specified
 func (pt PipelineTask) validateRefOrSpec() (errs *apis.FieldError) {
 	// can't have both taskRef and taskSpec at the same time

--- a/pkg/apis/pipeline/v1/pipeline_types_test.go
+++ b/pkg/apis/pipeline/v1/pipeline_types_test.go
@@ -965,3 +965,48 @@ func TestPipelineTask_IsMatrixed(t *testing.T) {
 		})
 	}
 }
+
+func TestEmbeddedTask_IsCustomTask(t *testing.T) {
+	tests := []struct {
+		name string
+		et   *EmbeddedTask
+		want bool
+	}{{
+		name: "not a custom task - APIVersion and Kind are not set",
+		et:   &EmbeddedTask{},
+		want: false,
+	}, {
+		name: "not a custom task - APIVersion is not set",
+		et: &EmbeddedTask{
+			TypeMeta: runtime.TypeMeta{
+				Kind: "Example",
+			},
+		},
+		want: false,
+	}, {
+		name: "not a custom task - Kind is not set",
+		et: &EmbeddedTask{
+			TypeMeta: runtime.TypeMeta{
+				APIVersion: "example/v0",
+			},
+		},
+		want: false,
+	}, {
+		name: "custom task - APIVersion and Kind are set",
+		et: &EmbeddedTask{
+			TypeMeta: runtime.TypeMeta{
+				Kind:       "Example",
+				APIVersion: "example/v0",
+			},
+		},
+		want: true,
+	},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.et.IsCustomTask(); got != tt.want {
+				t.Errorf("IsCustomTask() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/apis/pipeline/v1/swagger.json
+++ b/pkg/apis/pipeline/v1/swagger.json
@@ -1670,11 +1670,11 @@
       "type": "object",
       "properties": {
         "apiVersion": {
-          "description": "API version of the referent",
+          "description": "API version of the referent Note: A Task with non-empty APIVersion and Kind is considered a Custom Task",
           "type": "string"
         },
         "kind": {
-          "description": "TaskKind indicates the kind of the task, namespaced or cluster scoped.",
+          "description": "TaskKind indicates the Kind of the Task: 1. Namespaced Task when Kind is set to \"Task\". If Kind is \"\", it defaults to \"Task\". 2. Custom Task when Kind is non-empty and APIVersion is non-empty",
           "type": "string"
         },
         "name": {

--- a/pkg/apis/pipeline/v1/taskref_types.go
+++ b/pkg/apis/pipeline/v1/taskref_types.go
@@ -20,9 +20,12 @@ package v1
 type TaskRef struct {
 	// Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names
 	Name string `json:"name,omitempty"`
-	// TaskKind indicates the kind of the task, namespaced or cluster scoped.
+	// TaskKind indicates the Kind of the Task:
+	// 1. Namespaced Task when Kind is set to "Task". If Kind is "", it defaults to "Task".
+	// 2. Custom Task when Kind is non-empty and APIVersion is non-empty
 	Kind TaskKind `json:"kind,omitempty"`
 	// API version of the referent
+	// Note: A Task with non-empty APIVersion and Kind is considered a Custom Task
 	// +optional
 	APIVersion string `json:"apiVersion,omitempty"`
 
@@ -40,3 +43,10 @@ const (
 	// NamespacedTaskKind indicates that the task type has a namespaced scope.
 	NamespacedTaskKind TaskKind = "Task"
 )
+
+// IsCustomTask checks whether the reference is to a Custom Task
+func (tr *TaskRef) IsCustomTask() bool {
+	// Note that if `apiVersion` is set to `"tekton.dev/v1beta1"` and `kind` is set to `"Task"`,
+	// the reference will be considered a Custom Task - https://github.com/tektoncd/pipeline/issues/6457
+	return tr != nil && tr.APIVersion != "" && tr.Kind != ""
+}

--- a/pkg/apis/pipeline/v1/taskref_types_test.go
+++ b/pkg/apis/pipeline/v1/taskref_types_test.go
@@ -1,0 +1,55 @@
+package v1
+
+import "testing"
+
+func TestTaskRef_IsCustomTask(t *testing.T) {
+	tests := []struct {
+		name string
+		tr   *TaskRef
+		want bool
+	}{{
+		name: "not a custom task - apiVersion and Kind are not set",
+		tr: &TaskRef{
+			Name: "foo",
+		},
+		want: false,
+	}, {
+		// related issue: https://github.com/tektoncd/pipeline/issues/6459
+		name: "not a custom task - apiVersion is not set",
+		tr: &TaskRef{
+			Name: "foo",
+			Kind: "Example",
+		},
+		want: false,
+	}, {
+		name: "not a custom task - kind is not set",
+		tr: &TaskRef{
+			Name:       "foo",
+			APIVersion: "example/v0",
+		},
+		want: false,
+	}, {
+		name: "custom task with name",
+		tr: &TaskRef{
+			Name:       "foo",
+			Kind:       "Example",
+			APIVersion: "example/v0",
+		},
+		want: true,
+	}, {
+		name: "custom task without name",
+		tr: &TaskRef{
+			Kind:       "Example",
+			APIVersion: "example/v0",
+		},
+		want: true,
+	},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.tr.IsCustomTask(); got != tt.want {
+				t.Errorf("IsCustomTask() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/apis/pipeline/v1beta1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1beta1/openapi_generated.go
@@ -3937,14 +3937,14 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRef(ref common.ReferenceCallback) comm
 					},
 					"kind": {
 						SchemaProps: spec.SchemaProps{
-							Description: "TaskKind indicates the kind of the task, namespaced or cluster scoped.",
+							Description: "TaskKind indicates the Kind of the Task: 1. Namespaced Task when Kind is set to \"Task\". If Kind is \"\", it defaults to \"Task\". 2. Cluster-Scoped Task when Kind is set to \"ClusterTask\" 3. Custom Task when Kind is non-empty and APIVersion is non-empty",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"apiVersion": {
 						SchemaProps: spec.SchemaProps{
-							Description: "API version of the referent",
+							Description: "API version of the referent Note: A Task with non-empty APIVersion and Kind is considered a Custom Task",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/apis/pipeline/v1beta1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types.go
@@ -223,6 +223,13 @@ type PipelineTask struct {
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
 }
 
+// IsCustomTask checks whether an embedded TaskSpec is a Custom Task
+func (et *EmbeddedTask) IsCustomTask() bool {
+	// Note that if `apiVersion` is set to `"tekton.dev/v1beta1"` and `kind` is set to `"Task"`,
+	// the reference will be considered a Custom Task - https://github.com/tektoncd/pipeline/issues/6457
+	return et != nil && et.APIVersion != "" && et.Kind != ""
+}
+
 // validateRefOrSpec validates at least one of taskRef or taskSpec is specified
 func (pt PipelineTask) validateRefOrSpec() (errs *apis.FieldError) {
 	// can't have both taskRef and taskSpec at the same time

--- a/pkg/apis/pipeline/v1beta1/pipeline_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types_test.go
@@ -939,3 +939,48 @@ func TestPipelineTask_IsMatrixed(t *testing.T) {
 		})
 	}
 }
+
+func TestEmbeddedTask_IsCustomTask(t *testing.T) {
+	tests := []struct {
+		name string
+		et   *EmbeddedTask
+		want bool
+	}{{
+		name: "not a custom task - APIVersion and Kind are not set",
+		et:   &EmbeddedTask{},
+		want: false,
+	}, {
+		name: "not a custom task - APIVersion is not set",
+		et: &EmbeddedTask{
+			TypeMeta: runtime.TypeMeta{
+				Kind: "Example",
+			},
+		},
+		want: false,
+	}, {
+		name: "not a custom task - Kind is not set",
+		et: &EmbeddedTask{
+			TypeMeta: runtime.TypeMeta{
+				APIVersion: "example/v0",
+			},
+		},
+		want: false,
+	}, {
+		name: "custom task - APIVersion and Kind are set",
+		et: &EmbeddedTask{
+			TypeMeta: runtime.TypeMeta{
+				Kind:       "Example",
+				APIVersion: "example/v0",
+			},
+		},
+		want: true,
+	},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.et.IsCustomTask(); got != tt.want {
+				t.Errorf("IsCustomTask() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/apis/pipeline/v1beta1/swagger.json
+++ b/pkg/apis/pipeline/v1beta1/swagger.json
@@ -2184,7 +2184,7 @@
       "type": "object",
       "properties": {
         "apiVersion": {
-          "description": "API version of the referent",
+          "description": "API version of the referent Note: A Task with non-empty APIVersion and Kind is considered a Custom Task",
           "type": "string"
         },
         "bundle": {
@@ -2192,7 +2192,7 @@
           "type": "string"
         },
         "kind": {
-          "description": "TaskKind indicates the kind of the task, namespaced or cluster scoped.",
+          "description": "TaskKind indicates the Kind of the Task: 1. Namespaced Task when Kind is set to \"Task\". If Kind is \"\", it defaults to \"Task\". 2. Cluster-Scoped Task when Kind is set to \"ClusterTask\" 3. Custom Task when Kind is non-empty and APIVersion is non-empty",
           "type": "string"
         },
         "name": {

--- a/pkg/apis/pipeline/v1beta1/taskref_types.go
+++ b/pkg/apis/pipeline/v1beta1/taskref_types.go
@@ -20,9 +20,13 @@ package v1beta1
 type TaskRef struct {
 	// Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names
 	Name string `json:"name,omitempty"`
-	// TaskKind indicates the kind of the task, namespaced or cluster scoped.
+	// TaskKind indicates the Kind of the Task:
+	// 1. Namespaced Task when Kind is set to "Task". If Kind is "", it defaults to "Task".
+	// 2. Cluster-Scoped Task when Kind is set to "ClusterTask"
+	// 3. Custom Task when Kind is non-empty and APIVersion is non-empty
 	Kind TaskKind `json:"kind,omitempty"`
 	// API version of the referent
+	// Note: A Task with non-empty APIVersion and Kind is considered a Custom Task
 	// +optional
 	APIVersion string `json:"apiVersion,omitempty"`
 	// Bundle url reference to a Tekton Bundle.
@@ -49,3 +53,10 @@ const (
 	// ClusterTaskKind indicates that task type has a cluster scope.
 	ClusterTaskKind TaskKind = "ClusterTask"
 )
+
+// IsCustomTask checks whether the reference is to a Custom Task
+func (tr *TaskRef) IsCustomTask() bool {
+	// Note that if `apiVersion` is set to `"tekton.dev/v1beta1"` and `kind` is set to `"Task"`,
+	// the reference will be considered a Custom Task - https://github.com/tektoncd/pipeline/issues/6457
+	return tr != nil && tr.APIVersion != "" && tr.Kind != ""
+}

--- a/pkg/apis/pipeline/v1beta1/taskref_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskref_types_test.go
@@ -1,0 +1,55 @@
+package v1beta1
+
+import "testing"
+
+func TestTaskRef_IsCustomTask(t *testing.T) {
+	tests := []struct {
+		name string
+		tr   *TaskRef
+		want bool
+	}{{
+		name: "not a custom task - apiVersion and Kind are not set",
+		tr: &TaskRef{
+			Name: "foo",
+		},
+		want: false,
+	}, {
+		// related issue: https://github.com/tektoncd/pipeline/issues/6459
+		name: "not a custom task - apiVersion is not set",
+		tr: &TaskRef{
+			Name: "foo",
+			Kind: "Example",
+		},
+		want: false,
+	}, {
+		name: "not a custom task - kind is not set",
+		tr: &TaskRef{
+			Name:       "foo",
+			APIVersion: "example/v0",
+		},
+		want: false,
+	}, {
+		name: "custom task with name",
+		tr: &TaskRef{
+			Name:       "foo",
+			Kind:       "Example",
+			APIVersion: "example/v0",
+		},
+		want: true,
+	}, {
+		name: "custom task without name",
+		tr: &TaskRef{
+			Kind:       "Example",
+			APIVersion: "example/v0",
+		},
+		want: true,
+	},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.tr.IsCustomTask(); got != tt.want {
+				t.Errorf("IsCustomTask() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -574,15 +574,6 @@ func ValidateTaskRunSpecs(p *v1beta1.PipelineSpec, pr *v1beta1.PipelineRun) erro
 	return nil
 }
 
-func isCustomTask(ctx context.Context, rpt ResolvedPipelineTask) bool {
-	invalidSpec := rpt.PipelineTask.TaskRef != nil && rpt.PipelineTask.TaskSpec != nil
-	isTaskRefCustomTask := rpt.PipelineTask.TaskRef != nil && rpt.PipelineTask.TaskRef.APIVersion != "" &&
-		rpt.PipelineTask.TaskRef.Kind != ""
-	isTaskSpecCustomTask := rpt.PipelineTask.TaskSpec != nil && rpt.PipelineTask.TaskSpec.APIVersion != "" &&
-		rpt.PipelineTask.TaskSpec.Kind != ""
-	return !invalidSpec && (isTaskRefCustomTask || isTaskSpecCustomTask)
-}
-
 // ResolvePipelineTask retrieves a single Task's instance using the getTask to fetch
 // the spec. If it is unable to retrieve an instance of a referenced Task, it  will return
 // an error, otherwise it returns a list of all the Tasks retrieved.  It will retrieve
@@ -598,7 +589,7 @@ func ResolvePipelineTask(
 	rpt := ResolvedPipelineTask{
 		PipelineTask: &pipelineTask,
 	}
-	rpt.CustomTask = isCustomTask(ctx, rpt)
+	rpt.CustomTask = rpt.PipelineTask.TaskRef.IsCustomTask() || rpt.PipelineTask.TaskSpec.IsCustomTask()
 	switch {
 	case rpt.IsCustomTask() && rpt.PipelineTask.IsMatrixed():
 		rpt.RunObjectNames = getNamesOfRuns(pipelineRun.Status.ChildReferences, pipelineTask.Name, pipelineRun.Name, pipelineTask.Matrix.CountCombinations())

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
@@ -2285,21 +2285,6 @@ func TestIsCustomTask(t *testing.T) {
 		},
 		want: true,
 	}, {
-		name: "custom both taskRef and taskSpec",
-		pt: v1beta1.PipelineTask{
-			TaskRef: &v1beta1.TaskRef{
-				APIVersion: "example.dev/v0",
-				Kind:       "Sample",
-			},
-			TaskSpec: &v1beta1.EmbeddedTask{
-				TypeMeta: runtime.TypeMeta{
-					APIVersion: "example.dev/v0",
-					Kind:       "Sample",
-				},
-			},
-		},
-		want: false,
-	}, {
 		name: "custom taskRef missing kind",
 		pt: v1beta1.PipelineTask{
 			TaskRef: &v1beta1.TaskRef{


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

In this change, we clean up the `isCustomTask` function:
- Remove unused `context.Context`.
- Remove the check that either `TaskRef` or `TaskSpec` is specified because we check that way before - see [code].
- Define the check that `TaskRef` is a `CustomTask` as a member function of `TaskRef`; and add tests for the member function.
- Define the check that `TaskSpec` is a `CustomTask` as a member function of `TaskSpec`; and add tests for the member function.
- Update the docstring for `Kind` and `APIVersion` in `TaskRef`.

There are no user-facing changes in this commit.

From this cleanup, there are two issues that have been raised that will be addressed separately:
- https://github.com/tektoncd/pipeline/issues/6457
- https://github.com/tektoncd/pipeline/issues/6459

/kind cleanup

[code]: https://github.com/tektoncd/pipeline/blob/b7d815a9d8528547994f65da097050f472bbb8b2/pkg/apis/pipeline/v1beta1/pipeline_types.go#L216-L227


# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- ~[ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing~
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- ~[ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)~
- ~[ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release~

# Release Notes

```release-note
NONE
```
