### PR TITLE
Make sure we pass the live config to the conversion webhook

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -158,6 +158,9 @@ func newConversionController(ctx context.Context, cmw configmap.Watcher) *contro
 		resolutionv1alpha1GroupVersion = resolutionv1alpha1.SchemeGroupVersion.Version
 		resolutionv1beta1GroupVersion  = resolutionv1beta1.SchemeGroupVersion.Version
 	)
+	// Decorate contexts with the current state of the config.
+	store := defaultconfig.NewStore(logging.FromContext(ctx).Named("config-store"))
+	store.WatchConfigs(cmw)
 	return conversion.NewConversionController(ctx,
 		// The path on which to serve the webhook
 		"/resource-conversion",
@@ -209,7 +212,7 @@ func newConversionController(ctx context.Context, cmw configmap.Watcher) *contro
 
 		// A function that infuses the context passed to ConvertTo/ConvertFrom/SetDefaults with custom metadata
 		func(ctx context.Context) context.Context {
-			return ctx
+			return store.ToContext(ctx)
 		},
 	)
 }


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This makes sure we pass the "live" configuration to the conversion webhook. Without this, that controller doesn't see any changes on the `feature-flags` configmap, and thus only uses the default value.

This is a relatively big problem if some part of the conversion depends on it (which was the case for `embedded-status` for example) as it would cause loss of data.

Fixes #6443 
Fixes possibly other "weird" behavior we've seen in the past or present (like https://github.com/tektoncd/pipeline/issues/5964). 

As this has been there for as long as we had conversion webhook, we need backport this to all supported LTS at least (0.44.0 and 0.41.0).

/kind bug
/cc @JeromeJu @lbernick @tektoncd/core-maintainers 

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Make sure the conversion webhook sees the live configmaps instead of the default ones
```
