### PR TITLE
Fixed nil panic scenarios.

### DIFF
--- a/test/timeout_test.go
+++ b/test/timeout_test.go
@@ -204,10 +204,13 @@ spec:
 	if err != nil {
 		t.Errorf("Error getting Taskrun: %v", err)
 	}
+	if tr == nil {
+		t.Fatalf("no TaskRun details available")
+	}
 	if tr.Status.Steps[0].Terminated == nil {
-		if tr.Status.Steps[0].Terminated.Reason != "Completed" {
-			t.Errorf("step-no-timeout should not have been terminated")
-		}
+		t.Errorf("step-no-timeout should have Completed.")
+	} else if tr.Status.Steps[0].Terminated.Reason != "Completed" {
+		t.Errorf("step-no-timeout should not have been terminated")
 	}
 	if tr.Status.Steps[2].Terminated == nil {
 		t.Errorf("step-canceled should have been canceled after step-timeout timed out")


### PR DESCRIPTION
# Changes

Prior to this change, some test failures resulted in nil panic. With this change, said failures will instead provide helpful error messages.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [N/A] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [N/A] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [N/A] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [N/A] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

/kind bug

# Release Notes

```release-note
NONE
```
