### PR TITLE
Update docstring of v1beta1.PipelineObject

### DIFF
--- a/docs/pipeline-api.md
+++ b/docs/pipeline-api.md
@@ -8924,7 +8924,7 @@ map[string]string
 <h3 id="tekton.dev/v1beta1.PipelineObject">PipelineObject
 </h3>
 <div>
-<p>PipelineObject is implemented by Pipeline and ClusterPipeline</p>
+<p>PipelineObject is implemented by Pipeline</p>
 </div>
 <h3 id="tekton.dev/v1beta1.PipelineRef">PipelineRef
 </h3>

--- a/pkg/apis/pipeline/v1beta1/pipeline_interface.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_interface.go
@@ -21,7 +21,7 @@ import (
 	"knative.dev/pkg/apis"
 )
 
-// PipelineObject is implemented by Pipeline and ClusterPipeline
+// PipelineObject is implemented by Pipeline
 type PipelineObject interface {
 	apis.Defaultable
 	PipelineMetadata() metav1.ObjectMeta


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This commit clarifies the v1beta1.PipelineObject by deleting the ClusterPipeline which had not been implemented.

/kind documentation

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [n/a] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [n/a] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [n/a] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
