### PR TITLE
Small docs fix to make the timeout field value more obvious.

### DIFF
--- a/docs/pipelineruns.md
+++ b/docs/pipelineruns.md
@@ -1141,10 +1141,6 @@ timeouts:
 All three sub-fields are optional, and will be automatically processed according to the following constraint:
 * `timeouts.pipeline >= timeouts.tasks + timeouts.finally`
 
-The global default timeout is set to 60 minutes when you first install Tekton. You can set
-a different global default timeout value using the `default-timeout-minutes` field in
-[`config/config-defaults.yaml`](./../config/config-defaults.yaml).
-
 Each `timeout` field is a `duration` conforming to Go's
 [`ParseDuration`](https://golang.org/pkg/time/#ParseDuration) format. For example, valid
 values are `1h30m`, `1h`, `1m`, and `60s`.
@@ -1152,6 +1148,10 @@ values are `1h30m`, `1h`, `1m`, and `60s`.
 If any of the sub-fields are set to "0", there is no timeout for that section of the PipelineRun,
 meaning that it will run until it completes successfully or encounters an error.
 To set `timeouts.tasks` or `timeouts.finally` to "0", you must also set `timeouts.pipeline` to "0".
+
+The global default timeout is set to 60 minutes when you first install Tekton. You can set
+a different global default timeout value using the `default-timeout-minutes` field in
+[`config/config-defaults.yaml`](./../config/config-defaults.yaml).
 
 Example timeouts usages are as follows:
 

--- a/docs/taskruns.md
+++ b/docs/taskruns.md
@@ -668,12 +668,6 @@ You can use the `timeout` field to set the `TaskRun's` desired timeout value for
 not specify this value, the global default timeout value applies (the same, to `each retry attempt`). If you set the timeout to 0,
 the `TaskRun` will have no timeout and will run until it completes successfully or fails from an error.
 
-The global default timeout is set to 60 minutes when you first install Tekton. You can set
-a different global default timeout value using the `default-timeout-minutes` field in
-[`config/config-defaults.yaml`](./../config/config-defaults.yaml). If you set the global timeout to 0,
-all `TaskRuns` that do not have a timeout set will have no timeout and will run until it completes successfully
-or fails from an error.
-
 The `timeout` value is a `duration` conforming to Go's
 [`ParseDuration`](https://golang.org/pkg/time/#ParseDuration) format. For example, valid
 values are `1h30m`, `1h`, `1m`, `60s`, and `0`.
@@ -681,6 +675,12 @@ values are `1h30m`, `1h`, `1m`, `60s`, and `0`.
 If a `TaskRun` runs longer than its timeout value, the pod associated with the `TaskRun` will be deleted. This
 means that the logs of the `TaskRun` are not preserved. The deletion of the `TaskRun` pod is necessary in order to
 stop `TaskRun` step containers from running.
+
+The global default timeout is set to 60 minutes when you first install Tekton. You can set
+a different global default timeout value using the `default-timeout-minutes` field in
+[`config/config-defaults.yaml`](./../config/config-defaults.yaml). If you set the global timeout to 0,
+all `TaskRuns` that do not have a timeout set will have no timeout and will run until it completes successfully
+or fails from an error.
 
 ### Specifying `ServiceAccount` credentials
 


### PR DESCRIPTION
# Changes

Reorders the docs for PipelineRuns and TaskRuns to mention the global default timeout after the regular timeout field. This is because the timeout field expects a Go-style durations string but the global config expects an integer number of minutes. The way it is ordered currently can make someone think that the global config expects a duration string (source: I made this mistake 😄 )

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
