### PR TITLE
Replace v1beta1.TaskObject with *v1beta1.Task in TaskRun Reconciler

### DIFF
--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -692,7 +692,7 @@ func resolveTask(
 	pipelineTask v1beta1.PipelineTask,
 ) (v1beta1.TaskSpec, string, v1beta1.TaskKind, error) {
 	var (
-		t        v1beta1.TaskObject
+		t        *v1beta1.Task
 		err      error
 		spec     v1beta1.TaskSpec
 		taskName string

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
@@ -47,7 +47,7 @@ import (
 func nopGetRun(string) (v1beta1.RunObject, error) {
 	return nil, errors.New("GetRun should not be called")
 }
-func nopGetTask(context.Context, string) (v1beta1.TaskObject, *v1beta1.ConfigSource, error) {
+func nopGetTask(context.Context, string) (*v1beta1.Task, *v1beta1.ConfigSource, error) {
 	return nil, nil, errors.New("GetTask should not be called")
 }
 func nopGetTaskRun(string) (*v1beta1.TaskRun, error) {
@@ -1871,7 +1871,7 @@ func TestResolvePipelineRun_PipelineTaskHasNoResources(t *testing.T) {
 		TaskRef: &v1beta1.TaskRef{Name: "task"},
 	}}
 
-	getTask := func(ctx context.Context, name string) (v1beta1.TaskObject, *v1beta1.ConfigSource, error) {
+	getTask := func(ctx context.Context, name string) (*v1beta1.Task, *v1beta1.ConfigSource, error) {
 		return task, nil, nil
 	}
 	getTaskRun := func(name string) (*v1beta1.TaskRun, error) { return &trs[0], nil }
@@ -1921,7 +1921,7 @@ func TestResolvePipelineRun_TaskDoesntExist(t *testing.T) {
 		}}}
 
 	// Return an error when the Task is retrieved, as if it didn't exist
-	getTask := func(ctx context.Context, name string) (v1beta1.TaskObject, *v1beta1.ConfigSource, error) {
+	getTask := func(ctx context.Context, name string) (*v1beta1.Task, *v1beta1.ConfigSource, error) {
 		return nil, nil, kerrors.NewNotFound(v1beta1.Resource("task"), name)
 	}
 	getTaskRun := func(name string) (*v1beta1.TaskRun, error) {
@@ -1962,7 +1962,7 @@ func TestResolvePipelineRun_VerificationFailed(t *testing.T) {
 			}},
 		}}}
 
-	getTask := func(ctx context.Context, name string) (v1beta1.TaskObject, *v1beta1.ConfigSource, error) {
+	getTask := func(ctx context.Context, name string) (*v1beta1.Task, *v1beta1.ConfigSource, error) {
 		return nil, nil, trustedresources.ErrResourceVerificationFailed
 	}
 	getTaskRun := func(name string) (*v1beta1.TaskRun, error) { return nil, nil }
@@ -2199,7 +2199,7 @@ func TestResolvePipeline_WhenExpressions(t *testing.T) {
 		WhenExpressions: []v1beta1.WhenExpression{ptwe1},
 	}
 
-	getTask := func(_ context.Context, name string) (v1beta1.TaskObject, *v1beta1.ConfigSource, error) {
+	getTask := func(_ context.Context, name string) (*v1beta1.Task, *v1beta1.ConfigSource, error) {
 		return task, nil, nil
 	}
 	pr := v1beta1.PipelineRun{
@@ -2232,7 +2232,7 @@ func TestIsCustomTask(t *testing.T) {
 			Name: "pipelinerun",
 		},
 	}
-	getTask := func(ctx context.Context, name string) (v1beta1.TaskObject, *v1beta1.ConfigSource, error) {
+	getTask := func(ctx context.Context, name string) (*v1beta1.Task, *v1beta1.ConfigSource, error) {
 		return task, nil, nil
 	}
 	getTaskRun := func(name string) (*v1beta1.TaskRun, error) { return nil, nil }
@@ -2999,7 +2999,7 @@ func TestIsMatrixed(t *testing.T) {
 			Name: "pipelinerun",
 		},
 	}
-	getTask := func(ctx context.Context, name string) (v1beta1.TaskObject, *v1beta1.ConfigSource, error) {
+	getTask := func(ctx context.Context, name string) (*v1beta1.Task, *v1beta1.ConfigSource, error) {
 		return task, nil, nil
 	}
 	getTaskRun := func(name string) (*v1beta1.TaskRun, error) { return &trs[0], nil }
@@ -3133,7 +3133,7 @@ func TestResolvePipelineRunTask_WithMatrix(t *testing.T) {
 		}}},
 	}
 
-	getTask := func(ctx context.Context, name string) (v1beta1.TaskObject, *v1beta1.ConfigSource, error) {
+	getTask := func(ctx context.Context, name string) (*v1beta1.Task, *v1beta1.ConfigSource, error) {
 		return task, nil, nil
 	}
 	getTaskRun := func(name string) (*v1beta1.TaskRun, error) { return taskRunsMap[name], nil }
@@ -3237,7 +3237,7 @@ func TestResolvePipelineRunTask_WithMatrixedCustomTask(t *testing.T) {
 			}}},
 	}}
 
-	getTask := func(ctx context.Context, name string) (v1beta1.TaskObject, *v1beta1.ConfigSource, error) {
+	getTask := func(ctx context.Context, name string) (*v1beta1.Task, *v1beta1.ConfigSource, error) {
 		return task, nil, nil
 	}
 	getTaskRun := func(name string) (*v1beta1.TaskRun, error) { return &trs[0], nil }

--- a/pkg/reconciler/taskrun/resources/taskref_test.go
+++ b/pkg/reconciler/taskrun/resources/taskref_test.go
@@ -184,7 +184,11 @@ func TestLocalTaskRef(t *testing.T) {
 				Name: "cluster-task",
 				Kind: "ClusterTask",
 			},
-			expected: &v1beta1.ClusterTask{
+			expected: &v1beta1.Task{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "tekton.dev/v1beta1",
+					Kind:       "Task",
+				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-task",
 				},
@@ -397,11 +401,11 @@ func TestGetTaskFunc(t *testing.T) {
 				Kind:       v1beta1.ClusterTaskKind,
 				Bundle:     u.Host + "/remote-cluster-task",
 			},
-			expected: &v1beta1.ClusterTask{
+			expected: &v1beta1.Task{
 				ObjectMeta: metav1.ObjectMeta{Name: "simple"},
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "tekton.dev/v1beta1",
-					Kind:       "ClusterTask",
+					Kind:       "Task",
 				},
 			},
 			expectedKind: v1beta1.ClusterTaskKind,
@@ -422,8 +426,21 @@ func TestGetTaskFunc(t *testing.T) {
 				Name: "simple",
 				Kind: v1beta1.ClusterTaskKind,
 			},
-			expected:     simpleClusterTask,
-			expectedKind: v1beta1.ClusterTaskKind,
+			expected: &v1beta1.Task{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "simple",
+				},
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "tekton.dev/v1beta1",
+					Kind:       "Task",
+				},
+				Spec: v1beta1.TaskSpec{
+					Steps: []v1beta1.Step{{
+						Image: "something",
+					}},
+				},
+			},
+			expectedKind: v1beta1.NamespacedTaskKind,
 		},
 	}
 
@@ -892,7 +909,7 @@ func TestGetVerifiedTaskFunc_VerifyError(t *testing.T) {
 		name                      string
 		requester                 *test.Requester
 		verificationNoMatchPolicy string
-		expected                  runtime.Object
+		expected                  *v1beta1.Task
 		expectedErr               error
 	}{{
 		name:                      "unsigned task with fails verification with fail no match policy",

--- a/pkg/reconciler/taskrun/resources/taskspec.go
+++ b/pkg/reconciler/taskrun/resources/taskspec.go
@@ -35,7 +35,7 @@ type ResolvedTask struct {
 }
 
 // GetTask is a function used to retrieve Tasks.
-type GetTask func(context.Context, string) (v1beta1.TaskObject, *v1beta1.ConfigSource, error)
+type GetTask func(context.Context, string) (*v1beta1.Task, *v1beta1.ConfigSource, error)
 
 // GetTaskRun is a function used to retrieve TaskRuns
 type GetTaskRun func(string) (*v1beta1.TaskRun, error)

--- a/pkg/reconciler/taskrun/resources/taskspec_test.go
+++ b/pkg/reconciler/taskrun/resources/taskspec_test.go
@@ -50,7 +50,7 @@ func TestGetTaskSpec_Ref(t *testing.T) {
 		},
 	}
 
-	gt := func(ctx context.Context, n string) (v1beta1.TaskObject, *v1beta1.ConfigSource, error) {
+	gt := func(ctx context.Context, n string) (*v1beta1.Task, *v1beta1.ConfigSource, error) {
 		return task, sampleConfigSource.DeepCopy(), nil
 	}
 	resolvedObjectMeta, taskSpec, err := resources.GetTaskData(context.Background(), tr, gt)
@@ -84,7 +84,7 @@ func TestGetTaskSpec_Embedded(t *testing.T) {
 			},
 		},
 	}
-	gt := func(ctx context.Context, n string) (v1beta1.TaskObject, *v1beta1.ConfigSource, error) {
+	gt := func(ctx context.Context, n string) (*v1beta1.Task, *v1beta1.ConfigSource, error) {
 		return nil, nil, errors.New("shouldn't be called")
 	}
 	resolvedObjectMeta, taskSpec, err := resources.GetTaskData(context.Background(), tr, gt)
@@ -113,7 +113,7 @@ func TestGetTaskSpec_Invalid(t *testing.T) {
 			Name: "mytaskrun",
 		},
 	}
-	gt := func(ctx context.Context, n string) (v1beta1.TaskObject, *v1beta1.ConfigSource, error) {
+	gt := func(ctx context.Context, n string) (*v1beta1.Task, *v1beta1.ConfigSource, error) {
 		return nil, nil, errors.New("shouldn't be called")
 	}
 	_, _, err := resources.GetTaskData(context.Background(), tr, gt)
@@ -133,7 +133,7 @@ func TestGetTaskSpec_Error(t *testing.T) {
 			},
 		},
 	}
-	gt := func(ctx context.Context, n string) (v1beta1.TaskObject, *v1beta1.ConfigSource, error) {
+	gt := func(ctx context.Context, n string) (*v1beta1.Task, *v1beta1.ConfigSource, error) {
 		return nil, nil, errors.New("something went wrong")
 	}
 	_, _, err := resources.GetTaskData(context.Background(), tr, gt)
@@ -173,7 +173,7 @@ func TestGetTaskData_ResolutionSuccess(t *testing.T) {
 		}},
 	}
 
-	getTask := func(ctx context.Context, n string) (v1beta1.TaskObject, *v1beta1.ConfigSource, error) {
+	getTask := func(ctx context.Context, n string) (*v1beta1.Task, *v1beta1.ConfigSource, error) {
 		return &v1beta1.Task{
 			ObjectMeta: *sourceMeta.DeepCopy(),
 			Spec:       *sourceSpec.DeepCopy(),
@@ -210,7 +210,7 @@ func TestGetPipelineData_ResolutionError(t *testing.T) {
 			},
 		},
 	}
-	getTask := func(ctx context.Context, n string) (v1beta1.TaskObject, *v1beta1.ConfigSource, error) {
+	getTask := func(ctx context.Context, n string) (*v1beta1.Task, *v1beta1.ConfigSource, error) {
 		return nil, nil, errors.New("something went wrong")
 	}
 	ctx := context.Background()
@@ -233,7 +233,7 @@ func TestGetTaskData_ResolvedNilTask(t *testing.T) {
 			},
 		},
 	}
-	getTask := func(ctx context.Context, n string) (v1beta1.TaskObject, *v1beta1.ConfigSource, error) {
+	getTask := func(ctx context.Context, n string) (*v1beta1.Task, *v1beta1.ConfigSource, error) {
 		return nil, nil, nil
 	}
 	ctx := context.Background()

--- a/pkg/trustedresources/verify.go
+++ b/pkg/trustedresources/verify.go
@@ -46,7 +46,7 @@ const (
 // Return an error when no policies are found and trusted-resources-verification-no-match-policy is set to fail,
 // or the resource fails to pass matched enforce verification policy
 // source is from ConfigSource.URI, which will be used to match policy patterns. k8s is used to fetch secret from cluster
-func VerifyTask(ctx context.Context, taskObj v1beta1.TaskObject, k8s kubernetes.Interface, source string, verificationpolicies []*v1alpha1.VerificationPolicy) error {
+func VerifyTask(ctx context.Context, taskObj *v1beta1.Task, k8s kubernetes.Interface, source string, verificationpolicies []*v1alpha1.VerificationPolicy) error {
 	matchedPolicies, err := getMatchedPolicies(taskObj.TaskMetadata().Name, source, verificationpolicies)
 	if err != nil {
 		if errors.Is(err, ErrNoMatchedPolicies) {

--- a/pkg/trustedresources/verify_test.go
+++ b/pkg/trustedresources/verify_test.go
@@ -199,7 +199,7 @@ func TestVerifyTask_Success(t *testing.T) {
 	mismatchedSource := "wrong source"
 	tcs := []struct {
 		name                      string
-		task                      v1beta1.TaskObject
+		task                      *v1beta1.Task
 		source                    string
 		signer                    signature.SignerVerifier
 		verificationNoMatchPolicy string
@@ -276,7 +276,7 @@ func TestVerifyTask_Error(t *testing.T) {
 	mismatchedSource := "wrong source"
 	tcs := []struct {
 		name               string
-		task               v1beta1.TaskObject
+		task               *v1beta1.Task
 		source             string
 		verificationPolicy []*v1alpha1.VerificationPolicy
 		expectedError      error


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This commit replaces the v1beta1.TaskObject interface with the *v1beta1.Task by converting ClusterTask to Task for resolving Tasks for TaskRun. The deprecated v1beta1 ClusterTasks are converted to Tasks since the GetTask func and its upstream callers only fetch a task spec and store it in the taskrun status while the kind info is not being used.

/kind misc
part of #5979 
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [n/a] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [n/a] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
