### PR TITLE
Update min k8s version to 1.24

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,11 +8,10 @@
 
 As the author of this PR, please check off the items in this checklist:
 
-- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
+- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
 - [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
 - [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
-- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
-  functionality, content, code)
+- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
 - [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
 - [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
 - [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -266,7 +266,7 @@ as follows.
 
 The recommended minimum development configuration is:
 
-- Kubernetes version 1.22 or later
+- Kubernetes version 1.24 or later
 - 4 (virtual) CPU nodes
   - 8 GB of (actual or virtualized) platform memory
 - Node autoscaling, up to 3 nodes
@@ -324,7 +324,7 @@ optional: As a convenience, the [Tekton plumbing project](https://github.com/tek
      --region=us-central1 \
      --machine-type=e2-standard-4 \
      --num-nodes=1 \
-     --cluster-version=1.22
+     --cluster-version=1.24
     ```
 
     > **Note**: The recommended [GCE machine type](https://cloud.google.com/compute/docs/machine-types) is `'e2-standard-4'`.

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -42,7 +42,7 @@ This document makes reference in a few places to different profiles for Tekton i
 
 The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “NOT RECOMMENDED”, “MAY”, and “OPTIONAL” are to be interpreted as described in [RFC 2119](https://tools.ietf.org/html/rfc2119).
 
-There is no formal specification of the Kubernetes API and Resource Model. This document assumes Kubernetes 1.22 behavior; this behavior will typically be supported by many future Kubernetes versions. Additionally, this document may reference specific core Kubernetes resources; these references may be illustrative (i.e. an implementation on Kubernetes) or descriptive (i.e. this Kubernetes resource MUST be exposed). References to these core Kubernetes resources will be annotated as either illustrative or descriptive.
+There is no formal specification of the Kubernetes API and Resource Model. This document assumes Kubernetes 1.24 behavior; this behavior will typically be supported by many future Kubernetes versions. Additionally, this document may reference specific core Kubernetes resources; these references may be illustrative (i.e. an implementation on Kubernetes) or descriptive (i.e. this Kubernetes resource MUST be exposed). References to these core Kubernetes resources will be annotated as either illustrative or descriptive.
 
 ## Modifying This Specification
 

--- a/docs/how-to-write-a-resolver.md
+++ b/docs/how-to-write-a-resolver.md
@@ -54,7 +54,7 @@ You'll also need the following:
 - A computer with
   [`kubectl`](https://kubernetes.io/docs/tasks/tools/#kubectl) and
   [`ko`](https://github.com/google/ko) installed.
-- A Kubernetes cluster running at least Kubernetes 1.22. A [`kind`
+- A Kubernetes cluster running at least Kubernetes 1.24. A [`kind`
   cluster](https://kind.sigs.k8s.io/docs/user/quick-start/#installation)
   should work fine for following the guide on your local machine.
 - An image registry that you can push images to. If you're using `kind`

--- a/docs/resolution-getting-started.md
+++ b/docs/resolution-getting-started.md
@@ -18,7 +18,7 @@ with a Pipeline stored in a git repo.
 
 - A computer with
   [`kubectl`](https://kubernetes.io/docs/tasks/tools/#kubectl).
-- A Kubernetes cluster running at least Kubernetes 1.22. A [`kind`
+- A Kubernetes cluster running at least Kubernetes 1.24. A [`kind`
   cluster](https://kind.sigs.k8s.io/docs/user/quick-start/#installation)
   should work fine for following the guide on your local machine.
 - An image registry that you can push images to. If you're using `kind`


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

Prior to this change, the docs indicate that the min k8s version is 1.22. However, the min k8s version was bumped to 1.23 in v0.41 and bumped to 1.24 in v0.45. This change updates the docs to the min version of v0.45.

This change also adds a reminder in the pull requests checklist to update docs of the min requirements if any have changed.

This change supersedes https://github.com/tektoncd/pipeline/pull/6366 from @bobcatfish.

Co-authored-by: Christie Warwick (Wilson) <christiewilson@google.com>

/kind documentation

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- ~[ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed~
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- ~[ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)~
- ~[ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release~

# Release Notes

```release-note
NONE
```
