### PR TITLE
Hygiene: enable `exhaustive` linter.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,6 +28,7 @@ linters:
   - errchkjson
   - errname
   - errorlint
+  - exhaustive
   - goconst
   - gocritic
   - gofmt

--- a/pkg/apis/pipeline/v1/param_types.go
+++ b/pkg/apis/pipeline/v1/param_types.go
@@ -454,6 +454,8 @@ func (paramValues *ParamValue) ApplyReplacements(stringReplacements map[string]s
 			newObjectVal[k] = substitution.ApplyReplacements(v, stringReplacements)
 		}
 		paramValues.ObjectVal = newObjectVal
+	case ParamTypeString:
+		fallthrough
 	default:
 		paramValues.applyOrCorrect(stringReplacements, arrayReplacements, objectReplacements)
 	}
@@ -543,6 +545,8 @@ func validatePipelineParametersVariablesInTaskParameters(params Params, prefix s
 			for key, val := range param.Value.ObjectVal {
 				errs = errs.Also(validateStringVariable(val, prefix, paramNames, arrayParamNames, objectParamNameKeys).ViaFieldKey("properties", key).ViaFieldKey("params", param.Name))
 			}
+		case ParamTypeString:
+			fallthrough
 		default:
 			errs = errs.Also(validateParamStringValue(param, prefix, paramNames, arrayParamNames, objectParamNameKeys))
 		}

--- a/pkg/apis/pipeline/v1/task_validation.go
+++ b/pkg/apis/pipeline/v1/task_validation.go
@@ -381,6 +381,8 @@ func ValidateParameterVariables(ctx context.Context, steps []Step, params []Para
 			arrayParameterNames.Insert(p.Name)
 		case ParamTypeObject:
 			objectParamSpecs = append(objectParamSpecs, p)
+		case ParamTypeString:
+			fallthrough
 		default:
 			stringParameterNames.Insert(p.Name)
 		}

--- a/pkg/apis/pipeline/v1beta1/param_types.go
+++ b/pkg/apis/pipeline/v1beta1/param_types.go
@@ -452,6 +452,8 @@ func (paramValues *ParamValue) ApplyReplacements(stringReplacements map[string]s
 			newObjectVal[k] = substitution.ApplyReplacements(v, stringReplacements)
 		}
 		paramValues.ObjectVal = newObjectVal
+	case ParamTypeString:
+		fallthrough
 	default:
 		paramValues.applyOrCorrect(stringReplacements, arrayReplacements, objectReplacements)
 	}
@@ -539,6 +541,8 @@ func validatePipelineParametersVariablesInTaskParameters(params Params, prefix s
 			for key, val := range param.Value.ObjectVal {
 				errs = errs.Also(validateStringVariable(val, prefix, paramNames, arrayParamNames, objectParamNameKeys).ViaFieldKey("properties", key).ViaFieldKey("params", param.Name))
 			}
+		case ParamTypeString:
+			fallthrough
 		default:
 			errs = errs.Also(validateParamStringValue(param, prefix, paramNames, arrayParamNames, objectParamNameKeys))
 		}

--- a/pkg/apis/pipeline/v1beta1/task_validation.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation.go
@@ -384,6 +384,8 @@ func ValidateParameterVariables(ctx context.Context, steps []Step, params []Para
 			arrayParameterNames.Insert(p.Name)
 		case ParamTypeObject:
 			objectParamSpecs = append(objectParamSpecs, p)
+		case ParamTypeString:
+			fallthrough
 		default:
 			stringParameterNames.Insert(p.Name)
 		}

--- a/pkg/credentials/dockercreds/creds.go
+++ b/pkg/credentials/dockercreds/creds.go
@@ -157,6 +157,10 @@ func (*basicDockerBuilder) MatchingAnnotations(secret *corev1.Secret) []string {
 		flags = append(flags, fmt.Sprintf("-docker-config=%s", secret.Name))
 	case corev1.SecretTypeDockercfg:
 		flags = append(flags, fmt.Sprintf("-docker-cfg=%s", secret.Name))
+
+	case corev1.SecretTypeOpaque, corev1.SecretTypeServiceAccountToken, corev1.SecretTypeSSHAuth, corev1.SecretTypeTLS, corev1.SecretTypeBootstrapToken:
+		return flags
+
 	default:
 		return flags
 	}

--- a/pkg/credentials/dockercreds/creds_test.go
+++ b/pkg/credentials/dockercreds/creds_test.go
@@ -210,13 +210,35 @@ func TestMatchingAnnotations(t *testing.T) {
 			"-basic-docker=ssh=keys2",
 			"-basic-docker=ssh=keys3",
 		},
+	}, {
+		secret: &corev1.Secret{
+			Type:       corev1.SecretTypeDockercfg,
+			ObjectMeta: metav1.ObjectMeta{Name: "my-dockercfg"},
+		},
+		wantFlag: []string{"-docker-cfg=my-dockercfg"},
+	}, {
+		secret: &corev1.Secret{
+			Type:       corev1.SecretTypeDockerConfigJson,
+			ObjectMeta: metav1.ObjectMeta{Name: "my-dockerconfigjson"},
+		},
+		wantFlag: []string{"-docker-config=my-dockerconfigjson"},
+	}, {
+		secret: &corev1.Secret{Type: corev1.SecretTypeOpaque},
+	}, {
+		secret: &corev1.Secret{Type: corev1.SecretTypeServiceAccountToken},
+	}, {
+		secret: &corev1.Secret{Type: corev1.SecretTypeTLS},
+	}, {
+		secret: &corev1.Secret{Type: corev1.SecretTypeBootstrapToken},
+	}, {
+		secret: &corev1.Secret{}, // An empty secret should result in no flags.
 	}}
 
 	nb := NewBuilder()
 	for _, ts := range tests {
 		gotFlag := nb.MatchingAnnotations(ts.secret)
 		if !cmp.Equal(ts.wantFlag, gotFlag) {
-			t.Errorf("MatchingAnnotations() Mismatch of flags; wanted: %v got: %v ", ts.wantFlag, gotFlag)
+			t.Errorf("Mismatch of flags for %v; want: %v got: %v ", ts.secret.Type, ts.wantFlag, gotFlag)
 		}
 	}
 }

--- a/pkg/credentials/gitcreds/creds.go
+++ b/pkg/credentials/gitcreds/creds.go
@@ -66,6 +66,9 @@ func (*gitConfigBuilder) MatchingAnnotations(secret *corev1.Secret) []string {
 	case corev1.SecretTypeSSHAuth:
 		flagName = sshFlag
 
+	case corev1.SecretTypeOpaque, corev1.SecretTypeServiceAccountToken, corev1.SecretTypeDockercfg, corev1.SecretTypeDockerConfigJson, corev1.SecretTypeTLS, corev1.SecretTypeBootstrapToken:
+		return flags
+
 	default:
 		return flags
 	}

--- a/pkg/credentials/gitcreds/creds_test.go
+++ b/pkg/credentials/gitcreds/creds_test.go
@@ -438,6 +438,20 @@ func TestMatchingAnnotations(t *testing.T) {
 			},
 		},
 		wantFlag: []string{fmt.Sprintf("-%s=ssh=keys1", sshFlag), fmt.Sprintf("-%s=ssh=keys2", sshFlag), fmt.Sprintf("-%s=ssh=keys3", sshFlag)},
+	}, {
+		secret: &corev1.Secret{Type: corev1.SecretTypeOpaque},
+	}, {
+		secret: &corev1.Secret{Type: corev1.SecretTypeServiceAccountToken},
+	}, {
+		secret: &corev1.Secret{Type: corev1.SecretTypeDockercfg},
+	}, {
+		secret: &corev1.Secret{Type: corev1.SecretTypeDockerConfigJson},
+	}, {
+		secret: &corev1.Secret{Type: corev1.SecretTypeTLS},
+	}, {
+		secret: &corev1.Secret{Type: corev1.SecretTypeBootstrapToken},
+	}, {
+		secret: &corev1.Secret{}, // An empty secret should result in no flags.
 	}}
 
 	nb := NewBuilder()

--- a/pkg/pod/status.go
+++ b/pkg/pod/status.go
@@ -380,6 +380,8 @@ func updateIncompleteTaskRunStatus(trs *v1beta1.TaskRunStatus, pod *corev1.Pod) 
 		default:
 			markStatusRunning(trs, ReasonPending, getWaitingMessage(pod))
 		}
+	case corev1.PodSucceeded, corev1.PodFailed, corev1.PodUnknown:
+		// Do nothing; pod has completed or is in an unknown state.
 	}
 }
 

--- a/pkg/reconciler/pipelinerun/resources/apply.go
+++ b/pkg/reconciler/pipelinerun/resources/apply.go
@@ -78,6 +78,8 @@ func ApplyParameters(ctx context.Context, p *v1beta1.PipelineSpec, pr *v1beta1.P
 				for k, v := range p.Default.ObjectVal {
 					stringReplacements[fmt.Sprintf(objectIndividualVariablePattern, p.Name, k)] = v
 				}
+			case v1beta1.ParamTypeString:
+				fallthrough
 			default:
 				for _, pattern := range paramPatterns {
 					stringReplacements[fmt.Sprintf(pattern, p.Name)] = p.Default.StringVal
@@ -127,6 +129,8 @@ func paramsFromPipelineRun(ctx context.Context, pr *v1beta1.PipelineRun) (map[st
 			for k, v := range p.Value.ObjectVal {
 				stringReplacements[fmt.Sprintf(objectIndividualVariablePattern, p.Name, k)] = v
 			}
+		case v1beta1.ParamTypeString:
+			fallthrough
 		default:
 			for _, pattern := range paramPatterns {
 				stringReplacements[fmt.Sprintf(pattern, p.Name)] = p.Value.StringVal

--- a/pkg/reconciler/pipelinerun/resources/resultrefresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/resultrefresolution.go
@@ -198,6 +198,8 @@ func (rs ResolvedResultRefs) getStringReplacements() map[string]string {
 				}
 			}
 
+		case v1beta1.ParamTypeString:
+			fallthrough
 		default:
 			for _, target := range r.getReplaceTarget() {
 				replacements[target] = r.Value.StringVal

--- a/pkg/reconciler/taskrun/resources/apply.go
+++ b/pkg/reconciler/taskrun/resources/apply.go
@@ -74,6 +74,8 @@ func ApplyParameters(ctx context.Context, spec *v1beta1.TaskSpec, tr *v1beta1.Ta
 				for k, v := range p.Default.ObjectVal {
 					stringReplacements[fmt.Sprintf(objectIndividualVariablePattern, p.Name, k)] = v
 				}
+			case v1beta1.ParamTypeString:
+				fallthrough
 			default:
 				for _, pattern := range paramPatterns {
 					stringReplacements[fmt.Sprintf(pattern, p.Name)] = p.Default.StringVal
@@ -115,6 +117,8 @@ func paramsFromTaskRun(ctx context.Context, tr *v1beta1.TaskRun) (map[string]str
 			for k, v := range p.Value.ObjectVal {
 				stringReplacements[fmt.Sprintf(objectIndividualVariablePattern, p.Name, k)] = v
 			}
+		case v1beta1.ParamTypeString:
+			fallthrough
 		default:
 			for _, pattern := range paramPatterns {
 				stringReplacements[fmt.Sprintf(pattern, p.Name)] = p.Value.StringVal


### PR DESCRIPTION
# Changes

The [exhaustive](https://pkg.go.dev/github.com/nishanths/exhaustive) linter checks exhaustiveness of switch statements, ensuring completeness of given cases.

There are no expected functional changes in this CL.

Context: https://github.com/tektoncd/pipeline/issues/5899

/kind cleanup

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [N/A] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [N/A] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [N/A] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [N/A] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
