### PR TITLE
chore: add all optional parameters default value for config-observability configmap

### DIFF
--- a/config/config-observability.yaml
+++ b/config/config-observability.yaml
@@ -40,21 +40,44 @@ data:
     # metrics.backend-destination field specifies the system metrics destination.
     # It supports either prometheus (the default) or stackdriver.
     # Note: Using Stackdriver will incur additional charges.
-    metrics.backend-destination: prometheus
 
     # metrics.stackdriver-project-id field specifies the Stackdriver project ID. This
     # field is optional. When running on GCE, application default credentials will be
     # used and metrics will be sent to the cluster's project if this field is
     # not provided.
-    metrics.stackdriver-project-id: "<your stackdriver project id>"
 
     # metrics.allow-stackdriver-custom-metrics indicates whether it is allowed
     # to send metrics to Stackdriver using "global" resource type and custom
     # metric type. Setting this flag to "true" could cause extra Stackdriver
     # charge.  If metrics.backend-destination is not Stackdriver, this is
     # ignored.
+
+    # logging.enable-var-log-collection specifies whether the logs under /var/log/ should be available
+    # for collection on the host node by the fluentd daemon set.
+
+    # logging.revision-url-template is a string containing the logging url template where
+    # the variable REVISION_UID will be replaced with the created revision's UID.
+
+    # logging.request-log-template is the go template to use to shape the request logs.
+
+    # logging.enable-request-log enables activator/queue-proxy to write request logs.
+
+    # profiling.enable indicates whether it is allowed to retrieve runtime profiling data from
+    # the pods via an HTTP server in the format expected by the pprof visualization tool.
+
+    # metrics.opencensus-address specifies the metrics collector address. This is only used
+    # when the metrics backend is opencensus.
+
     metrics.allow-stackdriver-custom-metrics: "false"
     metrics.taskrun.level: "task"
     metrics.taskrun.duration-type: "histogram"
     metrics.pipelinerun.level: "pipeline"
     metrics.pipelinerun.duration-type: "histogram"
+    logging.enable-var-log-collection: "false"
+    logging.revision-url-template: ""
+    logging.request-log-template: '{"httpRequest": {"requestMethod": "{{.Request.Method}}", "requestUrl": "{{js .Request.RequestURI}}", "requestSize": "{{.Request.ContentLength}}", "status": {{.Response.Code}}, "responseSize": "{{.Response.Size}}", "userAgent": "{{js .Request.UserAgent}}", "remoteIp": "{{js .Request.RemoteAddr}}", "serverIp": "{{.Revision.PodIP}}", "referer": "{{js .Request.Referer}}", "latency": "{{.Response.Latency}}s", "protocol": "{{.Request.Proto}}"}, "traceId": "{{index .Request.Header "X-B3-Traceid"}}"}'
+    logging.enable-probe-request-log: "false"
+    metrics.request-metrics-backend-destination: "prometheus"
+    metrics.stackdriver-project-id: "<your stackdriver project id>"
+    profiling.enable: "false"
+    metrics.opencensus-address: ""


### PR DESCRIPTION
# Changes
#6490 
add all optional parameters default value for `config-observability` configmap yaml
help users know more clearly about configuring observability options

there are all [optional parameters](https://github.com/knative/pkg/blob/ee73c9355c9d6d17bef0bb5403fa303758e07d58/metrics/config_observability.go#L30-L51)

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
