### PR TITLE
Export required Conversions for Reconciling the Deprecated CustomRun

### DIFF
--- a/pkg/apis/pipeline/v1beta1/param_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/param_conversion.go
@@ -61,7 +61,8 @@ func (p Param) convertTo(ctx context.Context, sink *v1.Param) {
 	sink.Value = newValue
 }
 
-func (p *Param) convertFrom(ctx context.Context, source v1.Param) {
+// ConvertFrom v1 Param is exported for reconciling the deprecated v1beta1 CustomRun
+func (p *Param) ConvertFrom(ctx context.Context, source v1.Param) {
 	p.Name = source.Name
 	newValue := ParamValue{}
 	newValue.convertFrom(ctx, source.Value)

--- a/pkg/apis/pipeline/v1beta1/pipeline_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_conversion.go
@@ -189,7 +189,7 @@ func (pt *PipelineTask) convertFrom(ctx context.Context, source v1.PipelineTask)
 	pt.Description = source.Description
 	if source.TaskRef != nil {
 		newTaskRef := TaskRef{}
-		newTaskRef.convertFrom(ctx, *source.TaskRef)
+		newTaskRef.ConvertFrom(ctx, *source.TaskRef)
 		pt.TaskRef = &newTaskRef
 	}
 	if source.TaskSpec != nil {
@@ -211,7 +211,7 @@ func (pt *PipelineTask) convertFrom(ctx context.Context, source v1.PipelineTask)
 	pt.Params = nil
 	for _, p := range source.Params {
 		new := Param{}
-		new.convertFrom(ctx, p)
+		new.ConvertFrom(ctx, p)
 		pt.Params = append(pt.Params, new)
 	}
 	pt.Matrix = nil
@@ -278,7 +278,7 @@ func (m *Matrix) convertTo(ctx context.Context, sink *v1.Matrix) {
 func (m *Matrix) convertFrom(ctx context.Context, source v1.Matrix) {
 	for _, param := range source.Params {
 		new := Param{}
-		new.convertFrom(ctx, param)
+		new.ConvertFrom(ctx, param)
 		m.Params = append(m.Params, new)
 	}
 
@@ -286,7 +286,7 @@ func (m *Matrix) convertFrom(ctx context.Context, source v1.Matrix) {
 		m.Include = append(m.Include, IncludeParams{Name: include.Name})
 		for _, p := range include.Params {
 			new := Param{}
-			new.convertFrom(ctx, p)
+			new.ConvertFrom(ctx, p)
 			m.Include[i].Params = append(m.Include[i].Params, new)
 		}
 	}

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_conversion.go
@@ -121,7 +121,7 @@ func (prs *PipelineRunSpec) ConvertFrom(ctx context.Context, source *v1.Pipeline
 	prs.Params = nil
 	for _, p := range source.Params {
 		new := Param{}
-		new.convertFrom(ctx, p)
+		new.ConvertFrom(ctx, p)
 		prs.Params = append(prs.Params, new)
 	}
 	prs.ServiceAccountName = source.TaskRunTemplate.ServiceAccountName
@@ -135,7 +135,7 @@ func (prs *PipelineRunSpec) ConvertFrom(ctx context.Context, source *v1.Pipeline
 	prs.Workspaces = nil
 	for _, w := range source.Workspaces {
 		new := WorkspaceBinding{}
-		new.convertFrom(ctx, w)
+		new.ConvertFrom(ctx, w)
 		prs.Workspaces = append(prs.Workspaces, new)
 	}
 	prs.TaskRunSpecs = nil

--- a/pkg/apis/pipeline/v1beta1/resolver_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/resolver_conversion.go
@@ -21,7 +21,7 @@ func (rr *ResolverRef) convertFrom(ctx context.Context, source v1.ResolverRef) {
 	rr.Params = nil
 	for _, r := range source.Params {
 		new := Param{}
-		new.convertFrom(ctx, r)
+		new.ConvertFrom(ctx, r)
 		rr.Params = append(rr.Params, new)
 	}
 }

--- a/pkg/apis/pipeline/v1beta1/taskref_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/taskref_conversion.go
@@ -18,7 +18,8 @@ func (tr TaskRef) convertTo(ctx context.Context, sink *v1.TaskRef) {
 	tr.convertBundleToResolver(sink)
 }
 
-func (tr *TaskRef) convertFrom(ctx context.Context, source v1.TaskRef) {
+// ConvertFrom v1 TaskRef is exported for reconciling the deprecated v1beta1 CustomRun
+func (tr *TaskRef) ConvertFrom(ctx context.Context, source v1.TaskRef) {
 	tr.Name = source.Name
 	tr.Kind = TaskKind(source.Kind)
 	tr.APIVersion = source.APIVersion

--- a/pkg/apis/pipeline/v1beta1/taskrun_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_conversion.go
@@ -140,13 +140,13 @@ func (trs *TaskRunSpec) ConvertFrom(ctx context.Context, source *v1.TaskRunSpec)
 	trs.Params = nil
 	for _, p := range source.Params {
 		new := Param{}
-		new.convertFrom(ctx, p)
+		new.ConvertFrom(ctx, p)
 		trs.Params = append(trs.Params, new)
 	}
 	trs.ServiceAccountName = source.ServiceAccountName
 	if source.TaskRef != nil {
 		newTaskRef := TaskRef{}
-		newTaskRef.convertFrom(ctx, *source.TaskRef)
+		newTaskRef.ConvertFrom(ctx, *source.TaskRef)
 		trs.TaskRef = &newTaskRef
 	}
 	if source.TaskSpec != nil {
@@ -165,7 +165,7 @@ func (trs *TaskRunSpec) ConvertFrom(ctx context.Context, source *v1.TaskRunSpec)
 	trs.Workspaces = nil
 	for _, w := range source.Workspaces {
 		new := WorkspaceBinding{}
-		new.convertFrom(ctx, w)
+		new.ConvertFrom(ctx, w)
 		trs.Workspaces = append(trs.Workspaces, new)
 	}
 	trs.StepOverrides = nil

--- a/pkg/apis/pipeline/v1beta1/workspace_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/workspace_conversion.go
@@ -68,7 +68,8 @@ func (w WorkspaceBinding) convertTo(ctx context.Context, sink *v1.WorkspaceBindi
 	sink.CSI = w.CSI
 }
 
-func (w *WorkspaceBinding) convertFrom(ctx context.Context, source v1.WorkspaceBinding) {
+// ConvertFrom v1 WorkspaceBinding is exported for reconciling the deprecated v1beta1 CustomRun
+func (w *WorkspaceBinding) ConvertFrom(ctx context.Context, source v1.WorkspaceBinding) {
 	w.Name = source.Name
 	w.SubPath = source.SubPath
 	w.VolumeClaimTemplate = source.VolumeClaimTemplate


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This commit exports the required conversions for reconciling v1beta1
CustomRun in the PipelineRun reconciler. It involves the following
ConvertFrom funcs:
- Param
- WorkspaceBinding
- TaskRef

ie. we would want to convert the fields back in v1beta1 at https://github.com/tektoncd/pipeline/blob/main/pkg/reconciler/pipelinerun/pipelinerun.go#L970-L975

part of #5541
/kind misc
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [n/a] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [n/a] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
