### PR TITLE
hotfix 0.41.x no logs in stdout/stderr if uses stdoutConfig

### DIFF
--- a/cmd/entrypoint/runner.go
+++ b/cmd/entrypoint/runner.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -84,26 +83,25 @@ func (rr *realRunner) Run(ctx context.Context, args ...string) error {
 
 	cmd := exec.CommandContext(ctx, name, args...)
 
-	// Build a list of tee readers that we'll read from after the command is
-	// is started. If we are not configured to tee stdout/stderr this will be
-	// empty and contents will not be copied.
-	var readers []*namedReader
+	// if a standard output file is specified
+	// create the log file and add to the std multi writer
 	if rr.stdoutPath != "" {
-		stdout, err := newTeeReader(cmd.StdoutPipe, rr.stdoutPath)
+		stdout, err := newStdLogWriter(rr.stdoutPath)
 		if err != nil {
 			return err
 		}
-		readers = append(readers, stdout)
+		defer stdout.Close()
+		cmd.Stdout = io.MultiWriter(os.Stdout, stdout)
 	} else {
-		// This needs to be set in an else since StdoutPipe will fail if cmd.Stdout is already set.
 		cmd.Stdout = os.Stdout
 	}
 	if rr.stderrPath != "" {
-		stderr, err := newTeeReader(cmd.StderrPipe, rr.stderrPath)
+		stderr, err := newStdLogWriter(rr.stderrPath)
 		if err != nil {
 			return err
 		}
-		readers = append(readers, stderr)
+		defer stderr.Close()
+		cmd.Stderr = io.MultiWriter(os.Stderr, stderr)
 	} else {
 		cmd.Stderr = os.Stderr
 	}
@@ -134,22 +132,6 @@ func (rr *realRunner) Run(ctx context.Context, args ...string) error {
 		}
 	}()
 
-	wg := new(sync.WaitGroup)
-	for _, r := range readers {
-		wg.Add(1)
-		// Read concurrently so that we can pipe stdout and stderr at the same
-		// time.
-		go func(r *namedReader) {
-			defer wg.Done()
-			if _, err := io.ReadAll(r); err != nil {
-				log.Printf("error reading to %s: %v", r.name, err)
-			}
-		}(r)
-	}
-
-	// Wait for stdout/err buffers to finish reading before returning.
-	wg.Wait()
-
 	// Wait for command to exit
 	if err := cmd.Wait(); err != nil {
 		if ctx.Err() == context.DeadlineExceeded {
@@ -161,36 +143,18 @@ func (rr *realRunner) Run(ctx context.Context, args ...string) error {
 	return nil
 }
 
-// newTeeReader creates a new Reader that copies data from the given pipe function
-// (i.e. cmd.StdoutPipe, cmd.StderrPipe) into a file specified by path.
-// The file is opened with os.O_WRONLY|os.O_CREATE|os.O_APPEND, and will not
+// newStdLogWriter create a new file writer that used for collecting std log
+// the file is opened with os.O_WRONLY|os.O_CREATE|os.O_APPEND, and will not
 // override any existing content in the path. This means that the same file can
-// be used for multiple streams if desired.
-// The behavior of the Reader is the same as io.TeeReader - reads from the pipe
-// will be written to the file.
-func newTeeReader(pipe func() (io.ReadCloser, error), path string) (*namedReader, error) {
-	in, err := pipe()
-	if err != nil {
-		return nil, fmt.Errorf("error creating pipe: %w", err)
-	}
-
+// be used for multiple streams if desired. note that close after use
+func newStdLogWriter(path string) (*os.File, error) {
 	if err := os.MkdirAll(filepath.Dir(path), os.ModePerm); err != nil {
 		return nil, fmt.Errorf("error creating parent directory: %w", err)
 	}
-	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0600)
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
 	if err != nil {
 		return nil, fmt.Errorf("error opening %s: %w", path, err)
 	}
 
-	return &namedReader{
-		name:   path,
-		Reader: io.TeeReader(in, f),
-	}, nil
-}
-
-// namedReader is just a helper struct that lets us give a reader a name for
-// logging purposes.
-type namedReader struct {
-	io.Reader
-	name string
+	return f, nil
 }


### PR DESCRIPTION
 [source fix pr](https://github.com/tektoncd/pipeline/pull/6162)

used to only collect stdout and err to a file if the std{out/err}Path is specified, now add both os.std{out/err} and the std{out/err}Path to multiwriter to collect logs

io/ioutil has been deprecaed in Go 1.16

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
users can still view the output through the Pod log API if stdoutConfig.path or stderrConfig.path is specified
```
