### PR TITLE
Fix resolutionrequest conversion

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -166,7 +166,9 @@ func newConversionController(ctx context.Context, cmw configmap.Watcher) *contro
 		"/resource-conversion",
 
 		// Specify the types of custom resource definitions that should be converted
-		// "HubVersion" is the stored version, and "Zygotes" are the supported versions
+		// "HubVersion" specifies which version of the CustomResource supports
+		// conversions to and from all types.
+		// "Zygotes" are the supported versions.
 		map[schema.GroupKind]conversion.GroupKindConversion{
 			v1.Kind("Task"): {
 				DefinitionName: pipeline.TaskResource.String(),
@@ -202,7 +204,7 @@ func newConversionController(ctx context.Context, cmw configmap.Watcher) *contro
 			},
 			resolutionv1beta1.Kind("ResolutionRequest"): {
 				DefinitionName: resolution.ResolutionRequestResource.String(),
-				HubVersion:     resolutionv1beta1GroupVersion,
+				HubVersion:     resolutionv1alpha1GroupVersion,
 				Zygotes: map[string]conversion.ConvertibleObject{
 					resolutionv1alpha1GroupVersion: &resolutionv1alpha1.ResolutionRequest{},
 					resolutionv1beta1GroupVersion:  &resolutionv1beta1.ResolutionRequest{},


### PR DESCRIPTION
This commit addresses two issues with ResolutionRequest conversion. First, it updates the "hubVersion" to v1alpha1, since v1alpha1 is the version that supports conversion between versions, and addresses an incorrect comment about what "hubVersion" represents.

Second, it adds conversion for ResolutionRequest statuses.
It updates tests to test the round trip conversion instead of one-way conversion,
as this helps avoid bugs with copy-paste.

/kind bug
Closes https://github.com/tektoncd/pipeline/issues/6442
Closes https://github.com/tektoncd/pipeline/issues/6075
Closes https://github.com/tektoncd/pipeline/issues/5873

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- n/a Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- n/a Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
bug fix: reduced webhook log spam related to conversion of ResolutionRequests
```
