### PR TITLE
feat/Cancel taskrun using entrypoint binary

### DIFF
--- a/cmd/entrypoint/waiter_test.go
+++ b/cmd/entrypoint/waiter_test.go
@@ -17,11 +17,14 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"errors"
 	"os"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/tektoncd/pipeline/pkg/entrypoint"
 )
 
 const testWaitPollingInterval = 50 * time.Millisecond
@@ -38,7 +41,7 @@ func TestRealWaiterWaitMissingFile(t *testing.T) {
 	rw := realWaiter{}
 	doneCh := make(chan struct{})
 	go func() {
-		err := rw.setWaitPollingInterval(testWaitPollingInterval).Wait(tmp.Name(), false, false)
+		err := rw.setWaitPollingInterval(testWaitPollingInterval).Wait(context.Background(), tmp.Name(), false, false)
 		if err != nil {
 			t.Errorf("error waiting on tmp file %q", tmp.Name())
 		}
@@ -66,7 +69,7 @@ func TestRealWaiterWaitWithFile(t *testing.T) {
 	rw := realWaiter{}
 	doneCh := make(chan struct{})
 	go func() {
-		err := rw.setWaitPollingInterval(testWaitPollingInterval).Wait(tmp.Name(), false, false)
+		err := rw.setWaitPollingInterval(testWaitPollingInterval).Wait(context.Background(), tmp.Name(), false, false)
 		if err != nil {
 			t.Errorf("error waiting on tmp file %q", tmp.Name())
 		}
@@ -90,7 +93,7 @@ func TestRealWaiterWaitMissingContent(t *testing.T) {
 	rw := realWaiter{}
 	doneCh := make(chan struct{})
 	go func() {
-		err := rw.setWaitPollingInterval(testWaitPollingInterval).Wait(tmp.Name(), true, false)
+		err := rw.setWaitPollingInterval(testWaitPollingInterval).Wait(context.Background(), tmp.Name(), true, false)
 		if err != nil {
 			t.Errorf("error waiting on tmp file %q", tmp.Name())
 		}
@@ -117,7 +120,7 @@ func TestRealWaiterWaitWithContent(t *testing.T) {
 	rw := realWaiter{}
 	doneCh := make(chan struct{})
 	go func() {
-		err := rw.setWaitPollingInterval(testWaitPollingInterval).Wait(tmp.Name(), true, false)
+		err := rw.setWaitPollingInterval(testWaitPollingInterval).Wait(context.Background(), tmp.Name(), true, false)
 		if err != nil {
 			t.Errorf("error waiting on tmp file %q", tmp.Name())
 		}
@@ -146,7 +149,7 @@ func TestRealWaiterWaitWithErrorWaitfile(t *testing.T) {
 	doneCh := make(chan struct{})
 	go func() {
 		// error of type skipError is returned after encountering a error waitfile
-		err := rw.setWaitPollingInterval(testWaitPollingInterval).Wait(tmpFileName, false, false)
+		err := rw.setWaitPollingInterval(testWaitPollingInterval).Wait(context.Background(), tmpFileName, false, false)
 		if err == nil {
 			t.Errorf("expected skipError upon encounter error waitfile")
 		}
@@ -177,7 +180,7 @@ func TestRealWaiterWaitWithBreakpointOnFailure(t *testing.T) {
 	doneCh := make(chan struct{})
 	go func() {
 		// When breakpoint on failure is enabled skipError shouldn't be returned for a error waitfile
-		err := rw.setWaitPollingInterval(testWaitPollingInterval).Wait(tmpFileName, false, true)
+		err := rw.setWaitPollingInterval(testWaitPollingInterval).Wait(context.Background(), tmpFileName, false, true)
 		if err != nil {
 			t.Errorf("error waiting on tmp file %q", tmp.Name())
 		}
@@ -189,5 +192,176 @@ func TestRealWaiterWaitWithBreakpointOnFailure(t *testing.T) {
 		// Success
 	case <-delay.C:
 		t.Errorf("expected Wait() to have detected a non-zero file size by now")
+	}
+}
+
+func TestRealWaiterWaitWithContextCanceled(t *testing.T) {
+	tmp, err := os.CreateTemp("", "real_waiter_test_file")
+	if err != nil {
+		t.Errorf("error creating temp file: %v", err)
+	}
+	defer os.Remove(tmp.Name())
+	ctx, cancel := context.WithCancel(context.Background())
+	rw := realWaiter{}
+	errCh := make(chan error)
+	go func() {
+		err := rw.setWaitPollingInterval(testWaitPollingInterval).Wait(ctx, tmp.Name(), true, false)
+		if err == nil {
+			t.Errorf("expected context canceled error")
+		}
+		errCh <- err
+	}()
+	cancel()
+	delay := time.NewTimer(2 * testWaitPollingInterval)
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, entrypoint.ErrContextCanceled) {
+			t.Errorf("expected ErrContextCanceled, got %T", err)
+		}
+	case <-delay.C:
+		t.Errorf("expected Wait() to have a ErrContextCanceled")
+	}
+}
+
+func TestRealWaiterWaitWithTimeout(t *testing.T) {
+	tmp, err := os.CreateTemp("", "real_waiter_test_file")
+	if err != nil {
+		t.Errorf("error creating temp file: %v", err)
+	}
+	defer os.Remove(tmp.Name())
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+	defer cancel()
+	rw := realWaiter{}
+	errCh := make(chan error)
+	go func() {
+		err := rw.setWaitPollingInterval(testWaitPollingInterval).Wait(ctx, tmp.Name(), true, false)
+		if err == nil {
+			t.Errorf("expected context deadline error")
+		}
+		errCh <- err
+	}()
+	delay := time.NewTimer(2 * time.Second)
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, entrypoint.ErrContextDeadlineExceeded) {
+			t.Errorf("expected ErrContextDeadlineExceeded, got %T", err)
+		}
+	case <-delay.C:
+		t.Errorf("expected Wait() to have a ErrContextDeadlineExceeded")
+	}
+}
+
+func TestRealWaiterWaitContextWithBreakpointOnFailure(t *testing.T) {
+	tmp, err := os.CreateTemp("", "real_waiter_test_file*.err")
+	if err != nil {
+		t.Errorf("error creating temp file: %v", err)
+	}
+	tmpFileName := strings.Replace(tmp.Name(), ".err", "", 1)
+	defer os.Remove(tmp.Name())
+	rw := realWaiter{}
+	doneCh := make(chan struct{})
+	go func() {
+		// When breakpoint on failure is enabled skipError shouldn't be returned for a error waitfile
+		err := rw.setWaitPollingInterval(testWaitPollingInterval).Wait(context.Background(), tmpFileName, false, true)
+		if err != nil {
+			t.Errorf("error waiting on tmp file %q", tmp.Name())
+		}
+		close(doneCh)
+	}()
+	delay := time.NewTimer(2 * testWaitPollingInterval)
+	select {
+	case <-doneCh:
+		// Success
+	case <-delay.C:
+		t.Errorf("expected Wait() to have detected a non-zero file size by now")
+	}
+}
+
+func TestRealWaiterWaitContextWithErrorWaitfile(t *testing.T) {
+	tmp, err := os.CreateTemp("", "real_waiter_test_file*.err")
+	if err != nil {
+		t.Errorf("error creating temp file: %v", err)
+	}
+	tmpFileName := strings.Replace(tmp.Name(), ".err", "", 1)
+	defer os.Remove(tmp.Name())
+	rw := realWaiter{}
+	doneCh := make(chan struct{})
+	go func() {
+		// error of type skipError is returned after encountering a error waitfile
+		err := rw.setWaitPollingInterval(testWaitPollingInterval).Wait(context.Background(), tmpFileName, false, false)
+		if err == nil {
+			t.Errorf("expected skipError upon encounter error waitfile")
+		}
+		var skipErr skipError
+		if errors.As(err, &skipErr) {
+			close(doneCh)
+		} else {
+			t.Errorf("unexpected error type %T", err)
+		}
+	}()
+	delay := time.NewTimer(10 * testWaitPollingInterval)
+	select {
+	case <-doneCh:
+		// Success
+	case <-delay.C:
+		t.Errorf("expected Wait() to have detected a non-zero file size by now")
+	}
+}
+
+func TestRealWaiterWaitContextWithContent(t *testing.T) {
+	tmp, err := os.CreateTemp("", "real_waiter_test_file")
+	if err != nil {
+		t.Errorf("error creating temp file: %v", err)
+	}
+	defer os.Remove(tmp.Name())
+	rw := realWaiter{}
+	doneCh := make(chan struct{})
+	go func() {
+		err := rw.setWaitPollingInterval(testWaitPollingInterval).Wait(context.Background(), tmp.Name(), true, false)
+		if err != nil {
+			t.Errorf("error waiting on tmp file %q", tmp.Name())
+		}
+		close(doneCh)
+	}()
+	if err := os.WriteFile(tmp.Name(), []byte("😺"), 0700); err != nil {
+		t.Errorf("error writing content to temp file: %v", err)
+	}
+	delay := time.NewTimer(2 * testWaitPollingInterval)
+	select {
+	case <-doneCh:
+		// Success
+	case <-delay.C:
+		t.Errorf("expected Wait() to have detected a non-zero file size by now")
+	}
+}
+
+func TestRealWaiterWaitContextMissingFile(t *testing.T) {
+	// Create a temp file and then immediately delete it to get
+	// a legitimate tmp path and ensure the file doesnt exist
+	// prior to testing Wait().
+	tmp, err := os.CreateTemp("", "real_waiter_test_file")
+	if err != nil {
+		t.Errorf("error creating temp file: %v", err)
+	}
+	os.Remove(tmp.Name())
+	rw := realWaiter{}
+	doneCh := make(chan struct{})
+	go func() {
+		err := rw.setWaitPollingInterval(testWaitPollingInterval).Wait(context.Background(), tmp.Name(), false, false)
+		if err != nil {
+			t.Errorf("error waiting on tmp file %q", tmp.Name())
+		}
+		close(doneCh)
+	}()
+
+	delay := time.NewTimer(2 * testWaitPollingInterval)
+	select {
+	case <-delay.C:
+		// Success
+	case <-doneCh:
+		t.Errorf("did not expect Wait() to have detected a file at path %q", tmp.Name())
+		if !delay.Stop() {
+			<-delay.C
+		}
 	}
 }

--- a/config/config-feature-flags.yaml
+++ b/config/config-feature-flags.yaml
@@ -118,3 +118,6 @@ data:
   # This allows TaskRuns to run in namespaces with "restricted" pod security standards.
   # Not all Kubernetes implementations support this option.
   set-security-context: "false"
+  # Setting this flag to "true" will keep pod on cancellation
+  # allowing examination of the logs on the pods from cancelled taskruns
+  keep-pod-on-cancel: "false"

--- a/docs/additional-configs.md
+++ b/docs/additional-configs.md
@@ -316,7 +316,8 @@ Features currently in "alpha" are:
 | [Trusted Resources](./trusted-resources.md)                                                         | [TEP-0091](https://github.com/tektoncd/community/blob/main/teps/0091-trusted-resources.md)                                 | N/A                                                                  | `trusted-resources-verification-no-match-policy`  |
 | [Larger Results via Sidecar Logs](#enabling-larger-results-using-sidecar-logs)                      | [TEP-0127](https://github.com/tektoncd/community/blob/main/teps/0127-larger-results-via-sidecar-logs.md)                   | [v0.43.0](https://github.com/tektoncd/pipeline/releases/tag/v0.43.0) | `results-from`                |
 | [Configure Default Resolver](./resolution.md#configuring-built-in-resolvers)                        | [TEP-0133](https://github.com/tektoncd/community/blob/main/teps/0133-configure-default-resolver.md)                        | N/A                                 |                                |
-| [Coschedule](./affinityassistants.md)                        | [TEP-0135](https://github.com/tektoncd/community/blob/main/teps/0135-coscheduling-pipelinerun-pods.md)                        | N/A                                 |`coschedule`                                |
+| [Coschedule](./affinityassistants.md)                                                               | [TEP-0135](https://github.com/tektoncd/community/blob/main/teps/0135-coscheduling-pipelinerun-pods.md)                        | N/A                                 |`coschedule`                                |
+| [keep pod on cancel](./taskruns.md#cancelling-a-taskrun)                                            | N/A |  v0.52 | keep-pod-on-cancel |
 
 ### Beta Features
 

--- a/docs/taskruns.md
+++ b/docs/taskruns.md
@@ -910,6 +910,9 @@ When you cancel a TaskRun, the running pod associated with that `TaskRun` is del
 means that the logs of the `TaskRun` are not preserved. The deletion of the `TaskRun` pod is necessary
 in order to stop `TaskRun` step containers from running.
 
+**Note: if `keep-pod-on-cancel` is set to
+`"true"` in the `feature-flags`,  the pod associated with that `TaskRun` will not be deleted**
+
 Example of cancelling a `TaskRun`:
 
 ```yaml

--- a/pkg/apis/config/feature_flags.go
+++ b/pkg/apis/config/feature_flags.go
@@ -88,6 +88,10 @@ const (
 	DefaultSetSecurityContext = false
 	// DefaultCoschedule is the default value for coschedule
 	DefaultCoschedule = CoscheduleWorkspaces
+	// KeepPodOnCancel is the flag used to enable cancelling a pod using the entrypoint, and keep pod on cancel
+	KeepPodOnCancel = "keep-pod-on-cancel"
+	// DefaultEnableKeepPodOnCancel is the default value for "keep-pod-on-cancel"
+	DefaultEnableKeepPodOnCancel = false
 
 	disableAffinityAssistantKey         = "disable-affinity-assistant"
 	disableCredsInitKey                 = "disable-creds-init"
@@ -124,6 +128,7 @@ type FeatureFlags struct {
 	SendCloudEventsForRuns           bool
 	AwaitSidecarReadiness            bool
 	EnforceNonfalsifiability         string
+	EnableKeepPodOnCancel            bool
 	// VerificationNoMatchPolicy is the feature flag for "trusted-resources-verification-no-match-policy"
 	// VerificationNoMatchPolicy can be set to "ignore", "warn" and "fail" values.
 	// ignore: skip trusted resources verification when no matching verification policies found
@@ -193,6 +198,9 @@ func NewFeatureFlagsFromMap(cfgMap map[string]string) (*FeatureFlags, error) {
 		return nil, err
 	}
 	if err := setMaxResultSize(cfgMap, DefaultMaxResultSize, &tc.MaxResultSize); err != nil {
+		return nil, err
+	}
+	if err := setFeature(KeepPodOnCancel, DefaultEnableKeepPodOnCancel, &tc.EnableKeepPodOnCancel); err != nil {
 		return nil, err
 	}
 	if err := setEnforceNonFalsifiability(cfgMap, &tc.EnforceNonfalsifiability); err != nil {

--- a/pkg/apis/config/feature_flags_test.go
+++ b/pkg/apis/config/feature_flags_test.go
@@ -69,6 +69,7 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 				VerificationNoMatchPolicy:        config.FailNoMatchPolicy,
 				EnableProvenanceInStatus:         false,
 				ResultExtractionMethod:           "termination-message",
+				EnableKeepPodOnCancel:            true,
 				MaxResultSize:                    4096,
 				SetSecurityContext:               true,
 				Coschedule:                       config.CoscheduleDisabled,
@@ -259,6 +260,15 @@ func TestNewFeatureFlagsConfigMapErrors(t *testing.T) {
 	}, {
 		fileName: "feature-flags-invalid-coschedule",
 		want:     `invalid value for feature flag "coschedule": "invalid"`,
+	}, {
+		fileName: "feature-flags-invalid-keep-pod-on-cancel",
+		want:     `failed parsing feature flags config "invalid": strconv.ParseBool: parsing "invalid": invalid syntax`,
+	}, {
+		fileName: "feature-flags-invalid-running-in-environment-with-injected-sidecars",
+		want:     `failed parsing feature flags config "invalid-boolean": strconv.ParseBool: parsing "invalid-boolean": invalid syntax`,
+	}, {
+		fileName: "feature-flags-invalid-disable-affinity-assistant",
+		want:     `failed parsing feature flags config "truee": strconv.ParseBool: parsing "truee": invalid syntax`,
 	}} {
 		t.Run(tc.fileName, func(t *testing.T) {
 			cm := test.ConfigMapFromTestFile(t, tc.fileName)

--- a/pkg/apis/config/testdata/feature-flags-invalid-disable-affinity-assistant.yaml
+++ b/pkg/apis/config/testdata/feature-flags-invalid-disable-affinity-assistant.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 The Tekton Authors
+# Copyright 2023 The Tekton Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,17 +18,4 @@ metadata:
   name: feature-flags
   namespace: tekton-pipelines
 data:
-  disable-affinity-assistant: "true"
-  coschedule: "disabled"
-  running-in-environment-with-injected-sidecars: "false"
-  await-sidecar-readiness: "false"
-  require-git-ssh-secret-known-hosts: "true"
-  enable-tekton-oci-bundles: "true"
-  enable-custom-tasks: "true"
-  enable-api-fields: "alpha"
-  send-cloudevents-for-runs: "true"
-  enforce-nonfalsifiability: "spire"
-  trusted-resources-verification-no-match-policy: "fail"
-  enable-provenance-in-status: "false"
-  set-security-context: "true"
-  keep-pod-on-cancel: "true"
+  disable-affinity-assistant: "truee"

--- a/pkg/apis/config/testdata/feature-flags-invalid-keep-pod-on-cancel.yaml
+++ b/pkg/apis/config/testdata/feature-flags-invalid-keep-pod-on-cancel.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 The Tekton Authors
+# Copyright 2023 The Tekton Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,17 +18,4 @@ metadata:
   name: feature-flags
   namespace: tekton-pipelines
 data:
-  disable-affinity-assistant: "true"
-  coschedule: "disabled"
-  running-in-environment-with-injected-sidecars: "false"
-  await-sidecar-readiness: "false"
-  require-git-ssh-secret-known-hosts: "true"
-  enable-tekton-oci-bundles: "true"
-  enable-custom-tasks: "true"
-  enable-api-fields: "alpha"
-  send-cloudevents-for-runs: "true"
-  enforce-nonfalsifiability: "spire"
-  trusted-resources-verification-no-match-policy: "fail"
-  enable-provenance-in-status: "false"
-  set-security-context: "true"
-  keep-pod-on-cancel: "true"
+  keep-pod-on-cancel: "invalid"

--- a/pkg/apis/config/testdata/feature-flags-invalid-running-in-environment-with-injected-sidecars.yaml
+++ b/pkg/apis/config/testdata/feature-flags-invalid-running-in-environment-with-injected-sidecars.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 The Tekton Authors
+# Copyright 2023 The Tekton Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,17 +18,4 @@ metadata:
   name: feature-flags
   namespace: tekton-pipelines
 data:
-  disable-affinity-assistant: "true"
-  coschedule: "disabled"
-  running-in-environment-with-injected-sidecars: "false"
-  await-sidecar-readiness: "false"
-  require-git-ssh-secret-known-hosts: "true"
-  enable-tekton-oci-bundles: "true"
-  enable-custom-tasks: "true"
-  enable-api-fields: "alpha"
-  send-cloudevents-for-runs: "true"
-  enforce-nonfalsifiability: "spire"
-  trusted-resources-verification-no-match-policy: "fail"
-  enable-provenance-in-status: "false"
-  set-security-context: "true"
-  keep-pod-on-cancel: "true"
+  running-in-environment-with-injected-sidecars: "invalid-boolean"

--- a/pkg/entrypoint/entrypointer_test.go
+++ b/pkg/entrypoint/entrypointer_test.go
@@ -26,12 +26,14 @@ import (
 	"path"
 	"path/filepath"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/pkg/pod"
 	"github.com/tektoncd/pipeline/pkg/result"
 	"github.com/tektoncd/pipeline/pkg/spire"
 	"github.com/tektoncd/pipeline/pkg/termination"
@@ -194,15 +196,19 @@ func TestEntrypointer(t *testing.T) {
 			}
 
 			if len(c.waitFiles) > 0 {
+				fw.Lock()
 				if fw.waited == nil {
 					t.Error("Wanted waited file, got nil")
-				} else if !reflect.DeepEqual(fw.waited, c.waitFiles) {
+				} else if !reflect.DeepEqual(fw.waited, append(c.waitFiles, "/tekton/downward/cancel")) {
 					t.Errorf("Waited for %v, want %v", fw.waited, c.waitFiles)
 				}
+				fw.Unlock()
 			}
-			if len(c.waitFiles) == 0 && fw.waited != nil {
+			fw.Lock()
+			if len(c.waitFiles) == 0 && len(fw.waited) != 1 {
 				t.Errorf("Waited for file when not required")
 			}
+			fw.Unlock()
 
 			wantArgs := append([]string{c.entrypoint}, c.args...)
 			if len(wantArgs) != 0 {
@@ -602,10 +608,101 @@ func TestEntrypointerResults(t *testing.T) {
 	}
 }
 
-type fakeWaiter struct{ waited []string }
+func Test_waitingCancellation(t *testing.T) {
+	testCases := []struct {
+		name         string
+		expectCtxErr error
+	}{
+		{
+			name:         "stopOnCancel is true and want context canceled",
+			expectCtxErr: context.Canceled,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			fw := &fakeWaiter{}
+			err := Entrypointer{
+				Waiter: fw,
+			}.waitingCancellation(ctx, cancel)
+			if err != nil {
+				t.Fatalf("Entrypointer waitingCancellation failed: %v", err)
+			}
+			if tc.expectCtxErr != nil && !errors.Is(ctx.Err(), tc.expectCtxErr) {
+				t.Errorf("expected context error %v, got %v", tc.expectCtxErr, ctx.Err())
+			}
+		})
+	}
+}
 
-func (f *fakeWaiter) Wait(file string, _ bool, _ bool) error {
+func TestEntrypointerStopOnCancel(t *testing.T) {
+	testCases := []struct {
+		name                   string
+		runningDuration        time.Duration
+		waitingDuration        time.Duration
+		runningWaitingDuration time.Duration
+		expectError            error
+	}{
+		{
+			name:                   "generally running, expect no error",
+			runningDuration:        1 * time.Second,
+			runningWaitingDuration: 1 * time.Second,
+			waitingDuration:        2 * time.Second,
+			expectError:            nil,
+		},
+		{
+			name:                   "context canceled during running, expect context canceled error",
+			runningDuration:        2 * time.Second,
+			runningWaitingDuration: 2 * time.Second,
+			waitingDuration:        1 * time.Second,
+			expectError:            ErrContextCanceled,
+		},
+		{
+			name:                   "time exceeded during running, expect context deadline exceeded error",
+			runningDuration:        2 * time.Second,
+			runningWaitingDuration: 1 * time.Second,
+			waitingDuration:        1 * time.Second,
+			expectError:            ErrContextDeadlineExceeded,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			terminationPath := "termination"
+			if terminationFile, err := os.CreateTemp("", "termination"); err != nil {
+				t.Fatalf("unexpected error creating temporary termination file: %v", err)
+			} else {
+				terminationPath = terminationFile.Name()
+				defer os.Remove(terminationFile.Name())
+			}
+			fw := &fakeWaiter{waitCancelDuration: tc.waitingDuration}
+			fr := &fakeLongRunner{runningDuration: tc.runningDuration, waitingDuration: tc.runningWaitingDuration}
+			fp := &fakePostWriter{}
+			err := Entrypointer{
+				Waiter:          fw,
+				Runner:          fr,
+				PostWriter:      fp,
+				TerminationPath: terminationPath,
+			}.Go()
+			if !errors.Is(err, tc.expectError) {
+				t.Errorf("expected error %v, got %v", tc.expectError, err)
+			}
+		})
+	}
+}
+
+type fakeWaiter struct {
+	sync.Mutex
+	waited             []string
+	waitCancelDuration time.Duration
+}
+
+func (f *fakeWaiter) Wait(ctx context.Context, file string, _ bool, _ bool) error {
+	if file == pod.DownwardMountCancelFile && f.waitCancelDuration > 0 {
+		time.Sleep(f.waitCancelDuration)
+	}
+	f.Lock()
 	f.waited = append(f.waited, file)
+	f.Unlock()
 	return nil
 }
 
@@ -633,7 +730,7 @@ func (f *fakePostWriter) Write(file, content string) {
 
 type fakeErrorWaiter struct{ waited *string }
 
-func (f *fakeErrorWaiter) Wait(file string, expectContent bool, breakpointOnFailure bool) error {
+func (f *fakeErrorWaiter) Wait(ctx context.Context, file string, expectContent bool, breakpointOnFailure bool) error {
 	f.waited = &file
 	return errors.New("waiter failed")
 }
@@ -670,6 +767,29 @@ type fakeExitErrorRunner struct{ args *[]string }
 func (f *fakeExitErrorRunner) Run(ctx context.Context, args ...string) error {
 	f.args = &args
 	return exec.Command("ls", "/bogus/path").Run()
+}
+
+type fakeLongRunner struct {
+	runningDuration time.Duration
+	waitingDuration time.Duration
+}
+
+func (f *fakeLongRunner) Run(ctx context.Context, _ ...string) error {
+	if f.waitingDuration < f.runningDuration {
+		return ErrContextDeadlineExceeded
+	}
+	select {
+	case <-time.After(f.runningDuration):
+		return nil
+	case <-ctx.Done():
+		if errors.Is(ctx.Err(), context.Canceled) {
+			return ErrContextCanceled
+		}
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return ErrContextDeadlineExceeded
+		}
+		return nil
+	}
 }
 
 type fakeResultsWriter struct {

--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -2079,6 +2079,120 @@ _EOF_
 				}, runVolume(0)),
 				ActiveDeadlineSeconds: &defaultActiveDeadlineSeconds,
 			},
+		}, {
+			desc:         "keep pod on cancel enabled",
+			featureFlags: map[string]string{"keep-pod-on-cancel": "true", "enable-api-fields": "alpha"},
+			ts: v1.TaskSpec{
+				Steps: []v1.Step{{
+					Name:    "name",
+					Image:   "image",
+					Command: []string{"cmd"}, // avoid entrypoint lookup.
+				}},
+			},
+			want: &corev1.PodSpec{
+				RestartPolicy: corev1.RestartPolicyNever,
+				InitContainers: []corev1.Container{
+					entrypointInitContainer(images.EntrypointImage, []v1.Step{{Name: "name"}}, false, false),
+				},
+				Containers: []corev1.Container{{
+					Name:    "step-name",
+					Image:   "image",
+					Command: []string{"/tekton/bin/entrypoint"},
+					Args: []string{
+						"-wait_file",
+						"/tekton/downward/ready",
+						"-wait_file_content",
+						"-post_file",
+						"/tekton/run/0/out",
+						"-termination_path",
+						"/tekton/termination",
+						"-step_metadata_dir",
+						"/tekton/run/0/status",
+						"-entrypoint",
+						"cmd",
+						"--",
+					},
+					VolumeMounts: append([]corev1.VolumeMount{binROMount, runMount(0, false), downwardMount, {
+						Name:      "tekton-creds-init-home-0",
+						MountPath: "/tekton/creds",
+					}}, implicitVolumeMounts...),
+					TerminationMessagePath: "/tekton/termination",
+				}},
+				Volumes: append(implicitVolumes, binVolume, runVolume(0), corev1.Volume{
+					Name: downwardVolumeName,
+					VolumeSource: corev1.VolumeSource{
+						DownwardAPI: &corev1.DownwardAPIVolumeSource{
+							Items: []corev1.DownwardAPIVolumeFile{{
+								Path: downwardMountReadyFile,
+								FieldRef: &corev1.ObjectFieldSelector{
+									FieldPath: fmt.Sprintf("metadata.annotations['%s']", readyAnnotation),
+								},
+							}, downwardCancelVolumeItem},
+						},
+					},
+				}, corev1.Volume{
+					Name:         "tekton-creds-init-home-0",
+					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
+				}),
+				ActiveDeadlineSeconds: &defaultActiveDeadlineSeconds,
+			},
+		}, {
+			desc:         "keep pod on cancel enabled but not alpha",
+			featureFlags: map[string]string{"keep-pod-on-cancel": "true"},
+			ts: v1.TaskSpec{
+				Steps: []v1.Step{{
+					Name:    "name",
+					Image:   "image",
+					Command: []string{"cmd"}, // avoid entrypoint lookup.
+				}},
+			},
+			want: &corev1.PodSpec{
+				RestartPolicy: corev1.RestartPolicyNever,
+				InitContainers: []corev1.Container{
+					entrypointInitContainer(images.EntrypointImage, []v1.Step{{Name: "name"}}, false, false),
+				},
+				Containers: []corev1.Container{{
+					Name:    "step-name",
+					Image:   "image",
+					Command: []string{"/tekton/bin/entrypoint"},
+					Args: []string{
+						"-wait_file",
+						"/tekton/downward/ready",
+						"-wait_file_content",
+						"-post_file",
+						"/tekton/run/0/out",
+						"-termination_path",
+						"/tekton/termination",
+						"-step_metadata_dir",
+						"/tekton/run/0/status",
+						"-entrypoint",
+						"cmd",
+						"--",
+					},
+					VolumeMounts: append([]corev1.VolumeMount{binROMount, runMount(0, false), downwardMount, {
+						Name:      "tekton-creds-init-home-0",
+						MountPath: "/tekton/creds",
+					}}, implicitVolumeMounts...),
+					TerminationMessagePath: "/tekton/termination",
+				}},
+				Volumes: append(implicitVolumes, binVolume, runVolume(0), corev1.Volume{
+					Name: downwardVolumeName,
+					VolumeSource: corev1.VolumeSource{
+						DownwardAPI: &corev1.DownwardAPIVolumeSource{
+							Items: []corev1.DownwardAPIVolumeFile{{
+								Path: downwardMountReadyFile,
+								FieldRef: &corev1.ObjectFieldSelector{
+									FieldPath: fmt.Sprintf("metadata.annotations['%s']", readyAnnotation),
+								},
+							}},
+						},
+					},
+				}, corev1.Volume{
+					Name:         "tekton-creds-init-home-0",
+					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
+				}),
+				ActiveDeadlineSeconds: &defaultActiveDeadlineSeconds,
+			},
 		}} {
 		t.Run(c.desc, func(t *testing.T) {
 			names.TestingSeed()


### PR DESCRIPTION
The cancellation of taskruns is now done through the entrypoint binary through a new flag called 'stop_on_cancel'. This removes the need for deleting the pods to cancel a taskrun, allowing examination of the logs on the pods from cancelled taskruns. Part of work on issue #3238 
there are some codes carry over from #4618 


# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
if "enable-cancel-using-entrypoint" is set to
"true" in the `feature-flags`, Taskrun can now be cancelled using the entrypoint, which results of Pods from these TaskRun to be no longer deleted: they are stopped instead.
```
