### PR TITLE
add pipelinetask metadata validation

### DIFF
--- a/pkg/apis/pipeline/v1/pipeline_types_test.go
+++ b/pkg/apis/pipeline/v1/pipeline_types_test.go
@@ -220,6 +220,12 @@ func TestPipelineTask_ValidateRegularTask_Success(t *testing.T) {
 			TaskRef: &TaskRef{Name: "boo", ResolverRef: ResolverRef{Params: Params{{}}}},
 		},
 		enableBetaAPIFields: true,
+	}, {
+		name: "pipeline task - valid taskSpec and metadata",
+		tasks: PipelineTask{
+			Name:     "foo",
+			TaskSpec: &EmbeddedTask{TaskSpec: getTaskSpec(), Metadata: getValidMetadata()},
+		},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -289,6 +295,17 @@ func TestPipelineTask_ValidateRegularTask_Failure(t *testing.T) {
 			TaskRef: &TaskRef{Name: "boo", ResolverRef: ResolverRef{Params: Params{{}}}},
 		},
 		expectedError: *apis.ErrDisallowedFields("taskref.params"),
+	}, {
+		name: "pipeline task - invalid taskSpec metadata",
+		task: PipelineTask{
+			Name:     "foo",
+			TaskSpec: &EmbeddedTask{TaskSpec: getTaskSpec(), Metadata: getInValidMetadata()},
+		},
+		expectedError: apis.FieldError{
+			Message: `invalid value: name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an ` +
+				`alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')`,
+			Paths: []string{"taskSpec.metadata.labels._test"},
+		},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/apis/pipeline/v1beta1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types.go
@@ -19,6 +19,7 @@ package v1beta1
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strings"
 
 	"github.com/google/go-containerregistry/pkg/name"
@@ -26,6 +27,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/version"
 	"github.com/tektoncd/pipeline/pkg/reconciler/pipeline/dag"
+	api_validation "k8s.io/apimachinery/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -288,6 +290,10 @@ func (pt PipelineTask) validateTask(ctx context.Context) (errs *apis.FieldError)
 	// Validate TaskSpec if it's present
 	if pt.TaskSpec != nil {
 		errs = errs.Also(pt.TaskSpec.Validate(ctx).ViaField("taskSpec"))
+
+		if !reflect.DeepEqual(pt.TaskSpec.Metadata, PipelineTaskMetadata{}) {
+			errs = errs.Also(pt.validateTaskSpecMetaData().ViaField("taskSpec"))
+		}
 	}
 	if pt.TaskRef != nil {
 		if pt.TaskRef.Name != "" {
@@ -303,6 +309,33 @@ func (pt PipelineTask) validateTask(ctx context.Context) (errs *apis.FieldError)
 			errs = errs.Also(apis.ErrDisallowedFields("taskRef.bundle"))
 		}
 	}
+	return errs
+}
+
+// validateTaskSpecMetaData validates a pipeline task or a final task for taskSpec.metadata
+// For details, refer to https://github.com/kubernetes/apimachinery/pkg/api/validation/objectmeta.go#L44 and
+// https://github.com/kubernetes/apimachinery/blob/master/pkg/apis/meta/v1/validation/validation.go#L105
+func (pt *PipelineTask) validateTaskSpecMetaData() (errs *apis.FieldError) {
+	for k, v := range pt.TaskSpec.Metadata.Labels {
+		if errSlice := validation.IsQualifiedName(k); len(errSlice) != 0 {
+			errs = errs.Also(apis.ErrInvalidValue(strings.Join(errSlice, ","), fmt.Sprintf("metadata.labels.%s", k)))
+		}
+
+		if errSlice := validation.IsValidLabelValue(v); len(errSlice) != 0 {
+			errs = errs.Also(apis.ErrInvalidValue(strings.Join(errSlice, ","), fmt.Sprintf("metadata.labels.%s.value.%s", k, v)))
+		}
+	}
+
+	for k := range pt.TaskSpec.Metadata.Annotations {
+		if errSlice := validation.IsQualifiedName(strings.ToLower(k)); len(errSlice) != 0 {
+			errs = errs.Also(apis.ErrInvalidValue(strings.Join(errSlice, ","), fmt.Sprintf("metadata.annotations.%s", k)))
+		}
+	}
+
+	if err := api_validation.ValidateAnnotationsSize(pt.TaskSpec.Metadata.Annotations); err != nil {
+		errs = errs.Also(apis.ErrInvalidValue(err.Error(), "metadata.annotations"))
+	}
+
 	return errs
 }
 

--- a/pkg/apis/pipeline/v1beta1/pipeline_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types_test.go
@@ -252,6 +252,12 @@ func TestPipelineTask_ValidateRegularTask_Success(t *testing.T) {
 			TaskRef: &TaskRef{Name: "bar", Bundle: "docker.io/foo"},
 		},
 		enableBundles: true,
+	}, {
+		name: "pipeline task - valid taskSpec and metadata",
+		tasks: PipelineTask{
+			Name:     "foo",
+			TaskSpec: &EmbeddedTask{TaskSpec: getTaskSpec(), Metadata: getValidMetadata()},
+		},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -317,6 +323,17 @@ func TestPipelineTask_ValidateRegularTask_Failure(t *testing.T) {
 			TaskRef: &TaskRef{Name: "bar", Bundle: "docker.io/foo"},
 		},
 		expectedError: *apis.ErrDisallowedFields("taskRef.bundle"),
+	}, {
+		name: "pipeline task - invalid taskSpec metadata",
+		task: PipelineTask{
+			Name:     "foo",
+			TaskSpec: &EmbeddedTask{TaskSpec: getTaskSpec(), Metadata: getInValidMetadata()},
+		},
+		expectedError: apis.FieldError{
+			Message: `invalid value: name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an ` +
+				`alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')`,
+			Paths: []string{"taskSpec.metadata.labels._test"},
+		},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
@@ -71,6 +71,19 @@ func TestPipeline_Validate_Success(t *testing.T) {
 				}},
 			},
 		},
+	}, {
+		name: "valid taskSpec metadata",
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Tasks: []PipelineTask{{Name: "foo",
+					TaskSpec: &EmbeddedTask{
+						Metadata: getValidMetadata(),
+						TaskSpec: getTaskSpec(),
+					},
+				}},
+			},
+		},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -727,6 +740,21 @@ func TestValidatePipelineTasks_Failure(t *testing.T) {
 		expectedError: apis.FieldError{
 			Message: "taskSpec.kind cannot be specified when using taskSpec.steps",
 			Paths:   []string{"tasks[0].taskSpec.kind"},
+		},
+	}, {
+		name: "invalid taskSpec metadata",
+		tasks: []PipelineTask{{
+			Name: "foo",
+			TaskSpec: &EmbeddedTask{
+				Metadata: getInValidMetadata(),
+				TaskSpec: getTaskSpec(),
+			},
+		}},
+		finalTasks: nil,
+		expectedError: apis.FieldError{
+			Message: `invalid value: name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an ` +
+				`alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')`,
+			Paths: []string{"tasks[0].taskSpec.metadata.labels._test"},
 		},
 	}}
 	for _, tt := range tests {
@@ -3379,6 +3407,25 @@ func getTaskSpec() TaskSpec {
 		Steps: []Step{{
 			Name: "foo", Image: "bar",
 		}},
+	}
+}
+
+func getValidMetadata() PipelineTaskMetadata {
+	return PipelineTaskMetadata{
+		Labels: map[string]string{
+			"example.io/test": "aValue",
+		},
+		Annotations: map[string]string{
+			"example.io/test": "aValue",
+		},
+	}
+}
+
+func getInValidMetadata() PipelineTaskMetadata {
+	return PipelineTaskMetadata{
+		Labels: map[string]string{
+			"_test": "test",
+		},
 	}
 }
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Add parameter validation of metatdata in pipelinetask taskSpec. 
Avoid invalid metadata causing PR to run stuck.

Fixes:  #6453 

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Add parameter validation of metatdata in pipelinetask taskSpec. 
```
