### PR TITLE
Fixed Broken Links in Cloud Events Documentation 

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -50,7 +50,7 @@ but the underlying `TaskRun` do.
 
 # Events via `CloudEvents`
 
-When you [configure a sink](install.md#configuring-cloudevents-notifications), Tekton emits
+When you [configure a sink](./additional-configs.md#configuring-cloudevents-notifications), Tekton emits
 events as described in the table below.
 
 Tekton sends cloud events in a parallel routine to allow for retries without blocking the
@@ -75,7 +75,7 @@ Resource      |Event    |Event Type
 `Run`         | `Succeed` | `dev.tekton.event.run.successful.v1`
 `Run`         | `Failed`  | `dev.tekton.event.run.failed.v1`
 
-`CloudEvents` for `Runs` are only sent when enabled in the [configuration](./install.md#configuring-cloudevents-notifications).
+`CloudEvents` for `Runs` are only sent when enabled in the [configuration](./additional-configs.md#configuring-cloudevents-notifications).
 
 **Note**: `CloudEvents` for `Runs` rely on an ephemeral cache to avoid duplicate
 events. In case of controller restart, the cache is reset and duplicate events
@@ -83,7 +83,7 @@ may be sent.
 
 ## Format of `CloudEvents`
 
-According to the [`CloudEvents` spec](https://github.com/cloudevents/spec/blob/master/spec.md), HTTP headers are included to match the context fields. For example:
+According to the [`CloudEvents` spec](https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md), HTTP headers are included to match the context fields. For example:
 
 ```
 "Ce-Id": "77f78ae7-ff6d-4e39-9d05-b9a0b7850527",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Fixed Broken Links in Events Documentation 
- Resolves issue #6423 
- Replaces broken link for [CloudEvents Spec](https://github.com/cloudevents/spec/blob/master/spec)  

Fixes: #6423
/kind documentation


<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
