### PR TITLE
Hygiene: enabled presets and various linters.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,7 +37,16 @@ linters:
   - gosec
   - gosimple
   - govet
+  - maintidx
+  - makezero
   - misspell
+  - musttag
+  - nakedret
+  - nilerr
+  - nilnil
+  - noctx
+  - nolintlint
+  - nosprintfhostport
   - thelper
   - typecheck
   - unconvert
@@ -45,12 +54,45 @@ linters:
   - usestdlibvars
   - whitespace
   disable:
+  - cyclop
+  - dupl
+  - exhaustruct
+  - forcetypeassert
+  - funlen
+  - gci
+  - gochecknoglobals
+  - gochecknoinits
+  - gocognit
+  - gocyclo
+  - godot
+  - godox
+  - goerr113
+  - gofumpt
+  - gomnd
+  - gomoddirectives
+  - ireturn
+  - lll
+  - nestif
+  - nlreturn
+  - nonamedreturns
+  - paralleltest
+  - prealloc
+  - predeclared
   - revive
   - staticcheck
-# Enabling presets means that new linters that we automatically adopt new
-# linters that augment a preset. This also opts us in for replacement linters
-# when a linter is deprecated.
-presets:
+  - stylecheck
+  - tagliatelle
+  - testpackage
+  - tparallel
+  - unparam
+  - varnamelen
+  - wastedassign
+  - wrapcheck
+  - wsl
+  # Enabling presets means that new linters that we automatically adopt new
+  # linters that augment a preset. This also opts us in for replacement linters
+  # when a linter is deprecated.
+  presets:
   - bugs
   - comment
   - complexity
@@ -67,41 +109,71 @@ presets:
 output:
   uniq-by-line: false
 issues:
+  # Note: path identifiers are regular expressions, hence the \.go suffixes.
   exclude-rules:
+  - path: main\.go
+    linters:
+    - forbidigo
+  - path: test/build_logs\.go
+    linters:
+    - typecheck
   - path: _test\.go
     linters:
-    - goconst
     - dogsled
     - errcheck
+    - goconst
     - gosec
     - ineffassign
+    - maintidx
+    - typecheck
   - path: test/pipelinerun_test\.go
     linters:
     - unused
-  - path: pkg/apis/config/feature_flags_test.go
+  - path: pkg/apis/config/feature_flags_test\.go
     linters:
     - containedctx
-  - path: pkg/pipelinerunmetrics/injection.go
+  - path: pkg/pipelinerunmetrics/injection\.go
     linters:
     - containedctx
-  - path: pkg/pod/creds_init_test.go
+  - path: pkg/pod/pod\.go
+    linters:
+    - maintidx
+  - path: pkg/pod/creds_init_test\.go
     linters:
     - containedctx
-  - path: pkg/taskrunmetrics/injection.go
+  - path: pkg/reconciler/pipelinerun/pipelinerun\.go
+    linters:
+    - maintidx
+  - path: pkg/taskrunmetrics/injection\.go
     linters:
     - containedctx
-  - path: test/controller.go
+  - path: test/controller\.go
     linters:
     - containedctx
+  - path: internal/sidecarlogresults/sidecarlogresults\.go
+    linters:
+    - musttag
   - path: internal/sidecarlogresults/sidecarlogresults_test\.go
     linters:
     - errchkjson
+  - path: pkg/apis/pipeline/v1.*/param_types\.go
+    linters:
+    - musttag
+  - path: pkg/resolution/resolver/framework/testing/fakecontroller\.go
+    linters:
+    - contextcheck
+  - path: pkg/pipelinerunmetrics/metrics\.go
+    linters:
+    - contextcheck
+  - path: pkg/reconciler/pipelinerun/pipelinerun\.go
+    linters:
+    - contextcheck
   max-issues-per-linter: 0
   max-same-issues: 0
   include:
   # Enable off-by-default rules for revive requiring that all exported elements have a properly formatted comment.
-  - EXC0012
-  - EXC0014
+  - EXC0012 # https://golangci-lint.run/usage/false-positives/#exc0012
+  - EXC0014 # https://golangci-lint.run/usage/false-positives/#exc0014
 run:
   issues-exit-code: 1
   build-tags:
@@ -113,5 +185,5 @@ run:
   - vendor
   - pkg/client
   - pkg/spire/test
-  timeout: 10m
+  timeout: 20m
   modules-download-mode: vendor

--- a/cmd/entrypoint/main.go
+++ b/cmd/entrypoint/main.go
@@ -174,7 +174,7 @@ func main() {
 
 	if err := e.Go(); err != nil {
 		breakpointExitPostFile := e.PostFile + breakpointExitSuffix
-		switch t := err.(type) { // nolint -- checking for multiple types with errors.As is ugly.
+		switch t := err.(type) { //nolint:errorlint // checking for multiple types with errors.As is ugly.
 		case skipError:
 			log.Print("Skipping step because a previous step failed")
 			os.Exit(1)

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -150,7 +150,6 @@ func newConfigValidationController(name string) func(context.Context, configmap.
 }
 
 func newConversionController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
-	// nolint: revive
 	var (
 		v1beta1GroupVersion            = v1beta1.SchemeGroupVersion.Version
 		v1GroupVersion                 = v1.SchemeGroupVersion.Version

--- a/pkg/apis/config/feature_flags.go
+++ b/pkg/apis/config/feature_flags.go
@@ -81,7 +81,7 @@ const (
 	disableCredsInitKey                 = "disable-creds-init"
 	runningInEnvWithInjectedSidecarsKey = "running-in-environment-with-injected-sidecars"
 	awaitSidecarReadinessKey            = "await-sidecar-readiness"
-	requireGitSSHSecretKnownHostsKey    = "require-git-ssh-secret-known-hosts" // nolint: gosec
+	requireGitSSHSecretKnownHostsKey    = "require-git-ssh-secret-known-hosts" //nolint:gosec
 	enableTektonOCIBundles              = "enable-tekton-oci-bundles"
 	enableAPIFields                     = "enable-api-fields"
 	sendCloudEventsForRuns              = "send-cloudevents-for-runs"
@@ -94,6 +94,8 @@ const (
 
 // FeatureFlags holds the features configurations
 // +k8s:deepcopy-gen=true
+//
+//nolint:musttag
 type FeatureFlags struct {
 	DisableAffinityAssistant         bool
 	DisableCredsInit                 bool

--- a/pkg/apis/pipeline/controller.go
+++ b/pkg/apis/pipeline/controller.go
@@ -18,11 +18,9 @@ package pipeline
 
 const (
 	// PipelineRunControllerName holds the name of the PipelineRun controller
-	// nolint: revive
 	PipelineRunControllerName = "PipelineRun"
 
 	// PipelineControllerName holds the name of the Pipeline controller
-	// nolint: revive
 	PipelineControllerName = "Pipeline"
 
 	// TaskRunControllerName holds the name of the TaskRun controller

--- a/pkg/apis/pipeline/v1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1/taskrun_types.go
@@ -415,7 +415,7 @@ func (tr *TaskRun) GetTimeout(ctx context.Context) time.Duration {
 	// Use the platform default is no timeout is set
 	if tr.Spec.Timeout == nil {
 		defaultTimeout := time.Duration(config.FromContextOrDefaults(ctx).Defaults.DefaultTimeoutMinutes)
-		return defaultTimeout * time.Minute
+		return defaultTimeout * time.Minute //nolint:durationcheck
 	}
 	return tr.Spec.Timeout.Duration
 }

--- a/pkg/apis/pipeline/v1beta1/pipelineref_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipelineref_validation.go
@@ -64,7 +64,7 @@ func (ref *PipelineRef) Validate(ctx context.Context) (errs *apis.FieldError) {
 			}
 		}
 	}
-	return
+	return //nolint:nakedret
 }
 
 func validateBundleFeatureFlag(ctx context.Context, featureName string, wantValue bool) *apis.FieldError {

--- a/pkg/apis/pipeline/v1beta1/taskref_validation.go
+++ b/pkg/apis/pipeline/v1beta1/taskref_validation.go
@@ -62,5 +62,5 @@ func (ref *TaskRef) Validate(ctx context.Context) (errs *apis.FieldError) {
 			}
 		}
 	}
-	return
+	return //nolint:nakedret
 }

--- a/pkg/apis/pipeline/v1beta1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_types.go
@@ -494,7 +494,7 @@ func (tr *TaskRun) GetTimeout(ctx context.Context) time.Duration {
 	// Use the platform default is no timeout is set
 	if tr.Spec.Timeout == nil {
 		defaultTimeout := time.Duration(config.FromContextOrDefaults(ctx).Defaults.DefaultTimeoutMinutes)
-		return defaultTimeout * time.Minute
+		return defaultTimeout * time.Minute //nolint:durationcheck
 	}
 	return tr.Spec.Timeout.Duration
 }

--- a/pkg/credentials/initialize.go
+++ b/pkg/credentials/initialize.go
@@ -83,7 +83,7 @@ func SortAnnotations(secrets map[string]string, annotationPrefix string) []strin
 // /tekton/creds directory is not considered an error.
 func CopyCredsToHome(credPaths []string) error {
 	if info, err := os.Stat(pipeline.CredsDir); err != nil || !info.IsDir() {
-		return nil
+		return nil //nolint:nilerr // safe to ignore error; no credentials available to copy
 	}
 
 	homepath, err := homedir.Dir()

--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -223,7 +223,7 @@ func (b *Builder) Build(ctx context.Context, taskRun *v1beta1.TaskRun, taskSpec 
 	// Superceded by podTemplate envs
 	if len(implicitEnvVars) > 0 {
 		for i, s := range stepContainers {
-			env := append(implicitEnvVars, s.Env...) // nolint:gocritic
+			env := append(implicitEnvVars, s.Env...) //nolint:gocritic
 			stepContainers[i].Env = env
 		}
 	}
@@ -235,7 +235,7 @@ func (b *Builder) Build(ctx context.Context, taskRun *v1beta1.TaskRun, taskSpec 
 	}
 	if len(podTemplate.Env) > 0 {
 		for i, s := range stepContainers {
-			env := append(s.Env, filteredEnvs...) // nolint:gocritic
+			env := append(s.Env, filteredEnvs...) //nolint:gocritic
 			stepContainers[i].Env = env
 		}
 	}
@@ -243,7 +243,7 @@ func (b *Builder) Build(ctx context.Context, taskRun *v1beta1.TaskRun, taskSpec 
 	if taskRun.Annotations[ExecutionModeAnnotation] == ExecutionModeHermetic && alphaAPIEnabled {
 		for i, s := range stepContainers {
 			// Add it at the end so it overrides
-			env := append(s.Env, corev1.EnvVar{Name: TektonHermeticEnvVar, Value: "1"}) // nolint:gocritic
+			env := append(s.Env, corev1.EnvVar{Name: TektonHermeticEnvVar, Value: "1"}) //nolint:gocritic
 			stepContainers[i].Env = env
 		}
 	}
@@ -280,7 +280,7 @@ func (b *Builder) Build(ctx context.Context, taskRun *v1beta1.TaskRun, taskSpec 
 				toAdd = append(toAdd, imp)
 			}
 		}
-		vms := append(s.VolumeMounts, toAdd...) // nolint:gocritic
+		vms := append(s.VolumeMounts, toAdd...) //nolint:gocritic
 		stepContainers[i].VolumeMounts = vms
 	}
 
@@ -301,7 +301,7 @@ func (b *Builder) Build(ctx context.Context, taskRun *v1beta1.TaskRun, taskSpec 
 					toAdd = append(toAdd, imp)
 				}
 			}
-			vms := append(s.VolumeMounts, toAdd...) // nolint:gocritic
+			vms := append(s.VolumeMounts, toAdd...) //nolint:gocritic
 			sidecarContainers[i].VolumeMounts = vms
 		}
 	}

--- a/pkg/pod/status.go
+++ b/pkg/pod/status.go
@@ -335,7 +335,7 @@ func extractStartedAtTimeFromResults(results []result.RunResult) (*metav1.Time, 
 			return &startedAt, nil
 		}
 	}
-	return nil, nil
+	return nil, nil //nolint:nilnil // would be more ergonomic to return a sentinel error
 }
 
 func extractExitCodeFromResults(results []result.RunResult) (*int32, error) {
@@ -350,7 +350,7 @@ func extractExitCodeFromResults(results []result.RunResult) (*int32, error) {
 			return &exitCode, nil
 		}
 	}
-	return nil, nil
+	return nil, nil //nolint:nilnil // would be more ergonomic to return a sentinel error
 }
 
 func updateCompletedTaskRunStatus(logger *zap.SugaredLogger, trs *v1beta1.TaskRunStatus, pod *corev1.Pod) {

--- a/pkg/reconciler/pipelinerun/resources/pipelineref.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelineref.go
@@ -119,7 +119,7 @@ func GetVerifiedPipelineFunc(ctx context.Context, k8s kubernetes.Interface, tekt
 		if err := trustedresources.VerifyPipeline(ctx, p, k8s, refSource, verificationpolicies); err != nil {
 			// FixMe: the below %v should be %w (and the nolint pragma removed)
 			// but making that change causes e2e test failures.
-			return nil, nil, fmt.Errorf("GetVerifiedPipelineFunc failed: %w: %v", trustedresources.ErrResourceVerificationFailed, err) // nolint:errorlint
+			return nil, nil, fmt.Errorf("GetVerifiedPipelineFunc failed: %w: %v", trustedresources.ErrResourceVerificationFailed, err) //nolint:errorlint
 		}
 		return p, s, nil
 	}

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
@@ -1944,7 +1944,7 @@ func TestResolvePipelineRun_VerificationFailed(t *testing.T) {
 	getTask := func(ctx context.Context, name string) (*v1beta1.Task, *v1beta1.RefSource, error) {
 		return nil, nil, trustedresources.ErrResourceVerificationFailed
 	}
-	getTaskRun := func(name string) (*v1beta1.TaskRun, error) { return nil, nil }
+	getTaskRun := func(name string) (*v1beta1.TaskRun, error) { return nil, nil } //nolint:nilnil
 	pr := v1beta1.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "pipelinerun",
@@ -2214,7 +2214,7 @@ func TestIsCustomTask(t *testing.T) {
 	getTask := func(ctx context.Context, name string) (*v1beta1.Task, *v1beta1.RefSource, error) {
 		return task, nil, nil
 	}
-	getTaskRun := func(name string) (*v1beta1.TaskRun, error) { return nil, nil }
+	getTaskRun := func(name string) (*v1beta1.TaskRun, error) { return nil, nil } //nolint:nilnil
 	getRun := func(name string) (v1beta1.RunObject, error) { return nil, nil }
 
 	for _, tc := range []struct {

--- a/pkg/reconciler/taskrun/resources/taskref.go
+++ b/pkg/reconciler/taskrun/resources/taskref.go
@@ -95,7 +95,7 @@ func GetVerifiedTaskFunc(ctx context.Context, k8s kubernetes.Interface, tekton c
 			refSource = s.URI
 		}
 		if err := trustedresources.VerifyTask(ctx, t, k8s, refSource, verificationpolicies); err != nil {
-			return nil, nil, fmt.Errorf("GetVerifiedTaskFunc failed: %w: %v", trustedresources.ErrResourceVerificationFailed, err) // nolint:errorlint
+			return nil, nil, fmt.Errorf("GetVerifiedTaskFunc failed: %w: %v", trustedresources.ErrResourceVerificationFailed, err) //nolint:errorlint
 		}
 		return t, s, nil
 	}

--- a/pkg/result/result.go
+++ b/pkg/result/result.go
@@ -51,7 +51,8 @@ type RunResult struct {
 // ResultType used to find out whether a RunResult is from a task result or not
 // Note that ResultsType is another type which is used to define the data type
 // (e.g. string, array, etc) we used for Results
-// nolint:revive // revive complains about stutter of `result.ResultType`.
+//
+//nolint:revive // revive complains about stutter of `result.ResultType`.
 type ResultType int
 
 // UnmarshalJSON unmarshals either an int or a string into a ResultType. String

--- a/pkg/spire/verify.go
+++ b/pkg/spire/verify.go
@@ -339,7 +339,7 @@ func getResultValue(result result.RunResult) (string, error) {
 		valList = append(valList, aos.ArrayVal...)
 		return strings.Join(valList, ","), nil
 	case v1beta1.ParamTypeObject:
-		keys := make([]string, len(aos.ObjectVal))
+		keys := make([]string, 0, len(aos.ObjectVal))
 		for k := range aos.ObjectVal {
 			keys = append(keys, k)
 		}

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -38,7 +38,7 @@ func GetTaskRunStatusForPipelineTask(ctx context.Context, client versioned.Inter
 		return nil, err
 	}
 	if tr == nil {
-		return nil, nil
+		return nil, nil //nolint:nilnil // would be more ergonomic to return a sentinel error
 	}
 
 	return &tr.Status, nil
@@ -56,7 +56,7 @@ func GetCustomRunStatusForPipelineTask(ctx context.Context, client versioned.Int
 			return nil, err
 		}
 		if r == nil {
-			return nil, nil
+			return nil, nil //nolint:nilnil // would be more ergonomic to return a sentinel error
 		}
 		runStatus = &r.Status
 	default:

--- a/pkg/trustedresources/verifier/verifier.go
+++ b/pkg/trustedresources/verifier/verifier.go
@@ -97,7 +97,7 @@ func fromKeyRef(ctx context.Context, keyRef string, hashAlgorithm crypto.Hash, k
 	}
 	raw, err := os.ReadFile(filepath.Clean(keyRef))
 	if err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrFailedLoadKeyFile, err) // nolint:errorlint
+		return nil, fmt.Errorf("%w: %v", ErrFailedLoadKeyFile, err) //nolint:errorlint
 	}
 	v, err := fromData(raw, hashAlgorithm)
 	if err != nil {
@@ -136,11 +136,11 @@ func fromSecret(ctx context.Context, secretRef string, hashAlgorithm crypto.Hash
 func fromData(raw []byte, hashAlgorithm crypto.Hash) (signature.Verifier, error) {
 	pubKey, err := cryptoutils.UnmarshalPEMToPublicKey(raw)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrDecodeKey, err) // nolint:errorlint
+		return nil, fmt.Errorf("%w: %v", ErrDecodeKey, err) //nolint:errorlint
 	}
 	v, err := signature.LoadVerifier(pubKey, hashAlgorithm)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrLoadVerifier, err) // nolint:errorlint
+		return nil, fmt.Errorf("%w: %v", ErrLoadVerifier, err) //nolint:errorlint
 	}
 	return v, nil
 }
@@ -156,7 +156,7 @@ func getKeyPairSecret(ctx context.Context, k8sRef string, k8s kubernetes.Interfa
 
 	s, err := k8s.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrSecretNotFound, err) // nolint:errorlint
+		return nil, fmt.Errorf("%w: %v", ErrSecretNotFound, err) //nolint:errorlint
 	}
 
 	return s, nil

--- a/pkg/trustedresources/verify.go
+++ b/pkg/trustedresources/verify.go
@@ -120,7 +120,7 @@ func getMatchedPolicies(resourceName string, source string, policies []*v1alpha1
 			matching, err := regexp.MatchString(r.Pattern, source)
 			if err != nil {
 				// FixMe: changing %v to %w breaks integration tests.
-				return matchedPolicies, fmt.Errorf("%v: %w", err, ErrRegexMatch) // nolint:errorlint
+				return matchedPolicies, fmt.Errorf("%v: %w", err, ErrRegexMatch) //nolint:errorlint
 			}
 			if matching {
 				matchedPolicies = append(matchedPolicies, p)
@@ -179,7 +179,7 @@ func verifyInterface(obj interface{}, verifier signature.Verifier, signature []b
 
 	if err := verifier.VerifySignature(bytes.NewReader(signature), bytes.NewReader(h.Sum(nil))); err != nil {
 		// FixMe: changing %v to %w breaks integration tests.
-		return fmt.Errorf("%w:%v", ErrResourceVerificationFailed, err.Error()) // nolint:errorlint
+		return fmt.Errorf("%w:%v", ErrResourceVerificationFailed, err.Error())
 	}
 
 	return nil

--- a/test/controller.go
+++ b/test/controller.go
@@ -164,7 +164,8 @@ func AddToInformer(t *testing.T, store cache.Store) func(ktesting.Action) (bool,
 
 // SeedTestData returns Clients and Informers populated with the
 // given Data.
-// nolint: revive
+//
+//nolint:revive
 func SeedTestData(t *testing.T, ctx context.Context, d Data) (Clients, Informers) {
 	t.Helper()
 	c := Clients{

--- a/test/duplicate_test.go
+++ b/test/duplicate_test.go
@@ -66,7 +66,7 @@ spec:
 		if _, err := c.V1beta1TaskRunClient.Create(ctx, taskrun, metav1.CreateOptions{}); err != nil {
 			t.Fatalf("Error creating taskrun: %v", err)
 		}
-		go func(t *testing.T) { //nolint: thelper
+		go func(t *testing.T) { //nolint:thelper
 			defer wg.Done()
 
 			if err := WaitForTaskRunState(ctx, c, taskrunName, TaskRunSucceed(taskrunName), "TaskRunDuplicatePodTaskRunFailed", v1beta1Version); err != nil {

--- a/test/resolvers_test.go
+++ b/test/resolvers_test.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -488,7 +489,7 @@ func TestGitResolver_API(t *testing.T) {
 
 	t.Logf("Creating ConfigMap %s", git.ConfigMapName)
 	configMapData := map[string]string{
-		git.ServerURLKey:          fmt.Sprintf("http://%s:3000/", giteaClusterHostname),
+		git.ServerURLKey:          fmt.Sprint("http://", net.JoinHostPort(giteaClusterHostname, "3000")),
 		git.SCMTypeKey:            "gitea",
 		git.APISecretNameKey:      tokenSecretName,
 		git.APISecretKeyKey:       scmTokenSecretKey,

--- a/test/step_output_test.go
+++ b/test/step_output_test.go
@@ -96,16 +96,17 @@ func TestStepOutput(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error getting Taskrun %q: %v", taskRun.Name, err)
 	}
-	var gotResult *v1beta1.TaskRunResult
+	var found bool
 	for _, result := range tr.Status.TaskRunResults {
 		if result.Name == wantResultName {
-			gotResult = &result
+			found = true
+			if got, want := result.Value.StringVal, wantResultValue; got != want {
+				t.Errorf("Result %s: got %q, wanted %q", wantResultName, got, want)
+			}
 		}
 	}
-	if gotResult == nil {
+	if !found {
 		t.Errorf("Result %s not found", wantResultName)
-	} else if gotResult.Value.StringVal != wantResultValue {
-		t.Errorf("Result %s: got %q, wanted %q", wantResultName, gotResult.Value, wantResultValue)
 	}
 }
 
@@ -170,15 +171,16 @@ func TestStepOutputWithWorkspace(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error getting Taskrun %q: %v", taskRun.Name, err)
 	}
-	var gotResult *v1beta1.TaskRunResult
+	var found bool
 	for _, result := range tr.Status.TaskRunResults {
 		if result.Name == wantResultName {
-			gotResult = &result
+			found = true
+			if got, want := result.Value.StringVal, wantResultValue; got != want {
+				t.Errorf("Result %s: got %q, wanted %q", wantResultName, got, want)
+			}
 		}
 	}
-	if gotResult == nil {
+	if !found {
 		t.Errorf("Result %s not found", wantResultName)
-	} else if gotResult.Value.StringVal != wantResultValue {
-		t.Errorf("Result %s: got %q, wanted %q", wantResultName, gotResult.Value, wantResultValue)
 	}
 }


### PR DESCRIPTION
# Changes

Context: https://github.com/tektoncd/pipeline/issues/5899
There are no expected functional changes in this PR.

Explicitly enabled:
- maintidx
- makezero
- mustag
- nakedret
- nilerr
- nilnil
- noctx
- nolintlint
- nosprintfhostport

Implicitly enabled: all other default linters in the presets.

- fixed `presets` configuration, which wasn't formated properly and did not in fact activate the presets
- explicitly disabled some linters (enabled by `presets`) that highlight too many issues to resolve in this PR
- fixed host-port issues identified by `nosprintfhostport`
- removed defunct `nolint:revive` pragmas
- fixed format of `//nolint` directives in conformance with `nolintlint`
- added needed `//nolint` directives.

Note: hub resolver now passes `context.Context` through to http `GET` call. It is possible that, prior to this
change, the http `GET` would succeed despite a context timeout or cancellation; after this change, that call
would fail with a context timeout or cancellation error. I consider this a pathological condition and not a
functional change.

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [N/A] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [N/A] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [N/A] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [N/A] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
