### PR TITLE
[TEP-0089] SPIRE for non-falsifiable provenance - IsSpireEnabled

### DIFF
--- a/pkg/apis/config/feature_flags.go
+++ b/pkg/apis/config/feature_flags.go
@@ -316,6 +316,11 @@ func CheckAlphaOrBetaAPIFields(ctx context.Context) bool {
 	return cfg.FeatureFlags.EnableAPIFields == AlphaAPIFields || cfg.FeatureFlags.EnableAPIFields == BetaAPIFields
 }
 
+// IsSpireEnabled checks if non-falsifiable provenance is enforced through SPIRE
+func IsSpireEnabled(ctx context.Context) bool {
+	return FromContextOrDefaults(ctx).FeatureFlags.EnforceNonfalsifiability == EnforceNonfalsifiabilityWithSpire
+}
+
 func setEnableAPIFields(ctx context.Context, want string) context.Context {
 	featureFlags, _ := NewFeatureFlagsFromMap(map[string]string{
 		"enable-api-fields": want,

--- a/pkg/apis/config/feature_flags_test.go
+++ b/pkg/apis/config/feature_flags_test.go
@@ -307,37 +307,37 @@ func TestCheckAlphaOrBetaAPIFields(t *testing.T) {
 
 func TestIsSpireEnabled(t *testing.T) {
 	testCases := []struct {
-		name                   string
-		configmap              map[string]string
-		expectedIsSpireEnabled bool
+		name      string
+		configmap map[string]string
+		want      bool
 	}{{
 		name: "when enable-api-fields is set to beta and non-falsifiablity is not set.",
 		configmap: map[string]string{
 			"enable-api-fields":         "beta",
 			"enforce-nonfalsifiability": config.EnforceNonfalsifiabilityNone,
 		},
-		expectedIsSpireEnabled: false,
+		want: false,
 	}, {
 		name: "when enable-api-fields is set to beta and non-falsifiability is set to 'spire'",
 		configmap: map[string]string{
 			"enable-api-fields":         "beta",
 			"enforce-nonfalsifiability": config.EnforceNonfalsifiabilityWithSpire,
 		},
-		expectedIsSpireEnabled: false,
+		want: false,
 	}, {
 		name: "when enable-api-fields is set to alpha and non-falsifiability is not set",
 		configmap: map[string]string{
 			"enable-api-fields":         "alpha",
 			"enforce-nonfalsifiability": config.EnforceNonfalsifiabilityNone,
 		},
-		expectedIsSpireEnabled: false,
+		want: false,
 	}, {
 		name: "when enable-api-fields is set to alpha and non-falsifiability is set to 'spire'",
 		configmap: map[string]string{
 			"enable-api-fields":         "alpha",
 			"enforce-nonfalsifiability": config.EnforceNonfalsifiabilityWithSpire,
 		},
-		expectedIsSpireEnabled: true,
+		want: true,
 	}}
 	ctx := context.Background()
 	store := config.NewStore(logging.FromContext(ctx).Named("config-store"))
@@ -350,11 +350,10 @@ func TestIsSpireEnabled(t *testing.T) {
 		}
 		store.OnConfigChanged(featureflags)
 		ctx = store.ToContext(ctx)
-		want := tc.expectedIsSpireEnabled
 		got := config.IsSpireEnabled(ctx)
 
-		if want != got {
-			t.Errorf("IsSpireEnabled() = %t, want %t", got, want)
+		if tc.want != got {
+			t.Errorf("IsSpireEnabled() = %t, want %t", got, tc.want)
 		}
 	}
 }


### PR DESCRIPTION
[TEP-0089] SPIRE for non-falsifiable provenance.

This PR is a part of a larger set of PRs to provide non-falsifiable provenance through SPIRE.
In particular this PR adds utility functions to check if the SPIRE based non-falsifiable provenance has been enabled.

Previously merged PRs are
- [PR-5039](https://github.com/tektoncd/pipeline/pull/5039)
- [PR-5647](https://github.com/tektoncd/pipeline/pull/5647)
- [PR-5676](https://github.com/tektoncd/pipeline/pull/5676)
- [PR-5902](https://github.com/tektoncd/pipeline/pull/5902)

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [X] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [X] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [X] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [X] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
