### PR TITLE
TEP-0089: Refactor setting of "enforce-nonfalsifiability" feature flag

### DIFF
--- a/docs/spire.md
+++ b/docs/spire.md
@@ -64,7 +64,7 @@ When a TaskRun is created:
 ## Enabling TaskRun result attestations
 
 To enable TaskRun attestations:
-1. Make sure `enforce-nonfalsifiability` is set to `"spire"` in the `feature-flags` configmap, see [`install.md`](./install.md#customizing-the-pipelines-controller-behavior) for details
+1. Make sure `enforce-nonfalsifiability` is set to `"spire"` and `enable-api-fields` is set to `"alpha"` in the `feature-flags` configmap, see [`install.md`](./install.md#customizing-the-pipelines-controller-behavior) for details
 1. Create a SPIRE deployment containing a SPIRE server, SPIRE agents and the SPIRE CSI driver, for convenience, [this sample single cluster deployment](https://github.com/spiffe/spiffe-csi/tree/main/example/config) can be used.
 1. Register the SPIRE workload entry for Tekton with the "Admin" flag, which will allow the Tekton controller to communicate with the SPIRE server to manage the TaskRun identities dynamically.
     ```

--- a/pkg/apis/config/feature_flags_test.go
+++ b/pkg/apis/config/feature_flags_test.go
@@ -209,27 +209,37 @@ func TestGetFeatureFlagsConfigName(t *testing.T) {
 func TestNewFeatureFlagsConfigMapErrors(t *testing.T) {
 	for _, tc := range []struct {
 		fileName string
+		want     string
 	}{{
 		fileName: "feature-flags-invalid-boolean",
+		want:     `failed parsing feature flags config "im-really-not-a-valid-boolean": strconv.ParseBool: parsing "im-really-not-a-valid-boolean": invalid syntax`,
 	}, {
 		fileName: "feature-flags-invalid-enable-api-fields",
+		want:     `invalid value for feature flag "enable-api-fields": "im-not-a-valid-feature-gate"`,
 	}, {
 		fileName: "feature-flags-invalid-trusted-resources-verification-no-match-policy",
+		want:     `invalid value for feature flag "trusted-resources-verification-no-match-policy": "wrong value"`,
 	}, {
 		fileName: "feature-flags-invalid-results-from",
+		want:     `invalid value for feature flag "results-from": "im-not-a-valid-results-from"`,
 	}, {
 		fileName: "feature-flags-invalid-max-result-size-too-large",
+		want:     `invalid value for feature flag "results-from": "10000000000000". This is exceeding the CRD limit`,
 	}, {
 		fileName: "feature-flags-invalid-max-result-size-bad-value",
+		want:     `strconv.Atoi: parsing "foo": invalid syntax`,
 	}, {
 		fileName: "feature-flags-enforce-nonfalsifiability-bad-flag",
+		want:     `invalid value for feature flag "enforce-nonfalsifiability": "bad-value"`,
 	}, {
 		fileName: "feature-flags-spire-with-stable",
+		want:     `"enforce-nonfalsifiability" can be set to non-default values ("spire") only in alpha`,
 	}} {
 		t.Run(tc.fileName, func(t *testing.T) {
 			cm := test.ConfigMapFromTestFile(t, tc.fileName)
-			if _, err := config.NewFeatureFlagsFromConfigMap(cm); err == nil {
-				t.Error("expected error but received nil")
+			_, err := config.NewFeatureFlagsFromConfigMap(cm)
+			if d := cmp.Diff(tc.want, err.Error()); d != "" {
+				t.Errorf("failed to get expected error; diff:\n%s", diff.PrintWantGot(d))
 			}
 		})
 	}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

In this change, we refactor the code for setting `enforce-nonfalsifiability` feature flag to make it easier to understand, and consistent with the rest of the code. This refactor will make it easier to promote the feature to beta, and beyond.

This change also documents that `enable-api-fields` has to be set to `"alpha"` for non-falsifiability to work.

This commit also includes a change to `TestNewFeatureFlagsConfigMapErrors` to check the exact error, instead of just checking that there was an error. This is useful in validating that both errors that can be triggered while setting the `enforce-nonfalsifiability` feature flag are tested.


/kind cleanup
/cc @jagathprakash 

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```

