### PR TITLE
Update API compatibility policy for stable CRDs

### DIFF
--- a/api_compatibility_policy.md
+++ b/api_compatibility_policy.md
@@ -31,14 +31,19 @@ The `apiVersion` field in a Tekton CRD determines whether the overall API (and i
 
 Within a stable CRD, certain opt-in features or API fields gated may be considered `alpha` or `beta`. Similarly, within a beta CRD, certain opt-in features may be considered `alpha`. See the section on Feature Gates for details.
 
-The following CRDs are considered beta, though features may be introduced that are
-alpha:
+The following CRDs are considered stable, though features may be introduced that are
+alpha or beta:
 
-- `Task`
-- `TaskRun`
-- `ClusterTask`
-- `Pipeline`
-- `PipelineRun`
+- `v1.Task`
+- `v1.TaskRun`
+- `v1.Pipeline`
+- `v1.PipelineRun`
+
+`v1beta1.CustomRun` is considered a beta CRD. Adding new fields to `CustomRun`
+that all `CustomRun` controllers are required to support is considered a [backwards incompatible change](#backwards-incompatible-changes),
+and follows the [beta policy](#beta-crds) for backwards incompatible changes.
+
+`v1beta1.ClusterTask` is a deprecated beta CRD. New features will not be added to `ClusterTask`.
 
 ### Alpha CRDs
 


### PR DESCRIPTION
This commit updates the API stability policy to clarify the stability levels of existing CRDs.

/kind documentation

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- n/a Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- n/a Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- n/a Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
