### PR TITLE
Fix Timeouts Default in v1 PipelienRun

### DIFF
--- a/pkg/apis/pipeline/v1/pipelinerun_defaults.go
+++ b/pkg/apis/pipeline/v1/pipelinerun_defaults.go
@@ -40,10 +40,12 @@ func (prs *PipelineRunSpec) SetDefaults(ctx context.Context) {
 		prs.PipelineRef.Resolver = ResolverName(cfg.Defaults.DefaultResolverType)
 	}
 
-	if prs.Timeouts == nil || prs.Timeouts.Pipeline == nil {
-		prs.Timeouts = &TimeoutFields{
-			Pipeline: &metav1.Duration{Duration: time.Duration(cfg.Defaults.DefaultTimeoutMinutes) * time.Minute},
-		}
+	if prs.Timeouts == nil {
+		prs.Timeouts = &TimeoutFields{}
+	}
+
+	if prs.Timeouts.Pipeline == nil {
+		prs.Timeouts.Pipeline = &metav1.Duration{Duration: time.Duration(cfg.Defaults.DefaultTimeoutMinutes) * time.Minute}
 	}
 
 	defaultSA := cfg.Defaults.DefaultServiceAccount

--- a/pkg/apis/pipeline/v1/pipelinerun_defaults_test.go
+++ b/pkg/apis/pipeline/v1/pipelinerun_defaults_test.go
@@ -82,6 +82,25 @@ func TestPipelineRunSpec_SetDefaults(t *testing.T) {
 			},
 		},
 		{
+			desc: "timeouts.pipeline is nil with timeouts.tasks and timeouts.finally",
+			prs: &v1.PipelineRunSpec{
+				Timeouts: &v1.TimeoutFields{
+					Tasks:   &metav1.Duration{Duration: (config.DefaultTimeoutMinutes + 1) * time.Minute},
+					Finally: &metav1.Duration{Duration: (config.DefaultTimeoutMinutes + 1) * time.Minute},
+				},
+			},
+			want: &v1.PipelineRunSpec{
+				TaskRunTemplate: v1.PipelineTaskRunTemplate{
+					ServiceAccountName: config.DefaultServiceAccountValue,
+				},
+				Timeouts: &v1.TimeoutFields{
+					Pipeline: &metav1.Duration{Duration: (config.DefaultTimeoutMinutes) * time.Minute},
+					Tasks:    &metav1.Duration{Duration: (config.DefaultTimeoutMinutes + 1) * time.Minute},
+					Finally:  &metav1.Duration{Duration: (config.DefaultTimeoutMinutes + 1) * time.Minute},
+				},
+			},
+		},
+		{
 			desc: "pod template is nil",
 			prs:  &v1.PipelineRunSpec{},
 			want: &v1.PipelineRunSpec{


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This commit fixes the SetDefault for v1 pipelinerun.timeouts. Previously it would reset pipelinerun.timeouts fields with only timeouts.pipeline while it should have kept timeouts.tasks and timeouts.finally as expected.

/kind bug
follows: https://github.com/tektoncd/pipeline/pull/6311
needed by: #6444 
cc @jerop @lbernick 

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [n/a] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [n/a] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
