### PR TITLE
Keep securitycontext fields simple in e2e

### DIFF
--- a/test/conversion_test.go
+++ b/test/conversion_test.go
@@ -82,7 +82,7 @@ spec:
         mountPath: /messages
     imagePullPolicy: IfNotPresent
     securityContext: 
-      runAsUser: 2000
+      runAsNonRoot: true
     timeout: 60s
     secret:
       secretName: test-ssh-credentials
@@ -110,7 +110,7 @@ spec:
       mountPath: /messages
     imagePullPolicy: IfNotPresent
     securityContext: 
-        runAsUser: 2000
+        runAsNonRoot: true
   sidecars:
   - name: server
     image: alpine/git:v2.26.2
@@ -133,7 +133,7 @@ spec:
     readinessProbe:
       periodSeconds: 1
     securityContext:
-      runAsUser: 0
+      runAsNonRoot: true
     volumeMounts:
     - name: messages
       mountPath: /messages
@@ -180,7 +180,7 @@ spec:
         mountPath: /messages
     imagePullPolicy: IfNotPresent
     securityContext: 
-      runAsUser: 2000
+      runAsNonRoot: true
     timeout: 60s
     secret:
       secretName: test-ssh-credentials
@@ -201,7 +201,7 @@ spec:
       mountPath: /messages
     imagePullPolicy: IfNotPresent
     securityContext: 
-        runAsUser: 2000
+        runAsNonRoot: true
   sidecars:
   - name: server
     image: alpine/git:v2.26.2
@@ -224,7 +224,7 @@ spec:
     - name: messages
       mountPath: /messages
     securityContext:
-      runAsUser: 0
+      runAsNonRoot: true
     script: echo test
   volumes:
     - name: messages
@@ -274,7 +274,7 @@ spec:
   timeout: 60s
   podTemplate:
     securityContext:
-      fsGroup: 65532
+      runAsNonRoot: true
   workspaces:
   - name: password-vault
   finally:
@@ -328,7 +328,7 @@ spec:
   timeout: 60s
   podTemplate:
     securityContext:
-      fsGroup: 65532
+      runAsNonRoot: true
   workspaces:
   - name: password-vault
   finally:
@@ -375,7 +375,7 @@ spec:
       emptyDir: {}
   podTemplate:
     securityContext:
-      fsGroup: 65532
+      allowPrivilegeEscalation: false
 `
 
 	v1beta1TaskRunExpectedYaml = `
@@ -392,7 +392,7 @@ spec:
   timeout: 60s
   podTemplate:
     securityContext:
-      fsGroup: 65532
+      allowPrivilegeEscalation: false
   taskSpec:
     steps:
     - computeResources: {}
@@ -444,7 +444,7 @@ spec:
   timeout: 60s
   podTemplate:
     securityContext:
-      fsGroup: 65532
+      allowPrivilegeEscalation: false
   workspaces:
   - emptyDir: {}
     name: output     
@@ -474,7 +474,7 @@ spec:
   timeout: 60s
   podTemplate:
     securityContext:
-      fsGroup: 65532
+      allowPrivilegeEscalation: false
   workspaces:
     - emptyDir: {}
       name: output 


### PR DESCRIPTION
This will make securitycontext fields to be simple and easy in e2e so that tests can be run on different platform like openshift where runasUser 65532 and 2000 etc can fail, here we are just checking the conversion of fields so simple configuration will also do the job

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Keep securitycontext fields simple in e2e
```
