### PR TITLE
Fix v1beta1.CustomRun GVK

### DIFF
--- a/pkg/apis/pipeline/v1beta1/customrun_types.go
+++ b/pkg/apis/pipeline/v1beta1/customrun_types.go
@@ -194,7 +194,7 @@ func (r *CustomRun) GetStatusCondition() apis.ConditionAccessor {
 
 // GetGroupVersionKind implements kmeta.OwnerRefable.
 func (*CustomRun) GetGroupVersionKind() schema.GroupVersionKind {
-	return SchemeGroupVersion.WithKind(pipeline.RunControllerName)
+	return SchemeGroupVersion.WithKind(pipeline.CustomRunControllerName)
 }
 
 // HasPipelineRunOwnerReference returns true of CustomRun has


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

Follow up to https://github.com/tektoncd/pipeline/pull/6531#discussion_r1166976053

This was using `Runs` but should be `CustomRuns`.
Be aware this is potentially breaking behavior, but is a bug fix to what the value should be.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
BREAKING CHANGE: v1beta1.CustomRuns GVK was changed to properly match it's type (Runs -> CustomRuns). This may break relationships that are relying on the incorrect GVK value. Clients not relying on the GVK value from the Go type are unaffected.
```
