### PR TITLE
Add developer guidance for API changes to CustomRuns

### DIFF
--- a/api_compatibility_policy.md
+++ b/api_compatibility_policy.md
@@ -155,4 +155,4 @@ but a change that renames the Go struct type for that field is allowed.
 ## Notes for Developers
 
 Are you a Tekton contributor looking to make a backwards incompatible change?
-Read more on additional considerations at [deprecations.md](./docs/developers/deprecations.md).
+Read more on additional considerations at [api-changes.md](./docs/developers/api-changes.md#deprecations).

--- a/docs/developers/api-changes.md
+++ b/docs/developers/api-changes.md
@@ -1,7 +1,16 @@
-# Deprecations
+# API Changes
 
 ✋ Before reading this, please read the
 [API Compatibility Policy](../../api_compatibility_policy.md)
+
+## CustomRuns
+
+Before adding an optional field to the spec or status of `CustomRun`,
+consider whether it could be part of the custom spec or custom status instead.
+New fields should be added to the spec or status of the `CustomRun` API only if they
+make sense for all custom run controllers to support.
+
+## Deprecations
 
 The following are things developers should keep in mind for deprecations. These
 tips may not apply in every case, so use your best judgement! If you're not sure


### PR DESCRIPTION
CustomRun is different from other Tekton APIs because its API is implemented by custom run controllers, rather than in-tree controllers. Therefore, adding new fields to this API should be done with extra caution. This commit adds guidance for Tekton devs on whether a new field should go in the CustomRun
API or left to custom run controllers to support as part of the custom spec or custom status, based on whether a feature is applicable to all CustomRuns or just a feature of some of them.

/kind documentation

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- n/a Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- n/a Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- n/a Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
