### PR TITLE
Update wording for end-of-life in releases.md

### DIFF
--- a/releases.md
+++ b/releases.md
@@ -45,28 +45,28 @@ Further documentation available:
 
 - **Latest Release**: [v0.46.0][v0-46-0] (2023-03-17) ([docs][v0-46-0-docs], [examples][v0-46-0-examples])
 - **Initial Release**: [v0.46.0][v0-46-0] (2023-03-17)
-- **End of Life**: 2023-04-17
+- **Estimated End of Life**: 2023-04-17
 - **Patch Releases**: [v0.46.0][v0-46-0]
 
 ### v0.44 (LTS)
 
 - **Latest Release**: [v0.44.0][v0-44-0] (2023-01-24) ([docs][v0-44-0-docs], [examples][v0-44-0-examples])
 - **Initial Release**: [v0.44.0][v0-44-0] (2023-01-24)
-- **End of Life**: 2024-01-24
+- **Estimated End of Life**: 2024-01-24
 - **Patch Releases**: [v0.44.0][v0-44-0]
 
 ### v0.43
 
 - **Latest Release**: [v0.43.2][v0-43-2] (2023-01-10) ([docs][v0-43-2-docs], [examples][v0-43-2-examples])
 - **Initial Release**: [v0.43.0][v0-43-0] (2022-12-22)
-- **End of Life**: 2023-04-22
+- **Estimated End of Life**: 2023-04-22
 - **Patch Releases**: [v0.43.0][v0-43-0], [v0.43.1][v0-43-1], [v0.43.2][v0-43-2]
  
 ### v0.41 (LTS)
 
 - **Latest Release**: [0.41.2][v0-41-2] (2023-04-06) ([docs][v0-41-2-docs], [examples][v0-41-2-examples])
 - **Initial Release**: [v0.41.0][v0-41-0] (2022-10-31)
-- **End of Life**: 2023-10-30
+- **Estimated End of Life**: 2023-10-30
 - **Patch Releases**: [v0.41.0][v0-41-0], [v0.41.1][v0-41-1], [v0.41.2][v0-41-2]
 
 ## End of Life Releases


### PR DESCRIPTION
LTS releases are supported for about 1 year and non-LTS releases are supported for about 1 month, but they don't reach their end-of-life until the next version of Tekton is released. This commit updates releases.md to clarify that the end-of-life dates for existing releases are estimates based on a fixed length of time from when the release was cut. The EOL for a release will be updated when the release that replaces it is cut.

/kind documentation

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- n/a Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- n/a Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- n/a Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
