### PR TITLE
Guard Empty TaskResult Properties Type Assign

### DIFF
--- a/pkg/apis/pipeline/v1/result_defaults.go
+++ b/pkg/apis/pipeline/v1/result_defaults.go
@@ -21,7 +21,7 @@ func (tr *TaskResult) SetDefaults(context.Context) {
 		return
 	}
 	if tr.Type == "" {
-		if tr.Properties != nil {
+		if len(tr.Properties) != 0 {
 			// Set type to object if `properties` is given
 			tr.Type = ResultsTypeObject
 		} else {

--- a/pkg/apis/pipeline/v1/result_defaults_test.go
+++ b/pkg/apis/pipeline/v1/result_defaults_test.go
@@ -61,6 +61,17 @@ func TestTaskResult_SetDefaults(t *testing.T) {
 			Type: v1.ResultsTypeArray,
 		},
 	}, {
+		name: "default type with empty properties",
+		before: &v1.TaskResult{
+			Name:       "resultname",
+			Properties: make(map[string]v1.PropertySpec),
+		},
+		after: &v1.TaskResult{
+			Name:       "resultname",
+			Type:       v1.ResultsTypeString,
+			Properties: make(map[string]v1.PropertySpec),
+		},
+	}, {
 		name: "inferred object type from properties - PropertySpec type is provided",
 		before: &v1.TaskResult{
 			Name:       "resultname",

--- a/pkg/apis/pipeline/v1beta1/result_defaults.go
+++ b/pkg/apis/pipeline/v1beta1/result_defaults.go
@@ -21,7 +21,7 @@ func (tr *TaskResult) SetDefaults(context.Context) {
 		return
 	}
 	if tr.Type == "" {
-		if tr.Properties != nil {
+		if len(tr.Properties) != 0 {
 			// Set type to object if `properties` is given
 			tr.Type = ResultsTypeObject
 		} else {

--- a/pkg/apis/pipeline/v1beta1/result_defaults_test.go
+++ b/pkg/apis/pipeline/v1beta1/result_defaults_test.go
@@ -61,6 +61,17 @@ func TestTaskResult_SetDefaults(t *testing.T) {
 			Type: v1beta1.ResultsTypeArray,
 		},
 	}, {
+		name: "default type with empty properties",
+		before: &v1beta1.TaskResult{
+			Name:       "resultname",
+			Properties: make(map[string]v1beta1.PropertySpec),
+		},
+		after: &v1beta1.TaskResult{
+			Name:       "resultname",
+			Type:       v1beta1.ResultsTypeString,
+			Properties: make(map[string]v1beta1.PropertySpec),
+		},
+	}, {
 		name: "inferred object type from properties - PropertySpec type is provided",
 		before: &v1beta1.TaskResult{
 			Name:       "resultname",


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This commit guards the empty taskResult Properties check, which would otherwise assign default ResultTypeObject to TaskResults with empty Properties maps.

Thanks to @Yongxuanzhang this would help not to default ResultTypeObject to Properties that are set as map.

/kind misc


<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [n/a] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [n/a] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
