### PR TITLE
Remove v1alpha1 Runs Client setup in init test

### DIFF
--- a/test/clients.go
+++ b/test/clients.go
@@ -62,7 +62,6 @@ type clients struct {
 	V1beta1TaskRunClient             v1beta1.TaskRunInterface
 	V1beta1PipelineRunClient         v1beta1.PipelineRunInterface
 	V1beta1CustomRunClient           v1beta1.CustomRunInterface
-	V1alpha1RunClient                v1alpha1.RunInterface
 	V1alpha1ResolutionRequestclient  resolutionv1alpha1.ResolutionRequestInterface
 	V1alpha1VerificationPolicyClient v1alpha1.VerificationPolicyInterface
 	V1PipelineClient                 v1.PipelineInterface

--- a/test/init_test.go
+++ b/test/init_test.go
@@ -291,15 +291,6 @@ func getCRDYaml(ctx context.Context, cs *clients, ns string) ([]byte, error) {
 		printOrAdd(i)
 	}
 
-	v1alpha1Runs, err := cs.V1alpha1RunClient.List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("could not get v1alpha1 runs: %w", err)
-	}
-	for _, i := range v1alpha1Runs.Items {
-		i.SetManagedFields(nil)
-		printOrAdd(i)
-	}
-
 	v1beta1CustomRuns, err := cs.V1beta1CustomRunClient.List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("could not get v1beta1 customruns: %w", err)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This commit removes the alpha1 Runs client setup in init_test
because the v1alpha1 Run support has been removed according to
TEP-114. The error occurs during e2e tests that is introduced as
a flake:
ie. https://storage.googleapis.com/tekton-prow/pr-logs/pull/tektoncd_pipeline/6567/pull-tekton-pipeline-alpha-integration-tests/1649045464097492992/build-log.txt

/kind misc

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [n/a] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [n/a] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [n/a] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
