### PR TITLE
Retry using different pod when node shutdown.

### DIFF
--- a/pkg/pod/status.go
+++ b/pkg/pod/status.go
@@ -400,7 +400,8 @@ func DidTaskRunFail(pod *corev1.Pod) bool {
 			}
 		}
 	}
-	return false
+	// when the node shutdown the pod will be in Terminating and be deleted
+	return pod.DeletionTimestamp != nil
 }
 
 // IsPodArchived indicates if a pod is archived in the retriesStatus.


### PR DESCRIPTION
When node shutdown then the retry pod will always use the same pod because it can not recongize that the pod can not work anymore and k8s can not delete it before the node recovered and it will cause retry is actually not working.

I fix it by check the DeletionTimestamp to know if the pod is actually not work any more.

Fix https://github.com/tektoncd/pipeline/issues/6558

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
