### PR TITLE
Guard Empty ParamSpec Properties Type Assign

### DIFF
--- a/pkg/apis/pipeline/v1/param_types.go
+++ b/pkg/apis/pipeline/v1/param_types.go
@@ -83,7 +83,7 @@ func (pp *ParamSpec) SetDefaults(context.Context) {
 	case pp.Type != "":
 		// If param type is provided by the author, do nothing but just set default type for PropertySpec in case `properties` section is provided.
 		pp.setDefaultsForProperties()
-	case pp.Properties != nil:
+	case len(pp.Properties) != 0:
 		pp.Type = ParamTypeObject
 		// Also set default type for PropertySpec
 		pp.setDefaultsForProperties()

--- a/pkg/apis/pipeline/v1/param_types_test.go
+++ b/pkg/apis/pipeline/v1/param_types_test.go
@@ -111,6 +111,17 @@ func TestParamSpec_SetDefaults(t *testing.T) {
 			Properties: map[string]v1.PropertySpec{"key2": {Type: "string"}},
 		},
 	}, {
+		name: "default type from properties - Properties is an empty map",
+		before: &v1.ParamSpec{
+			Name:       "parametername",
+			Properties: map[string]v1.PropertySpec{},
+		},
+		defaultsApplied: &v1.ParamSpec{
+			Name:       "parametername",
+			Type:       v1.ParamTypeString,
+			Properties: map[string]v1.PropertySpec{},
+		},
+	}, {
 		name: "fully defined ParamSpec - array",
 		before: &v1.ParamSpec{
 			Name:        "parametername",

--- a/pkg/apis/pipeline/v1beta1/param_types.go
+++ b/pkg/apis/pipeline/v1beta1/param_types.go
@@ -76,7 +76,7 @@ func (pp *ParamSpec) SetDefaults(context.Context) {
 	case pp.Type != "":
 		// If param type is provided by the author, do nothing but just set default type for PropertySpec in case `properties` section is provided.
 		pp.setDefaultsForProperties()
-	case pp.Properties != nil:
+	case len(pp.Properties) != 0:
 		pp.Type = ParamTypeObject
 		// Also set default type for PropertySpec
 		pp.setDefaultsForProperties()

--- a/pkg/apis/pipeline/v1beta1/param_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/param_types_test.go
@@ -111,6 +111,17 @@ func TestParamSpec_SetDefaults(t *testing.T) {
 			Properties: map[string]v1beta1.PropertySpec{"key2": {Type: "string"}},
 		},
 	}, {
+		name: "default type from properties - Properties is an empty map",
+		before: &v1beta1.ParamSpec{
+			Name:       "parametername",
+			Properties: map[string]v1beta1.PropertySpec{},
+		},
+		defaultsApplied: &v1beta1.ParamSpec{
+			Name:       "parametername",
+			Type:       v1beta1.ParamTypeString,
+			Properties: map[string]v1beta1.PropertySpec{},
+		},
+	}, {
 		name: "fully defined ParamSpec - array",
 		before: &v1beta1.ParamSpec{
 			Name:        "parametername",


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This commit guards the empty ParamSpec Properties from being casted
as ParamTypeObject, which would otherwise assign default Obejct type
to empty Properties map.

/kind misc
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
