### PR TITLE
Allow references to ClusterTasks in v1 Pipeline Tasks

### DIFF
--- a/docs/pipeline-api.md
+++ b/docs/pipeline-api.md
@@ -4516,7 +4516,11 @@ More info: <a href="https://kubernetes.io/docs/tasks/configure-pod-container/sec
 <th>Description</th>
 </tr>
 </thead>
-<tbody><tr><td><p>&#34;Task&#34;</p></td>
+<tbody><tr><td><p>&#34;ClusterTask&#34;</p></td>
+<td><p>ClusterTaskRefKind is the task type for a reference to a task with cluster scope.
+ClusterTasks are not supported in v1, but v1 types may reference ClusterTasks.</p>
+</td>
+</tr><tr><td><p>&#34;Task&#34;</p></td>
 <td><p>NamespacedTaskKind indicates that the task type has a namespaced scope.</p>
 </td>
 </tr></tbody>

--- a/pkg/apis/pipeline/v1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1/pipeline_validation.go
@@ -131,6 +131,7 @@ func (pt PipelineTask) Validate(ctx context.Context) (errs *apis.FieldError) {
 	taskKinds := map[TaskKind]bool{
 		"":                 true,
 		NamespacedTaskKind: true,
+		ClusterTaskRefKind: true,
 	}
 	// Pipeline task having taskRef/taskSpec with APIVersion is classified as custom task
 	switch {

--- a/pkg/apis/pipeline/v1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1/pipeline_validation_test.go
@@ -77,6 +77,14 @@ func TestPipeline_Validate_Success(t *testing.T) {
 				Tasks: []PipelineTask{{Name: "foo", TaskRef: &TaskRef{Name: "bar", Kind: NamespacedTaskKind}}},
 			},
 		},
+	}, {
+		name: "valid reference to clusterTask",
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Tasks: []PipelineTask{{Name: "foo", TaskRef: &TaskRef{Name: "bar", Kind: ClusterTaskRefKind}}},
+			},
+		},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/apis/pipeline/v1/taskref_types.go
+++ b/pkg/apis/pipeline/v1/taskref_types.go
@@ -42,6 +42,9 @@ type TaskKind string
 const (
 	// NamespacedTaskKind indicates that the task type has a namespaced scope.
 	NamespacedTaskKind TaskKind = "Task"
+	// ClusterTaskRefKind is the task type for a reference to a task with cluster scope.
+	// ClusterTasks are not supported in v1, but v1 types may reference ClusterTasks.
+	ClusterTaskRefKind TaskKind = "ClusterTask"
 )
 
 // IsCustomTask checks whether the reference is to a Custom Task


### PR DESCRIPTION
We cannot yet remove support for ClusterTasks, so they should continue to be referenceable from v1 Pipelines. This commit removes an error message associated with referencing ClusterTasks in v1 Pipelines.

Closes https://github.com/tektoncd/pipeline/issues/6587

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- n/a Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- n/a Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Continue to allow v1beta1 ClusterTasks (deprecated) to be referenced in v1 Pipelines
```
