### PR TITLE
metric type handling changed to reflect documentation

### DIFF
--- a/pkg/pipelinerunmetrics/metrics.go
+++ b/pkg/pipelinerunmetrics/metrics.go
@@ -128,18 +128,15 @@ func viewRegister(cfg *config.Metrics) error {
 		return errors.New("invalid config for PipelinerunLevel: " + cfg.PipelinerunLevel)
 	}
 
-	distribution := view.Distribution(10, 30, 60, 300, 900, 1800, 3600, 5400, 10800, 21600, 43200, 86400)
+	var distribution *view.Aggregation
 
-	if cfg.PipelinerunLevel == config.PipelinerunLevelAtPipelinerun {
+	switch cfg.DurationPipelinerunType {
+	case config.DurationPipelinerunTypeHistogram:
+		distribution = view.Distribution(10, 30, 60, 300, 900, 1800, 3600, 5400, 10800, 21600, 43200, 86400)
+	case config.DurationPipelinerunTypeLastValue:
 		distribution = view.LastValue()
-	} else {
-		switch cfg.DurationPipelinerunType {
-		case config.DurationTaskrunTypeHistogram:
-		case config.DurationTaskrunTypeLastValue:
-			distribution = view.LastValue()
-		default:
-			return errors.New("invalid config for DurationTaskrunType: " + cfg.DurationTaskrunType)
-		}
+	default:
+		return errors.New("invalid config for DurationTaskrunType: " + cfg.DurationTaskrunType)
 	}
 
 	prDurationView = &view.View{

--- a/pkg/pipelinerunmetrics/metrics_test.go
+++ b/pkg/pipelinerunmetrics/metrics_test.go
@@ -48,8 +48,8 @@ func getConfigContext() context.Context {
 		Metrics: &config.Metrics{
 			TaskrunLevel:            config.TaskrunLevelAtTaskrun,
 			PipelinerunLevel:        config.PipelinerunLevelAtPipelinerun,
-			DurationTaskrunType:     config.DefaultDurationTaskrunType,
-			DurationPipelinerunType: config.DefaultDurationPipelinerunType,
+			DurationTaskrunType:     config.DurationTaskrunTypeLastValue,
+			DurationPipelinerunType: config.DurationPipelinerunTypeLastValue,
 		},
 	}
 	return config.ToContext(ctx, cfg)

--- a/pkg/taskrunmetrics/metrics.go
+++ b/pkg/taskrunmetrics/metrics.go
@@ -165,19 +165,15 @@ func viewRegister(cfg *config.Metrics) error {
 		return errors.New("invalid config for TaskrunLevel: " + cfg.TaskrunLevel)
 	}
 
-	distribution := view.Distribution(10, 30, 60, 300, 900, 1800, 3600, 5400, 10800, 21600, 43200, 86400)
+	var distribution *view.Aggregation
 
-	if cfg.TaskrunLevel == config.TaskrunLevelAtTaskrun ||
-		cfg.PipelinerunLevel == config.PipelinerunLevelAtPipelinerun {
+	switch cfg.DurationTaskrunType {
+	case config.DurationTaskrunTypeHistogram:
+		distribution = view.Distribution(10, 30, 60, 300, 900, 1800, 3600, 5400, 10800, 21600, 43200, 86400)
+	case config.DurationTaskrunTypeLastValue:
 		distribution = view.LastValue()
-	} else {
-		switch cfg.DurationTaskrunType {
-		case config.DurationTaskrunTypeHistogram:
-		case config.DurationTaskrunTypeLastValue:
-			distribution = view.LastValue()
-		default:
-			return errors.New("invalid config for DurationTaskrunType: " + cfg.DurationTaskrunType)
-		}
+	default:
+		return errors.New("invalid config for DurationTaskrunType: " + cfg.DurationTaskrunType)
 	}
 
 	trDurationView = &view.View{

--- a/pkg/taskrunmetrics/metrics_test.go
+++ b/pkg/taskrunmetrics/metrics_test.go
@@ -49,8 +49,8 @@ func getConfigContext() context.Context {
 		Metrics: &config.Metrics{
 			TaskrunLevel:            config.TaskrunLevelAtTaskrun,
 			PipelinerunLevel:        config.PipelinerunLevelAtPipelinerun,
-			DurationTaskrunType:     config.DefaultDurationTaskrunType,
-			DurationPipelinerunType: config.DefaultDurationPipelinerunType,
+			DurationTaskrunType:     config.DurationTaskrunTypeLastValue,
+			DurationPipelinerunType: config.DurationPipelinerunTypeLastValue,
 		},
 	}
 	return config.ToContext(ctx, cfg)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
In the documentation of the metrics it is written, that one can set histogram **or** lastvalue for the type of the duration metric. This PR actually allows to set either type for taskrun and pipelinerun duration metrics. Until now it was only possible to set lastvalue for the taskrun and pipelinerun level. 

Additionally the constants inside the switch statement were changed to reflect the correct type constant for the pipelinerun duration type
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
