### PR TITLE
update affinity assistant creation implementation

### DIFF
--- a/config/200-clusterrole.yaml
+++ b/config/200-clusterrole.yaml
@@ -25,6 +25,10 @@ rules:
     # Controller needs to watch Pods created by TaskRuns to see them progress.
     resources: ["pods"]
     verbs: ["list", "watch"]
+  - apiGroups: [""]
+    # Controller needs to get the list of cordoned nodes over the course of a single run
+    resources: ["nodes"]
+    verbs: ["list"]
     # Controller needs cluster access to all of the CRDs that it is responsible for
     # managing.
   - apiGroups: ["tekton.dev"]

--- a/docs/additional-configs.md
+++ b/docs/additional-configs.md
@@ -30,6 +30,7 @@ installation.
     - [Verify signatures using `cosign`](#verify-signatures-using-cosign)
     - [Verify the transparency logs using `rekor-cli`](#verify-the-transparency-logs-using-rekor-cli)
   - [Verify Tekton Resources](#verify-tekton-resources)
+  - [Pipelinerun with Affinity Assistant](#pipelineruns-with-affinity-assistant)
   - [Next steps](#next-steps)
 
 
@@ -553,6 +554,11 @@ gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/webhook
 Trusted Resources is a feature to verify Tekton Tasks and Pipelines. The current
 version of feature supports `v1beta1` `Task` and `Pipeline`. For more details
 please take a look at [Trusted Resources](./trusted-resources.md).
+
+## Pipelineruns with Affinity Assistant
+
+The cluster operators can review the [guidelines](developers/affinity-assistant.md) to `cordon` a node in the cluster
+with the tekton controller and the affinity assistant is enabled.
 
 ## Next steps
 

--- a/docs/developers/README.md
+++ b/docs/developers/README.md
@@ -21,3 +21,4 @@ channel for training and tutorials on Tekton!
 - How specific features are implemented:
   - [PipelineResources (deprecated)](./pipelineresources.md)
   - [Results](./results-lifecycle.md)
+  - [Affinity Assistant](./affinity-assistant.md)

--- a/docs/developers/affinity-assistant.md
+++ b/docs/developers/affinity-assistant.md
@@ -1,0 +1,125 @@
+# Affinity Assistant
+
+
+[Specifying `Workspaces` in a `Pipeline`](../workspaces.md#specifying-workspace-order-in-a-pipeline-and-affinity-assistants) explains
+how an affinity assistant is created when a `persistentVolumeClaim` is used as a volume source for a `workspace` in a `pipelineRun`.
+Please refer to the same section for more details on the affinity assistant.
+
+This section gives an overview of how the affinity assistant is resilient to a cluster maintenance without losing
+the running `pipelineRun`. (Please refer to the issue https://github.com/tektoncd/pipeline/issues/6586 for more details.)
+
+When a list of `tasks` share a single workspace, the affinity assistant pod gets created on a `node` along with all
+`taskRun` pods. It is very common for a `pipeline` author to design a long-running tasks with a single workspace.
+With these long-running tasks, a `node` on which these pods are scheduled can be cordoned while the `pipelineRun` is
+still running. The tekton controller migrates the affinity assistant pod to any available `node` in a cluster along with
+the rest of the `taskRun` pods sharing the same workspace.
+
+Let's understand this with a sample `pipelineRun`:
+
+```yaml
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  generateName: pipeline-run-
+spec:
+  workspaces:
+  - name: source
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Mi
+  pipelineSpec:
+    workspaces:
+    - name: source
+    tasks:
+    - name: first-task
+      taskSpec:
+        workspaces:
+        - name: source
+        steps:
+        - image: alpine
+          script: |
+            echo $(workspaces.source.path)
+            sleep 60
+      workspaces:
+      - name: source
+    - name: last-task
+      taskSpec:
+        workspaces:
+        - name: source
+        steps:
+        - image: alpine
+          script: |
+            echo $(workspaces.source.path)
+            sleep 60
+      runAfter: ["first-task"]
+      workspaces:
+      - name: source
+```
+
+This `pipelineRun` has two long-running tasks, `first-task` and `last-task`. Both of these tasks are sharing a single
+volume with the access mode set to `ReadWriteOnce` which means the volume can be mounted to a single `node` at any
+given point of time.
+
+Create a `pipelineRun` and determine on which `node` the affinity assistant pod is scheduled:
+
+```shell
+kubectl get pods -l app.kubernetes.io/component=affinity-assistant -o wide -w
+NAME                              READY   STATUS    RESTARTS   AGE   IP       NODE     NOMINATED NODE   READINESS GATES
+affinity-assistant-c7b485007a-0   0/1     Pending   0          0s    <none>   <none>   <none>           <none>
+affinity-assistant-c7b485007a-0   0/1     Pending   0          0s    <none>   kind-multinode-worker1   <none>           <none>
+affinity-assistant-c7b485007a-0   0/1     ContainerCreating   0          0s    <none>   kind-multinode-worker1   <none>           <none>
+affinity-assistant-c7b485007a-0   0/1     ContainerCreating   0          1s    <none>   kind-multinode-worker1   <none>           <none>
+affinity-assistant-c7b485007a-0   1/1     Running             0          5s    10.244.1.144   kind-multinode-worker1   <none>           <none>
+```
+
+Now, `cordon` that node to mark it unschedulable for any new pods:
+
+```shell
+kubectl cordon kind-multinode-worker1
+node/kind-multinode-worker1 cordoned
+```
+
+The node is cordoned:
+
+```shell
+kubectl get node
+NAME                           STATUS                     ROLES           AGE   VERSION
+kind-multinode-control-plane   Ready                      control-plane   13d   v1.26.3
+kind-multinode-worker1         Ready,SchedulingDisabled   <none>          13d   v1.26.3
+kind-multinode-worker2         Ready                      <none>          13d   v1.26.3
+```
+
+Now, watch the affinity assistant pod getting transferred onto other available node `kind-multinode-worker2`:
+
+```shell
+kubectl get pods -l app.kubernetes.io/component=affinity-assistant -o wide -w
+NAME                              READY   STATUS    RESTARTS   AGE   IP              NODE            NOMINATED NODE   READINESS GATES
+affinity-assistant-c7b485007a-0   1/1     Running   0          49s   10.244.1.144   kind-multinode-worker1   <none>           <none>
+affinity-assistant-c7b485007a-0   1/1     Terminating   0          70s   10.244.1.144   kind-multinode-worker1   <none>           <none>
+affinity-assistant-c7b485007a-0   1/1     Terminating   0          70s   10.244.1.144   kind-multinode-worker1   <none>           <none>
+affinity-assistant-c7b485007a-0   0/1     Terminating   0          70s   10.244.1.144   kind-multinode-worker1   <none>           <none>
+affinity-assistant-c7b485007a-0   0/1     Terminating   0          70s   10.244.1.144   kind-multinode-worker1   <none>           <none>
+affinity-assistant-c7b485007a-0   0/1     Terminating   0          70s   10.244.1.144   kind-multinode-worker1   <none>           <none>
+affinity-assistant-c7b485007a-0   0/1     Pending       0          0s    <none>          <none>          <none>           <none>
+affinity-assistant-c7b485007a-0   0/1     Pending       0          1s    <none>          kind-multinode-worker2   <none>           <none>
+affinity-assistant-c7b485007a-0   0/1     ContainerCreating   0          1s    <none>          kind-multinode-worker2   <none>           <none>
+affinity-assistant-c7b485007a-0   0/1     ContainerCreating   0          2s    <none>          kind-multinode-worker2   <none>           <none>
+affinity-assistant-c7b485007a-0   1/1     Running             0          4s    10.244.2.144    kind-multinode-worker2   <none>           <none>
+```
+
+And, the `pipelineRun` finishes to completion:
+
+```shell
+kubectl get pr
+NAME                     SUCCEEDED   REASON      STARTTIME   COMPLETIONTIME
+pipeline-run-r2c7k       True        Succeeded   4m22s       2m1s
+
+kubectl get tr
+NAME                            SUCCEEDED   REASON      STARTTIME   COMPLETIONTIME
+pipeline-run-r2c7k-first-task   True        Succeeded   5m16s       4m7s
+pipeline-run-r2c7k-last-task    True        Succeeded   4m6s        2m56s
+```

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -381,6 +381,12 @@ significantly. We do not recommend using them in clusters larger than several hu
 node in the cluster must have an appropriate label matching `topologyKey`. If some or all nodes
 are missing the specified `topologyKey` label, it can lead to unintended behavior.
 
+**Note:** Any time during the execution of a `pipelineRun`, if the node with a placeholder Affinity Assistant pod and
+the `taskRun` pods sharing a `workspace` is `cordoned` or disabled for scheduling anything new (`tainted`), the
+`pipelineRun` controller deletes the placeholder pod. The `taskRun` pods on a `cordoned` node continues running
+until completion. The deletion of a placeholder pod triggers creating a new placeholder pod on any available node
+such that the rest of the `pipelineRun` can continue without any disruption until it finishes.
+
 #### Specifying `Workspaces` in `PipelineRuns`
 
 For a `PipelineRun` to execute a `Pipeline` that includes one or more `Workspaces`, it needs to

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -609,16 +609,18 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1beta1.PipelineRun, get
 				return controller.NewPermanentError(err)
 			}
 		}
+	}
 
-		if !c.isAffinityAssistantDisabled(ctx) {
-			// create Affinity Assistant (StatefulSet) so that taskRun pods that share workspace PVC achieve Node Affinity
-			if err = c.createAffinityAssistants(ctx, pr.Spec.Workspaces, pr, pr.Namespace); err != nil {
-				logger.Errorf("Failed to create affinity assistant StatefulSet for PipelineRun %s: %v", pr.Name, err)
-				pr.Status.MarkFailed(ReasonCouldntCreateAffinityAssistantStatefulSet,
-					"Failed to create StatefulSet for PipelineRun %s/%s correctly: %s",
-					pr.Namespace, pr.Name, err)
-				return controller.NewPermanentError(err)
-			}
+	// Make an attempt to create Affinity Assistant if it does not exist
+	// if the Affinity Assistant already exists, handle the possibility of assigned node becoming unschedulable by deleting the pod
+	if !c.isAffinityAssistantDisabled(ctx) {
+		// create Affinity Assistant (StatefulSet) so that taskRun pods that share workspace PVC achieve Node Affinity
+		if err = c.createOrUpdateAffinityAssistants(ctx, pr.Spec.Workspaces, pr, pr.Namespace); err != nil {
+			logger.Errorf("Failed to create affinity assistant StatefulSet for PipelineRun %s: %v", pr.Name, err)
+			pr.Status.MarkFailed(ReasonCouldntCreateOrUpdateAffinityAssistantStatefulSet,
+				"Failed to create StatefulSet or update affinity assistant replicas for PipelineRun %s/%s correctly: %s",
+				pr.Namespace, pr.Name, err)
+			return controller.NewPermanentError(err)
 		}
 	}
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Before this commit, the affinity assistant was created in the beginning of the `pipelineRun`. And the same affinity assistant was used throughout the entire lifecycle of a `pipelineRun`. Now, there could be a case when the node on which affinity assistant pod is created is `cordoned` for maintenance purpose. In this case, the rest of the `pipelineRun` is stuck and cannot run to the competition since the affinity assistant (StatefulSet) tries to schedule rest of the pods (`taskRuns`) on the same node but that node is `cordoned` or not scheduling anything new.

This commit always makes an attempt to create Affinity Assistant (StatefulSet) in case it does not exist. If it exist, the controller checks if the node on which Affinity Assistant pod is created is healthy to schedule subsequent pods. If not, the controller deletes Affinity Assistant pod so that StatefulSet can upscale the replicas (set to 1) on other node in the cluster.

Closes https://github.com/tektoncd/pipeline/issues/6586.

<del>Testing is pending, will update the PR after testing locally.</del> 

These changes are now tested locally on a cluster with two nodes and works as expected. The affinity assistant pod along with remaining `taskRun` pods are created on a healthy node when the existing node is cordoned.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Resilient Affinity Assistant - make sure the Affinity Assistant pod is always on a healthy node during the entire life cycle of the pipelineRun
```
