### PR TITLE
Add support for consuming whole array results in matrix

### DIFF
--- a/docs/matrix.md
+++ b/docs/matrix.md
@@ -303,7 +303,7 @@ See the end-to-end example in [`PipelineRun` with `Matrix` and `Results`][pr-wit
 
 #### Results in Matrix.Params
 
-`Matrix.Params` supports string replacements from `Results` of type String, Array or Object.
+`Matrix.Params` supports whole array replacements and string replacements from `Results` of type String, Array or Object
 
 ```yaml
 tasks:
@@ -314,15 +314,8 @@ tasks:
   matrix:
     params:
     - name: values
-      value:
-      - $(tasks.task-1.results.foo) # string replacement from string result
-      - $(tasks.task-2.results.bar[0]) # string replacement from array result
-      - $(tasks.task-3.results.rad.key) # string replacement from object result
+      value: $(tasks.task-4.results.whole-array[*])
 ```
-
-For further information, see the example in [`PipelineRun` with `Matrix` and `Results`][pr-with-matrix-and-results].
-
-We plan to add support passing whole Array `Results` into the `Matrix` (#5925):
 
 ```yaml
 tasks:
@@ -333,8 +326,15 @@ tasks:
   matrix:
     params:
     - name: values
-      value: $(tasks.task-4.results.foo) # array
+      value:
+        - $(tasks.task-1.results.a-string-result)
+        - $(tasks.task-2.results.an-array-result[0])
+        - $(tasks.task-3.results.an-object-result.key)
 ```
+
+
+For further information, see the example in [`PipelineRun` with `Matrix` and `Results`][pr-with-matrix-and-results].
+
 
 #### Results in Matrix.Include.Params
 

--- a/examples/v1beta1/pipelineruns/alpha/pipelinerun-with-matrix-and-results.yaml
+++ b/examples/v1beta1/pipelineruns/alpha/pipelinerun-with-matrix-and-results.yaml
@@ -21,7 +21,7 @@ kind: PipelineRun
 metadata:
   generateName: matrixed-pr-
 spec:
-  serviceAccountName: 'default'
+  serviceAccountName: "default"
   pipelineSpec:
     tasks:
       - name: get-platforms
@@ -56,10 +56,7 @@ spec:
         matrix:
           params:
             - name: platform
-              value:
-                - $(tasks.get-platforms.results.platforms[0])
-                - $(tasks.get-platforms.results.platforms[1])
-                - $(tasks.get-platforms.results.platforms[2])
+              value: $(tasks.get-platforms.results.platforms[*])
             - name: browser
               value:
                 - $(tasks.get-browsers-and-url.results.browsers[0])

--- a/pkg/apis/pipeline/v1/matrix_types.go
+++ b/pkg/apis/pipeline/v1/matrix_types.go
@@ -348,24 +348,3 @@ func (m *Matrix) validateParameterInOneOfMatrixOrParams(params []Param) (errs *a
 	}
 	return errs
 }
-
-// validateNoWholeArrayResults() is used to ensure a matrix parameter does not contain result references
-// to entire arrays. This is temporary until whole array replacements for matrix parameters are supported.
-// See issue #6056 for more details
-func (m *Matrix) validateNoWholeArrayResults() (errs *apis.FieldError) {
-	if m.HasParams() {
-		for i, param := range m.Params {
-			val := param.Value.StringVal
-			expressions, ok := GetVarSubstitutionExpressionsForParam(param)
-			if ok {
-				if LooksLikeContainsResultRefs(expressions) {
-					_, stringIdx := ParseResultName(val)
-					if stringIdx == "*" {
-						errs = errs.Also(apis.ErrGeneric("matrix parameters cannot contain whole array result references", "").ViaFieldIndex("matrix.params", i))
-					}
-				}
-			}
-		}
-	}
-	return errs
-}

--- a/pkg/apis/pipeline/v1/pipeline_types_test.go
+++ b/pkg/apis/pipeline/v1/pipeline_types_test.go
@@ -697,19 +697,6 @@ func TestPipelineTask_ValidateMatrix(t *testing.T) {
 				}}},
 		},
 	}, {
-		name: "parameters in matrix contain whole array results references",
-		pt: &PipelineTask{
-			Name: "task",
-			Matrix: &Matrix{
-				Params: Params{{
-					Name: "a-param", Value: ParamValue{Type: ParamTypeString, StringVal: "$(tasks.foo-task.results.arr-results[*])"},
-				}}},
-		},
-		wantErrs: &apis.FieldError{
-			Message: "matrix parameters cannot contain whole array result references",
-			Paths:   []string{"matrix.params[0]"},
-		},
-	}, {
 		name: "count of combinations of parameters in the matrix exceeds the maximum",
 		pt: &PipelineTask{
 			Name: "task",

--- a/pkg/apis/pipeline/v1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1/pipeline_validation.go
@@ -227,7 +227,6 @@ func (pt *PipelineTask) validateMatrix(ctx context.Context) (errs *apis.FieldErr
 		// when the enable-api-fields feature gate is anything but "alpha".
 		errs = errs.Also(version.ValidateEnabledAPIFields(ctx, "matrix", config.AlphaAPIFields))
 		errs = errs.Also(pt.Matrix.validateCombinationsCount(ctx))
-		errs = errs.Also(pt.Matrix.validateNoWholeArrayResults())
 		errs = errs.Also(pt.Matrix.validateUniqueParams())
 	}
 	errs = errs.Also(pt.Matrix.validateParameterInOneOfMatrixOrParams(pt.Params))

--- a/pkg/apis/pipeline/v1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1/pipeline_validation_test.go
@@ -3150,6 +3150,16 @@ func Test_validateMatrix(t *testing.T) {
 					Name: "b-param", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"$(tasks.bar-task.results.b-result)"}},
 				}}},
 		}},
+	}, {
+		name: "parameters in matrix contain whole array results references",
+		tasks: PipelineTaskList{{
+			Name:    "a-task",
+			TaskRef: &TaskRef{Name: "a-task"},
+			Matrix: &Matrix{
+				Params: Params{{
+					Name: "a-param", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"$(tasks.foo-task.results.a-task-results[*])"}},
+				}}},
+		}},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/apis/pipeline/v1beta1/matrix_types.go
+++ b/pkg/apis/pipeline/v1beta1/matrix_types.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"fmt"
 	"sort"
-	"strings"
 
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"golang.org/x/exp/maps"
@@ -345,24 +344,6 @@ func (m *Matrix) validateParameterInOneOfMatrixOrParams(params Params) (errs *ap
 	for _, param := range params {
 		if matrixParamNames.Has(param.Name) {
 			errs = errs.Also(apis.ErrMultipleOneOf("matrix["+param.Name+"]", "params["+param.Name+"]"))
-		}
-	}
-	return errs
-}
-
-// validateNoWholeArrayResults() is used to ensure a matrix parameter does not contain result references
-// to entire arrays. This is temporary until whole array replacements for matrix paraemeters are supported.
-// See issue #6056 for more details
-func (m *Matrix) validateNoWholeArrayResults() (errs *apis.FieldError) {
-	if m.HasParams() {
-		for i, param := range m.Params {
-			val := param.Value.StringVal
-			expressions, ok := GetVarSubstitutionExpressionsForParam(param)
-			if ok {
-				if LooksLikeContainsResultRefs(expressions) && strings.Contains(val, "[*]") {
-					errs = errs.Also(apis.ErrGeneric("matrix parameters cannot contain whole array result references", "").ViaFieldIndex("matrix.params", i))
-				}
-			}
 		}
 	}
 	return errs

--- a/pkg/apis/pipeline/v1beta1/pipeline_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types_test.go
@@ -681,19 +681,6 @@ func TestPipelineTask_validateMatrix(t *testing.T) {
 				}}},
 		},
 	}, {
-		name: "parameters in matrix contain whole array results references",
-		pt: &PipelineTask{
-			Name: "task",
-			Matrix: &Matrix{
-				Params: Params{{
-					Name: "a-param", Value: ParamValue{Type: ParamTypeString, StringVal: "$(tasks.foo-task.results.arr-results[*])"},
-				}}},
-		},
-		wantErrs: &apis.FieldError{
-			Message: "matrix parameters cannot contain whole array result references",
-			Paths:   []string{"matrix.params[0]"},
-		},
-	}, {
 		name: "count of combinations of parameters in the matrix exceeds the maximum",
 		pt: &PipelineTask{
 			Name: "task",

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation.go
@@ -179,7 +179,6 @@ func (pt *PipelineTask) validateMatrix(ctx context.Context) (errs *apis.FieldErr
 		// when the enable-api-fields feature gate is anything but "alpha".
 		errs = errs.Also(version.ValidateEnabledAPIFields(ctx, "matrix", config.AlphaAPIFields))
 		errs = errs.Also(pt.Matrix.validateCombinationsCount(ctx))
-		errs = errs.Also(pt.Matrix.validateNoWholeArrayResults())
 		errs = errs.Also(pt.Matrix.validateUniqueParams())
 	}
 	errs = errs.Also(pt.Matrix.validateParameterInOneOfMatrixOrParams(pt.Params))

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
@@ -3193,6 +3193,16 @@ func Test_validateMatrix(t *testing.T) {
 					Name: "b-param", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"$(tasks.bar-task.results.b-result)"}},
 				}}},
 		}},
+	}, {
+		name: "parameters in matrix contain whole array results references",
+		tasks: PipelineTaskList{{
+			Name:    "a-task",
+			TaskRef: &TaskRef{Name: "a-task"},
+			Matrix: &Matrix{
+				Params: Params{{
+					Name: "a-param", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"$(tasks.foo-task.results.a-task-results[*])"}},
+				}}},
+		}},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -812,7 +812,6 @@ func (c *Reconciler) createTaskRuns(ctx context.Context, rpt *resources.Resolved
 	if rpt.PipelineTask.IsMatrixed() {
 		matrixCombinations = rpt.PipelineTask.Matrix.FanOut()
 	}
-
 	for i, taskRunName := range rpt.TaskRunNames {
 		var params v1.Params
 		if len(matrixCombinations) > i {
@@ -894,7 +893,6 @@ func (c *Reconciler) createCustomRuns(ctx context.Context, rpt *resources.Resolv
 	if rpt.PipelineTask.IsMatrixed() {
 		matrixCombinations = rpt.PipelineTask.Matrix.FanOut()
 	}
-
 	for i, customRunName := range rpt.CustomRunNames {
 		var params v1.Params
 		if len(matrixCombinations) > i {

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -91,6 +91,7 @@ var (
 	ignoreStartTime          = cmpopts.IgnoreFields(v1.PipelineRunStatusFields{}, "StartTime")
 	ignoreCompletionTime     = cmpopts.IgnoreFields(v1.PipelineRunStatusFields{}, "CompletionTime")
 	ignoreFinallyStartTime   = cmpopts.IgnoreFields(v1.PipelineRunStatusFields{}, "FinallyStartTime")
+	ignoreProvenance         = cmpopts.IgnoreFields(v1.PipelineRunStatusFields{}, "Provenance")
 	trueb                    = true
 	simpleHelloWorldTask     = &v1.Task{ObjectMeta: baseObjectMeta("hello-world", "foo")}
 	simpleSomeTask           = &v1.Task{ObjectMeta: baseObjectMeta("some-task", "foo")}
@@ -10072,7 +10073,7 @@ spec:
 	}
 }
 
-func TestReconciler_PipelineTaskMatrixResultsWithArrayIndexing(t *testing.T) {
+func TestReconciler_PipelineTaskMatrixResultsWithArrays(t *testing.T) {
 	names.TestingSeed()
 	task := parse.MustParseV1Task(t, `
 metadata:
@@ -10400,6 +10401,153 @@ status:
       ResultExtractionMethod: "termination-message"
       MaxResultSize: 4096
 `),
+	}, {
+		name:  "whole array result replacements in matrix.params",
+		pName: "p-dag-3",
+		p: parse.MustParseV1Pipeline(t, fmt.Sprintf(`
+metadata:
+  name: %s
+  namespace: foo
+spec:
+  tasks:
+    - name: pt-with-result
+      params:
+       - name: platforms
+         type: array
+      taskRef:
+        name: taskwithresults
+    - name: echo-platforms
+      matrix:
+        params:
+          - name: platform
+            value: $(tasks.pt-with-result.results.platforms[*])
+      taskRef:
+        name: mytask
+`, "p-dag-3")),
+		tr: mustParseTaskRunWithObjectMeta(t,
+			taskRunObjectMeta("pr-pt-with-result", "foo",
+				"pr", "p-dag-3", "pt-with-result", false),
+			`
+spec:
+  serviceAccountName: test-sa
+  taskRef:
+    name: taskwithresults
+status:
+ conditions:
+  - type: Succeeded
+    status: "True"
+    reason: Succeeded
+    message: All Tasks have completed executing
+ results:
+  - name: platforms
+    value:
+     - linux
+     - mac
+     - windows
+`),
+		expectedTaskRuns: []*v1.TaskRun{
+			mustParseTaskRunWithObjectMeta(t,
+				taskRunObjectMeta("pr-echo-platforms-0", "foo",
+					"pr", "p-dag-3", "echo-platforms", false),
+				`
+spec:
+  params:
+  - name: platform
+    value: linux
+  serviceAccountName: test-sa
+  taskRef:
+    name: mytask
+    kind: Task
+labels:
+    tekton.dev/memberOf: tasks
+    tekton.dev/pipeline: p-dag-3
+`),
+			mustParseTaskRunWithObjectMeta(t,
+				taskRunObjectMeta("pr-echo-platforms-1", "foo",
+					"pr", "p-dag-3", "echo-platforms", false),
+				`
+spec:
+  params:
+  - name: platform
+    value: mac
+  serviceAccountName: test-sa
+  taskRef:
+    name: mytask
+    kind: Task
+labels:
+    tekton.dev/memberOf: tasks
+    tekton.dev/pipeline: p-dag-3
+`),
+			mustParseTaskRunWithObjectMeta(t,
+				taskRunObjectMeta("pr-echo-platforms-2", "foo",
+					"pr", "p-dag-3", "echo-platforms", false),
+				`
+spec:
+  params:
+  - name: platform
+    value: windows
+  serviceAccountName: test-sa
+  taskRef:
+    name: mytask
+    kind: Task
+labels:
+    tekton.dev/memberOf: tasks
+    tekton.dev/pipeline: p-dag-3
+`),
+		},
+		expectedPipelineRun: parse.MustParseV1PipelineRun(t, `
+metadata:
+  name: pr
+  namespace: foo
+  annotations: {}
+  labels:
+    tekton.dev/pipeline: p-dag-3
+spec:
+  taskRunTemplate:
+    serviceAccountName: test-sa
+  pipelineRef:
+    name: p-dag-3
+status:
+  pipelineSpec:
+    tasks:
+    - name: pt-with-result
+      params:
+        - name: platforms
+          type: array
+      taskRef:
+        name: taskwithresults
+        kind: Task
+    - name: echo-platforms
+      taskRef:
+        name: mytask
+        kind: Task
+      matrix:
+        params:
+          - name: platform
+            value: $(tasks.pt-with-result.results.platforms[*])
+  conditions:
+  - type: Succeeded
+    status: "Unknown"
+    reason: "Running"
+    message: "Tasks Completed: 1 (Failed: 0, Cancelled 0), Incomplete: 1, Skipped: 0"
+  childReferences:
+  - apiVersion: tekton.dev/v1
+    kind: TaskRun
+    name: pr-pt-with-result
+    pipelineTaskName: pt-with-result
+  - apiVersion: tekton.dev/v1
+    kind: TaskRun
+    name: pr-echo-platforms-0
+    pipelineTaskName: echo-platforms
+  - apiVersion: tekton.dev/v1
+    kind: TaskRun
+    name: pr-echo-platforms-1
+    pipelineTaskName: echo-platforms
+  - apiVersion: tekton.dev/v1
+    kind: TaskRun
+    name: pr-echo-platforms-2
+    pipelineTaskName: echo-platforms
+`),
 	}}
 	for _, tt := range tests {
 		t.Run(tt.pName, func(t *testing.T) {
@@ -10433,6 +10581,249 @@ spec:
 				actual := getTaskRunByName(t, taskRuns, trName)
 				if d := cmp.Diff(expectedTaskRun, actual, ignoreResourceVersion, ignoreTypeMeta); d != "" {
 					t.Errorf("expected to see TaskRun %v created. Diff %s", expectedTaskRun.Name, diff.PrintWantGot(d))
+				}
+			}
+
+			if d := cmp.Diff(tt.expectedPipelineRun, pipelineRun, ignoreResourceVersion, ignoreTypeMeta, ignoreLastTransitionTime, ignoreStartTime, ignoreFinallyStartTime, ignoreProvenance, cmpopts.EquateEmpty()); d != "" {
+				t.Errorf("expected PipelineRun was not created. Diff %s", diff.PrintWantGot(d))
+			}
+		})
+	}
+}
+
+func TestReconciler_CustomPipelineTaskMatrixResultsWholeArray(t *testing.T) {
+	names.TestingSeed()
+	taskwithresults := parse.MustParseV1Task(t, `
+metadata:
+  name: taskwithresults
+  namespace: foo
+spec:
+  results:
+    - name: platforms
+      type: array
+  steps:
+    - name: produce-a-list-of-platforms
+      image: bash:latest
+      script: |
+        #!/usr/bin/env bash
+        echo -n "[\"linux\",\"mac\",\"windows\"]" | tee $(results.platforms.path)
+`)
+	expectedCustomRuns := []*v1beta1.CustomRun{
+		mustParseCustomRunWithObjectMeta(t,
+			taskRunObjectMeta("pr-pt-matrix-custom-task-0", "foo",
+				"pr", "p-dag", "pt-matrix-custom-task", false),
+			`
+spec:
+  customRef:
+    apiVersion: example.dev/v0
+    kind: Example
+  params:
+  - name: platform
+    value: linux
+  serviceAccountName: test-sa
+  taskRef:
+    name: mytask
+    kind: Task
+  labels:
+    tekton.dev/memberOf: tasks
+    tekton.dev/pipeline: p-dag
+`),
+		mustParseCustomRunWithObjectMeta(t,
+			taskRunObjectMeta("pr-pt-matrix-custom-task-1", "foo",
+				"pr", "p-dag", "pt-matrix-custom-task", false),
+			`
+spec:
+  customRef:
+    apiVersion: example.dev/v0
+    kind: Example
+  params:
+  - name: platform
+    value: mac
+  serviceAccountName: test-sa
+  taskRef:
+    name: mytask
+    kind: Task
+  labels:
+    tekton.dev/memberOf: tasks
+    tekton.dev/pipeline: p-dag
+`),
+		mustParseCustomRunWithObjectMeta(t,
+			taskRunObjectMeta("pr-pt-matrix-custom-task-2", "foo",
+				"pr", "p-dag", "pt-matrix-custom-task", false),
+			`
+spec:
+  customRef:
+    apiVersion: example.dev/v0
+    kind: Example
+  params:
+  - name: platform
+    value: windows
+  serviceAccountName: test-sa
+  taskRef:
+    name: mytask
+    kind: Task
+  labels:
+    tekton.dev/memberOf: tasks
+    tekton.dev/pipeline: p-dag
+`),
+	}
+	cms := []*corev1.ConfigMap{withEnabledAlphaAPIFields(newFeatureFlagsConfigMap())}
+	cms = append(cms, withMaxMatrixCombinationsCount(newDefaultsConfigMap(), 10))
+	tests := []struct {
+		name                string
+		pName               string
+		p                   *v1.Pipeline
+		tr                  *v1.TaskRun
+		expectedPipelineRun *v1.PipelineRun
+	}{{
+		name:  "whole array results replacements in a matrix",
+		pName: "p-dag",
+		p: parse.MustParseV1Pipeline(t, fmt.Sprintf(`
+metadata:
+  name: %s
+  namespace: foo
+spec:
+  tasks:
+    - name: pt-with-result
+      params:
+       - name: platforms
+         type: array
+      taskRef:
+        name: taskwithresults
+    - name: pt-matrix-custom-task
+      matrix:
+        params:
+          - name: platform
+            value: $(tasks.pt-with-result.results.platforms[*])
+      taskRef:
+        apiVersion: example.dev/v0
+        kind: Example
+`, "p-dag")),
+		tr: mustParseTaskRunWithObjectMeta(t,
+			taskRunObjectMeta("pr-pt-with-result", "foo",
+				"pr", "p-dag", "pt-with-result", false),
+			`
+spec:
+  serviceAccountName: test-sa
+  taskRef:
+    name: taskwithresults
+status:
+ conditions:
+  - type: Succeeded
+    status: "True"
+    reason: Succeeded
+    message: All Tasks have completed executing
+ results:
+  - name: platforms
+    value:
+     - linux
+     - mac
+     - windows
+`),
+		expectedPipelineRun: parse.MustParseV1PipelineRun(t, `
+metadata:
+  name: pr
+  namespace: foo
+  annotations: {}
+  labels:
+    tekton.dev/pipeline: p-dag
+spec:
+  serviceAccountName: test-sa
+  pipelineRef:
+    name: p-dag
+  taskRunTemplate:
+    serviceAccountName: test-sa
+status:
+  pipelineSpec:
+    tasks:
+    - name: pt-with-result
+      params:
+        - name: platforms
+          type: array
+      taskRef:
+        name: taskwithresults
+        kind: Task
+    - name: pt-matrix-custom-task
+      taskRef:
+        apiVersion: example.dev/v0
+        kind: Example
+      matrix:
+        params:
+          - name: platform
+            value: $(tasks.pt-with-result.results.platforms[*])
+  conditions:
+  - type: Succeeded
+    status: "Unknown"
+    reason: "Running"
+    message: "Tasks Completed: 1 (Failed: 0, Cancelled 0), Incomplete: 1, Skipped: 0"
+  childReferences:
+  - apiVersion: tekton.dev/v1
+    kind: TaskRun
+    name: pr-pt-with-result
+    pipelineTaskName: pt-with-result
+  - apiVersion: tekton.dev/v1beta1
+    kind: CustomRun
+    name:  pr-pt-matrix-custom-task-0
+    pipelineTaskName: pt-matrix-custom-task
+  - apiVersion: tekton.dev/v1beta1
+    kind: CustomRun
+    name:  pr-pt-matrix-custom-task-1
+    pipelineTaskName: pt-matrix-custom-task
+  - apiVersion: tekton.dev/v1beta1
+    kind: CustomRun
+    name:  pr-pt-matrix-custom-task-2
+    pipelineTaskName: pt-matrix-custom-task
+  provenance:
+    featureFlags:
+      RunningInEnvWithInjectedSidecars: true
+      EnableTektonOCIBundles: true
+      EnableAPIFields: "alpha"
+      AwaitSidecarReadiness: true
+      VerificationNoMatchPolicy: "ignore"
+      EnableProvenanceInStatus: true
+      ResultExtractionMethod: "termination-message"
+      MaxResultSize: 4096
+`),
+	}}
+	for _, tt := range tests {
+		t.Run(tt.pName, func(t *testing.T) {
+			pr := parse.MustParseV1PipelineRun(t, fmt.Sprintf(`
+metadata:
+  name: pr
+  namespace: foo
+spec:
+  taskRunTemplate:
+    serviceAccountName: test-sa
+  pipelineRef:
+    name: %s
+`, tt.pName))
+			d := test.Data{
+				PipelineRuns: []*v1.PipelineRun{pr},
+				Pipelines:    []*v1.Pipeline{tt.p},
+				Tasks:        []*v1.Task{taskwithresults},
+				ConfigMaps:   cms,
+			}
+			if tt.tr != nil {
+				d.TaskRuns = []*v1.TaskRun{tt.tr}
+			}
+
+			prt := newPipelineRunTest(t, d)
+			defer prt.Cancel()
+
+			pipelineRun, clients := prt.reconcileRun("foo", "pr", []string{}, false)
+			customRuns, err := clients.Pipeline.TektonV1beta1().CustomRuns("foo").List(prt.TestAssets.Ctx, metav1.ListOptions{})
+			if err != nil {
+				t.Fatalf("Failure to list customRuns's %s", err)
+			}
+
+			if len(customRuns.Items) != 3 {
+				t.Fatalf("Expected 3 customRuns got %d", len(customRuns.Items))
+			}
+
+			for i := range customRuns.Items {
+				expectedCustomRun := expectedCustomRuns[i]
+				if d := cmp.Diff(expectedCustomRun, &customRuns.Items[i], ignoreResourceVersion, ignoreTypeMeta, cmpopts.EquateEmpty()); d != "" {
+					t.Errorf("expected to see CustomRun %v created. Diff %s", expectedCustomRun.Name, diff.PrintWantGot(d))
 				}
 			}
 

--- a/pkg/reconciler/pipelinerun/resources/apply.go
+++ b/pkg/reconciler/pipelinerun/resources/apply.go
@@ -177,9 +177,10 @@ func ApplyTaskResults(targets PipelineRunState, resolvedResultRefs ResolvedResul
 			pipelineTask := resolvedPipelineRunTask.PipelineTask.DeepCopy()
 			pipelineTask.Params = pipelineTask.Params.ReplaceVariables(stringReplacements, arrayReplacements, objectReplacements)
 			if pipelineTask.IsMatrixed() {
-				// Only string replacements from string, array or object results are supported
-				// We plan to support array replacements from array results soon (#5925)
-				pipelineTask.Matrix.Params = pipelineTask.Matrix.Params.ReplaceVariables(stringReplacements, nil, nil)
+				// Matrixed pipeline results replacements support:
+				// 1. String replacements from string, array or object results
+				// 2. array replacements from array results are supported
+				pipelineTask.Matrix.Params = pipelineTask.Matrix.Params.ReplaceVariables(stringReplacements, arrayReplacements, nil)
 				for i := range pipelineTask.Matrix.Include {
 					// matrix include parameters can only be type string
 					pipelineTask.Matrix.Include[i].Params = pipelineTask.Matrix.Include[i].Params.ReplaceVariables(stringReplacements, nil, nil)

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -550,8 +550,8 @@ func ResolvePipelineTask(
 	rpt.CustomTask = rpt.PipelineTask.TaskRef.IsCustomTask() || rpt.PipelineTask.TaskSpec.IsCustomTask()
 	numCombinations := 1
 	// We want to resolve all of the result references and ignore any errors at this point since there could be
-	// instances where result references are missing here, but will be later skipped or resolved in a subsequent
-	// TaskRun. The final validation is handled in skipBecauseResultReferencesAreMissing.
+	// instances where result references are missing here, but will be later skipped and resolved in
+	// skipBecauseResultReferencesAreMissing. The final validation is handled in CheckMissingResultReferences.
 	resolvedResultRefs, _, _ := ResolveResultRefs(pst, PipelineRunState{&rpt})
 	if err := validateArrayResultsIndex(resolvedResultRefs); err != nil {
 		return nil, err

--- a/pkg/reconciler/pipelinerun/resources/resultrefresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/resultrefresolution_test.go
@@ -221,10 +221,10 @@ var pipelineRunState = PipelineRunState{{
 		Matrix: &v1.Matrix{
 			Params: v1.Params{{
 				Name:  "dResults",
-				Value: *v1.NewStructuredValues("$(tasks.dTask.results.dResult[0])"),
+				Value: *v1.NewStructuredValues("$(tasks.dTask.results.dResult[*])"),
 			}, {
 				Name:  "cResults",
-				Value: *v1.NewStructuredValues("$(tasks.cTask.results.cResult[1])"),
+				Value: *v1.NewStructuredValues("$(tasks.cTask.results.cResult[*])"),
 			}},
 		},
 	},
@@ -247,7 +247,7 @@ var pipelineRunState = PipelineRunState{{
 		Matrix: &v1.Matrix{
 			Params: v1.Params{{
 				Name:  "iDoNotExist",
-				Value: *v1.NewStructuredValues("$(tasks.dTask.results.iDoNotExist[0])"),
+				Value: *v1.NewStructuredValues("$(tasks.dTask.results.iDoNotExist[*])"),
 			}},
 		},
 	},
@@ -289,7 +289,7 @@ func TestResolveResultRefs(t *testing.T) {
 		}},
 		wantErr: false,
 	}, {
-		name:             "Test successful array result references resolution - params",
+		name:             "Test successful array result references - array indexing",
 		pipelineRunState: pipelineRunState,
 		targets: PipelineRunState{
 			pipelineRunState[7],
@@ -302,6 +302,30 @@ func TestResolveResultRefs(t *testing.T) {
 				ResultsIndex: 1,
 			},
 			FromTaskRun: "cTaskRun",
+		}},
+		wantErr: false,
+	}, {
+		name:             "Test successful matrix array result references resolution - whole array references",
+		pipelineRunState: pipelineRunState,
+		targets: PipelineRunState{
+			pipelineRunState[11],
+		},
+		want: ResolvedResultRefs{{
+			Value: *v1.NewStructuredValues("arrayResultOne", "arrayResultTwo"),
+			ResultReference: v1.ResultRef{
+				PipelineTask: "cTask",
+				Result:       "cResult",
+				ResultsIndex: 0,
+			},
+			FromTaskRun: "cTaskRun",
+		}, {
+			Value: *v1.NewStructuredValues("arrayResultOne", "arrayResultTwo"),
+			ResultReference: v1.ResultRef{
+				PipelineTask: "dTask",
+				Result:       "dResult",
+				ResultsIndex: 0,
+			},
+			FromTaskRun: "dTaskRun",
 		}},
 		wantErr: false,
 	}, {
@@ -577,7 +601,7 @@ func TestCheckMissingResultReferences(t *testing.T) {
 			pipelineRunState[10],
 		},
 	}, {
-		name:             "Valid: Test successful result references resolution - matrix - array indexing",
+		name:             "Valid: Test successful result references resolution - matrix - whole array replacements",
 		pipelineRunState: pipelineRunState,
 		targets: PipelineRunState{
 			pipelineRunState[11],
@@ -589,7 +613,7 @@ func TestCheckMissingResultReferences(t *testing.T) {
 			pipelineRunState[12],
 		},
 	}, {
-		name:             "Invalid: Test result references resolution - matrix - missing references to array replacements",
+		name:             "Invalid: Test result references resolution - matrix - missing references to whole array replacements",
 		pipelineRunState: pipelineRunState,
 		targets: PipelineRunState{
 			pipelineRunState[13],

--- a/test/custom-task-ctrls/wait-task-beta/example_customrun_matrix_results.yaml
+++ b/test/custom-task-ctrls/wait-task-beta/example_customrun_matrix_results.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: echo-duration
+  annotations:
+    description: |
+      A task that echos duration
+spec:
+  params:
+    - name: duration
+  steps:
+    - name: echo
+      image: alpine
+      script: |
+        echo "$(params.duration)"
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: produce-duration
+spec:
+  results:
+    - name: durations
+      type: array
+  steps:
+    - name: produce-a-list-of-durations
+      image: bash:latest
+      script: |
+        #!/usr/bin/env bash
+        echo -n "[\"10s\",\"2s\",\"5s\"]" | tee $(results.durations.path)
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: matrixed-pr-
+spec:
+  pipelineSpec:
+    tasks:
+      - name: pt-with-result
+        taskRef:
+          name: produce-duration
+      - name: pt-matrix-echo-duration
+        matrix:
+          params:
+            - name: duration
+              value: $(tasks.pt-with-result.results.durations[*])
+        taskRef:
+          name: echo-duration
+      - name: pt-matrix-custom-task
+        matrix:
+          params:
+            - name: duration
+              value: $(tasks.pt-with-result.results.durations[*])
+        taskRef:
+          apiVersion: wait.testing.tekton.dev/v1beta1
+          kind: Wait


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
This PR adds support for referencing whole array results produced by another PipelineTask as a matrix parameter value.

This feature request is necessary before promoting Matrix to beta. 
For me details please see Issue #6110.

This closes issue #6602.

Co-authored-by: Yongxuan Zhang  <YongxuanZhang@google.com>
/kind feature

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
TEP-0090: Pipeline Tasks may now reference whole array results in a Matrix. See https://github.com/tektoncd/pipeline/blob/09d422cff057f67170b4c2f76097ac6ffded33ef/docs/matrix.md?specifying-results-in-a-matrix#specifying-results-in-a-matrix docs for more information.
```
