### PR TITLE
Fix conversion of non-object results declared in Tasks

### DIFF
--- a/pkg/apis/pipeline/v1beta1/result_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/result_conversion.go
@@ -26,20 +26,24 @@ func (r TaskResult) convertTo(ctx context.Context, sink *v1.TaskResult) {
 	sink.Name = r.Name
 	sink.Type = v1.ResultsType(r.Type)
 	sink.Description = r.Description
-	properties := make(map[string]v1.PropertySpec)
-	for k, v := range r.Properties {
-		properties[k] = v1.PropertySpec{Type: v1.ParamType(v.Type)}
+	if r.Properties != nil {
+		properties := make(map[string]v1.PropertySpec)
+		for k, v := range r.Properties {
+			properties[k] = v1.PropertySpec{Type: v1.ParamType(v.Type)}
+		}
+		sink.Properties = properties
 	}
-	sink.Properties = properties
 }
 
 func (r *TaskResult) convertFrom(ctx context.Context, source v1.TaskResult) {
 	r.Name = source.Name
 	r.Type = ResultsType(source.Type)
 	r.Description = source.Description
-	properties := make(map[string]PropertySpec)
-	for k, v := range source.Properties {
-		properties[k] = PropertySpec{Type: ParamType(v.Type)}
+	if source.Properties != nil {
+		properties := make(map[string]PropertySpec)
+		for k, v := range source.Properties {
+			properties[k] = PropertySpec{Type: ParamType(v.Type)}
+		}
+		r.Properties = properties
 	}
-	r.Properties = properties
 }

--- a/pkg/apis/pipeline/v1beta1/task_conversion_test.go
+++ b/pkg/apis/pipeline/v1beta1/task_conversion_test.go
@@ -66,6 +66,11 @@ func TestTaskConversion(t *testing.T) {
 					Type:        v1beta1.ParamTypeString,
 					Description: "My first param",
 				}},
+				Results: []v1beta1.TaskResult{{
+					Name:        "result-1",
+					Type:        v1beta1.ResultsTypeString,
+					Description: "a result",
+				}},
 			},
 		},
 	}, {


### PR DESCRIPTION
Prior to this commit, conversion between v1beta1 and v1 Tasks would create an empty map for task.spec.results.properties, even if the Task result was not an object result.

Currently, if Task result properties are a nil map, the result is treated as a string result. If Task result properties are an empty map, the result is treated as an object result. This commit only updates the conversion logic of Task results to match the conversion logic of task params; it creates a non-nil Properties map only if Properties was already non-nil.

Addressing the differences in how nil vs empty Properties are treated will be handled in a separate commit (https://github.com/tektoncd/pipeline/issues/6605).

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- n/a Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- n/a Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Fix conversion bug preventing tasks with non-object results and parameters successfully round-tripping between api versions
```
