### PR TITLE
move trusted resources verification after we resolve the remote resources

### DIFF
--- a/docs/trusted-resources.md
+++ b/docs/trusted-resources.md
@@ -14,7 +14,9 @@ weight: 312
 
 ## Overview
 
-Trusted Resources is a feature which can be used to sign Tekton Resources and verify them. Details of design can be found at [TEP--0091](https://github.com/tektoncd/community/blob/main/teps/0091-trusted-resources.md). This feature is under `alpha` version and support `v1beta1` version of `Task` and `Pipeline`.
+Trusted Resources is a feature which can be used to sign Tekton Resources and verify them. Details of design can be found at [TEP--0091](https://github.com/tektoncd/community/blob/main/teps/0091-trusted-resources.md). This is an alpha feature and supports `v1beta1` version of  `Task` and `Pipeline`.
+
+**Note**: Currently, trusted resources only support verifying Tekton resources that come from remote places i.e. git, OCI registry and Artifact Hub. To use [cluster resolver](./cluster-resolver.md) for in-cluster resources, make sure to set all default values for the resources before applied to cluster, because the mutating webhook will update the default fields if not given and fail the verification.
 
 Verification failure will mark corresponding taskrun/pipelinerun as Failed status and stop the execution.
 

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -220,7 +220,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pr *v1beta1.PipelineRun)
 	if err != nil {
 		return fmt.Errorf("failed to list VerificationPolicies from namespace %s with error %w", pr.Namespace, err)
 	}
-	getPipelineFunc := resources.GetVerifiedPipelineFunc(ctx, c.KubeClientSet, c.PipelineClientSet, c.resolutionRequester, pr, vp)
+	getPipelineFunc := resources.GetPipelineFunc(ctx, c.KubeClientSet, c.PipelineClientSet, c.resolutionRequester, pr, vp)
 
 	if pr.IsDone() {
 		pr.SetDefaults(ctx)
@@ -331,7 +331,7 @@ func (c *Reconciler) resolvePipelineState(
 		if err != nil {
 			return nil, fmt.Errorf("failed to list VerificationPolicies from namespace %s with error %w", pr.Namespace, err)
 		}
-		fn := tresources.GetVerifiedTaskFunc(ctx, c.KubeClientSet, c.PipelineClientSet, c.resolutionRequester, pr, task.TaskRef, trName, pr.Namespace, pr.Spec.ServiceAccountName, vp)
+		fn := tresources.GetTaskFunc(ctx, c.KubeClientSet, c.PipelineClientSet, c.resolutionRequester, pr, task.TaskRef, trName, pr.Namespace, pr.Spec.ServiceAccountName, vp)
 
 		getRunObjectFunc := func(name string) (v1beta1.RunObject, error) {
 			r, err := c.customRunLister.CustomRuns(pr.Namespace).Get(name)

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	resolutionv1beta1 "github.com/tektoncd/pipeline/pkg/apis/resolution/v1beta1"
 	resolutionutil "github.com/tektoncd/pipeline/pkg/internal/resolution"
 	podconvert "github.com/tektoncd/pipeline/pkg/pod"
 	"github.com/tektoncd/pipeline/pkg/reconciler/events/cloudevent"
@@ -45,6 +46,7 @@ import (
 	ttesting "github.com/tektoncd/pipeline/pkg/reconciler/testing"
 	"github.com/tektoncd/pipeline/pkg/reconciler/volumeclaim"
 	resolutioncommon "github.com/tektoncd/pipeline/pkg/resolution/common"
+	remoteresource "github.com/tektoncd/pipeline/pkg/resolution/resource"
 	"github.com/tektoncd/pipeline/pkg/trustedresources"
 	"github.com/tektoncd/pipeline/pkg/workspace"
 	"github.com/tektoncd/pipeline/test"
@@ -72,6 +74,7 @@ import (
 	pkgreconciler "knative.dev/pkg/reconciler"
 	"knative.dev/pkg/system"
 	_ "knative.dev/pkg/system/testing" // Setup system.Namespace()
+	"sigs.k8s.io/yaml"
 )
 
 const (
@@ -1603,17 +1606,17 @@ status:
   - reason: ToBeRetried
     status: Unknown
     type: Succeeded
-    message: "error when listing tasks for taskRun test-taskrun-run-retry-prepare-failure: failed to get task: tasks.tekton.dev \"test-task\" not found"
+    message: "error when listing tasks for taskRun test-taskrun-run-retry-prepare-failure: tasks.tekton.dev \"test-task\" not found"
   retriesStatus:
   - conditions:
     - reason: TaskRunResolutionFailed
       status: "False"
       type: "Succeeded"
-      message: "error when listing tasks for taskRun test-taskrun-run-retry-prepare-failure: failed to get task: tasks.tekton.dev \"test-task\" not found"
+      message: "error when listing tasks for taskRun test-taskrun-run-retry-prepare-failure: tasks.tekton.dev \"test-task\" not found"
     startTime: "2021-12-31T23:59:59Z"
     completionTime: "2022-01-01T00:00:00Z"
 `)
-		prepareError                    = fmt.Errorf("1 error occurred:\n\t* error when listing tasks for taskRun test-taskrun-run-retry-prepare-failure: failed to get task: tasks.tekton.dev \"test-task\" not found")
+		prepareError                    = fmt.Errorf("1 error occurred:\n\t* error when listing tasks for taskRun test-taskrun-run-retry-prepare-failure: tasks.tekton.dev \"test-task\" not found")
 		toFailOnReconcileFailureTaskRun = parse.MustParseV1beta1TaskRun(t, `
 metadata:
   name: test-taskrun-results-type-mismatched
@@ -4876,10 +4879,7 @@ status:
 }
 
 func TestReconcile_verifyResolvedTask_Success(t *testing.T) {
-	ctx := context.Background()
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
+	resolverName := "foobar"
 	ts := parse.MustParseV1beta1Task(t, `
 metadata:
   name: test-task
@@ -4894,7 +4894,18 @@ spec:
     image: myimage
     name: mycontainer
 `)
-	tr := parse.MustParseV1beta1TaskRun(t, `
+
+	signer, _, vps := test.SetupMatchAllVerificationPolicies(t, ts.Namespace)
+	signedTask, err := test.GetSignedTask(ts, signer, "test-task")
+	if err != nil {
+		t.Fatal("fail to sign task", err)
+	}
+	signedTaskBytes, err := yaml.Marshal(signedTask)
+	if err != nil {
+		t.Fatal("fail to marshal task", err)
+	}
+
+	tr := parse.MustParseV1beta1TaskRun(t, fmt.Sprintf(`
 metadata:
   name: test-taskrun
   namespace: foo
@@ -4903,16 +4914,11 @@ spec:
   - name: myarg
     value: foo
   taskRef:
-    name: test-task
+    resolver: %s
+  serviceAccountName: default
 status:
   podName: the-pod
-`)
-
-	signer, _, vps := test.SetupMatchAllVerificationPolicies(t, tr.Namespace)
-	signedTask, err := test.GetSignedTask(ts, signer, "test-task")
-	if err != nil {
-		t.Fatal("fail to sign task", err)
-	}
+`, resolverName))
 
 	cms := []*corev1.ConfigMap{
 		{
@@ -4922,12 +4928,12 @@ status:
 			},
 		},
 	}
-
+	rr := getResolvedResolutionRequest(t, resolverName, signedTaskBytes, tr.Namespace, tr.Name)
 	d := test.Data{
 		TaskRuns:             []*v1beta1.TaskRun{tr},
-		Tasks:                []*v1beta1.Task{signedTask},
 		ConfigMaps:           cms,
 		VerificationPolicies: vps,
+		ResolutionRequests:   []*resolutionv1beta1.ResolutionRequest{&rr},
 	}
 
 	testAssets, cancel := getTaskRunController(t, d)
@@ -4938,14 +4944,22 @@ status:
 	if ok, _ := controller.IsRequeueKey(err); !ok {
 		t.Errorf("Error reconciling TaskRun. Got error %v", err)
 	}
+	tr, err = testAssets.Clients.Pipeline.TektonV1beta1().TaskRuns(tr.Namespace).Get(testAssets.Ctx, tr.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("getting updated taskrun: %v", err)
+	}
+	condition := tr.Status.GetCondition(apis.ConditionSucceeded)
+	if condition == nil || condition.Status != corev1.ConditionUnknown {
+		t.Errorf("Expected fresh TaskRun to have in progress status, but had %v", condition)
+	}
+	if condition != nil && condition.Reason != v1beta1.TaskRunReasonRunning.String() {
+		t.Errorf("Expected reason %q but was %s", v1beta1.TaskRunReasonRunning.String(), condition.Reason)
+	}
 }
 
 func TestReconcile_verifyResolvedTask_Error(t *testing.T) {
-	ctx := context.Background()
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	ts := parse.MustParseV1beta1Task(t, `
+	resolverName := "foobar"
+	unsignedTask := parse.MustParseV1beta1Task(t, `
 metadata:
   name: test-task
   namespace: foo
@@ -4959,7 +4973,54 @@ spec:
     image: myimage
     name: mycontainer
 `)
-	tr := parse.MustParseV1beta1TaskRun(t, `
+	unsignedTaskBytes, err := yaml.Marshal(unsignedTask)
+	if err != nil {
+		t.Fatal("fail to marshal task", err)
+	}
+
+	signer, _, vps := test.SetupMatchAllVerificationPolicies(t, unsignedTask.Namespace)
+	signedTask, err := test.GetSignedTask(unsignedTask, signer, "test-task")
+	if err != nil {
+		t.Fatal("fail to sign task", err)
+	}
+
+	modifiedTask := signedTask.DeepCopy()
+	if modifiedTask.Annotations == nil {
+		modifiedTask.Annotations = make(map[string]string)
+	}
+	modifiedTask.Annotations["random"] = "attack"
+	modifiedTaskBytes, err := yaml.Marshal(modifiedTask)
+	if err != nil {
+		t.Fatal("fail to marshal task", err)
+	}
+
+	cms := []*corev1.ConfigMap{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: config.GetFeatureFlagsConfigName(), Namespace: system.Namespace()},
+			Data: map[string]string{
+				"trusted-resources-verification-no-match-policy": config.FailNoMatchPolicy,
+				"enable-tekton-oci-bundles":                      "true",
+			},
+		},
+	}
+
+	testCases := []struct {
+		name      string
+		taskBytes []byte
+	}{
+		{
+			name:      "unsigned task fails verification",
+			taskBytes: unsignedTaskBytes,
+		},
+		{
+			name:      "modified task fails verification",
+			taskBytes: modifiedTaskBytes,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tr := parse.MustParseV1beta1TaskRun(t, fmt.Sprintf(`
 metadata:
   name: test-taskrun
   namespace: foo
@@ -4968,57 +5029,17 @@ spec:
   - name: myarg
     value: foo
   taskRef:
+    resolver: %s
     name: test-task
 status:
   podName: the-pod
-`)
-
-	signer, _, vps := test.SetupMatchAllVerificationPolicies(t, tr.Namespace)
-	signedTask, err := test.GetSignedTask(ts, signer, "test-task")
-	if err != nil {
-		t.Fatal("fail to sign task", err)
-	}
-
-	tamperedTask := signedTask.DeepCopy()
-	if tamperedTask.Annotations == nil {
-		tamperedTask.Annotations = make(map[string]string)
-	}
-	tamperedTask.Annotations["random"] = "attack"
-
-	cms := []*corev1.ConfigMap{
-		{
-			ObjectMeta: metav1.ObjectMeta{Name: config.GetFeatureFlagsConfigName(), Namespace: system.Namespace()},
-			Data: map[string]string{
-				"trusted-resources-verification-no-match-policy": config.FailNoMatchPolicy,
-			},
-		},
-	}
-
-	testCases := []struct {
-		name          string
-		taskrun       []*v1beta1.TaskRun
-		task          []*v1beta1.Task
-		expectedError error
-	}{
-		{
-			name:          "unsigned task fails verification",
-			task:          []*v1beta1.Task{ts},
-			expectedError: trustedresources.ErrResourceVerificationFailed,
-		},
-		{
-			name:          "modified task fails verification",
-			task:          []*v1beta1.Task{tamperedTask},
-			expectedError: trustedresources.ErrResourceVerificationFailed,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
+`, resolverName))
+			rr := getResolvedResolutionRequest(t, resolverName, tc.taskBytes, tr.Namespace, tr.Name)
 			d := test.Data{
 				TaskRuns:             []*v1beta1.TaskRun{tr},
-				Tasks:                tc.task,
 				ConfigMaps:           cms,
 				VerificationPolicies: vps,
+				ResolutionRequests:   []*resolutionv1beta1.ResolutionRequest{&rr},
 			}
 
 			testAssets, cancel := getTaskRunController(t, d)
@@ -5026,10 +5047,10 @@ status:
 			createServiceAccount(t, testAssets, tr.Spec.ServiceAccountName, tr.Namespace)
 			err := testAssets.Controller.Reconciler.Reconcile(testAssets.Ctx, getRunName(tr))
 
-			if !errors.Is(err, tc.expectedError) {
-				t.Errorf("Reconcile got %v but want %v", err, tc.expectedError)
+			if !errors.Is(err, trustedresources.ErrResourceVerificationFailed) {
+				t.Errorf("Reconcile got %v but want %v", err, trustedresources.ErrResourceVerificationFailed)
 			}
-			tr, err := testAssets.Clients.Pipeline.TektonV1beta1().TaskRuns(tr.Namespace).Get(testAssets.Ctx, tr.Name, metav1.GetOptions{})
+			tr, err = testAssets.Clients.Pipeline.TektonV1beta1().TaskRuns(tr.Namespace).Get(testAssets.Ctx, tr.Name, metav1.GetOptions{})
 			if err != nil {
 				t.Fatalf("getting updated taskrun: %v", err)
 			}
@@ -5039,4 +5060,24 @@ status:
 			}
 		})
 	}
+}
+
+// getResolvedResolutionRequest is a helper function to return the ResolutionRequest and the data is filled with resourceBytes,
+// the ResolutionRequest's name is generated by resolverName, namespace and runName.
+func getResolvedResolutionRequest(t *testing.T, resolverName string, resourceBytes []byte, namespace string, runName string) resolutionv1beta1.ResolutionRequest {
+	t.Helper()
+	name, err := remoteresource.GenerateDeterministicName(resolverName, namespace+"/"+runName, nil)
+	if err != nil {
+		t.Errorf("error generating name for %s/%s/%s: %v", resolverName, namespace, runName, err)
+	}
+	rr := resolutionv1beta1.ResolutionRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         namespace,
+			CreationTimestamp: metav1.Time{Time: time.Now()},
+		},
+	}
+	rr.Status.ResolutionRequestStatusFields.Data = base64.StdEncoding.Strict().EncodeToString(resourceBytes)
+	rr.Status.MarkSucceeded()
+	return rr
 }

--- a/pkg/trustedresources/verify.go
+++ b/pkg/trustedresources/verify.go
@@ -45,8 +45,12 @@ const (
 // Skip the verification when no policies are found and trusted-resources-verification-no-match-policy is set to ignore or warn
 // Return an error when no policies are found and trusted-resources-verification-no-match-policy is set to fail,
 // or the resource fails to pass matched enforce verification policy
-// refSourceURI is from RefSource.URI, which will be used to match policy patterns. k8s is used to fetch secret from cluster
-func VerifyTask(ctx context.Context, taskObj *v1beta1.Task, k8s kubernetes.Interface, refSourceURI string, verificationpolicies []*v1alpha1.VerificationPolicy) error {
+// refSource contains the source information of the task.
+func VerifyTask(ctx context.Context, taskObj *v1beta1.Task, k8s kubernetes.Interface, refSource *v1beta1.RefSource, verificationpolicies []*v1alpha1.VerificationPolicy) error {
+	var refSourceURI string
+	if refSource != nil {
+		refSourceURI = refSource.URI
+	}
 	matchedPolicies, err := getMatchedPolicies(taskObj.TaskMetadata().Name, refSourceURI, verificationpolicies)
 	if err != nil {
 		if errors.Is(err, ErrNoMatchedPolicies) {
@@ -81,8 +85,12 @@ func VerifyTask(ctx context.Context, taskObj *v1beta1.Task, k8s kubernetes.Inter
 // Skip the verification when no policies are found and trusted-resources-verification-no-match-policy is set to ignore or warn
 // Return an error when no policies are found and trusted-resources-verification-no-match-policy is set to fail,
 // or the resource fails to pass matched enforce verification policy
-// refSourceURI is from RefSource.URI, which will be used to match policy patterns. k8s is used to fetch secret from cluster
-func VerifyPipeline(ctx context.Context, pipelineObj *v1beta1.Pipeline, k8s kubernetes.Interface, refSourceURI string, verificationpolicies []*v1alpha1.VerificationPolicy) error {
+// refSource contains the source information of the pipeline.
+func VerifyPipeline(ctx context.Context, pipelineObj *v1beta1.Pipeline, k8s kubernetes.Interface, refSource *v1beta1.RefSource, verificationpolicies []*v1alpha1.VerificationPolicy) error {
+	var refSourceURI string
+	if refSource != nil {
+		refSourceURI = refSource.URI
+	}
 	matchedPolicies, err := getMatchedPolicies(pipelineObj.PipelineMetadata().Name, refSourceURI, verificationpolicies)
 	if err != nil {
 		if errors.Is(err, ErrNoMatchedPolicies) {

--- a/pkg/trustedresources/verify_test.go
+++ b/pkg/trustedresources/verify_test.go
@@ -200,48 +200,48 @@ func TestVerifyTask_Success(t *testing.T) {
 	tcs := []struct {
 		name                      string
 		task                      *v1beta1.Task
-		source                    string
+		source                    *v1beta1.RefSource
 		signer                    signature.SignerVerifier
 		verificationNoMatchPolicy string
 		verificationPolicies      []*v1alpha1.VerificationPolicy
 	}{{
 		name:                      "signed git source task passes verification",
 		task:                      signedTask,
-		source:                    "git+https://github.com/tektoncd/catalog.git",
+		source:                    &v1beta1.RefSource{URI: "git+https://github.com/tektoncd/catalog.git"},
 		verificationNoMatchPolicy: config.FailNoMatchPolicy,
 		verificationPolicies:      vps,
 	}, {
 		name:                      "signed bundle source task passes verification",
 		task:                      signedTask,
-		source:                    "gcr.io/tekton-releases/catalog/upstream/git-clone",
+		source:                    &v1beta1.RefSource{URI: "gcr.io/tekton-releases/catalog/upstream/git-clone"},
 		verificationNoMatchPolicy: config.FailNoMatchPolicy,
 		verificationPolicies:      vps,
 	}, {
 		name:                      "signed task with sha384 key",
 		task:                      signedTask384,
-		source:                    "gcr.io/tekton-releases/catalog/upstream/sha384",
+		source:                    &v1beta1.RefSource{URI: "gcr.io/tekton-releases/catalog/upstream/sha384"},
 		verificationNoMatchPolicy: config.FailNoMatchPolicy,
 		verificationPolicies:      []*v1alpha1.VerificationPolicy{sha384Vp},
 	}, {
 		name:                      "ignore no match policy skips verification when no matching policies",
 		task:                      unsignedTask,
-		source:                    mismatchedSource,
+		source:                    &v1beta1.RefSource{URI: mismatchedSource},
 		verificationNoMatchPolicy: config.IgnoreNoMatchPolicy,
 	}, {
 		name:                      "warn no match policy skips verification when no matching policies",
 		task:                      unsignedTask,
-		source:                    mismatchedSource,
+		source:                    &v1beta1.RefSource{URI: mismatchedSource},
 		verificationNoMatchPolicy: config.WarnNoMatchPolicy,
 	}, {
 		name:                      "unsigned task matches warn policy doesn't fail verification",
 		task:                      unsignedTask,
-		source:                    "git+https://github.com/tektoncd/catalog.git",
+		source:                    &v1beta1.RefSource{URI: "git+https://github.com/tektoncd/catalog.git"},
 		verificationNoMatchPolicy: config.FailNoMatchPolicy,
 		verificationPolicies:      []*v1alpha1.VerificationPolicy{warnPolicy},
 	}, {
 		name:                      "modified task matches warn policy doesn't fail verification",
 		task:                      modifiedTask,
-		source:                    "git+https://github.com/tektoncd/catalog.git",
+		source:                    &v1beta1.RefSource{URI: "git+https://github.com/tektoncd/catalog.git"},
 		verificationNoMatchPolicy: config.FailNoMatchPolicy,
 		verificationPolicies:      []*v1alpha1.VerificationPolicy{warnPolicy},
 	}}
@@ -277,37 +277,37 @@ func TestVerifyTask_Error(t *testing.T) {
 	tcs := []struct {
 		name               string
 		task               *v1beta1.Task
-		source             string
+		source             *v1beta1.RefSource
 		verificationPolicy []*v1alpha1.VerificationPolicy
 		expectedError      error
 	}{{
 		name:               "unsigned Task fails verification",
 		task:               unsignedTask,
-		source:             "git+https://github.com/tektoncd/catalog.git",
+		source:             &v1beta1.RefSource{URI: "git+https://github.com/tektoncd/catalog.git"},
 		verificationPolicy: vps,
 		expectedError:      ErrResourceVerificationFailed,
 	}, {
 		name:               "modified Task fails verification",
 		task:               tamperedTask,
-		source:             matchingSource,
+		source:             &v1beta1.RefSource{URI: matchingSource},
 		verificationPolicy: vps,
 		expectedError:      ErrResourceVerificationFailed,
 	}, {
 		name:               "task not matching pattern fails verification",
 		task:               signedTask,
-		source:             mismatchedSource,
+		source:             &v1beta1.RefSource{URI: mismatchedSource},
 		verificationPolicy: vps,
 		expectedError:      ErrNoMatchedPolicies,
 	}, {
 		name:               "verification fails with empty policy",
 		task:               tamperedTask,
-		source:             matchingSource,
+		source:             &v1beta1.RefSource{URI: matchingSource},
 		verificationPolicy: []*v1alpha1.VerificationPolicy{},
 		expectedError:      ErrNoMatchedPolicies,
 	}, {
 		name:   "Verification fails with regex error",
 		task:   signedTask,
-		source: "git+https://github.com/tektoncd/catalog.git",
+		source: &v1beta1.RefSource{URI: "git+https://github.com/tektoncd/catalog.git"},
 		verificationPolicy: []*v1alpha1.VerificationPolicy{
 			{
 				ObjectMeta: metav1.ObjectMeta{
@@ -324,7 +324,7 @@ func TestVerifyTask_Error(t *testing.T) {
 	}, {
 		name:   "Verification fails with error from policy",
 		task:   signedTask,
-		source: "git+https://github.com/tektoncd/catalog.git",
+		source: &v1beta1.RefSource{URI: "git+https://github.com/tektoncd/catalog.git"},
 		verificationPolicy: []*v1alpha1.VerificationPolicy{
 			{
 				ObjectMeta: metav1.ObjectMeta{
@@ -369,27 +369,27 @@ func TestVerifyPipeline_Success(t *testing.T) {
 	tcs := []struct {
 		name                      string
 		pipeline                  *v1beta1.Pipeline
-		source                    string
+		source                    *v1beta1.RefSource
 		verificationNoMatchPolicy string
 	}{{
 		name:                      "signed git source pipeline passes verification",
 		pipeline:                  signedPipeline,
-		source:                    "git+https://github.com/tektoncd/catalog.git",
+		source:                    &v1beta1.RefSource{URI: "git+https://github.com/tektoncd/catalog.git"},
 		verificationNoMatchPolicy: config.FailNoMatchPolicy,
 	}, {
 		name:                      "signed bundle source pipeline passes verification",
 		pipeline:                  signedPipeline,
-		source:                    "gcr.io/tekton-releases/catalog/upstream/git-clone",
+		source:                    &v1beta1.RefSource{URI: "gcr.io/tekton-releases/catalog/upstream/git-clone"},
 		verificationNoMatchPolicy: config.FailNoMatchPolicy,
 	}, {
 		name:                      "ignore no match policy skips verification when no matching policies",
 		pipeline:                  unsignedPipeline,
-		source:                    mismatchedSource,
+		source:                    &v1beta1.RefSource{URI: mismatchedSource},
 		verificationNoMatchPolicy: config.IgnoreNoMatchPolicy,
 	}, {
 		name:                      "warn no match policy skips verification when no matching policies",
 		pipeline:                  unsignedPipeline,
-		source:                    mismatchedSource,
+		source:                    &v1beta1.RefSource{URI: mismatchedSource},
 		verificationNoMatchPolicy: config.WarnNoMatchPolicy,
 	}}
 	for _, tc := range tcs {
@@ -422,22 +422,22 @@ func TestVerifyPipeline_Error(t *testing.T) {
 	tcs := []struct {
 		name               string
 		pipeline           *v1beta1.Pipeline
-		source             string
+		source             *v1beta1.RefSource
 		verificationPolicy []*v1alpha1.VerificationPolicy
 	}{{
 		name:               "Tampered Task Fails Verification with tampered content",
 		pipeline:           tamperedPipeline,
-		source:             matchingSource,
+		source:             &v1beta1.RefSource{URI: matchingSource},
 		verificationPolicy: vps,
 	}, {
 		name:               "Task Not Matching Pattern Fails Verification",
 		pipeline:           signedPipeline,
-		source:             mismatchedSource,
+		source:             &v1beta1.RefSource{URI: mismatchedSource},
 		verificationPolicy: vps,
 	}, {
 		name:     "Verification fails with regex error",
 		pipeline: signedPipeline,
-		source:   "git+https://github.com/tektoncd/catalog.git",
+		source:   &v1beta1.RefSource{URI: "git+https://github.com/tektoncd/catalog.git"},
 		verificationPolicy: []*v1alpha1.VerificationPolicy{
 			{
 				ObjectMeta: metav1.ObjectMeta{

--- a/test/trusted_resources_test.go
+++ b/test/trusted_resources_test.go
@@ -112,9 +112,16 @@ spec:
   tasks:
   - name: task
     taskRef:
-      name: %s
+      resolver: cluster
       kind: Task
-`, helpers.ObjectNameForTest(t), namespace, signedTask.Name))
+      params:
+      - name: kind
+        value: task
+      - name: name
+        value: %s
+      - name: namespace
+        value: %s
+`, helpers.ObjectNameForTest(t), namespace, signedTask.Name, namespace))
 
 	signedPipeline, err := GetSignedPipeline(pipeline, signer, "signedpipeline")
 	if err != nil {
@@ -131,8 +138,16 @@ metadata:
   namespace: %s
 spec:
   pipelineRef:
-    name: %s
-`, helpers.ObjectNameForTest(t), namespace, signedPipeline.Name))
+    resolver: cluster
+    kind: Pipeline
+    params:
+    - name: kind
+      value: pipeline
+    - name: name
+      value: %s
+    - name: namespace
+      value: %s
+`, helpers.ObjectNameForTest(t), namespace, signedPipeline.Name, namespace))
 
 	t.Logf("Creating PipelineRun %s", pr.Name)
 	if _, err := c.V1beta1PipelineRunClient.Create(ctx, pr, metav1.CreateOptions{}); err != nil {
@@ -213,9 +228,16 @@ spec:
   tasks:
   - name: task
     taskRef:
-      name: %s
+      resolver: cluster
       kind: Task
-`, helpers.ObjectNameForTest(t), namespace, signedTask.Name))
+      params:
+      - name: kind
+        value: task
+      - name: name
+        value: %s
+      - name: namespace
+        value: %s
+`, helpers.ObjectNameForTest(t), namespace, signedTask.Name, namespace))
 
 	signedPipeline, err := GetSignedPipeline(pipeline, signer, "signedpipeline")
 	if err != nil {
@@ -232,8 +254,16 @@ metadata:
   namespace: %s
 spec:
   pipelineRef:
-    name: %s
-`, helpers.ObjectNameForTest(t), namespace, signedPipeline.Name))
+    resolver: cluster
+    kind: Pipeline
+    params:
+    - name: kind
+      value: pipeline
+    - name: name
+      value: %s
+    - name: namespace
+      value: %s
+`, helpers.ObjectNameForTest(t), namespace, signedPipeline.Name, namespace))
 
 	t.Logf("Creating PipelineRun %s", pr.Name)
 	if _, err := c.V1beta1PipelineRunClient.Create(ctx, pr, metav1.CreateOptions{}); err != nil {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR moves the trusted resources verification to readRuntimeObjectAsTask and readRuntimeObjectAsPipline, the reasons we need this change include:
 1) unblock the work for v1, since v1 will mutate, validate and convert the resources, the mutation will break trusted resources verification thus we need to verify right after we resolve the remote resources. 
2) Prepare the support for verifying different api versions. This commit also makes it clear that currently we only support verification for remote resources.

/kind misc
Closes https://github.com/tektoncd/pipeline/issues/6618

Signed-off-by: Yongxuan Zhang yongxuanzhang@google.com

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
