### PR TITLE
Don't mark done PipelineRuns as timed out

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -185,7 +185,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pr *v1beta1.PipelineRun)
 	// reconcile. We are assuming here that if the PipelineRun has timed out for a long time, it had time to run
 	// before and it kept failing. One reason that can happen is exceeding etcd request size limit. Finishing it early
 	// makes sure the request size is manageable
-	if pr.HasTimedOutForALongTime(ctx, c.Clock) && !pr.IsTimeoutConditionSet() {
+	if !pr.IsDone() && pr.HasTimedOutForALongTime(ctx, c.Clock) && !pr.IsTimeoutConditionSet() {
 		if err := timeoutPipelineRun(ctx, logger, pr, c.PipelineClientSet); err != nil {
 			return err
 		}

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -11583,3 +11583,70 @@ spec:
 		t.Errorf("Expected PipelineRun to be create run failed, but condition reason is %s", reconciledRun.Status.GetCondition(apis.ConditionSucceeded))
 	}
 }
+
+func TestReconcileWithTimeoutsOfCompletedPipelineRun(t *testing.T) {
+	// TestReconcileWithTimeoutsOfCompletedPipelineRun runs "Reconcile" on a PipelineRun that has completed and
+	// which has a passed timeout.
+	// It verifies that reconcile is successful, and the PipelineRun is not marked as timed out.
+	ps := []*v1beta1.Pipeline{parse.MustParseV1beta1Pipeline(t, `
+metadata:
+  name: test-pipeline
+  namespace: foo
+spec:
+  tasks:
+  - name: hello-world-1
+    taskRef:
+      name: hello-world
+`)}
+	prs := []*v1beta1.PipelineRun{parse.MustParseV1beta1PipelineRun(t, `
+metadata:
+  name: test-pipeline-run-with-timeout
+  namespace: foo
+spec:
+  pipelineRef:
+    name: test-pipeline
+  serviceAccountName: test-sa
+  timeouts:
+    pipeline: 2m
+status:
+  conditions:
+  - lastTransitionTime: "2021-12-31T11:01:00Z"
+    message: 'Tasks Completed: 1 (Failed: 0, Cancelled 0), Skipped: 0'
+    reason: Succeeded
+    status: "True"
+    type: Succeeded
+  completionTime: "2021-12-31T11:01:00Z"
+  startTime: "2021-12-31T11:00:00Z"
+  childReferences:
+  - name: test-pipeline-run-with-timeout-hello-world-1
+    pipelineTaskName: hello-world-1
+    kind: TaskRun
+`)}
+	ts := []*v1beta1.Task{simpleHelloWorldTask}
+
+	trs := []*v1beta1.TaskRun{mustParseTaskRunWithObjectMeta(t, taskRunObjectMeta("test-pipeline-run-with-timeout-hello-world-1", "foo", "test-pipeline-run-with-timeout",
+		"test-pipeline", "hello-world-1", false), `
+spec:
+  serviceAccountName: test-sa
+  taskRef:
+    name: hello-world
+    kind: Task
+`)}
+
+	d := test.Data{
+		PipelineRuns: prs,
+		Pipelines:    ps,
+		Tasks:        ts,
+		TaskRuns:     trs,
+	}
+	prt := newPipelineRunTest(t, d)
+	defer prt.Cancel()
+
+	wantEvents := []string{}
+	reconciledRun, _ := prt.reconcileRun("foo", "test-pipeline-run-with-timeout", wantEvents, false)
+
+	// The PipelineRun should not be timed out.
+	if reconciledRun.Status.GetCondition(apis.ConditionSucceeded).Reason != "Succeeded" {
+		t.Errorf("Expected PipelineRun to still be Succeeded, but reason is %s", reconciledRun.Status.GetCondition(apis.ConditionSucceeded))
+	}
+}


### PR DESCRIPTION
# Changes

This PR fixes a bug that causes all completed PipelineRuns to eventually go into PipelineRunTimeout status. This was imo introduced by [Fix for PipelineRuns getting stuck in the running state in the cluster #6095](https://github.com/tektoncd/pipeline/pull/6095) in v0.47.0 @RafaeLeal @lbernick @jerop

To reproduce the issue, perform these three steps:

(1) Create a simple Pipeline

```yaml
apiVersion: tekton.dev/v1
kind: Pipeline
metadata:
  name: noop
spec:
  tasks:
    - name: noop
      taskSpec:
        steps:
          - name: noop
            image: busybox
            command:
              - sleep
            args:
              - "1"
      timeout: 1m
```

(2) Create a simple PipelineRun

```yaml
apiVersion: tekton.dev/v1
kind: PipelineRun
metadata:
  generateName: noop-
spec:
  pipelineRef:
    name: noop
  timeouts:
    pipeline: 1m
```

(3) The PipelineRun will complete successfully within a few seconds. Now wait three minutes.

(4) Restart the tekton-pipelines-controller. This will cause all PipelineRuns in the system to get reconciled.

And now the PipelineRun is moved into PipelineRunTimeout status.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

/kind bug

# Release Notes

```release-note
Completed PipelineRuns are not anymore changed to PipelineRunTimeout status
```