### PR TITLE
Keeps Deprecated Fields in Step and StepTemplate When Switching Versions

### DIFF
--- a/pkg/apis/pipeline/v1beta1/container_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/container_conversion.go
@@ -47,10 +47,6 @@ func (s Step) convertTo(ctx context.Context, sink *v1.Step) {
 	sink.OnError = (v1.OnErrorType)(s.OnError)
 	sink.StdoutConfig = (*v1.StepOutputConfig)(s.StdoutConfig)
 	sink.StderrConfig = (*v1.StepOutputConfig)(s.StderrConfig)
-
-	// TODO(#4546): Handle deprecated fields
-	// Ports, LivenessProbe, ReadinessProbe, StartupProbe, Lifecycle, TerminationMessagePath
-	// TerminationMessagePolicy, Stdin, StdinOnce, TTY
 }
 
 func (s *Step) convertFrom(ctx context.Context, source v1.Step) {

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_conversion.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"knative.dev/pkg/apis"
 )
@@ -34,24 +36,24 @@ func (pr *PipelineRun) ConvertTo(ctx context.Context, to apis.Convertible) error
 	switch sink := to.(type) {
 	case *v1.PipelineRun:
 		sink.ObjectMeta = pr.ObjectMeta
-		if err := pr.Status.convertTo(ctx, &sink.Status); err != nil {
+		if err := pr.Status.convertTo(ctx, &sink.Status, &sink.ObjectMeta); err != nil {
 			return err
 		}
-		return pr.Spec.ConvertTo(ctx, &sink.Spec)
+		return pr.Spec.ConvertTo(ctx, &sink.Spec, &sink.ObjectMeta)
 	default:
 		return fmt.Errorf("unknown version, got: %T", sink)
 	}
 }
 
 // ConvertTo implements apis.Convertible
-func (prs PipelineRunSpec) ConvertTo(ctx context.Context, sink *v1.PipelineRunSpec) error {
+func (prs PipelineRunSpec) ConvertTo(ctx context.Context, sink *v1.PipelineRunSpec, meta *metav1.ObjectMeta) error {
 	if prs.PipelineRef != nil {
 		sink.PipelineRef = &v1.PipelineRef{}
 		prs.PipelineRef.convertTo(ctx, sink.PipelineRef)
 	}
 	if prs.PipelineSpec != nil {
 		sink.PipelineSpec = &v1.PipelineSpec{}
-		err := prs.PipelineSpec.ConvertTo(ctx, sink.PipelineSpec)
+		err := prs.PipelineSpec.ConvertTo(ctx, sink.PipelineSpec, meta)
 		if err != nil {
 			return err
 		}
@@ -94,17 +96,17 @@ func (pr *PipelineRun) ConvertFrom(ctx context.Context, from apis.Convertible) e
 	switch source := from.(type) {
 	case *v1.PipelineRun:
 		pr.ObjectMeta = source.ObjectMeta
-		if err := pr.Status.convertFrom(ctx, &source.Status); err != nil {
+		if err := pr.Status.convertFrom(ctx, &source.Status, &pr.ObjectMeta); err != nil {
 			return err
 		}
-		return pr.Spec.ConvertFrom(ctx, &source.Spec)
+		return pr.Spec.ConvertFrom(ctx, &source.Spec, &pr.ObjectMeta)
 	default:
 		return fmt.Errorf("unknown version, got: %T", pr)
 	}
 }
 
 // ConvertFrom implements apis.Convertible
-func (prs *PipelineRunSpec) ConvertFrom(ctx context.Context, source *v1.PipelineRunSpec) error {
+func (prs *PipelineRunSpec) ConvertFrom(ctx context.Context, source *v1.PipelineRunSpec, meta *metav1.ObjectMeta) error {
 	if source.PipelineRef != nil {
 		newPipelineRef := PipelineRef{}
 		newPipelineRef.convertFrom(ctx, *source.PipelineRef)
@@ -112,7 +114,7 @@ func (prs *PipelineRunSpec) ConvertFrom(ctx context.Context, source *v1.Pipeline
 	}
 	if source.PipelineSpec != nil {
 		newPipelineSpec := PipelineSpec{}
-		err := newPipelineSpec.ConvertFrom(ctx, source.PipelineSpec)
+		err := newPipelineSpec.ConvertFrom(ctx, source.PipelineSpec, meta)
 		if err != nil {
 			return err
 		}
@@ -206,7 +208,7 @@ func (ptrs *PipelineTaskRunSpec) convertFrom(ctx context.Context, source v1.Pipe
 	ptrs.ComputeResources = source.ComputeResources
 }
 
-func (prs *PipelineRunStatus) convertTo(ctx context.Context, sink *v1.PipelineRunStatus) error {
+func (prs *PipelineRunStatus) convertTo(ctx context.Context, sink *v1.PipelineRunStatus, meta *metav1.ObjectMeta) error {
 	sink.Status = prs.Status
 	sink.StartTime = prs.StartTime
 	sink.CompletionTime = prs.CompletionTime
@@ -218,7 +220,7 @@ func (prs *PipelineRunStatus) convertTo(ctx context.Context, sink *v1.PipelineRu
 	}
 	if prs.PipelineSpec != nil {
 		sink.PipelineSpec = &v1.PipelineSpec{}
-		err := prs.PipelineSpec.ConvertTo(ctx, sink.PipelineSpec)
+		err := prs.PipelineSpec.ConvertTo(ctx, sink.PipelineSpec, meta)
 		if err != nil {
 			return err
 		}
@@ -244,7 +246,7 @@ func (prs *PipelineRunStatus) convertTo(ctx context.Context, sink *v1.PipelineRu
 	return nil
 }
 
-func (prs *PipelineRunStatus) convertFrom(ctx context.Context, source *v1.PipelineRunStatus) error {
+func (prs *PipelineRunStatus) convertFrom(ctx context.Context, source *v1.PipelineRunStatus, meta *metav1.ObjectMeta) error {
 	prs.Status = source.Status
 	prs.StartTime = source.StartTime
 	prs.CompletionTime = source.CompletionTime
@@ -256,7 +258,7 @@ func (prs *PipelineRunStatus) convertFrom(ctx context.Context, source *v1.Pipeli
 	}
 	if source.PipelineSpec != nil {
 		newPipelineSpec := PipelineSpec{}
-		err := newPipelineSpec.ConvertFrom(ctx, source.PipelineSpec)
+		err := newPipelineSpec.ConvertFrom(ctx, source.PipelineSpec, meta)
 		if err != nil {
 			return err
 		}

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_conversion_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_conversion_test.go
@@ -151,7 +151,67 @@ func TestPipelineRunConversion(t *testing.T) {
 			Spec: v1beta1.PipelineRunSpec{
 				PipelineRef: &v1beta1.PipelineRef{Name: "pipeline-1"},
 			},
-		}}, {
+		},
+	}, {
+		name: "pipelinerun with deprecated fields in step and stepTemplate",
+		in: &v1beta1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "bar",
+			},
+			Spec: v1beta1.PipelineRunSpec{
+				PipelineSpec: &v1beta1.PipelineSpec{
+					Tasks: []v1beta1.PipelineTask{{
+						Name: "task-1",
+						TaskSpec: &v1beta1.EmbeddedTask{
+							TaskSpec: v1beta1.TaskSpec{
+								Steps: []v1beta1.Step{{
+									DeprecatedLivenessProbe:  &corev1.Probe{InitialDelaySeconds: 1},
+									DeprecatedReadinessProbe: &corev1.Probe{InitialDelaySeconds: 2},
+									DeprecatedPorts:          []corev1.ContainerPort{{Name: "port"}},
+									DeprecatedStartupProbe:   &corev1.Probe{InitialDelaySeconds: 3},
+									DeprecatedLifecycle: &corev1.Lifecycle{PostStart: &corev1.LifecycleHandler{Exec: &corev1.ExecAction{
+										Command: []string{"lifecycle command"},
+									}}},
+									DeprecatedTerminationMessagePath:   "path",
+									DeprecatedTerminationMessagePolicy: corev1.TerminationMessagePolicy("policy"),
+									DeprecatedStdin:                    true,
+									DeprecatedStdinOnce:                true,
+									DeprecatedTTY:                      true,
+								}},
+								StepTemplate: &v1beta1.StepTemplate{
+									DeprecatedLivenessProbe:  &corev1.Probe{InitialDelaySeconds: 1},
+									DeprecatedReadinessProbe: &corev1.Probe{InitialDelaySeconds: 2},
+									DeprecatedPorts:          []corev1.ContainerPort{{Name: "port"}},
+									DeprecatedStartupProbe:   &corev1.Probe{InitialDelaySeconds: 3},
+									DeprecatedLifecycle: &corev1.Lifecycle{PostStart: &corev1.LifecycleHandler{Exec: &corev1.ExecAction{
+										Command: []string{"lifecycle command"},
+									}}},
+									DeprecatedTerminationMessagePath:   "path",
+									DeprecatedTerminationMessagePolicy: corev1.TerminationMessagePolicy("policy"),
+									DeprecatedStdin:                    true,
+									DeprecatedStdinOnce:                true,
+									DeprecatedTTY:                      true,
+								},
+							},
+						},
+					}, {
+						Name: "task-2",
+						TaskSpec: &v1beta1.EmbeddedTask{
+							TaskSpec: v1beta1.TaskSpec{
+								Steps: []v1beta1.Step{{
+									DeprecatedLivenessProbe: &corev1.Probe{InitialDelaySeconds: 1},
+								}},
+								StepTemplate: &v1beta1.StepTemplate{
+									DeprecatedLivenessProbe: &corev1.Probe{InitialDelaySeconds: 1},
+								},
+							},
+						},
+					}},
+				},
+			},
+		},
+	}, {
 		name: "pipelinerun conversion all non deprecated fields",
 		in: &v1beta1.PipelineRun{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/apis/pipeline/v1beta1/task_types.go
+++ b/pkg/apis/pipeline/v1beta1/task_types.go
@@ -130,3 +130,41 @@ type TaskList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []Task `json:"items"`
 }
+
+// HasDeprecatedFields returns true if the TaskSpec has deprecated field specified.
+func (ts *TaskSpec) HasDeprecatedFields() bool {
+	if ts == nil {
+		return false
+	}
+	if len(ts.Steps) > 0 {
+		for _, s := range ts.Steps {
+			if len(s.DeprecatedPorts) > 0 ||
+				s.DeprecatedLivenessProbe != nil ||
+				s.DeprecatedReadinessProbe != nil ||
+				s.DeprecatedStartupProbe != nil ||
+				s.DeprecatedLifecycle != nil ||
+				s.DeprecatedTerminationMessagePath != "" ||
+				s.DeprecatedTerminationMessagePolicy != "" ||
+				s.DeprecatedStdin ||
+				s.DeprecatedStdinOnce ||
+				s.DeprecatedTTY {
+				return true
+			}
+		}
+	}
+	if ts.StepTemplate != nil {
+		if len(ts.StepTemplate.DeprecatedPorts) > 0 ||
+			ts.StepTemplate.DeprecatedName != "" ||
+			ts.StepTemplate.DeprecatedReadinessProbe != nil ||
+			ts.StepTemplate.DeprecatedStartupProbe != nil ||
+			ts.StepTemplate.DeprecatedLifecycle != nil ||
+			ts.StepTemplate.DeprecatedTerminationMessagePath != "" ||
+			ts.StepTemplate.DeprecatedTerminationMessagePolicy != "" ||
+			ts.StepTemplate.DeprecatedStdin ||
+			ts.StepTemplate.DeprecatedStdinOnce ||
+			ts.StepTemplate.DeprecatedTTY {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/apis/pipeline/v1beta1/taskrun_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_conversion.go
@@ -44,17 +44,17 @@ func (tr *TaskRun) ConvertTo(ctx context.Context, to apis.Convertible) error {
 		if err := serializeTaskRunCloudEvents(&sink.ObjectMeta, &tr.Status); err != nil {
 			return err
 		}
-		if err := tr.Status.ConvertTo(ctx, &sink.Status); err != nil {
+		if err := tr.Status.ConvertTo(ctx, &sink.Status, &sink.ObjectMeta); err != nil {
 			return err
 		}
-		return tr.Spec.ConvertTo(ctx, &sink.Spec)
+		return tr.Spec.ConvertTo(ctx, &sink.Spec, &sink.ObjectMeta)
 	default:
 		return fmt.Errorf("unknown version, got: %T", sink)
 	}
 }
 
 // ConvertTo implements apis.Convertible
-func (trs *TaskRunSpec) ConvertTo(ctx context.Context, sink *v1.TaskRunSpec) error {
+func (trs *TaskRunSpec) ConvertTo(ctx context.Context, sink *v1.TaskRunSpec, meta *metav1.ObjectMeta) error {
 	if trs.Debug != nil {
 		sink.Debug = &v1.TaskRunDebug{}
 		trs.Debug.convertTo(ctx, sink.Debug)
@@ -72,7 +72,7 @@ func (trs *TaskRunSpec) ConvertTo(ctx context.Context, sink *v1.TaskRunSpec) err
 	}
 	if trs.TaskSpec != nil {
 		sink.TaskSpec = &v1.TaskSpec{}
-		err := trs.TaskSpec.ConvertTo(ctx, sink.TaskSpec)
+		err := trs.TaskSpec.ConvertTo(ctx, sink.TaskSpec, meta, meta.Name)
 		if err != nil {
 			return err
 		}
@@ -115,17 +115,17 @@ func (tr *TaskRun) ConvertFrom(ctx context.Context, from apis.Convertible) error
 		if err := deserializeTaskRunCloudEvents(&tr.ObjectMeta, &tr.Status); err != nil {
 			return err
 		}
-		if err := tr.Status.ConvertFrom(ctx, source.Status); err != nil {
+		if err := tr.Status.ConvertFrom(ctx, source.Status, &tr.ObjectMeta); err != nil {
 			return err
 		}
-		return tr.Spec.ConvertFrom(ctx, &source.Spec)
+		return tr.Spec.ConvertFrom(ctx, &source.Spec, &tr.ObjectMeta)
 	default:
 		return fmt.Errorf("unknown version, got: %T", tr)
 	}
 }
 
 // ConvertFrom implements apis.Convertible
-func (trs *TaskRunSpec) ConvertFrom(ctx context.Context, source *v1.TaskRunSpec) error {
+func (trs *TaskRunSpec) ConvertFrom(ctx context.Context, source *v1.TaskRunSpec, meta *metav1.ObjectMeta) error {
 	if source.Debug != nil {
 		newDebug := TaskRunDebug{}
 		newDebug.convertFrom(ctx, *source.Debug)
@@ -145,7 +145,7 @@ func (trs *TaskRunSpec) ConvertFrom(ctx context.Context, source *v1.TaskRunSpec)
 	}
 	if source.TaskSpec != nil {
 		newTaskSpec := TaskSpec{}
-		err := newTaskSpec.ConvertFrom(ctx, source.TaskSpec)
+		err := newTaskSpec.ConvertFrom(ctx, source.TaskSpec, meta, meta.Name)
 		if err != nil {
 			return err
 		}
@@ -207,7 +207,7 @@ func (trso *TaskRunSidecarOverride) convertFrom(ctx context.Context, source v1.T
 }
 
 // ConvertTo implements apis.Convertible
-func (trs *TaskRunStatus) ConvertTo(ctx context.Context, sink *v1.TaskRunStatus) error {
+func (trs *TaskRunStatus) ConvertTo(ctx context.Context, sink *v1.TaskRunStatus, meta *metav1.ObjectMeta) error {
 	sink.Status = trs.Status
 	sink.PodName = trs.PodName
 	sink.StartTime = trs.StartTime
@@ -221,7 +221,7 @@ func (trs *TaskRunStatus) ConvertTo(ctx context.Context, sink *v1.TaskRunStatus)
 	sink.RetriesStatus = nil
 	for _, rr := range trs.RetriesStatus {
 		new := v1.TaskRunStatus{}
-		err := rr.ConvertTo(ctx, &new)
+		err := rr.ConvertTo(ctx, &new, meta)
 		if err != nil {
 			return err
 		}
@@ -242,7 +242,7 @@ func (trs *TaskRunStatus) ConvertTo(ctx context.Context, sink *v1.TaskRunStatus)
 
 	if trs.TaskSpec != nil {
 		sink.TaskSpec = &v1.TaskSpec{}
-		err := trs.TaskSpec.ConvertTo(ctx, sink.TaskSpec)
+		err := trs.TaskSpec.ConvertTo(ctx, sink.TaskSpec, meta, meta.Name)
 		if err != nil {
 			return err
 		}
@@ -256,7 +256,7 @@ func (trs *TaskRunStatus) ConvertTo(ctx context.Context, sink *v1.TaskRunStatus)
 }
 
 // ConvertFrom implements apis.Convertible
-func (trs *TaskRunStatus) ConvertFrom(ctx context.Context, source v1.TaskRunStatus) error {
+func (trs *TaskRunStatus) ConvertFrom(ctx context.Context, source v1.TaskRunStatus, meta *metav1.ObjectMeta) error {
 	trs.Status = source.Status
 	trs.PodName = source.PodName
 	trs.StartTime = source.StartTime
@@ -270,7 +270,7 @@ func (trs *TaskRunStatus) ConvertFrom(ctx context.Context, source v1.TaskRunStat
 	trs.RetriesStatus = nil
 	for _, rr := range source.RetriesStatus {
 		new := TaskRunStatus{}
-		err := new.ConvertFrom(ctx, rr)
+		err := new.ConvertFrom(ctx, rr, meta)
 		if err != nil {
 			return err
 		}
@@ -291,7 +291,7 @@ func (trs *TaskRunStatus) ConvertFrom(ctx context.Context, source v1.TaskRunStat
 
 	if source.TaskSpec != nil {
 		trs.TaskSpec = &TaskSpec{}
-		err := trs.TaskSpec.ConvertFrom(ctx, source.TaskSpec)
+		err := trs.TaskSpec.ConvertFrom(ctx, source.TaskSpec, meta, meta.Name)
 		if err != nil {
 			return err
 		}

--- a/pkg/apis/pipeline/v1beta1/taskrun_conversion_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_conversion_test.go
@@ -66,6 +66,47 @@ func TestTaskRunConversion(t *testing.T) {
 			},
 		},
 	}, {
+		name: "taskrun conversion deprecated step fields",
+		in: &v1beta1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "bar",
+			},
+			Spec: v1beta1.TaskRunSpec{
+				TaskSpec: &v1beta1.TaskSpec{
+					Steps: []v1beta1.Step{{
+						DeprecatedLivenessProbe:  &corev1.Probe{InitialDelaySeconds: 1},
+						DeprecatedReadinessProbe: &corev1.Probe{InitialDelaySeconds: 2},
+						DeprecatedPorts:          []corev1.ContainerPort{{Name: "port"}},
+						DeprecatedStartupProbe:   &corev1.Probe{InitialDelaySeconds: 3},
+						DeprecatedLifecycle: &corev1.Lifecycle{PostStart: &corev1.LifecycleHandler{Exec: &corev1.ExecAction{
+							Command: []string{"lifecycle command"},
+						}}},
+						DeprecatedTerminationMessagePath:   "path",
+						DeprecatedTerminationMessagePolicy: corev1.TerminationMessagePolicy("policy"),
+						DeprecatedStdin:                    true,
+						DeprecatedStdinOnce:                true,
+						DeprecatedTTY:                      true,
+					}},
+					StepTemplate: &v1beta1.StepTemplate{
+						DeprecatedName:           "name",
+						DeprecatedLivenessProbe:  &corev1.Probe{InitialDelaySeconds: 1},
+						DeprecatedReadinessProbe: &corev1.Probe{InitialDelaySeconds: 2},
+						DeprecatedPorts:          []corev1.ContainerPort{{Name: "port"}},
+						DeprecatedStartupProbe:   &corev1.Probe{InitialDelaySeconds: 3},
+						DeprecatedLifecycle: &corev1.Lifecycle{PostStart: &corev1.LifecycleHandler{Exec: &corev1.ExecAction{
+							Command: []string{"lifecycle command"},
+						}}},
+						DeprecatedTerminationMessagePath:   "path",
+						DeprecatedTerminationMessagePolicy: corev1.TerminationMessagePolicy("policy"),
+						DeprecatedStdin:                    true,
+						DeprecatedStdinOnce:                true,
+						DeprecatedTTY:                      true,
+					},
+				},
+			},
+		},
+	}, {
 		name: "taskrun conversion all non deprecated fields",
 		in: &v1beta1.TaskRun{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/apis/version/conversion.go
+++ b/pkg/apis/version/conversion.go
@@ -41,7 +41,7 @@ func SerializeToMetadata(meta *metav1.ObjectMeta, field interface{}, key string)
 // deserializes it into "to", and removes the key from the metadata's annotations.
 // Returns nil if the key is not present in the annotations.
 func DeserializeFromMetadata(meta *metav1.ObjectMeta, to interface{}, key string) error {
-	if meta.Annotations == nil {
+	if meta == nil || meta.Annotations == nil {
 		return nil
 	}
 	if str, ok := meta.Annotations[key]; ok {

--- a/test/conversion_test.go
+++ b/test/conversion_test.go
@@ -33,14 +33,8 @@ import (
 )
 
 var (
-	ReleaseAnnotation = "pipeline.tekton.dev/release"
-
-	// release Annotation is ignored when populated by TaskRuns
-	ignoreReleaseAnnotation = func(k string, v string) bool {
-		return k == ReleaseAnnotation
-	}
-
 	filterLabels                   = cmpopts.IgnoreFields(metav1.ObjectMeta{}, "Labels")
+	filterAnnotations              = cmpopts.IgnoreFields(metav1.ObjectMeta{}, "Annotations")
 	filterV1TaskRunStatus          = cmpopts.IgnoreFields(v1.TaskRunStatusFields{}, "StartTime", "CompletionTime")
 	filterV1PipelineRunStatus      = cmpopts.IgnoreFields(v1.PipelineRunStatusFields{}, "StartTime", "CompletionTime")
 	filterV1beta1TaskRunStatus     = cmpopts.IgnoreFields(v1beta1.TaskRunStatusFields{}, "StartTime", "CompletionTime")
@@ -48,13 +42,12 @@ var (
 	filterContainerStateTerminated = cmpopts.IgnoreFields(corev1.ContainerStateTerminated{}, "StartedAt", "FinishedAt", "ContainerID", "Message")
 	filterV1StepState              = cmpopts.IgnoreFields(v1.StepState{}, "Name", "ImageID", "Container")
 	filterV1beta1StepState         = cmpopts.IgnoreFields(v1beta1.StepState{}, "Name", "ImageID", "ContainerName")
-	filterReleaseAnnotation        = cmpopts.IgnoreMapEntries(ignoreReleaseAnnotation)
 
-	filterMetadata                 = []cmp.Option{filterTypeMeta, filterObjectMeta}
-	filterV1TaskRunFields          = []cmp.Option{filterTypeMeta, filterObjectMeta, filterLabels, filterCondition, filterReleaseAnnotation, filterV1TaskRunStatus, filterContainerStateTerminated, filterV1StepState}
-	filterV1beta1TaskRunFields     = []cmp.Option{filterTypeMeta, filterObjectMeta, filterLabels, filterV1beta1TaskRunStatus, filterCondition, filterReleaseAnnotation, filterContainerStateTerminated, filterV1beta1StepState}
-	filterV1PipelineRunFields      = []cmp.Option{filterTypeMeta, filterObjectMeta, filterLabels, filterCondition, filterV1PipelineRunStatus}
-	filterV1beta1PipelineRunFields = []cmp.Option{filterTypeMeta, filterObjectMeta, filterLabels, filterCondition, filterV1beta1PipelineRunStatus, filterV1beta1TaskRunStatus, filterV1beta1StepState, filterContainerStateTerminated}
+	filterMetadata                 = []cmp.Option{filterTypeMeta, filterObjectMeta, filterAnnotations}
+	filterV1TaskRunFields          = []cmp.Option{filterTypeMeta, filterObjectMeta, filterLabels, filterAnnotations, filterCondition, filterV1TaskRunStatus, filterContainerStateTerminated, filterV1StepState}
+	filterV1beta1TaskRunFields     = []cmp.Option{filterTypeMeta, filterObjectMeta, filterLabels, filterAnnotations, filterV1beta1TaskRunStatus, filterCondition, filterContainerStateTerminated, filterV1beta1StepState}
+	filterV1PipelineRunFields      = []cmp.Option{filterTypeMeta, filterObjectMeta, filterLabels, filterAnnotations, filterCondition, filterV1PipelineRunStatus}
+	filterV1beta1PipelineRunFields = []cmp.Option{filterTypeMeta, filterObjectMeta, filterLabels, filterAnnotations, filterCondition, filterV1beta1PipelineRunStatus, filterV1beta1TaskRunStatus, filterV1beta1StepState, filterContainerStateTerminated}
 
 	v1beta1TaskYaml = `
 metadata:


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes


    Prior to this PR, we have information loss when converting the
    step and steptemplate from v1beta1 to v1. This PR preserves
    those information by serializing steps and stepTemplate, saving
    them in object annoations when converting from v1beta1 to v1, then
    deserializing when converting back.
    
/kind bug

fix #6575 
closes #4546

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] ~Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps~
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
