### PR TITLE
[TEP-0089] Inject SpireControllerAPIClient into the Taskrun controller and reconciler.

### DIFF
--- a/pkg/reconciler/taskrun/controller.go
+++ b/pkg/reconciler/taskrun/controller.go
@@ -32,6 +32,7 @@ import (
 	cloudeventclient "github.com/tektoncd/pipeline/pkg/reconciler/events/cloudevent"
 	"github.com/tektoncd/pipeline/pkg/reconciler/volumeclaim"
 	resolution "github.com/tektoncd/pipeline/pkg/resolution/resource"
+	"github.com/tektoncd/pipeline/pkg/spire"
 	"github.com/tektoncd/pipeline/pkg/taskrunmetrics"
 	"go.opentelemetry.io/otel/trace"
 	"k8s.io/client-go/tools/cache"
@@ -55,7 +56,8 @@ func NewController(opts *pipeline.Options, clock clock.PassiveClock, tracerProvi
 		limitrangeInformer := limitrangeinformer.Get(ctx)
 		verificationpolicyInformer := verificationpolicyinformer.Get(ctx)
 		resolutionInformer := resolutioninformer.Get(ctx)
-		configStore := config.NewStore(logger.Named("config-store"), taskrunmetrics.MetricsOnStore(logger))
+		spireClient := spire.GetControllerAPIClient(ctx)
+		configStore := config.NewStore(logger.Named("config-store"), taskrunmetrics.MetricsOnStore(logger), spire.OnStore(ctx, logger))
 		configStore.WatchConfigs(cmw)
 
 		entrypointCache, err := pod.NewEntrypointCache(kubeclientset)
@@ -68,6 +70,7 @@ func NewController(opts *pipeline.Options, clock clock.PassiveClock, tracerProvi
 			PipelineClientSet:        pipelineclientset,
 			Images:                   opts.Images,
 			Clock:                    clock,
+			spireClient:              spireClient,
 			taskRunLister:            taskRunInformer.Lister(),
 			limitrangeLister:         limitrangeInformer.Lister(),
 			verificationPolicyLister: verificationpolicyInformer.Lister(),

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -45,6 +45,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/reconciler/volumeclaim"
 	"github.com/tektoncd/pipeline/pkg/remote"
 	resolution "github.com/tektoncd/pipeline/pkg/resolution/resource"
+	"github.com/tektoncd/pipeline/pkg/spire"
 	"github.com/tektoncd/pipeline/pkg/taskrunmetrics"
 	_ "github.com/tektoncd/pipeline/pkg/taskrunmetrics/fake" // Make sure the taskrunmetrics are setup
 	"github.com/tektoncd/pipeline/pkg/trustedresources"
@@ -78,6 +79,7 @@ type Reconciler struct {
 	Clock             clock.PassiveClock
 
 	// listers index properties about resources
+	spireClient              spire.ControllerAPIClient
 	taskRunLister            listers.TaskRunLister
 	limitrangeLister         corev1Listers.LimitRangeLister
 	podLister                corev1Listers.PodLister

--- a/pkg/spire/controller.go
+++ b/pkg/spire/controller.go
@@ -27,8 +27,10 @@ import (
 	"github.com/spiffe/go-spiffe/v2/workloadapi"
 	entryv1 "github.com/spiffe/spire-api-sdk/proto/spire/api/server/entry/v1"
 	spiffetypes "github.com/spiffe/spire-api-sdk/proto/spire/api/types"
+	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	spireconfig "github.com/tektoncd/pipeline/pkg/spire/config"
+	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
@@ -45,6 +47,22 @@ func init() {
 // controllerKey is a way to associate the ControllerAPIClient from inside the context.Context
 type controllerKey struct{}
 
+// OnStore stores the changed spire config into the SpireClientApi
+func OnStore(ctx context.Context, logger *zap.SugaredLogger) func(name string, value interface{}) {
+	return func(name string, value interface{}) {
+		if name == config.GetSpireConfigName() {
+			cfg, ok := value.(*spireconfig.SpireConfig)
+			if !ok {
+				logger.Error("Failed to do type assertion for extracting SPIRE config")
+				return
+			}
+			controllerAPIClient := GetControllerAPIClient(ctx)
+			controllerAPIClient.Close()
+			controllerAPIClient.SetConfig(*cfg)
+		}
+	}
+}
+
 // GetControllerAPIClient extracts the ControllerAPIClient from the context.
 func GetControllerAPIClient(ctx context.Context) ControllerAPIClient {
 	untyped := ctx.Value(controllerKey{})
@@ -52,7 +70,7 @@ func GetControllerAPIClient(ctx context.Context) ControllerAPIClient {
 		logging.FromContext(ctx).Errorf("Unable to fetch client from context.")
 		return nil
 	}
-	return untyped.(*spireControllerAPIClient)
+	return untyped.(ControllerAPIClient)
 }
 
 func withControllerClient(ctx context.Context, cfg *rest.Config) context.Context {
@@ -66,6 +84,8 @@ type spireControllerAPIClient struct {
 	entryClient  entryv1.EntryClient
 	workloadAPI  *workloadapi.Client
 }
+
+var _ ControllerAPIClient = (*spireControllerAPIClient)(nil)
 
 func (sc *spireControllerAPIClient) setupClient(ctx context.Context) error {
 	if sc.config == nil {
@@ -297,18 +317,22 @@ func (sc *spireControllerAPIClient) Close() error {
 		if err != nil {
 			return err
 		}
+		sc.serverConn = nil
 	}
 	if sc.workloadAPI != nil {
 		err = sc.workloadAPI.Close()
 		if err != nil {
 			return err
 		}
+		sc.workloadAPI = nil
 	}
 	if sc.workloadConn != nil {
 		err = sc.workloadConn.Close()
 		if err != nil {
 			return err
 		}
+		sc.workloadConn = nil
 	}
+	sc.entryClient = nil
 	return nil
 }

--- a/pkg/spire/spire_mock.go
+++ b/pkg/spire/spire_mock.go
@@ -77,6 +77,9 @@ type MockClient struct {
 	SignOverride func(ctx context.Context, results []result.RunResult) ([]result.RunResult, error)
 }
 
+var _ ControllerAPIClient = (*MockClient)(nil)
+var _ EntrypointerAPIClient = (*MockClient)(nil)
+
 const controllerSvid = "CONTROLLER_SVID_DATA"
 
 func (*MockClient) mockSign(content, signedBy string) string {


### PR DESCRIPTION
This PR injects the spireControllerAPIClient into the pipelines controller and the taskrun reconciler. It makes it available in these objects to be used for signing and verification of the taskrunResults and the taskrun object itself.

Before this change the spireAPIController object was not injected into the taskRun and as such SPIRE was not available to be used.

After this change,
- spireApiController will be available to be used by the pipeline controller and the taskrun object.
- The spireApiController will be update with the spire config whenever the config changes.

This commit is part of a series of PRs to implement TEP-0089. The implementation of TEP-0089 is tracked in the issue https://github.com/tektoncd/pipeline/issues/6597.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [X] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [X] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [X] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [X] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
