### PR TITLE
Add Json Annotation To The ParamValue

### DIFF
--- a/pkg/apis/pipeline/v1/param_types.go
+++ b/pkg/apis/pipeline/v1/param_types.go
@@ -377,11 +377,11 @@ var AllParamTypes = []ParamType{ParamTypeString, ParamTypeArray, ParamTypeObject
 // Used in JSON unmarshalling so that a single JSON field can accept
 // either an individual string or an array of strings.
 type ParamValue struct {
-	Type      ParamType // Represents the stored type of ParamValues.
-	StringVal string
+	Type      ParamType `json:"type,omitempty"` // Represents the stored type of ParamValues.
+	StringVal string    `json:"stringVal,omitempty"`
 	// +listType=atomic
-	ArrayVal  []string
-	ObjectVal map[string]string
+	ArrayVal  []string          `json:"arrayVal,omitempty"`
+	ObjectVal map[string]string `json:"objectVal,omitempty"`
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface.

--- a/pkg/apis/pipeline/v1beta1/param_types.go
+++ b/pkg/apis/pipeline/v1beta1/param_types.go
@@ -370,11 +370,11 @@ var AllParamTypes = []ParamType{ParamTypeString, ParamTypeArray, ParamTypeObject
 // Used in JSON unmarshalling so that a single JSON field can accept
 // either an individual string or an array of strings.
 type ParamValue struct {
-	Type      ParamType // Represents the stored type of ParamValues.
-	StringVal string
+	Type      ParamType `json:"type,omitempty"` // Represents the stored type of ParamValues.
+	StringVal string    `json:"stringVal,omitempty"`
 	// +listType=atomic
-	ArrayVal  []string
-	ObjectVal map[string]string
+	ArrayVal  []string          `json:"arrayVal,omitempty"`
+	ObjectVal map[string]string `json:"objectVal,omitempty"`
 }
 
 // ArrayOrString is deprecated, this is to keep backward compatibility


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Small fix For the following findings:

```
❯ golangci-lint run --fix
param_types.go:372:6: `ParamValue` should be annotated with the `json` tag as it is passed to `json.Unmarshal` at pkg/apis/pipeline/v1beta1/param_types_test.go:363:14 (musttag)
type ParamValue struct {
     ^
param_types.go:372:6: `ParamValue` should be annotated with the `json` tag as it is passed to `json.Unmarshal` at pkg/apis/pipeline/v1beta1/param_types_test.go:410:13 (musttag)
type ParamValue struct {
     ^
param_types.go:372:6: `ParamValue` should be annotated with the `json` tag as it is passed to `json.Marshal` at pkg/apis/pipeline/v1beta1/param_types_test.go:429:18 (musttag)
type ParamValue struct {
     ^
```

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] ~Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps~
- [x] ~Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed~
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
