### PR TITLE
Add validation for array indexing in finally when expressions

### DIFF
--- a/pkg/apis/pipeline/v1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1/pipeline_validation.go
@@ -721,6 +721,7 @@ func (ps *PipelineSpec) ValidateParamArrayIndex(ctx context.Context, params Para
 			paramsRefs = append(paramsRefs, ps.Finally[i].Matrix.Params.extractValues()...)
 		}
 		for _, wes := range ps.Finally[i].When {
+			paramsRefs = append(paramsRefs, wes.Input)
 			paramsRefs = append(paramsRefs, wes.Values...)
 		}
 	}

--- a/pkg/apis/pipeline/v1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1/pipeline_validation_test.go
@@ -3573,14 +3573,14 @@ func TestValidateParamArrayIndex_invalid(t *testing.T) {
 					{Name: "final-task-second-param", Value: *NewStructuredValues("$(params.second-param[2])")},
 				},
 				When: WhenExpressions{{
-					Input:    "$(params.first-param[0])",
+					Input:    "$(params.first-param[5])",
 					Operator: selection.In,
 					Values:   []string{"$(params.second-param[1])"},
 				}},
 			}},
 		},
 		params:   Params{{Name: "second-param", Value: *NewStructuredValues("second-value", "second-value-again")}},
-		expected: fmt.Errorf("non-existent param references:[$(params.first-param[2]) $(params.second-param[2])]"),
+		expected: fmt.Errorf("non-existent param references:[$(params.first-param[2]) $(params.first-param[5]) $(params.second-param[2])]"),
 	}, {
 		name: "parameter evaluation with both tasks and final tasks reference out of bound",
 		original: PipelineSpec{

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation.go
@@ -745,6 +745,7 @@ func (ps *PipelineSpec) ValidateParamArrayIndex(ctx context.Context, params Para
 			paramsRefs = append(paramsRefs, ps.Finally[i].Matrix.Params.extractValues()...)
 		}
 		for _, wes := range ps.Finally[i].WhenExpressions {
+			paramsRefs = append(paramsRefs, wes.Input)
 			paramsRefs = append(paramsRefs, wes.Values...)
 		}
 	}

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
@@ -3633,14 +3633,14 @@ func TestValidateParamArrayIndex_invalid(t *testing.T) {
 					{Name: "final-task-second-param", Value: *NewStructuredValues("$(params.second-param[2])")},
 				},
 				WhenExpressions: WhenExpressions{{
-					Input:    "$(params.first-param[0])",
+					Input:    "$(params.first-param[5])",
 					Operator: selection.In,
 					Values:   []string{"$(params.second-param[1])"},
 				}},
 			}},
 		},
 		params:   Params{{Name: "second-param", Value: *NewStructuredValues("second-value", "second-value-again")}},
-		expected: fmt.Errorf("non-existent param references:[$(params.first-param[2]) $(params.second-param[2])]"),
+		expected: fmt.Errorf("non-existent param references:[$(params.first-param[2]) $(params.first-param[5]) $(params.second-param[2])]"),
 	}, {
 		name: "parameter evaluation with both tasks and final tasks reference out of bound",
 		original: PipelineSpec{


### PR DESCRIPTION
Currently, the pipelines reconciler validates that array indexing references to parameters are not out of bounds. Prior to this commit, validation was accidentally skipped for pipeline.spec.finally.when.inputs. This commit adds this validation.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- n/a Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- n/a Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Bug fix: add validation for out-of-bounds indexing into array parameters referenced in pipeline.spec.finally.when.inputs
```
