### PR TITLE
Cleanp - Adding a single variable for default configmaps.

### DIFF
--- a/pkg/apis/config/default.go
+++ b/pkg/apis/config/default.go
@@ -59,6 +59,9 @@ const (
 	defaultResolverTypeKey               = "default-resolver-type"
 )
 
+// DefaultConfig holds all the default configurations for the config.
+var DefaultConfig, _ = NewDefaultsFromMap(map[string]string{})
+
 // Defaults holds the default configurations
 // +k8s:deepcopy-gen=true
 type Defaults struct {

--- a/pkg/apis/config/feature_flags.go
+++ b/pkg/apis/config/feature_flags.go
@@ -92,6 +92,9 @@ const (
 	maxResultSize                       = "max-result-size"
 )
 
+// DefaultFeatureFlags holds all the default configurations for the feature flags configmap.
+var DefaultFeatureFlags, _ = NewFeatureFlagsFromMap(map[string]string{})
+
 // FeatureFlags holds the features configurations
 // +k8s:deepcopy-gen=true
 //

--- a/pkg/apis/config/metrics.go
+++ b/pkg/apis/config/metrics.go
@@ -82,6 +82,9 @@ const (
 	DurationPipelinerunTypeLastValue = "lastvalue"
 )
 
+// DefaultMetrics holds all the default configurations for the metrics.
+var DefaultMetrics, _ = newMetricsFromMap(map[string]string{})
+
 // Metrics holds the configurations for the metrics
 // +k8s:deepcopy-gen=true
 type Metrics struct {

--- a/pkg/apis/config/spire_config.go
+++ b/pkg/apis/config/spire_config.go
@@ -47,6 +47,9 @@ const (
 	SpireNodeAliasPrefixDefault = "/tekton-node/"
 )
 
+// DefaultSpire hols all the default configurations for the spire.
+var DefaultSpire, _ = NewSpireConfigFromMap(map[string]string{})
+
 // NewSpireConfigFromMap creates a Config from the supplied map
 func NewSpireConfigFromMap(data map[string]string) (*sc.SpireConfig, error) {
 	cfg := &sc.SpireConfig{}

--- a/pkg/apis/config/store.go
+++ b/pkg/apis/config/store.go
@@ -49,16 +49,12 @@ func FromContextOrDefaults(ctx context.Context) *Config {
 	if cfg := FromContext(ctx); cfg != nil {
 		return cfg
 	}
-	defaults, _ := NewDefaultsFromMap(map[string]string{})
-	featureFlags, _ := NewFeatureFlagsFromMap(map[string]string{})
-	metrics, _ := newMetricsFromMap(map[string]string{})
-	spireconfig, _ := NewSpireConfigFromMap(map[string]string{})
 
 	return &Config{
-		Defaults:     defaults,
-		FeatureFlags: featureFlags,
-		Metrics:      metrics,
-		SpireConfig:  spireconfig,
+		Defaults:     DefaultConfig.DeepCopy(),
+		FeatureFlags: DefaultFeatureFlags.DeepCopy(),
+		Metrics:      DefaultMetrics.DeepCopy(),
+		SpireConfig:  DefaultSpire.DeepCopy(),
 	}
 }
 
@@ -102,20 +98,20 @@ func (s *Store) ToContext(ctx context.Context) context.Context {
 func (s *Store) Load() *Config {
 	defaults := s.UntypedLoad(GetDefaultsConfigName())
 	if defaults == nil {
-		defaults, _ = NewDefaultsFromMap(map[string]string{})
+		defaults = DefaultConfig.DeepCopy()
 	}
 	featureFlags := s.UntypedLoad(GetFeatureFlagsConfigName())
 	if featureFlags == nil {
-		featureFlags, _ = NewFeatureFlagsFromMap(map[string]string{})
+		featureFlags = DefaultFeatureFlags.DeepCopy()
 	}
 	metrics := s.UntypedLoad(GetMetricsConfigName())
 	if metrics == nil {
-		metrics, _ = newMetricsFromMap(map[string]string{})
+		metrics = DefaultMetrics.DeepCopy()
 	}
 
 	spireconfig := s.UntypedLoad(GetSpireConfigName())
 	if spireconfig == nil {
-		spireconfig, _ = NewSpireConfigFromMap(map[string]string{})
+		spireconfig = DefaultSpire.DeepCopy()
 	}
 
 	return &Config{

--- a/pkg/apis/config/store_test.go
+++ b/pkg/apis/config/store_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	test "github.com/tektoncd/pipeline/pkg/reconciler/testing"
 	"github.com/tektoncd/pipeline/test/diff"
-	corev1 "k8s.io/api/core/v1"
 	logtesting "knative.dev/pkg/logging/testing"
 )
 
@@ -60,16 +59,11 @@ func TestStoreLoadWithContext(t *testing.T) {
 }
 
 func TestStoreLoadWithContext_Empty(t *testing.T) {
-	defaults, _ := config.NewDefaultsFromMap(map[string]string{})
-	featureFlags, _ := config.NewFeatureFlagsFromMap(map[string]string{})
-	metrics, _ := config.NewMetricsFromConfigMap(&corev1.ConfigMap{Data: map[string]string{}})
-	spireConfig, _ := config.NewSpireConfigFromMap(map[string]string{})
-
 	want := &config.Config{
-		Defaults:     defaults,
-		FeatureFlags: featureFlags,
-		Metrics:      metrics,
-		SpireConfig:  spireConfig,
+		Defaults:     config.DefaultConfig.DeepCopy(),
+		FeatureFlags: config.DefaultFeatureFlags.DeepCopy(),
+		Metrics:      config.DefaultMetrics.DeepCopy(),
+		SpireConfig:  config.DefaultSpire.DeepCopy(),
 	}
 
 	store := config.NewStore(logtesting.TestLogger(t))

--- a/pkg/reconciler/events/cloudevent/cloud_event_controller_test.go
+++ b/pkg/reconciler/events/cloudevent/cloud_event_controller_test.go
@@ -195,10 +195,9 @@ func TestEmitCloudEvents(t *testing.T) {
 
 		// Setup the config and add it to the context
 		defaults, _ := config.NewDefaultsFromMap(tc.data)
-		featureFlags, _ := config.NewFeatureFlagsFromMap(map[string]string{})
 		cfg := &config.Config{
 			Defaults:     defaults,
-			FeatureFlags: featureFlags,
+			FeatureFlags: config.DefaultFeatureFlags.DeepCopy(),
 		}
 		ctx = config.ToContext(ctx, cfg)
 
@@ -241,10 +240,9 @@ func TestEmitCloudEventsWhenConditionChange(t *testing.T) {
 
 	// Setup the config and add it to the context
 	defaults, _ := config.NewDefaultsFromMap(data)
-	featureFlags, _ := config.NewFeatureFlagsFromMap(map[string]string{})
 	cfg := &config.Config{
 		Defaults:     defaults,
-		FeatureFlags: featureFlags,
+		FeatureFlags: config.DefaultFeatureFlags.DeepCopy(),
 	}
 	ctx = config.ToContext(ctx, cfg)
 

--- a/pkg/reconciler/events/event_test.go
+++ b/pkg/reconciler/events/event_test.go
@@ -82,10 +82,9 @@ func TestEmit(t *testing.T) {
 
 		// Setup the config and add it to the context
 		defaults, _ := config.NewDefaultsFromMap(tc.data)
-		featureFlags, _ := config.NewFeatureFlagsFromMap(map[string]string{})
 		cfg := &config.Config{
 			Defaults:     defaults,
-			FeatureFlags: featureFlags,
+			FeatureFlags: config.DefaultFeatureFlags.DeepCopy(),
 		}
 		ctx = config.ToContext(ctx, cfg)
 

--- a/pkg/reconciler/events/k8sevent/event_test.go
+++ b/pkg/reconciler/events/k8sevent/event_test.go
@@ -228,10 +228,9 @@ func TestEmitK8sEvents(t *testing.T) {
 
 		// Setup the config and add it to the context
 		defaults, _ := config.NewDefaultsFromMap(tc.data)
-		featureFlags, _ := config.NewFeatureFlagsFromMap(map[string]string{})
 		cfg := &config.Config{
 			Defaults:     defaults,
-			FeatureFlags: featureFlags,
+			FeatureFlags: config.DefaultFeatureFlags.DeepCopy(),
 		}
 		ctx = config.ToContext(ctx, cfg)
 


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

/kind cleanup

Prior, the New* function was called each time when we need to get the
default configuration for the default, feature flags, metrics and spire configmap.

Now, we created those variables first in corresponding file, and use a deepcopy
of it each time.


<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep

# Release Notes

```release-note
NONE
```
