### PR TITLE
Refactor validation functions for indexing into array params

### DIFF
--- a/pkg/apis/pipeline/v1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1/pipeline_validation.go
@@ -699,7 +699,16 @@ func (ps *PipelineSpec) ValidateParamArrayIndex(ctx context.Context, params Para
 	for k, v := range params.extractParamArrayLengths() {
 		arrayParamsLengths[k] = v
 	}
+	// extract all array indexing references, for example []{"$(params.array-params[1])"}
+	arrayIndexParamRefs := ps.GetIndexingReferencesToArrayParams().List()
+	return validateOutofBoundArrayParams(arrayIndexParamRefs, arrayParamsLengths)
+}
 
+// GetIndexingReferencesToArrayParams returns all strings referencing indices of PipelineRun array parameters
+// from parameters, workspaces, and when expressions defined in the Pipeline's Tasks and Finally Tasks.
+// For example, if a Task in the Pipeline has a parameter with a value "$(params.array-param-name[1])",
+// this would be one of the strings returned.
+func (ps *PipelineSpec) GetIndexingReferencesToArrayParams() sets.String {
 	paramsRefs := []string{}
 	for i := range ps.Tasks {
 		paramsRefs = append(paramsRefs, ps.Tasks[i].Params.extractValues()...)
@@ -714,7 +723,6 @@ func (ps *PipelineSpec) ValidateParamArrayIndex(ctx context.Context, params Para
 			paramsRefs = append(paramsRefs, wes.Values...)
 		}
 	}
-
 	for i := range ps.Finally {
 		paramsRefs = append(paramsRefs, ps.Finally[i].Params.extractValues()...)
 		if ps.Finally[i].IsMatrixed() {
@@ -725,12 +733,10 @@ func (ps *PipelineSpec) ValidateParamArrayIndex(ctx context.Context, params Para
 			paramsRefs = append(paramsRefs, wes.Values...)
 		}
 	}
-
 	// extract all array indexing references, for example []{"$(params.array-params[1])"}
 	arrayIndexParamRefs := []string{}
 	for _, p := range paramsRefs {
 		arrayIndexParamRefs = append(arrayIndexParamRefs, extractArrayIndexingParamRefs(p)...)
 	}
-
-	return validateOutofBoundArrayParams(arrayIndexParamRefs, arrayParamsLengths)
+	return sets.NewString(arrayIndexParamRefs...)
 }

--- a/pkg/apis/pipeline/v1/task_validation.go
+++ b/pkg/apis/pipeline/v1/task_validation.go
@@ -618,7 +618,17 @@ func (ts *TaskSpec) ValidateParamArrayIndex(ctx context.Context, params Params) 
 	for k, v := range params.extractParamArrayLengths() {
 		arrayParamsLengths[k] = v
 	}
+	// extract all array indexing references, for example []{"$(params.array-params[1])"}
+	arrayIndexParamRefs := ts.GetIndexingReferencesToArrayParams().List()
 
+	return validateOutofBoundArrayParams(arrayIndexParamRefs, arrayParamsLengths)
+}
+
+// GetIndexingReferencesToArrayParams returns all strings referencing indices of TaskRun array parameters
+// from parameters, workspaces, and when expressions defined in the Task.
+// For example, if a Task has a parameter with a value "$(params.array-param-name[1])",
+// this would be one of the strings returned.
+func (ts *TaskSpec) GetIndexingReferencesToArrayParams() sets.String {
 	// collect all the possible places to use param references
 	paramsRefs := []string{}
 	paramsRefs = append(paramsRefs, extractParamRefsFromSteps(ts.Steps)...)
@@ -628,12 +638,10 @@ func (ts *TaskSpec) ValidateParamArrayIndex(ctx context.Context, params Params) 
 		paramsRefs = append(paramsRefs, v.MountPath)
 	}
 	paramsRefs = append(paramsRefs, extractParamRefsFromSidecars(ts.Sidecars)...)
-
 	// extract all array indexing references, for example []{"$(params.array-params[1])"}
 	arrayIndexParamRefs := []string{}
 	for _, p := range paramsRefs {
 		arrayIndexParamRefs = append(arrayIndexParamRefs, extractArrayIndexingParamRefs(p)...)
 	}
-
-	return validateOutofBoundArrayParams(arrayIndexParamRefs, arrayParamsLengths)
+	return sets.NewString(arrayIndexParamRefs...)
 }

--- a/pkg/apis/pipeline/v1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1/task_validation_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/tektoncd/pipeline/test/diff"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"knative.dev/pkg/apis"
 )
 
@@ -1921,6 +1922,186 @@ func TestValidateParamArrayIndex(t *testing.T) {
 			err := tc.taskspec.ValidateParamArrayIndex(ctx, tc.params)
 			if d := cmp.Diff(tc.expectedError.Error(), err.Error()); d != "" {
 				t.Errorf("validateParamArrayIndex() errors diff %s", diff.PrintWantGot(d))
+			}
+		})
+	}
+}
+
+func TestGetArrayIndexParamRefs(t *testing.T) {
+	stepsReferences := []string{}
+	for i := 10; i <= 26; i++ {
+		stepsReferences = append(stepsReferences, fmt.Sprintf("$(params.array-params[%d])", i))
+	}
+	volumesReferences := []string{}
+	for i := 10; i <= 22; i++ {
+		volumesReferences = append(volumesReferences, fmt.Sprintf("$(params.array-params[%d])", i))
+	}
+
+	tcs := []struct {
+		name     string
+		taskspec *v1.TaskSpec
+		want     sets.String
+	}{{
+		name: "steps reference",
+		taskspec: &v1.TaskSpec{
+			Params: []v1.ParamSpec{{
+				Name:    "array-params",
+				Default: v1.NewStructuredValues("bar", "foo"),
+			}},
+			Steps: []v1.Step{{
+				Name:    "$(params.array-params[10])",
+				Image:   "$(params.array-params[11])",
+				Command: []string{"$(params.array-params[12])"},
+				Args:    []string{"$(params.array-params[13])"},
+				Script:  "echo $(params.array-params[14])",
+				Env: []corev1.EnvVar{{
+					Value: "$(params.array-params[15])",
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							Key: "$(params.array-params[16])",
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "$(params.array-params[17])",
+							},
+						},
+						ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+							Key: "$(params.array-params[18])",
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "$(params.array-params[19])",
+							},
+						},
+					},
+				}},
+				EnvFrom: []corev1.EnvFromSource{{
+					Prefix: "$(params.array-params[20])",
+					ConfigMapRef: &corev1.ConfigMapEnvSource{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "$(params.array-params[21])",
+						},
+					},
+					SecretRef: &corev1.SecretEnvSource{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "$(params.array-params[22])",
+						},
+					},
+				}},
+				WorkingDir: "$(params.array-params[23])",
+				VolumeMounts: []corev1.VolumeMount{{
+					Name:      "$(params.array-params[24])",
+					MountPath: "$(params.array-params[25])",
+					SubPath:   "$(params.array-params[26])",
+				}},
+			}},
+			StepTemplate: &v1.StepTemplate{
+				Image: "$(params.array-params[27])",
+			},
+		},
+		want: sets.NewString("$(params.array-params[10])", "$(params.array-params[11])", "$(params.array-params[12])", "$(params.array-params[13])", "$(params.array-params[14])",
+			"$(params.array-params[15])", "$(params.array-params[16])", "$(params.array-params[17])", "$(params.array-params[18])", "$(params.array-params[19])", "$(params.array-params[20])",
+			"$(params.array-params[21])", "$(params.array-params[22])", "$(params.array-params[23])", "$(params.array-params[24])", "$(params.array-params[25])", "$(params.array-params[26])", "$(params.array-params[27])"),
+	}, {
+		name: "stepTemplate reference",
+		taskspec: &v1.TaskSpec{
+			Params: []v1.ParamSpec{{
+				Name:    "array-params",
+				Default: v1.NewStructuredValues("bar", "foo"),
+			}},
+			StepTemplate: &v1.StepTemplate{
+				Image: "$(params.array-params[3])",
+			},
+		},
+		want: sets.NewString("$(params.array-params[3])"),
+	}, {
+		name: "volumes references",
+		taskspec: &v1.TaskSpec{
+			Params: []v1.ParamSpec{{
+				Name:    "array-params",
+				Default: v1.NewStructuredValues("bar", "foo"),
+			}},
+			Volumes: []corev1.Volume{{
+				Name: "$(params.array-params[10])",
+				VolumeSource: corev1.VolumeSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "$(params.array-params[11])",
+						},
+						Items: []corev1.KeyToPath{{
+							Key:  "$(params.array-params[12])",
+							Path: "$(params.array-params[13])",
+						},
+						},
+					},
+					Secret: &corev1.SecretVolumeSource{
+						SecretName: "$(params.array-params[14])",
+						Items: []corev1.KeyToPath{{
+							Key:  "$(params.array-params[15])",
+							Path: "$(params.array-params[16])",
+						}},
+					},
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: "$(params.array-params[17])",
+					},
+					Projected: &corev1.ProjectedVolumeSource{
+						Sources: []corev1.VolumeProjection{{
+							ConfigMap: &corev1.ConfigMapProjection{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: "$(params.array-params[18])",
+								},
+							},
+							Secret: &corev1.SecretProjection{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: "$(params.array-params[19])",
+								},
+							},
+							ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+								Audience: "$(params.array-params[20])",
+							},
+						}},
+					},
+					CSI: &corev1.CSIVolumeSource{
+						NodePublishSecretRef: &corev1.LocalObjectReference{
+							Name: "$(params.array-params[21])",
+						},
+						VolumeAttributes: map[string]string{"key": "$(params.array-params[22])"},
+					},
+				},
+			},
+			},
+		},
+		want: sets.NewString("$(params.array-params[10])", "$(params.array-params[11])", "$(params.array-params[12])", "$(params.array-params[13])", "$(params.array-params[14])",
+			"$(params.array-params[15])", "$(params.array-params[16])", "$(params.array-params[17])", "$(params.array-params[18])", "$(params.array-params[19])", "$(params.array-params[20])",
+			"$(params.array-params[21])", "$(params.array-params[22])"),
+	}, {
+		name: "workspaces references",
+		taskspec: &v1.TaskSpec{
+			Params: []v1.ParamSpec{{
+				Name:    "array-params",
+				Default: v1.NewStructuredValues("bar", "foo"),
+			}},
+			Workspaces: []v1.WorkspaceDeclaration{{
+				MountPath: "$(params.array-params[3])",
+			}},
+		},
+		want: sets.NewString("$(params.array-params[3])"),
+	}, {
+		name: "sidecar references",
+		taskspec: &v1.TaskSpec{
+			Params: []v1.ParamSpec{{
+				Name:    "array-params",
+				Default: v1.NewStructuredValues("bar", "foo"),
+			}},
+			Sidecars: []v1.Sidecar{{
+				Script: "$(params.array-params[3])",
+			},
+			},
+		},
+		want: sets.NewString("$(params.array-params[3])"),
+	},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.taskspec.GetIndexingReferencesToArrayParams()
+			if d := cmp.Diff(tc.want, got); d != "" {
+				t.Errorf("GetIndexingReferencesToArrayParams diff %s", diff.PrintWantGot(d))
 			}
 		})
 	}

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
@@ -29,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"knative.dev/pkg/apis"
 	logtesting "knative.dev/pkg/logging/testing"
 )
@@ -3743,6 +3744,159 @@ func TestValidateParamArrayIndex_invalid(t *testing.T) {
 			err := tt.original.ValidateParamArrayIndex(ctx, tt.params)
 			if d := cmp.Diff(tt.expected.Error(), err.Error()); d != "" {
 				t.Errorf("ValidateParamArrayIndex() errors diff %s", diff.PrintWantGot(d))
+			}
+		})
+	}
+}
+
+func TestGetIndexingReferencesToArrayParams(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		spec PipelineSpec
+		want sets.String
+	}{{
+		name: "references in task params",
+		spec: PipelineSpec{
+			Params: []ParamSpec{
+				{Name: "first-param", Type: ParamTypeArray, Default: NewStructuredValues("default-value", "default-value-again")},
+				{Name: "second-param", Type: ParamTypeString},
+			},
+			Tasks: []PipelineTask{{
+				Params: Params{
+					{Name: "first-task-first-param", Value: *NewStructuredValues("$(params.first-param[1])")},
+					{Name: "first-task-second-param", Value: *NewStructuredValues("$(params.second-param[0])")},
+					{Name: "first-task-third-param", Value: *NewStructuredValues("static value")},
+				},
+			}},
+		},
+		want: sets.NewString("$(params.first-param[1])", "$(params.second-param[0])"),
+	}, {
+		name: "references in when expression",
+		spec: PipelineSpec{
+			Params: []ParamSpec{
+				{Name: "first-param", Type: ParamTypeArray, Default: NewStructuredValues("default-value", "default-value-again")},
+				{Name: "second-param", Type: ParamTypeString},
+			},
+			Tasks: []PipelineTask{{
+				WhenExpressions: []WhenExpression{{
+					Input:    "$(params.first-param[1])",
+					Operator: selection.In,
+					Values:   []string{"$(params.second-param[0])"},
+				}},
+			}},
+		},
+		want: sets.NewString("$(params.first-param[1])", "$(params.second-param[0])"),
+	}, {
+		name: "nested references in task params",
+		spec: PipelineSpec{
+			Params: []ParamSpec{
+				{Name: "first-param", Type: ParamTypeArray, Default: NewStructuredValues("default-value", "default-value-again")},
+				{Name: "second-param", Type: ParamTypeArray, Default: NewStructuredValues("default-value", "default-value-again")},
+			},
+			Tasks: []PipelineTask{{
+				Params: Params{
+					{Name: "first-task-first-param", Value: *NewStructuredValues("$(input.workspace.$(params.first-param[0]))")},
+					{Name: "first-task-second-param", Value: *NewStructuredValues("$(input.workspace.$(params.second-param[1]))")},
+				},
+			}},
+		},
+		want: sets.NewString("$(params.first-param[0])", "$(params.second-param[1])"),
+	}, {
+		name: "array parameter",
+		spec: PipelineSpec{
+			Params: []ParamSpec{
+				{Name: "first-param", Type: ParamTypeArray, Default: NewStructuredValues("default", "array", "value")},
+				{Name: "second-param", Type: ParamTypeArray},
+			},
+			Tasks: []PipelineTask{{
+				Params: Params{
+					{Name: "first-task-first-param", Value: *NewStructuredValues("firstelement", "$(params.first-param)")},
+					{Name: "first-task-second-param", Value: *NewStructuredValues("firstelement", "$(params.second-param[0])")},
+				},
+			}},
+		},
+		want: sets.NewString("$(params.second-param[0])"),
+	}, {
+		name: "references in finally params",
+		spec: PipelineSpec{
+			Params: []ParamSpec{
+				{Name: "first-param", Type: ParamTypeArray, Default: NewStructuredValues("default-value", "default-value-again")},
+				{Name: "second-param", Type: ParamTypeArray},
+			},
+			Finally: []PipelineTask{{
+				Params: Params{
+					{Name: "final-task-first-param", Value: *NewStructuredValues("$(params.first-param[0])")},
+					{Name: "final-task-second-param", Value: *NewStructuredValues("$(params.second-param[1])")},
+				},
+			}},
+		},
+		want: sets.NewString("$(params.first-param[0])", "$(params.second-param[1])"),
+	}, {
+		name: "references in finally when expressions",
+		spec: PipelineSpec{
+			Params: []ParamSpec{
+				{Name: "first-param", Type: ParamTypeArray, Default: NewStructuredValues("default-value", "default-value-again")},
+				{Name: "second-param", Type: ParamTypeArray},
+			},
+			Finally: []PipelineTask{{
+				WhenExpressions: WhenExpressions{{
+					Input:    "$(params.first-param[0])",
+					Operator: selection.In,
+					Values:   []string{"$(params.second-param[1])"},
+				}},
+			}},
+		},
+		want: sets.NewString("$(params.first-param[0])", "$(params.second-param[1])"),
+	}, {
+		name: "parameter references with bracket notation and special characters",
+		spec: PipelineSpec{
+			Params: []ParamSpec{
+				{Name: "first.param", Type: ParamTypeArray, Default: NewStructuredValues("default-value", "default-value-again")},
+				{Name: "second/param", Type: ParamTypeArray},
+				{Name: "third.param", Type: ParamTypeArray, Default: NewStructuredValues("default-value", "default-value-again")},
+				{Name: "fourth/param", Type: ParamTypeArray},
+			},
+			Tasks: []PipelineTask{{
+				Params: Params{
+					{Name: "first-task-first-param", Value: *NewStructuredValues(`$(params["first.param"][0])`)},
+					{Name: "first-task-second-param", Value: *NewStructuredValues(`$(params["first.param"][0])`)},
+					{Name: "first-task-third-param", Value: *NewStructuredValues(`$(params['third.param'][1])`)},
+					{Name: "first-task-fourth-param", Value: *NewStructuredValues(`$(params['fourth/param'][1])`)},
+					{Name: "first-task-fifth-param", Value: *NewStructuredValues("static value")},
+				},
+			}},
+		},
+		want: sets.NewString(`$(params["first.param"][0])`, `$(params["first.param"][0])`, `$(params['third.param'][1])`, `$(params['fourth/param'][1])`),
+	}, {
+		name: "single parameter in workspace subpath",
+		spec: PipelineSpec{
+			Params: []ParamSpec{
+				{Name: "first-param", Type: ParamTypeArray, Default: NewStructuredValues("default-value", "default-value-again")},
+				{Name: "second-param", Type: ParamTypeArray},
+			},
+			Tasks: []PipelineTask{{
+				Params: Params{
+					{Name: "first-task-first-param", Value: *NewStructuredValues("$(params.first-param[0])")},
+					{Name: "first-task-second-param", Value: *NewStructuredValues("static value")},
+				},
+				Workspaces: []WorkspacePipelineTaskBinding{
+					{
+						Name:      "first-workspace",
+						Workspace: "first-workspace",
+						SubPath:   "$(params.second-param[1])",
+					},
+				},
+			}},
+		},
+		want: sets.NewString("$(params.first-param[0])", "$(params.second-param[1])"),
+	},
+	} {
+		tt := tt // capture range variable
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := tt.spec.GetIndexingReferencesToArrayParams()
+			if d := cmp.Diff(tt.want, got); d != "" {
+				t.Errorf("wrong array index references: %s", d)
 			}
 		})
 	}

--- a/pkg/apis/pipeline/v1beta1/task_validation.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation.go
@@ -617,7 +617,16 @@ func (ts *TaskSpec) ValidateParamArrayIndex(ctx context.Context, params Params) 
 	for k, v := range params.extractParamArrayLengths() {
 		arrayParamsLengths[k] = v
 	}
+	// extract all array indexing references, for example []{"$(params.array-params[1])"}
+	arrayIndexParamRefs := ts.GetIndexingReferencesToArrayParams().List()
+	return validateOutofBoundArrayParams(arrayIndexParamRefs, arrayParamsLengths)
+}
 
+// GetIndexingReferencesToArrayParams returns all strings referencing indices of TaskRun array parameters
+// from parameters, workspaces, and when expressions defined in the Task.
+// For example, if a Task has a parameter with a value "$(params.array-param-name[1])",
+// this would be one of the strings returned.
+func (ts *TaskSpec) GetIndexingReferencesToArrayParams() sets.String {
 	// collect all the possible places to use param references
 	paramsRefs := []string{}
 	paramsRefs = append(paramsRefs, extractParamRefsFromSteps(ts.Steps)...)
@@ -627,12 +636,10 @@ func (ts *TaskSpec) ValidateParamArrayIndex(ctx context.Context, params Params) 
 		paramsRefs = append(paramsRefs, v.MountPath)
 	}
 	paramsRefs = append(paramsRefs, extractParamRefsFromSidecars(ts.Sidecars)...)
-
 	// extract all array indexing references, for example []{"$(params.array-params[1])"}
 	arrayIndexParamRefs := []string{}
 	for _, p := range paramsRefs {
 		arrayIndexParamRefs = append(arrayIndexParamRefs, extractArrayIndexingParamRefs(p)...)
 	}
-
-	return validateOutofBoundArrayParams(arrayIndexParamRefs, arrayParamsLengths)
+	return sets.NewString(arrayIndexParamRefs...)
 }

--- a/pkg/apis/pipeline/v1beta1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/tektoncd/pipeline/test/diff"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"knative.dev/pkg/apis"
 )
 
@@ -1932,6 +1933,186 @@ func TestValidateParamArrayIndex(t *testing.T) {
 			err := tc.taskspec.ValidateParamArrayIndex(context.Background(), tc.params)
 			if d := cmp.Diff(tc.expectedError.Error(), err.Error()); d != "" {
 				t.Errorf("validateParamArrayIndex() errors diff %s", diff.PrintWantGot(d))
+			}
+		})
+	}
+}
+
+func TestGetArrayIndexParamRefs(t *testing.T) {
+	stepsReferences := []string{}
+	for i := 10; i <= 26; i++ {
+		stepsReferences = append(stepsReferences, fmt.Sprintf("$(params.array-params[%d])", i))
+	}
+	volumesReferences := []string{}
+	for i := 10; i <= 22; i++ {
+		volumesReferences = append(volumesReferences, fmt.Sprintf("$(params.array-params[%d])", i))
+	}
+
+	tcs := []struct {
+		name     string
+		taskspec *v1beta1.TaskSpec
+		want     sets.String
+	}{{
+		name: "steps reference",
+		taskspec: &v1beta1.TaskSpec{
+			Params: []v1beta1.ParamSpec{{
+				Name:    "array-params",
+				Default: v1beta1.NewStructuredValues("bar", "foo"),
+			}},
+			Steps: []v1beta1.Step{{
+				Name:    "$(params.array-params[10])",
+				Image:   "$(params.array-params[11])",
+				Command: []string{"$(params.array-params[12])"},
+				Args:    []string{"$(params.array-params[13])"},
+				Script:  "echo $(params.array-params[14])",
+				Env: []corev1.EnvVar{{
+					Value: "$(params.array-params[15])",
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							Key: "$(params.array-params[16])",
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "$(params.array-params[17])",
+							},
+						},
+						ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+							Key: "$(params.array-params[18])",
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "$(params.array-params[19])",
+							},
+						},
+					},
+				}},
+				EnvFrom: []corev1.EnvFromSource{{
+					Prefix: "$(params.array-params[20])",
+					ConfigMapRef: &corev1.ConfigMapEnvSource{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "$(params.array-params[21])",
+						},
+					},
+					SecretRef: &corev1.SecretEnvSource{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "$(params.array-params[22])",
+						},
+					},
+				}},
+				WorkingDir: "$(params.array-params[23])",
+				VolumeMounts: []corev1.VolumeMount{{
+					Name:      "$(params.array-params[24])",
+					MountPath: "$(params.array-params[25])",
+					SubPath:   "$(params.array-params[26])",
+				}},
+			}},
+			StepTemplate: &v1beta1.StepTemplate{
+				Image: "$(params.array-params[27])",
+			},
+		},
+		want: sets.NewString("$(params.array-params[10])", "$(params.array-params[11])", "$(params.array-params[12])", "$(params.array-params[13])", "$(params.array-params[14])",
+			"$(params.array-params[15])", "$(params.array-params[16])", "$(params.array-params[17])", "$(params.array-params[18])", "$(params.array-params[19])", "$(params.array-params[20])",
+			"$(params.array-params[21])", "$(params.array-params[22])", "$(params.array-params[23])", "$(params.array-params[24])", "$(params.array-params[25])", "$(params.array-params[26])", "$(params.array-params[27])"),
+	}, {
+		name: "stepTemplate reference",
+		taskspec: &v1beta1.TaskSpec{
+			Params: []v1beta1.ParamSpec{{
+				Name:    "array-params",
+				Default: v1beta1.NewStructuredValues("bar", "foo"),
+			}},
+			StepTemplate: &v1beta1.StepTemplate{
+				Image: "$(params.array-params[3])",
+			},
+		},
+		want: sets.NewString("$(params.array-params[3])"),
+	}, {
+		name: "volumes references",
+		taskspec: &v1beta1.TaskSpec{
+			Params: []v1beta1.ParamSpec{{
+				Name:    "array-params",
+				Default: v1beta1.NewStructuredValues("bar", "foo"),
+			}},
+			Volumes: []corev1.Volume{{
+				Name: "$(params.array-params[10])",
+				VolumeSource: corev1.VolumeSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "$(params.array-params[11])",
+						},
+						Items: []corev1.KeyToPath{{
+							Key:  "$(params.array-params[12])",
+							Path: "$(params.array-params[13])",
+						},
+						},
+					},
+					Secret: &corev1.SecretVolumeSource{
+						SecretName: "$(params.array-params[14])",
+						Items: []corev1.KeyToPath{{
+							Key:  "$(params.array-params[15])",
+							Path: "$(params.array-params[16])",
+						}},
+					},
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: "$(params.array-params[17])",
+					},
+					Projected: &corev1.ProjectedVolumeSource{
+						Sources: []corev1.VolumeProjection{{
+							ConfigMap: &corev1.ConfigMapProjection{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: "$(params.array-params[18])",
+								},
+							},
+							Secret: &corev1.SecretProjection{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: "$(params.array-params[19])",
+								},
+							},
+							ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+								Audience: "$(params.array-params[20])",
+							},
+						}},
+					},
+					CSI: &corev1.CSIVolumeSource{
+						NodePublishSecretRef: &corev1.LocalObjectReference{
+							Name: "$(params.array-params[21])",
+						},
+						VolumeAttributes: map[string]string{"key": "$(params.array-params[22])"},
+					},
+				},
+			},
+			},
+		},
+		want: sets.NewString("$(params.array-params[10])", "$(params.array-params[11])", "$(params.array-params[12])", "$(params.array-params[13])", "$(params.array-params[14])",
+			"$(params.array-params[15])", "$(params.array-params[16])", "$(params.array-params[17])", "$(params.array-params[18])", "$(params.array-params[19])", "$(params.array-params[20])",
+			"$(params.array-params[21])", "$(params.array-params[22])"),
+	}, {
+		name: "workspaces references",
+		taskspec: &v1beta1.TaskSpec{
+			Params: []v1beta1.ParamSpec{{
+				Name:    "array-params",
+				Default: v1beta1.NewStructuredValues("bar", "foo"),
+			}},
+			Workspaces: []v1beta1.WorkspaceDeclaration{{
+				MountPath: "$(params.array-params[3])",
+			}},
+		},
+		want: sets.NewString("$(params.array-params[3])"),
+	}, {
+		name: "sidecar references",
+		taskspec: &v1beta1.TaskSpec{
+			Params: []v1beta1.ParamSpec{{
+				Name:    "array-params",
+				Default: v1beta1.NewStructuredValues("bar", "foo"),
+			}},
+			Sidecars: []v1beta1.Sidecar{{
+				Script: "$(params.array-params[3])",
+			},
+			},
+		},
+		want: sets.NewString("$(params.array-params[3])"),
+	},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.taskspec.GetIndexingReferencesToArrayParams()
+			if d := cmp.Diff(tc.want, got); d != "" {
+				t.Errorf("GetIndexingReferencesToArrayParams diff %s", diff.PrintWantGot(d))
 			}
 		})
 	}


### PR DESCRIPTION
This commit refactors validation functions for Tasks and Pipelines that index into array params by creating helper functions for getting all indexing references to array params in Task and Pipeline specs. No functional changes expected from this commit.

Refactoring to split out non-functional changes from https://github.com/tektoncd/pipeline/pull/6617.

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- n/a Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- n/a Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- n/a Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
