### PR TITLE
remove beta flag check for v1beta1 object param,results and array result

### DIFF
--- a/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
@@ -1335,8 +1335,7 @@ func TestValidatePipelineParameterVariables_Success(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := config.EnableAlphaAPIFields(context.Background())
-			ctx = config.SkipValidationDueToPropagatedParametersAndWorkspaces(ctx, false)
+			ctx := config.SkipValidationDueToPropagatedParametersAndWorkspaces(context.Background(), false)
 			err := ValidatePipelineParameterVariables(ctx, tt.tasks, tt.params)
 			if err != nil {
 				t.Errorf("Pipeline.ValidatePipelineParameterVariables() returned error for valid pipeline parameters: %v", err)

--- a/pkg/apis/pipeline/v1beta1/pipelineref_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelineref_validation_test.go
@@ -120,21 +120,6 @@ func TestPipelineRef_Invalid(t *testing.T) {
 		},
 		wantErr:     apis.ErrMultipleOneOf("bundle", "params").Also(apis.ErrMissingField("resolver")),
 		withContext: enableTektonOCIBundles(t),
-	}, {
-		name: "pipelineref param object requires alpha",
-		ref: &v1beta1.PipelineRef{
-			ResolverRef: v1beta1.ResolverRef{
-				Resolver: "some-resolver",
-				Params: v1beta1.Params{{
-					Name: "foo",
-					Value: v1beta1.ParamValue{
-						Type:      v1beta1.ParamTypeObject,
-						ObjectVal: map[string]string{"bar": "baz"},
-					},
-				}},
-			},
-		},
-		wantErr: apis.ErrGeneric("object type parameter requires \"enable-api-fields\" feature gate to be \"alpha\" or \"beta\" but it is \"stable\""),
 	}}
 
 	for _, tc := range tests {

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_validation_test.go
@@ -173,7 +173,6 @@ func TestPipelineRun_Invalid(t *testing.T) {
 			Message: `non-existent variable in "$(params.pipeline-words.not-hello)"`,
 			Paths:   []string{"spec.steps[0].args[0]"},
 		},
-		wc: config.EnableAlphaAPIFields,
 	}, {
 		name: "propagating object params with pipelinespec and taskspec params not provided",
 		pr: v1beta1.PipelineRun{
@@ -211,7 +210,6 @@ func TestPipelineRun_Invalid(t *testing.T) {
 			Message: `non-existent variable in "$(params.pipeline-words.not-hello)"`,
 			Paths:   []string{"spec.steps[0].args[0]"},
 		},
-		wc: config.EnableAlphaAPIFields,
 	}, {
 		name: "propagating object params with pipelinespec and taskspec params provided in taskrun",
 		pr: v1beta1.PipelineRun{
@@ -256,7 +254,6 @@ func TestPipelineRun_Invalid(t *testing.T) {
 			Message: `non-existent variable in "$(params.pipeline-words.not-hello)"`,
 			Paths:   []string{"spec.steps[0].args[0]"},
 		},
-		wc: config.EnableAlphaAPIFields,
 	}, {
 		name: "propagating params with pipelinespec and taskspec",
 		pr: v1beta1.PipelineRun{
@@ -352,7 +349,6 @@ func TestPipelineRun_Invalid(t *testing.T) {
 			Message: `non-existent variable in "$(params.pipeline-words.not-hello)"`,
 			Paths:   []string{"spec.steps[0].args[0]"},
 		},
-		wc: config.EnableAlphaAPIFields,
 	}, {
 		name: "duplicate param names",
 		pr: v1beta1.PipelineRun{
@@ -613,7 +609,6 @@ func TestPipelineRun_Validate(t *testing.T) {
 				},
 			},
 		},
-		wc: config.EnableAlphaAPIFields,
 	}, {
 		name: "propagating params with pipelinespec and taskspec",
 		pr: v1beta1.PipelineRun{
@@ -643,7 +638,6 @@ func TestPipelineRun_Validate(t *testing.T) {
 				},
 			},
 		},
-		wc: config.EnableAlphaAPIFields,
 	}, {
 		name: "propagating object params with pipelinespec and taskspec",
 		pr: v1beta1.PipelineRun{
@@ -673,7 +667,6 @@ func TestPipelineRun_Validate(t *testing.T) {
 				},
 			},
 		},
-		wc: config.EnableAlphaAPIFields,
 	}, {
 		name: "propagating object params no value in params but value in default",
 		pr: v1beta1.PipelineRun{
@@ -713,7 +706,6 @@ func TestPipelineRun_Validate(t *testing.T) {
 				},
 			},
 		},
-		wc: config.EnableAlphaAPIFields,
 	}, {
 		name: "propagating object params with some params defined in taskspec only",
 		pr: v1beta1.PipelineRun{
@@ -754,7 +746,6 @@ func TestPipelineRun_Validate(t *testing.T) {
 				},
 			},
 		},
-		wc: config.EnableAlphaAPIFields,
 	}, {
 		name: "propagating workspaces",
 		pr: v1beta1.PipelineRun{

--- a/pkg/apis/pipeline/v1beta1/result_validation.go
+++ b/pkg/apis/pipeline/v1beta1/result_validation.go
@@ -17,8 +17,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/tektoncd/pipeline/pkg/apis/config"
-	"github.com/tektoncd/pipeline/pkg/apis/version"
 	"knative.dev/pkg/apis"
 )
 
@@ -29,14 +27,10 @@ func (tr TaskResult) Validate(ctx context.Context) (errs *apis.FieldError) {
 	}
 
 	switch {
-	// Object results is a beta feature - make sure the feature flag is set to "beta"
 	case tr.Type == ResultsTypeObject:
 		errs := validateObjectResult(tr)
-		errs = errs.Also(version.ValidateEnabledAPIFields(ctx, "results type", config.BetaAPIFields))
 		return errs
-	// Array results is a beta feature - make sure the feature flag is set to "beta"
 	case tr.Type == ResultsTypeArray:
-		errs = errs.Also(version.ValidateEnabledAPIFields(ctx, "results type", config.BetaAPIFields))
 		return errs
 	// Resources created before the result. Type was introduced may not have Type set
 	// and should be considered valid

--- a/pkg/apis/pipeline/v1beta1/result_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/result_validation_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/test/diff"
 	"knative.dev/pkg/apis"
@@ -30,16 +29,14 @@ import (
 
 func TestResultsValidate(t *testing.T) {
 	tests := []struct {
-		name      string
-		Result    v1beta1.TaskResult
-		apiFields string
+		name   string
+		Result v1beta1.TaskResult
 	}{{
 		name: "valid result type empty",
 		Result: v1beta1.TaskResult{
 			Name:        "MY-RESULT",
 			Description: "my great result",
 		},
-		apiFields: "stable",
 	}, {
 		name: "valid result type string",
 		Result: v1beta1.TaskResult{
@@ -47,8 +44,6 @@ func TestResultsValidate(t *testing.T) {
 			Type:        v1beta1.ResultsTypeString,
 			Description: "my great result",
 		},
-
-		apiFields: "stable",
 	}, {
 		name: "valid result type array",
 		Result: v1beta1.TaskResult{
@@ -56,17 +51,6 @@ func TestResultsValidate(t *testing.T) {
 			Type:        v1beta1.ResultsTypeArray,
 			Description: "my great result",
 		},
-
-		apiFields: "alpha",
-	}, {
-		name: "valid result type array",
-		Result: v1beta1.TaskResult{
-			Name:        "MY-RESULT",
-			Type:        v1beta1.ResultsTypeArray,
-			Description: "my great result",
-		},
-
-		apiFields: config.BetaAPIFields,
 	}, {
 		name: "valid result type object",
 		Result: v1beta1.TaskResult{
@@ -75,17 +59,10 @@ func TestResultsValidate(t *testing.T) {
 			Description: "my great result",
 			Properties:  map[string]v1beta1.PropertySpec{"hello": {Type: v1beta1.ParamTypeString}},
 		},
-		apiFields: "alpha",
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
-			if tt.apiFields == "alpha" {
-				ctx = config.EnableAlphaAPIFields(ctx)
-			}
-			if tt.apiFields == config.BetaAPIFields {
-				ctx = config.EnableBetaAPIFields(ctx)
-			}
 			if err := tt.Result.Validate(ctx); err != nil {
 				t.Errorf("TaskSpec.Validate() = %v", err)
 			}
@@ -97,7 +74,6 @@ func TestResultsValidateError(t *testing.T) {
 	tests := []struct {
 		name          string
 		Result        v1beta1.TaskResult
-		apiFields     string
 		expectedError apis.FieldError
 	}{{
 		name: "invalid result type in stable",
@@ -106,47 +82,10 @@ func TestResultsValidateError(t *testing.T) {
 			Type:        "wrong",
 			Description: "my great result",
 		},
-		apiFields: "stable",
 		expectedError: apis.FieldError{
 			Message: `invalid value: wrong`,
 			Paths:   []string{"type"},
 			Details: "type must be string",
-		},
-	}, {
-		name: "invalid result type in alpha",
-		Result: v1beta1.TaskResult{
-			Name:        "MY-RESULT",
-			Type:        "wrong",
-			Description: "my great result",
-		},
-		apiFields: "alpha",
-		expectedError: apis.FieldError{
-			Message: `invalid value: wrong`,
-			Paths:   []string{"type"},
-			Details: "type must be string",
-		},
-	}, {
-		name: "invalid array result type in stable",
-		Result: v1beta1.TaskResult{
-			Name:        "MY-RESULT",
-			Type:        v1beta1.ResultsTypeArray,
-			Description: "my great result",
-		},
-		apiFields: "stable",
-		expectedError: apis.FieldError{
-			Message: "results type requires \"enable-api-fields\" feature gate to be \"alpha\" or \"beta\" but it is \"stable\"",
-		},
-	}, {
-		name: "invalid object result type in stable",
-		Result: v1beta1.TaskResult{
-			Name:        "MY-RESULT",
-			Type:        v1beta1.ResultsTypeObject,
-			Description: "my great result",
-			Properties:  map[string]v1beta1.PropertySpec{"hello": {Type: v1beta1.ParamTypeString}},
-		},
-		apiFields: "stable",
-		expectedError: apis.FieldError{
-			Message: "results type requires \"enable-api-fields\" feature gate to be \"alpha\" or \"beta\" but it is \"stable\"",
 		},
 	}, {
 		name: "invalid object properties type",
@@ -156,7 +95,6 @@ func TestResultsValidateError(t *testing.T) {
 			Description: "my great result",
 			Properties:  map[string]v1beta1.PropertySpec{"hello": {Type: "wrong type"}},
 		},
-		apiFields: "alpha",
 		expectedError: apis.FieldError{
 			Message: "The value type specified for these keys [hello] is invalid, the type must be string",
 			Paths:   []string{"MY-RESULT.properties"},
@@ -168,7 +106,6 @@ func TestResultsValidateError(t *testing.T) {
 			Type:        v1beta1.ResultsTypeObject,
 			Description: "my great result",
 		},
-		apiFields: "alpha",
 		expectedError: apis.FieldError{
 			Message: "missing field(s)",
 			Paths:   []string{"MY-RESULT.properties"},
@@ -177,9 +114,6 @@ func TestResultsValidateError(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
-			if tt.apiFields == "alpha" {
-				ctx = config.EnableAlphaAPIFields(ctx)
-			}
 			err := tt.Result.Validate(ctx)
 			if err == nil {
 				t.Fatalf("Expected an error, got nothing for %v", tt.Result)

--- a/pkg/apis/pipeline/v1beta1/task_validation.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation.go
@@ -325,11 +325,6 @@ func validateStep(ctx context.Context, s Step, names sets.String) (errs *apis.Fi
 // ValidateParameterTypes validates all the types within a slice of ParamSpecs
 func ValidateParameterTypes(ctx context.Context, params []ParamSpec) (errs *apis.FieldError) {
 	for _, p := range params {
-		if p.Type == ParamTypeObject {
-			// Object type parameter is a beta feature and will fail validation if it's used in a task spec
-			// when the enable-api-fields feature gate is not "alpha" or "beta".
-			errs = errs.Also(version.ValidateEnabledAPIFields(ctx, "object type parameter", config.BetaAPIFields))
-		}
 		errs = errs.Also(p.ValidateType(ctx))
 	}
 	return errs

--- a/pkg/apis/pipeline/v1beta1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation_test.go
@@ -516,7 +516,7 @@ func TestTaskSpecValidate(t *testing.T) {
 				Workspaces:   tt.fields.Workspaces,
 				Results:      tt.fields.Results,
 			}
-			ctx := config.EnableAlphaAPIFields(context.Background())
+			ctx := context.Background()
 			ts.SetDefaults(ctx)
 			if err := ts.Validate(ctx); err != nil {
 				t.Errorf("TaskSpec.Validate() = %v", err)
@@ -1327,7 +1327,7 @@ func TestTaskSpecValidateError(t *testing.T) {
 				Results:      tt.fields.Results,
 				Resources:    tt.fields.Resources,
 			}
-			ctx := config.EnableAlphaAPIFields(context.Background())
+			ctx := context.Background()
 			ts.SetDefaults(ctx)
 			ctx = config.SkipValidationDueToPropagatedParametersAndWorkspaces(ctx, false)
 			err := ts.Validate(ctx)

--- a/pkg/apis/pipeline/v1beta1/taskref_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskref_validation_test.go
@@ -164,21 +164,6 @@ func TestTaskRef_Invalid(t *testing.T) {
 		},
 		wantErr: apis.ErrMultipleOneOf("bundle", "params").Also(apis.ErrMissingField("resolver")),
 		wc:      enableTektonOCIBundles(t),
-	}, {
-		name: "taskref param object requires alpha",
-		taskRef: &v1beta1.TaskRef{
-			ResolverRef: v1beta1.ResolverRef{
-				Resolver: "some-resolver",
-				Params: v1beta1.Params{{
-					Name: "foo",
-					Value: v1beta1.ParamValue{
-						Type:      v1beta1.ParamTypeObject,
-						ObjectVal: map[string]string{"bar": "baz"},
-					},
-				}},
-			},
-		},
-		wantErr: apis.ErrGeneric("object type parameter requires \"enable-api-fields\" feature gate to be \"alpha\" or \"beta\" but it is \"stable\""),
 	}}
 	for _, ts := range tests {
 		t.Run(ts.name, func(t *testing.T) {

--- a/pkg/apis/pipeline/v1beta1/taskrun_validation.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_validation.go
@@ -244,11 +244,6 @@ func ValidateWorkspaceBindings(ctx context.Context, wb []WorkspaceBinding) (errs
 func ValidateParameters(ctx context.Context, params Params) (errs *apis.FieldError) {
 	var names []string
 	for _, p := range params {
-		if p.Value.Type == ParamTypeObject {
-			// Object type parameter is a beta feature and will fail validation if it's used in a taskrun spec
-			// when the enable-api-fields feature gate is not "alpha" or "beta".
-			errs = errs.Also(version.ValidateEnabledAPIFields(ctx, "object type parameter", config.BetaAPIFields))
-		}
 		names = append(names, p.Name)
 	}
 	return errs.Also(validateNoDuplicateNames(names, false))

--- a/pkg/apis/pipeline/v1beta1/taskrun_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_validation_test.go
@@ -108,7 +108,6 @@ func TestTaskRun_Invalidate(t *testing.T) {
 			Message: `non-existent variable in "$(params.task-words.hello)"`,
 			Paths:   []string{"spec.steps[0].args[0]"},
 		},
-		wc: config.EnableAlphaAPIFields,
 	}, {
 		name: "propagating object properties not provided",
 		taskRun: &v1beta1.TaskRun{
@@ -143,7 +142,6 @@ func TestTaskRun_Invalidate(t *testing.T) {
 			Message: `missing field(s)`,
 			Paths:   []string{"spec.task-words.properties"},
 		},
-		wc: config.EnableAlphaAPIFields,
 	}}
 	for _, ts := range tests {
 		t.Run(ts.name, func(t *testing.T) {
@@ -208,7 +206,6 @@ func TestTaskRun_Validate(t *testing.T) {
 				},
 			},
 		},
-		wc: config.EnableAlphaAPIFields,
 	}, {
 		name: "propagating object params with taskrun no value provided",
 		taskRun: &v1beta1.TaskRun{
@@ -241,7 +238,6 @@ func TestTaskRun_Validate(t *testing.T) {
 				},
 			},
 		},
-		wc: config.EnableAlphaAPIFields,
 	}, {
 		name: "propagating partial params with different provided and default names",
 		taskRun: &v1beta1.TaskRun{
@@ -306,7 +302,6 @@ func TestTaskRun_Validate(t *testing.T) {
 				},
 			},
 		},
-		wc: config.EnableAlphaAPIFields,
 	}, {
 		name: "propagating partial params in taskrun",
 		taskRun: &v1beta1.TaskRun{
@@ -375,7 +370,6 @@ func TestTaskRun_Validate(t *testing.T) {
 				},
 			},
 		},
-		wc: config.EnableAlphaAPIFields,
 	}, {
 		name: "propagating params with taskrun same names",
 		taskRun: &v1beta1.TaskRun{
@@ -435,7 +429,6 @@ func TestTaskRun_Validate(t *testing.T) {
 				},
 			},
 		},
-		wc: config.EnableAlphaAPIFields,
 	}, {
 		name: "alpha feature: valid step and sidecar overrides",
 		taskRun: &v1beta1.TaskRun{
@@ -625,7 +618,6 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 			TaskRef: &v1beta1.TaskRef{Name: "mytask"},
 		},
 		wantErr: apis.ErrMultipleOneOf("params[myobjectparam].name"),
-		wc:      config.EnableAlphaAPIFields,
 	}, {
 		name: "using debug when apifields stable",
 		spec: v1beta1.TaskRunSpec{


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This commit removes the beta feature flag check for v1beta1 object param,results and array result. Beta features are considered to be 'stable' for v1beta1 CRDs, so we shouldn't check them.

Related TEP for more context: https://github.com/tektoncd/community/blob/main/teps/0033-tekton-feature-gates.md#new-api-fields

/kind bug

Signed-off-by: Yongxuan Zhang yongxuanzhang@google.com

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Remove beta feature flag check for v1beta1 object param, results and array result. Object param, results and array result will be enabled if the  enable-api-fields feature flag is not alpha for v1beta1 CRDs (e.g. Tasks and Pipelines)
```
