### PR TITLE
Validate specs of remote Pipelines before conversion

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinespec/pipelinespec.go
+++ b/pkg/reconciler/pipelinerun/pipelinespec/pipelinespec.go
@@ -67,7 +67,6 @@ func GetPipelineData(ctx context.Context, pipelineRun *v1beta1.PipelineRun, getP
 		return nil, nil, fmt.Errorf("pipelineRun %s not providing PipelineRef or PipelineSpec", pipelineRun.Name)
 	}
 
-	pipelineSpec.SetDefaults(ctx)
 	return &resolutionutil.ResolvedObjectMeta{
 		ObjectMeta: &pipelineMeta,
 		RefSource:  refSource,

--- a/pkg/reconciler/pipelinerun/pipelinespec/pipelinespec_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinespec/pipelinespec_test.go
@@ -218,10 +218,12 @@ func TestGetPipelineData_ResolutionSuccess(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := cfgtesting.SetDefaults(context.Background(), t, tc.defaults)
 			getPipeline := func(ctx context.Context, n string) (*v1beta1.Pipeline, *v1beta1.RefSource, error) {
-				return &v1beta1.Pipeline{
+				p := v1beta1.Pipeline{
 					ObjectMeta: *tc.sourceMeta.DeepCopy(),
 					Spec:       *tc.sourceSpec.DeepCopy(),
-				}, tc.refSource.DeepCopy(), nil
+				}
+				p.SetDefaults(ctx)
+				return &p, tc.refSource.DeepCopy(), nil
 			}
 
 			resolvedObjectMeta, resolvedPipelineSpec, err := pipelinespec.GetPipelineData(ctx, tc.pr, getPipeline)

--- a/test/trustedresources.go
+++ b/test/trustedresources.go
@@ -89,6 +89,10 @@ func GetUnsignedPipeline(name string) *v1beta1.Pipeline {
 			Tasks: []v1beta1.PipelineTask{
 				{
 					Name: "task",
+					TaskRef: &v1beta1.TaskRef{
+						Name: "task",
+						Kind: "Task",
+					},
 				},
 			},
 		},


### PR DESCRIPTION
Prior to this commit, all remote Pipelines were converted into the stored version of the API before being validated. However, validation can differ between API versions (notably, whether beta features are allowed when "enable-api-fields" is set to "stable"). This commit moves defaulting and validation behavior to immediately after fetching the remote Pipeline, before converting it to the storage version of the API. This commit assumes that local Pipelines were validated on creation, but sets their defaults in case defaulting behavior has changed since they were created. We cannot know what API version was used to create a local Pipeline.

The corresponding change for referenced Tasks will be made in a separate commit.

Partially addresses https://github.com/tektoncd/pipeline/issues/6616

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- n/a Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- n/a Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- n/a Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
