### PR TITLE
Remove enable-api-fields validation for array index replacements

### DIFF
--- a/pkg/reconciler/pipelinerun/resources/apply.go
+++ b/pkg/reconciler/pipelinerun/resources/apply.go
@@ -22,8 +22,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/tektoncd/pipeline/pkg/apis/config"
-
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/reconciler/taskrun/resources"
 	"github.com/tektoncd/pipeline/pkg/substitution"
@@ -63,11 +61,8 @@ func ApplyParameters(ctx context.Context, p *v1beta1.PipelineSpec, pr *v1beta1.P
 			switch p.Default.Type {
 			case v1beta1.ParamTypeArray:
 				for _, pattern := range paramPatterns {
-					// array indexing for param is beta feature - the feature flag can be either set to alpha or beta
-					if config.CheckAlphaOrBetaAPIFields(ctx) {
-						for i := 0; i < len(p.Default.ArrayVal); i++ {
-							stringReplacements[fmt.Sprintf(pattern+"[%d]", p.Name, i)] = p.Default.ArrayVal[i]
-						}
+					for i := 0; i < len(p.Default.ArrayVal); i++ {
+						stringReplacements[fmt.Sprintf(pattern+"[%d]", p.Name, i)] = p.Default.ArrayVal[i]
 					}
 					arrayReplacements[fmt.Sprintf(pattern, p.Name)] = p.Default.ArrayVal
 				}
@@ -114,11 +109,8 @@ func paramsFromPipelineRun(ctx context.Context, pr *v1beta1.PipelineRun) (map[st
 		switch p.Value.Type {
 		case v1beta1.ParamTypeArray:
 			for _, pattern := range paramPatterns {
-				// array indexing for param is beta feature - the feature flag can be either set to alpha ot beta
-				if config.CheckAlphaOrBetaAPIFields(ctx) {
-					for i := 0; i < len(p.Value.ArrayVal); i++ {
-						stringReplacements[fmt.Sprintf(pattern+"[%d]", p.Name, i)] = p.Value.ArrayVal[i]
-					}
+				for i := 0; i < len(p.Value.ArrayVal); i++ {
+					stringReplacements[fmt.Sprintf(pattern+"[%d]", p.Name, i)] = p.Value.ArrayVal[i]
 				}
 				arrayReplacements[fmt.Sprintf(pattern, p.Name)] = p.Value.ArrayVal
 			}

--- a/pkg/reconciler/pipelinerun/resources/apply_test.go
+++ b/pkg/reconciler/pipelinerun/resources/apply_test.go
@@ -1727,10 +1727,6 @@ func TestApplyParameters(t *testing.T) {
 }
 
 func TestApplyParameters_ArrayIndexing(t *testing.T) {
-	ctx := context.Background()
-	cfg := config.FromContextOrDefaults(ctx)
-	cfg.FeatureFlags.EnableAPIFields = config.BetaAPIFields
-	ctx = config.ToContext(ctx, cfg)
 	for _, tt := range []struct {
 		name     string
 		original v1beta1.PipelineSpec
@@ -2027,7 +2023,7 @@ func TestApplyParameters_ArrayIndexing(t *testing.T) {
 					Params: tt.params,
 				},
 			}
-			got := resources.ApplyParameters(ctx, &tt.original, run)
+			got := resources.ApplyParameters(context.Background(), &tt.original, run)
 			if d := cmp.Diff(&tt.expected, got); d != "" {
 				t.Errorf("ApplyParameters() got diff %s", diff.PrintWantGot(d))
 			}
@@ -2036,10 +2032,6 @@ func TestApplyParameters_ArrayIndexing(t *testing.T) {
 }
 
 func TestApplyReplacementsMatrix(t *testing.T) {
-	ctx := context.Background()
-	cfg := config.FromContextOrDefaults(ctx)
-	cfg.FeatureFlags.EnableAPIFields = config.AlphaAPIFields
-	ctx = config.ToContext(ctx, cfg)
 	for _, tt := range []struct {
 		name     string
 		original v1beta1.PipelineSpec
@@ -2283,7 +2275,7 @@ func TestApplyReplacementsMatrix(t *testing.T) {
 					Params: tt.params,
 				},
 			}
-			got := resources.ApplyParameters(ctx, &tt.original, run)
+			got := resources.ApplyParameters(context.Background(), &tt.original, run)
 			if d := cmp.Diff(&tt.expected, got); d != "" {
 				t.Errorf("ApplyParameters() got diff %s", diff.PrintWantGot(d))
 			}

--- a/pkg/reconciler/taskrun/resources/apply.go
+++ b/pkg/reconciler/taskrun/resources/apply.go
@@ -62,11 +62,8 @@ func ApplyParameters(ctx context.Context, spec *v1beta1.TaskSpec, tr *v1beta1.Ta
 			switch p.Default.Type {
 			case v1beta1.ParamTypeArray:
 				for _, pattern := range paramPatterns {
-					// array indexing for param is beta feature
-					if config.CheckAlphaOrBetaAPIFields(ctx) {
-						for i := 0; i < len(p.Default.ArrayVal); i++ {
-							stringReplacements[fmt.Sprintf(pattern+"[%d]", p.Name, i)] = p.Default.ArrayVal[i]
-						}
+					for i := 0; i < len(p.Default.ArrayVal); i++ {
+						stringReplacements[fmt.Sprintf(pattern+"[%d]", p.Name, i)] = p.Default.ArrayVal[i]
 					}
 					arrayReplacements[fmt.Sprintf(pattern, p.Name)] = p.Default.ArrayVal
 				}
@@ -105,11 +102,8 @@ func paramsFromTaskRun(ctx context.Context, tr *v1beta1.TaskRun) (map[string]str
 		switch p.Value.Type {
 		case v1beta1.ParamTypeArray:
 			for _, pattern := range paramPatterns {
-				// array indexing for param is beta feature
-				if config.CheckAlphaOrBetaAPIFields(ctx) {
-					for i := 0; i < len(p.Value.ArrayVal); i++ {
-						stringReplacements[fmt.Sprintf(pattern+"[%d]", p.Name, i)] = p.Value.ArrayVal[i]
-					}
+				for i := 0; i < len(p.Value.ArrayVal); i++ {
+					stringReplacements[fmt.Sprintf(pattern+"[%d]", p.Name, i)] = p.Value.ArrayVal[i]
 				}
 				arrayReplacements[fmt.Sprintf(pattern, p.Name)] = p.Value.ArrayVal
 			}

--- a/pkg/reconciler/taskrun/resources/apply_test.go
+++ b/pkg/reconciler/taskrun/resources/apply_test.go
@@ -862,11 +862,7 @@ func TestApplyParameters_ArrayIndexing(t *testing.T) {
 		spec.Sidecars[0].Image = "bar"
 		spec.Sidecars[0].Env[0].Value = "world"
 	})
-	ctx := context.Background()
-	cfg := config.FromContextOrDefaults(ctx)
-	cfg.FeatureFlags.EnableAPIFields = config.BetaAPIFields
-	ctx = config.ToContext(ctx, cfg)
-	got := resources.ApplyParameters(ctx, simpleTaskSpecArrayIndexing, tr, dp...)
+	got := resources.ApplyParameters(context.Background(), simpleTaskSpecArrayIndexing, tr, dp...)
 	if d := cmp.Diff(want, got); d != "" {
 		t.Errorf("ApplyParameters() got diff %s", diff.PrintWantGot(d))
 	}


### PR DESCRIPTION
Prior to this commit, the PipelineRun and TaskRun reconcilers checked whether "enable-api-fields" was set to "alpha" or "beta" before performing array param index replacement..
There were several problems with this logic:
- Beta CRDs don't require "enable-api-fields" to be "beta" to use beta features.
- This validation depends on the API version of the CRD that was created, so it belongs in the admission webhook rather than the reconciler.
- If "enable-api-fields" was set to "stable", param replacement was skipped. This means a user could create a valid array indexing expression in a beta CRD, and the reconciler would not correctly replace this param with its value.

This commit removes this logic.
/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- n/a Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- n/a Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- n/a Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
