### PR TITLE
Refactor ResolvedPipelineTask and remove redundant fields

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -772,33 +772,18 @@ func (c *Reconciler) runNextSchedulableTask(ctx context.Context, pr *v1beta1.Pip
 			}
 		}()
 
-		switch {
-		case rpt.IsCustomTask() && rpt.PipelineTask.IsMatrixed():
+		if rpt.IsCustomTask() {
 			rpt.RunObjects, err = c.createRunObjects(ctx, rpt, pr)
 			if err != nil {
 				recorder.Eventf(pr, corev1.EventTypeWarning, "RunsCreationFailed", "Failed to create Runs %q: %v", rpt.RunObjectNames, err)
 				err = fmt.Errorf("error creating Runs called %s for PipelineTask %s from PipelineRun %s: %w", rpt.RunObjectNames, rpt.PipelineTask.Name, pr.Name, err)
 				return err
 			}
-		case rpt.IsCustomTask():
-			rpt.RunObject, err = c.createRunObject(ctx, rpt.RunObjectName, nil, rpt, pr)
-			if err != nil {
-				recorder.Eventf(pr, corev1.EventTypeWarning, "RunCreationFailed", "Failed to create Run %q: %v", rpt.RunObjectName, err)
-				err = fmt.Errorf("error creating Run called %s for PipelineTask %s from PipelineRun %s: %w", rpt.RunObjectName, rpt.PipelineTask.Name, pr.Name, err)
-				return err
-			}
-		case rpt.PipelineTask.IsMatrixed():
+		} else {
 			rpt.TaskRuns, err = c.createTaskRuns(ctx, rpt, pr)
 			if err != nil {
 				recorder.Eventf(pr, corev1.EventTypeWarning, "TaskRunsCreationFailed", "Failed to create TaskRuns %q: %v", rpt.TaskRunNames, err)
 				err = fmt.Errorf("error creating TaskRuns called %s for PipelineTask %s from PipelineRun %s: %w", rpt.TaskRunNames, rpt.PipelineTask.Name, pr.Name, err)
-				return err
-			}
-		default:
-			rpt.TaskRun, err = c.createTaskRun(ctx, rpt.TaskRunName, nil, rpt, pr)
-			if err != nil {
-				recorder.Eventf(pr, corev1.EventTypeWarning, "TaskRunCreationFailed", "Failed to create TaskRun %q: %v", rpt.TaskRunName, err)
-				err = fmt.Errorf("error creating TaskRun called %s for PipelineTask %s from PipelineRun %s: %w", rpt.TaskRunName, rpt.PipelineTask.Name, pr.Name, err)
 				return err
 			}
 		}
@@ -820,9 +805,17 @@ func (c *Reconciler) createTaskRuns(ctx context.Context, rpt *resources.Resolved
 	ctx, span := c.tracerProvider.Tracer(TracerName).Start(ctx, "createTaskRuns")
 	defer span.End()
 	var taskRuns []*v1beta1.TaskRun
-	matrixCombinations := rpt.PipelineTask.Matrix.FanOut()
+	var matrixCombinations []v1beta1.Params
+
+	if rpt.PipelineTask.IsMatrixed() {
+		matrixCombinations = rpt.PipelineTask.Matrix.FanOut()
+	}
+
 	for i, taskRunName := range rpt.TaskRunNames {
-		params := matrixCombinations[i]
+		var params v1beta1.Params
+		if len(matrixCombinations) > i {
+			params = matrixCombinations[i]
+		}
 		taskRun, err := c.createTaskRun(ctx, taskRunName, params, rpt, pr)
 		if err != nil {
 			return nil, err
@@ -893,9 +886,17 @@ func (c *Reconciler) createRunObjects(ctx context.Context, rpt *resources.Resolv
 	var runObjects []v1beta1.RunObject
 	ctx, span := c.tracerProvider.Tracer(TracerName).Start(ctx, "createRunObjects")
 	defer span.End()
-	matrixCombinations := rpt.PipelineTask.Matrix.FanOut()
+	var matrixCombinations []v1beta1.Params
+
+	if rpt.PipelineTask.IsMatrixed() {
+		matrixCombinations = rpt.PipelineTask.Matrix.FanOut()
+	}
+
 	for i, runObjectName := range rpt.RunObjectNames {
-		params := matrixCombinations[i]
+		var params v1beta1.Params
+		if len(matrixCombinations) > i {
+			params = matrixCombinations[i]
+		}
 		runObject, err := c.createRunObject(ctx, runObjectName, params, rpt, pr)
 		if err != nil {
 			return nil, err

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -11709,9 +11709,9 @@ spec:
 
 	wantEvents := []string{
 		"Normal Started",
-		"Warning TaskRunCreationFailed",
-		"error creating TaskRun called test-pipeline-run-with-create-run-failed-hello-world for PipelineTask hello-world from PipelineRun test-pipeline-run-with-create-run-failed: expected workspace \"source\" to be provided by pipelinerun for pipeline task \"hello-world\"",
-		"error creating TaskRun called test-pipeline-run-with-create-run-failed-hello-world for PipelineTask hello-world from PipelineRun test-pipeline-run-with-create-run-failed: expected workspace \"source\" to be provided by pipelinerun for pipeline task \"hello-world\"",
+		"Warning TaskRunsCreationFailed",
+		"error creating TaskRuns called \\[test-pipeline-run-with-create-run-failed-hello-world]\\ for PipelineTask hello-world from PipelineRun test-pipeline-run-with-create-run-failed: expected workspace \"source\" to be provided by pipelinerun for pipeline task \"hello-world\"",
+		"error creating TaskRuns called \\[test-pipeline-run-with-create-run-failed-hello-world]\\ for PipelineTask hello-world from PipelineRun test-pipeline-run-with-create-run-failed: expected workspace \"source\" to be provided by pipelinerun for pipeline task \"hello-world\"",
 	}
 	reconciledRun, _ := prt.reconcileRun("foo", "test-pipeline-run-with-create-run-failed", wantEvents, true)
 

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
@@ -382,15 +382,15 @@ func newCustomRun(run v1beta1.CustomRun) *v1beta1.CustomRun {
 
 var noneStartedState = PipelineRunState{{
 	PipelineTask: &pts[0],
-	TaskRunName:  "pipelinerun-mytask1",
-	TaskRun:      nil,
+	TaskRunNames: []string{"pipelinerun-mytask1"},
+	TaskRuns:     nil,
 	ResolvedTask: &resources.ResolvedTask{
 		TaskSpec: &task.Spec,
 	},
 }, {
 	PipelineTask: &pts[1],
-	TaskRunName:  "pipelinerun-mytask2",
-	TaskRun:      nil,
+	TaskRunNames: []string{"pipelinerun-mytask2"},
+	TaskRuns:     nil,
 	ResolvedTask: &resources.ResolvedTask{
 		TaskSpec: &task.Spec,
 	},
@@ -398,15 +398,15 @@ var noneStartedState = PipelineRunState{{
 
 var oneStartedState = PipelineRunState{{
 	PipelineTask: &pts[0],
-	TaskRunName:  "pipelinerun-mytask1",
-	TaskRun:      makeStarted(trs[0]),
+	TaskRunNames: []string{"pipelinerun-mytask1"},
+	TaskRuns:     []*v1beta1.TaskRun{makeStarted(trs[0])},
 	ResolvedTask: &resources.ResolvedTask{
 		TaskSpec: &task.Spec,
 	},
 }, {
 	PipelineTask: &pts[1],
-	TaskRunName:  "pipelinerun-mytask2",
-	TaskRun:      nil,
+	TaskRunNames: []string{"pipelinerun-mytask2"},
+	TaskRuns:     nil,
 	ResolvedTask: &resources.ResolvedTask{
 		TaskSpec: &task.Spec,
 	},
@@ -414,15 +414,15 @@ var oneStartedState = PipelineRunState{{
 
 var oneFinishedState = PipelineRunState{{
 	PipelineTask: &pts[0],
-	TaskRunName:  "pipelinerun-mytask1",
-	TaskRun:      makeSucceeded(trs[0]),
+	TaskRunNames: []string{"pipelinerun-mytask1"},
+	TaskRuns:     []*v1beta1.TaskRun{makeSucceeded(trs[0])},
 	ResolvedTask: &resources.ResolvedTask{
 		TaskSpec: &task.Spec,
 	},
 }, {
 	PipelineTask: &pts[1],
-	TaskRunName:  "pipelinerun-mytask2",
-	TaskRun:      nil,
+	TaskRunNames: []string{"pipelinerun-mytask2"},
+	TaskRuns:     nil,
 	ResolvedTask: &resources.ResolvedTask{
 		TaskSpec: &task.Spec,
 	},
@@ -430,15 +430,15 @@ var oneFinishedState = PipelineRunState{{
 
 var oneFailedState = PipelineRunState{{
 	PipelineTask: &pts[0],
-	TaskRunName:  "pipelinerun-mytask1",
-	TaskRun:      makeFailed(trs[0]),
+	TaskRunNames: []string{"pipelinerun-mytask1"},
+	TaskRuns:     []*v1beta1.TaskRun{makeFailed(trs[0])},
 	ResolvedTask: &resources.ResolvedTask{
 		TaskSpec: &task.Spec,
 	},
 }, {
 	PipelineTask: &pts[1],
-	TaskRunName:  "pipelinerun-mytask2",
-	TaskRun:      nil,
+	TaskRunNames: []string{"pipelinerun-mytask2"},
+	TaskRuns:     nil,
 	ResolvedTask: &resources.ResolvedTask{
 		TaskSpec: &task.Spec,
 	},
@@ -446,15 +446,15 @@ var oneFailedState = PipelineRunState{{
 
 var finalScheduledState = PipelineRunState{{
 	PipelineTask: &pts[0],
-	TaskRunName:  "pipelinerun-mytask1",
-	TaskRun:      makeSucceeded(trs[0]),
+	TaskRunNames: []string{"pipelinerun-mytask1"},
+	TaskRuns:     []*v1beta1.TaskRun{makeSucceeded(trs[0])},
 	ResolvedTask: &resources.ResolvedTask{
 		TaskSpec: &task.Spec,
 	},
 }, {
 	PipelineTask: &pts[1],
-	TaskRunName:  "pipelinerun-mytask2",
-	TaskRun:      makeScheduled(trs[1]),
+	TaskRunNames: []string{"pipelinerun-mytask2"},
+	TaskRuns:     []*v1beta1.TaskRun{makeScheduled(trs[1])},
 	ResolvedTask: &resources.ResolvedTask{
 		TaskSpec: &task.Spec,
 	},
@@ -462,81 +462,81 @@ var finalScheduledState = PipelineRunState{{
 
 var allFinishedState = PipelineRunState{{
 	PipelineTask: &pts[0],
-	TaskRunName:  "pipelinerun-mytask1",
-	TaskRun:      makeSucceeded(trs[0]),
+	TaskRunNames: []string{"pipelinerun-mytask1"},
+	TaskRuns:     []*v1beta1.TaskRun{makeSucceeded(trs[0])},
 	ResolvedTask: &resources.ResolvedTask{
 		TaskSpec: &task.Spec,
 	},
 }, {
 	PipelineTask: &pts[1],
-	TaskRunName:  "pipelinerun-mytask2",
-	TaskRun:      makeSucceeded(trs[0]),
+	TaskRunNames: []string{"pipelinerun-mytask2"},
+	TaskRuns:     []*v1beta1.TaskRun{makeSucceeded(trs[0])},
 	ResolvedTask: &resources.ResolvedTask{
 		TaskSpec: &task.Spec,
 	},
 }}
 
 var noCustomRunStartedState = PipelineRunState{{
-	PipelineTask:  &pts[12],
-	CustomTask:    true,
-	RunObjectName: "pipelinerun-mytask13",
-	RunObject:     nil,
+	PipelineTask:   &pts[12],
+	CustomTask:     true,
+	RunObjectNames: []string{"pipelinerun-mytask13"},
+	RunObjects:     nil,
 }, {
-	PipelineTask:  &pts[13],
-	CustomTask:    true,
-	RunObjectName: "pipelinerun-mytask14",
-	RunObject:     nil,
+	PipelineTask:   &pts[13],
+	CustomTask:     true,
+	RunObjectNames: []string{"pipelinerun-mytask14"},
+	RunObjects:     nil,
 }}
 
 var oneCustomRunStartedState = PipelineRunState{{
-	PipelineTask:  &pts[12],
-	CustomTask:    true,
-	RunObjectName: "pipelinerun-mytask13",
-	RunObject:     makeCustomRunStarted(customRuns[0]),
+	PipelineTask:   &pts[12],
+	CustomTask:     true,
+	RunObjectNames: []string{"pipelinerun-mytask13"},
+	RunObjects:     []v1beta1.RunObject{makeCustomRunStarted(customRuns[0])},
 }, {
-	PipelineTask:  &pts[13],
-	CustomTask:    true,
-	RunObjectName: "pipelinerun-mytask14",
-	RunObject:     nil,
+	PipelineTask:   &pts[13],
+	CustomTask:     true,
+	RunObjectNames: []string{"pipelinerun-mytask14"},
+	RunObjects:     nil,
 }}
 
 var oneCustomRunFinishedState = PipelineRunState{{
-	PipelineTask:  &pts[12],
-	CustomTask:    true,
-	RunObjectName: "pipelinerun-mytask13",
-	RunObject:     makeCustomRunSucceeded(customRuns[0]),
+	PipelineTask:   &pts[12],
+	CustomTask:     true,
+	RunObjectNames: []string{"pipelinerun-mytask13"},
+	RunObjects:     []v1beta1.RunObject{makeCustomRunSucceeded(customRuns[0])},
 }, {
-	PipelineTask:  &pts[13],
-	CustomTask:    true,
-	RunObjectName: "pipelinerun-mytask14",
-	RunObject:     nil,
+	PipelineTask:   &pts[13],
+	CustomTask:     true,
+	RunObjectNames: []string{"pipelinerun-mytask14"},
+	RunObjects:     nil,
 }}
 
 var oneCustomRunFailedState = PipelineRunState{{
-	PipelineTask:  &pts[12],
-	CustomTask:    true,
-	RunObjectName: "pipelinerun-mytask13",
-	RunObject:     makeCustomRunFailed(customRuns[0]),
+	PipelineTask:   &pts[12],
+	CustomTask:     true,
+	RunObjectNames: []string{"pipelinerun-mytask13"},
+	RunObjects:     []v1beta1.RunObject{makeCustomRunFailed(customRuns[0])},
 }, {
-	PipelineTask:  &pts[13],
-	CustomTask:    true,
-	RunObjectName: "pipelinerun-mytask14",
-	RunObject:     nil,
+	PipelineTask:   &pts[13],
+	CustomTask:     true,
+	RunObjectNames: []string{"pipelinerun-mytask14"},
+	RunObjects:     nil,
 }}
 
 var taskCancelled = PipelineRunState{{
 	PipelineTask: &pts[4],
-	TaskRunName:  "pipelinerun-mytask1",
-	TaskRun:      withCancelled(makeRetried(trs[0])),
+	TaskRunNames: []string{"pipelinerun-mytask1"},
+	TaskRuns:     []*v1beta1.TaskRun{withCancelled(makeRetried(trs[0]))},
 	ResolvedTask: &resources.ResolvedTask{
 		TaskSpec: &task.Spec,
 	},
 }}
 
 var customRunCancelled = PipelineRunState{{
-	PipelineTask:  &pts[12],
-	RunObjectName: "pipelinerun-mytask13",
-	RunObject:     withCustomRunCancelled(newCustomRun(customRuns[0])),
+	PipelineTask:   &pts[12],
+	RunObjectNames: []string{"pipelinerun-mytask13"},
+	RunObjects:     []v1beta1.RunObject{withCustomRunCancelled(newCustomRun(customRuns[0]))},
 }}
 
 var noneStartedStateMatrix = PipelineRunState{{
@@ -597,7 +597,7 @@ var oneFailedStateMatrix = PipelineRunState{{
 }, {
 	PipelineTask: &pts[16],
 	TaskRunNames: []string{"pipelinerun-mytask2"},
-	TaskRun:      nil,
+	TaskRuns:     nil,
 	ResolvedTask: &resources.ResolvedTask{
 		TaskSpec: &task.Spec,
 	},
@@ -725,15 +725,15 @@ func TestIsSkipped(t *testing.T) {
 		name: "tasks-parent-failed",
 		state: PipelineRunState{{
 			PipelineTask: &pts[5],
-			TaskRunName:  "pipelinerun-mytask1",
-			TaskRun:      makeFailed(trs[0]),
+			TaskRunNames: []string{"pipelinerun-mytask1"},
+			TaskRuns:     []*v1beta1.TaskRun{makeFailed(trs[0])},
 			ResolvedTask: &resources.ResolvedTask{
 				TaskSpec: &task.Spec,
 			},
 		}, {
 			PipelineTask: &pts[6], // mytask7 runAfter mytask6
-			TaskRunName:  "pipelinerun-mytask2",
-			TaskRun:      nil,
+			TaskRunNames: []string{"pipelinerun-mytask2"},
+			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
 				TaskSpec: &task.Spec,
 			},
@@ -745,15 +745,15 @@ func TestIsSkipped(t *testing.T) {
 		name: "tasks-parent-cancelled",
 		state: PipelineRunState{{
 			PipelineTask: &pts[5],
-			TaskRunName:  "pipelinerun-mytask1",
-			TaskRun:      withCancelled(makeFailed(trs[0])),
+			TaskRunNames: []string{"pipelinerun-mytask1"},
+			TaskRuns:     []*v1beta1.TaskRun{withCancelled(makeFailed(trs[0]))},
 			ResolvedTask: &resources.ResolvedTask{
 				TaskSpec: &task.Spec,
 			},
 		}, {
 			PipelineTask: &pts[6], // mytask7 runAfter mytask6
-			TaskRunName:  "pipelinerun-mytask2",
-			TaskRun:      nil,
+			TaskRunNames: []string{"pipelinerun-mytask2"},
+			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
 				TaskSpec: &task.Spec,
 			},
@@ -765,15 +765,15 @@ func TestIsSkipped(t *testing.T) {
 		name: "tasks-grandparent-failed",
 		state: PipelineRunState{{
 			PipelineTask: &pts[5],
-			TaskRunName:  "pipelinerun-mytask1",
-			TaskRun:      makeFailed(trs[0]),
+			TaskRunNames: []string{"pipelinerun-mytask1"},
+			TaskRuns:     []*v1beta1.TaskRun{makeFailed(trs[0])},
 			ResolvedTask: &resources.ResolvedTask{
 				TaskSpec: &task.Spec,
 			},
 		}, {
 			PipelineTask: &pts[6], // mytask7 runAfter mytask6
-			TaskRunName:  "pipelinerun-mytask2",
-			TaskRun:      nil,
+			TaskRunNames: []string{"pipelinerun-mytask2"},
+			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
 				TaskSpec: &task.Spec,
 			},
@@ -783,8 +783,8 @@ func TestIsSkipped(t *testing.T) {
 				TaskRef:  &v1beta1.TaskRef{Name: "task"},
 				RunAfter: []string{"mytask7"},
 			}, // mytask10 runAfter mytask7 runAfter mytask6
-			TaskRunName: "pipelinerun-mytask3",
-			TaskRun:     nil,
+			TaskRunNames: []string{"pipelinerun-mytask3"},
+			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
 				TaskSpec: &task.Spec,
 			},
@@ -796,22 +796,22 @@ func TestIsSkipped(t *testing.T) {
 		name: "tasks-parents-failed-passed",
 		state: PipelineRunState{{
 			PipelineTask: &pts[5],
-			TaskRunName:  "pipelinerun-mytask1",
-			TaskRun:      makeSucceeded(trs[0]),
+			TaskRunNames: []string{"pipelinerun-mytask1"},
+			TaskRuns:     []*v1beta1.TaskRun{makeSucceeded(trs[0])},
 			ResolvedTask: &resources.ResolvedTask{
 				TaskSpec: &task.Spec,
 			},
 		}, {
 			PipelineTask: &pts[0],
-			TaskRunName:  "pipelinerun-mytask2",
-			TaskRun:      makeFailed(trs[0]),
+			TaskRunNames: []string{"pipelinerun-mytask2"},
+			TaskRuns:     []*v1beta1.TaskRun{makeFailed(trs[0])},
 			ResolvedTask: &resources.ResolvedTask{
 				TaskSpec: &task.Spec,
 			},
 		}, {
 			PipelineTask: &pts[7], // mytask8 runAfter mytask1, mytask6
-			TaskRunName:  "pipelinerun-mytask3",
-			TaskRun:      nil,
+			TaskRunNames: []string{"pipelinerun-mytask3"},
+			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
 				TaskSpec: &task.Spec,
 			},
@@ -823,22 +823,22 @@ func TestIsSkipped(t *testing.T) {
 		name: "task-failed-pipeline-stopping",
 		state: PipelineRunState{{
 			PipelineTask: &pts[0],
-			TaskRunName:  "pipelinerun-mytask1",
-			TaskRun:      makeFailed(trs[0]),
+			TaskRunNames: []string{"pipelinerun-mytask1"},
+			TaskRuns:     []*v1beta1.TaskRun{makeFailed(trs[0])},
 			ResolvedTask: &resources.ResolvedTask{
 				TaskSpec: &task.Spec,
 			},
 		}, {
 			PipelineTask: &pts[5],
-			TaskRunName:  "pipelinerun-mytask2",
-			TaskRun:      makeStarted(trs[1]),
+			TaskRunNames: []string{"pipelinerun-mytask2"},
+			TaskRuns:     []*v1beta1.TaskRun{makeStarted(trs[1])},
 			ResolvedTask: &resources.ResolvedTask{
 				TaskSpec: &task.Spec,
 			},
 		}, {
 			PipelineTask: &pts[6], // mytask7 runAfter mytask6
-			TaskRunName:  "pipelinerun-mytask3",
-			TaskRun:      nil,
+			TaskRunNames: []string{"pipelinerun-mytask3"},
+			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
 				TaskSpec: &task.Spec,
 			},
@@ -850,8 +850,8 @@ func TestIsSkipped(t *testing.T) {
 		name: "tasks-when-expressions-passed",
 		state: PipelineRunState{{
 			PipelineTask: &pts[9],
-			TaskRunName:  "pipelinerun-guardedtask",
-			TaskRun:      nil,
+			TaskRunNames: []string{"pipelinerun-guardedtask"},
+			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
 				TaskSpec: &task.Spec,
 			},
@@ -863,8 +863,8 @@ func TestIsSkipped(t *testing.T) {
 		name: "tasks-when-expression-failed",
 		state: PipelineRunState{{
 			PipelineTask: &pts[10],
-			TaskRunName:  "pipelinerun-guardedtask",
-			TaskRun:      nil,
+			TaskRunNames: []string{"pipelinerun-guardedtask"},
+			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
 				TaskSpec: &task.Spec,
 			},
@@ -876,13 +876,13 @@ func TestIsSkipped(t *testing.T) {
 		name: "when-expression-task-but-without-parent-done",
 		state: PipelineRunState{{
 			PipelineTask: &pts[0],
-			TaskRun:      nil,
+			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
 				TaskSpec: &task.Spec,
 			},
 		}, {
 			PipelineTask: &pts[11],
-			TaskRun:      nil,
+			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
 				TaskSpec: &task.Spec,
 			},
@@ -907,8 +907,8 @@ func TestIsSkipped(t *testing.T) {
 		state: PipelineRunState{{
 			// skipped because when expressions evaluate to false
 			PipelineTask: &pts[10],
-			TaskRunName:  "pipelinerun-guardedtask",
-			TaskRun:      nil,
+			TaskRunNames: []string{"pipelinerun-guardedtask"},
+			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
 				TaskSpec: &task.Spec,
 			},
@@ -919,8 +919,8 @@ func TestIsSkipped(t *testing.T) {
 				TaskRef:  &v1beta1.TaskRef{Name: "task"},
 				RunAfter: []string{"mytask11"},
 			},
-			TaskRunName: "pipelinerun-ordering-dependent-task-1",
-			TaskRun:     nil,
+			TaskRunNames: []string{"pipelinerun-ordering-dependent-task-1"},
+			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
 				TaskSpec: &task.Spec,
 			},
@@ -934,8 +934,8 @@ func TestIsSkipped(t *testing.T) {
 		state: PipelineRunState{{
 			// skipped because when expressions evaluate to false
 			PipelineTask: &pts[10],
-			TaskRunName:  "pipelinerun-guardedtask",
-			TaskRun:      nil,
+			TaskRunNames: []string{"pipelinerun-guardedtask"},
+			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
 				TaskSpec: &task.Spec,
 			},
@@ -946,8 +946,8 @@ func TestIsSkipped(t *testing.T) {
 				TaskRef:  &v1beta1.TaskRef{Name: "task"},
 				RunAfter: []string{"mytask11"},
 			},
-			TaskRunName: "pipelinerun-ordering-dependent-task-1",
-			TaskRun:     nil,
+			TaskRunNames: []string{"pipelinerun-ordering-dependent-task-1"},
+			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
 				TaskSpec: &task.Spec,
 			},
@@ -958,8 +958,8 @@ func TestIsSkipped(t *testing.T) {
 				TaskRef:  &v1beta1.TaskRef{Name: "task"},
 				RunAfter: []string{"mytask18"},
 			},
-			TaskRunName: "pipelinerun-ordering-dependent-task-2",
-			TaskRun:     nil,
+			TaskRunNames: []string{"pipelinerun-ordering-dependent-task-2"},
+			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
 				TaskSpec: &task.Spec,
 			},
@@ -974,8 +974,8 @@ func TestIsSkipped(t *testing.T) {
 		state: PipelineRunState{{
 			// skipped because when expressions evaluate to false
 			PipelineTask: &pts[10],
-			TaskRunName:  "pipelinerun-guardedtask",
-			TaskRun:      nil,
+			TaskRunNames: []string{"pipelinerun-guardedtask"},
+			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
 				TaskSpec: &task.Spec,
 			},
@@ -986,8 +986,8 @@ func TestIsSkipped(t *testing.T) {
 				TaskRef:  &v1beta1.TaskRef{Name: "task"},
 				RunAfter: []string{"mytask11"},
 			},
-			TaskRunName: "pipelinerun-ordering-dependent-task-1",
-			TaskRun:     nil,
+			TaskRunNames: []string{"pipelinerun-ordering-dependent-task-1"},
+			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
 				TaskSpec: &task.Spec,
 			},
@@ -998,8 +998,8 @@ func TestIsSkipped(t *testing.T) {
 				TaskRef:  &v1beta1.TaskRef{Name: "task"},
 				RunAfter: []string{"mytask18"},
 			},
-			TaskRunName: "pipelinerun-ordering-dependent-task-2",
-			TaskRun:     nil,
+			TaskRunNames: []string{"pipelinerun-ordering-dependent-task-2"},
+			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
 				TaskSpec: &task.Spec,
 			},
@@ -1013,8 +1013,8 @@ func TestIsSkipped(t *testing.T) {
 					Value: *v1beta1.NewStructuredValues("$(tasks.mytask11.results.missingResult)"),
 				}},
 			},
-			TaskRunName: "pipelinerun-resource-dependent-task-1",
-			TaskRun:     nil,
+			TaskRunNames: []string{"pipelinerun-resource-dependent-task-1"},
+			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
 				TaskSpec: &task.Spec,
 			},
@@ -1026,8 +1026,8 @@ func TestIsSkipped(t *testing.T) {
 				TaskRef:  &v1beta1.TaskRef{Name: "task"},
 				RunAfter: []string{"mytask20"},
 			},
-			TaskRunName: "pipelinerun-ordering-dependent-task-3",
-			TaskRun:     nil,
+			TaskRunNames: []string{"pipelinerun-ordering-dependent-task-3"},
+			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
 				TaskSpec: &task.Spec,
 			},
@@ -1042,8 +1042,8 @@ func TestIsSkipped(t *testing.T) {
 					Values:   []string{"expectedResult"},
 				}},
 			},
-			TaskRunName: "pipelinerun-resource-dependent-task-2",
-			TaskRun:     nil,
+			TaskRunNames: []string{"pipelinerun-resource-dependent-task-2"},
+			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
 				TaskSpec: &task.Spec,
 			},
@@ -1055,8 +1055,8 @@ func TestIsSkipped(t *testing.T) {
 				TaskRef:  &v1beta1.TaskRef{Name: "task"},
 				RunAfter: []string{"mytask22"},
 			},
-			TaskRunName: "pipelinerun-ordering-dependent-task-4",
-			TaskRun:     nil,
+			TaskRunNames: []string{"pipelinerun-ordering-dependent-task-4"},
+			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
 				TaskSpec: &task.Spec,
 			},
@@ -1122,8 +1122,8 @@ func TestIsSkipped(t *testing.T) {
 						},
 					}}},
 			},
-			TaskRunName: "pipelinerun-matrix-empty-params",
-			TaskRun:     nil,
+			TaskRunNames: []string{"pipelinerun-matrix-empty-params"},
+			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
 				TaskSpec: &task.Spec,
 			},
@@ -1141,8 +1141,8 @@ func TestIsSkipped(t *testing.T) {
 						},
 					}}},
 			},
-			TaskRunName: "pipelinerun-matrix-empty-params",
-			TaskRun:     nil,
+			TaskRunNames: []string{"pipelinerun-matrix-empty-params"},
+			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
 				TaskSpec: &task.Spec,
 			},
@@ -1166,8 +1166,8 @@ func TestIsSkipped(t *testing.T) {
 						},
 					}}},
 			},
-			TaskRunName: "pipelinerun-matrix-empty-params",
-			TaskRun:     nil,
+			TaskRunNames: []string{"pipelinerun-matrix-empty-params"},
+			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
 				TaskSpec: &task.Spec,
 			},
@@ -1238,7 +1238,7 @@ func TestIsFailure(t *testing.T) {
 		name: "taskrun running",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
-			TaskRun:      makeStarted(trs[0]),
+			TaskRuns:     []*v1beta1.TaskRun{makeStarted(trs[0])},
 		},
 		want: false,
 	}, {
@@ -1246,14 +1246,14 @@ func TestIsFailure(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
 			CustomTask:   true,
-			RunObject:    makeCustomRunStarted(customRuns[0]),
+			RunObjects:   []v1beta1.RunObject{makeCustomRunStarted(customRuns[0])},
 		},
 		want: false,
 	}, {
 		name: "taskrun succeeded",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
-			TaskRun:      makeSucceeded(trs[0]),
+			TaskRuns:     []*v1beta1.TaskRun{makeSucceeded(trs[0])},
 		},
 		want: false,
 	}, {
@@ -1261,14 +1261,14 @@ func TestIsFailure(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
 			CustomTask:   true,
-			RunObject:    makeCustomRunSucceeded(customRuns[0]),
+			RunObjects:   []v1beta1.RunObject{makeCustomRunSucceeded(customRuns[0])},
 		},
 		want: false,
 	}, {
 		name: "taskrun failed",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
-			TaskRun:      makeFailed(trs[0]),
+			TaskRuns:     []*v1beta1.TaskRun{makeFailed(trs[0])},
 		},
 		want: true,
 	}, {
@@ -1276,7 +1276,7 @@ func TestIsFailure(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
 			CustomTask:   true,
-			RunObject:    makeCustomRunFailed(customRuns[0]),
+			RunObjects:   []v1beta1.RunObject{makeCustomRunFailed(customRuns[0])},
 		},
 		want: true,
 	}, {
@@ -1284,14 +1284,14 @@ func TestIsFailure(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task", Retries: 1},
 			CustomTask:   true,
-			RunObject:    makeCustomRunFailed(customRuns[0]),
+			RunObjects:   []v1beta1.RunObject{makeCustomRunFailed(customRuns[0])},
 		},
 		want: true,
 	}, {
 		name: "taskrun failed - Retried",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task", Retries: 1},
-			TaskRun:      withRetries(makeFailed(trs[0])),
+			TaskRuns:     []*v1beta1.TaskRun{withRetries(makeFailed(trs[0]))},
 		},
 		want: true,
 	}, {
@@ -1299,35 +1299,35 @@ func TestIsFailure(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task", Retries: 1},
 			CustomTask:   true,
-			RunObject:    withCustomRunRetries(makeCustomRunFailed(customRuns[0])),
+			RunObjects:   []v1beta1.RunObject{withCustomRunRetries(makeCustomRunFailed(customRuns[0]))},
 		},
 		want: true,
 	}, {
 		name: "taskrun cancelled",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
-			TaskRun:      withCancelled(makeFailed(trs[0])),
+			TaskRuns:     []*v1beta1.TaskRun{withCancelled(makeFailed(trs[0]))},
 		},
 		want: true,
 	}, {
 		name: "taskrun cancelled but not failed",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
-			TaskRun:      withCancelled(newTaskRun(trs[0])),
+			TaskRuns:     []*v1beta1.TaskRun{withCancelled(newTaskRun(trs[0]))},
 		},
 		want: false,
 	}, {
 		name: "taskrun cancelled for timeout",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
-			TaskRun:      withCancelledForTimeout(makeFailed(trs[0])),
+			TaskRuns:     []*v1beta1.TaskRun{withCancelledForTimeout(makeFailed(trs[0]))},
 		},
 		want: true,
 	}, {
 		name: "customrun cancelled",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
-			RunObject:    withCustomRunCancelled(makeCustomRunFailed(customRuns[0])),
+			RunObjects:   []v1beta1.RunObject{withCustomRunCancelled(makeCustomRunFailed(customRuns[0]))},
 			CustomTask:   true,
 		},
 		want: true,
@@ -1335,7 +1335,7 @@ func TestIsFailure(t *testing.T) {
 		name: "customrun cancelled for timeout",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
-			RunObject:    withCustomRunCancelledForTimeout(makeCustomRunFailed(customRuns[0])),
+			RunObjects:   []v1beta1.RunObject{withCustomRunCancelledForTimeout(makeCustomRunFailed(customRuns[0]))},
 			CustomTask:   true,
 		},
 		want: true,
@@ -1343,7 +1343,7 @@ func TestIsFailure(t *testing.T) {
 		name: "customrun cancelled but not failed",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
-			RunObject:    withCustomRunCancelled(newCustomRun(customRuns[0])),
+			RunObjects:   []v1beta1.RunObject{withCustomRunCancelled(newCustomRun(customRuns[0]))},
 			CustomTask:   true,
 		},
 		want: false,
@@ -1351,14 +1351,14 @@ func TestIsFailure(t *testing.T) {
 		name: "taskrun cancelled: retries remaining",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task", Retries: 1},
-			TaskRun:      withCancelled(makeFailed(trs[0])),
+			TaskRuns:     []*v1beta1.TaskRun{withCancelled(makeFailed(trs[0]))},
 		},
 		want: true,
 	}, {
 		name: "customrun cancelled: retries remaining",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task", Retries: 1},
-			RunObject:    withCustomRunCancelled(makeCustomRunFailed(customRuns[0])),
+			RunObjects:   []v1beta1.RunObject{withCustomRunCancelled(makeCustomRunFailed(customRuns[0]))},
 			CustomTask:   true,
 		},
 		want: true,
@@ -1366,14 +1366,14 @@ func TestIsFailure(t *testing.T) {
 		name: "taskrun cancelled: retried",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task", Retries: 1},
-			TaskRun:      withCancelled(withRetries(makeFailed(trs[0]))),
+			TaskRuns:     []*v1beta1.TaskRun{withCancelled(withRetries(makeFailed(trs[0])))},
 		},
 		want: true,
 	}, {
 		name: "custom run cancelled: retried",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task", Retries: 1},
-			RunObject:    withCustomRunCancelled(withCustomRunRetries(makeCustomRunFailed(customRuns[0]))),
+			RunObjects:   []v1beta1.RunObject{withCustomRunCancelled(withCustomRunRetries(makeCustomRunFailed(customRuns[0])))},
 			CustomTask:   true,
 		},
 		want: true,
@@ -1639,7 +1639,7 @@ func TestIsFailure(t *testing.T) {
 	}
 }
 
-func TestIsStarted(t *testing.T) {
+func TestHasTaskRunsStarted(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		rpt  ResolvedPipelineTask
@@ -1651,67 +1651,29 @@ func TestIsStarted(t *testing.T) {
 		},
 		want: false,
 	}, {
-		name: "run not started",
-		rpt: ResolvedPipelineTask{
-			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
-			CustomTask:   true,
-		},
-		want: false,
-	}, {
 		name: "taskrun running",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
-			TaskRun:      makeStarted(trs[0]),
-		},
-		want: true,
-	}, {
-		name: "run running",
-		rpt: ResolvedPipelineTask{
-			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
-			CustomTask:   true,
-			RunObject:    makeCustomRunStarted(customRuns[0]),
+			TaskRuns:     []*v1beta1.TaskRun{makeStarted(trs[0])},
 		},
 		want: true,
 	}, {
 		name: "taskrun succeeded",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
-			TaskRun:      makeSucceeded(trs[0]),
-		},
-		want: true,
-	}, {
-		name: "run succeeded",
-		rpt: ResolvedPipelineTask{
-			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
-			CustomTask:   true,
-			RunObject:    makeCustomRunSucceeded(customRuns[0]),
+			TaskRuns:     []*v1beta1.TaskRun{makeSucceeded(trs[0])},
 		},
 		want: true,
 	}, {
 		name: "taskrun failed",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
-			TaskRun:      makeFailed(trs[0]),
-		},
-		want: true,
-	}, {
-		name: "run failed",
-		rpt: ResolvedPipelineTask{
-			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
-			CustomTask:   true,
-			RunObject:    makeCustomRunFailed(customRuns[0]),
+			TaskRuns:     []*v1beta1.TaskRun{makeFailed(trs[0])},
 		},
 		want: true,
 	}, {
 		name: "matrixed taskruns not started",
 		rpt: ResolvedPipelineTask{
-			PipelineTask: matrixedPipelineTask,
-		},
-		want: false,
-	}, {
-		name: "matrixed runs not started",
-		rpt: ResolvedPipelineTask{
-			CustomTask:   true,
 			PipelineTask: matrixedPipelineTask,
 		},
 		want: false,
@@ -1723,26 +1685,10 @@ func TestIsStarted(t *testing.T) {
 		},
 		want: true,
 	}, {
-		name: "matrixed runs running",
-		rpt: ResolvedPipelineTask{
-			CustomTask:   true,
-			PipelineTask: matrixedPipelineTask,
-			RunObjects:   []v1beta1.RunObject{makeCustomRunStarted(customRuns[0]), makeCustomRunStarted(customRuns[1])},
-		},
-		want: true,
-	}, {
 		name: "one matrixed taskrun running",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: matrixedPipelineTask,
 			TaskRuns:     []*v1beta1.TaskRun{makeStarted(trs[0]), makeSucceeded(trs[1])},
-		},
-		want: true,
-	}, {
-		name: "one matrixed run running",
-		rpt: ResolvedPipelineTask{
-			CustomTask:   true,
-			PipelineTask: matrixedPipelineTask,
-			RunObjects:   []v1beta1.RunObject{makeCustomRunStarted(customRuns[0]), makeCustomRunSucceeded(customRuns[1])},
 		},
 		want: true,
 	}, {
@@ -1760,18 +1706,86 @@ func TestIsStarted(t *testing.T) {
 		},
 		want: true,
 	}, {
+		name: "matrixed taskruns failed",
+		rpt: ResolvedPipelineTask{
+			PipelineTask: matrixedPipelineTask,
+			TaskRuns:     []*v1beta1.TaskRun{makeFailed(trs[0]), makeFailed(trs[1])},
+		},
+		want: true,
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.rpt.hasTaskRunsStarted(); got != tc.want {
+				t.Errorf("expected isStarted: %t but got %t", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestHasRunObjectsStarted(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		rpt  ResolvedPipelineTask
+		want bool
+	}{{
+		name: "run not started",
+		rpt: ResolvedPipelineTask{
+			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
+			CustomTask:   true,
+		},
+		want: false,
+	}, {
+		name: "run running",
+		rpt: ResolvedPipelineTask{
+			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
+			CustomTask:   true,
+			RunObjects:   []v1beta1.RunObject{makeCustomRunStarted(customRuns[0])},
+		},
+		want: true,
+	}, {
+		name: "run succeeded",
+		rpt: ResolvedPipelineTask{
+			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
+			CustomTask:   true,
+			RunObjects:   []v1beta1.RunObject{makeCustomRunSucceeded(customRuns[0])},
+		},
+		want: true,
+	}, {
+		name: "run failed",
+		rpt: ResolvedPipelineTask{
+			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
+			CustomTask:   true,
+			RunObjects:   []v1beta1.RunObject{makeCustomRunFailed(customRuns[0])},
+		},
+		want: true,
+	}, {
+		name: "matrixed runs not started",
+		rpt: ResolvedPipelineTask{
+			CustomTask:   true,
+			PipelineTask: matrixedPipelineTask,
+		},
+		want: false,
+	}, {
+		name: "matrixed runs running",
+		rpt: ResolvedPipelineTask{
+			CustomTask:   true,
+			PipelineTask: matrixedPipelineTask,
+			RunObjects:   []v1beta1.RunObject{makeCustomRunStarted(customRuns[0]), makeCustomRunStarted(customRuns[1])},
+		},
+		want: true,
+	}, {
+		name: "one matrixed run running",
+		rpt: ResolvedPipelineTask{
+			CustomTask:   true,
+			PipelineTask: matrixedPipelineTask,
+			RunObjects:   []v1beta1.RunObject{makeCustomRunStarted(customRuns[0]), makeCustomRunSucceeded(customRuns[1])},
+		},
+		want: true,
+	}, {
 		name: "one matrixed run succeeded",
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: matrixedPipelineTask,
 			RunObjects:   []v1beta1.RunObject{makeCustomRunSucceeded(customRuns[0]), makeCustomRunStarted(customRuns[1])},
-		},
-		want: true,
-	}, {
-		name: "matrixed taskruns failed",
-		rpt: ResolvedPipelineTask{
-			PipelineTask: matrixedPipelineTask,
-			TaskRuns:     []*v1beta1.TaskRun{makeFailed(trs[0]), makeFailed(trs[1])},
 		},
 		want: true,
 	}, {
@@ -1784,25 +1798,19 @@ func TestIsStarted(t *testing.T) {
 		want: true,
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := tc.rpt.isStarted(); got != tc.want {
+			if got := tc.rpt.hasRunObjectsStarted(); got != tc.want {
 				t.Errorf("expected isStarted: %t but got %t", tc.want, got)
 			}
 		})
 	}
 }
 
-func TestIsConditionStatusFalse(t *testing.T) {
+func TestAreRunObjectsConditionStatusFalse(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		rpt  ResolvedPipelineTask
 		want bool
 	}{{
-		name: "taskrun not started",
-		rpt: ResolvedPipelineTask{
-			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
-		},
-		want: false,
-	}, {
 		name: "run not started",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
@@ -1810,25 +1818,11 @@ func TestIsConditionStatusFalse(t *testing.T) {
 		},
 		want: false,
 	}, {
-		name: "taskrun running",
-		rpt: ResolvedPipelineTask{
-			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
-			TaskRun:      makeStarted(trs[0]),
-		},
-		want: false,
-	}, {
 		name: "run running",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
 			CustomTask:   true,
-			RunObject:    makeCustomRunStarted(customRuns[0]),
-		},
-		want: false,
-	}, {
-		name: "taskrun succeeded",
-		rpt: ResolvedPipelineTask{
-			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
-			TaskRun:      makeSucceeded(trs[0]),
+			RunObjects:   []v1beta1.RunObject{makeCustomRunStarted(customRuns[0])},
 		},
 		want: false,
 	}, {
@@ -1836,50 +1830,22 @@ func TestIsConditionStatusFalse(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
 			CustomTask:   true,
-			RunObject:    makeCustomRunSucceeded(customRuns[0]),
+			RunObjects:   []v1beta1.RunObject{makeCustomRunSucceeded(customRuns[0])},
 		},
 		want: false,
-	}, {
-		name: "taskrun failed",
-		rpt: ResolvedPipelineTask{
-			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
-			TaskRun:      makeFailed(trs[0]),
-		},
-		want: true,
 	}, {
 		name: "run failed",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
 			CustomTask:   true,
-			RunObject:    makeCustomRunFailed(customRuns[0]),
-		},
-		want: true,
-	}, {
-		name: "taskrun cancelled",
-		rpt: ResolvedPipelineTask{
-			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
-			TaskRun:      withCancelled(makeFailed(trs[0])),
-		},
-		want: true,
-	}, {
-		name: "taskrun cancelled but not failed",
-		rpt: ResolvedPipelineTask{
-			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
-			TaskRun:      withCancelled(newTaskRun(trs[0])),
-		},
-		want: false,
-	}, {
-		name: "taskrun cancelled for timeout",
-		rpt: ResolvedPipelineTask{
-			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
-			TaskRun:      withCancelledForTimeout(makeFailed(trs[0])),
+			RunObjects:   []v1beta1.RunObject{makeCustomRunFailed(customRuns[0])},
 		},
 		want: true,
 	}, {
 		name: "customrun cancelled",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
-			RunObject:    withCustomRunCancelled(makeCustomRunFailed(customRuns[0])),
+			RunObjects:   []v1beta1.RunObject{withCustomRunCancelled(makeCustomRunFailed(customRuns[0]))},
 			CustomTask:   true,
 		},
 		want: true,
@@ -1887,7 +1853,7 @@ func TestIsConditionStatusFalse(t *testing.T) {
 		name: "customrun cancelled for timeout",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
-			RunObject:    withCustomRunCancelledForTimeout(makeCustomRunFailed(customRuns[0])),
+			RunObjects:   []v1beta1.RunObject{withCustomRunCancelledForTimeout(makeCustomRunFailed(customRuns[0]))},
 			CustomTask:   true,
 		},
 		want: true,
@@ -1895,14 +1861,8 @@ func TestIsConditionStatusFalse(t *testing.T) {
 		name: "customrun cancelled but not failed",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
-			RunObject:    withCustomRunCancelled(newCustomRun(customRuns[0])),
+			RunObjects:   []v1beta1.RunObject{withCustomRunCancelled(newCustomRun(customRuns[0]))},
 			CustomTask:   true,
-		},
-		want: false,
-	}, {
-		name: "matrixed taskruns not started",
-		rpt: ResolvedPipelineTask{
-			PipelineTask: matrixedPipelineTask,
 		},
 		want: false,
 	}, {
@@ -1910,13 +1870,6 @@ func TestIsConditionStatusFalse(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: matrixedPipelineTask,
-		},
-		want: false,
-	}, {
-		name: "matrixed taskruns running",
-		rpt: ResolvedPipelineTask{
-			PipelineTask: matrixedPipelineTask,
-			TaskRuns:     []*v1beta1.TaskRun{makeStarted(trs[0]), makeStarted(trs[1])},
 		},
 		want: false,
 	}, {
@@ -1928,32 +1881,11 @@ func TestIsConditionStatusFalse(t *testing.T) {
 		},
 		want: false,
 	}, {
-		name: "one matrixed taskrun running",
-		rpt: ResolvedPipelineTask{
-			PipelineTask: matrixedPipelineTask,
-			TaskRuns:     []*v1beta1.TaskRun{makeStarted(trs[0]), makeSucceeded(trs[1])},
-		},
-		want: false,
-	}, {
 		name: "one matrixed run running",
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: matrixedPipelineTask,
 			RunObjects:   []v1beta1.RunObject{makeCustomRunStarted(customRuns[0]), makeCustomRunSucceeded(customRuns[1])},
-		},
-		want: false,
-	}, {
-		name: "matrixed taskruns succeeded",
-		rpt: ResolvedPipelineTask{
-			PipelineTask: matrixedPipelineTask,
-			TaskRuns:     []*v1beta1.TaskRun{makeSucceeded(trs[0]), makeSucceeded(trs[1])},
-		},
-		want: false,
-	}, {
-		name: "one matrixed taskrun succeeded",
-		rpt: ResolvedPipelineTask{
-			PipelineTask: matrixedPipelineTask,
-			TaskRuns:     []*v1beta1.TaskRun{makeSucceeded(trs[0]), makeStarted(trs[1])},
 		},
 		want: false,
 	}, {
@@ -1965,25 +1897,11 @@ func TestIsConditionStatusFalse(t *testing.T) {
 		},
 		want: false,
 	}, {
-		name: "matrixed taskruns failed",
-		rpt: ResolvedPipelineTask{
-			PipelineTask: matrixedPipelineTask,
-			TaskRuns:     []*v1beta1.TaskRun{makeFailed(trs[0]), makeFailed(trs[1])},
-		},
-		want: true,
-	}, {
 		name: "matrixed runs failed",
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: matrixedPipelineTask,
 			RunObjects:   []v1beta1.RunObject{makeCustomRunFailed(customRuns[0]), makeCustomRunFailed(customRuns[1])},
-		},
-		want: true,
-	}, {
-		name: "one matrixed taskrun failed, one matrixed taskrun running",
-		rpt: ResolvedPipelineTask{
-			PipelineTask: matrixedPipelineTask,
-			TaskRuns:     []*v1beta1.TaskRun{makeFailed(trs[0]), makeStarted(trs[1])},
 		},
 		want: true,
 	}, {
@@ -1995,25 +1913,11 @@ func TestIsConditionStatusFalse(t *testing.T) {
 		},
 		want: true,
 	}, {
-		name: "matrixed taskruns cancelled",
-		rpt: ResolvedPipelineTask{
-			PipelineTask: matrixedPipelineTask,
-			TaskRuns:     []*v1beta1.TaskRun{withCancelled(makeFailed(trs[0])), withCancelled(makeFailed(trs[1]))},
-		},
-		want: true,
-	}, {
 		name: "matrixed runs cancelled",
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: matrixedPipelineTask,
 			RunObjects:   []v1beta1.RunObject{withCustomRunCancelled(makeCustomRunFailed(customRuns[0])), withCustomRunCancelled(makeCustomRunFailed(customRuns[1]))},
-		},
-		want: true,
-	}, {
-		name: "one matrixed taskrun cancelled, one matrixed taskrun running",
-		rpt: ResolvedPipelineTask{
-			PipelineTask: matrixedPipelineTask,
-			TaskRuns:     []*v1beta1.TaskRun{withCancelled(makeFailed(trs[0])), makeStarted(trs[1])},
 		},
 		want: true,
 	}, {
@@ -2025,25 +1929,11 @@ func TestIsConditionStatusFalse(t *testing.T) {
 		},
 		want: true,
 	}, {
-		name: "matrixed taskruns cancelled but not failed",
-		rpt: ResolvedPipelineTask{
-			PipelineTask: matrixedPipelineTask,
-			TaskRuns:     []*v1beta1.TaskRun{withCancelled(newTaskRun(trs[0])), withCancelled(newTaskRun(trs[1]))},
-		},
-		want: false,
-	}, {
 		name: "matrixed runs cancelled but not failed",
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: matrixedPipelineTask,
 			RunObjects:   []v1beta1.RunObject{withCustomRunCancelled(newCustomRun(customRuns[0])), withCustomRunCancelled(newCustomRun(customRuns[1]))},
-		},
-		want: false,
-	}, {
-		name: "one matrixed taskrun cancelled but not failed",
-		rpt: ResolvedPipelineTask{
-			PipelineTask: matrixedPipelineTask,
-			TaskRuns:     []*v1beta1.TaskRun{withCancelled(newTaskRun(trs[0])), makeStarted(trs[1])},
 		},
 		want: false,
 	}, {
@@ -2056,8 +1946,146 @@ func TestIsConditionStatusFalse(t *testing.T) {
 		want: false,
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := tc.rpt.isConditionStatusFalse(); got != tc.want {
-				t.Errorf("expected isConditionStatusFalse: %t but got %t", tc.want, got)
+			if got := tc.rpt.areRunObjectsConditionStatusFalse(); got != tc.want {
+				t.Errorf("expected areRunObjectsConditionStatusFalse: %t but got %t", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestAreTaskRunsConditionStatusFalse(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		rpt  ResolvedPipelineTask
+		want bool
+	}{{
+		name: "taskrun not started",
+		rpt: ResolvedPipelineTask{
+			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
+		},
+		want: false,
+	}, {
+		name: "taskrun running",
+		rpt: ResolvedPipelineTask{
+			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
+			TaskRuns:     []*v1beta1.TaskRun{makeStarted(trs[0])},
+		},
+		want: false,
+	}, {
+		name: "taskrun succeeded",
+		rpt: ResolvedPipelineTask{
+			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
+			TaskRuns:     []*v1beta1.TaskRun{makeSucceeded(trs[0])},
+		},
+		want: false,
+	}, {
+		name: "taskrun failed",
+		rpt: ResolvedPipelineTask{
+			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
+			TaskRuns:     []*v1beta1.TaskRun{makeFailed(trs[0])},
+		},
+		want: true,
+	}, {
+		name: "taskrun cancelled",
+		rpt: ResolvedPipelineTask{
+			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
+			TaskRuns:     []*v1beta1.TaskRun{withCancelled(makeFailed(trs[0]))},
+		},
+		want: true,
+	}, {
+		name: "taskrun cancelled but not failed",
+		rpt: ResolvedPipelineTask{
+			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
+			TaskRuns:     []*v1beta1.TaskRun{withCancelled(newTaskRun(trs[0]))},
+		},
+		want: false,
+	}, {
+		name: "taskrun cancelled for timeout",
+		rpt: ResolvedPipelineTask{
+			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
+			TaskRuns:     []*v1beta1.TaskRun{withCancelledForTimeout(makeFailed(trs[0]))},
+		},
+		want: true,
+	}, {
+		name: "matrixed taskruns not started",
+		rpt: ResolvedPipelineTask{
+			PipelineTask: matrixedPipelineTask,
+		},
+		want: false,
+	}, {
+		name: "matrixed taskruns running",
+		rpt: ResolvedPipelineTask{
+			PipelineTask: matrixedPipelineTask,
+			TaskRuns:     []*v1beta1.TaskRun{makeStarted(trs[0]), makeStarted(trs[1])},
+		},
+		want: false,
+	}, {
+		name: "one matrixed taskrun running",
+		rpt: ResolvedPipelineTask{
+			PipelineTask: matrixedPipelineTask,
+			TaskRuns:     []*v1beta1.TaskRun{makeStarted(trs[0]), makeSucceeded(trs[1])},
+		},
+		want: false,
+	}, {
+		name: "matrixed taskruns succeeded",
+		rpt: ResolvedPipelineTask{
+			PipelineTask: matrixedPipelineTask,
+			TaskRuns:     []*v1beta1.TaskRun{makeSucceeded(trs[0]), makeSucceeded(trs[1])},
+		},
+		want: false,
+	}, {
+		name: "one matrixed taskrun succeeded",
+		rpt: ResolvedPipelineTask{
+			PipelineTask: matrixedPipelineTask,
+			TaskRuns:     []*v1beta1.TaskRun{makeSucceeded(trs[0]), makeStarted(trs[1])},
+		},
+		want: false,
+	}, {
+		name: "matrixed taskruns failed",
+		rpt: ResolvedPipelineTask{
+			PipelineTask: matrixedPipelineTask,
+			TaskRuns:     []*v1beta1.TaskRun{makeFailed(trs[0]), makeFailed(trs[1])},
+		},
+		want: true,
+	}, {
+		name: "one matrixed taskrun failed, one matrixed taskrun running",
+		rpt: ResolvedPipelineTask{
+			PipelineTask: matrixedPipelineTask,
+			TaskRuns:     []*v1beta1.TaskRun{makeFailed(trs[0]), makeStarted(trs[1])},
+		},
+		want: true,
+	}, {
+		name: "matrixed taskruns cancelled",
+		rpt: ResolvedPipelineTask{
+			PipelineTask: matrixedPipelineTask,
+			TaskRuns:     []*v1beta1.TaskRun{withCancelled(makeFailed(trs[0])), withCancelled(makeFailed(trs[1]))},
+		},
+		want: true,
+	}, {
+		name: "one matrixed taskrun cancelled, one matrixed taskrun running",
+		rpt: ResolvedPipelineTask{
+			PipelineTask: matrixedPipelineTask,
+			TaskRuns:     []*v1beta1.TaskRun{withCancelled(makeFailed(trs[0])), makeStarted(trs[1])},
+		},
+		want: true,
+	}, {
+		name: "matrixed taskruns cancelled but not failed",
+		rpt: ResolvedPipelineTask{
+			PipelineTask: matrixedPipelineTask,
+			TaskRuns:     []*v1beta1.TaskRun{withCancelled(newTaskRun(trs[0])), withCancelled(newTaskRun(trs[1]))},
+		},
+		want: false,
+	}, {
+		name: "one matrixed taskrun cancelled but not failed",
+		rpt: ResolvedPipelineTask{
+			PipelineTask: matrixedPipelineTask,
+			TaskRuns:     []*v1beta1.TaskRun{withCancelled(newTaskRun(trs[0])), makeStarted(trs[1])},
+		},
+		want: false,
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.rpt.areTaskRunsConditionStatusFalse(); got != tc.want {
+				t.Errorf("expected areTaskRunsConditionStatusFalse: %t but got %t", tc.want, got)
 			}
 		})
 	}
@@ -2073,14 +2101,14 @@ func TestSkipBecauseParentTaskWasSkipped(t *testing.T) {
 		state: PipelineRunState{{
 			// parent task has when expressions but is not yet done
 			PipelineTask: &pts[0],
-			TaskRun:      nil,
+			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
 				TaskSpec: &task.Spec,
 			},
 		}, {
 			// child task not skipped because parent is not yet done
 			PipelineTask: &pts[11],
-			TaskRun:      nil,
+			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
 				TaskSpec: &task.Spec,
 			},
@@ -2093,8 +2121,8 @@ func TestSkipBecauseParentTaskWasSkipped(t *testing.T) {
 		state: PipelineRunState{{
 			// parent task is skipped because when expressions evaluate to false, not because of its parent tasks
 			PipelineTask: &pts[10],
-			TaskRunName:  "pipelinerun-guardedtask",
-			TaskRun:      nil,
+			TaskRunNames: []string{"pipelinerun-guardedtask"},
+			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
 				TaskSpec: &task.Spec,
 			},
@@ -2106,8 +2134,8 @@ func TestSkipBecauseParentTaskWasSkipped(t *testing.T) {
 				TaskRef:  &v1beta1.TaskRef{Name: "task"},
 				RunAfter: []string{"mytask11"},
 			},
-			TaskRunName: "pipelinerun-ordering-dependent-task-1",
-			TaskRun:     nil,
+			TaskRunNames: []string{"pipelinerun-ordering-dependent-task-1"},
+			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
 				TaskSpec: &task.Spec,
 			},
@@ -2121,8 +2149,8 @@ func TestSkipBecauseParentTaskWasSkipped(t *testing.T) {
 		state: PipelineRunState{{
 			// parent task is skipped because when expressions evaluate to false, not because of its parent tasks
 			PipelineTask: &pts[10],
-			TaskRunName:  "pipelinerun-guardedtask",
-			TaskRun:      nil,
+			TaskRunNames: []string{"pipelinerun-guardedtask"},
+			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
 				TaskSpec: &task.Spec,
 			},
@@ -2134,8 +2162,8 @@ func TestSkipBecauseParentTaskWasSkipped(t *testing.T) {
 				TaskRef:  &v1beta1.TaskRef{Name: "task"},
 				RunAfter: []string{"mytask11"},
 			},
-			TaskRunName: "pipelinerun-ordering-dependent-task-1",
-			TaskRun:     nil,
+			TaskRunNames: []string{"pipelinerun-ordering-dependent-task-1"},
+			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
 				TaskSpec: &task.Spec,
 			},
@@ -2147,8 +2175,8 @@ func TestSkipBecauseParentTaskWasSkipped(t *testing.T) {
 				TaskRef:  &v1beta1.TaskRef{Name: "task"},
 				RunAfter: []string{"mytask18"},
 			},
-			TaskRunName: "pipelinerun-ordering-dependent-task-2",
-			TaskRun:     nil,
+			TaskRunNames: []string{"pipelinerun-ordering-dependent-task-2"},
+			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
 				TaskSpec: &task.Spec,
 			},
@@ -2241,20 +2269,20 @@ func TestResolvePipelineRun_CustomTask(t *testing.T) {
 	}
 
 	expectedState := PipelineRunState{{
-		PipelineTask:  &pts[0],
-		CustomTask:    true,
-		RunObjectName: "pipelinerun-customtask",
-		RunObject:     nil,
+		PipelineTask:   &pts[0],
+		CustomTask:     true,
+		RunObjectNames: []string{"pipelinerun-customtask"},
+		RunObjects:     nil,
 	}, {
-		PipelineTask:  &pts[1],
-		CustomTask:    true,
-		RunObjectName: "pipelinerun-customtask-spec",
-		RunObject:     nil,
+		PipelineTask:   &pts[1],
+		CustomTask:     true,
+		RunObjectNames: []string{"pipelinerun-customtask-spec"},
+		RunObjects:     nil,
 	}, {
-		PipelineTask:  &pts[2],
-		CustomTask:    true,
-		RunObjectName: "pipelinerun-run-exists",
-		RunObject:     run,
+		PipelineTask:   &pts[2],
+		CustomTask:     true,
+		RunObjectNames: []string{"pipelinerun-run-exists"},
+		RunObjects:     []v1beta1.RunObject{run},
 	}}
 	if d := cmp.Diff(expectedState, pipelineState); d != "" {
 		t.Errorf("Unexpected pipeline state: %s", diff.PrintWantGot(d))
@@ -2760,8 +2788,8 @@ func TestResolvedPipelineRunTask_IsFinallySkipped(t *testing.T) {
 	}
 
 	state := PipelineRunState{{
-		TaskRunName: "dag-task",
-		TaskRun:     tr,
+		TaskRunNames: []string{"dag-task"},
+		TaskRuns:     []*v1beta1.TaskRun{tr},
 		PipelineTask: &v1beta1.PipelineTask{
 			Name:    "dag-task",
 			TaskRef: &v1beta1.TaskRef{Name: "task"},
@@ -2969,8 +2997,8 @@ func TestResolvedPipelineRunTask_IsFinallySkipped(t *testing.T) {
 
 func TestResolvedPipelineRunTask_IsFinallySkippedByCondition(t *testing.T) {
 	task := &ResolvedPipelineTask{
-		TaskRunName: "dag-task",
-		TaskRun: &v1beta1.TaskRun{
+		TaskRunNames: []string{"dag-task"},
+		TaskRuns: []*v1beta1.TaskRun{{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "dag-task",
 			},
@@ -2982,7 +3010,7 @@ func TestResolvedPipelineRunTask_IsFinallySkippedByCondition(t *testing.T) {
 					}},
 				},
 			},
-		},
+		}},
 		PipelineTask: &v1beta1.PipelineTask{
 			Name:    "dag-task",
 			TaskRef: &v1beta1.TaskRef{Name: "task"},
@@ -2997,7 +3025,7 @@ func TestResolvedPipelineRunTask_IsFinallySkippedByCondition(t *testing.T) {
 		state: PipelineRunState{
 			task,
 			{
-				TaskRun: &v1beta1.TaskRun{
+				TaskRuns: []*v1beta1.TaskRun{{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "final-task",
 					},
@@ -3009,7 +3037,7 @@ func TestResolvedPipelineRunTask_IsFinallySkippedByCondition(t *testing.T) {
 							}},
 						},
 					},
-				},
+				}},
 				PipelineTask: &v1beta1.PipelineTask{
 					Name:    "final-task",
 					TaskRef: &v1beta1.TaskRef{Name: "task"},
@@ -3032,8 +3060,8 @@ func TestResolvedPipelineRunTask_IsFinallySkippedByCondition(t *testing.T) {
 		state: PipelineRunState{
 			task,
 			{
-				TaskRunName: "final-task",
-				TaskRun: &v1beta1.TaskRun{
+				TaskRunNames: []string{"final-task"},
+				TaskRuns: []*v1beta1.TaskRun{{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "final-task",
 					},
@@ -3042,7 +3070,7 @@ func TestResolvedPipelineRunTask_IsFinallySkippedByCondition(t *testing.T) {
 							Conditions: []apis.Condition{ /* explicitly empty */ },
 						},
 					},
-				},
+				}},
 				PipelineTask: &v1beta1.PipelineTask{
 					Name:    "final-task",
 					TaskRef: &v1beta1.TaskRef{Name: "task"},
@@ -3120,8 +3148,8 @@ func TestResolvedPipelineRunTask_IsFinalTask(t *testing.T) {
 	}
 
 	state := PipelineRunState{{
-		TaskRunName: "dag-task",
-		TaskRun:     tr,
+		TaskRunNames: []string{"dag-task"},
+		TaskRuns:     []*v1beta1.TaskRun{tr},
 		PipelineTask: &v1beta1.PipelineTask{
 			Name:    "dag-task",
 			TaskRef: &v1beta1.TaskRef{Name: "task"},
@@ -3728,7 +3756,7 @@ func TestIsSuccessful(t *testing.T) {
 		name: "taskrun running",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
-			TaskRun:      makeStarted(trs[0]),
+			TaskRuns:     []*v1beta1.TaskRun{makeStarted(trs[0])},
 		},
 		want: false,
 	}, {
@@ -3736,14 +3764,14 @@ func TestIsSuccessful(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
 			CustomTask:   true,
-			RunObject:    makeCustomRunStarted(customRuns[0]),
+			RunObjects:   []v1beta1.RunObject{makeCustomRunStarted(customRuns[0])},
 		},
 		want: false,
 	}, {
 		name: "taskrun succeeded",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
-			TaskRun:      makeSucceeded(trs[0]),
+			TaskRuns:     []*v1beta1.TaskRun{makeSucceeded(trs[0])},
 		},
 		want: true,
 	}, {
@@ -3751,14 +3779,14 @@ func TestIsSuccessful(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
 			CustomTask:   true,
-			RunObject:    makeCustomRunSucceeded(customRuns[0]),
+			RunObjects:   []v1beta1.RunObject{makeCustomRunSucceeded(customRuns[0])},
 		},
 		want: true,
 	}, {
 		name: "taskrun failed",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
-			TaskRun:      makeFailed(trs[0]),
+			TaskRuns:     []*v1beta1.TaskRun{makeFailed(trs[0])},
 		},
 		want: false,
 	}, {
@@ -3766,14 +3794,14 @@ func TestIsSuccessful(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
 			CustomTask:   true,
-			RunObject:    makeCustomRunFailed(customRuns[0]),
+			RunObjects:   []v1beta1.RunObject{makeCustomRunFailed(customRuns[0])},
 		},
 		want: false,
 	}, {
 		name: "taskrun failed: retries remaining",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task", Retries: 1},
-			TaskRun:      withRetries(makeToBeRetried(trs[0])),
+			TaskRuns:     []*v1beta1.TaskRun{withRetries(makeToBeRetried(trs[0]))},
 		},
 		want: false,
 	}, {
@@ -3781,7 +3809,7 @@ func TestIsSuccessful(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task", Retries: 1},
 			CustomTask:   true,
-			RunObject:    makeCustomRunFailed(customRuns[0]),
+			RunObjects:   []v1beta1.RunObject{makeCustomRunFailed(customRuns[0])},
 		},
 		want: false,
 	}, {
@@ -3789,28 +3817,28 @@ func TestIsSuccessful(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task", Retries: 1},
 			CustomTask:   true,
-			RunObject:    withCustomRunRetries(makeCustomRunFailed(customRuns[0])),
+			RunObjects:   []v1beta1.RunObject{withCustomRunRetries(makeCustomRunFailed(customRuns[0]))},
 		},
 		want: false,
 	}, {
 		name: "taskrun cancelled",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
-			TaskRun:      withCancelled(makeFailed(trs[0])),
+			TaskRuns:     []*v1beta1.TaskRun{withCancelled(makeFailed(trs[0]))},
 		},
 		want: false,
 	}, {
 		name: "taskrun cancelled but not failed",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
-			TaskRun:      withCancelled(newTaskRun(trs[0])),
+			TaskRuns:     []*v1beta1.TaskRun{withCancelled(newTaskRun(trs[0]))},
 		},
 		want: false,
 	}, {
 		name: "run cancelled",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
-			RunObject:    withCustomRunCancelled(makeCustomRunFailed(customRuns[0])),
+			RunObjects:   []v1beta1.RunObject{withCustomRunCancelled(makeCustomRunFailed(customRuns[0]))},
 			CustomTask:   true,
 		},
 		want: false,
@@ -3818,7 +3846,7 @@ func TestIsSuccessful(t *testing.T) {
 		name: "run cancelled but not failed",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
-			RunObject:    withCustomRunCancelled(newCustomRun(customRuns[0])),
+			RunObjects:   []v1beta1.RunObject{withCustomRunCancelled(newCustomRun(customRuns[0]))},
 			CustomTask:   true,
 		},
 		want: false,
@@ -3826,14 +3854,14 @@ func TestIsSuccessful(t *testing.T) {
 		name: "taskrun cancelled: retries remaining",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task", Retries: 1},
-			TaskRun:      withCancelled(makeFailed(trs[0])),
+			TaskRuns:     []*v1beta1.TaskRun{withCancelled(makeFailed(trs[0]))},
 		},
 		want: false,
 	}, {
 		name: "run cancelled: retries remaining",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task", Retries: 1},
-			RunObject:    withCustomRunCancelled(makeCustomRunFailed(customRuns[0])),
+			RunObjects:   []v1beta1.RunObject{withCustomRunCancelled(makeCustomRunFailed(customRuns[0]))},
 			CustomTask:   true,
 		},
 		want: false,
@@ -3841,14 +3869,14 @@ func TestIsSuccessful(t *testing.T) {
 		name: "taskrun cancelled: retried",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task", Retries: 1},
-			TaskRun:      withCancelled(withRetries(makeFailed(trs[0]))),
+			TaskRuns:     []*v1beta1.TaskRun{withCancelled(withRetries(makeFailed(trs[0])))},
 		},
 		want: false,
 	}, {
 		name: "run cancelled: retried",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task", Retries: 1},
-			RunObject:    withCustomRunCancelled(withCustomRunRetries(makeCustomRunFailed(customRuns[0]))),
+			RunObjects:   []v1beta1.RunObject{withCustomRunCancelled(withCustomRunRetries(makeCustomRunFailed(customRuns[0])))},
 			CustomTask:   true,
 		},
 		want: false,
@@ -4144,7 +4172,7 @@ func TestIsRunning(t *testing.T) {
 		name: "taskrun running",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
-			TaskRun:      makeStarted(trs[0]),
+			TaskRuns:     []*v1beta1.TaskRun{makeStarted(trs[0])},
 		},
 		want: true,
 	}, {
@@ -4152,14 +4180,14 @@ func TestIsRunning(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
 			CustomTask:   true,
-			RunObject:    makeCustomRunStarted(customRuns[0]),
+			RunObjects:   []v1beta1.RunObject{makeCustomRunStarted(customRuns[0])},
 		},
 		want: true,
 	}, {
 		name: "taskrun succeeded",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
-			TaskRun:      makeSucceeded(trs[0]),
+			TaskRuns:     []*v1beta1.TaskRun{makeSucceeded(trs[0])},
 		},
 		want: false,
 	}, {
@@ -4167,14 +4195,14 @@ func TestIsRunning(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
 			CustomTask:   true,
-			RunObject:    makeCustomRunSucceeded(customRuns[0]),
+			RunObjects:   []v1beta1.RunObject{makeCustomRunSucceeded(customRuns[0])},
 		},
 		want: false,
 	}, {
 		name: "taskrun failed",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
-			TaskRun:      makeFailed(trs[0]),
+			TaskRuns:     []*v1beta1.TaskRun{makeFailed(trs[0])},
 		},
 		want: false,
 	}, {
@@ -4182,14 +4210,14 @@ func TestIsRunning(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
 			CustomTask:   true,
-			RunObject:    makeCustomRunFailed(customRuns[0]),
+			RunObjects:   []v1beta1.RunObject{makeCustomRunFailed(customRuns[0])},
 		},
 		want: false,
 	}, {
 		name: "taskrun failed: retried",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task", Retries: 1},
-			TaskRun:      withRetries(makeFailed(trs[0])),
+			TaskRuns:     []*v1beta1.TaskRun{withRetries(makeFailed(trs[0]))},
 		},
 		want: false,
 	}, {
@@ -4197,7 +4225,7 @@ func TestIsRunning(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task", Retries: 1},
 			CustomTask:   true,
-			RunObject:    makeCustomRunFailed(customRuns[0]),
+			RunObjects:   []v1beta1.RunObject{makeCustomRunFailed(customRuns[0])},
 		},
 		want: false,
 	}, {
@@ -4205,28 +4233,28 @@ func TestIsRunning(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task", Retries: 1},
 			CustomTask:   true,
-			RunObject:    withCustomRunRetries(makeCustomRunFailed(customRuns[0])),
+			RunObjects:   []v1beta1.RunObject{withCustomRunRetries(makeCustomRunFailed(customRuns[0]))},
 		},
 		want: false,
 	}, {
 		name: "taskrun cancelled",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
-			TaskRun:      withCancelled(makeFailed(trs[0])),
+			TaskRuns:     []*v1beta1.TaskRun{withCancelled(makeFailed(trs[0]))},
 		},
 		want: false,
 	}, {
 		name: "taskrun cancelled but not failed",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
-			TaskRun:      withCancelled(newTaskRun(trs[0])),
+			TaskRuns:     []*v1beta1.TaskRun{withCancelled(newTaskRun(trs[0]))},
 		},
 		want: true,
 	}, {
 		name: "run cancelled",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
-			RunObject:    withCustomRunCancelled(makeCustomRunFailed(customRuns[0])),
+			RunObjects:   []v1beta1.RunObject{withCustomRunCancelled(makeCustomRunFailed(customRuns[0]))},
 			CustomTask:   true,
 		},
 		want: false,
@@ -4234,7 +4262,7 @@ func TestIsRunning(t *testing.T) {
 		name: "run cancelled but not failed",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
-			RunObject:    withCustomRunCancelled(newCustomRun(customRuns[0])),
+			RunObjects:   []v1beta1.RunObject{withCustomRunCancelled(newCustomRun(customRuns[0]))},
 			CustomTask:   true,
 		},
 		want: true,
@@ -4242,14 +4270,14 @@ func TestIsRunning(t *testing.T) {
 		name: "taskrun cancelled: retries remaining",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task", Retries: 1},
-			TaskRun:      withCancelled(makeFailed(trs[0])),
+			TaskRuns:     []*v1beta1.TaskRun{withCancelled(makeFailed(trs[0]))},
 		},
 		want: false,
 	}, {
 		name: "run cancelled: retries remaining",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task", Retries: 1},
-			RunObject:    withCustomRunCancelled(makeCustomRunFailed(customRuns[0])),
+			RunObjects:   []v1beta1.RunObject{withCustomRunCancelled(makeCustomRunFailed(customRuns[0]))},
 			CustomTask:   true,
 		},
 		want: false,
@@ -4257,14 +4285,14 @@ func TestIsRunning(t *testing.T) {
 		name: "taskrun cancelled: retried",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task", Retries: 1},
-			TaskRun:      withCancelled(withRetries(makeFailed(trs[0]))),
+			TaskRuns:     []*v1beta1.TaskRun{withCancelled(withRetries(makeFailed(trs[0])))},
 		},
 		want: false,
 	}, {
 		name: "run cancelled: retried",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task", Retries: 1},
-			RunObject:    withCustomRunCancelled(withCustomRunRetries(makeCustomRunFailed(customRuns[0]))),
+			RunObjects:   []v1beta1.RunObject{withCustomRunCancelled(withCustomRunRetries(makeCustomRunFailed(customRuns[0])))},
 			CustomTask:   true,
 		},
 		want: false,

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
@@ -112,9 +112,7 @@ func (state PipelineRunState) ToMap() map[string]*ResolvedPipelineTask {
 // IsBeforeFirstTaskRun returns true if the PipelineRun has not yet started its first TaskRun
 func (state PipelineRunState) IsBeforeFirstTaskRun() bool {
 	for _, t := range state {
-		if t.IsCustomTask() && (t.RunObject != nil || len(t.RunObjects) > 0) {
-			return false
-		} else if t.TaskRun != nil || len(t.TaskRuns) > 0 {
+		if len(t.RunObjects) > 0 || len(t.TaskRuns) > 0 {
 			return false
 		}
 	}
@@ -132,28 +130,15 @@ func (state PipelineRunState) IsBeforeFirstTaskRun() bool {
 func (state PipelineRunState) AdjustStartTime(unadjustedStartTime *metav1.Time) *metav1.Time {
 	adjustedStartTime := unadjustedStartTime
 	for _, rpt := range state {
-		switch {
-		case len(rpt.RunObjects) > 0:
-			for _, runObject := range rpt.RunObjects {
-				creationTime := runObject.GetObjectMeta().GetCreationTimestamp()
-				if creationTime.Time.Before(adjustedStartTime.Time) {
-					adjustedStartTime = &creationTime
-				}
-			}
-		case rpt.RunObject != nil:
-			creationTime := rpt.RunObject.GetObjectMeta().GetCreationTimestamp()
+		for _, runObject := range rpt.RunObjects {
+			creationTime := runObject.GetObjectMeta().GetCreationTimestamp()
 			if creationTime.Time.Before(adjustedStartTime.Time) {
 				adjustedStartTime = &creationTime
 			}
-		case len(rpt.TaskRuns) > 0:
-			for _, taskRun := range rpt.TaskRuns {
-				if taskRun.CreationTimestamp.Time.Before(adjustedStartTime.Time) {
-					adjustedStartTime = &taskRun.CreationTimestamp
-				}
-			}
-		case rpt.TaskRun != nil:
-			if rpt.TaskRun.CreationTimestamp.Time.Before(adjustedStartTime.Time) {
-				adjustedStartTime = &rpt.TaskRun.CreationTimestamp
+		}
+		for _, taskRun := range rpt.TaskRuns {
+			if taskRun.CreationTimestamp.Time.Before(adjustedStartTime.Time) {
+				adjustedStartTime = &taskRun.CreationTimestamp
 			}
 		}
 	}
@@ -171,8 +156,9 @@ func (state PipelineRunState) GetTaskRunsResults() map[string][]v1beta1.TaskRunR
 		if !rpt.isSuccessful() {
 			continue
 		}
-		if rpt.TaskRun != nil {
-			results[rpt.PipelineTask.Name] = rpt.TaskRun.Status.TaskRunResults
+		// Currently a Matrix cannot produce results so this is for a singular TaskRun
+		if len(rpt.TaskRuns) == 1 {
+			results[rpt.PipelineTask.Name] = rpt.TaskRuns[0].Status.TaskRunResults
 		}
 	}
 	return results
@@ -189,8 +175,9 @@ func (state PipelineRunState) GetRunsResults() map[string][]v1beta1.CustomRunRes
 		if !rpt.isSuccessful() {
 			continue
 		}
-		if rpt.RunObject != nil {
-			cr := rpt.RunObject.(*v1beta1.CustomRun)
+		// Currently a Matrix cannot produce results so this is for a singular CustomRun
+		if len(rpt.RunObjects) == 1 {
+			cr := rpt.RunObjects[0].(*v1beta1.CustomRun)
 			results[rpt.PipelineTask.Name] = cr.Status.Results
 		}
 	}
@@ -205,10 +192,6 @@ func (state PipelineRunState) GetChildReferences() []v1beta1.ChildStatusReferenc
 
 	for _, rpt := range state {
 		switch {
-		case rpt.RunObject != nil:
-			childRefs = append(childRefs, rpt.getChildRefForRun(rpt.RunObject))
-		case rpt.TaskRun != nil:
-			childRefs = append(childRefs, rpt.getChildRefForTaskRun(rpt.TaskRun))
 		case len(rpt.TaskRuns) != 0:
 			for _, taskRun := range rpt.TaskRuns {
 				if taskRun != nil {
@@ -257,7 +240,7 @@ func (state PipelineRunState) getNextTasks(candidateTasks sets.String) []*Resolv
 	tasks := []*ResolvedPipelineTask{}
 	for _, t := range state {
 		if _, ok := candidateTasks[t.PipelineTask.Name]; ok {
-			if t.TaskRun == nil && t.RunObject == nil && len(t.TaskRuns) == 0 && len(t.RunObjects) == 0 {
+			if len(t.TaskRuns) == 0 && len(t.RunObjects) == 0 {
 				tasks = append(tasks, t)
 			}
 		}
@@ -514,7 +497,7 @@ func (facts *PipelineRunFacts) GetPipelineTaskStatus() map[string]string {
 		for _, t := range facts.State {
 			if facts.isDAGTask(t.PipelineTask.Name) {
 				// if any of the dag task failed, change the aggregate status to failed and return
-				if t.isConditionStatusFalse() {
+				if !t.IsCustomTask() && t.areTaskRunsConditionStatusFalse() || t.IsCustomTask() && t.areRunObjectsConditionStatusFalse() {
 					aggregateStatus = v1beta1.PipelineRunReasonFailed.String()
 					break
 				}

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
@@ -46,8 +46,8 @@ var testClock = clock.NewFakePassiveClock(now)
 func TestPipelineRunFacts_CheckDAGTasksDoneDone(t *testing.T) {
 	var taskCancelledByStatusState = PipelineRunState{{
 		PipelineTask: &pts[4], // 2 retries needed
-		TaskRunName:  "pipelinerun-mytask1",
-		TaskRun:      withCancelled(makeRetried(trs[0])),
+		TaskRunNames: []string{"pipelinerun-mytask1"},
+		TaskRuns:     []*v1beta1.TaskRun{withCancelled(makeRetried(trs[0]))},
 		ResolvedTask: &resources.ResolvedTask{
 			TaskSpec: &task.Spec,
 		},
@@ -55,8 +55,8 @@ func TestPipelineRunFacts_CheckDAGTasksDoneDone(t *testing.T) {
 
 	var taskCancelledBySpecState = PipelineRunState{{
 		PipelineTask: &pts[4],
-		TaskRunName:  "pipelinerun-mytask1",
-		TaskRun:      withCancelledBySpec(makeRetried(trs[0])),
+		TaskRunNames: []string{"pipelinerun-mytask1"},
+		TaskRuns:     []*v1beta1.TaskRun{withCancelledBySpec(makeRetried(trs[0]))},
 		ResolvedTask: &resources.ResolvedTask{
 			TaskSpec: &task.Spec,
 		},
@@ -64,8 +64,8 @@ func TestPipelineRunFacts_CheckDAGTasksDoneDone(t *testing.T) {
 
 	var taskRunningState = PipelineRunState{{
 		PipelineTask: &pts[4],
-		TaskRunName:  "pipelinerun-mytask1",
-		TaskRun:      makeStarted(trs[0]),
+		TaskRunNames: []string{"pipelinerun-mytask1"},
+		TaskRuns:     []*v1beta1.TaskRun{makeStarted(trs[0])},
 		ResolvedTask: &resources.ResolvedTask{
 			TaskSpec: &task.Spec,
 		},
@@ -73,8 +73,8 @@ func TestPipelineRunFacts_CheckDAGTasksDoneDone(t *testing.T) {
 
 	var taskSucceededState = PipelineRunState{{
 		PipelineTask: &pts[4],
-		TaskRunName:  "pipelinerun-mytask1",
-		TaskRun:      makeSucceeded(trs[0]),
+		TaskRunNames: []string{"pipelinerun-mytask1"},
+		TaskRuns:     []*v1beta1.TaskRun{makeSucceeded(trs[0])},
 		ResolvedTask: &resources.ResolvedTask{
 			TaskSpec: &task.Spec,
 		},
@@ -82,8 +82,8 @@ func TestPipelineRunFacts_CheckDAGTasksDoneDone(t *testing.T) {
 
 	var taskRetriedState = PipelineRunState{{
 		PipelineTask: &pts[3], // 1 retry needed
-		TaskRunName:  "pipelinerun-mytask1",
-		TaskRun:      withCancelled(makeRetried(trs[0])),
+		TaskRunNames: []string{"pipelinerun-mytask1"},
+		TaskRuns:     []*v1beta1.TaskRun{withCancelled(makeRetried(trs[0]))},
 		ResolvedTask: &resources.ResolvedTask{
 			TaskSpec: &task.Spec,
 		},
@@ -91,8 +91,8 @@ func TestPipelineRunFacts_CheckDAGTasksDoneDone(t *testing.T) {
 
 	var taskExpectedState = PipelineRunState{{
 		PipelineTask: &pts[4], // 2 retries needed
-		TaskRunName:  "pipelinerun-mytask1",
-		TaskRun:      withRetries(makeToBeRetried(trs[0])),
+		TaskRunNames: []string{"pipelinerun-mytask1"},
+		TaskRuns:     []*v1beta1.TaskRun{withRetries(makeToBeRetried(trs[0]))},
 		ResolvedTask: &resources.ResolvedTask{
 			TaskSpec: &task.Spec,
 		},
@@ -100,38 +100,38 @@ func TestPipelineRunFacts_CheckDAGTasksDoneDone(t *testing.T) {
 
 	var noTaskRunState = PipelineRunState{{
 		PipelineTask: &pts[4], // 2 retries needed
-		TaskRunName:  "pipelinerun-mytask1",
-		TaskRun:      nil,
+		TaskRunNames: []string{"pipelinerun-mytask1"},
+		TaskRuns:     nil,
 		ResolvedTask: &resources.ResolvedTask{
 			TaskSpec: &task.Spec,
 		},
 	}}
 
 	var customRunRunningState = PipelineRunState{{
-		PipelineTask:  &pts[12],
-		CustomTask:    true,
-		RunObjectName: "pipelinerun-mytask13",
-		RunObject:     makeCustomRunStarted(customRuns[0]),
+		PipelineTask:   &pts[12],
+		CustomTask:     true,
+		RunObjectNames: []string{"pipelinerun-mytask13"},
+		RunObjects:     []v1beta1.RunObject{makeCustomRunStarted(customRuns[0])},
 	}}
 
 	var customRunSucceededState = PipelineRunState{{
-		PipelineTask:  &pts[12],
-		CustomTask:    true,
-		RunObjectName: "pipelinerun-mytask13",
-		RunObject:     makeCustomRunSucceeded(customRuns[0]),
+		PipelineTask:   &pts[12],
+		CustomTask:     true,
+		RunObjectNames: []string{"pipelinerun-mytask13"},
+		RunObjects:     []v1beta1.RunObject{makeCustomRunSucceeded(customRuns[0])},
 	}}
 
 	var customRunFailedState = PipelineRunState{{
-		PipelineTask:  &pts[12],
-		CustomTask:    true,
-		RunObjectName: "pipelinerun-mytask13",
-		RunObject:     makeCustomRunFailed(customRuns[0]),
+		PipelineTask:   &pts[12],
+		CustomTask:     true,
+		RunObjectNames: []string{"pipelinerun-mytask13"},
+		RunObjects:     []v1beta1.RunObject{makeCustomRunFailed(customRuns[0])},
 	}}
 
 	var taskCancelledFailedWithRetries = PipelineRunState{{
 		PipelineTask: &pts[4], // 2 retries needed
-		TaskRunName:  "pipelinerun-mytask1",
-		TaskRun:      withCancelled(makeFailed(trs[0])),
+		TaskRunNames: []string{"pipelinerun-mytask1"},
+		TaskRuns:     []*v1beta1.TaskRun{withCancelled(makeFailed(trs[0]))},
 		ResolvedTask: &resources.ResolvedTask{
 			TaskSpec: &task.Spec,
 		},
@@ -240,6 +240,12 @@ func TestIsBeforeFirstTaskRun_WithNotStartedRun(t *testing.T) {
 	}
 }
 
+func TestIsBeforeFirstTaskRun_WithNotStartedMatrixedTask(t *testing.T) {
+	if !noneStartedStateMatrix.IsBeforeFirstTaskRun() {
+		t.Fatalf("Expected state to be before first taskrun")
+	}
+}
+
 func TestIsBeforeFirstTaskRun_WithStartedTask(t *testing.T) {
 	if oneStartedState.IsBeforeFirstTaskRun() {
 		t.Fatalf("Expected state to be after first taskrun")
@@ -251,8 +257,26 @@ func TestIsBeforeFirstTaskRun_WithStartedRun(t *testing.T) {
 		t.Fatalf("Expected state to be after first taskrun (Run test)")
 	}
 }
+
+func TestIsBeforeFirstTaskRun_WithStartedMatrixedTask(t *testing.T) {
+	if oneStartedStateMatrix.IsBeforeFirstTaskRun() {
+		t.Fatalf("Expected state to be after first taskrun")
+	}
+}
+
+func TestIsBeforeFirstTaskRun_WithStartedMatrixedCustomTask(t *testing.T) {
+	if oneCustomRunStartedStateMatrix.IsBeforeFirstTaskRun() {
+		t.Fatalf("Expected state to be after first customrun")
+	}
+}
 func TestIsBeforeFirstTaskRun_WithSucceededTask(t *testing.T) {
 	if finalScheduledState.IsBeforeFirstTaskRun() {
+		t.Fatalf("Expected state to be after first taskrun")
+	}
+}
+
+func TestIsBeforeFirstTaskRun_WithSucceededMatrixedTask(t *testing.T) {
+	if finalScheduledStateMatrix.IsBeforeFirstTaskRun() {
 		t.Fatalf("Expected state to be after first taskrun")
 	}
 }
@@ -557,8 +581,8 @@ func TestGetNextTasks(t *testing.T) {
 func TestGetNextTaskWithRetries(t *testing.T) {
 	var taskCancelledByStatusState = PipelineRunState{{
 		PipelineTask: &pts[4], // 2 retries needed
-		TaskRunName:  "pipelinerun-mytask1",
-		TaskRun:      withCancelled(makeRetried(trs[0])),
+		TaskRunNames: []string{"pipelinerun-mytask1"},
+		TaskRuns:     []*v1beta1.TaskRun{withCancelled(makeRetried(trs[0]))},
 		ResolvedTask: &resources.ResolvedTask{
 			TaskSpec: &task.Spec,
 		},
@@ -566,8 +590,8 @@ func TestGetNextTaskWithRetries(t *testing.T) {
 
 	var taskCancelledBySpecState = PipelineRunState{{
 		PipelineTask: &pts[4],
-		TaskRunName:  "pipelinerun-mytask1",
-		TaskRun:      withCancelledBySpec(makeRetried(trs[0])),
+		TaskRunNames: []string{"pipelinerun-mytask1"},
+		TaskRuns:     []*v1beta1.TaskRun{withCancelledBySpec(makeRetried(trs[0]))},
 		ResolvedTask: &resources.ResolvedTask{
 			TaskSpec: &task.Spec,
 		},
@@ -575,8 +599,8 @@ func TestGetNextTaskWithRetries(t *testing.T) {
 
 	var taskRunningState = PipelineRunState{{
 		PipelineTask: &pts[4],
-		TaskRunName:  "pipelinerun-mytask1",
-		TaskRun:      makeStarted(trs[0]),
+		TaskRunNames: []string{"pipelinerun-mytask1"},
+		TaskRuns:     []*v1beta1.TaskRun{makeStarted(trs[0])},
 		ResolvedTask: &resources.ResolvedTask{
 			TaskSpec: &task.Spec,
 		},
@@ -584,8 +608,8 @@ func TestGetNextTaskWithRetries(t *testing.T) {
 
 	var taskSucceededState = PipelineRunState{{
 		PipelineTask: &pts[4],
-		TaskRunName:  "pipelinerun-mytask1",
-		TaskRun:      makeSucceeded(trs[0]),
+		TaskRunNames: []string{"pipelinerun-mytask1"},
+		TaskRuns:     []*v1beta1.TaskRun{makeSucceeded(trs[0])},
 		ResolvedTask: &resources.ResolvedTask{
 			TaskSpec: &task.Spec,
 		},
@@ -593,48 +617,48 @@ func TestGetNextTaskWithRetries(t *testing.T) {
 
 	var taskRetriedState = PipelineRunState{{
 		PipelineTask: &pts[3], // 1 retry needed
-		TaskRunName:  "pipelinerun-mytask1",
-		TaskRun:      withCancelled(makeRetried(trs[0])),
+		TaskRunNames: []string{"pipelinerun-mytask1"},
+		TaskRuns:     []*v1beta1.TaskRun{withCancelled(makeRetried(trs[0]))},
 		ResolvedTask: &resources.ResolvedTask{
 			TaskSpec: &task.Spec,
 		},
 	}}
 
 	var customRunCancelledByStatusState = PipelineRunState{{
-		PipelineTask:  &pts[4], // 2 retries needed
-		RunObjectName: "pipelinerun-mytask1",
-		RunObject:     withCustomRunCancelled(withCustomRunRetries(newCustomRun(customRuns[0]))),
-		CustomTask:    true,
+		PipelineTask:   &pts[4], // 2 retries needed
+		RunObjectNames: []string{"pipelinerun-mytask1"},
+		RunObjects:     []v1beta1.RunObject{withCustomRunCancelled(withCustomRunRetries(newCustomRun(customRuns[0])))},
+		CustomTask:     true,
 		ResolvedTask: &resources.ResolvedTask{
 			TaskSpec: &task.Spec,
 		},
 	}}
 
 	var customRunCancelledBySpecState = PipelineRunState{{
-		PipelineTask:  &pts[4],
-		RunObjectName: "pipelinerun-mytask1",
-		RunObject:     withCustomRunCancelledBySpec(withCustomRunRetries(newCustomRun(customRuns[0]))),
-		CustomTask:    true,
+		PipelineTask:   &pts[4],
+		RunObjectNames: []string{"pipelinerun-mytask1"},
+		RunObjects:     []v1beta1.RunObject{withCustomRunCancelledBySpec(withCustomRunRetries(newCustomRun(customRuns[0])))},
+		CustomTask:     true,
 		ResolvedTask: &resources.ResolvedTask{
 			TaskSpec: &task.Spec,
 		},
 	}}
 
 	var customRunRunningState = PipelineRunState{{
-		PipelineTask:  &pts[4],
-		RunObjectName: "pipelinerun-mytask1",
-		RunObject:     makeCustomRunStarted(customRuns[0]),
-		CustomTask:    true,
+		PipelineTask:   &pts[4],
+		RunObjectNames: []string{"pipelinerun-mytask1"},
+		RunObjects:     []v1beta1.RunObject{makeCustomRunStarted(customRuns[0])},
+		CustomTask:     true,
 		ResolvedTask: &resources.ResolvedTask{
 			TaskSpec: &task.Spec,
 		},
 	}}
 
 	var customRunSucceededState = PipelineRunState{{
-		PipelineTask:  &pts[4],
-		RunObjectName: "pipelinerun-mytask1",
-		RunObject:     makeCustomRunSucceeded(customRuns[0]),
-		CustomTask:    true,
+		PipelineTask:   &pts[4],
+		RunObjectNames: []string{"pipelinerun-mytask1"},
+		RunObjects:     []v1beta1.RunObject{makeCustomRunSucceeded(customRuns[0])},
+		CustomTask:     true,
 		ResolvedTask: &resources.ResolvedTask{
 			TaskSpec: &task.Spec,
 		},
@@ -858,7 +882,7 @@ func TestDAGExecutionQueue(t *testing.T) {
 			Name:    "createdtask",
 			TaskRef: &v1beta1.TaskRef{Name: "task"},
 		},
-		TaskRunName: "createdtask",
+		TaskRunNames: []string{"createdtask"},
 		ResolvedTask: &resources.ResolvedTask{
 			TaskSpec: &task.Spec,
 		},
@@ -868,16 +892,16 @@ func TestDAGExecutionQueue(t *testing.T) {
 			Name:    "createdrun",
 			TaskRef: &v1beta1.TaskRef{Name: "task"},
 		},
-		RunObjectName: "createdrun",
-		CustomTask:    true,
+		RunObjectNames: []string{"createdrun"},
+		CustomTask:     true,
 	}
 	runningTask := ResolvedPipelineTask{
 		PipelineTask: &v1beta1.PipelineTask{
 			Name:    "runningtask",
 			TaskRef: &v1beta1.TaskRef{Name: "task"},
 		},
-		TaskRunName: "runningtask",
-		TaskRun:     newTaskRun(trs[0]),
+		TaskRunNames: []string{"runningtask"},
+		TaskRuns:     []*v1beta1.TaskRun{newTaskRun(trs[0])},
 		ResolvedTask: &resources.ResolvedTask{
 			TaskSpec: &task.Spec,
 		},
@@ -887,17 +911,17 @@ func TestDAGExecutionQueue(t *testing.T) {
 			Name:    "runningrun",
 			TaskRef: &v1beta1.TaskRef{Name: "task"},
 		},
-		RunObjectName: "runningrun",
-		RunObject:     newCustomRun(customRuns[0]),
-		CustomTask:    true,
+		RunObjectNames: []string{"runningrun"},
+		RunObjects:     []v1beta1.RunObject{newCustomRun(customRuns[0])},
+		CustomTask:     true,
 	}
 	successfulTask := ResolvedPipelineTask{
 		PipelineTask: &v1beta1.PipelineTask{
 			Name:    "successfultask",
 			TaskRef: &v1beta1.TaskRef{Name: "task"},
 		},
-		TaskRunName: "successfultask",
-		TaskRun:     makeSucceeded(trs[0]),
+		TaskRunNames: []string{"successfultask"},
+		TaskRuns:     []*v1beta1.TaskRun{makeSucceeded(trs[0])},
 		ResolvedTask: &resources.ResolvedTask{
 			TaskSpec: &task.Spec,
 		},
@@ -907,17 +931,17 @@ func TestDAGExecutionQueue(t *testing.T) {
 			Name:    "successfulrun",
 			TaskRef: &v1beta1.TaskRef{Name: "task"},
 		},
-		RunObjectName: "successfulrun",
-		RunObject:     makeCustomRunSucceeded(customRuns[0]),
-		CustomTask:    true,
+		RunObjectNames: []string{"successfulrun"},
+		RunObjects:     []v1beta1.RunObject{makeCustomRunSucceeded(customRuns[0])},
+		CustomTask:     true,
 	}
 	failedTask := ResolvedPipelineTask{
 		PipelineTask: &v1beta1.PipelineTask{
 			Name:    "failedtask",
 			TaskRef: &v1beta1.TaskRef{Name: "task"},
 		},
-		TaskRunName: "failedtask",
-		TaskRun:     makeFailed(trs[0]),
+		TaskRunNames: []string{"failedtask"},
+		TaskRuns:     []*v1beta1.TaskRun{makeFailed(trs[0])},
 		ResolvedTask: &resources.ResolvedTask{
 			TaskSpec: &task.Spec,
 		},
@@ -927,9 +951,9 @@ func TestDAGExecutionQueue(t *testing.T) {
 			Name:    "failedrun",
 			TaskRef: &v1beta1.TaskRef{Name: "task"},
 		},
-		RunObjectName: "failedrun",
-		RunObject:     makeCustomRunFailed(customRuns[0]),
-		CustomTask:    true,
+		RunObjectNames: []string{"failedrun"},
+		RunObjects:     []v1beta1.RunObject{makeCustomRunFailed(customRuns[0])},
+		CustomTask:     true,
 	}
 	tcs := []struct {
 		name       string
@@ -1042,7 +1066,7 @@ func TestDAGExecutionQueueSequentialTasks(t *testing.T) {
 					Name:    "task-1",
 					TaskRef: &v1beta1.TaskRef{Name: "task"},
 				},
-				TaskRunName: "task-1",
+				TaskRunNames: []string{"task-1"},
 				ResolvedTask: &resources.ResolvedTask{
 					TaskSpec: &task.Spec,
 				},
@@ -1053,13 +1077,17 @@ func TestDAGExecutionQueueSequentialTasks(t *testing.T) {
 					TaskRef:  &v1beta1.TaskRef{Name: "task"},
 					RunAfter: []string{"task-1"},
 				},
-				TaskRunName: "task-2",
+				TaskRunNames: []string{"task-2"},
 				ResolvedTask: &resources.ResolvedTask{
 					TaskSpec: &task.Spec,
 				},
 			}
-			firstTask.TaskRun = tc.firstTaskRun
-			secondTask.TaskRun = tc.secondTaskRun
+			if tc.firstTaskRun != nil {
+				firstTask.TaskRuns = append(firstTask.TaskRuns, tc.firstTaskRun)
+			}
+			if tc.secondTaskRun != nil {
+				secondTask.TaskRuns = append(secondTask.TaskRuns, tc.secondTaskRun)
+			}
 			state := PipelineRunState{&firstTask, &secondTask}
 			d, err := dagFromState(state)
 			if err != nil {
@@ -1079,10 +1107,10 @@ func TestDAGExecutionQueueSequentialTasks(t *testing.T) {
 				t.Errorf("unexpected error getting DAG execution queue but got error %s", err)
 			}
 			var expectedQueue PipelineRunState
-			if tc.wantFirst {
+			if tc.wantFirst && &firstTask != nil {
 				expectedQueue = append(expectedQueue, &firstTask)
 			}
-			if tc.wantSecond {
+			if tc.wantSecond && &secondTask != nil {
 				expectedQueue = append(expectedQueue, &secondTask)
 			}
 			if d := cmp.Diff(expectedQueue, queue, cmpopts.EquateEmpty()); d != "" {
@@ -1135,8 +1163,8 @@ func TestDAGExecutionQueueSequentialRuns(t *testing.T) {
 					Name:    "task-1",
 					TaskRef: &v1beta1.TaskRef{Name: "task"},
 				},
-				RunObjectName: "task-1",
-				CustomTask:    true,
+				RunObjectNames: []string{"task-1"},
+				CustomTask:     true,
 			}
 			secondRun := ResolvedPipelineTask{
 				PipelineTask: &v1beta1.PipelineTask{
@@ -1144,14 +1172,14 @@ func TestDAGExecutionQueueSequentialRuns(t *testing.T) {
 					TaskRef:  &v1beta1.TaskRef{Name: "task"},
 					RunAfter: []string{"task-1"},
 				},
-				RunObjectName: "task-2",
-				CustomTask:    true,
+				RunObjectNames: []string{"task-2"},
+				CustomTask:     true,
 			}
 			if tc.firstRun != nil {
-				firstRun.RunObject = tc.firstRun
+				firstRun.RunObjects = append(firstRun.RunObjects, tc.firstRun)
 			}
 			if tc.secondRun != nil {
-				secondRun.RunObject = tc.secondRun
+				secondRun.RunObjects = append(secondRun.RunObjects, tc.secondRun)
 			}
 			state := PipelineRunState{&firstRun, &secondRun}
 			d, err := dagFromState(state)
@@ -1293,7 +1321,7 @@ func buildPipelineStateWithLargeDependencyGraph(t *testing.T) PipelineRunState {
 			Name:    "t1",
 			TaskRef: &v1beta1.TaskRef{Name: "task"},
 		},
-		TaskRun: nil,
+		TaskRuns: nil,
 		ResolvedTask: &resources.ResolvedTask{
 			TaskSpec: &task.Spec,
 		},
@@ -1324,7 +1352,7 @@ func buildPipelineStateWithLargeDependencyGraph(t *testing.T) PipelineRunState {
 				Params:  params,
 				TaskRef: &v1beta1.TaskRef{Name: "task"},
 			},
-			TaskRun: nil,
+			TaskRuns: nil,
 			ResolvedTask: &resources.ResolvedTask{
 				TaskSpec: &task.Spec,
 			},
@@ -1352,7 +1380,7 @@ func buildPipelineStateWithMultipleTaskResults(t *testing.T, includeWhen bool) P
 			Name:    "t1",
 			TaskRef: &v1beta1.TaskRef{Name: "task"},
 		},
-		TaskRun: nil,
+		TaskRuns: nil,
 		ResolvedTask: &resources.ResolvedTask{
 			TaskSpec: &task.Spec,
 		},
@@ -1392,7 +1420,7 @@ func buildPipelineStateWithMultipleTaskResults(t *testing.T, includeWhen bool) P
 				TaskRef:         &v1beta1.TaskRef{Name: "task"},
 				WhenExpressions: whenExpressions,
 			},
-			TaskRun: nil,
+			TaskRuns: nil,
 			ResolvedTask: &resources.ResolvedTask{
 				TaskSpec: &task.Spec,
 			},
@@ -1519,8 +1547,8 @@ func TestPipelineRunState_GetFinalTasksAndNames(t *testing.T) {
 func TestGetPipelineConditionStatus(t *testing.T) {
 	var taskRetriedState = PipelineRunState{{
 		PipelineTask: &pts[3], // 1 retry needed
-		TaskRunName:  "pipelinerun-mytask1",
-		TaskRun:      withCancelled(makeRetried(trs[0])),
+		TaskRunNames: []string{"pipelinerun-mytask1"},
+		TaskRuns:     []*v1beta1.TaskRun{withCancelled(makeRetried(trs[0]))},
 		ResolvedTask: &resources.ResolvedTask{
 			TaskSpec: &task.Spec,
 		},
@@ -1528,20 +1556,20 @@ func TestGetPipelineConditionStatus(t *testing.T) {
 
 	var taskCancelledFailed = PipelineRunState{{
 		PipelineTask: &pts[4],
-		TaskRunName:  "pipelinerun-mytask1",
-		TaskRun:      withCancelled(makeFailed(trs[0])),
+		TaskRunNames: []string{"pipelinerun-mytask1"},
+		TaskRuns:     []*v1beta1.TaskRun{withCancelled(makeFailed(trs[0]))},
 	}}
 
 	var taskCancelledFailedTimedOut = PipelineRunState{{
 		PipelineTask: &pts[4],
-		TaskRunName:  "pipelinerun-mytask1",
-		TaskRun:      withCancelledForTimeout(makeFailed(trs[0])),
+		TaskRunNames: []string{"pipelinerun-mytask1"},
+		TaskRuns:     []*v1beta1.TaskRun{withCancelledForTimeout(makeFailed(trs[0]))},
 	}}
 
 	var cancelledTask = PipelineRunState{{
 		PipelineTask: &pts[3], // 1 retry needed
-		TaskRunName:  "pipelinerun-mytask1",
-		TaskRun: &v1beta1.TaskRun{
+		TaskRunNames: []string{"pipelinerun-mytask1"},
+		TaskRuns: []*v1beta1.TaskRun{{
 			Status: v1beta1.TaskRunStatus{
 				Status: duckv1.Status{Conditions: []apis.Condition{{
 					Type:   apis.ConditionSucceeded,
@@ -1549,49 +1577,51 @@ func TestGetPipelineConditionStatus(t *testing.T) {
 					Reason: v1beta1.TaskRunSpecStatusCancelled,
 				}}},
 			},
-		},
+		}},
 		ResolvedTask: &resources.ResolvedTask{
 			TaskSpec: &task.Spec,
 		},
 	}}
 
 	var cancelledRun = PipelineRunState{{
-		PipelineTask:  &pts[12],
-		CustomTask:    true,
-		RunObjectName: "pipelinerun-mytask13",
-		RunObject: &v1beta1.CustomRun{
-			Status: v1beta1.CustomRunStatus{
-				Status: duckv1.Status{Conditions: []apis.Condition{{
-					Type:   apis.ConditionSucceeded,
-					Status: corev1.ConditionFalse,
-					Reason: v1beta1.CustomRunReasonCancelled.String(),
-				}}},
-			},
-		},
+		PipelineTask:   &pts[12],
+		CustomTask:     true,
+		RunObjectNames: []string{"pipelinerun-mytask13"},
+		RunObjects: []v1beta1.RunObject{
+			&v1beta1.CustomRun{
+				Status: v1beta1.CustomRunStatus{
+					Status: duckv1.Status{Conditions: []apis.Condition{{
+						Type:   apis.ConditionSucceeded,
+						Status: corev1.ConditionFalse,
+						Reason: v1beta1.CustomRunReasonCancelled.String(),
+					}}},
+				},
+			}},
 	}}
 
 	var timedOutRun = PipelineRunState{{
-		PipelineTask:  &pts[12],
-		CustomTask:    true,
-		RunObjectName: "pipelinerun-mytask14",
-		RunObject: &v1beta1.CustomRun{
-			Spec: v1beta1.CustomRunSpec{
-				StatusMessage: v1beta1.CustomRunCancelledByPipelineTimeoutMsg,
-			},
-			Status: v1beta1.CustomRunStatus{
-				Status: duckv1.Status{Conditions: []apis.Condition{{
-					Type:   apis.ConditionSucceeded,
-					Status: corev1.ConditionFalse,
-					Reason: v1beta1.CustomRunReasonCancelled.String(),
-				}}},
-			},
-		},
+		PipelineTask:   &pts[12],
+		CustomTask:     true,
+		RunObjectNames: []string{"pipelinerun-mytask14"},
+		RunObjects: []v1beta1.RunObject{
+			&v1beta1.CustomRun{
+				Spec: v1beta1.CustomRunSpec{
+					StatusMessage: v1beta1.CustomRunCancelledByPipelineTimeoutMsg,
+				},
+				Status: v1beta1.CustomRunStatus{
+					Status: duckv1.Status{Conditions: []apis.Condition{{
+						Type:   apis.ConditionSucceeded,
+						Status: corev1.ConditionFalse,
+						Reason: v1beta1.CustomRunReasonCancelled.String(),
+					}}},
+				},
+			}},
 	}}
 
 	var notRunningRun = PipelineRunState{{
-		PipelineTask:  &pts[12],
-		CustomTask:    true,
-		RunObjectName: "pipelinerun-mytask14",
+		PipelineTask:   &pts[12],
+		CustomTask:     true,
+		RunObjectNames: []string{"pipelinerun-mytask14"},
 	}}
 
 	// 6 Tasks, 4 that run in parallel in the beginning
@@ -1599,34 +1629,34 @@ func TestGetPipelineConditionStatus(t *testing.T) {
 	// 1 runAfter the passed one, currently running
 	// 1 runAfter the failed one, which is marked as incomplete
 	var taskMultipleFailuresSkipRunning = PipelineRunState{{
-		TaskRunName:  "task0taskrun",
+		TaskRunNames: []string{"task0taskrun"},
 		PipelineTask: &pts[5],
-		TaskRun:      makeSucceeded(trs[0]),
+		TaskRuns:     []*v1beta1.TaskRun{makeSucceeded(trs[0])},
 	}, {
-		TaskRunName:  "runningTaskRun", // this is running
+		TaskRunNames: []string{"runningTaskRun"}, // this is running
 		PipelineTask: &pts[6],
-		TaskRun:      makeStarted(trs[1]),
+		TaskRuns:     []*v1beta1.TaskRun{makeStarted(trs[1])},
 	}, {
-		TaskRunName:  "failedTaskRun", // this failed
+		TaskRunNames: []string{"failedTaskRun"}, // this failed
 		PipelineTask: &pts[0],
-		TaskRun:      makeFailed(trs[0]),
+		TaskRuns:     []*v1beta1.TaskRun{makeFailed(trs[0])},
 	}}
 
 	var taskMultipleFailuresOneCancel = taskMultipleFailuresSkipRunning
 	taskMultipleFailuresOneCancel = append(taskMultipleFailuresOneCancel, cancelledTask[0])
 
 	var taskNotRunningWithSuccesfulParentsOneFailed = PipelineRunState{{
-		TaskRunName:  "task0taskrun",
+		TaskRunNames: []string{"task0taskrun"},
 		PipelineTask: &pts[5],
-		TaskRun:      makeSucceeded(trs[0]),
+		TaskRuns:     []*v1beta1.TaskRun{makeSucceeded(trs[0])},
 	}, {
-		TaskRunName:  "notRunningTaskRun", // runAfter pts[5], not started yet
+		TaskRunNames: []string{"notRunningTaskRun"}, // runAfter pts[5], not started yet
 		PipelineTask: &pts[6],
-		TaskRun:      nil,
+		TaskRuns:     nil,
 	}, {
-		TaskRunName:  "failedTaskRun", // this failed
+		TaskRunNames: []string{"failedTaskRun"}, // this failed
 		PipelineTask: &pts[0],
-		TaskRun:      makeFailed(trs[0]),
+		TaskRuns:     []*v1beta1.TaskRun{makeFailed(trs[0])},
 	}}
 
 	tenMinutesAgo := now.Add(-10 * time.Minute)
@@ -1832,42 +1862,42 @@ func TestGetPipelineConditionStatus(t *testing.T) {
 func TestGetPipelineConditionStatus_WithFinalTasks(t *testing.T) {
 	// pipeline state with one DAG successful, one final task failed
 	dagSucceededFinalFailed := PipelineRunState{{
-		TaskRunName:  "task0taskrun",
+		TaskRunNames: []string{"task0taskrun"},
 		PipelineTask: &pts[0],
-		TaskRun:      makeSucceeded(trs[0]),
+		TaskRuns:     []*v1beta1.TaskRun{makeSucceeded(trs[0])},
 	}, {
-		TaskRunName:  "failedTaskRun",
+		TaskRunNames: []string{"failedTaskRun"},
 		PipelineTask: &pts[1],
-		TaskRun:      makeFailed(trs[0]),
+		TaskRuns:     []*v1beta1.TaskRun{makeFailed(trs[0])},
 	}}
 
 	// pipeline state with one DAG failed, no final started
 	dagFailedFinalNotStarted := PipelineRunState{{
-		TaskRunName:  "task0taskrun",
+		TaskRunNames: []string{"task0taskrun"},
 		PipelineTask: &pts[0],
-		TaskRun:      makeFailed(trs[0]),
+		TaskRuns:     []*v1beta1.TaskRun{makeFailed(trs[0])},
 	}, {
-		TaskRunName:  "notRunningTaskRun",
+		TaskRunNames: []string{"notRunningTaskRun"},
 		PipelineTask: &pts[1],
-		TaskRun:      nil,
+		TaskRuns:     nil,
 	}}
 
 	// pipeline state with one DAG failed, one final task failed
 	dagFailedFinalFailed := PipelineRunState{{
-		TaskRunName:  "task0taskrun",
+		TaskRunNames: []string{"task0taskrun"},
 		PipelineTask: &pts[0],
-		TaskRun:      makeFailed(trs[0]),
+		TaskRuns:     []*v1beta1.TaskRun{makeFailed(trs[0])},
 	}, {
-		TaskRunName:  "failedTaskRun",
+		TaskRunNames: []string{"failedTaskRun"},
 		PipelineTask: &pts[1],
-		TaskRun:      makeFailed(trs[0]),
+		TaskRuns:     []*v1beta1.TaskRun{makeFailed(trs[0])},
 	}}
 
 	// pipeline state with one DAG failed, one final task skipped
 	dagFailedFinalSkipped := PipelineRunState{{
-		TaskRunName:  "task0taskrun",
+		TaskRunNames: []string{"task0taskrun"},
 		PipelineTask: &pts[0],
-		TaskRun:      makeFailed(trs[0]),
+		TaskRuns:     []*v1beta1.TaskRun{makeFailed(trs[0])},
 	}, {
 		PipelineTask: &pts[14],
 	}}
@@ -2047,63 +2077,63 @@ func TestAdjustStartTime(t *testing.T) {
 	}{{
 		name: "same times",
 		prs: PipelineRunState{{
-			TaskRun: &v1beta1.TaskRun{
+			TaskRuns: []*v1beta1.TaskRun{{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "blah",
 					CreationTimestamp: baseline,
 				},
-			},
+			}},
 		}},
 		want: baseline.Time,
 	}, {
 		name: "taskrun starts later",
 		prs: PipelineRunState{{
-			TaskRun: &v1beta1.TaskRun{
+			TaskRuns: []*v1beta1.TaskRun{{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "blah",
 					CreationTimestamp: metav1.Time{Time: baseline.Time.Add(1 * time.Second)},
 				},
-			},
+			}},
 		}},
 		// Stay where you are, you are before the TaskRun.
 		want: baseline.Time,
 	}, {
 		name: "taskrun starts earlier",
 		prs: PipelineRunState{{
-			TaskRun: &v1beta1.TaskRun{
+			TaskRuns: []*v1beta1.TaskRun{{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "blah",
 					CreationTimestamp: metav1.Time{Time: baseline.Time.Add(-1 * time.Second)},
 				},
-			},
+			}},
 		}},
 		// We expect this to adjust to the earlier time.
 		want: baseline.Time.Add(-1 * time.Second),
 	}, {
 		name: "multiple taskruns, some earlier",
 		prs: PipelineRunState{{
-			TaskRun: &v1beta1.TaskRun{
+			TaskRuns: []*v1beta1.TaskRun{{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "blah1",
 					CreationTimestamp: metav1.Time{Time: baseline.Time.Add(-1 * time.Second)},
 				},
-			},
+			}},
 		}, {
-			TaskRun: &v1beta1.TaskRun{
+			TaskRuns: []*v1beta1.TaskRun{{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "blah2",
 					CreationTimestamp: metav1.Time{Time: baseline.Time.Add(-2 * time.Second)},
 				},
-			},
+			}},
 		}, {
-			TaskRun: nil,
+			TaskRuns: nil,
 		}, {
-			TaskRun: &v1beta1.TaskRun{
+			TaskRuns: []*v1beta1.TaskRun{{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "blah3",
 					CreationTimestamp: metav1.Time{Time: baseline.Time.Add(2 * time.Second)},
 				},
-			},
+			}},
 		}},
 		// We expect this to adjust to the earlier time.
 		want: baseline.Time.Add(-2 * time.Second),
@@ -2155,24 +2185,26 @@ func TestAdjustStartTime(t *testing.T) {
 	}, {
 		name: "CustomRun starts later",
 		prs: PipelineRunState{{
-			RunObject: &v1beta1.CustomRun{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "blah",
-					CreationTimestamp: metav1.Time{Time: baseline.Time.Add(1 * time.Second)},
-				},
-			},
+			RunObjects: []v1beta1.RunObject{
+				&v1beta1.CustomRun{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "blah",
+						CreationTimestamp: metav1.Time{Time: baseline.Time.Add(1 * time.Second)},
+					},
+				}},
 		}},
 		// Stay where you are, you are before the Run.
 		want: baseline.Time,
 	}, {
 		name: "CustomRun starts earlier",
 		prs: PipelineRunState{{
-			RunObject: &v1beta1.CustomRun{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "blah",
-					CreationTimestamp: metav1.Time{Time: baseline.Time.Add(-1 * time.Second)},
-				},
-			},
+			RunObjects: []v1beta1.RunObject{
+				&v1beta1.CustomRun{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "blah",
+						CreationTimestamp: metav1.Time{Time: baseline.Time.Add(-1 * time.Second)},
+					},
+				}},
 		}},
 		// We expect this to adjust to the earlier time.
 		want: baseline.Time.Add(-1 * time.Second),
@@ -2243,8 +2275,8 @@ func TestPipelineRunFacts_GetPipelineTaskStatus(t *testing.T) {
 		name: "task-with-when-expressions-passed",
 		state: PipelineRunState{{
 			PipelineTask: &pts[9],
-			TaskRunName:  "pr-guard-succeeded-task-not-started",
-			TaskRun:      nil,
+			TaskRunNames: []string{"pr-guard-succeeded-task-not-started"},
+			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
 				TaskSpec: &task.Spec,
 			},
@@ -2258,7 +2290,7 @@ func TestPipelineRunFacts_GetPipelineTaskStatus(t *testing.T) {
 		name: "tasks-when-expression-failed-and-task-skipped",
 		state: PipelineRunState{{
 			PipelineTask: &pts[10],
-			TaskRunName:  "pr-guardedtask-skipped",
+			TaskRunNames: []string{"pr-guardedtask-skipped"},
 			ResolvedTask: &resources.ResolvedTask{
 				TaskSpec: &task.Spec,
 			},
@@ -2272,13 +2304,13 @@ func TestPipelineRunFacts_GetPipelineTaskStatus(t *testing.T) {
 		name: "when-expression-task-with-parent-started",
 		state: PipelineRunState{{
 			PipelineTask: &pts[0],
-			TaskRun:      makeStarted(trs[0]),
+			TaskRuns:     []*v1beta1.TaskRun{makeStarted(trs[0])},
 			ResolvedTask: &resources.ResolvedTask{
 				TaskSpec: &task.Spec,
 			},
 		}, {
 			PipelineTask: &pts[11],
-			TaskRun:      nil,
+			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
 				TaskSpec: &task.Spec,
 			},
@@ -2301,14 +2333,14 @@ func TestPipelineRunFacts_GetPipelineTaskStatus(t *testing.T) {
 		name: "one-skipped-one-failed-aggregate-status-must-be-failed",
 		state: PipelineRunState{{
 			PipelineTask: &pts[10],
-			TaskRunName:  "pr-guardedtask-skipped",
+			TaskRunNames: []string{"pr-guardedtask-skipped"},
 			ResolvedTask: &resources.ResolvedTask{
 				TaskSpec: &task.Spec,
 			},
 		}, {
 			PipelineTask: &pts[0],
-			TaskRunName:  "pipelinerun-mytask1",
-			TaskRun:      makeFailed(trs[0]),
+			TaskRunNames: []string{"pipelinerun-mytask1"},
+			TaskRuns:     []*v1beta1.TaskRun{makeFailed(trs[0])},
 			ResolvedTask: &resources.ResolvedTask{
 				TaskSpec: &task.Spec,
 			},
@@ -2353,7 +2385,7 @@ func TestPipelineRunFacts_GetSkippedTasks(t *testing.T) {
 		name: "stopping-skip-taskruns",
 		state: PipelineRunState{{
 			PipelineTask: &pts[0],
-			TaskRun:      makeFailed(trs[0]),
+			TaskRuns:     []*v1beta1.TaskRun{makeFailed(trs[0])},
 		}, {
 			PipelineTask: &pts[14],
 		}},
@@ -2365,9 +2397,9 @@ func TestPipelineRunFacts_GetSkippedTasks(t *testing.T) {
 	}, {
 		name: "missing-results-skip-finally",
 		state: PipelineRunState{{
-			TaskRunName:  "task0taskrun",
+			TaskRunNames: []string{"task0taskrun"},
 			PipelineTask: &pts[0],
-			TaskRun:      makeFailed(trs[0]),
+			TaskRuns:     []*v1beta1.TaskRun{makeFailed(trs[0])},
 		}, {
 			PipelineTask: &pts[14],
 		}},
@@ -2474,11 +2506,11 @@ func TestPipelineRunFacts_IsRunning(t *testing.T) {
 
 func TestPipelineRunState_GetResultsFuncs(t *testing.T) {
 	state := PipelineRunState{{
-		TaskRunName: "successful-task-with-results",
+		TaskRunNames: []string{"successful-task-with-results"},
 		PipelineTask: &v1beta1.PipelineTask{
 			Name: "successful-task-with-results-1",
 		},
-		TaskRun: &v1beta1.TaskRun{
+		TaskRuns: []*v1beta1.TaskRun{{
 			Status: v1beta1.TaskRunStatus{
 				Status: duckv1.Status{Conditions: []apis.Condition{{
 					Type:   apis.ConditionSucceeded,
@@ -2494,13 +2526,13 @@ func TestPipelineRunState_GetResultsFuncs(t *testing.T) {
 					}},
 				},
 			},
-		},
+		}},
 	}, {
-		TaskRunName: "successful-task-without-results",
+		TaskRunNames: []string{"successful-task-without-results"},
 		PipelineTask: &v1beta1.PipelineTask{
 			Name: "successful-task-without-results-1",
 		},
-		TaskRun: &v1beta1.TaskRun{
+		TaskRuns: []*v1beta1.TaskRun{{
 			Status: v1beta1.TaskRunStatus{
 				Status: duckv1.Status{Conditions: []apis.Condition{{
 					Type:   apis.ConditionSucceeded,
@@ -2508,13 +2540,13 @@ func TestPipelineRunState_GetResultsFuncs(t *testing.T) {
 				}}},
 				TaskRunStatusFields: v1beta1.TaskRunStatusFields{},
 			},
-		},
+		}},
 	}, {
-		TaskRunName: "failed-task",
+		TaskRunNames: []string{"failed-task"},
 		PipelineTask: &v1beta1.PipelineTask{
 			Name: "failed-task-1",
 		},
-		TaskRun: &v1beta1.TaskRun{
+		TaskRuns: []*v1beta1.TaskRun{{
 			Status: v1beta1.TaskRunStatus{
 				Status: duckv1.Status{Conditions: []apis.Condition{{
 					Type:   apis.ConditionSucceeded,
@@ -2527,13 +2559,13 @@ func TestPipelineRunState_GetResultsFuncs(t *testing.T) {
 					}},
 				},
 			},
-		},
+		}},
 	}, {
-		TaskRunName: "incomplete-task",
+		TaskRunNames: []string{"incomplete-task"},
 		PipelineTask: &v1beta1.PipelineTask{
 			Name: "incomplete-task-1",
 		},
-		TaskRun: &v1beta1.TaskRun{
+		TaskRuns: []*v1beta1.TaskRun{{
 			Status: v1beta1.TaskRunStatus{
 				Status: duckv1.Status{Conditions: []apis.Condition{{
 					Type:   apis.ConditionSucceeded,
@@ -2546,91 +2578,95 @@ func TestPipelineRunState_GetResultsFuncs(t *testing.T) {
 					}},
 				},
 			},
-		},
+		}},
 	}, {
-		TaskRunName: "nil-taskrun",
+		TaskRunNames: []string{"nil-taskrun"},
 		PipelineTask: &v1beta1.PipelineTask{
 			Name: "nil-taskrun-1",
 		},
 	}, {
-		RunObjectName: "successful-run-with-results",
-		CustomTask:    true,
+		RunObjectNames: []string{"successful-run-with-results"},
+		CustomTask:     true,
 		PipelineTask: &v1beta1.PipelineTask{
 			Name: "successful-run-with-results-1",
 		},
-		RunObject: &v1beta1.CustomRun{
-			Status: v1beta1.CustomRunStatus{
-				Status: duckv1.Status{Conditions: []apis.Condition{{
-					Type:   apis.ConditionSucceeded,
-					Status: corev1.ConditionTrue,
-				}}},
-				CustomRunStatusFields: v1beta1.CustomRunStatusFields{
-					Results: []v1beta1.CustomRunResult{{
-						Name:  "foo",
-						Value: "oof",
-					}, {
-						Name:  "bar",
-						Value: "rab",
-					}},
+		RunObjects: []v1beta1.RunObject{
+			&v1beta1.CustomRun{
+				Status: v1beta1.CustomRunStatus{
+					Status: duckv1.Status{Conditions: []apis.Condition{{
+						Type:   apis.ConditionSucceeded,
+						Status: corev1.ConditionTrue,
+					}}},
+					CustomRunStatusFields: v1beta1.CustomRunStatusFields{
+						Results: []v1beta1.CustomRunResult{{
+							Name:  "foo",
+							Value: "oof",
+						}, {
+							Name:  "bar",
+							Value: "rab",
+						}},
+					},
 				},
-			},
-		},
+			}},
 	}, {
-		RunObjectName: "successful-run-without-results",
-		CustomTask:    true,
+		RunObjectNames: []string{"successful-run-without-results"},
+		CustomTask:     true,
 		PipelineTask: &v1beta1.PipelineTask{
 			Name: "successful-run-without-results-1",
 		},
-		RunObject: &v1beta1.CustomRun{
-			Status: v1beta1.CustomRunStatus{
-				Status: duckv1.Status{Conditions: []apis.Condition{{
-					Type:   apis.ConditionSucceeded,
-					Status: corev1.ConditionTrue,
-				}}},
-				CustomRunStatusFields: v1beta1.CustomRunStatusFields{},
-			},
-		},
+		RunObjects: []v1beta1.RunObject{
+			&v1beta1.CustomRun{
+				Status: v1beta1.CustomRunStatus{
+					Status: duckv1.Status{Conditions: []apis.Condition{{
+						Type:   apis.ConditionSucceeded,
+						Status: corev1.ConditionTrue,
+					}}},
+					CustomRunStatusFields: v1beta1.CustomRunStatusFields{},
+				},
+			}},
 	}, {
-		RunObjectName: "failed-run",
+		RunObjectNames: []string{"failed-run"},
 		PipelineTask: &v1beta1.PipelineTask{
 			Name: "failed-run-1",
 		},
-		RunObject: &v1beta1.CustomRun{
-			Status: v1beta1.CustomRunStatus{
-				Status: duckv1.Status{Conditions: []apis.Condition{{
-					Type:   apis.ConditionSucceeded,
-					Status: corev1.ConditionFalse,
-				}}},
-				CustomRunStatusFields: v1beta1.CustomRunStatusFields{
-					Results: []v1beta1.CustomRunResult{{
-						Name:  "fail-foo",
-						Value: "fail-oof",
-					}},
-				},
-			},
+		RunObjects: []v1beta1.RunObject{
+			&v1beta1.CustomRun{
+				Status: v1beta1.CustomRunStatus{
+					Status: duckv1.Status{Conditions: []apis.Condition{{
+						Type:   apis.ConditionSucceeded,
+						Status: corev1.ConditionFalse,
+					}}},
+					CustomRunStatusFields: v1beta1.CustomRunStatusFields{
+						Results: []v1beta1.CustomRunResult{{
+							Name:  "fail-foo",
+							Value: "fail-oof",
+						}},
+					},
+				}},
 		},
 	}, {
-		RunObjectName: "incomplete-run",
+		RunObjectNames: []string{"incomplete-run"},
 		PipelineTask: &v1beta1.PipelineTask{
 			Name: "incomplete-run-1",
 		},
-		RunObject: &v1beta1.CustomRun{
-			Status: v1beta1.CustomRunStatus{
-				Status: duckv1.Status{Conditions: []apis.Condition{{
-					Type:   apis.ConditionSucceeded,
-					Status: corev1.ConditionUnknown,
-				}}},
-				CustomRunStatusFields: v1beta1.CustomRunStatusFields{
-					Results: []v1beta1.CustomRunResult{{
-						Name:  "unknown-foo",
-						Value: "unknown-oof",
-					}},
+		RunObjects: []v1beta1.RunObject{
+			&v1beta1.CustomRun{
+				Status: v1beta1.CustomRunStatus{
+					Status: duckv1.Status{Conditions: []apis.Condition{{
+						Type:   apis.ConditionSucceeded,
+						Status: corev1.ConditionUnknown,
+					}}},
+					CustomRunStatusFields: v1beta1.CustomRunStatusFields{
+						Results: []v1beta1.CustomRunResult{{
+							Name:  "unknown-foo",
+							Value: "unknown-oof",
+						}},
+					},
 				},
-			},
-		},
+			}},
 	}, {
-		RunObjectName: "nil-run",
-		CustomTask:    true,
+		RunObjectNames: []string{"nil-run"},
+		CustomTask:     true,
 		PipelineTask: &v1beta1.PipelineTask{
 			Name: "nil-run-1",
 		},
@@ -2843,7 +2879,7 @@ func TestPipelineRunState_GetChildReferences(t *testing.T) {
 		{
 			name: "unresolved-task",
 			state: PipelineRunState{{
-				TaskRunName: "unresolved-task-run",
+				TaskRunNames: []string{"unresolved-task-run"},
 				PipelineTask: &v1beta1.PipelineTask{
 					Name: "unresolved-task-1",
 					TaskRef: &v1beta1.TaskRef{
@@ -2858,8 +2894,8 @@ func TestPipelineRunState_GetChildReferences(t *testing.T) {
 		{
 			name: "unresolved-custom-task",
 			state: PipelineRunState{{
-				RunObjectName: "unresolved-custom-task-run",
-				CustomTask:    true,
+				RunObjectNames: []string{"unresolved-custom-task-run"},
+				CustomTask:     true,
 				PipelineTask: &v1beta1.PipelineTask{
 					Name: "unresolved-custom-task-1",
 					TaskRef: &v1beta1.TaskRef{
@@ -2874,7 +2910,7 @@ func TestPipelineRunState_GetChildReferences(t *testing.T) {
 		{
 			name: "single-task",
 			state: PipelineRunState{{
-				TaskRunName: "single-task-run",
+				TaskRunNames: []string{"single-task-run"},
 				PipelineTask: &v1beta1.PipelineTask{
 					Name: "single-task-1",
 					TaskRef: &v1beta1.TaskRef{
@@ -2888,10 +2924,10 @@ func TestPipelineRunState_GetChildReferences(t *testing.T) {
 						Values:   []string{"foo", "bar"},
 					}},
 				},
-				TaskRun: &v1beta1.TaskRun{
+				TaskRuns: []*v1beta1.TaskRun{{
 					TypeMeta:   metav1.TypeMeta{APIVersion: "tekton.dev/v1beta1"},
 					ObjectMeta: metav1.ObjectMeta{Name: "single-task-run"},
-				},
+				}},
 			}},
 			childRefs: []v1beta1.ChildStatusReference{{
 				TypeMeta: runtime.TypeMeta{
@@ -2910,8 +2946,8 @@ func TestPipelineRunState_GetChildReferences(t *testing.T) {
 		{
 			name: "single-custom-task",
 			state: PipelineRunState{{
-				RunObjectName: "single-custom-task-run",
-				CustomTask:    true,
+				RunObjectNames: []string{"single-custom-task-run"},
+				CustomTask:     true,
 				PipelineTask: &v1beta1.PipelineTask{
 					Name: "single-custom-task-1",
 					TaskRef: &v1beta1.TaskRef{
@@ -2925,10 +2961,11 @@ func TestPipelineRunState_GetChildReferences(t *testing.T) {
 						Values:   []string{"foo", "bar"},
 					}},
 				},
-				RunObject: &v1beta1.CustomRun{
-					TypeMeta:   metav1.TypeMeta{APIVersion: "tekton.dev/v1beta1"},
-					ObjectMeta: metav1.ObjectMeta{Name: "single-custom-task-run"},
-				},
+				RunObjects: []v1beta1.RunObject{
+					&v1beta1.CustomRun{
+						TypeMeta:   metav1.TypeMeta{APIVersion: "tekton.dev/v1beta1"},
+						ObjectMeta: metav1.ObjectMeta{Name: "single-custom-task-run"},
+					}},
 			}},
 			childRefs: []v1beta1.ChildStatusReference{{
 				TypeMeta: runtime.TypeMeta{
@@ -2947,7 +2984,7 @@ func TestPipelineRunState_GetChildReferences(t *testing.T) {
 		{
 			name: "task-and-custom-task",
 			state: PipelineRunState{{
-				TaskRunName: "single-task-run",
+				TaskRunNames: []string{"single-task-run"},
 				PipelineTask: &v1beta1.PipelineTask{
 					Name: "single-task-1",
 					TaskRef: &v1beta1.TaskRef{
@@ -2956,13 +2993,13 @@ func TestPipelineRunState_GetChildReferences(t *testing.T) {
 						APIVersion: "v1beta1",
 					},
 				},
-				TaskRun: &v1beta1.TaskRun{
+				TaskRuns: []*v1beta1.TaskRun{{
 					TypeMeta:   metav1.TypeMeta{APIVersion: "tekton.dev/v1beta1"},
 					ObjectMeta: metav1.ObjectMeta{Name: "single-task-run"},
-				},
+				}},
 			}, {
-				RunObjectName: "single-custom-task-run",
-				CustomTask:    true,
+				RunObjectNames: []string{"single-custom-task-run"},
+				CustomTask:     true,
 				PipelineTask: &v1beta1.PipelineTask{
 					Name: "single-custom-task-1",
 					TaskRef: &v1beta1.TaskRef{
@@ -2971,10 +3008,11 @@ func TestPipelineRunState_GetChildReferences(t *testing.T) {
 						Name:       "single-custom-task",
 					},
 				},
-				RunObject: &v1beta1.CustomRun{
-					TypeMeta:   metav1.TypeMeta{APIVersion: "tekton.dev/v1beta1"},
-					ObjectMeta: metav1.ObjectMeta{Name: "single-custom-task-run"},
-				},
+				RunObjects: []v1beta1.RunObject{
+					&v1beta1.CustomRun{
+						TypeMeta:   metav1.TypeMeta{APIVersion: "tekton.dev/v1beta1"},
+						ObjectMeta: metav1.ObjectMeta{Name: "single-custom-task-run"},
+					}},
 			}},
 			childRefs: []v1beta1.ChildStatusReference{{
 				TypeMeta: runtime.TypeMeta{
@@ -3024,7 +3062,7 @@ func TestPipelineRunState_GetChildReferences(t *testing.T) {
 		{
 			name: "matrixed-task",
 			state: PipelineRunState{{
-				TaskRunName: "matrixed-task-run-0",
+				TaskRunNames: []string{"matrixed-task-run-0"},
 				PipelineTask: &v1beta1.PipelineTask{
 					Name: "matrixed-task",
 					TaskRef: &v1beta1.TaskRef{

--- a/pkg/reconciler/pipelinerun/resources/resultrefresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/resultrefresolution_test.go
@@ -43,8 +43,8 @@ var (
 )
 
 var pipelineRunState = PipelineRunState{{
-	TaskRunName: "aTaskRun",
-	TaskRun: &v1beta1.TaskRun{
+	TaskRunNames: []string{"aTaskRun"},
+	TaskRuns: []*v1beta1.TaskRun{{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "aTaskRun",
 		},
@@ -59,7 +59,7 @@ var pipelineRunState = PipelineRunState{{
 				}},
 			},
 		},
-	},
+	}},
 	PipelineTask: &v1beta1.PipelineTask{
 		Name:    "aTask",
 		TaskRef: &v1beta1.TaskRef{Name: "aTask"},
@@ -103,22 +103,23 @@ var pipelineRunState = PipelineRunState{{
 		}},
 	},
 }, {
-	CustomTask:    true,
-	RunObjectName: "aRun",
-	RunObject: &v1beta1.CustomRun{
-		ObjectMeta: metav1.ObjectMeta{Name: "aRun"},
-		Status: v1beta1.CustomRunStatus{
-			Status: duckv1.Status{
-				Conditions: []apis.Condition{successCondition},
+	CustomTask:     true,
+	RunObjectNames: []string{"aRun"},
+	RunObjects: []v1beta1.RunObject{
+		&v1beta1.CustomRun{
+			ObjectMeta: metav1.ObjectMeta{Name: "aRun"},
+			Status: v1beta1.CustomRunStatus{
+				Status: duckv1.Status{
+					Conditions: []apis.Condition{successCondition},
+				},
+				CustomRunStatusFields: v1beta1.CustomRunStatusFields{
+					Results: []v1beta1.CustomRunResult{{
+						Name:  "aResult",
+						Value: "aResultValue",
+					}},
+				},
 			},
-			CustomRunStatusFields: v1beta1.CustomRunStatusFields{
-				Results: []v1beta1.CustomRunResult{{
-					Name:  "aResult",
-					Value: "aResultValue",
-				}},
-			},
-		},
-	},
+		}},
 	PipelineTask: &v1beta1.PipelineTask{
 		Name:    "aCustomPipelineTask",
 		TaskRef: &v1beta1.TaskRef{APIVersion: "example.dev/v0", Kind: "Example", Name: "aTask"},
@@ -133,8 +134,8 @@ var pipelineRunState = PipelineRunState{{
 		}},
 	},
 }, {
-	TaskRunName: "cTaskRun",
-	TaskRun: &v1beta1.TaskRun{
+	TaskRunNames: []string{"cTaskRun"},
+	TaskRuns: []*v1beta1.TaskRun{{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "cTaskRun",
 		},
@@ -149,7 +150,7 @@ var pipelineRunState = PipelineRunState{{
 				}},
 			},
 		},
-	},
+	}},
 	PipelineTask: &v1beta1.PipelineTask{
 		Name:    "cTask",
 		TaskRef: &v1beta1.TaskRef{Name: "cTask"},
@@ -159,8 +160,8 @@ var pipelineRunState = PipelineRunState{{
 		}},
 	},
 }, {
-	TaskRunName: "dTaskRun",
-	TaskRun: &v1beta1.TaskRun{
+	TaskRunNames: []string{"dTaskRun"},
+	TaskRuns: []*v1beta1.TaskRun{{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "dTaskRun",
 		},
@@ -175,7 +176,7 @@ var pipelineRunState = PipelineRunState{{
 				}},
 			},
 		},
-	},
+	}},
 	PipelineTask: &v1beta1.PipelineTask{
 		Name:    "dTask",
 		TaskRef: &v1beta1.TaskRef{Name: "dTask"},
@@ -185,8 +186,8 @@ var pipelineRunState = PipelineRunState{{
 		}},
 	},
 }, {
-	TaskRunName: "eTaskRun",
-	TaskRun: &v1beta1.TaskRun{
+	TaskRunNames: []string{"eTaskRun"},
+	TaskRuns: []*v1beta1.TaskRun{{
 		ObjectMeta: metav1.ObjectMeta{Name: "eTaskRun"},
 		Status: v1beta1.TaskRunStatus{
 			Status: duckv1.Status{
@@ -199,7 +200,7 @@ var pipelineRunState = PipelineRunState{{
 				}},
 			},
 		},
-	},
+	}},
 	PipelineTask: &v1beta1.PipelineTask{
 		Name:    "eTask",
 		TaskRef: &v1beta1.TaskRef{Name: "eTask"},
@@ -212,6 +213,96 @@ var pipelineRunState = PipelineRunState{{
 			Name:  "fParam",
 			Value: *v1beta1.NewStructuredValues("$(tasks.eTask.results.eResult)"),
 		}},
+	},
+}, {
+	TaskRunNames: []string{"xTaskRun"},
+	TaskRuns: []*v1beta1.TaskRun{{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "xTaskRun",
+		},
+		Status: v1beta1.TaskRunStatus{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{successCondition},
+			},
+			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+				TaskRunResults: []v1beta1.TaskRunResult{{
+					Name:  "xResult",
+					Value: *v1beta1.NewStructuredValues("arrayResultOne", "arrayResultTwo"),
+				}},
+			},
+		},
+	}, {
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "yTaskRun",
+		},
+		Status: v1beta1.TaskRunStatus{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{successCondition},
+			},
+			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+				TaskRunResults: []v1beta1.TaskRunResult{{
+					Name:  "yResult",
+					Value: *v1beta1.NewStructuredValues("arrayResultOne", "arrayResultTwo"),
+				}},
+			},
+		},
+	}},
+	PipelineTask: &v1beta1.PipelineTask{
+		Name:    "xTask",
+		TaskRef: &v1beta1.TaskRef{Name: "xTask"},
+		Matrix: &v1beta1.Matrix{
+			Params: v1beta1.Params{{
+				Name:  "xParam",
+				Value: *v1beta1.NewStructuredValues("$(tasks.xTask.results.xResult[*])"),
+			}, {
+				Name:  "yParam",
+				Value: *v1beta1.NewStructuredValues("$(tasks.yTask.results.yResult[*])"),
+			}},
+		},
+	},
+}, {
+	CustomTask:     true,
+	RunObjectNames: []string{"xRun"},
+	RunObjects: []v1beta1.RunObject{
+		&v1beta1.CustomRun{
+			ObjectMeta: metav1.ObjectMeta{Name: "xRun"},
+			Status: v1beta1.CustomRunStatus{
+				Status: duckv1.Status{
+					Conditions: []apis.Condition{successCondition},
+				},
+				CustomRunStatusFields: v1beta1.CustomRunStatusFields{
+					Results: []v1beta1.CustomRunResult{{
+						Name:  "xResult",
+						Value: "xResultValue",
+					}},
+				},
+			},
+		}, &v1beta1.CustomRun{
+			ObjectMeta: metav1.ObjectMeta{Name: "yRun"},
+			Status: v1beta1.CustomRunStatus{
+				Status: duckv1.Status{
+					Conditions: []apis.Condition{successCondition},
+				},
+				CustomRunStatusFields: v1beta1.CustomRunStatusFields{
+					Results: []v1beta1.CustomRunResult{{
+						Name:  "yResult",
+						Value: "yResultValue",
+					}},
+				},
+			},
+		}},
+	PipelineTask: &v1beta1.PipelineTask{
+		Name:    "xTask",
+		TaskRef: &v1beta1.TaskRef{Name: "xTask"},
+		Matrix: &v1beta1.Matrix{
+			Params: v1beta1.Params{{
+				Name:  "xParam",
+				Value: *v1beta1.NewStructuredValues("$(tasks.xCustomPipelineTask.results.xResult[*])"),
+			}, {
+				Name:  "yParam",
+				Value: *v1beta1.NewStructuredValues("$(tasks.yCustomPipelineTask.results.yResult[*])"),
+			}},
+		},
 	},
 }}
 
@@ -255,6 +346,15 @@ func TestResolveResultRefs(t *testing.T) {
 		}},
 		wantErr: false,
 	}, {
+		name:             "Test unsuccessful matrix array result references resolution",
+		pipelineRunState: pipelineRunState,
+		targets: PipelineRunState{
+			pipelineRunState[11],
+		},
+		want:    nil,
+		wantErr: true,
+		wantPt:  "xTask",
+	}, {
 		name:             "Test unsuccessful result references resolution - params",
 		pipelineRunState: pipelineRunState,
 		targets: PipelineRunState{
@@ -262,6 +362,15 @@ func TestResolveResultRefs(t *testing.T) {
 		},
 		want:    nil,
 		wantErr: true,
+	}, {
+		name:             "Test unsuccessful matrix array result references resolution - customrun",
+		pipelineRunState: pipelineRunState,
+		targets: PipelineRunState{
+			pipelineRunState[12],
+		},
+		want:    nil,
+		wantErr: true,
+		wantPt:  "xCustomPipelineTask",
 	}, {
 		name:             "Test successful result references resolution - when expressions",
 		pipelineRunState: pipelineRunState,

--- a/pkg/reconciler/pipelinerun/resources/validate_dependencies_test.go
+++ b/pkg/reconciler/pipelinerun/resources/validate_dependencies_test.go
@@ -96,8 +96,8 @@ func TestValidatePipelineTaskResults_ValidStates(t *testing.T) {
 			PipelineTask: &v1beta1.PipelineTask{
 				Name: "pt1",
 			},
-			CustomTask:    true,
-			RunObjectName: "foo-run",
+			CustomTask:     true,
+			RunObjectNames: []string{"foo-run"},
 		}, {
 			PipelineTask: &v1beta1.PipelineTask{
 				Name: "pt2",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Currently, PipelineRun resolution code can be difficult to understand. This commit removes some of the redundant fields in ResolvedPipelineTask including the singular version of: TaskRun, TaskRunName, ObjectRun, ObjectRunName so that only the list of TaskRuns, TaskRunNames,  ObjectRuns, ObjectRunNames can be used  regardless if the PipelineTask is matrixed or not. This also streamlines the codebase by removing the switch statements used throughout. This partially addresses Issue #6628.

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
None
```
