### PR TITLE
Clean up Task parameter validation logic

### DIFF
--- a/pkg/apis/pipeline/v1/param_types.go
+++ b/pkg/apis/pipeline/v1/param_types.go
@@ -110,6 +110,51 @@ func (pp *ParamSpec) setDefaultsForProperties() {
 	}
 }
 
+// getNames returns all the names of the declared parameters
+func (ps ParamSpecs) getNames() []string {
+	var names []string
+	for _, p := range ps {
+		names = append(names, p.Name)
+	}
+	return names
+}
+
+// sortByType splits the input params into string params, array params, and object params, in that order
+func (ps ParamSpecs) sortByType() (ParamSpecs, ParamSpecs, ParamSpecs) {
+	var stringParams, arrayParams, objectParams ParamSpecs
+	for _, p := range ps {
+		switch p.Type {
+		case ParamTypeArray:
+			arrayParams = append(arrayParams, p)
+		case ParamTypeObject:
+			objectParams = append(objectParams, p)
+		case ParamTypeString:
+			fallthrough
+		default:
+			stringParams = append(stringParams, p)
+		}
+	}
+	return stringParams, arrayParams, objectParams
+}
+
+// validateNoDuplicateNames returns an error if any of the params have the same name
+func (ps ParamSpecs) validateNoDuplicateNames() *apis.FieldError {
+	names := ps.getNames()
+	seen := sets.String{}
+	dups := sets.String{}
+	var errs *apis.FieldError
+	for _, n := range names {
+		if seen.Has(n) {
+			dups.Insert(n)
+		}
+		seen.Insert(n)
+	}
+	for n := range dups {
+		errs = errs.Also(apis.ErrGeneric("parameter appears more than once", "").ViaFieldKey("params", n))
+	}
+	return errs
+}
+
 // Param declares an ParamValues to use for the parameter called name.
 type Param struct {
 	Name  string     `json:"name"`
@@ -573,23 +618,23 @@ func validateParamStringValue(param Param, prefix string, paramNames sets.String
 
 // validateStringVariable validates the normal string fields that can only accept references to string param or individual keys of object param
 func validateStringVariable(value, prefix string, stringVars sets.String, arrayVars sets.String, objectParamNameKeys map[string][]string) *apis.FieldError {
-	errs := substitution.ValidateVariableP(value, prefix, stringVars)
+	errs := substitution.ValidateNoReferencesToUnknownVariables(value, prefix, stringVars)
 	errs = errs.Also(validateObjectVariable(value, prefix, objectParamNameKeys))
-	return errs.Also(substitution.ValidateVariableProhibitedP(value, prefix, arrayVars))
+	return errs.Also(substitution.ValidateNoReferencesToProhibitedVariables(value, prefix, arrayVars))
 }
 
 func validateArrayVariable(value, prefix string, stringVars sets.String, arrayVars sets.String, objectParamNameKeys map[string][]string) *apis.FieldError {
-	errs := substitution.ValidateVariableP(value, prefix, stringVars)
+	errs := substitution.ValidateNoReferencesToUnknownVariables(value, prefix, stringVars)
 	errs = errs.Also(validateObjectVariable(value, prefix, objectParamNameKeys))
-	return errs.Also(substitution.ValidateVariableIsolatedP(value, prefix, arrayVars))
+	return errs.Also(substitution.ValidateVariableReferenceIsIsolated(value, prefix, arrayVars))
 }
 
 func validateObjectVariable(value, prefix string, objectParamNameKeys map[string][]string) (errs *apis.FieldError) {
 	objectNames := sets.NewString()
 	for objectParamName, keys := range objectParamNameKeys {
 		objectNames.Insert(objectParamName)
-		errs = errs.Also(substitution.ValidateVariableP(value, fmt.Sprintf("%s\\.%s", prefix, objectParamName), sets.NewString(keys...)))
+		errs = errs.Also(substitution.ValidateNoReferencesToUnknownVariables(value, fmt.Sprintf("%s\\.%s", prefix, objectParamName), sets.NewString(keys...)))
 	}
 
-	return errs.Also(substitution.ValidateEntireVariableProhibitedP(value, prefix, objectNames))
+	return errs.Also(substitution.ValidateNoReferencesToEntireProhibitedVariables(value, prefix, objectNames))
 }

--- a/pkg/apis/pipeline/v1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1/pipeline_validation.go
@@ -504,7 +504,7 @@ func validateExecutionStatusVariablesExpressions(expressions []string, ptNames s
 }
 func validatePipelineContextVariablesInParamValues(paramValues []string, prefix string, contextNames sets.String) (errs *apis.FieldError) {
 	for _, paramValue := range paramValues {
-		errs = errs.Also(substitution.ValidateVariableP(paramValue, prefix, contextNames).ViaField("value"))
+		errs = errs.Also(substitution.ValidateNoReferencesToUnknownVariables(paramValue, prefix, contextNames).ViaField("value"))
 	}
 	return errs
 }

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation.go
@@ -527,7 +527,7 @@ func validateExecutionStatusVariablesExpressions(expressions []string, ptNames s
 
 func validatePipelineContextVariablesInParamValues(paramValues []string, prefix string, contextNames sets.String) (errs *apis.FieldError) {
 	for _, paramValue := range paramValues {
-		errs = errs.Also(substitution.ValidateVariableP(paramValue, prefix, contextNames).ViaField("value"))
+		errs = errs.Also(substitution.ValidateNoReferencesToUnknownVariables(paramValue, prefix, contextNames).ViaField("value"))
 	}
 	return errs
 }

--- a/pkg/apis/pipeline/v1beta1/task_validation.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation.go
@@ -366,38 +366,23 @@ func (p ParamSpec) ValidateObjectType(ctx context.Context) *apis.FieldError {
 }
 
 // ValidateParameterVariables validates all variables within a slice of ParamSpecs against a slice of Steps
-func ValidateParameterVariables(ctx context.Context, steps []Step, params []ParamSpec) *apis.FieldError {
-	allParameterNames := sets.NewString()
-	stringParameterNames := sets.NewString()
-	arrayParameterNames := sets.NewString()
-	objectParamSpecs := []ParamSpec{}
+func ValidateParameterVariables(ctx context.Context, steps []Step, params ParamSpecs) *apis.FieldError {
 	var errs *apis.FieldError
-	for _, p := range params {
-		// validate no duplicate names
-		if allParameterNames.Has(p.Name) {
-			errs = errs.Also(apis.ErrGeneric("parameter appears more than once", "").ViaFieldKey("params", p.Name))
-		}
-		allParameterNames.Insert(p.Name)
+	errs = errs.Also(params.validateNoDuplicateNames())
+	stringParams, arrayParams, objectParams := params.sortByType()
+	stringParameterNames := sets.NewString(stringParams.getNames()...)
+	arrayParameterNames := sets.NewString(arrayParams.getNames()...)
+	allParameterNames := sets.NewString(params.getNames()...)
 
-		switch p.Type {
-		case ParamTypeArray:
-			arrayParameterNames.Insert(p.Name)
-		case ParamTypeObject:
-			objectParamSpecs = append(objectParamSpecs, p)
-		case ParamTypeString:
-			fallthrough
-		default:
-			stringParameterNames.Insert(p.Name)
-		}
-	}
-	errs = errs.Also(validateNameFormat(stringParameterNames.Insert(arrayParameterNames.List()...), objectParamSpecs))
+	errs = errs.Also(validateNameFormat(stringParameterNames.Insert(arrayParameterNames.List()...), objectParams))
 	if config.ValidateParameterVariablesAndWorkspaces(ctx) {
 		errs = errs.Also(validateVariables(ctx, steps, "params", allParameterNames))
-		errs = errs.Also(validateObjectUsage(ctx, steps, objectParamSpecs))
+		errs = errs.Also(validateObjectUsage(ctx, steps, objectParams))
 	}
 	return errs.Also(validateArrayUsage(steps, "params", arrayParameterNames))
 }
 
+// validateTaskContextVariables returns an error if any Steps reference context variables that don't exist.
 func validateTaskContextVariables(ctx context.Context, steps []Step) *apis.FieldError {
 	taskRunContextNames := sets.NewString().Insert(
 		"name",
@@ -419,7 +404,7 @@ func validateTaskResultsVariables(ctx context.Context, steps []Step, results []T
 		resultsNames.Insert(r.Name)
 	}
 	for idx, step := range steps {
-		errs = errs.Also(validateTaskVariable(step.Script, "results", resultsNames).ViaField("script").ViaFieldIndex("steps", idx))
+		errs = errs.Also(substitution.ValidateNoReferencesToUnknownVariables(step.Script, "results", resultsNames).ViaField("script").ViaFieldIndex("steps", idx))
 	}
 	return errs
 }
@@ -444,8 +429,7 @@ func validateObjectUsage(ctx context.Context, steps []Step, params []ParamSpec) 
 	return errs.Also(validateObjectUsageAsWhole(steps, "params", objectParameterNames))
 }
 
-// validateObjectUsageAsWhole makes sure the object params are not used as whole when providing values for strings
-// i.e. param.objectParam, param.objectParam[*]
+// validateObjectUsageAsWhole returns an error if the Steps contain references to the entire input object params in fields where these references are prohibited
 func validateObjectUsageAsWhole(steps []Step, prefix string, vars sets.String) (errs *apis.FieldError) {
 	for idx, step := range steps {
 		errs = errs.Also(validateStepObjectUsageAsWhole(step, prefix, vars)).ViaFieldIndex("steps", idx)
@@ -453,57 +437,61 @@ func validateObjectUsageAsWhole(steps []Step, prefix string, vars sets.String) (
 	return errs
 }
 
+// validateStepObjectUsageAsWhole returns an error if the Step contains references to the entire input object params in fields where these references are prohibited
 func validateStepObjectUsageAsWhole(step Step, prefix string, vars sets.String) *apis.FieldError {
-	errs := validateTaskNoObjectReferenced(step.Name, prefix, vars).ViaField("name")
-	errs = errs.Also(validateTaskNoObjectReferenced(step.Image, prefix, vars).ViaField("image"))
-	errs = errs.Also(validateTaskNoObjectReferenced(step.WorkingDir, prefix, vars).ViaField("workingDir"))
-	errs = errs.Also(validateTaskNoObjectReferenced(step.Script, prefix, vars).ViaField("script"))
+	errs := substitution.ValidateNoReferencesToEntireProhibitedVariables(step.Name, prefix, vars).ViaField("name")
+	errs = errs.Also(substitution.ValidateNoReferencesToEntireProhibitedVariables(step.Image, prefix, vars).ViaField("image"))
+	errs = errs.Also(substitution.ValidateNoReferencesToEntireProhibitedVariables(step.WorkingDir, prefix, vars).ViaField("workingDir"))
+	errs = errs.Also(substitution.ValidateNoReferencesToEntireProhibitedVariables(step.Script, prefix, vars).ViaField("script"))
 	for i, cmd := range step.Command {
-		errs = errs.Also(validateTaskNoObjectReferenced(cmd, prefix, vars).ViaFieldIndex("command", i))
+		errs = errs.Also(substitution.ValidateNoReferencesToEntireProhibitedVariables(cmd, prefix, vars).ViaFieldIndex("command", i))
 	}
 	for i, arg := range step.Args {
-		errs = errs.Also(validateTaskNoObjectReferenced(arg, prefix, vars).ViaFieldIndex("args", i))
+		errs = errs.Also(substitution.ValidateNoReferencesToEntireProhibitedVariables(arg, prefix, vars).ViaFieldIndex("args", i))
 	}
 	for _, env := range step.Env {
-		errs = errs.Also(validateTaskNoObjectReferenced(env.Value, prefix, vars).ViaFieldKey("env", env.Name))
+		errs = errs.Also(substitution.ValidateNoReferencesToEntireProhibitedVariables(env.Value, prefix, vars).ViaFieldKey("env", env.Name))
 	}
 	for i, v := range step.VolumeMounts {
-		errs = errs.Also(validateTaskNoObjectReferenced(v.Name, prefix, vars).ViaField("name").ViaFieldIndex("volumeMount", i))
-		errs = errs.Also(validateTaskNoObjectReferenced(v.MountPath, prefix, vars).ViaField("mountPath").ViaFieldIndex("volumeMount", i))
-		errs = errs.Also(validateTaskNoObjectReferenced(v.SubPath, prefix, vars).ViaField("subPath").ViaFieldIndex("volumeMount", i))
+		errs = errs.Also(substitution.ValidateNoReferencesToEntireProhibitedVariables(v.Name, prefix, vars).ViaField("name").ViaFieldIndex("volumeMount", i))
+		errs = errs.Also(substitution.ValidateNoReferencesToEntireProhibitedVariables(v.MountPath, prefix, vars).ViaField("mountPath").ViaFieldIndex("volumeMount", i))
+		errs = errs.Also(substitution.ValidateNoReferencesToEntireProhibitedVariables(v.SubPath, prefix, vars).ViaField("subPath").ViaFieldIndex("volumeMount", i))
 	}
 	return errs
 }
 
-func validateArrayUsage(steps []Step, prefix string, vars sets.String) (errs *apis.FieldError) {
+// validateArrayUsage returns an error if the Steps contain references to the input array params in fields where these references are prohibited
+func validateArrayUsage(steps []Step, prefix string, arrayParamNames sets.String) (errs *apis.FieldError) {
 	for idx, step := range steps {
-		errs = errs.Also(validateStepArrayUsage(step, prefix, vars)).ViaFieldIndex("steps", idx)
+		errs = errs.Also(validateStepArrayUsage(step, prefix, arrayParamNames)).ViaFieldIndex("steps", idx)
 	}
 	return errs
 }
 
-func validateStepArrayUsage(step Step, prefix string, vars sets.String) *apis.FieldError {
-	errs := validateTaskNoArrayReferenced(step.Name, prefix, vars).ViaField("name")
-	errs = errs.Also(validateTaskNoArrayReferenced(step.Image, prefix, vars).ViaField("image"))
-	errs = errs.Also(validateTaskNoArrayReferenced(step.WorkingDir, prefix, vars).ViaField("workingDir"))
-	errs = errs.Also(validateTaskNoArrayReferenced(step.Script, prefix, vars).ViaField("script"))
+// validateStepArrayUsage returns an error if the Step contains references to the input array params in fields where these references are prohibited
+func validateStepArrayUsage(step Step, prefix string, arrayParamNames sets.String) *apis.FieldError {
+	errs := substitution.ValidateNoReferencesToProhibitedVariables(step.Name, prefix, arrayParamNames).ViaField("name")
+	errs = errs.Also(substitution.ValidateNoReferencesToProhibitedVariables(step.Image, prefix, arrayParamNames).ViaField("image"))
+	errs = errs.Also(substitution.ValidateNoReferencesToProhibitedVariables(step.WorkingDir, prefix, arrayParamNames).ViaField("workingDir"))
+	errs = errs.Also(substitution.ValidateNoReferencesToProhibitedVariables(step.Script, prefix, arrayParamNames).ViaField("script"))
 	for i, cmd := range step.Command {
-		errs = errs.Also(validateTaskArraysIsolated(cmd, prefix, vars).ViaFieldIndex("command", i))
+		errs = errs.Also(substitution.ValidateVariableReferenceIsIsolated(cmd, prefix, arrayParamNames).ViaFieldIndex("command", i))
 	}
 	for i, arg := range step.Args {
-		errs = errs.Also(validateTaskArraysIsolated(arg, prefix, vars).ViaFieldIndex("args", i))
+		errs = errs.Also(substitution.ValidateVariableReferenceIsIsolated(arg, prefix, arrayParamNames).ViaFieldIndex("args", i))
 	}
 	for _, env := range step.Env {
-		errs = errs.Also(validateTaskNoArrayReferenced(env.Value, prefix, vars).ViaFieldKey("env", env.Name))
+		errs = errs.Also(substitution.ValidateNoReferencesToProhibitedVariables(env.Value, prefix, arrayParamNames).ViaFieldKey("env", env.Name))
 	}
 	for i, v := range step.VolumeMounts {
-		errs = errs.Also(validateTaskNoArrayReferenced(v.Name, prefix, vars).ViaField("name").ViaFieldIndex("volumeMount", i))
-		errs = errs.Also(validateTaskNoArrayReferenced(v.MountPath, prefix, vars).ViaField("mountPath").ViaFieldIndex("volumeMount", i))
-		errs = errs.Also(validateTaskNoArrayReferenced(v.SubPath, prefix, vars).ViaField("subPath").ViaFieldIndex("volumeMount", i))
+		errs = errs.Also(substitution.ValidateNoReferencesToProhibitedVariables(v.Name, prefix, arrayParamNames).ViaField("name").ViaFieldIndex("volumeMount", i))
+		errs = errs.Also(substitution.ValidateNoReferencesToProhibitedVariables(v.MountPath, prefix, arrayParamNames).ViaField("mountPath").ViaFieldIndex("volumeMount", i))
+		errs = errs.Also(substitution.ValidateNoReferencesToProhibitedVariables(v.SubPath, prefix, arrayParamNames).ViaField("subPath").ViaFieldIndex("volumeMount", i))
 	}
 	return errs
 }
 
+// validateVariables returns an error if the Steps contain references to any unknown variables
 func validateVariables(ctx context.Context, steps []Step, prefix string, vars sets.String) (errs *apis.FieldError) {
 	// We've checked param name format. Now, we want to check if param names are referenced correctly in each step
 	for idx, step := range steps {
@@ -561,43 +549,28 @@ func validateNameFormat(stringAndArrayParams sets.String, objectParams []ParamSp
 	return errs
 }
 
+// validateStepVariables returns an error if the Step contains references to any unknown variables
 func validateStepVariables(ctx context.Context, step Step, prefix string, vars sets.String) *apis.FieldError {
-	errs := validateTaskVariable(step.Name, prefix, vars).ViaField("name")
-	errs = errs.Also(validateTaskVariable(step.Image, prefix, vars).ViaField("image"))
-	errs = errs.Also(validateTaskVariable(step.WorkingDir, prefix, vars).ViaField("workingDir"))
-	errs = errs.Also(validateTaskVariable(step.Script, prefix, vars).ViaField("script"))
+	errs := substitution.ValidateNoReferencesToUnknownVariables(step.Name, prefix, vars).ViaField("name")
+	errs = errs.Also(substitution.ValidateNoReferencesToUnknownVariables(step.Image, prefix, vars).ViaField("image"))
+	errs = errs.Also(substitution.ValidateNoReferencesToUnknownVariables(step.WorkingDir, prefix, vars).ViaField("workingDir"))
+	errs = errs.Also(substitution.ValidateNoReferencesToUnknownVariables(step.Script, prefix, vars).ViaField("script"))
 	for i, cmd := range step.Command {
-		errs = errs.Also(validateTaskVariable(cmd, prefix, vars).ViaFieldIndex("command", i))
+		errs = errs.Also(substitution.ValidateNoReferencesToUnknownVariables(cmd, prefix, vars).ViaFieldIndex("command", i))
 	}
 	for i, arg := range step.Args {
-		errs = errs.Also(validateTaskVariable(arg, prefix, vars).ViaFieldIndex("args", i))
+		errs = errs.Also(substitution.ValidateNoReferencesToUnknownVariables(arg, prefix, vars).ViaFieldIndex("args", i))
 	}
 	for _, env := range step.Env {
-		errs = errs.Also(validateTaskVariable(env.Value, prefix, vars).ViaFieldKey("env", env.Name))
+		errs = errs.Also(substitution.ValidateNoReferencesToUnknownVariables(env.Value, prefix, vars).ViaFieldKey("env", env.Name))
 	}
 	for i, v := range step.VolumeMounts {
-		errs = errs.Also(validateTaskVariable(v.Name, prefix, vars).ViaField("name").ViaFieldIndex("volumeMount", i))
-		errs = errs.Also(validateTaskVariable(v.MountPath, prefix, vars).ViaField("MountPath").ViaFieldIndex("volumeMount", i))
-		errs = errs.Also(validateTaskVariable(v.SubPath, prefix, vars).ViaField("SubPath").ViaFieldIndex("volumeMount", i))
+		errs = errs.Also(substitution.ValidateNoReferencesToUnknownVariables(v.Name, prefix, vars).ViaField("name").ViaFieldIndex("volumeMount", i))
+		errs = errs.Also(substitution.ValidateNoReferencesToUnknownVariables(v.MountPath, prefix, vars).ViaField("MountPath").ViaFieldIndex("volumeMount", i))
+		errs = errs.Also(substitution.ValidateNoReferencesToUnknownVariables(v.SubPath, prefix, vars).ViaField("SubPath").ViaFieldIndex("volumeMount", i))
 	}
-	errs = errs.Also(validateTaskVariable(string(step.OnError), prefix, vars).ViaField("onError"))
+	errs = errs.Also(substitution.ValidateNoReferencesToUnknownVariables(string(step.OnError), prefix, vars).ViaField("onError"))
 	return errs
-}
-
-func validateTaskVariable(value, prefix string, vars sets.String) *apis.FieldError {
-	return substitution.ValidateVariableP(value, prefix, vars)
-}
-
-func validateTaskNoObjectReferenced(value, prefix string, objectNames sets.String) *apis.FieldError {
-	return substitution.ValidateEntireVariableProhibitedP(value, prefix, objectNames)
-}
-
-func validateTaskNoArrayReferenced(value, prefix string, arrayNames sets.String) *apis.FieldError {
-	return substitution.ValidateVariableProhibitedP(value, prefix, arrayNames)
-}
-
-func validateTaskArraysIsolated(value, prefix string, arrayNames sets.String) *apis.FieldError {
-	return substitution.ValidateVariableIsolatedP(value, prefix, arrayNames)
 }
 
 // isParamRefs attempts to check if a specified string looks like it contains any parameter reference


### PR DESCRIPTION
This commit adds docstrings for many functions in the substitution package and in task_validation.go. It also cleans up the substitution package by removing unused functions, adding tests for functions that lack them, renaming functions to better reflect their purpose, and replacing calls to regexp.MustCompile (which can panic) with regexp.Compile (which does not panic). It cleans up task_validation.go by removing functions that are just wrappers around functions in the substitution package, and splitting ValidateParameterVariables into several helpers. No functional changes expected as a result of this commit.

This refactoring will help to address https://github.com/tektoncd/pipeline/issues/6647.
/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- n/a Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- n/a Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Some functions in pkg/substitution have been removed or renamed.
```
