### PR TITLE
Split array param indexing validation between reconciler and webhook

### DIFF
--- a/pkg/apis/pipeline/v1/task_validation.go
+++ b/pkg/apis/pipeline/v1/task_validation.go
@@ -96,6 +96,7 @@ func (ts *TaskSpec) Validate(ctx context.Context) (errs *apis.FieldError) {
 	errs = errs.Also(validateSidecarNames(ts.Sidecars))
 	errs = errs.Also(ValidateParameterTypes(ctx, ts.Params).ViaField("params"))
 	errs = errs.Also(ValidateParameterVariables(ctx, ts.Steps, ts.Params))
+	errs = errs.Also(ts.ValidateBetaFeaturesEnabledForParamArrayIndexing(ctx))
 	errs = errs.Also(validateTaskContextVariables(ctx, ts.Steps))
 	errs = errs.Also(validateTaskResultsVariables(ctx, ts.Steps, ts.Results))
 	errs = errs.Also(validateResults(ctx, ts.Results).ViaField("results"))
@@ -575,16 +576,27 @@ func isParamRefs(s string) bool {
 	return strings.HasPrefix(s, "$("+ParamsPrefix)
 }
 
+// ValidateBetaFeaturesEnabledForParamArrayIndexing validates that "enable-api-fields" is set to "alpha" or "beta" if the task spec
+// contains indexing references to array params.
+// This can be removed when array param indexing is moved to "stable".
+func (ts *TaskSpec) ValidateBetaFeaturesEnabledForParamArrayIndexing(ctx context.Context) *apis.FieldError {
+	if config.CheckAlphaOrBetaAPIFields(ctx) {
+		return nil
+	}
+	arrayIndexParamRefs := ts.GetIndexingReferencesToArrayParams()
+	if len(arrayIndexParamRefs) == 0 {
+		return nil
+	}
+	return apis.ErrGeneric(fmt.Sprintf("cannot index into array parameters when 'enable-api-fields' is 'stable', but found indexing references: %s", arrayIndexParamRefs))
+}
+
 // ValidateParamArrayIndex validates if the param reference to an array param is out of bound.
 // error is returned when the array indexing reference is out of bound of the array param
 // e.g. if a param reference of $(params.array-param[2]) and the array param is of length 2.
 // - `trParams` are params from taskrun.
 // - `taskSpec` contains params declarations.
+// TODO(#6616): Move this functionality to the reconciler, as it is only used there
 func (ts *TaskSpec) ValidateParamArrayIndex(ctx context.Context, params Params) error {
-	if !config.CheckAlphaOrBetaAPIFields(ctx) {
-		return nil
-	}
-
 	// Collect all array params lengths
 	arrayParamsLengths := ts.Params.extractParamArrayLengths()
 	for k, v := range params.extractParamArrayLengths() {

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation.go
@@ -713,6 +713,7 @@ func validateResultsFromMatrixedPipelineTasksNotConsumed(tasks []PipelineTask, f
 // ValidateParamArrayIndex validates if the param reference to an array param is out of bound.
 // error is returned when the array indexing reference is out of bound of the array param
 // e.g. if a param reference of $(params.array-param[2]) and the array param is of length 2.
+// TODO(#6616): Move this functionality to the reconciler, as it is only used there
 func (ps *PipelineSpec) ValidateParamArrayIndex(ctx context.Context, params Params) error {
 	// Collect all array params lengths
 	arrayParamsLengths := ps.Params.extractParamArrayLengths()

--- a/pkg/apis/pipeline/v1beta1/task_validation.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation.go
@@ -584,6 +584,7 @@ func isParamRefs(s string) bool {
 // e.g. if a param reference of $(params.array-param[2]) and the array param is of length 2.
 // - `trParams` are params from taskrun.
 // - `taskSpec` contains params declarations.
+// TODO(#6616): Move this functionality to the reconciler, as it is only used there
 func (ts *TaskSpec) ValidateParamArrayIndex(ctx context.Context, params Params) error {
 	// Collect all array params lengths
 	arrayParamsLengths := ts.Params.extractParamArrayLengths()


### PR DESCRIPTION
There are two components to validation of array param indexing:

1. Validating that beta features are enabled.
2. Validating that array indexes are in bounds.

Prior to this commit, both of these forms of validation were done in the PipelineRun reconciler. However, the first form of validation differs between the v1beta1 and the v1 API version. In addition, array index bounds checking was skipped if beta features were disabled. This meant that if "enable-api-fields" was set to "stable", a user could create a beta Task/Pipeline using array parameter indexing, and we would not validate whether indexes were in bounds, potentially leading to a confusing error message or reconciler panic.

This commit moves the first form of validation to take place only in the webhook, leaving validation for bounds checking in the reconciler. Bounds checking is performed regardless of what feature flags are enabled.

/kind bug
Partially addresses https://github.com/tektoncd/pipeline/issues/6616
Closes https://github.com/tektoncd/pipeline/issues/6102
Related: https://github.com/tektoncd/pipeline/issues/6607

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- n/a Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- n/a Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
bug fix: always perform validation of array parameter index bounds checking
```
