### PR TITLE
Split Pipeline validation tests into separate test classes

### DIFF
--- a/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
@@ -1344,7 +1344,7 @@ func TestValidatePipelineParameterVariables_Success(t *testing.T) {
 	}
 }
 
-func TestValidatePipelineParameterVariables_Failure(t *testing.T) {
+func TestValidatePipelineDeclaredParameterUsage_Failure(t *testing.T) {
 	tests := []struct {
 		name          string
 		params        []ParamSpec
@@ -1463,154 +1463,6 @@ func TestValidatePipelineParameterVariables_Failure(t *testing.T) {
 		expectedError: apis.FieldError{
 			Message: `non-existent variable in "$(params.does-not-exist)"`,
 			Paths:   []string{"[0].params[b-param]"},
-		},
-	}, {
-		name: "invalid parameter type",
-		params: []ParamSpec{{
-			Name: "foo", Type: "invalidtype",
-		}},
-		tasks: []PipelineTask{{
-			Name:    "foo",
-			TaskRef: &TaskRef{Name: "foo-task"},
-		}},
-		expectedError: apis.FieldError{
-			Message: `invalid value: invalidtype`,
-			Paths:   []string{"params.foo.type"},
-		},
-	}, {
-		name: "array parameter mismatching default type",
-		params: []ParamSpec{{
-			Name: "foo", Type: ParamTypeArray, Default: &ParamValue{Type: ParamTypeString, StringVal: "astring"},
-		}},
-		tasks: []PipelineTask{{
-			Name:    "foo",
-			TaskRef: &TaskRef{Name: "foo-task"},
-		}},
-		expectedError: apis.FieldError{
-			Message: `"array" type does not match default value's type: "string"`,
-			Paths:   []string{"params.foo.default.type", "params.foo.type"},
-		},
-	}, {
-		name: "string parameter mismatching default type",
-		params: []ParamSpec{{
-			Name: "foo", Type: ParamTypeString, Default: &ParamValue{Type: ParamTypeArray, ArrayVal: []string{"anarray", "elements"}},
-		}},
-		tasks: []PipelineTask{{
-			Name:    "foo",
-			TaskRef: &TaskRef{Name: "foo-task"},
-		}},
-		expectedError: apis.FieldError{
-			Message: `"string" type does not match default value's type: "array"`,
-			Paths:   []string{"params.foo.default.type", "params.foo.type"},
-		},
-	}, {
-		name: "array parameter used as string",
-		params: []ParamSpec{{
-			Name: "baz", Type: ParamTypeString, Default: &ParamValue{Type: ParamTypeArray, ArrayVal: []string{"anarray", "elements"}},
-		}},
-		tasks: []PipelineTask{{
-			Name:    "bar",
-			TaskRef: &TaskRef{Name: "bar-task"},
-			Params: Params{{
-				Name: "a-param", Value: ParamValue{Type: ParamTypeString, StringVal: "$(params.baz)"},
-			}},
-		}},
-		expectedError: apis.FieldError{
-			Message: `"string" type does not match default value's type: "array"`,
-			Paths:   []string{"params.baz.default.type", "params.baz.type"},
-		},
-	}, {
-		name: "star array parameter used as string",
-		params: []ParamSpec{{
-			Name: "baz", Type: ParamTypeString, Default: &ParamValue{Type: ParamTypeArray, ArrayVal: []string{"anarray", "elements"}},
-		}},
-		tasks: []PipelineTask{{
-			Name:    "bar",
-			TaskRef: &TaskRef{Name: "bar-task"},
-			Params: Params{{
-				Name: "a-param", Value: ParamValue{Type: ParamTypeString, StringVal: "$(params.baz[*])"},
-			}},
-		}},
-		expectedError: apis.FieldError{
-			Message: `"string" type does not match default value's type: "array"`,
-			Paths:   []string{"params.baz.default.type", "params.baz.type"},
-		},
-	}, {
-		name: "array parameter string template not isolated",
-		params: []ParamSpec{{
-			Name: "baz", Type: ParamTypeString, Default: &ParamValue{Type: ParamTypeArray, ArrayVal: []string{"anarray", "elements"}},
-		}},
-		tasks: []PipelineTask{{
-			Name:    "bar",
-			TaskRef: &TaskRef{Name: "bar-task"},
-			Params: Params{{
-				Name: "a-param", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"value: $(params.baz)", "last"}},
-			}},
-		}},
-		expectedError: apis.FieldError{
-			Message: `"string" type does not match default value's type: "array"`,
-			Paths:   []string{"params.baz.default.type", "params.baz.type"},
-		},
-	}, {
-		name: "star array parameter string template not isolated",
-		params: []ParamSpec{{
-			Name: "baz", Type: ParamTypeString, Default: &ParamValue{Type: ParamTypeArray, ArrayVal: []string{"anarray", "elements"}},
-		}},
-		tasks: []PipelineTask{{
-			Name:    "bar",
-			TaskRef: &TaskRef{Name: "bar-task"},
-			Params: Params{{
-				Name: "a-param", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"value: $(params.baz[*])", "last"}},
-			}},
-		}},
-		expectedError: apis.FieldError{
-			Message: `"string" type does not match default value's type: "array"`,
-			Paths:   []string{"params.baz.default.type", "params.baz.type"},
-		},
-	}, {
-		name: "multiple string parameters with the same name",
-		params: []ParamSpec{{
-			Name: "baz", Type: ParamTypeString,
-		}, {
-			Name: "baz", Type: ParamTypeString,
-		}},
-		tasks: []PipelineTask{{
-			Name:    "foo",
-			TaskRef: &TaskRef{Name: "foo-task"},
-		}},
-		expectedError: apis.FieldError{
-			Message: `parameter appears more than once`,
-			Paths:   []string{"params[baz]"},
-		},
-	}, {
-		name: "multiple array parameters with the same name",
-		params: []ParamSpec{{
-			Name: "baz", Type: ParamTypeArray,
-		}, {
-			Name: "baz", Type: ParamTypeArray,
-		}},
-		tasks: []PipelineTask{{
-			Name:    "foo",
-			TaskRef: &TaskRef{Name: "foo-task"},
-		}},
-		expectedError: apis.FieldError{
-			Message: `parameter appears more than once`,
-			Paths:   []string{"params[baz]"},
-		},
-	}, {
-		name: "multiple different type parameters with the same name",
-		params: []ParamSpec{{
-			Name: "baz", Type: ParamTypeArray,
-		}, {
-			Name: "baz", Type: ParamTypeString,
-		}},
-		tasks: []PipelineTask{{
-			Name:    "foo",
-			TaskRef: &TaskRef{Name: "foo-task"},
-		}},
-		expectedError: apis.FieldError{
-			Message: `parameter appears more than once`,
-			Paths:   []string{"params[baz]"},
 		},
 	}, {
 		name: "invalid pipeline task with a matrix parameter which is missing from the param declarations",
@@ -1827,6 +1679,179 @@ func TestValidatePipelineParameterVariables_Failure(t *testing.T) {
 			Paths:   []string{"[0].matrix.params[b-param].value[0]"},
 		},
 		api: "alpha",
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			if tt.api == "alpha" {
+				ctx = config.EnableAlphaAPIFields(context.Background())
+			}
+			ctx = config.SkipValidationDueToPropagatedParametersAndWorkspaces(ctx, false)
+			err := ValidatePipelineParameterVariables(ctx, tt.tasks, tt.params)
+			if err == nil {
+				t.Errorf("Pipeline.ValidatePipelineParameterVariables() did not return error for invalid pipeline parameters")
+			}
+			if d := cmp.Diff(tt.expectedError.Error(), err.Error(), cmpopts.IgnoreUnexported(apis.FieldError{})); d != "" {
+				t.Errorf("PipelineSpec.Validate() errors diff %s", diff.PrintWantGot(d))
+			}
+		})
+	}
+}
+
+func TestValidatePipelineParameterVariables_Failure(t *testing.T) {
+	tests := []struct {
+		name          string
+		params        []ParamSpec
+		tasks         []PipelineTask
+		expectedError apis.FieldError
+	}{{
+		name: "invalid parameter type",
+		params: []ParamSpec{{
+			Name: "foo", Type: "invalidtype",
+		}},
+		tasks: []PipelineTask{{
+			Name:    "foo",
+			TaskRef: &TaskRef{Name: "foo-task"},
+		}},
+		expectedError: apis.FieldError{
+			Message: `invalid value: invalidtype`,
+			Paths:   []string{"params.foo.type"},
+		},
+	}, {
+		name: "array parameter mismatching default type",
+		params: []ParamSpec{{
+			Name: "foo", Type: ParamTypeArray, Default: &ParamValue{Type: ParamTypeString, StringVal: "astring"},
+		}},
+		tasks: []PipelineTask{{
+			Name:    "foo",
+			TaskRef: &TaskRef{Name: "foo-task"},
+		}},
+		expectedError: apis.FieldError{
+			Message: `"array" type does not match default value's type: "string"`,
+			Paths:   []string{"params.foo.default.type", "params.foo.type"},
+		},
+	}, {
+		name: "string parameter mismatching default type",
+		params: []ParamSpec{{
+			Name: "foo", Type: ParamTypeString, Default: &ParamValue{Type: ParamTypeArray, ArrayVal: []string{"anarray", "elements"}},
+		}},
+		tasks: []PipelineTask{{
+			Name:    "foo",
+			TaskRef: &TaskRef{Name: "foo-task"},
+		}},
+		expectedError: apis.FieldError{
+			Message: `"string" type does not match default value's type: "array"`,
+			Paths:   []string{"params.foo.default.type", "params.foo.type"},
+		},
+	}, {
+		name: "array parameter used as string",
+		params: []ParamSpec{{
+			Name: "baz", Type: ParamTypeString, Default: &ParamValue{Type: ParamTypeArray, ArrayVal: []string{"anarray", "elements"}},
+		}},
+		tasks: []PipelineTask{{
+			Name:    "bar",
+			TaskRef: &TaskRef{Name: "bar-task"},
+			Params: Params{{
+				Name: "a-param", Value: ParamValue{Type: ParamTypeString, StringVal: "$(params.baz)"},
+			}},
+		}},
+		expectedError: apis.FieldError{
+			Message: `"string" type does not match default value's type: "array"`,
+			Paths:   []string{"params.baz.default.type", "params.baz.type"},
+		},
+	}, {
+		name: "star array parameter used as string",
+		params: []ParamSpec{{
+			Name: "baz", Type: ParamTypeString, Default: &ParamValue{Type: ParamTypeArray, ArrayVal: []string{"anarray", "elements"}},
+		}},
+		tasks: []PipelineTask{{
+			Name:    "bar",
+			TaskRef: &TaskRef{Name: "bar-task"},
+			Params: Params{{
+				Name: "a-param", Value: ParamValue{Type: ParamTypeString, StringVal: "$(params.baz[*])"},
+			}},
+		}},
+		expectedError: apis.FieldError{
+			Message: `"string" type does not match default value's type: "array"`,
+			Paths:   []string{"params.baz.default.type", "params.baz.type"},
+		},
+	}, {
+		name: "array parameter string template not isolated",
+		params: []ParamSpec{{
+			Name: "baz", Type: ParamTypeString, Default: &ParamValue{Type: ParamTypeArray, ArrayVal: []string{"anarray", "elements"}},
+		}},
+		tasks: []PipelineTask{{
+			Name:    "bar",
+			TaskRef: &TaskRef{Name: "bar-task"},
+			Params: Params{{
+				Name: "a-param", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"value: $(params.baz)", "last"}},
+			}},
+		}},
+		expectedError: apis.FieldError{
+			Message: `"string" type does not match default value's type: "array"`,
+			Paths:   []string{"params.baz.default.type", "params.baz.type"},
+		},
+	}, {
+		name: "star array parameter string template not isolated",
+		params: []ParamSpec{{
+			Name: "baz", Type: ParamTypeString, Default: &ParamValue{Type: ParamTypeArray, ArrayVal: []string{"anarray", "elements"}},
+		}},
+		tasks: []PipelineTask{{
+			Name:    "bar",
+			TaskRef: &TaskRef{Name: "bar-task"},
+			Params: Params{{
+				Name: "a-param", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"value: $(params.baz[*])", "last"}},
+			}},
+		}},
+		expectedError: apis.FieldError{
+			Message: `"string" type does not match default value's type: "array"`,
+			Paths:   []string{"params.baz.default.type", "params.baz.type"},
+		},
+	}, {
+		name: "multiple string parameters with the same name",
+		params: []ParamSpec{{
+			Name: "baz", Type: ParamTypeString,
+		}, {
+			Name: "baz", Type: ParamTypeString,
+		}},
+		tasks: []PipelineTask{{
+			Name:    "foo",
+			TaskRef: &TaskRef{Name: "foo-task"},
+		}},
+		expectedError: apis.FieldError{
+			Message: `parameter appears more than once`,
+			Paths:   []string{"params[baz]"},
+		},
+	}, {
+		name: "multiple array parameters with the same name",
+		params: []ParamSpec{{
+			Name: "baz", Type: ParamTypeArray,
+		}, {
+			Name: "baz", Type: ParamTypeArray,
+		}},
+		tasks: []PipelineTask{{
+			Name:    "foo",
+			TaskRef: &TaskRef{Name: "foo-task"},
+		}},
+		expectedError: apis.FieldError{
+			Message: `parameter appears more than once`,
+			Paths:   []string{"params[baz]"},
+		},
+	}, {
+		name: "multiple different type parameters with the same name",
+		params: []ParamSpec{{
+			Name: "baz", Type: ParamTypeArray,
+		}, {
+			Name: "baz", Type: ParamTypeString,
+		}},
+		tasks: []PipelineTask{{
+			Name:    "foo",
+			TaskRef: &TaskRef{Name: "foo-task"},
+		}},
+		expectedError: apis.FieldError{
+			Message: `parameter appears more than once`,
+			Paths:   []string{"params[baz]"},
+		},
 	}, {
 		name: "invalid task use duplicate parameters",
 		tasks: []PipelineTask{{
@@ -1848,9 +1873,6 @@ func TestValidatePipelineParameterVariables_Failure(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
-			if tt.api == "alpha" {
-				ctx = config.EnableAlphaAPIFields(context.Background())
-			}
 			ctx = config.SkipValidationDueToPropagatedParametersAndWorkspaces(ctx, false)
 			err := ValidatePipelineParameterVariables(ctx, tt.tasks, tt.params)
 			if err == nil {


### PR DESCRIPTION
Some parts of Pipeline validation happen only when extra validation is performed after propagating parameters and workspaces. This commit splits existing Pipeline tests in TestValidatePipelineParameterVariables_Failure into tests for functionality that happens before propagation and tests for functionality that happens after propagation. This commit is solely for refactoring purposes to make subsequent cleanup easier. No functional changes.

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- n/a Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- n/a Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- n/a Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
