### PR TITLE
[TEP-0091] add condition for trusted resources

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinespec/pipelinespec.go
+++ b/pkg/reconciler/pipelinerun/pipelinespec/pipelinespec.go
@@ -23,53 +23,57 @@ import (
 
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	resolutionutil "github.com/tektoncd/pipeline/pkg/internal/resolution"
+	"github.com/tektoncd/pipeline/pkg/trustedresources"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // GetPipeline is a function used to retrieve Pipelines.
-type GetPipeline func(context.Context, string) (*v1beta1.Pipeline, *v1beta1.RefSource, error)
+type GetPipeline func(context.Context, string) (*v1beta1.Pipeline, *v1beta1.RefSource, *trustedresources.VerificationResult, error)
 
 // GetPipelineData will retrieve the Pipeline metadata and Spec associated with the
 // provided PipelineRun. This can come from a reference Pipeline or from the PipelineRun's
 // metadata and embedded PipelineSpec.
-func GetPipelineData(ctx context.Context, pipelineRun *v1beta1.PipelineRun, getPipeline GetPipeline) (*resolutionutil.ResolvedObjectMeta, *v1beta1.PipelineSpec, error) {
+func GetPipelineData(ctx context.Context, pipelineRun *v1beta1.PipelineRun, getPipeline GetPipeline) (*resolutionutil.ResolvedObjectMeta, *v1beta1.PipelineSpec, *trustedresources.VerificationResult, error) {
 	pipelineMeta := metav1.ObjectMeta{}
 	var refSource *v1beta1.RefSource
+	var verificationResult *trustedresources.VerificationResult
 	pipelineSpec := v1beta1.PipelineSpec{}
 	switch {
 	case pipelineRun.Spec.PipelineRef != nil && pipelineRun.Spec.PipelineRef.Name != "":
 		// Get related pipeline for pipelinerun
-		p, source, err := getPipeline(ctx, pipelineRun.Spec.PipelineRef.Name)
+		p, source, vr, err := getPipeline(ctx, pipelineRun.Spec.PipelineRef.Name)
 		if err != nil {
-			return nil, nil, fmt.Errorf("error when listing pipelines for pipelineRun %s: %w", pipelineRun.Name, err)
+			return nil, nil, nil, fmt.Errorf("error when listing pipelines for pipelineRun %s: %w", pipelineRun.Name, err)
 		}
 		pipelineMeta = p.PipelineMetadata()
 		pipelineSpec = p.PipelineSpec()
 		refSource = source
+		verificationResult = vr
 	case pipelineRun.Spec.PipelineSpec != nil:
 		pipelineMeta = pipelineRun.ObjectMeta
 		pipelineSpec = *pipelineRun.Spec.PipelineSpec
 		// TODO: if we want to set RefSource for embedded pipeline, set it here.
 		// https://github.com/tektoncd/pipeline/issues/5522
 	case pipelineRun.Spec.PipelineRef != nil && pipelineRun.Spec.PipelineRef.Resolver != "":
-		pipeline, source, err := getPipeline(ctx, "")
+		pipeline, source, vr, err := getPipeline(ctx, "")
 		switch {
 		case err != nil:
-			return nil, nil, err
+			return nil, nil, nil, err
 		case pipeline == nil:
-			return nil, nil, errors.New("resolution of remote resource completed successfully but no pipeline was returned")
+			return nil, nil, nil, errors.New("resolution of remote resource completed successfully but no pipeline was returned")
 		default:
 			pipelineMeta = pipeline.PipelineMetadata()
 			pipelineSpec = pipeline.PipelineSpec()
+			verificationResult = vr
 		}
 		refSource = source
 	default:
-		return nil, nil, fmt.Errorf("pipelineRun %s not providing PipelineRef or PipelineSpec", pipelineRun.Name)
+		return nil, nil, nil, fmt.Errorf("pipelineRun %s not providing PipelineRef or PipelineSpec", pipelineRun.Name)
 	}
 
 	pipelineSpec.SetDefaults(ctx)
 	return &resolutionutil.ResolvedObjectMeta{
 		ObjectMeta: &pipelineMeta,
 		RefSource:  refSource,
-	}, &pipelineSpec, nil
+	}, &pipelineSpec, verificationResult, nil
 }

--- a/pkg/reconciler/pipelinerun/pipelinespec/pipelinespec_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinespec/pipelinespec_test.go
@@ -25,6 +25,7 @@ import (
 	cfgtesting "github.com/tektoncd/pipeline/pkg/apis/config/testing"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	pipelinespec "github.com/tektoncd/pipeline/pkg/reconciler/pipelinerun/pipelinespec"
+	"github.com/tektoncd/pipeline/pkg/trustedresources"
 	"github.com/tektoncd/pipeline/test/diff"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -53,10 +54,10 @@ func TestGetPipelineSpec_Ref(t *testing.T) {
 			},
 		},
 	}
-	gt := func(ctx context.Context, n string) (*v1beta1.Pipeline, *v1beta1.RefSource, error) {
-		return pipeline, nil, nil
+	gt := func(ctx context.Context, n string) (*v1beta1.Pipeline, *v1beta1.RefSource, *trustedresources.VerificationResult, error) {
+		return pipeline, nil, nil, nil
 	}
-	resolvedObjectMeta, pipelineSpec, err := pipelinespec.GetPipelineData(context.Background(), pr, gt)
+	resolvedObjectMeta, pipelineSpec, _, err := pipelinespec.GetPipelineData(context.Background(), pr, gt)
 
 	if err != nil {
 		t.Fatalf("Did not expect error getting pipeline spec but got: %s", err)
@@ -91,10 +92,10 @@ func TestGetPipelineSpec_Embedded(t *testing.T) {
 			},
 		},
 	}
-	gt := func(ctx context.Context, n string) (*v1beta1.Pipeline, *v1beta1.RefSource, error) {
-		return nil, nil, errors.New("shouldn't be called")
+	gt := func(ctx context.Context, n string) (*v1beta1.Pipeline, *v1beta1.RefSource, *trustedresources.VerificationResult, error) {
+		return nil, nil, nil, errors.New("shouldn't be called")
 	}
-	resolvedObjectMeta, pipelineSpec, err := pipelinespec.GetPipelineData(context.Background(), pr, gt)
+	resolvedObjectMeta, pipelineSpec, _, err := pipelinespec.GetPipelineData(context.Background(), pr, gt)
 
 	if err != nil {
 		t.Fatalf("Did not expect error getting pipeline spec but got: %s", err)
@@ -119,10 +120,10 @@ func TestGetPipelineSpec_Invalid(t *testing.T) {
 			Name: "mypipelinerun",
 		},
 	}
-	gt := func(ctx context.Context, n string) (*v1beta1.Pipeline, *v1beta1.RefSource, error) {
-		return nil, nil, errors.New("shouldn't be called")
+	gt := func(ctx context.Context, n string) (*v1beta1.Pipeline, *v1beta1.RefSource, *trustedresources.VerificationResult, error) {
+		return nil, nil, nil, errors.New("shouldn't be called")
 	}
-	_, _, err := pipelinespec.GetPipelineData(context.Background(), tr, gt)
+	_, _, _, err := pipelinespec.GetPipelineData(context.Background(), tr, gt)
 	if err == nil {
 		t.Fatalf("Expected error resolving spec with no embedded or referenced pipeline spec but didn't get error")
 	}
@@ -217,14 +218,14 @@ func TestGetPipelineData_ResolutionSuccess(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := cfgtesting.SetDefaults(context.Background(), t, tc.defaults)
-			getPipeline := func(ctx context.Context, n string) (*v1beta1.Pipeline, *v1beta1.RefSource, error) {
+			getPipeline := func(ctx context.Context, n string) (*v1beta1.Pipeline, *v1beta1.RefSource, *trustedresources.VerificationResult, error) {
 				return &v1beta1.Pipeline{
 					ObjectMeta: *tc.sourceMeta.DeepCopy(),
 					Spec:       *tc.sourceSpec.DeepCopy(),
-				}, tc.refSource.DeepCopy(), nil
+				}, tc.refSource.DeepCopy(), nil, nil
 			}
 
-			resolvedObjectMeta, resolvedPipelineSpec, err := pipelinespec.GetPipelineData(ctx, tc.pr, getPipeline)
+			resolvedObjectMeta, resolvedPipelineSpec, _, err := pipelinespec.GetPipelineData(ctx, tc.pr, getPipeline)
 			if err != nil {
 				t.Fatalf("did not expect error getting pipeline spec but got: %s", err)
 			}
@@ -253,10 +254,10 @@ func TestGetPipelineSpec_Error(t *testing.T) {
 			},
 		},
 	}
-	gt := func(ctx context.Context, n string) (*v1beta1.Pipeline, *v1beta1.RefSource, error) {
-		return nil, nil, errors.New("something went wrong")
+	gt := func(ctx context.Context, n string) (*v1beta1.Pipeline, *v1beta1.RefSource, *trustedresources.VerificationResult, error) {
+		return nil, nil, nil, errors.New("something went wrong")
 	}
-	_, _, err := pipelinespec.GetPipelineData(context.Background(), tr, gt)
+	_, _, _, err := pipelinespec.GetPipelineData(context.Background(), tr, gt)
 	if err == nil {
 		t.Fatalf("Expected error when unable to find referenced Pipeline but got none")
 	}
@@ -275,11 +276,11 @@ func TestGetPipelineData_ResolutionError(t *testing.T) {
 			},
 		},
 	}
-	getPipeline := func(ctx context.Context, n string) (*v1beta1.Pipeline, *v1beta1.RefSource, error) {
-		return nil, nil, errors.New("something went wrong")
+	getPipeline := func(ctx context.Context, n string) (*v1beta1.Pipeline, *v1beta1.RefSource, *trustedresources.VerificationResult, error) {
+		return nil, nil, nil, errors.New("something went wrong")
 	}
 	ctx := context.Background()
-	_, _, err := pipelinespec.GetPipelineData(ctx, pr, getPipeline)
+	_, _, _, err := pipelinespec.GetPipelineData(ctx, pr, getPipeline)
 	if err == nil {
 		t.Fatalf("Expected error when unable to find referenced Pipeline but got none")
 	}
@@ -298,11 +299,11 @@ func TestGetPipelineData_ResolvedNilPipeline(t *testing.T) {
 			},
 		},
 	}
-	getPipeline := func(ctx context.Context, n string) (*v1beta1.Pipeline, *v1beta1.RefSource, error) {
-		return nil, nil, nil
+	getPipeline := func(ctx context.Context, n string) (*v1beta1.Pipeline, *v1beta1.RefSource, *trustedresources.VerificationResult, error) {
+		return nil, nil, nil, nil
 	}
 	ctx := context.Background()
-	_, _, err := pipelinespec.GetPipelineData(ctx, pr, getPipeline)
+	_, _, _, err := pipelinespec.GetPipelineData(ctx, pr, getPipeline)
 	if err == nil {
 		t.Fatalf("Expected error when unable to find referenced Pipeline but got none")
 	}

--- a/pkg/reconciler/taskrun/resources/taskref_test.go
+++ b/pkg/reconciler/taskrun/resources/taskref_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/go-containerregistry/pkg/registry"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
@@ -219,7 +220,7 @@ func TestLocalTaskRef(t *testing.T) {
 				Tektonclient: tektonclient,
 			}
 
-			task, refSource, err := lc.GetTask(ctx, tc.ref.Name)
+			task, refSource, _, err := lc.GetTask(ctx, tc.ref.Name)
 			if tc.wantErr && err == nil {
 				t.Fatal("Expected error but found nil instead")
 			} else if !tc.wantErr && err != nil {
@@ -467,7 +468,7 @@ func TestGetTaskFunc(t *testing.T) {
 			}
 			fn := resources.GetTaskFunc(ctx, kubeclient, tektonclient, nil, trForFunc, tc.ref, "", "default", "default", nil /*VerificationPolicies*/)
 
-			task, refSource, err := fn(ctx, tc.ref.Name)
+			task, refSource, _, err := fn(ctx, tc.ref.Name)
 			if err != nil {
 				t.Fatalf("failed to call taskfn: %s", err.Error())
 			}
@@ -534,7 +535,7 @@ echo hello
 
 	fn := resources.GetTaskFuncFromTaskRun(ctx, kubeclient, tektonclient, nil, TaskRun, []*v1alpha1.VerificationPolicy{})
 
-	actualTask, actualRefSource, err := fn(ctx, name)
+	actualTask, actualRefSource, _, err := fn(ctx, name)
 	if err != nil {
 		t.Fatalf("failed to call Taskfn: %s", err.Error())
 	}
@@ -586,7 +587,7 @@ func TestGetTaskFunc_RemoteResolution(t *testing.T) {
 			}
 			fn := resources.GetTaskFunc(ctx, nil, nil, requester, tr, tr.Spec.TaskRef, "", "default", "default", nil /*VerificationPolicies*/)
 
-			resolvedTask, resolvedRefSource, err := fn(ctx, taskRef.Name)
+			resolvedTask, resolvedRefSource, _, err := fn(ctx, taskRef.Name)
 			if err != nil {
 				t.Fatalf("failed to call pipelinefn: %s", err.Error())
 			}
@@ -652,7 +653,7 @@ func TestGetTaskFunc_RemoteResolution_ReplacedParams(t *testing.T) {
 	}
 	fn := resources.GetTaskFunc(ctx, nil, nil, requester, tr, tr.Spec.TaskRef, "", "default", "default", nil /*VerificationPolicies*/)
 
-	resolvedTask, resolvedRefSource, err := fn(ctx, taskRef.Name)
+	resolvedTask, resolvedRefSource, _, err := fn(ctx, taskRef.Name)
 	if err != nil {
 		t.Fatalf("failed to call pipelinefn: %s", err.Error())
 	}
@@ -694,7 +695,7 @@ func TestGetTaskFunc_RemoteResolution_ReplacedParams(t *testing.T) {
 	}
 	fnNotMatching := resources.GetTaskFunc(ctx, nil, nil, requester, trNotMatching, trNotMatching.Spec.TaskRef, "", "default", "default", nil /*VerificationPolicies*/)
 
-	_, _, err = fnNotMatching(ctx, taskRefNotMatching.Name)
+	_, _, _, err = fnNotMatching(ctx, taskRefNotMatching.Name)
 	if err == nil {
 		t.Fatal("expected error for non-matching params, did not get one")
 	}
@@ -719,7 +720,7 @@ func TestGetPipelineFunc_RemoteResolutionInvalidData(t *testing.T) {
 		},
 	}
 	fn := resources.GetTaskFunc(ctx, nil, nil, requester, tr, tr.Spec.TaskRef, "", "default", "default", nil /*VerificationPolicies*/)
-	if _, _, err := fn(ctx, taskRef.Name); err == nil {
+	if _, _, _, err := fn(ctx, taskRef.Name); err == nil {
 		t.Fatalf("expected error due to invalid pipeline data but saw none")
 	}
 }
@@ -765,64 +766,86 @@ func TestGetTaskFunc_VerifySuccess(t *testing.T) {
 	resolvedMatched := test.NewResolvedResource(signedTaskBytes, nil, matchPolicyRefSource, nil)
 	requesterMatched := test.NewRequester(resolvedMatched, nil)
 
+	warnPolicyRefSource := &v1beta1.RefSource{
+		URI: "	warnVP",
+	}
+	resolvedUnsignedMatched := test.NewResolvedResource(unsignedTaskBytes, nil, warnPolicyRefSource, nil)
+	requesterUnsignedUnmatched := test.NewRequester(resolvedUnsignedMatched, nil)
+
 	taskRef := &v1beta1.TaskRef{ResolverRef: v1beta1.ResolverRef{Resolver: "git"}}
 
 	testcases := []struct {
-		name                      string
-		requester                 *test.Requester
-		verificationNoMatchPolicy string
-		policies                  []*v1alpha1.VerificationPolicy
-		expected                  runtime.Object
-		expectedRefSource         *v1beta1.RefSource
+		name                       string
+		requester                  *test.Requester
+		verificationNoMatchPolicy  string
+		policies                   []*v1alpha1.VerificationPolicy
+		expected                   runtime.Object
+		expectedRefSource          *v1beta1.RefSource
+		expectedVerificationResult *trustedresources.VerificationResult
 	}{{
-		name:                      "signed task with matching policy pass verification with enforce no match policy",
-		requester:                 requesterMatched,
-		verificationNoMatchPolicy: config.FailNoMatchPolicy,
-		policies:                  vps,
-		expected:                  signedTask,
-		expectedRefSource:         matchPolicyRefSource,
+		name:                       "signed task with matching policy pass verification with enforce no match policy",
+		requester:                  requesterMatched,
+		verificationNoMatchPolicy:  config.FailNoMatchPolicy,
+		policies:                   vps,
+		expected:                   signedTask,
+		expectedRefSource:          matchPolicyRefSource,
+		expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationPass},
 	}, {
-		name:                      "signed task with matching policy pass verification with warn no match policy",
-		requester:                 requesterMatched,
-		verificationNoMatchPolicy: config.WarnNoMatchPolicy,
-		policies:                  vps,
-		expected:                  signedTask,
-		expectedRefSource:         matchPolicyRefSource,
+		name:                       "signed task with matching policy pass verification with warn no match policy",
+		requester:                  requesterMatched,
+		verificationNoMatchPolicy:  config.WarnNoMatchPolicy,
+		policies:                   vps,
+		expected:                   signedTask,
+		expectedRefSource:          matchPolicyRefSource,
+		expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationPass},
 	}, {
-		name:                      "signed task with matching policy pass verification with ignore no match policy",
-		requester:                 requesterMatched,
-		verificationNoMatchPolicy: config.IgnoreNoMatchPolicy,
-		policies:                  vps,
-		expected:                  signedTask,
-		expectedRefSource:         matchPolicyRefSource,
+		name:                       "signed task with matching policy pass verification with ignore no match policy",
+		requester:                  requesterMatched,
+		verificationNoMatchPolicy:  config.IgnoreNoMatchPolicy,
+		policies:                   vps,
+		expected:                   signedTask,
+		expectedRefSource:          matchPolicyRefSource,
+		expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationPass},
 	}, {
-		name:                      "warn unsigned task without matching policies",
-		requester:                 requesterUnmatched,
-		verificationNoMatchPolicy: config.WarnNoMatchPolicy,
-		policies:                  vps,
-		expected:                  unsignedTask,
-		expectedRefSource:         noMatchPolicyRefSource,
+		name:                       "warn unsigned task without matching policies",
+		requester:                  requesterUnmatched,
+		verificationNoMatchPolicy:  config.WarnNoMatchPolicy,
+		policies:                   vps,
+		expected:                   unsignedTask,
+		expectedRefSource:          noMatchPolicyRefSource,
+		expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationWarn, Err: trustedresources.ErrNoMatchedPolicies},
 	}, {
-		name:                      "allow unsigned task without matching policies",
-		requester:                 requesterUnmatched,
-		verificationNoMatchPolicy: config.IgnoreNoMatchPolicy,
-		policies:                  vps,
-		expected:                  unsignedTask,
-		expectedRefSource:         noMatchPolicyRefSource,
+		name:                       "warn unsigned task fails matching policies",
+		requester:                  requesterUnsignedUnmatched,
+		verificationNoMatchPolicy:  config.FailNoMatchPolicy,
+		policies:                   vps,
+		expected:                   unsignedTask,
+		expectedRefSource:          warnPolicyRefSource,
+		expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationWarn, Err: trustedresources.ErrResourceVerificationFailed},
 	}, {
-		name:                      "warn no policies",
-		requester:                 requesterUnmatched,
-		verificationNoMatchPolicy: config.WarnNoMatchPolicy,
-		policies:                  []*v1alpha1.VerificationPolicy{},
-		expected:                  unsignedTask,
-		expectedRefSource:         noMatchPolicyRefSource,
+		name:                       "allow unsigned task without matching policies",
+		requester:                  requesterUnmatched,
+		verificationNoMatchPolicy:  config.IgnoreNoMatchPolicy,
+		policies:                   vps,
+		expected:                   unsignedTask,
+		expectedRefSource:          noMatchPolicyRefSource,
+		expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationSkip},
 	}, {
-		name:                      "allow no policies",
-		requester:                 requesterUnmatched,
-		verificationNoMatchPolicy: config.IgnoreNoMatchPolicy,
-		policies:                  []*v1alpha1.VerificationPolicy{},
-		expected:                  unsignedTask,
-		expectedRefSource:         noMatchPolicyRefSource,
+		name:                       "warn no policies",
+		requester:                  requesterUnmatched,
+		verificationNoMatchPolicy:  config.WarnNoMatchPolicy,
+		policies:                   []*v1alpha1.VerificationPolicy{},
+		expected:                   unsignedTask,
+		expectedRefSource:          noMatchPolicyRefSource,
+		expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationWarn, Err: trustedresources.ErrNoMatchedPolicies},
+	}, {
+		name:                       "ignore no policies",
+		requester:                  requesterUnmatched,
+		verificationNoMatchPolicy:  config.IgnoreNoMatchPolicy,
+		policies:                   []*v1alpha1.VerificationPolicy{},
+		expected:                   unsignedTask,
+		expectedRefSource:          noMatchPolicyRefSource,
+		expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationSkip},
 	},
 	}
 	for _, tc := range testcases {
@@ -837,7 +860,7 @@ func TestGetTaskFunc_VerifySuccess(t *testing.T) {
 			}
 			fn := resources.GetTaskFunc(ctx, k8sclient, tektonclient, tc.requester, tr, tr.Spec.TaskRef, "", "default", "default", tc.policies)
 
-			resolvedTask, refSource, err := fn(ctx, taskRef.Name)
+			resolvedTask, refSource, vr, err := fn(ctx, taskRef.Name)
 
 			if err != nil {
 				t.Fatalf("Received unexpected error ( %#v )", err)
@@ -849,6 +872,9 @@ func TestGetTaskFunc_VerifySuccess(t *testing.T) {
 
 			if d := cmp.Diff(tc.expectedRefSource, refSource); d != "" {
 				t.Errorf("configSources did not match: %s", diff.PrintWantGot(d))
+			}
+			if d := cmp.Diff(tc.expectedVerificationResult, vr, cmpopts.EquateErrors()); d != "" {
+				t.Errorf("VerifitionResult did not match: %s", diff.PrintWantGot(d))
 			}
 		})
 	}
@@ -906,53 +932,61 @@ func TestGetTaskFunc_VerifyError(t *testing.T) {
 	taskRef := &v1beta1.TaskRef{ResolverRef: v1beta1.ResolverRef{Resolver: "git"}}
 
 	testcases := []struct {
-		name                      string
-		requester                 *test.Requester
-		verificationNoMatchPolicy string
-		expected                  *v1beta1.Task
-		expectedErr               error
+		name                           string
+		requester                      *test.Requester
+		verificationNoMatchPolicy      string
+		expected                       *v1beta1.Task
+		expectedErr                    error
+		expectedVerificationResultType trustedresources.VerificationResultType
 	}{{
-		name:                      "unsigned task with fails verification with fail no match policy",
-		requester:                 requesterUnsigned,
-		verificationNoMatchPolicy: config.FailNoMatchPolicy,
-		expected:                  nil,
-		expectedErr:               trustedresources.ErrResourceVerificationFailed,
+		name:                           "unsigned task with fails verification with fail no match policy",
+		requester:                      requesterUnsigned,
+		verificationNoMatchPolicy:      config.FailNoMatchPolicy,
+		expected:                       nil,
+		expectedErr:                    trustedresources.ErrResourceVerificationFailed,
+		expectedVerificationResultType: trustedresources.VerificationError,
 	}, {
-		name:                      "unsigned task with fails verification with warn no match policy",
-		requester:                 requesterUnsigned,
-		verificationNoMatchPolicy: config.WarnNoMatchPolicy,
-		expected:                  nil,
-		expectedErr:               trustedresources.ErrResourceVerificationFailed,
+		name:                           "unsigned task with fails verification with warn no match policy",
+		requester:                      requesterUnsigned,
+		verificationNoMatchPolicy:      config.WarnNoMatchPolicy,
+		expected:                       nil,
+		expectedErr:                    trustedresources.ErrResourceVerificationFailed,
+		expectedVerificationResultType: trustedresources.VerificationError,
 	}, {
-		name:                      "unsigned task with fails verification with ignore no match policy",
-		requester:                 requesterUnsigned,
-		verificationNoMatchPolicy: config.IgnoreNoMatchPolicy,
-		expected:                  nil,
-		expectedErr:               trustedresources.ErrResourceVerificationFailed,
+		name:                           "unsigned task with fails verification with ignore no match policy",
+		requester:                      requesterUnsigned,
+		verificationNoMatchPolicy:      config.IgnoreNoMatchPolicy,
+		expected:                       nil,
+		expectedErr:                    trustedresources.ErrResourceVerificationFailed,
+		expectedVerificationResultType: trustedresources.VerificationError,
 	}, {
-		name:                      "modified task fails verification with fail no match policy",
-		requester:                 requesterModified,
-		verificationNoMatchPolicy: config.FailNoMatchPolicy,
-		expected:                  nil,
-		expectedErr:               trustedresources.ErrResourceVerificationFailed,
+		name:                           "modified task fails verification with fail no match policy",
+		requester:                      requesterModified,
+		verificationNoMatchPolicy:      config.FailNoMatchPolicy,
+		expected:                       nil,
+		expectedErr:                    trustedresources.ErrResourceVerificationFailed,
+		expectedVerificationResultType: trustedresources.VerificationError,
 	}, {
-		name:                      "modified task fails verification with warn no match policy",
-		requester:                 requesterModified,
-		verificationNoMatchPolicy: config.WarnNoMatchPolicy,
-		expected:                  nil,
-		expectedErr:               trustedresources.ErrResourceVerificationFailed,
+		name:                           "modified task fails verification with warn no match policy",
+		requester:                      requesterModified,
+		verificationNoMatchPolicy:      config.WarnNoMatchPolicy,
+		expected:                       nil,
+		expectedErr:                    trustedresources.ErrResourceVerificationFailed,
+		expectedVerificationResultType: trustedresources.VerificationError,
 	}, {
-		name:                      "modified task fails verification with ignore no match policy",
-		requester:                 requesterModified,
-		verificationNoMatchPolicy: config.IgnoreNoMatchPolicy,
-		expected:                  nil,
-		expectedErr:               trustedresources.ErrResourceVerificationFailed,
+		name:                           "modified task fails verification with ignore no match policy",
+		requester:                      requesterModified,
+		verificationNoMatchPolicy:      config.IgnoreNoMatchPolicy,
+		expected:                       nil,
+		expectedErr:                    trustedresources.ErrResourceVerificationFailed,
+		expectedVerificationResultType: trustedresources.VerificationError,
 	}, {
-		name:                      "unmatched task fails with fail no match policy",
-		requester:                 requesterUnmatched,
-		verificationNoMatchPolicy: config.FailNoMatchPolicy,
-		expected:                  nil,
-		expectedErr:               trustedresources.ErrNoMatchedPolicies,
+		name:                           "unmatched task fails with fail no match policy",
+		requester:                      requesterUnmatched,
+		verificationNoMatchPolicy:      config.FailNoMatchPolicy,
+		expected:                       nil,
+		expectedErr:                    trustedresources.ErrNoMatchedPolicies,
+		expectedVerificationResultType: trustedresources.VerificationError,
 	},
 	}
 	for _, tc := range testcases {
@@ -967,18 +1001,12 @@ func TestGetTaskFunc_VerifyError(t *testing.T) {
 			}
 			fn := resources.GetTaskFunc(ctx, k8sclient, tektonclient, tc.requester, tr, tr.Spec.TaskRef, "", "default", "default", vps)
 
-			resolvedTask, resolvedRefSource, err := fn(ctx, taskRef.Name)
-
-			if !errors.Is(err, tc.expectedErr) {
-				t.Errorf("GetTaskFunc got %v but want %v", err, tc.expectedErr)
+			_, _, vr, _ := fn(ctx, taskRef.Name)
+			if !errors.Is(vr.Err, tc.expectedErr) {
+				t.Errorf("GetPipelineFunc got %v, want %v", err, tc.expectedErr)
 			}
-
-			if d := cmp.Diff(tc.expected, resolvedTask); d != "" {
-				t.Errorf("resolvedTask did not match: %s", diff.PrintWantGot(d))
-			}
-
-			if resolvedRefSource != nil {
-				t.Errorf("refSource is: %v but want is nil", resolvedRefSource)
+			if tc.expectedVerificationResultType != vr.VerificationResultType {
+				t.Errorf("VerificationResultType mismatch, want %d got %d", tc.expectedVerificationResultType, vr.VerificationResultType)
 			}
 		})
 	}
@@ -1059,7 +1087,7 @@ func TestGetTaskFunc_GetFuncError(t *testing.T) {
 
 			fn := resources.GetTaskFunc(ctx, k8sclient, tektonclient, tc.requester, &tc.taskrun, tc.taskrun.Spec.TaskRef, "", "default", "default", vps)
 
-			_, _, err = fn(ctx, tc.taskrun.Spec.TaskRef.Name)
+			_, _, _, err = fn(ctx, tc.taskrun.Spec.TaskRef.Name)
 
 			if d := cmp.Diff(err.Error(), tc.expectedErr.Error()); d != "" {
 				t.Fatalf("Expected error %v but found %v instead", tc.expectedErr, err)

--- a/pkg/reconciler/taskrun/resources/taskspec.go
+++ b/pkg/reconciler/taskrun/resources/taskspec.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	resolutionutil "github.com/tektoncd/pipeline/pkg/internal/resolution"
+	"github.com/tektoncd/pipeline/pkg/trustedresources"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -35,7 +36,7 @@ type ResolvedTask struct {
 }
 
 // GetTask is a function used to retrieve Tasks.
-type GetTask func(context.Context, string) (*v1beta1.Task, *v1beta1.RefSource, error)
+type GetTask func(context.Context, string) (*v1beta1.Task, *v1beta1.RefSource, *trustedresources.VerificationResult, error)
 
 // GetTaskRun is a function used to retrieve TaskRuns
 type GetTaskRun func(string) (*v1beta1.TaskRun, error)
@@ -43,44 +44,47 @@ type GetTaskRun func(string) (*v1beta1.TaskRun, error)
 // GetTaskData will retrieve the Task metadata and Spec associated with the
 // provided TaskRun. This can come from a reference Task or from the TaskRun's
 // metadata and embedded TaskSpec.
-func GetTaskData(ctx context.Context, taskRun *v1beta1.TaskRun, getTask GetTask) (*resolutionutil.ResolvedObjectMeta, *v1beta1.TaskSpec, error) {
+func GetTaskData(ctx context.Context, taskRun *v1beta1.TaskRun, getTask GetTask) (*resolutionutil.ResolvedObjectMeta, *v1beta1.TaskSpec, *trustedresources.VerificationResult, error) {
 	taskMeta := metav1.ObjectMeta{}
 	var refSource *v1beta1.RefSource
+	var verificationResult *trustedresources.VerificationResult
 	taskSpec := v1beta1.TaskSpec{}
 	switch {
 	case taskRun.Spec.TaskRef != nil && taskRun.Spec.TaskRef.Name != "":
 		// Get related task for taskrun
-		t, source, err := getTask(ctx, taskRun.Spec.TaskRef.Name)
+		t, source, vr, err := getTask(ctx, taskRun.Spec.TaskRef.Name)
 		if err != nil {
-			return nil, nil, fmt.Errorf("error when listing tasks for taskRun %s: %w", taskRun.Name, err)
+			return nil, nil, nil, fmt.Errorf("error when listing tasks for taskRun %s: %w", taskRun.Name, err)
 		}
 		taskMeta = t.TaskMetadata()
 		taskSpec = t.TaskSpec()
 		refSource = source
+		verificationResult = vr
 	case taskRun.Spec.TaskSpec != nil:
 		taskMeta = taskRun.ObjectMeta
 		taskSpec = *taskRun.Spec.TaskSpec
 		// TODO: if we want to set RefSource for embedded taskspec, set it here.
 		// https://github.com/tektoncd/pipeline/issues/5522
 	case taskRun.Spec.TaskRef != nil && taskRun.Spec.TaskRef.Resolver != "":
-		task, source, err := getTask(ctx, taskRun.Name)
+		task, source, vr, err := getTask(ctx, taskRun.Name)
 		switch {
 		case err != nil:
-			return nil, nil, err
+			return nil, nil, nil, err
 		case task == nil:
-			return nil, nil, errors.New("resolution of remote resource completed successfully but no task was returned")
+			return nil, nil, nil, errors.New("resolution of remote resource completed successfully but no task was returned")
 		default:
 			taskMeta = task.TaskMetadata()
 			taskSpec = task.TaskSpec()
+			verificationResult = vr
 		}
 		refSource = source
 	default:
-		return nil, nil, fmt.Errorf("taskRun %s not providing TaskRef or TaskSpec", taskRun.Name)
+		return nil, nil, nil, fmt.Errorf("taskRun %s not providing TaskRef or TaskSpec", taskRun.Name)
 	}
 
 	taskSpec.SetDefaults(ctx)
 	return &resolutionutil.ResolvedObjectMeta{
 		ObjectMeta: &taskMeta,
 		RefSource:  refSource,
-	}, &taskSpec, nil
+	}, &taskSpec, verificationResult, nil
 }

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -328,16 +328,12 @@ func (c *Reconciler) prepare(ctx context.Context, tr *v1beta1.TaskRun) (*v1beta1
 	}
 	getTaskfunc := resources.GetTaskFuncFromTaskRun(ctx, c.KubeClientSet, c.PipelineClientSet, c.resolutionRequester, tr, vp)
 
-	taskMeta, taskSpec, err := resources.GetTaskData(ctx, tr, getTaskfunc)
+	taskMeta, taskSpec, verificationResult, err := resources.GetTaskData(ctx, tr, getTaskfunc)
 	switch {
 	case errors.Is(err, remote.ErrRequestInProgress):
 		message := fmt.Sprintf("TaskRun %s/%s awaiting remote resource", tr.Namespace, tr.Name)
 		tr.Status.MarkResourceOngoing(v1beta1.TaskRunReasonResolvingTaskRef, message)
 		return nil, nil, err
-	case errors.Is(err, trustedresources.ErrResourceVerificationFailed):
-		logger.Errorf("TaskRun %s/%s referred task failed signature verification", tr.Namespace, tr.Name)
-		tr.Status.MarkResourceFailed(podconvert.ReasonResourceVerificationFailed, err)
-		return nil, nil, controller.NewPermanentError(err)
 	case err != nil:
 		logger.Errorf("Failed to determine Task spec to use for taskrun %s: %v", tr.Name, err)
 		if resources.IsGetTaskErrTransient(err) {
@@ -349,6 +345,32 @@ func (c *Reconciler) prepare(ctx context.Context, tr *v1beta1.TaskRun) (*v1beta1
 		// Store the fetched TaskSpec on the TaskRun for auditing
 		if err := storeTaskSpecAndMergeMeta(ctx, tr, taskSpec, taskMeta); err != nil {
 			logger.Errorf("Failed to store TaskSpec on TaskRun.Statusfor taskrun %s: %v", tr.Name, err)
+		}
+	}
+	if verificationResult != nil {
+		switch verificationResult.VerificationResultType {
+		case trustedresources.VerificationError:
+			logger.Errorf("TaskRun %s/%s referred task failed signature verification", tr.Namespace, tr.Name)
+			tr.Status.MarkResourceFailed(podconvert.ReasonResourceVerificationFailed, verificationResult.Err)
+			tr.Status.SetCondition(&apis.Condition{
+				Type:    trustedresources.ConditionTrustedResourcesVerified,
+				Status:  corev1.ConditionFalse,
+				Message: verificationResult.Err.Error(),
+			})
+			return nil, nil, controller.NewPermanentError(verificationResult.Err)
+		case trustedresources.VerificationSkip:
+			// do nothing
+		case trustedresources.VerificationWarn:
+			tr.Status.SetCondition(&apis.Condition{
+				Type:    trustedresources.ConditionTrustedResourcesVerified,
+				Status:  corev1.ConditionFalse,
+				Message: verificationResult.Err.Error(),
+			})
+		case trustedresources.VerificationPass:
+			tr.Status.SetCondition(&apis.Condition{
+				Type:   trustedresources.ConditionTrustedResourcesVerified,
+				Status: corev1.ConditionTrue,
+			})
 		}
 	}
 

--- a/pkg/trustedresources/verify_test.go
+++ b/pkg/trustedresources/verify_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/sigstore/sigstore/pkg/signature"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
@@ -191,6 +192,23 @@ func TestVerifyTask_Success(t *testing.T) {
 		},
 	}
 
+	warnNoKeyPolicy := &v1alpha1.VerificationPolicy{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "VerificationPolicy",
+			APIVersion: "v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "warnPolicy",
+			Namespace: namespace,
+		},
+		Spec: v1alpha1.VerificationPolicySpec{
+			Resources: []v1alpha1.ResourcePattern{
+				{Pattern: "https://github.com/tektoncd/catalog.git"},
+			},
+			Mode: v1alpha1.ModeWarn,
+		},
+	}
+
 	signedTask384, err := test.GetSignedTask(unsignedTask, signer384, "signed384")
 	if err != nil {
 		t.Fatal("fail to sign task", err)
@@ -198,60 +216,75 @@ func TestVerifyTask_Success(t *testing.T) {
 
 	mismatchedSource := "wrong source"
 	tcs := []struct {
-		name                      string
-		task                      *v1beta1.Task
-		source                    *v1beta1.RefSource
-		signer                    signature.SignerVerifier
-		verificationNoMatchPolicy string
-		verificationPolicies      []*v1alpha1.VerificationPolicy
+		name                       string
+		task                       *v1beta1.Task
+		source                     *v1beta1.RefSource
+		signer                     signature.SignerVerifier
+		verificationNoMatchPolicy  string
+		verificationPolicies       []*v1alpha1.VerificationPolicy
+		expectedVerificationResult *VerificationResult
 	}{{
-		name:                      "signed git source task passes verification",
-		task:                      signedTask,
-		source:                    &v1beta1.RefSource{URI: "git+https://github.com/tektoncd/catalog.git"},
-		verificationNoMatchPolicy: config.FailNoMatchPolicy,
-		verificationPolicies:      vps,
+		name:                       "signed git source task passes verification",
+		task:                       signedTask,
+		source:                     &v1beta1.RefSource{URI: "git+https://github.com/tektoncd/catalog.git"},
+		verificationNoMatchPolicy:  config.FailNoMatchPolicy,
+		verificationPolicies:       vps,
+		expectedVerificationResult: &VerificationResult{VerificationResultType: VerificationPass},
 	}, {
-		name:                      "signed bundle source task passes verification",
-		task:                      signedTask,
-		source:                    &v1beta1.RefSource{URI: "gcr.io/tekton-releases/catalog/upstream/git-clone"},
-		verificationNoMatchPolicy: config.FailNoMatchPolicy,
-		verificationPolicies:      vps,
+		name:                       "signed bundle source task passes verification",
+		task:                       signedTask,
+		source:                     &v1beta1.RefSource{URI: "gcr.io/tekton-releases/catalog/upstream/git-clone"},
+		verificationNoMatchPolicy:  config.FailNoMatchPolicy,
+		verificationPolicies:       vps,
+		expectedVerificationResult: &VerificationResult{VerificationResultType: VerificationPass},
 	}, {
-		name:                      "signed task with sha384 key",
-		task:                      signedTask384,
-		source:                    &v1beta1.RefSource{URI: "gcr.io/tekton-releases/catalog/upstream/sha384"},
-		verificationNoMatchPolicy: config.FailNoMatchPolicy,
-		verificationPolicies:      []*v1alpha1.VerificationPolicy{sha384Vp},
+		name:                       "signed task with sha384 key",
+		task:                       signedTask384,
+		source:                     &v1beta1.RefSource{URI: "gcr.io/tekton-releases/catalog/upstream/sha384"},
+		verificationNoMatchPolicy:  config.FailNoMatchPolicy,
+		verificationPolicies:       []*v1alpha1.VerificationPolicy{sha384Vp},
+		expectedVerificationResult: &VerificationResult{VerificationResultType: VerificationPass},
 	}, {
-		name:                      "ignore no match policy skips verification when no matching policies",
-		task:                      unsignedTask,
-		source:                    &v1beta1.RefSource{URI: mismatchedSource},
-		verificationNoMatchPolicy: config.IgnoreNoMatchPolicy,
+		name:                       "ignore no match policy skips verification when no matching policies",
+		task:                       unsignedTask,
+		source:                     &v1beta1.RefSource{URI: mismatchedSource},
+		verificationNoMatchPolicy:  config.IgnoreNoMatchPolicy,
+		expectedVerificationResult: &VerificationResult{VerificationResultType: VerificationSkip},
 	}, {
-		name:                      "warn no match policy skips verification when no matching policies",
-		task:                      unsignedTask,
-		source:                    &v1beta1.RefSource{URI: mismatchedSource},
-		verificationNoMatchPolicy: config.WarnNoMatchPolicy,
+		name:                       "warn no match policy skips verification when no matching policies",
+		task:                       unsignedTask,
+		source:                     &v1beta1.RefSource{URI: mismatchedSource},
+		verificationNoMatchPolicy:  config.WarnNoMatchPolicy,
+		expectedVerificationResult: &VerificationResult{VerificationResultType: VerificationWarn, Err: ErrNoMatchedPolicies},
 	}, {
-		name:                      "unsigned task matches warn policy doesn't fail verification",
-		task:                      unsignedTask,
-		source:                    &v1beta1.RefSource{URI: "git+https://github.com/tektoncd/catalog.git"},
-		verificationNoMatchPolicy: config.FailNoMatchPolicy,
-		verificationPolicies:      []*v1alpha1.VerificationPolicy{warnPolicy},
+		name:                       "unsigned task matches warn policy doesn't fail verification",
+		task:                       unsignedTask,
+		source:                     &v1beta1.RefSource{URI: "git+https://github.com/tektoncd/catalog.git"},
+		verificationNoMatchPolicy:  config.FailNoMatchPolicy,
+		verificationPolicies:       []*v1alpha1.VerificationPolicy{warnPolicy},
+		expectedVerificationResult: &VerificationResult{VerificationResultType: VerificationWarn, Err: ErrResourceVerificationFailed},
 	}, {
-		name:                      "modified task matches warn policy doesn't fail verification",
-		task:                      modifiedTask,
-		source:                    &v1beta1.RefSource{URI: "git+https://github.com/tektoncd/catalog.git"},
-		verificationNoMatchPolicy: config.FailNoMatchPolicy,
-		verificationPolicies:      []*v1alpha1.VerificationPolicy{warnPolicy},
+		name:                       "modified task matches warn policy doesn't fail verification",
+		task:                       modifiedTask,
+		source:                     &v1beta1.RefSource{URI: "git+https://github.com/tektoncd/catalog.git"},
+		verificationNoMatchPolicy:  config.FailNoMatchPolicy,
+		verificationPolicies:       []*v1alpha1.VerificationPolicy{warnPolicy},
+		expectedVerificationResult: &VerificationResult{VerificationResultType: VerificationWarn, Err: ErrResourceVerificationFailed},
+	}, {
+		name:                       "modified task matches warn policy with empty key doesn't fail verification",
+		task:                       modifiedTask,
+		source:                     &v1beta1.RefSource{URI: "git+https://github.com/tektoncd/catalog.git"},
+		verificationNoMatchPolicy:  config.FailNoMatchPolicy,
+		verificationPolicies:       []*v1alpha1.VerificationPolicy{warnNoKeyPolicy},
+		expectedVerificationResult: &VerificationResult{VerificationResultType: VerificationWarn, Err: verifier.ErrEmptyPublicKeys},
 	}}
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := test.SetupTrustedResourceConfig(context.Background(), tc.verificationNoMatchPolicy)
-			err := VerifyTask(ctx, tc.task, k8sclient, tc.source, tc.verificationPolicies)
-			if err != nil {
-				t.Fatalf("VerifyTask() get err %v", err)
+			vr := VerifyTask(ctx, tc.task, k8sclient, tc.source, tc.verificationPolicies)
+			if d := cmp.Diff(tc.expectedVerificationResult, vr, cmpopts.EquateErrors()); d != "" {
+				t.Errorf(diff.PrintWantGot(d))
 			}
 		})
 	}
@@ -349,8 +382,8 @@ func TestVerifyTask_Error(t *testing.T) {
 	}}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			err := VerifyTask(ctx, tc.task, k8sclient, tc.source, tc.verificationPolicy)
-			if !errors.Is(err, tc.expectedError) {
+			vr := VerifyTask(ctx, tc.task, k8sclient, tc.source, tc.verificationPolicy)
+			if !errors.Is(vr.Err, tc.expectedError) {
 				t.Errorf("VerifyTask got: %v, want: %v", err, tc.expectedError)
 			}
 		})
@@ -367,37 +400,42 @@ func TestVerifyPipeline_Success(t *testing.T) {
 
 	mismatchedSource := "wrong source"
 	tcs := []struct {
-		name                      string
-		pipeline                  *v1beta1.Pipeline
-		source                    *v1beta1.RefSource
-		verificationNoMatchPolicy string
+		name                       string
+		pipeline                   *v1beta1.Pipeline
+		source                     *v1beta1.RefSource
+		verificationNoMatchPolicy  string
+		expectedVerificationResult *VerificationResult
 	}{{
-		name:                      "signed git source pipeline passes verification",
-		pipeline:                  signedPipeline,
-		source:                    &v1beta1.RefSource{URI: "git+https://github.com/tektoncd/catalog.git"},
-		verificationNoMatchPolicy: config.FailNoMatchPolicy,
+		name:                       "signed git source pipeline passes verification",
+		pipeline:                   signedPipeline,
+		source:                     &v1beta1.RefSource{URI: "git+https://github.com/tektoncd/catalog.git"},
+		verificationNoMatchPolicy:  config.FailNoMatchPolicy,
+		expectedVerificationResult: &VerificationResult{VerificationResultType: VerificationPass},
 	}, {
-		name:                      "signed bundle source pipeline passes verification",
-		pipeline:                  signedPipeline,
-		source:                    &v1beta1.RefSource{URI: "gcr.io/tekton-releases/catalog/upstream/git-clone"},
-		verificationNoMatchPolicy: config.FailNoMatchPolicy,
+		name:                       "signed bundle source pipeline passes verification",
+		pipeline:                   signedPipeline,
+		source:                     &v1beta1.RefSource{URI: "gcr.io/tekton-releases/catalog/upstream/git-clone"},
+		verificationNoMatchPolicy:  config.FailNoMatchPolicy,
+		expectedVerificationResult: &VerificationResult{VerificationResultType: VerificationPass},
 	}, {
-		name:                      "ignore no match policy skips verification when no matching policies",
-		pipeline:                  unsignedPipeline,
-		source:                    &v1beta1.RefSource{URI: mismatchedSource},
-		verificationNoMatchPolicy: config.IgnoreNoMatchPolicy,
+		name:                       "ignore no match policy skips verification when no matching policies",
+		pipeline:                   unsignedPipeline,
+		source:                     &v1beta1.RefSource{URI: mismatchedSource},
+		verificationNoMatchPolicy:  config.IgnoreNoMatchPolicy,
+		expectedVerificationResult: &VerificationResult{VerificationResultType: VerificationSkip},
 	}, {
-		name:                      "warn no match policy skips verification when no matching policies",
-		pipeline:                  unsignedPipeline,
-		source:                    &v1beta1.RefSource{URI: mismatchedSource},
-		verificationNoMatchPolicy: config.WarnNoMatchPolicy,
+		name:                       "warn no match policy skips verification when no matching policies",
+		pipeline:                   unsignedPipeline,
+		source:                     &v1beta1.RefSource{URI: mismatchedSource},
+		verificationNoMatchPolicy:  config.WarnNoMatchPolicy,
+		expectedVerificationResult: &VerificationResult{VerificationResultType: VerificationWarn, Err: ErrNoMatchedPolicies},
 	}}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := test.SetupTrustedResourceConfig(context.Background(), tc.verificationNoMatchPolicy)
-			err := VerifyPipeline(ctx, tc.pipeline, k8sclient, tc.source, vps)
-			if err != nil {
-				t.Fatalf("VerifyPipeline() get err: %v", err)
+			vr := VerifyPipeline(ctx, tc.pipeline, k8sclient, tc.source, vps)
+			if d := cmp.Diff(tc.expectedVerificationResult, vr, cmpopts.EquateErrors()); d != "" {
+				t.Errorf(diff.PrintWantGot(d))
 			}
 		})
 	}
@@ -424,16 +462,19 @@ func TestVerifyPipeline_Error(t *testing.T) {
 		pipeline           *v1beta1.Pipeline
 		source             *v1beta1.RefSource
 		verificationPolicy []*v1alpha1.VerificationPolicy
+		expectedError      error
 	}{{
 		name:               "Tampered Task Fails Verification with tampered content",
 		pipeline:           tamperedPipeline,
 		source:             &v1beta1.RefSource{URI: matchingSource},
 		verificationPolicy: vps,
+		expectedError:      ErrResourceVerificationFailed,
 	}, {
 		name:               "Task Not Matching Pattern Fails Verification",
 		pipeline:           signedPipeline,
 		source:             &v1beta1.RefSource{URI: mismatchedSource},
 		verificationPolicy: vps,
+		expectedError:      ErrNoMatchedPolicies,
 	}, {
 		name:     "Verification fails with regex error",
 		pipeline: signedPipeline,
@@ -450,12 +491,13 @@ func TestVerifyPipeline_Error(t *testing.T) {
 				},
 			},
 		},
+		expectedError: ErrNoMatchedPolicies,
 	}}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			err := VerifyPipeline(ctx, tc.pipeline, k8sclient, tc.source, tc.verificationPolicy)
-			if err == nil {
-				t.Fatalf("VerifyPipeline() expects to get err but got nil")
+			vr := VerifyPipeline(ctx, tc.pipeline, k8sclient, tc.source, tc.verificationPolicy)
+			if !errors.Is(vr.Err, tc.expectedError) {
+				t.Errorf("VerifyPipeline got: %v, want: %v", vr.Err, tc.expectedError)
 			}
 		})
 	}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This commit adds the ConditionTrustedResourcesVerified for trusted resources into pipelinerun/taskrun status to show if the resources passes verification. Failing to verify will add a false condition to the taskrun/pipelinerun status and passing the verification will add a true status condition.

Though this is a big size PR, it contains several changes which can be grouped into:
1. Add `VerificationResult` to indicate different cases when the Verification doesn't return error (Files: verify.go)
2. Update GetTask and GetPipeline and all the functions in call stack to return `VerificationResult` back to `reconcile` (Files: pipelineref.go, pipelinerunresolution.go, pipelinespec.go, taskref.go, taskspec.go)
3. Update TrustedResources condition based on `VerificationResult` (Files: taskrun.go, pipelinerun.go)
4. Unit tests to cover those cases. (all test files)

Those changes cannot be split into separate PRs.

/kind feature

Signed-off-by: Yongxuan Zhang yongxuanzhang@google.com

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Add ConditionTrustedResourcesVerified condition to pipelinerun/taskrun status indicate whether trusted resources fails verification or not. Functions including GetTask, GetTaskData, GetPipeline, GetPipelineData are updated to return VerificationResult
```
