### PR TITLE
Sync pipelinerun validation between v1beta1 and v1

### DIFF
--- a/pkg/apis/pipeline/v1/pipelinerun_validation.go
+++ b/pkg/apis/pipeline/v1/pipelinerun_validation.go
@@ -148,66 +148,62 @@ func (ps *PipelineRunSpec) validateInlineParameters(ctx context.Context) (errs *
 	if ps.PipelineSpec == nil {
 		return errs
 	}
-	var paramSpec []ParamSpec
+	paramSpecForValidation := make(map[string]ParamSpec)
 	for _, p := range ps.Params {
-		pSpec := ParamSpec{
-			Name:    p.Name,
-			Default: &p.Value,
-		}
-		paramSpec = append(paramSpec, pSpec)
+		paramSpecForValidation = createParamSpecFromParam(p, paramSpecForValidation)
 	}
-	paramSpec = appendParamSpec(paramSpec, ps.PipelineSpec.Params)
-	for _, pt := range ps.PipelineSpec.Tasks {
-		paramSpec = appendParam(paramSpec, pt.Params)
-		if pt.TaskSpec != nil && pt.TaskSpec.Params != nil {
-			paramSpec = appendParamSpec(paramSpec, pt.TaskSpec.Params)
+	for _, p := range ps.PipelineSpec.Params {
+		var err *apis.FieldError
+		paramSpecForValidation, err = combineParamSpec(p, paramSpecForValidation)
+		if err != nil {
+			errs = errs.Also(err)
 		}
+	}
+	for _, pt := range ps.PipelineSpec.Tasks {
+		paramSpecForValidation = appendPipelineTaskParams(paramSpecForValidation, pt.Params)
+		if pt.TaskSpec != nil && pt.TaskSpec.Params != nil {
+			for _, p := range pt.TaskSpec.Params {
+				var err *apis.FieldError
+				paramSpecForValidation, err = combineParamSpec(p, paramSpecForValidation)
+				if err != nil {
+					errs = errs.Also(err)
+				}
+			}
+		}
+	}
+	var paramSpec []ParamSpec
+	for _, v := range paramSpecForValidation {
+		paramSpec = append(paramSpec, v)
 	}
 	if ps.PipelineSpec != nil && ps.PipelineSpec.Tasks != nil {
 		for _, pt := range ps.PipelineSpec.Tasks {
 			if pt.TaskSpec != nil && pt.TaskSpec.Steps != nil {
+				errs = errs.Also(ValidateParameterTypes(ctx, paramSpec))
 				errs = errs.Also(ValidateParameterVariables(
 					config.SkipValidationDueToPropagatedParametersAndWorkspaces(ctx, false), pt.TaskSpec.Steps, paramSpec))
 			}
 		}
+		errs = errs.Also(ValidatePipelineParameterVariables(
+			config.SkipValidationDueToPropagatedParametersAndWorkspaces(ctx, false), ps.PipelineSpec.Tasks, paramSpec))
 	}
 	return errs
 }
 
-func appendParamSpec(paramSpec []ParamSpec, params []ParamSpec) []ParamSpec {
+func appendPipelineTaskParams(paramSpecForValidation map[string]ParamSpec, params Params) map[string]ParamSpec {
 	for _, p := range params {
-		skip := false
-		for _, ps := range paramSpec {
-			if ps.Name == p.Name {
-				skip = true
-				break
+		if pSpec, ok := paramSpecForValidation[p.Name]; ok {
+			if p.Value.ObjectVal != nil {
+				for k, v := range p.Value.ObjectVal {
+					pSpec.Default.ObjectVal[k] = v
+					pSpec.Properties[k] = PropertySpec{Type: ParamTypeString}
+				}
 			}
-		}
-		if !skip {
-			paramSpec = append(paramSpec, p)
+			paramSpecForValidation[p.Name] = pSpec
+		} else {
+			paramSpecForValidation = createParamSpecFromParam(p, paramSpecForValidation)
 		}
 	}
-	return paramSpec
-}
-
-func appendParam(paramSpec []ParamSpec, params Params) []ParamSpec {
-	for _, p := range params {
-		skip := false
-		for _, ps := range paramSpec {
-			if ps.Name == p.Name {
-				skip = true
-				break
-			}
-		}
-		if !skip {
-			pSpec := ParamSpec{
-				Name:    p.Name,
-				Default: &p.Value,
-			}
-			paramSpec = append(paramSpec, pSpec)
-		}
-	}
-	return paramSpec
+	return paramSpecForValidation
 }
 
 func validateSpecStatus(status PipelineRunSpecStatus) *apis.FieldError {


### PR DESCRIPTION
In [this commit](https://github.com/tektoncd/pipeline/commit/a11c38585b924d9b07b93bc38524889c7413ce1d), I forgot to sync pipelinerun validation between v1beta1 and v1. Thank you @lbernick for noticing this. This PR syncs both of those version as expected.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Sync pipelinerun validation between v1beta1 and v1
```
/kind bug