### PR TITLE
Bug Fixes: Update Status for Matrixed PipelineTask

### DIFF
--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
@@ -2114,7 +2114,52 @@ func TestAdjustStartTime(t *testing.T) {
 		// We expect this to adjust to the earlier time.
 		want: baseline.Time.Add(-2 * time.Second),
 	}, {
-		name: "run starts later",
+		name: "multiple taskruns, some earlier",
+		prs: PipelineRunState{{
+			TaskRuns: []*v1beta1.TaskRun{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "blah1",
+					CreationTimestamp: metav1.Time{Time: baseline.Time.Add(-1 * time.Second)},
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "blah2",
+					CreationTimestamp: metav1.Time{Time: baseline.Time.Add(-2 * time.Second)},
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "blah3",
+					CreationTimestamp: metav1.Time{Time: baseline.Time.Add(2 * time.Second)},
+				},
+			}},
+		}},
+		// We expect this to adjust to the earlier time.
+		want: baseline.Time.Add(-2 * time.Second),
+	}, {
+		name: "multiple CustomRuns, some earlier",
+		prs: PipelineRunState{{
+			RunObjects: []v1beta1.RunObject{
+				&v1beta1.CustomRun{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "blah1",
+						CreationTimestamp: metav1.Time{Time: baseline.Time.Add(-1 * time.Second)},
+					},
+				}, &v1beta1.CustomRun{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "blah2",
+						CreationTimestamp: metav1.Time{Time: baseline.Time.Add(-2 * time.Second)},
+					},
+				}, &v1beta1.CustomRun{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "blah3",
+						CreationTimestamp: metav1.Time{Time: baseline.Time.Add(2 * time.Second)},
+					},
+				}},
+		}},
+		// We expect this to adjust to the earlier time.
+		want: baseline.Time.Add(-2 * time.Second),
+	}, {
+		name: "CustomRun starts later",
 		prs: PipelineRunState{{
 			RunObject: &v1beta1.CustomRun{
 				ObjectMeta: metav1.ObjectMeta{
@@ -2126,7 +2171,7 @@ func TestAdjustStartTime(t *testing.T) {
 		// Stay where you are, you are before the Run.
 		want: baseline.Time,
 	}, {
-		name: "run starts earlier",
+		name: "CustomRun starts earlier",
 		prs: PipelineRunState{{
 			RunObject: &v1beta1.CustomRun{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Prior to this commit, we were not checking the status for matrixed tasks and customTasks and only checking that status of singular TaskRun/RunObject. This is a bug since a matrixed PT would not have a nil TaskRun/RunObject since the TaskRuns/RunObjects fields would be used instead. Example functions: `AdjustStartTime`, `IsBeforeFirstTaskRun`, `isScheduled`, `isStarted`. Added test coverage.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Bug Fix: A matrixed pipelineTask will accurately reflect the status of isStarted(), isScheduled(), IsBeforeFirstTaskRun(), IsConditionStatusFalse() with the correct start time based on it's TaskRuns or custom RunObjects.
```
