### PR TITLE
[TEP-0091] add VerificationResult

### DIFF
--- a/pkg/trustedresources/verify.go
+++ b/pkg/trustedresources/verify.go
@@ -41,6 +41,28 @@ const (
 	SignatureAnnotation = "tekton.dev/signature"
 )
 
+const (
+	VerificationSkip = iota
+	VerificationPass
+	VerificationWarn
+	VerificationError
+)
+
+// VerificationResultType indicates different cases of a verification result
+type VerificationResultType int
+
+// VerificationResult contains the type and message about the result of verification
+type VerificationResult struct {
+	// VerificationResultType has 4 types which is corresponding to 4 cases:
+	// 0 (VerificationSkip): The verification was skipped. Err is nil in this case.
+	// 1 (VerificationPass): The verification passed. Err is nil in this case.
+	// 2 (VerificationWarn): A warning is logged. It could be no matching policies and feature flag "no-match-policy" is "warn", or only Warn mode verification policies fail.
+	// 3 (VerificationError): The verification failed, it could be the signature doesn't match the public key, no matching policies and "no-match-policy" is set to "fail" or there are errors during verification.
+	VerificationResultType VerificationResultType
+	// Err contains the error message when there is a warning logged or error returned.
+	Err error
+}
+
 // VerifyTask verifies the signature and public key against task.
 // Skip the verification when no policies are found and trusted-resources-verification-no-match-policy is set to ignore or warn
 // Return an error when no policies are found and trusted-resources-verification-no-match-policy is set to fail,


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The commit adds VerificationResult struct, the new struct has 2 fields, VerificationResultType and Err.
VerificationResultType has 4 types: VerificationSkip, VerificationPass,
VerificationWarn, VerificationError. 

VerificationResult will be used in reconciler to update taskrun, pipelinerun conditions, conditions' message will be filled with Err from VerificationResult.

This PR is a split from https://github.com/tektoncd/pipeline/pull/6654. 

/kind feature

Signed-off-by: Yongxuan Zhang yongxuanzhang@google.com

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
