### PR TITLE
[TEP-0091] use VerificationResult in verify

### DIFF
--- a/pkg/reconciler/pipelinerun/resources/pipelineref.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelineref.go
@@ -151,9 +151,12 @@ func readRuntimeObjectAsPipeline(ctx context.Context, obj runtime.Object, k8s ku
 	switch obj := obj.(type) {
 	case *v1beta1.Pipeline:
 		// Verify the Pipeline once we fetch from the remote resolution, mutating, validation and conversion of the pipeline should happen after the verification, since signatures are based on the remote pipeline contents
-		err := trustedresources.VerifyPipeline(ctx, obj, k8s, refSource, verificationPolicies)
-		if err != nil {
-			return nil, fmt.Errorf("remote Pipeline verification failed for object %s: %w", obj.GetName(), err)
+		vr := trustedresources.VerifyPipeline(ctx, obj, k8s, refSource, verificationPolicies)
+		if vr.VerificationResultType == trustedresources.VerificationError {
+			if vr.Err != nil {
+				return nil, fmt.Errorf("remote Pipeline verification failed for object %s: %w", obj.GetName(), vr.Err)
+			}
+			return nil, fmt.Errorf("remote Pipeline verification failed for object %s", obj.GetName())
 		}
 		return obj, nil
 	case *v1.Pipeline:

--- a/pkg/reconciler/taskrun/resources/taskref.go
+++ b/pkg/reconciler/taskrun/resources/taskref.go
@@ -172,9 +172,12 @@ func readRuntimeObjectAsTask(ctx context.Context, obj runtime.Object, k8s kubern
 	switch obj := obj.(type) {
 	case *v1beta1.Task:
 		// Verify the Task once we fetch from the remote resolution, mutating, validation and conversion of the task should happen after the verification, since signatures are based on the remote task contents
-		err := trustedresources.VerifyTask(ctx, obj, k8s, refSource, verificationPolicies)
-		if err != nil {
-			return nil, fmt.Errorf("remote Task verification failed for object %s: %w", obj.GetName(), err)
+		vr := trustedresources.VerifyTask(ctx, obj, k8s, refSource, verificationPolicies)
+		if vr.VerificationResultType == trustedresources.VerificationError {
+			if vr.Err != nil {
+				return nil, fmt.Errorf("remote Task verification failed for object %s: %w", obj.GetName(), vr.Err)
+			}
+			return nil, fmt.Errorf("remote Task verification failed for object %s", obj.GetName())
 		}
 		return obj, nil
 	case *v1beta1.ClusterTask:


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This commits uses the VerificationResult as the return value for VerifyTask and VerifyPipeline. Previously returned error will be replaced with a VerificationError type VerificationResult and error is in Err field. The cases when nil is returned are currently changed to 3 types of VerificationResult:
    1) Verification is skipped
    2) Verification passed
    3) Warning is logged during verification.

2nd PR of https://github.com/tektoncd/pipeline/issues/6665

Signed-off-by: Yongxuan Zhang yongxuanzhang@google.com

/kind feature

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
VerificationResult is the return value for instead of error for VerifyTask and VerifyPipeline.
```
