### PR TITLE
fix: taskrun still fails even with onerror set to continue

### DIFF
--- a/pkg/pod/status.go
+++ b/pkg/pod/status.go
@@ -189,8 +189,10 @@ func setTaskRunStatusBasedOnStepStatus(ctx context.Context, logger *zap.SugaredL
 	}
 	// Continue with extraction of termination messages
 	for _, s := range stepStatuses {
-		if s.State.Terminated != nil && len(s.State.Terminated.Message) != 0 {
-			msg := s.State.Terminated.Message
+		// Avoid changing the original value by modifying the pointer value.
+		state := s.State.DeepCopy()
+		if state.Terminated != nil && len(state.Terminated.Message) != 0 {
+			msg := state.Terminated.Message
 
 			results, err := termination.ParseMessage(logger, msg)
 			if err != nil {
@@ -217,18 +219,18 @@ func setTaskRunStatusBasedOnStepStatus(ctx context.Context, logger *zap.SugaredL
 					logger.Errorf("%v", err)
 					merr = multierror.Append(merr, err)
 				} else {
-					s.State.Terminated.Message = msg
+					state.Terminated.Message = msg
 				}
 				if time != nil {
-					s.State.Terminated.StartedAt = *time
+					state.Terminated.StartedAt = *time
 				}
 				if exitCode != nil {
-					s.State.Terminated.ExitCode = *exitCode
+					state.Terminated.ExitCode = *exitCode
 				}
 			}
 		}
 		trs.Steps = append(trs.Steps, v1beta1.StepState{
-			ContainerState: *s.State.DeepCopy(),
+			ContainerState: *state,
 			Name:           trimStepPrefix(s.Name),
 			ContainerName:  s.Name,
 			ImageID:        s.ImageID,


### PR DESCRIPTION
fix #6664

directly modifying the value returned by Lister may affect the evaluation during the next reconciliation.

Detailed analysis can be found in the comments:
* https://github.com/tektoncd/pipeline/issues/6664#issuecomment-1550580168
* https://github.com/tektoncd/pipeline/issues/6664#issuecomment-1551274333

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
bug fix: taskrun still fails even with onerror set to continue
```

/kind bug