### PR TITLE
Fix code blocks in the Tasks page

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -137,7 +137,7 @@ Below is an example of a Pipeline declaration that uses a `ClusterTask`:
 - The cluster resolver syntax below can be used to reference any task, not just a clustertask.
 
 {{< tabs >}}
-{{< tab "v1 & v1beta1" >}}
+{{< tab header="v1 & v1beta1" code=true lang="yaml" >}}
 ```yaml
 apiVersion: tekton.dev/v1
 kind: Pipeline
@@ -158,7 +158,7 @@ spec:
 ```
 {{< /tab >}}
 
-{{< tab "v1beta1" >}}
+{{< tab header="v1beta1" code=true lang="yaml" >}}
 ```yaml
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline
@@ -201,7 +201,7 @@ Below is an example of setting the resource requests and limits for a step:
 
 
 {{< tabs >}}
-{{< tab "v1" >}}
+{{< tab header="v1" code=true lang="yaml" >}}
 ```yaml
 spec:
   steps:
@@ -216,7 +216,7 @@ spec:
 ```
 {{< /tab >}}
 
-{{< tab "v1beta1" >}}
+{{< tab header="v1beta1" code=true lang="yaml" >}}
 ```yaml
 spec:
   steps:
@@ -790,7 +790,7 @@ When this Task is executed in a TaskRun, the results will appear in the TaskRun'
 
 
 {{< tabs >}}
-{{< tab "v1" >}}
+{{< tab header="v1" code=true lang="yaml" >}}
 ```yaml
 apiVersion: tekton.dev/v1
 kind: TaskRun
@@ -807,7 +807,7 @@ status:
 ```
 {{< /tab >}}
 
-{{< tab "v1beta1" >}}
+{{< tab header="v1beta1" code=true lang="yaml" >}}
 ```yaml
 apiVersion: tekton.dev/v1beta1
 kind: TaskRun


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

Fix code blocks in the Tasks page (#6636)

As part of website!421, changes were made to the tab shortcode
layouts. A code block within a tab does not get rendered due to
these changes. This MR changes the definition of the tabs
in the tasks.md documentation page that contain code so they get
rendered correctly. The other solution was to change the tab
code again to accomodate, but that would break the current
implementation

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
