### PR TITLE
Test refactor: separate Task validation tests for propagation

### DIFF
--- a/pkg/apis/pipeline/v1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1/task_validation_test.go
@@ -522,6 +522,214 @@ func TestTaskSpecValidate(t *testing.T) {
 	}
 }
 
+func TestTaskValidateError(t *testing.T) {
+	type fields struct {
+		Params []v1.ParamSpec
+		Steps  []v1.Step
+	}
+	tests := []struct {
+		name          string
+		fields        fields
+		expectedError apis.FieldError
+	}{{
+		name: "inexistent param variable",
+		fields: fields{
+			Steps: []v1.Step{{
+				Name:  "mystep",
+				Image: "myimage",
+				Args:  []string{"--flag=$(params.inexistent)"},
+			}},
+		},
+		expectedError: apis.FieldError{
+			Message: `non-existent variable in "--flag=$(params.inexistent)"`,
+			Paths:   []string{"spec.steps[0].args[0]"},
+		},
+	}, {
+		name: "object used in a string field",
+		fields: fields{
+			Params: []v1.ParamSpec{{
+				Name: "gitrepo",
+				Type: v1.ParamTypeObject,
+				Properties: map[string]v1.PropertySpec{
+					"url":    {},
+					"commit": {},
+				},
+			}},
+			Steps: []v1.Step{{
+				Name:       "do-the-clone",
+				Image:      "$(params.gitrepo)",
+				Args:       []string{"echo"},
+				WorkingDir: "/foo/bar/src/",
+			}},
+		},
+		expectedError: apis.FieldError{
+			Message: `variable type invalid in "$(params.gitrepo)"`,
+			Paths:   []string{"spec.steps[0].image"},
+		},
+	}, {
+		name: "object star used in a string field",
+		fields: fields{
+			Params: []v1.ParamSpec{{
+				Name: "gitrepo",
+				Type: v1.ParamTypeObject,
+				Properties: map[string]v1.PropertySpec{
+					"url":    {},
+					"commit": {},
+				},
+			}},
+			Steps: []v1.Step{{
+				Name:       "do-the-clone",
+				Image:      "$(params.gitrepo[*])",
+				Args:       []string{"echo"},
+				WorkingDir: "/foo/bar/src/",
+			}},
+		},
+		expectedError: apis.FieldError{
+			Message: `variable type invalid in "$(params.gitrepo[*])"`,
+			Paths:   []string{"spec.steps[0].image"},
+		},
+	}, {
+		name: "object used in a field that can accept array type",
+		fields: fields{
+			Params: []v1.ParamSpec{{
+				Name: "gitrepo",
+				Type: v1.ParamTypeObject,
+				Properties: map[string]v1.PropertySpec{
+					"url":    {},
+					"commit": {},
+				},
+			}},
+			Steps: []v1.Step{{
+				Name:       "do-the-clone",
+				Image:      "myimage",
+				Args:       []string{"$(params.gitrepo)"},
+				WorkingDir: "/foo/bar/src/",
+			}},
+		},
+		expectedError: apis.FieldError{
+			Message: `variable type invalid in "$(params.gitrepo)"`,
+			Paths:   []string{"spec.steps[0].args[0]"},
+		},
+	}, {
+		name: "object star used in a field that can accept array type",
+		fields: fields{
+			Params: []v1.ParamSpec{{
+				Name: "gitrepo",
+				Type: v1.ParamTypeObject,
+				Properties: map[string]v1.PropertySpec{
+					"url":    {},
+					"commit": {},
+				},
+			}},
+			Steps: []v1.Step{{
+				Name:       "do-the-clone",
+				Image:      "some-git-image",
+				Args:       []string{"$(params.gitrepo[*])"},
+				WorkingDir: "/foo/bar/src/",
+			}},
+		},
+		expectedError: apis.FieldError{
+			Message: `variable type invalid in "$(params.gitrepo[*])"`,
+			Paths:   []string{"spec.steps[0].args[0]"},
+		},
+	}, {
+		name: "non-existent individual key of an object param is used in task step",
+		fields: fields{
+			Params: []v1.ParamSpec{{
+				Name: "gitrepo",
+				Type: v1.ParamTypeObject,
+				Properties: map[string]v1.PropertySpec{
+					"url":    {},
+					"commit": {},
+				},
+			}},
+			Steps: []v1.Step{{
+				Name:       "do-the-clone",
+				Image:      "some-git-image",
+				Args:       []string{"$(params.gitrepo.non-exist-key)"},
+				WorkingDir: "/foo/bar/src/",
+			}},
+		},
+		expectedError: apis.FieldError{
+			Message: `non-existent variable in "$(params.gitrepo.non-exist-key)"`,
+			Paths:   []string{"spec.steps[0].args[0]"},
+		},
+	}, {
+		name: "Inexistent param variable in volumeMount with existing",
+		fields: fields{
+			Params: []v1.ParamSpec{
+				{
+					Name:        "foo",
+					Description: "param",
+					Default:     v1.NewStructuredValues("default"),
+				},
+			},
+			Steps: []v1.Step{{
+				Name:  "mystep",
+				Image: "myimage",
+				VolumeMounts: []corev1.VolumeMount{{
+					Name: "$(params.inexistent)-foo",
+				}},
+			}},
+		},
+		expectedError: apis.FieldError{
+			Message: `non-existent variable in "$(params.inexistent)-foo"`,
+			Paths:   []string{"spec.steps[0].volumeMount[0].name"},
+		},
+	}, {
+		name: "Inexistent param variable with existing",
+		fields: fields{
+			Params: []v1.ParamSpec{{
+				Name:        "foo",
+				Description: "param",
+				Default:     v1.NewStructuredValues("default"),
+			}},
+			Steps: []v1.Step{{
+				Name:  "mystep",
+				Image: "myimage",
+				Args:  []string{"$(params.foo) && $(params.inexistent)"},
+			}},
+		},
+		expectedError: apis.FieldError{
+			Message: `non-existent variable in "$(params.foo) && $(params.inexistent)"`,
+			Paths:   []string{"spec.steps[0].args[0]"},
+		},
+	}, {
+		name: "invalid step - invalid onError usage - set to a parameter which does not exist in the task",
+		fields: fields{
+			Steps: []v1.Step{{
+				OnError: "$(params.CONTINUE)",
+				Image:   "image",
+				Args:    []string{"arg"},
+			}},
+		},
+		expectedError: apis.FieldError{
+			Message: "non-existent variable in \"$(params.CONTINUE)\"",
+			Paths:   []string{"spec.steps[0].onError"},
+		},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			task := &v1.Task{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+				Spec: v1.TaskSpec{
+					Params: tt.fields.Params,
+					Steps:  tt.fields.Steps,
+				}}
+			ctx := config.EnableAlphaAPIFields(context.Background())
+			task.SetDefaults(ctx)
+			ctx = config.SkipValidationDueToPropagatedParametersAndWorkspaces(ctx, false)
+			err := task.Validate(ctx)
+			if err == nil {
+				t.Fatalf("Expected an error, got nothing for %v", task)
+			}
+			if d := cmp.Diff(tt.expectedError.Error(), err.Error(), cmpopts.IgnoreUnexported(apis.FieldError{})); d != "" {
+				t.Errorf("TaskSpec.Validate() errors diff %s", diff.PrintWantGot(d))
+			}
+		})
+	}
+}
+
 func TestTaskSpecValidateError(t *testing.T) {
 	type fields struct {
 		Params       []v1.ParamSpec
@@ -768,19 +976,6 @@ func TestTaskSpecValidateError(t *testing.T) {
 			Details: "Task step name must be a valid DNS Label, For more info refer to https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
 		},
 	}, {
-		name: "inexistent param variable",
-		fields: fields{
-			Steps: []v1.Step{{
-				Name:  "mystep",
-				Image: "myimage",
-				Args:  []string{"--flag=$(params.inexistent)"},
-			}},
-		},
-		expectedError: apis.FieldError{
-			Message: `non-existent variable in "--flag=$(params.inexistent)"`,
-			Paths:   []string{"steps[0].args[0]"},
-		},
-	}, {
 		name: "array used in unaccepted field",
 		fields: fields{
 			Params: []v1.ParamSpec{{
@@ -932,156 +1127,6 @@ func TestTaskSpecValidateError(t *testing.T) {
 		},
 		expectedError: apis.FieldError{
 			Message: `variable is not properly isolated in "not isolated: $(params.baz[*])"`,
-			Paths:   []string{"steps[0].args[0]"},
-		},
-	}, {
-		name: "object used in a string field",
-		fields: fields{
-			Params: []v1.ParamSpec{{
-				Name: "gitrepo",
-				Type: v1.ParamTypeObject,
-				Properties: map[string]v1.PropertySpec{
-					"url":    {},
-					"commit": {},
-				},
-			}},
-			Steps: []v1.Step{{
-				Name:       "do-the-clone",
-				Image:      "$(params.gitrepo)",
-				Args:       []string{"echo"},
-				WorkingDir: "/foo/bar/src/",
-			}},
-		},
-		expectedError: apis.FieldError{
-			Message: `variable type invalid in "$(params.gitrepo)"`,
-			Paths:   []string{"steps[0].image"},
-		},
-	}, {
-		name: "object star used in a string field",
-		fields: fields{
-			Params: []v1.ParamSpec{{
-				Name: "gitrepo",
-				Type: v1.ParamTypeObject,
-				Properties: map[string]v1.PropertySpec{
-					"url":    {},
-					"commit": {},
-				},
-			}},
-			Steps: []v1.Step{{
-				Name:       "do-the-clone",
-				Image:      "$(params.gitrepo[*])",
-				Args:       []string{"echo"},
-				WorkingDir: "/foo/bar/src/",
-			}},
-		},
-		expectedError: apis.FieldError{
-			Message: `variable type invalid in "$(params.gitrepo[*])"`,
-			Paths:   []string{"steps[0].image"},
-		},
-	}, {
-		name: "object used in a field that can accept array type",
-		fields: fields{
-			Params: []v1.ParamSpec{{
-				Name: "gitrepo",
-				Type: v1.ParamTypeObject,
-				Properties: map[string]v1.PropertySpec{
-					"url":    {},
-					"commit": {},
-				},
-			}},
-			Steps: []v1.Step{{
-				Name:       "do-the-clone",
-				Image:      "myimage",
-				Args:       []string{"$(params.gitrepo)"},
-				WorkingDir: "/foo/bar/src/",
-			}},
-		},
-		expectedError: apis.FieldError{
-			Message: `variable type invalid in "$(params.gitrepo)"`,
-			Paths:   []string{"steps[0].args[0]"},
-		},
-	}, {
-		name: "object star used in a field that can accept array type",
-		fields: fields{
-			Params: []v1.ParamSpec{{
-				Name: "gitrepo",
-				Type: v1.ParamTypeObject,
-				Properties: map[string]v1.PropertySpec{
-					"url":    {},
-					"commit": {},
-				},
-			}},
-			Steps: []v1.Step{{
-				Name:       "do-the-clone",
-				Image:      "some-git-image",
-				Args:       []string{"$(params.gitrepo[*])"},
-				WorkingDir: "/foo/bar/src/",
-			}},
-		},
-		expectedError: apis.FieldError{
-			Message: `variable type invalid in "$(params.gitrepo[*])"`,
-			Paths:   []string{"steps[0].args[0]"},
-		},
-	}, {
-		name: "non-existent individual key of an object param is used in task step",
-		fields: fields{
-			Params: []v1.ParamSpec{{
-				Name: "gitrepo",
-				Type: v1.ParamTypeObject,
-				Properties: map[string]v1.PropertySpec{
-					"url":    {},
-					"commit": {},
-				},
-			}},
-			Steps: []v1.Step{{
-				Name:       "do-the-clone",
-				Image:      "some-git-image",
-				Args:       []string{"$(params.gitrepo.non-exist-key)"},
-				WorkingDir: "/foo/bar/src/",
-			}},
-		},
-		expectedError: apis.FieldError{
-			Message: `non-existent variable in "$(params.gitrepo.non-exist-key)"`,
-			Paths:   []string{"steps[0].args[0]"},
-		},
-	}, {
-		name: "Inexistent param variable in volumeMount with existing",
-		fields: fields{
-			Params: []v1.ParamSpec{
-				{
-					Name:        "foo",
-					Description: "param",
-					Default:     v1.NewStructuredValues("default"),
-				},
-			},
-			Steps: []v1.Step{{
-				Name:  "mystep",
-				Image: "myimage",
-				VolumeMounts: []corev1.VolumeMount{{
-					Name: "$(params.inexistent)-foo",
-				}},
-			}},
-		},
-		expectedError: apis.FieldError{
-			Message: `non-existent variable in "$(params.inexistent)-foo"`,
-			Paths:   []string{"steps[0].volumeMount[0].name"},
-		},
-	}, {
-		name: "Inexistent param variable with existing",
-		fields: fields{
-			Params: []v1.ParamSpec{{
-				Name:        "foo",
-				Description: "param",
-				Default:     v1.NewStructuredValues("default"),
-			}},
-			Steps: []v1.Step{{
-				Name:  "mystep",
-				Image: "myimage",
-				Args:  []string{"$(params.foo) && $(params.inexistent)"},
-			}},
-		},
-		expectedError: apis.FieldError{
-			Message: `non-existent variable in "$(params.foo) && $(params.inexistent)"`,
 			Paths:   []string{"steps[0].args[0]"},
 		},
 	}, {
@@ -1317,7 +1362,6 @@ func TestTaskSpecValidateError(t *testing.T) {
 			}
 			ctx := config.EnableAlphaAPIFields(context.Background())
 			ts.SetDefaults(ctx)
-			ctx = config.SkipValidationDueToPropagatedParametersAndWorkspaces(ctx, false)
 			err := ts.Validate(ctx)
 			if err == nil {
 				t.Fatalf("Expected an error, got nothing for %v", ts)
@@ -1514,17 +1558,6 @@ func TestStepOnError(t *testing.T) {
 			Message: `invalid value: "onError"`,
 			Paths:   []string{"steps[0].onError"},
 			Details: `Task step onError must be either "continue" or "stopAndFail"`,
-		},
-	}, {
-		name: "invalid step - invalid onError usage - set to a parameter which does not exist in the task",
-		steps: []v1.Step{{
-			OnError: "$(params.CONTINUE)",
-			Image:   "image",
-			Args:    []string{"arg"},
-		}},
-		expectedError: &apis.FieldError{
-			Message: "non-existent variable in \"$(params.CONTINUE)\"",
-			Paths:   []string{"steps[0].onError"},
 		},
 	}}
 	for _, tt := range tests {


### PR DESCRIPTION
To support propagated parameters in inline Task specs, validation of variable usage is skipped for inline Task specs and performed only for referenced Tasks. This commit refactors TestTaskSpecValidateError to split out the test cases which rely on this validation logic from test cases that rely on validation logic that is always performed. Since validation logic for usage of declared variables should always be performed when a Task is created directly (but not always for a Task spec), it updates these tests to validate a Task rather than a Task spec. This refactoring will make cleanup for propagated parameters easier. No functional changes.

/kind cleanup
Partially addresses https://github.com/tektoncd/pipeline/issues/6647

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- n/a Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- n/a Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- n/a Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
