### PR TITLE
Add upgrade tests to test main against previous release

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -169,3 +169,10 @@ function delete_pipeline_resources() {
 function delete_resolvers_resources() {
   kubectl delete --ignore-not-found=true resolutionrequests.resolution.tekton.dev --all
 }
+
+function get_tests_from_release() {
+  previous_release=$1
+  PREVIOUS_BRANCH=release-${previous_release%.*}.x
+  echo ">> Retrieving tests from PREVIOUS_BRANCH"
+  git checkout $PREVIOUS_BRANCH
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
# Changes
This commit adds the upgrade tests for testing main against the e2e tests from the previous release to prevent regression. Incompatible changes made in the current release cycle are expected to be catched.

This should also catch the case where existing resources become invalid with tests from previous releases.

/kind misc
fixes #6728 


<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [n/a] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [n/a] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
