### PR TITLE
[TEP-0091] return VerificationResult from GetTask

### DIFF
--- a/pkg/internal/resolution/resolved_meta.go
+++ b/pkg/internal/resolution/resolved_meta.go
@@ -18,6 +18,7 @@ package resolution
 
 import (
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/pkg/trustedresources"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -26,4 +27,6 @@ type ResolvedObjectMeta struct {
 	*metav1.ObjectMeta `json:",omitempty"`
 	// RefSource identifies where the spec came from.
 	RefSource *v1beta1.RefSource `json:",omitempty"`
+	// VerificationResult contains the result of trusted resources verification
+	VerificationResult *trustedresources.VerificationResult `json:",omitempty"`
 }

--- a/pkg/reconciler/taskrun/resources/taskref.go
+++ b/pkg/reconciler/taskrun/resources/taskref.go
@@ -63,7 +63,7 @@ func GetTaskFuncFromTaskRun(ctx context.Context, k8s kubernetes.Interface, tekto
 	// if the spec is already in the status, do not try to fetch it again, just use it as source of truth.
 	// Same for the RefSource field in the Status.Provenance.
 	if taskrun.Status.TaskSpec != nil {
-		return func(_ context.Context, name string) (*v1beta1.Task, *v1beta1.RefSource, error) {
+		return func(_ context.Context, name string) (*v1beta1.Task, *v1beta1.RefSource, *trustedresources.VerificationResult, error) {
 			var refSource *v1beta1.RefSource
 			if taskrun.Status.Provenance != nil {
 				refSource = taskrun.Status.Provenance.RefSource
@@ -74,7 +74,7 @@ func GetTaskFuncFromTaskRun(ctx context.Context, k8s kubernetes.Interface, tekto
 					Namespace: taskrun.Namespace,
 				},
 				Spec: *taskrun.Status.TaskSpec,
-			}, refSource, nil
+			}, refSource, nil, nil
 		}
 	}
 	return GetTaskFunc(ctx, k8s, tekton, requester, taskrun, taskrun.Spec.TaskRef, taskrun.Name, taskrun.Namespace, taskrun.Spec.ServiceAccountName, verificationPolicies)
@@ -97,14 +97,14 @@ func GetTaskFunc(ctx context.Context, k8s kubernetes.Interface, tekton clientset
 	case cfg.FeatureFlags.EnableTektonOCIBundles && tr != nil && tr.Bundle != "":
 		// Return an inline function that implements GetTask by calling Resolver.Get with the specified task type and
 		// casting it to a TaskObject.
-		return func(ctx context.Context, name string) (*v1beta1.Task, *v1beta1.RefSource, error) {
+		return func(ctx context.Context, name string) (*v1beta1.Task, *v1beta1.RefSource, *trustedresources.VerificationResult, error) {
 			// If there is a bundle url at all, construct an OCI resolver to fetch the task.
 			kc, err := k8schain.New(ctx, k8s, k8schain.Options{
 				Namespace:          namespace,
 				ServiceAccountName: saName,
 			})
 			if err != nil {
-				return nil, nil, fmt.Errorf("failed to get keychain: %w", err)
+				return nil, nil, nil, fmt.Errorf("failed to get keychain: %w", err)
 			}
 			resolver := oci.NewResolver(tr.Bundle, kc)
 
@@ -113,7 +113,7 @@ func GetTaskFunc(ctx context.Context, k8s kubernetes.Interface, tekton clientset
 	case tr != nil && tr.Resolver != "" && requester != nil:
 		// Return an inline function that implements GetTask by calling Resolver.Get with the specified task type and
 		// casting it to a TaskObject.
-		return func(ctx context.Context, name string) (*v1beta1.Task, *v1beta1.RefSource, error) {
+		return func(ctx context.Context, name string) (*v1beta1.Task, *v1beta1.RefSource, *trustedresources.VerificationResult, error) {
 			var replacedParams v1beta1.Params
 			if ownerAsTR, ok := owner.(*v1beta1.TaskRun); ok {
 				stringReplacements, arrayReplacements := paramsFromTaskRun(ctx, ownerAsTR)
@@ -144,20 +144,21 @@ func GetTaskFunc(ctx context.Context, k8s kubernetes.Interface, tekton clientset
 
 // resolveTask accepts an impl of remote.Resolver and attempts to
 // fetch a task with given name and verify the v1beta1 task if trusted resources is enabled.
-// An error is returned if the remoteresource doesn't work, the verification fails
+// An error is returned if the remoteresource doesn't work
+// A VerificationResult is returned if trusted resources is enabled, VerificationResult contains the result type and err.
 // or the returned data isn't a valid *v1beta1.Task.
-func resolveTask(ctx context.Context, resolver remote.Resolver, name string, kind v1beta1.TaskKind, k8s kubernetes.Interface, verificationPolicies []*v1alpha1.VerificationPolicy) (*v1beta1.Task, *v1beta1.RefSource, error) {
+func resolveTask(ctx context.Context, resolver remote.Resolver, name string, kind v1beta1.TaskKind, k8s kubernetes.Interface, verificationPolicies []*v1alpha1.VerificationPolicy) (*v1beta1.Task, *v1beta1.RefSource, *trustedresources.VerificationResult, error) {
 	// Because the resolver will only return references with the same kind (eg ClusterTask), this will ensure we
 	// don't accidentally return a Task with the same name but different kind.
 	obj, refSource, err := resolver.Get(ctx, strings.TrimSuffix(strings.ToLower(string(kind)), "s"), name)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
-	taskObj, err := readRuntimeObjectAsTask(ctx, obj, k8s, refSource, verificationPolicies)
+	taskObj, vr, err := readRuntimeObjectAsTask(ctx, obj, k8s, refSource, verificationPolicies)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
-	return taskObj, refSource, nil
+	return taskObj, refSource, vr, nil
 }
 
 // readRuntimeObjectAsTask tries to convert a generic runtime.Object
@@ -166,28 +167,23 @@ func resolveTask(ctx context.Context, resolver remote.Resolver, name string, kin
 // An error is returned if the given object is not a Task nor a ClusterTask
 // or if there is an error validating or upgrading an older TaskObject into
 // its v1beta1 equivalent.
+// A VerificationResult is returned if trusted resources is enabled, VerificationResult contains the result type and err.
 // v1beta1 task will be verified by trusted resources if the feature is enabled
 // TODO(#5541): convert v1beta1 obj to v1 once we use v1 as the stored version
-func readRuntimeObjectAsTask(ctx context.Context, obj runtime.Object, k8s kubernetes.Interface, refSource *v1beta1.RefSource, verificationPolicies []*v1alpha1.VerificationPolicy) (*v1beta1.Task, error) {
+func readRuntimeObjectAsTask(ctx context.Context, obj runtime.Object, k8s kubernetes.Interface, refSource *v1beta1.RefSource, verificationPolicies []*v1alpha1.VerificationPolicy) (*v1beta1.Task, *trustedresources.VerificationResult, error) {
 	switch obj := obj.(type) {
 	case *v1beta1.Task:
 		// Verify the Task once we fetch from the remote resolution, mutating, validation and conversion of the task should happen after the verification, since signatures are based on the remote task contents
 		vr := trustedresources.VerifyTask(ctx, obj, k8s, refSource, verificationPolicies)
-		if vr.VerificationResultType == trustedresources.VerificationError {
-			if vr.Err != nil {
-				return nil, fmt.Errorf("Task verification failed for object %s: %w", obj.GetName(), vr.Err)
-			}
-			return nil, fmt.Errorf("Task verification failed for object %s", obj.GetName())
-		}
-		return obj, nil
+		return obj, &vr, nil
 	case *v1beta1.ClusterTask:
-		return convertClusterTaskToTask(*obj), nil
+		return convertClusterTaskToTask(*obj), nil, nil
 	case *v1.Task:
 		// TODO(#6356): Support V1 Task verification
 		// Validation of beta fields must happen before the V1 Task is converted into the storage version of the API.
 		// TODO(#6592): Decouple API versioning from feature versioning
 		if err := obj.Spec.ValidateBetaFields(ctx); err != nil {
-			return nil, fmt.Errorf("invalid Task %s: %w", obj.GetName(), err)
+			return nil, nil, fmt.Errorf("invalid Task %s: %w", obj.GetName(), err)
 		}
 		t := &v1beta1.Task{
 			TypeMeta: metav1.TypeMeta{
@@ -196,11 +192,11 @@ func readRuntimeObjectAsTask(ctx context.Context, obj runtime.Object, k8s kubern
 			},
 		}
 		if err := t.ConvertFrom(ctx, obj); err != nil {
-			return nil, fmt.Errorf("failed to convert obj %s into Task", obj.GetObjectKind().GroupVersionKind().String())
+			return nil, nil, fmt.Errorf("failed to convert obj %s into Task", obj.GetObjectKind().GroupVersionKind().String())
 		}
-		return t, nil
+		return t, nil, nil
 	}
-	return nil, errors.New("resource is not a task")
+	return nil, nil, errors.New("resource is not a task")
 }
 
 // LocalTaskRefResolver uses the current cluster to resolve a task reference.
@@ -212,24 +208,25 @@ type LocalTaskRefResolver struct {
 
 // GetTask will resolve either a Task or ClusterTask from the local cluster using a versioned Tekton client. It will
 // return an error if it can't find an appropriate Task for any reason.
-func (l *LocalTaskRefResolver) GetTask(ctx context.Context, name string) (*v1beta1.Task, *v1beta1.RefSource, error) {
+// TODO(#6666): support local task verification
+func (l *LocalTaskRefResolver) GetTask(ctx context.Context, name string) (*v1beta1.Task, *v1beta1.RefSource, *trustedresources.VerificationResult, error) {
 	if l.Kind == v1beta1.ClusterTaskKind {
 		task, err := l.Tektonclient.TektonV1beta1().ClusterTasks().Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
-		return convertClusterTaskToTask(*task), nil, nil
+		return convertClusterTaskToTask(*task), nil, nil, nil
 	}
 
 	// If we are going to resolve this reference locally, we need a namespace scope.
 	if l.Namespace == "" {
-		return nil, nil, fmt.Errorf("must specify namespace to resolve reference to task %s", name)
+		return nil, nil, nil, fmt.Errorf("must specify namespace to resolve reference to task %s", name)
 	}
 	task, err := l.Tektonclient.TektonV1beta1().Tasks(l.Namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
-	return task, nil, nil
+	return task, nil, nil, nil
 }
 
 // IsGetTaskErrTransient returns true if an error returned by GetTask is retryable.

--- a/pkg/reconciler/taskrun/resources/taskref_test.go
+++ b/pkg/reconciler/taskrun/resources/taskref_test.go
@@ -219,7 +219,7 @@ func TestLocalTaskRef(t *testing.T) {
 				Tektonclient: tektonclient,
 			}
 
-			task, refSource, err := lc.GetTask(ctx, tc.ref.Name)
+			task, refSource, _, err := lc.GetTask(ctx, tc.ref.Name)
 			if tc.wantErr && err == nil {
 				t.Fatal("Expected error but found nil instead")
 			} else if !tc.wantErr && err != nil {
@@ -466,7 +466,7 @@ func TestGetTaskFunc(t *testing.T) {
 			}
 			fn := resources.GetTaskFunc(ctx, kubeclient, tektonclient, nil, trForFunc, tc.ref, "", "default", "default", nil /*VerificationPolicies*/)
 
-			task, refSource, err := fn(ctx, tc.ref.Name)
+			task, refSource, _, err := fn(ctx, tc.ref.Name)
 			if err != nil {
 				t.Fatalf("failed to call taskfn: %s", err.Error())
 			}
@@ -533,7 +533,7 @@ echo hello
 
 	fn := resources.GetTaskFuncFromTaskRun(ctx, kubeclient, tektonclient, nil, TaskRun, []*v1alpha1.VerificationPolicy{})
 
-	actualTask, actualRefSource, err := fn(ctx, name)
+	actualTask, actualRefSource, _, err := fn(ctx, name)
 	if err != nil {
 		t.Fatalf("failed to call Taskfn: %s", err.Error())
 	}
@@ -604,7 +604,7 @@ func TestGetTaskFunc_RemoteResolution(t *testing.T) {
 			}
 			fn := resources.GetTaskFunc(ctx, nil, nil, requester, tr, tr.Spec.TaskRef, "", "default", "default", nil /*VerificationPolicies*/)
 
-			resolvedTask, resolvedRefSource, err := fn(ctx, taskRef.Name)
+			resolvedTask, resolvedRefSource, _, err := fn(ctx, taskRef.Name)
 			if tc.wantErr {
 				if err == nil {
 					t.Fatalf("expected an error when calling taskfunc but got none")
@@ -676,7 +676,7 @@ func TestGetTaskFunc_RemoteResolution_ReplacedParams(t *testing.T) {
 	}
 	fn := resources.GetTaskFunc(ctx, nil, nil, requester, tr, tr.Spec.TaskRef, "", "default", "default", nil /*VerificationPolicies*/)
 
-	resolvedTask, resolvedRefSource, err := fn(ctx, taskRef.Name)
+	resolvedTask, resolvedRefSource, _, err := fn(ctx, taskRef.Name)
 	if err != nil {
 		t.Fatalf("failed to call pipelinefn: %s", err.Error())
 	}
@@ -718,7 +718,7 @@ func TestGetTaskFunc_RemoteResolution_ReplacedParams(t *testing.T) {
 	}
 	fnNotMatching := resources.GetTaskFunc(ctx, nil, nil, requester, trNotMatching, trNotMatching.Spec.TaskRef, "", "default", "default", nil /*VerificationPolicies*/)
 
-	_, _, err = fnNotMatching(ctx, taskRefNotMatching.Name)
+	_, _, _, err = fnNotMatching(ctx, taskRefNotMatching.Name)
 	if err == nil {
 		t.Fatal("expected error for non-matching params, did not get one")
 	}
@@ -743,15 +743,12 @@ func TestGetPipelineFunc_RemoteResolutionInvalidData(t *testing.T) {
 		},
 	}
 	fn := resources.GetTaskFunc(ctx, nil, nil, requester, tr, tr.Spec.TaskRef, "", "default", "default", nil /*VerificationPolicies*/)
-	if _, _, err := fn(ctx, taskRef.Name); err == nil {
+	if _, _, _, err := fn(ctx, taskRef.Name); err == nil {
 		t.Fatalf("expected error due to invalid pipeline data but saw none")
 	}
 }
 
 func TestGetTaskFunc_VerifyNoError(t *testing.T) {
-	// This test case tests the success cases of trusted-resources-verification-no-match-policy when it is set to
-	// fail: passed matching policy verification
-	// warn and ignore: no matching policies.
 	ctx := context.Background()
 	signer, _, k8sclient, vps := test.SetupVerificationPolicies(t)
 	tektonclient := fake.NewSimpleClientset()
@@ -798,54 +795,61 @@ func TestGetTaskFunc_VerifyNoError(t *testing.T) {
 	taskRef := &v1beta1.TaskRef{ResolverRef: v1beta1.ResolverRef{Resolver: "git"}}
 
 	testcases := []struct {
-		name                      string
-		requester                 *test.Requester
-		verificationNoMatchPolicy string
-		policies                  []*v1alpha1.VerificationPolicy
-		expected                  runtime.Object
-		expectedRefSource         *v1beta1.RefSource
+		name                       string
+		requester                  *test.Requester
+		verificationNoMatchPolicy  string
+		policies                   []*v1alpha1.VerificationPolicy
+		expected                   runtime.Object
+		expectedRefSource          *v1beta1.RefSource
+		expectedVerificationResult *trustedresources.VerificationResult
 	}{{
-		name:                      "signed task with matching policy pass verification with enforce no match policy",
-		requester:                 requesterMatched,
-		verificationNoMatchPolicy: config.FailNoMatchPolicy,
-		policies:                  vps,
-		expected:                  signedTask,
-		expectedRefSource:         matchPolicyRefSource,
+		name:                       "signed task with matching policy pass verification with enforce no match policy",
+		requester:                  requesterMatched,
+		verificationNoMatchPolicy:  config.FailNoMatchPolicy,
+		policies:                   vps,
+		expected:                   signedTask,
+		expectedRefSource:          matchPolicyRefSource,
+		expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationPass},
 	}, {
-		name:                      "signed task with matching policy pass verification with warn no match policy",
-		requester:                 requesterMatched,
-		verificationNoMatchPolicy: config.WarnNoMatchPolicy,
-		policies:                  vps,
-		expected:                  signedTask,
-		expectedRefSource:         matchPolicyRefSource,
+		name:                       "signed task with matching policy pass verification with warn no match policy",
+		requester:                  requesterMatched,
+		verificationNoMatchPolicy:  config.WarnNoMatchPolicy,
+		policies:                   vps,
+		expected:                   signedTask,
+		expectedRefSource:          matchPolicyRefSource,
+		expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationPass},
 	}, {
-		name:                      "signed task with matching policy pass verification with ignore no match policy",
-		requester:                 requesterMatched,
-		verificationNoMatchPolicy: config.IgnoreNoMatchPolicy,
-		policies:                  vps,
-		expected:                  signedTask,
-		expectedRefSource:         matchPolicyRefSource,
+		name:                       "signed task with matching policy pass verification with ignore no match policy",
+		requester:                  requesterMatched,
+		verificationNoMatchPolicy:  config.IgnoreNoMatchPolicy,
+		policies:                   vps,
+		expected:                   signedTask,
+		expectedRefSource:          matchPolicyRefSource,
+		expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationPass},
 	}, {
-		name:                      "warn unsigned task without matching policies",
-		requester:                 requesterUnmatched,
-		verificationNoMatchPolicy: config.WarnNoMatchPolicy,
-		policies:                  vps,
-		expected:                  unsignedTask,
-		expectedRefSource:         noMatchPolicyRefSource,
+		name:                       "warn unsigned task without matching policies",
+		requester:                  requesterUnmatched,
+		verificationNoMatchPolicy:  config.WarnNoMatchPolicy,
+		policies:                   vps,
+		expected:                   unsignedTask,
+		expectedRefSource:          noMatchPolicyRefSource,
+		expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationWarn, Err: trustedresources.ErrNoMatchedPolicies},
 	}, {
-		name:                      "task fails warn mode policy doesn't return error",
-		requester:                 requesterUnsignedMatched,
-		verificationNoMatchPolicy: config.FailNoMatchPolicy,
-		policies:                  vps,
-		expected:                  unsignedTask,
-		expectedRefSource:         warnPolicyRefSource,
+		name:                       "task fails warn mode policy return warn VerificationResult",
+		requester:                  requesterUnsignedMatched,
+		verificationNoMatchPolicy:  config.FailNoMatchPolicy,
+		policies:                   vps,
+		expected:                   unsignedTask,
+		expectedRefSource:          warnPolicyRefSource,
+		expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationWarn, Err: trustedresources.ErrResourceVerificationFailed},
 	}, {
-		name:                      "ignore unsigned task without matching policies",
-		requester:                 requesterUnmatched,
-		verificationNoMatchPolicy: config.IgnoreNoMatchPolicy,
-		policies:                  vps,
-		expected:                  unsignedTask,
-		expectedRefSource:         noMatchPolicyRefSource,
+		name:                       "ignore unsigned task without matching policies",
+		requester:                  requesterUnmatched,
+		verificationNoMatchPolicy:  config.IgnoreNoMatchPolicy,
+		policies:                   vps,
+		expected:                   unsignedTask,
+		expectedRefSource:          noMatchPolicyRefSource,
+		expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationSkip},
 	},
 	}
 	for _, tc := range testcases {
@@ -860,7 +864,7 @@ func TestGetTaskFunc_VerifyNoError(t *testing.T) {
 			}
 			fn := resources.GetTaskFunc(ctx, k8sclient, tektonclient, tc.requester, tr, tr.Spec.TaskRef, "", "default", "default", tc.policies)
 
-			resolvedTask, refSource, err := fn(ctx, taskRef.Name)
+			resolvedTask, refSource, vr, err := fn(ctx, taskRef.Name)
 
 			if err != nil {
 				t.Fatalf("Received unexpected error ( %#v )", err)
@@ -872,6 +876,9 @@ func TestGetTaskFunc_VerifyNoError(t *testing.T) {
 
 			if d := cmp.Diff(tc.expectedRefSource, refSource); d != "" {
 				t.Errorf("configSources did not match: %s", diff.PrintWantGot(d))
+			}
+			if tc.expectedVerificationResult.VerificationResultType != vr.VerificationResultType && errors.Is(vr.Err, tc.expectedVerificationResult.Err) {
+				t.Errorf("VerificationResult mismatch: want %v, got %v", tc.expectedVerificationResult, vr)
 			}
 		})
 	}
@@ -929,53 +936,61 @@ func TestGetTaskFunc_VerifyError(t *testing.T) {
 	taskRef := &v1beta1.TaskRef{ResolverRef: v1beta1.ResolverRef{Resolver: "git"}}
 
 	testcases := []struct {
-		name                      string
-		requester                 *test.Requester
-		verificationNoMatchPolicy string
-		expected                  *v1beta1.Task
-		expectedErr               error
+		name                           string
+		requester                      *test.Requester
+		verificationNoMatchPolicy      string
+		expected                       *v1beta1.Task
+		expectedErr                    error
+		expectedVerificationResultType trustedresources.VerificationResultType
 	}{{
-		name:                      "unsigned task with fails verification with fail no match policy",
-		requester:                 requesterUnsigned,
-		verificationNoMatchPolicy: config.FailNoMatchPolicy,
-		expected:                  nil,
-		expectedErr:               trustedresources.ErrResourceVerificationFailed,
+		name:                           "unsigned task fails verification with fail no match policy",
+		requester:                      requesterUnsigned,
+		verificationNoMatchPolicy:      config.FailNoMatchPolicy,
+		expected:                       nil,
+		expectedErr:                    trustedresources.ErrResourceVerificationFailed,
+		expectedVerificationResultType: trustedresources.VerificationError,
 	}, {
-		name:                      "unsigned task with fails verification with warn no match policy",
-		requester:                 requesterUnsigned,
-		verificationNoMatchPolicy: config.WarnNoMatchPolicy,
-		expected:                  nil,
-		expectedErr:               trustedresources.ErrResourceVerificationFailed,
+		name:                           "unsigned task fails verification with warn no match policy",
+		requester:                      requesterUnsigned,
+		verificationNoMatchPolicy:      config.WarnNoMatchPolicy,
+		expected:                       nil,
+		expectedErr:                    trustedresources.ErrResourceVerificationFailed,
+		expectedVerificationResultType: trustedresources.VerificationError,
 	}, {
-		name:                      "unsigned task with fails verification with ignore no match policy",
-		requester:                 requesterUnsigned,
-		verificationNoMatchPolicy: config.IgnoreNoMatchPolicy,
-		expected:                  nil,
-		expectedErr:               trustedresources.ErrResourceVerificationFailed,
+		name:                           "unsigned task fails verification with ignore no match policy",
+		requester:                      requesterUnsigned,
+		verificationNoMatchPolicy:      config.IgnoreNoMatchPolicy,
+		expected:                       nil,
+		expectedErr:                    trustedresources.ErrResourceVerificationFailed,
+		expectedVerificationResultType: trustedresources.VerificationError,
 	}, {
-		name:                      "modified task fails verification with fail no match policy",
-		requester:                 requesterModified,
-		verificationNoMatchPolicy: config.FailNoMatchPolicy,
-		expected:                  nil,
-		expectedErr:               trustedresources.ErrResourceVerificationFailed,
+		name:                           "modified task fails verification with fail no match policy",
+		requester:                      requesterModified,
+		verificationNoMatchPolicy:      config.FailNoMatchPolicy,
+		expected:                       nil,
+		expectedErr:                    trustedresources.ErrResourceVerificationFailed,
+		expectedVerificationResultType: trustedresources.VerificationError,
 	}, {
-		name:                      "modified task fails verification with warn no match policy",
-		requester:                 requesterModified,
-		verificationNoMatchPolicy: config.WarnNoMatchPolicy,
-		expected:                  nil,
-		expectedErr:               trustedresources.ErrResourceVerificationFailed,
+		name:                           "modified task fails verification with warn no match policy",
+		requester:                      requesterModified,
+		verificationNoMatchPolicy:      config.WarnNoMatchPolicy,
+		expected:                       nil,
+		expectedErr:                    trustedresources.ErrResourceVerificationFailed,
+		expectedVerificationResultType: trustedresources.VerificationError,
 	}, {
-		name:                      "modified task fails verification with ignore no match policy",
-		requester:                 requesterModified,
-		verificationNoMatchPolicy: config.IgnoreNoMatchPolicy,
-		expected:                  nil,
-		expectedErr:               trustedresources.ErrResourceVerificationFailed,
+		name:                           "modified task fails verification with ignore no match policy",
+		requester:                      requesterModified,
+		verificationNoMatchPolicy:      config.IgnoreNoMatchPolicy,
+		expected:                       nil,
+		expectedErr:                    trustedresources.ErrResourceVerificationFailed,
+		expectedVerificationResultType: trustedresources.VerificationError,
 	}, {
-		name:                      "unmatched task fails with fail no match policy",
-		requester:                 requesterUnmatched,
-		verificationNoMatchPolicy: config.FailNoMatchPolicy,
-		expected:                  nil,
-		expectedErr:               trustedresources.ErrNoMatchedPolicies,
+		name:                           "unmatched task fails with verification fail no match policy",
+		requester:                      requesterUnmatched,
+		verificationNoMatchPolicy:      config.FailNoMatchPolicy,
+		expected:                       nil,
+		expectedErr:                    trustedresources.ErrNoMatchedPolicies,
+		expectedVerificationResultType: trustedresources.VerificationError,
 	},
 	}
 	for _, tc := range testcases {
@@ -990,18 +1005,12 @@ func TestGetTaskFunc_VerifyError(t *testing.T) {
 			}
 			fn := resources.GetTaskFunc(ctx, k8sclient, tektonclient, tc.requester, tr, tr.Spec.TaskRef, "", "default", "default", vps)
 
-			resolvedTask, resolvedRefSource, err := fn(ctx, taskRef.Name)
-
-			if !errors.Is(err, tc.expectedErr) {
-				t.Errorf("GetTaskFunc got %v but want %v", err, tc.expectedErr)
+			_, _, vr, _ := fn(ctx, taskRef.Name)
+			if !errors.Is(vr.Err, tc.expectedErr) {
+				t.Errorf("GetPipelineFunc got %v, want %v", err, tc.expectedErr)
 			}
-
-			if d := cmp.Diff(tc.expected, resolvedTask); d != "" {
-				t.Errorf("resolvedTask did not match: %s", diff.PrintWantGot(d))
-			}
-
-			if resolvedRefSource != nil {
-				t.Errorf("refSource is: %v but want is nil", resolvedRefSource)
+			if tc.expectedVerificationResultType != vr.VerificationResultType {
+				t.Errorf("VerificationResultType mismatch, want %d got %d", tc.expectedVerificationResultType, vr.VerificationResultType)
 			}
 		})
 	}
@@ -1082,7 +1091,7 @@ func TestGetTaskFunc_GetFuncError(t *testing.T) {
 
 			fn := resources.GetTaskFunc(ctx, k8sclient, tektonclient, tc.requester, &tc.taskrun, tc.taskrun.Spec.TaskRef, "", "default", "default", vps)
 
-			_, _, err = fn(ctx, tc.taskrun.Spec.TaskRef.Name)
+			_, _, _, err = fn(ctx, tc.taskrun.Spec.TaskRef.Name)
 
 			if d := cmp.Diff(err.Error(), tc.expectedErr.Error()); d != "" {
 				t.Fatalf("Expected error %v but found %v instead", tc.expectedErr, err)

--- a/pkg/reconciler/taskrun/resources/taskspec.go
+++ b/pkg/reconciler/taskrun/resources/taskspec.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	resolutionutil "github.com/tektoncd/pipeline/pkg/internal/resolution"
+	"github.com/tektoncd/pipeline/pkg/trustedresources"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -32,10 +33,13 @@ type ResolvedTask struct {
 	TaskName string
 	Kind     v1beta1.TaskKind
 	TaskSpec *v1beta1.TaskSpec
+	// VerificationResult is the result from trusted resources if the feature is enabled.
+	VerificationResult *trustedresources.VerificationResult
 }
 
 // GetTask is a function used to retrieve Tasks.
-type GetTask func(context.Context, string) (*v1beta1.Task, *v1beta1.RefSource, error)
+// VerificationResult is the result from trusted resources if the feature is enabled.
+type GetTask func(context.Context, string) (*v1beta1.Task, *v1beta1.RefSource, *trustedresources.VerificationResult, error)
 
 // GetTaskRun is a function used to retrieve TaskRuns
 type GetTaskRun func(string) (*v1beta1.TaskRun, error)
@@ -45,25 +49,27 @@ type GetTaskRun func(string) (*v1beta1.TaskRun, error)
 // metadata and embedded TaskSpec.
 func GetTaskData(ctx context.Context, taskRun *v1beta1.TaskRun, getTask GetTask) (*resolutionutil.ResolvedObjectMeta, *v1beta1.TaskSpec, error) {
 	taskMeta := metav1.ObjectMeta{}
-	var refSource *v1beta1.RefSource
 	taskSpec := v1beta1.TaskSpec{}
+	var refSource *v1beta1.RefSource
+	var verificationResult *trustedresources.VerificationResult
 	switch {
 	case taskRun.Spec.TaskRef != nil && taskRun.Spec.TaskRef.Name != "":
 		// Get related task for taskrun
-		t, source, err := getTask(ctx, taskRun.Spec.TaskRef.Name)
+		t, source, vr, err := getTask(ctx, taskRun.Spec.TaskRef.Name)
 		if err != nil {
 			return nil, nil, fmt.Errorf("error when listing tasks for taskRun %s: %w", taskRun.Name, err)
 		}
 		taskMeta = t.TaskMetadata()
 		taskSpec = t.TaskSpec()
 		refSource = source
+		verificationResult = vr
 	case taskRun.Spec.TaskSpec != nil:
 		taskMeta = taskRun.ObjectMeta
 		taskSpec = *taskRun.Spec.TaskSpec
 		// TODO: if we want to set RefSource for embedded taskspec, set it here.
 		// https://github.com/tektoncd/pipeline/issues/5522
 	case taskRun.Spec.TaskRef != nil && taskRun.Spec.TaskRef.Resolver != "":
-		task, source, err := getTask(ctx, taskRun.Name)
+		task, source, vr, err := getTask(ctx, taskRun.Name)
 		switch {
 		case err != nil:
 			return nil, nil, err
@@ -74,13 +80,15 @@ func GetTaskData(ctx context.Context, taskRun *v1beta1.TaskRun, getTask GetTask)
 			taskSpec = task.TaskSpec()
 		}
 		refSource = source
+		verificationResult = vr
 	default:
 		return nil, nil, fmt.Errorf("taskRun %s not providing TaskRef or TaskSpec", taskRun.Name)
 	}
 
 	taskSpec.SetDefaults(ctx)
 	return &resolutionutil.ResolvedObjectMeta{
-		ObjectMeta: &taskMeta,
-		RefSource:  refSource,
+		ObjectMeta:         &taskMeta,
+		RefSource:          refSource,
+		VerificationResult: verificationResult,
 	}, &taskSpec, nil
 }

--- a/pkg/reconciler/taskrun/resources/taskspec_test.go
+++ b/pkg/reconciler/taskrun/resources/taskspec_test.go
@@ -22,8 +22,10 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/reconciler/taskrun/resources"
+	"github.com/tektoncd/pipeline/pkg/trustedresources"
 	"github.com/tektoncd/pipeline/test/diff"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -50,8 +52,8 @@ func TestGetTaskSpec_Ref(t *testing.T) {
 		},
 	}
 
-	gt := func(ctx context.Context, n string) (*v1beta1.Task, *v1beta1.RefSource, error) {
-		return task, sampleRefSource.DeepCopy(), nil
+	gt := func(ctx context.Context, n string) (*v1beta1.Task, *v1beta1.RefSource, *trustedresources.VerificationResult, error) {
+		return task, sampleRefSource.DeepCopy(), nil, nil
 	}
 	resolvedObjectMeta, taskSpec, err := resources.GetTaskData(context.Background(), tr, gt)
 
@@ -84,8 +86,8 @@ func TestGetTaskSpec_Embedded(t *testing.T) {
 			},
 		},
 	}
-	gt := func(ctx context.Context, n string) (*v1beta1.Task, *v1beta1.RefSource, error) {
-		return nil, nil, errors.New("shouldn't be called")
+	gt := func(ctx context.Context, n string) (*v1beta1.Task, *v1beta1.RefSource, *trustedresources.VerificationResult, error) {
+		return nil, nil, nil, errors.New("shouldn't be called")
 	}
 	resolvedObjectMeta, taskSpec, err := resources.GetTaskData(context.Background(), tr, gt)
 
@@ -113,8 +115,8 @@ func TestGetTaskSpec_Invalid(t *testing.T) {
 			Name: "mytaskrun",
 		},
 	}
-	gt := func(ctx context.Context, n string) (*v1beta1.Task, *v1beta1.RefSource, error) {
-		return nil, nil, errors.New("shouldn't be called")
+	gt := func(ctx context.Context, n string) (*v1beta1.Task, *v1beta1.RefSource, *trustedresources.VerificationResult, error) {
+		return nil, nil, nil, errors.New("shouldn't be called")
 	}
 	_, _, err := resources.GetTaskData(context.Background(), tr, gt)
 	if err == nil {
@@ -133,8 +135,8 @@ func TestGetTaskSpec_Error(t *testing.T) {
 			},
 		},
 	}
-	gt := func(ctx context.Context, n string) (*v1beta1.Task, *v1beta1.RefSource, error) {
-		return nil, nil, errors.New("something went wrong")
+	gt := func(ctx context.Context, n string) (*v1beta1.Task, *v1beta1.RefSource, *trustedresources.VerificationResult, error) {
+		return nil, nil, nil, errors.New("something went wrong")
 	}
 	_, _, err := resources.GetTaskData(context.Background(), tr, gt)
 	if err == nil {
@@ -173,11 +175,11 @@ func TestGetTaskData_ResolutionSuccess(t *testing.T) {
 		}},
 	}
 
-	getTask := func(ctx context.Context, n string) (*v1beta1.Task, *v1beta1.RefSource, error) {
+	getTask := func(ctx context.Context, n string) (*v1beta1.Task, *v1beta1.RefSource, *trustedresources.VerificationResult, error) {
 		return &v1beta1.Task{
 			ObjectMeta: *sourceMeta.DeepCopy(),
 			Spec:       *sourceSpec.DeepCopy(),
-		}, sampleRefSource.DeepCopy(), nil
+		}, sampleRefSource.DeepCopy(), nil, nil
 	}
 	ctx := context.Background()
 	resolvedMeta, resolvedSpec, err := resources.GetTaskData(ctx, tr, getTask)
@@ -210,8 +212,8 @@ func TestGetPipelineData_ResolutionError(t *testing.T) {
 			},
 		},
 	}
-	getTask := func(ctx context.Context, n string) (*v1beta1.Task, *v1beta1.RefSource, error) {
-		return nil, nil, errors.New("something went wrong")
+	getTask := func(ctx context.Context, n string) (*v1beta1.Task, *v1beta1.RefSource, *trustedresources.VerificationResult, error) {
+		return nil, nil, nil, errors.New("something went wrong")
 	}
 	ctx := context.Background()
 	_, _, err := resources.GetTaskData(ctx, tr, getTask)
@@ -233,12 +235,62 @@ func TestGetTaskData_ResolvedNilTask(t *testing.T) {
 			},
 		},
 	}
-	getTask := func(ctx context.Context, n string) (*v1beta1.Task, *v1beta1.RefSource, error) {
-		return nil, nil, nil
+	getTask := func(ctx context.Context, n string) (*v1beta1.Task, *v1beta1.RefSource, *trustedresources.VerificationResult, error) {
+		return nil, nil, nil, nil
 	}
 	ctx := context.Background()
 	_, _, err := resources.GetTaskData(ctx, tr, getTask)
 	if err == nil {
 		t.Fatalf("Expected error when unable to find referenced Task but got none")
+	}
+}
+
+func TestGetTaskData_VerificationResult(t *testing.T) {
+	tr := &v1beta1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "mytaskrun",
+		},
+		Spec: v1beta1.TaskRunSpec{
+			TaskRef: &v1beta1.TaskRef{
+				ResolverRef: v1beta1.ResolverRef{
+					Resolver: "foo",
+					Params: v1beta1.Params{{
+						Name: "bar",
+						Value: v1beta1.ParamValue{
+							Type:      v1beta1.ParamTypeString,
+							StringVal: "baz",
+						},
+					}},
+				},
+			},
+		},
+	}
+	sourceMeta := metav1.ObjectMeta{
+		Name: "task",
+	}
+	sourceSpec := v1beta1.TaskSpec{
+		Steps: []v1beta1.Step{{
+			Name:   "step1",
+			Image:  "ubuntu",
+			Script: `echo "hello world!"`,
+		}},
+	}
+
+	verificationResult := &trustedresources.VerificationResult{
+		VerificationResultType: trustedresources.VerificationError,
+		Err:                    trustedresources.ErrResourceVerificationFailed,
+	}
+	getTask := func(ctx context.Context, n string) (*v1beta1.Task, *v1beta1.RefSource, *trustedresources.VerificationResult, error) {
+		return &v1beta1.Task{
+			ObjectMeta: *sourceMeta.DeepCopy(),
+			Spec:       *sourceSpec.DeepCopy(),
+		}, nil, verificationResult, nil
+	}
+	r, _, err := resources.GetTaskData(context.Background(), tr, getTask)
+	if err != nil {
+		t.Fatalf("Did not expect error but got: %s", err)
+	}
+	if d := cmp.Diff(verificationResult, r.VerificationResult, cmpopts.EquateErrors()); d != "" {
+		t.Errorf(diff.PrintWantGot(d))
 	}
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This commit returns from GetTask. VerificationResult is returned by VerifyTask in
remote resolution. The VerificationResult is used to indicate the result of trusted resources verification.

3rd PR of https://github.com/tektoncd/pipeline/issues/6665

To review this PR, you may want to follow this order:
taskref.go (readRuntimeObjectAsTask->resolveTask->GetTaskFunc) -> taskspec.go&pipelinerunresolution.go -> taskrun.go

/kind feature

Signed-off-by: Yongxuan Zhang yongxuanzhang@google.com

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Functions including GetTask, GetTaskData are updated to return VerificationResult, VerificationResult is the from trusted resources to indicate the result of the verification
```
