### PR TITLE
Validate parameters and workspaces for referenced pipelines

### DIFF
--- a/pkg/apis/pipeline/v1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1/pipeline_validation.go
@@ -50,8 +50,8 @@ func (p *Pipeline) Validate(ctx context.Context) *apis.FieldError {
 	// When a Pipeline is created directly, instead of declared inline in a PipelineRun,
 	// we do not support propagated parameters and workspaces.
 	// Validate that all params and workspaces it uses are declared.
-	errs = errs.Also(p.Spec.validatePipelineParameterUsage(ctx).ViaField("spec"))
-	errs = errs.Also(p.Spec.validatePipelineWorkspacesUsage().ViaField("spec"))
+	errs = errs.Also(p.Spec.ValidatePipelineParameterUsage(ctx).ViaField("spec"))
+	errs = errs.Also(p.Spec.ValidatePipelineWorkspacesUsage().ViaField("spec"))
 	// Validate beta fields when a Pipeline is defined, but not as part of validating a Pipeline spec.
 	// This prevents validation from failing when a Pipeline is converted to a different API version.
 	// See https://github.com/tektoncd/pipeline/issues/6616 for more information.
@@ -358,8 +358,8 @@ func validatePipelineWorkspacesDeclarations(wss []PipelineWorkspaceDeclaration) 
 	return errs
 }
 
-// validatePipelineParameterUsage validates that parameters referenced in the Pipeline are declared by the Pipeline
-func (ps *PipelineSpec) validatePipelineParameterUsage(ctx context.Context) (errs *apis.FieldError) {
+// ValidatePipelineParameterUsage validates that parameters referenced in the Pipeline are declared by the Pipeline
+func (ps *PipelineSpec) ValidatePipelineParameterUsage(ctx context.Context) (errs *apis.FieldError) {
 	errs = errs.Also(PipelineTaskList(ps.Tasks).validateUsageOfDeclaredPipelineTaskParameters(ctx, "tasks"))
 	errs = errs.Also(PipelineTaskList(ps.Finally).validateUsageOfDeclaredPipelineTaskParameters(ctx, "finally"))
 	errs = errs.Also(validatePipelineTaskParameterUsage(ps.Tasks, ps.Params).ViaField("tasks"))
@@ -385,8 +385,8 @@ func validatePipelineTaskParameterUsage(tasks []PipelineTask, params ParamSpecs)
 	return errs
 }
 
-// validatePipelineWorkspacesUsage validates that workspaces referenced in the Pipeline are declared by the Pipeline
-func (ps *PipelineSpec) validatePipelineWorkspacesUsage() (errs *apis.FieldError) {
+// ValidatePipelineWorkspacesUsage validates that workspaces referenced in the Pipeline are declared by the Pipeline
+func (ps *PipelineSpec) ValidatePipelineWorkspacesUsage() (errs *apis.FieldError) {
 	errs = errs.Also(validatePipelineTasksWorkspacesUsage(ps.Workspaces, ps.Tasks).ViaField("tasks"))
 	errs = errs.Also(validatePipelineTasksWorkspacesUsage(ps.Workspaces, ps.Finally).ViaField("finally"))
 	return errs

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation.go
@@ -51,8 +51,8 @@ func (p *Pipeline) Validate(ctx context.Context) *apis.FieldError {
 	// When a Pipeline is created directly, instead of declared inline in a PipelineRun,
 	// we do not support propagated parameters and workspaces.
 	// Validate that all params and workspaces it uses are declared.
-	errs = errs.Also(p.Spec.validatePipelineParameterUsage(ctx).ViaField("spec"))
-	return errs.Also(p.Spec.validatePipelineWorkspacesUsage().ViaField("spec"))
+	errs = errs.Also(p.Spec.ValidatePipelineParameterUsage(ctx).ViaField("spec"))
+	return errs.Also(p.Spec.ValidatePipelineWorkspacesUsage().ViaField("spec"))
 }
 
 // Validate checks that taskNames in the Pipeline are valid and that the graph
@@ -330,8 +330,8 @@ func validatePipelineWorkspacesDeclarations(wss []PipelineWorkspaceDeclaration) 
 	return errs
 }
 
-// validatePipelineParameterUsage validates that parameters referenced in the Pipeline are declared by the Pipeline
-func (ps *PipelineSpec) validatePipelineParameterUsage(ctx context.Context) (errs *apis.FieldError) {
+// ValidatePipelineParameterUsage validates that parameters referenced in the Pipeline are declared by the Pipeline
+func (ps *PipelineSpec) ValidatePipelineParameterUsage(ctx context.Context) (errs *apis.FieldError) {
 	errs = errs.Also(PipelineTaskList(ps.Tasks).validateUsageOfDeclaredPipelineTaskParameters(ctx, "tasks"))
 	errs = errs.Also(PipelineTaskList(ps.Finally).validateUsageOfDeclaredPipelineTaskParameters(ctx, "finally"))
 	errs = errs.Also(validatePipelineTaskParameterUsage(ps.Tasks, ps.Params).ViaField("tasks"))
@@ -357,8 +357,8 @@ func validatePipelineTaskParameterUsage(tasks []PipelineTask, params ParamSpecs)
 	return errs
 }
 
-// validatePipelineWorkspacesUsage validates that Workspaces referenced in the Pipeline are declared by the Pipeline
-func (ps *PipelineSpec) validatePipelineWorkspacesUsage() (errs *apis.FieldError) {
+// ValidatePipelineWorkspacesUsage validates that Workspaces referenced in the Pipeline are declared by the Pipeline
+func (ps *PipelineSpec) ValidatePipelineWorkspacesUsage() (errs *apis.FieldError) {
 	errs = errs.Also(validatePipelineTasksWorkspacesUsage(ps.Workspaces, ps.Tasks).ViaField("tasks"))
 	errs = errs.Also(validatePipelineTasksWorkspacesUsage(ps.Workspaces, ps.Finally).ViaField("finally"))
 	return errs


### PR DESCRIPTION
Prior to this, we skipped validation of propagated parameters and workspaces was skipped in the reconciler until pod creation time. As a result, validation of the pipeline spec from remote pipelines was completely ignored and we added accidental support for propagated params for remotely referenced pipeline. This PR fixes issue #6670

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Validate parameter and workspace usage for referenced pipelines.
```
/kind bug