### PR TITLE
Issue 6670 add invalid pipeline for remote resolution

### DIFF
--- a/examples/v1beta1/pipelineruns/no-ci/invalid-remote-pipeline.yaml
+++ b/examples/v1beta1/pipelineruns/no-ci/invalid-remote-pipeline.yaml
@@ -1,0 +1,11 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: invalid-pipeline-no-params-defined
+spec:
+  tasks:
+  - name: foo
+    taskSpec:
+      steps:
+      - image: busybox
+        script: echo $(params.abcd)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Prior to this, we skipped validation of propagated parameters and
workspaces was skipped in the reconciler until pod creation time.
As a result, validation of the pipeline spec from remote pipelines
was completely ignored. PR https://github.com/tektoncd/pipeline/pull/6693 has the actual fix.

This PR is assisting it and adding an example invalid pipeline spec for
validating the spec after remote resolution. Adding this to no-ci will skip example tests.
This PR fixes part of issue [#6670](https://github.com/tektoncd/pipeline/issues/6670).

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
/kind bug