### PR TITLE
Validate beta features only when v1 Tasks and Pipelines are defined

### DIFF
--- a/pkg/apis/pipeline/v1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1/pipeline_validation.go
@@ -51,7 +51,13 @@ func (p *Pipeline) Validate(ctx context.Context) *apis.FieldError {
 	// we do not support propagated parameters and workspaces.
 	// Validate that all params and workspaces it uses are declared.
 	errs = errs.Also(p.Spec.validatePipelineParameterUsage(ctx).ViaField("spec"))
-	return errs.Also(p.Spec.validatePipelineWorkspacesUsage().ViaField("spec"))
+	errs = errs.Also(p.Spec.validatePipelineWorkspacesUsage().ViaField("spec"))
+	// Validate beta fields when a Pipeline is defined, but not as part of validating a Pipeline spec.
+	// This prevents validation from failing when a Pipeline is converted to a different API version.
+	// See https://github.com/tektoncd/pipeline/issues/6616 for more information.
+	// TODO(#6592): Decouple API versioning from feature versioning
+	errs = errs.Also(p.Spec.ValidateBetaFields(ctx))
+	return errs
 }
 
 // Validate checks that taskNames in the Pipeline are valid and that the graph
@@ -70,7 +76,6 @@ func (ps *PipelineSpec) Validate(ctx context.Context) (errs *apis.FieldError) {
 	errs = errs.Also(validatePipelineContextVariables(ps.Tasks).ViaField("tasks"))
 	errs = errs.Also(validatePipelineContextVariables(ps.Finally).ViaField("finally"))
 	errs = errs.Also(validateExecutionStatusVariables(ps.Tasks, ps.Finally))
-	errs = errs.Also(ps.ValidateBetaFields(ctx))
 	// Validate the pipeline's workspaces.
 	errs = errs.Also(validatePipelineWorkspacesDeclarations(ps.Workspaces))
 	// Validate the pipeline's results

--- a/pkg/apis/pipeline/v1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1/task_validation_test.go
@@ -1869,7 +1869,7 @@ func TestValidateParamArrayIndex(t *testing.T) {
 	}
 }
 
-func TestTaskSpecBetaFields(t *testing.T) {
+func TestTaskBetaFields(t *testing.T) {
 	tests := []struct {
 		name string
 		spec v1.TaskSpec
@@ -1925,12 +1925,13 @@ func TestTaskSpecBetaFields(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := tt.spec.Validate(context.Background()); err == nil {
+			task := v1.Task{ObjectMeta: metav1.ObjectMeta{Name: "foo"}, Spec: tt.spec}
+			if err := task.Validate(context.Background()); err == nil {
 				t.Errorf("no error when using beta field when `enable-api-fields` is stable")
 			}
 
 			ctx := config.EnableBetaAPIFields(context.Background())
-			if err := tt.spec.Validate(ctx); err != nil {
+			if err := task.Validate(ctx); err != nil {
 				t.Errorf("unexpected error when using beta field: %s", err)
 			}
 		})


### PR DESCRIPTION
Currently, validation differs between api versions: when beta features are used in v1 APIs,
"enable-api-fields" must be set to "alpha" or "beta", but when beta features are used in beta APIs,
"enable-api-fields" may be set to "alpha", "beta", or "stable".

We also validate the specs of referenced Tasks or Pipelines in the TaskRun/PipelineRun reconciler.
This presents a problem when referencing a Task or Pipeline declared locally, since the Task or Pipeline may be converted into a different API version when it's stored.

This commit moves validation for beta features to apply only to Tasks and Pipelines when they are created or updated,
and not called when a Task spec or Pipeline spec is validated.

This commit will allow us to swap the storage version of our API without user-facing impact.
Separately, we plan to decouple feature versioning from API versioning, as it is a better long-term solution (https://github.com/tektoncd/pipeline/issues/6592).

This commit contains no expected functional changes, since the TaskRun and PipelineRun reconcilers do not
currently validate that"enable-api-fields" is set to "alpha" or "beta" when beta features are used in
referenced Tasks or Pipelines.

This validation will be added for v1 remote Tasks and Pipelines in a separate commit (https://github.com/tektoncd/pipeline/pull/6725).

Closes https://github.com/tektoncd/pipeline/issues/6616.
/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- n/a Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- n/a Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- n/a Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
