### PR TITLE
clarify in docs to not use apiVersion for taskRef for non-customtask

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -279,6 +279,8 @@ tasks:
       name: build-push
 ```
 
+**Note:** Using both `apiVersion` and `kind` will create [CustomRun](customruns.md), don't set `apiVersion` if only referring to [`Task`](tasks.md).
+
 or
 
 ```yaml
@@ -1537,7 +1539,8 @@ that is responsible for watching and updating `CustomRun`s which reference their
 ### Specifying the target Custom Task
 
 To specify the custom task type you want to execute, the `taskRef` field
-must include the custom task's `apiVersion` and `kind` as shown below:
+must include the custom task's `apiVersion` and `kind` as shown below.
+Using `apiVersion` will always create a `CustomRun`. If `apiVersion` is set, `kind` is required as well.
 
 ```yaml
 spec:

--- a/pkg/reconciler/taskrun/resources/taskref_test.go
+++ b/pkg/reconciler/taskrun/resources/taskref_test.go
@@ -396,10 +396,9 @@ func TestGetTaskFunc(t *testing.T) {
 				},
 			},
 			ref: &v1beta1.TaskRef{
-				Name:       "simple",
-				APIVersion: "tekton.dev/v1beta1",
-				Kind:       v1beta1.ClusterTaskKind,
-				Bundle:     u.Host + "/remote-cluster-task",
+				Name:   "simple",
+				Kind:   v1beta1.ClusterTaskKind,
+				Bundle: u.Host + "/remote-cluster-task",
 			},
 			expected: &v1beta1.Task{
 				ObjectMeta: metav1.ObjectMeta{Name: "simple"},


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This commit closes #6682. When apiversion and kind are both set for
task, it is also considered to be a custom task. If users want to refer
to tasks or cluster tasks, apiVersion shouldn't be set. This commit
clarify this in the docs.

/kind bug

Signed-off-by: Yongxuan Zhang yongxuanzhang@google.com

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
