### PR TITLE
feat: ensure git repositories actually resolve when validating

### DIFF
--- a/pkg/resolution/resolver/git/resolver.go
+++ b/pkg/resolution/resolver/git/resolver.go
@@ -119,6 +119,13 @@ func (r *Resolver) ValidateParams(ctx context.Context, params []pipelinev1beta1.
 	if err != nil {
 		return err
 	}
+
+	// vest to make sure we can actually resolve the repositories
+	_, err = r.Resolve(ctx, params)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -460,8 +467,6 @@ func populateDefaultParams(ctx context.Context, params []pipelinev1beta1.Param) 
 		return nil, fmt.Errorf("missing required git resolver params: %s", strings.Join(missingParams, ", "))
 	}
 
-	// TODO(sbwsg): validate repo url is well-formed, git:// or https://
-	// TODO(sbwsg): validate pathInRepo is valid relative pathInRepo
 	return paramsMap, nil
 }
 

--- a/pkg/resolution/resolver/git/resolver.go
+++ b/pkg/resolution/resolver/git/resolver.go
@@ -115,13 +115,13 @@ func (r *Resolver) ValidateParams(ctx context.Context, params []pipelinev1beta1.
 		return errors.New(disabledError)
 	}
 
-	_, err := populateDefaultParams(ctx, params)
+	rawParams, err := populateDefaultParams(ctx, params)
 	if err != nil {
 		return err
 	}
 
-	// vest to make sure we can actually resolve the repositories
-	_, err = r.Resolve(ctx, params)
+	// make sure we can actually resolve the repositories as the resource will never run successfully if we can't
+	_, err = r.resolveGit(ctx, rawParams)
 	if err != nil {
 		return err
 	}
@@ -141,6 +141,10 @@ func (r *Resolver) Resolve(ctx context.Context, origParams []pipelinev1beta1.Par
 		return nil, err
 	}
 
+	return r.resolveGit(ctx, params)
+}
+
+func (r *Resolver) resolveGit(ctx context.Context, params map[string]string) (framework.ResolvedResource, error) {
 	if params[urlParam] != "" {
 		return r.resolveAnonymousGit(ctx, params)
 	}


### PR DESCRIPTION
# Changes

This updates the git resolver validation logic to also resolve the git urls.

We've been seeing an issue where due to misconfiguration, the git doesn't actually resolve. Tekton will start this pipeline just fine and run the pipeline up until the task won't resolve, then it stops and you have to debug from there.

There was already a todo in place to add resolution, my thinking here was that if we can add it sooner, the pipelines become more declarative and help developers iterate quickly by viewing validation issues as they're adding them. I think it makes sense hooking into the preexisting resoultion logic as that way it will be added to the cache and then can be reused when the pipeline is ran.

This could theoretically save developers a lot of waiting time and improve the overall experience with git resolvers.

I'm leaving this as a draft to get some feedback, tests are on the way!

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
