### PR TITLE
Use original version of enable-api-fields for validating beta features

### DIFF
--- a/pkg/apis/pipeline/v1/pipelinerun_validation.go
+++ b/pkg/apis/pipeline/v1/pipelinerun_validation.go
@@ -66,7 +66,8 @@ func (ps *PipelineRunSpec) Validate(ctx context.Context) (errs *apis.FieldError)
 
 	// Validate PipelineSpec if it's present
 	if ps.PipelineSpec != nil {
-		errs = errs.Also(ps.PipelineSpec.Validate(ctx).ViaField("pipelineSpec"))
+		// Since Pipeline spec is declared inline, there's no object meta to use in validation
+		errs = errs.Also(ps.PipelineSpec.Validate(ctx, nil /* objectMeta */).ViaField("pipelineSpec"))
 	}
 
 	// Validate PipelineRun parameters
@@ -177,12 +178,12 @@ func (ps *PipelineRunSpec) validateInlineParameters(ctx context.Context) (errs *
 	if ps.PipelineSpec != nil && ps.PipelineSpec.Tasks != nil {
 		for _, pt := range ps.PipelineSpec.Tasks {
 			if pt.TaskSpec != nil && pt.TaskSpec.Steps != nil {
-				errs = errs.Also(ValidateParameterTypes(ctx, paramSpec))
+				errs = errs.Also(ValidateParameterTypes(ctx, paramSpec, nil))
 				errs = errs.Also(ValidateParameterVariables(ctx, pt.TaskSpec.Steps, paramSpec))
 				errs = errs.Also(ValidateUsageOfDeclaredParameters(ctx, pt.TaskSpec.Steps, paramSpec))
 			}
 		}
-		errs = errs.Also(ValidatePipelineParameterVariables(ctx, ps.PipelineSpec.Tasks, paramSpec))
+		errs = errs.Also(ValidatePipelineParameterVariables(ctx, ps.PipelineSpec.Tasks, paramSpec, nil))
 		errs = errs.Also(validatePipelineTaskParameterUsage(ps.PipelineSpec.Tasks, paramSpec))
 	}
 	return errs

--- a/pkg/apis/pipeline/v1/result_validation.go
+++ b/pkg/apis/pipeline/v1/result_validation.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/version"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 )
 
@@ -29,7 +30,7 @@ const ResultNameFormat = `^([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$`
 var resultNameFormatRegex = regexp.MustCompile(ResultNameFormat)
 
 // Validate implements apis.Validatable
-func (tr TaskResult) Validate(ctx context.Context) (errs *apis.FieldError) {
+func (tr TaskResult) Validate(ctx context.Context, objectMeta *metav1.ObjectMeta) (errs *apis.FieldError) {
 	if !resultNameFormatRegex.MatchString(tr.Name) {
 		return apis.ErrInvalidKeyName(tr.Name, "name", fmt.Sprintf("Name must consist of alphanumeric characters, '-', '_', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my-name',  or 'my_name', regex used for validation is '%s')", ResultNameFormat))
 	}
@@ -38,11 +39,11 @@ func (tr TaskResult) Validate(ctx context.Context) (errs *apis.FieldError) {
 	// Object results is beta feature - check if the feature flag is set to "beta" or "alpha"
 	case tr.Type == ResultsTypeObject:
 		errs := validateObjectResult(tr)
-		errs = errs.Also(version.ValidateEnabledAPIFields(ctx, "results type", config.BetaAPIFields))
+		errs = errs.Also(version.ValidateEnabledAPIFieldsBasedOnOriginalObject(ctx, "results type", config.BetaAPIFields, objectMeta))
 		return errs
 	// Array results is a beta feature - check if the feature flag is set to "beta" or "alpha"
 	case tr.Type == ResultsTypeArray:
-		errs = errs.Also(version.ValidateEnabledAPIFields(ctx, "results type", config.BetaAPIFields))
+		errs = errs.Also(version.ValidateEnabledAPIFieldsBasedOnOriginalObject(ctx, "results type", config.BetaAPIFields, objectMeta))
 		return errs
 	// Resources created before the result. Type was introduced may not have Type set
 	// and should be considered valid

--- a/pkg/apis/pipeline/v1/taskrun_validation.go
+++ b/pkg/apis/pipeline/v1/taskrun_validation.go
@@ -62,7 +62,8 @@ func (ts *TaskRunSpec) Validate(ctx context.Context) (errs *apis.FieldError) {
 	}
 	// Validate TaskSpec if it's present.
 	if ts.TaskSpec != nil {
-		errs = errs.Also(ts.TaskSpec.Validate(ctx).ViaField("taskSpec"))
+		// Since task spec is declared inline, there's no object meta to use in validation
+		errs = errs.Also(ts.TaskSpec.Validate(ctx, nil /* objectMeta */).ViaField("taskSpec"))
 	}
 
 	errs = errs.Also(ValidateParameters(ctx, ts.Params).ViaField("params"))
@@ -138,7 +139,7 @@ func (ts *TaskRunSpec) validateInlineParameters(ctx context.Context) (errs *apis
 		paramSpec = append(paramSpec, v)
 	}
 	if ts.TaskSpec != nil && ts.TaskSpec.Steps != nil {
-		errs = errs.Also(ValidateParameterTypes(ctx, paramSpec))
+		errs = errs.Also(ValidateParameterTypes(ctx, paramSpec, nil))
 		errs = errs.Also(ValidateParameterVariables(ctx, ts.TaskSpec.Steps, paramSpec))
 		errs = errs.Also(ValidateUsageOfDeclaredParameters(ctx, ts.TaskSpec.Steps, paramSpec))
 	}

--- a/pkg/apis/pipeline/v1beta1/cluster_task_validation.go
+++ b/pkg/apis/pipeline/v1beta1/cluster_task_validation.go
@@ -31,7 +31,7 @@ func (t *ClusterTask) Validate(ctx context.Context) *apis.FieldError {
 		return nil
 	}
 	errs := validate.ObjectMetadata(t.GetObjectMeta()).ViaField("metadata")
-	errs = errs.Also(t.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec"))
+	errs = errs.Also(t.Spec.Validate(apis.WithinSpec(ctx), &t.ObjectMeta).ViaField("spec"))
 	// We do not support propagated parameters in ClusterTasks.
 	// Validate that all params the ClusterTask uses are declared.
 	return errs.Also(ValidateUsageOfDeclaredParameters(ctx, t.Spec.Steps, t.Spec.Params))

--- a/pkg/apis/pipeline/v1beta1/pipeline_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_conversion.go
@@ -23,6 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"github.com/tektoncd/pipeline/pkg/apis/version"
 	"knative.dev/pkg/apis"
 )
 
@@ -36,6 +37,7 @@ func (p *Pipeline) ConvertTo(ctx context.Context, to apis.Convertible) error {
 	switch sink := to.(type) {
 	case *v1.Pipeline:
 		sink.ObjectMeta = p.ObjectMeta
+		version.AddVersioningInfoIfAbsent(ctx, &sink.ObjectMeta, &p.TypeMeta)
 		return p.Spec.ConvertTo(ctx, &sink.Spec, &sink.ObjectMeta)
 	default:
 		return fmt.Errorf("unknown version, got: %T", sink)

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_validation.go
@@ -71,7 +71,8 @@ func (ps *PipelineRunSpec) Validate(ctx context.Context) (errs *apis.FieldError)
 
 	// Validate PipelineSpec if it's present
 	if ps.PipelineSpec != nil {
-		errs = errs.Also(ps.PipelineSpec.Validate(ctx).ViaField("pipelineSpec"))
+		// Since Pipeline spec is declared inline, there's no object meta needed for validation
+		errs = errs.Also(ps.PipelineSpec.Validate(ctx, nil /* objectMeta */).ViaField("pipelineSpec"))
 	}
 
 	// Validate PipelineRun parameters

--- a/pkg/apis/pipeline/v1beta1/task_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/task_conversion.go
@@ -66,6 +66,7 @@ func (t *Task) ConvertTo(ctx context.Context, to apis.Convertible) error {
 	switch sink := to.(type) {
 	case *v1.Task:
 		sink.ObjectMeta = t.ObjectMeta
+		version.AddVersioningInfoIfAbsent(ctx, &sink.ObjectMeta, &t.TypeMeta)
 		return t.Spec.ConvertTo(ctx, &sink.Spec, &sink.ObjectMeta, t.Name)
 	default:
 		return fmt.Errorf("unknown version, got: %T", sink)

--- a/pkg/apis/pipeline/v1beta1/taskrun_validation.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_validation.go
@@ -62,7 +62,8 @@ func (ts *TaskRunSpec) Validate(ctx context.Context) (errs *apis.FieldError) {
 	}
 	// Validate TaskSpec if it's present.
 	if ts.TaskSpec != nil {
-		errs = errs.Also(ts.TaskSpec.Validate(ctx).ViaField("taskSpec"))
+		// Since Task spec is declared inline, no objectMeta is needed here for validation
+		errs = errs.Also(ts.TaskSpec.Validate(ctx, nil /* objectMeta */).ViaField("taskSpec"))
 	}
 
 	errs = errs.Also(ValidateParameters(ctx, ts.Params).ViaField("params"))

--- a/pkg/apis/version/version_validation.go
+++ b/pkg/apis/version/version_validation.go
@@ -31,18 +31,6 @@ func ValidateEnabledAPIFieldsBasedOnOriginalObject(ctx context.Context, featureN
 		originalAPIVersion := objectMeta.Annotations[OriginalVersionKey]
 		originalEnableAPIFields := objectMeta.Annotations[OriginalEnableAPIFieldsKey]
 
-		// If object was created as v1beta1 with "enable-api-fields" set to "stable", but has since been converted to v1,
-		// we need to validate as if "enable-api-fields" is "beta".
-		//
-		//   Original Object Version | Original enable-api-fields | Value of enable-api-fields to use | reason
-		//   ----------------------- | -------------------------- | --------------------------------- | ------
-		//   v1beta1                 | alpha                      | alpha                             |
-		//   v1beta1                 | beta                       | beta                              |
-		//   v1beta1                 | stable                     | beta                              | Avoid breaking v1beta1 objects converted to v1
-		//   v1                      | alpha                      | alpha                             |
-		//   v1                      | beta                       | beta                              |
-		//   v1                      | stable                     | stable                            |
-
 		if originalAPIVersion == "v1beta1" && originalEnableAPIFields == config.StableAPIFields {
 			return validateEnabledAPIFields(config.BetaAPIFields, featureName, wantVersion)
 		}

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -442,7 +442,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1beta1.PipelineRun, get
 		return controller.NewPermanentError(err)
 	}
 
-	if err := pipelineSpec.Validate(ctx); err != nil {
+	if err := pipelineSpec.Validate(ctx, pipelineMeta.ObjectMeta); err != nil {
 		// This Run has failed, so we need to mark it as failed and stop reconciling it
 		pr.Status.MarkFailed(ReasonFailedValidation,
 			"Pipeline %s/%s can't be Run; it has an invalid spec: %s",

--- a/pkg/reconciler/pipelinerun/resources/pipelineref.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelineref.go
@@ -26,6 +26,7 @@ import (
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/pkg/apis/version"
 	clientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	rprp "github.com/tektoncd/pipeline/pkg/reconciler/pipelinerun/pipelinespec"
 	"github.com/tektoncd/pipeline/pkg/remote"
@@ -158,6 +159,7 @@ func readRuntimeObjectAsPipeline(ctx context.Context, obj runtime.Object, k8s ku
 			}
 			return nil, fmt.Errorf("remote Pipeline verification failed for object %s", obj.GetName())
 		}
+		version.AddVersioningInfoIfAbsent(ctx, &obj.ObjectMeta, &obj.TypeMeta)
 		return obj, nil
 	case *v1.Pipeline:
 		// TODO(#6356): Support V1 Task verification
@@ -167,6 +169,7 @@ func readRuntimeObjectAsPipeline(ctx context.Context, obj runtime.Object, k8s ku
 				APIVersion: "tekton.dev/v1beta1",
 			},
 		}
+		version.AddVersioningInfoIfAbsent(ctx, &obj.ObjectMeta, &obj.TypeMeta)
 		if err := t.ConvertFrom(ctx, obj); err != nil {
 			return nil, fmt.Errorf("failed to convert obj %s into Pipeline", obj.GetObjectKind().GroupVersionKind().String())
 		}

--- a/pkg/reconciler/taskrun/resources/taskref.go
+++ b/pkg/reconciler/taskrun/resources/taskref.go
@@ -27,6 +27,7 @@ import (
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/pkg/apis/version"
 	clientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	"github.com/tektoncd/pipeline/pkg/remote"
 	"github.com/tektoncd/pipeline/pkg/remote/oci"
@@ -179,8 +180,10 @@ func readRuntimeObjectAsTask(ctx context.Context, obj runtime.Object, k8s kubern
 			}
 			return nil, fmt.Errorf("remote Task verification failed for object %s", obj.GetName())
 		}
+		version.AddVersioningInfoIfAbsent(ctx, &obj.ObjectMeta, &obj.TypeMeta)
 		return obj, nil
 	case *v1beta1.ClusterTask:
+		version.AddVersioningInfoIfAbsent(ctx, &obj.ObjectMeta, &obj.TypeMeta)
 		return convertClusterTaskToTask(*obj), nil
 	case *v1.Task:
 		// TODO(#6356): Support V1 Task verification
@@ -190,6 +193,7 @@ func readRuntimeObjectAsTask(ctx context.Context, obj runtime.Object, k8s kubern
 				APIVersion: "tekton.dev/v1beta1",
 			},
 		}
+		version.AddVersioningInfoIfAbsent(ctx, &obj.ObjectMeta, &obj.TypeMeta)
 		if err := t.ConvertFrom(ctx, obj); err != nil {
 			return nil, fmt.Errorf("failed to convert obj %s into Task", obj.GetObjectKind().GroupVersionKind().String())
 		}

--- a/pkg/reconciler/taskrun/resources/taskspec.go
+++ b/pkg/reconciler/taskrun/resources/taskspec.go
@@ -29,6 +29,7 @@ import (
 // ResolvedTask contains the data that is needed to execute
 // the TaskRun.
 type ResolvedTask struct {
+	TaskMeta *metav1.ObjectMeta
 	TaskName string
 	Kind     v1beta1.TaskKind
 	TaskSpec *v1beta1.TaskSpec

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -350,6 +350,7 @@ func (c *Reconciler) prepare(ctx context.Context, tr *v1beta1.TaskRun) (*v1beta1
 	}
 
 	rtr := &resources.ResolvedTask{
+		TaskMeta: taskMeta.ObjectMeta,
 		TaskName: taskMeta.Name,
 		TaskSpec: taskSpec,
 		Kind:     resources.GetTaskKind(tr),
@@ -695,7 +696,8 @@ func (c *Reconciler) createPod(ctx context.Context, ts *v1beta1.TaskSpec, tr *v1
 		logger.Errorf("Failed to create a pod for taskrun: %s due to task validation error %v", tr.Name, validateErr)
 		return nil, validateErr
 	}
-	if validateErr := ts.Validate(ctx); validateErr != nil {
+
+	if validateErr := ts.Validate(ctx, rtr.TaskMeta); validateErr != nil {
 		logger.Errorf("Failed to create a pod for taskrun: %s due to task validation error %v", tr.Name, validateErr)
 		return nil, validateErr
 	}


### PR DESCRIPTION
Currently, validation differs between api versions: when beta features are used in v1 APIs, "enable-api-fields" must be set to "alpha" or "beta", but when beta features are used in beta APIs, "enable-api-fields" may be set to "alpha", "beta", or "stable".

We also validate the specs of referenced Tasks or Pipelines in the TaskRun/PipelineRun reconciler. This presents a problem when referencing a Task or Pipeline declared locally, since the Task or Pipeline may be converted into a different API version when it's stored.

This commit updates validation of Tasks and Pipelines to handle the case where a v1beta1 task/pipeline using beta features with "enable-api-fields" set to "stable" has been converted into a v1 task/pipeline and would otherwise fail validation. It stores the original value of "enable-api-fields" when a task/pipeline is converted between api versions in the CRD annotations, and uses this info for validation.

Note:
- TaskRun and PipelineRun validation is unchanged, since they are not fetched remotely and re-validated in the reconciler.
- People other than the cluster operator can change what features are allowed by modifying object annotations.
- This still does not perform validation of beta features for remote v1 pipelines; we'd need a separate solution for that. It only prevents breakages of remote v1beta1 pipelines when swapping the storage version of the api.

No tests yet, just showing the high level approach.
Some tweaks we can make:
- use only one annotation value such as tekton.dev/v1beta1-compat=true
- add a new feature flag to allow a cluster operator more control over this behavior

This PR is an alternative to https://github.com/tektoncd/pipeline/pull/6701.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
