### PR TITLE
add missing unit test case for warn mode verification policy.

### DIFF
--- a/pkg/reconciler/pipelinerun/resources/pipelineref_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelineref_test.go
@@ -459,7 +459,7 @@ func TestGetPipelineFunc_RemoteResolutionInvalidData(t *testing.T) {
 	}
 }
 
-func TestGetPipelineFunc_VerifySuccess(t *testing.T) {
+func TestGetPipelineFunc_VerifyNoError(t *testing.T) {
 	// This test case tests the success cases of trusted-resources-verification-no-match-policy when it is set to
 	// fail: passed matching policy verification
 	// warn and ignore: no matching policies.
@@ -535,6 +535,12 @@ func TestGetPipelineFunc_VerifySuccess(t *testing.T) {
 		},
 	}
 
+	warnPolicyRefSource := &v1beta1.RefSource{
+		URI: "	warnVP",
+	}
+	resolvedUnsignedMatched := test.NewResolvedResource(unsignedPipelineBytes, nil, warnPolicyRefSource, nil)
+	requesterUnsignedMatched := test.NewRequester(resolvedUnsignedMatched, nil)
+
 	testcases := []struct {
 		name                      string
 		requester                 *test.Requester
@@ -576,27 +582,19 @@ func TestGetPipelineFunc_VerifySuccess(t *testing.T) {
 		expected:                  unsignedPipeline,
 		expectedRefSource:         noMatchPolicyRefSource,
 	}, {
+		name:                      "unsigned pipeline fails warn mode policies doesn't return error",
+		requester:                 requesterUnsignedMatched,
+		verificationNoMatchPolicy: config.FailNoMatchPolicy,
+		pipelinerun:               pr,
+		policies:                  vps,
+		expected:                  unsignedPipeline,
+		expectedRefSource:         warnPolicyRefSource,
+	}, {
 		name:                      "ignore unsigned pipeline without matching policies",
 		requester:                 requesterUnmatched,
 		verificationNoMatchPolicy: config.IgnoreNoMatchPolicy,
 		pipelinerun:               pr,
 		policies:                  vps,
-		expected:                  unsignedPipeline,
-		expectedRefSource:         noMatchPolicyRefSource,
-	}, {
-		name:                      "warn no policies",
-		requester:                 requesterUnmatched,
-		verificationNoMatchPolicy: config.WarnNoMatchPolicy,
-		pipelinerun:               pr,
-		policies:                  []*v1alpha1.VerificationPolicy{},
-		expected:                  unsignedPipeline,
-		expectedRefSource:         noMatchPolicyRefSource,
-	}, {
-		name:                      "ignore no policies",
-		requester:                 requesterUnmatched,
-		verificationNoMatchPolicy: config.IgnoreNoMatchPolicy,
-		pipelinerun:               pr,
-		policies:                  []*v1alpha1.VerificationPolicy{},
 		expected:                  unsignedPipeline,
 		expectedRefSource:         noMatchPolicyRefSource,
 	}, {

--- a/pkg/reconciler/taskrun/resources/taskref_test.go
+++ b/pkg/reconciler/taskrun/resources/taskref_test.go
@@ -724,7 +724,7 @@ func TestGetPipelineFunc_RemoteResolutionInvalidData(t *testing.T) {
 	}
 }
 
-func TestGetTaskFunc_VerifySuccess(t *testing.T) {
+func TestGetTaskFunc_VerifyNoError(t *testing.T) {
 	// This test case tests the success cases of trusted-resources-verification-no-match-policy when it is set to
 	// fail: passed matching policy verification
 	// warn and ignore: no matching policies.
@@ -765,6 +765,12 @@ func TestGetTaskFunc_VerifySuccess(t *testing.T) {
 	resolvedMatched := test.NewResolvedResource(signedTaskBytes, nil, matchPolicyRefSource, nil)
 	requesterMatched := test.NewRequester(resolvedMatched, nil)
 
+	warnPolicyRefSource := &v1beta1.RefSource{
+		URI: "	warnVP",
+	}
+	resolvedUnsignedMatched := test.NewResolvedResource(unsignedTaskBytes, nil, warnPolicyRefSource, nil)
+	requesterUnsignedMatched := test.NewRequester(resolvedUnsignedMatched, nil)
+
 	taskRef := &v1beta1.TaskRef{ResolverRef: v1beta1.ResolverRef{Resolver: "git"}}
 
 	testcases := []struct {
@@ -803,24 +809,17 @@ func TestGetTaskFunc_VerifySuccess(t *testing.T) {
 		expected:                  unsignedTask,
 		expectedRefSource:         noMatchPolicyRefSource,
 	}, {
-		name:                      "allow unsigned task without matching policies",
+		name:                      "task fails warn mode policy doesn't return error",
+		requester:                 requesterUnsignedMatched,
+		verificationNoMatchPolicy: config.FailNoMatchPolicy,
+		policies:                  vps,
+		expected:                  unsignedTask,
+		expectedRefSource:         warnPolicyRefSource,
+	}, {
+		name:                      "ignore unsigned task without matching policies",
 		requester:                 requesterUnmatched,
 		verificationNoMatchPolicy: config.IgnoreNoMatchPolicy,
 		policies:                  vps,
-		expected:                  unsignedTask,
-		expectedRefSource:         noMatchPolicyRefSource,
-	}, {
-		name:                      "warn no policies",
-		requester:                 requesterUnmatched,
-		verificationNoMatchPolicy: config.WarnNoMatchPolicy,
-		policies:                  []*v1alpha1.VerificationPolicy{},
-		expected:                  unsignedTask,
-		expectedRefSource:         noMatchPolicyRefSource,
-	}, {
-		name:                      "allow no policies",
-		requester:                 requesterUnmatched,
-		verificationNoMatchPolicy: config.IgnoreNoMatchPolicy,
-		policies:                  []*v1alpha1.VerificationPolicy{},
 		expected:                  unsignedTask,
 		expectedRefSource:         noMatchPolicyRefSource,
 	},

--- a/test/trustedresources.go
+++ b/test/trustedresources.go
@@ -113,10 +113,11 @@ func SetupTrustedResourceConfig(ctx context.Context, verificationNoMatchPolicy s
 }
 
 // SetupVerificationPolicies set verification policies and secrets to store public keys.
-// This function helps to setup 3 kinds of VerificationPolicies:
+// This function helps to setup 4 kinds of VerificationPolicies:
 // 1. One public key in inline data
 // 2. One public key in secret
-// 3. 2 authorities referring to the same secret. This is to test and make sure we don't have duplicate counts
+// 3. the policy pattern doesn't match any resources
+// 4. warn mode policy without keys
 // SignerVerifier is returned to sign resources
 // The k8s clientset is returned to fetch secret from it.
 // VerificationPolicies are returned to fetch public keys
@@ -151,7 +152,7 @@ func SetupVerificationPolicies(t *testing.T) (signature.SignerVerifier, *ecdsa.P
 					HashAlgorithm: "sha256",
 				},
 			},
-		})
+		}, v1alpha1.ModeEnforce)
 
 	keyInSecretVp := getVerificationPolicy(
 		"keyInSecretVp",
@@ -170,7 +171,7 @@ func SetupVerificationPolicies(t *testing.T) (signature.SignerVerifier, *ecdsa.P
 					HashAlgorithm: "sha256",
 				},
 			},
-		})
+		}, v1alpha1.ModeEnforce)
 
 	wrongKeyandPatternVp := getVerificationPolicy(
 		"wrongKeyInDataVp",
@@ -186,11 +187,30 @@ func SetupVerificationPolicies(t *testing.T) (signature.SignerVerifier, *ecdsa.P
 					HashAlgorithm: "sha256",
 				},
 			},
-		})
+		}, v1alpha1.ModeEnforce)
+
+	warnModeVP := getVerificationPolicy(
+		"warnModeVP",
+		namespace,
+		[]v1alpha1.ResourcePattern{{
+			Pattern: "warnVP"},
+		},
+		[]v1alpha1.Authority{
+			{
+				Name: "pubkey",
+				Key: &v1alpha1.KeyRef{
+					SecretRef: &v1.SecretReference{
+						Name:      secret.Name,
+						Namespace: secret.Namespace,
+					},
+					HashAlgorithm: "sha256",
+				},
+			},
+		}, v1alpha1.ModeWarn)
 
 	k8sclient := fakek8s.NewSimpleClientset(secret)
 
-	return sv, keys, k8sclient, []*v1alpha1.VerificationPolicy{&keyInDataVp, &keyInSecretVp, &wrongKeyandPatternVp}
+	return sv, keys, k8sclient, []*v1alpha1.VerificationPolicy{&keyInDataVp, &keyInSecretVp, &wrongKeyandPatternVp, &warnModeVP}
 }
 
 // SetupMatchAllVerificationPolicies set verification policies with a Pattern to match all resources
@@ -224,7 +244,7 @@ func SetupMatchAllVerificationPolicies(t *testing.T, namespace string) (signatur
 					HashAlgorithm: "sha256",
 				},
 			},
-		})
+		}, v1alpha1.ModeEnforce)
 
 	k8sclient := fakek8s.NewSimpleClientset(secret)
 
@@ -350,7 +370,7 @@ func readPasswordFn(confirm bool) func() ([]byte, error) {
 	}
 }
 
-func getVerificationPolicy(name, namespace string, patterns []v1alpha1.ResourcePattern, authorities []v1alpha1.Authority) v1alpha1.VerificationPolicy {
+func getVerificationPolicy(name, namespace string, patterns []v1alpha1.ResourcePattern, authorities []v1alpha1.Authority, mode v1alpha1.ModeType) v1alpha1.VerificationPolicy {
 	return v1alpha1.VerificationPolicy{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "VerificationPolicy",
@@ -363,7 +383,7 @@ func getVerificationPolicy(name, namespace string, patterns []v1alpha1.ResourceP
 		Spec: v1alpha1.VerificationPolicySpec{
 			Resources:   patterns,
 			Authorities: authorities,
-			Mode:        v1alpha1.ModeEnforce,
+			Mode:        mode,
 		},
 	}
 }


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This commit adds missing unit test case for warn mode verification
policy.

/kind misc

Signed-off-by: Yongxuan Zhang yongxuanzhang@google.com

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
