### PR TITLE
Cleanup: Use CustomRun instead of RunObject

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -333,15 +333,10 @@ func (c *Reconciler) resolvePipelineState(
 		}
 		fn := tresources.GetTaskFunc(ctx, c.KubeClientSet, c.PipelineClientSet, c.resolutionRequester, pr, task.TaskRef, trName, pr.Namespace, pr.Spec.ServiceAccountName, vp)
 
-		getRunObjectFunc := func(name string) (v1beta1.RunObject, error) {
+		getCustomRunFunc := func(name string) (*v1beta1.CustomRun, error) {
 			r, err := c.customRunLister.CustomRuns(pr.Namespace).Get(name)
 			if err != nil {
 				return nil, err
-			}
-			// If we just return c.customRunLister.CustomRuns(...).Get(...) and there is no run, we end up returning
-			// a v1beta1.RunObject that won't == nil, so do an explicit check.
-			if r == nil {
-				return nil, nil
 			}
 			return r, nil
 		}
@@ -352,7 +347,7 @@ func (c *Reconciler) resolvePipelineState(
 			func(name string) (*v1beta1.TaskRun, error) {
 				return c.taskRunLister.TaskRuns(pr.Namespace).Get(name)
 			},
-			getRunObjectFunc,
+			getCustomRunFunc,
 			task,
 		)
 		if err != nil {
@@ -775,10 +770,10 @@ func (c *Reconciler) runNextSchedulableTask(ctx context.Context, pr *v1beta1.Pip
 		}()
 
 		if rpt.IsCustomTask() {
-			rpt.RunObjects, err = c.createRunObjects(ctx, rpt, pr)
+			rpt.CustomRuns, err = c.createCustomRuns(ctx, rpt, pr)
 			if err != nil {
-				recorder.Eventf(pr, corev1.EventTypeWarning, "RunsCreationFailed", "Failed to create Runs %q: %v", rpt.RunObjectNames, err)
-				err = fmt.Errorf("error creating Runs called %s for PipelineTask %s from PipelineRun %s: %w", rpt.RunObjectNames, rpt.PipelineTask.Name, pr.Name, err)
+				recorder.Eventf(pr, corev1.EventTypeWarning, "RunsCreationFailed", "Failed to create CustomRuns %q: %v", rpt.CustomRunNames, err)
+				err = fmt.Errorf("error creating CustomRuns called %s for PipelineTask %s from PipelineRun %s: %w", rpt.CustomRunNames, rpt.PipelineTask.Name, pr.Name, err)
 				return err
 			}
 		} else {
@@ -884,9 +879,9 @@ func (c *Reconciler) createTaskRun(ctx context.Context, taskRunName string, para
 	return c.PipelineClientSet.TektonV1beta1().TaskRuns(pr.Namespace).Create(ctx, tr, metav1.CreateOptions{})
 }
 
-func (c *Reconciler) createRunObjects(ctx context.Context, rpt *resources.ResolvedPipelineTask, pr *v1beta1.PipelineRun) ([]v1beta1.RunObject, error) {
-	var runObjects []v1beta1.RunObject
-	ctx, span := c.tracerProvider.Tracer(TracerName).Start(ctx, "createRunObjects")
+func (c *Reconciler) createCustomRuns(ctx context.Context, rpt *resources.ResolvedPipelineTask, pr *v1beta1.PipelineRun) ([]*v1beta1.CustomRun, error) {
+	var customRuns []*v1beta1.CustomRun
+	ctx, span := c.tracerProvider.Tracer(TracerName).Start(ctx, "createCustomRuns")
 	defer span.End()
 	var matrixCombinations []v1beta1.Params
 
@@ -894,22 +889,22 @@ func (c *Reconciler) createRunObjects(ctx context.Context, rpt *resources.Resolv
 		matrixCombinations = rpt.PipelineTask.Matrix.FanOut()
 	}
 
-	for i, runObjectName := range rpt.RunObjectNames {
+	for i, customRunName := range rpt.CustomRunNames {
 		var params v1beta1.Params
 		if len(matrixCombinations) > i {
 			params = matrixCombinations[i]
 		}
-		runObject, err := c.createRunObject(ctx, runObjectName, params, rpt, pr)
+		customRun, err := c.createCustomRun(ctx, customRunName, params, rpt, pr)
 		if err != nil {
 			return nil, err
 		}
-		runObjects = append(runObjects, runObject)
+		customRuns = append(customRuns, customRun)
 	}
-	return runObjects, nil
+	return customRuns, nil
 }
 
-func (c *Reconciler) createRunObject(ctx context.Context, runName string, params v1beta1.Params, rpt *resources.ResolvedPipelineTask, pr *v1beta1.PipelineRun) (v1beta1.RunObject, error) {
-	ctx, span := c.tracerProvider.Tracer(TracerName).Start(ctx, "createRunObject")
+func (c *Reconciler) createCustomRun(ctx context.Context, runName string, params v1beta1.Params, rpt *resources.ResolvedPipelineTask, pr *v1beta1.PipelineRun) (*v1beta1.CustomRun, error) {
+	ctx, span := c.tracerProvider.Tracer(TracerName).Start(ctx, "createCustomRun")
 	defer span.End()
 	logger := logging.FromContext(ctx)
 	rpt.PipelineTask = resources.ApplyPipelineTaskContexts(rpt.PipelineTask)
@@ -1259,22 +1254,17 @@ func (c *Reconciler) updatePipelineRunStatusFromInformer(ctx context.Context, pr
 		logger.Errorf("could not list TaskRuns %#v", err)
 		return err
 	}
-	var runObjects []v1beta1.RunObject
 
 	customRuns, err := c.customRunLister.CustomRuns(pr.Namespace).List(k8slabels.SelectorFromSet(pipelineRunLabels))
 	if err != nil {
 		logger.Errorf("could not list CustomRuns %#v", err)
 		return err
 	}
-	for _, cr := range customRuns {
-		runObjects = append(runObjects, cr)
-	}
-
-	return updatePipelineRunStatusFromChildObjects(ctx, logger, pr, taskRuns, runObjects)
+	return updatePipelineRunStatusFromChildObjects(ctx, logger, pr, taskRuns, customRuns)
 }
 
-func updatePipelineRunStatusFromChildObjects(ctx context.Context, logger *zap.SugaredLogger, pr *v1beta1.PipelineRun, taskRuns []*v1beta1.TaskRun, runObjects []v1beta1.RunObject) error {
-	updatePipelineRunStatusFromChildRefs(logger, pr, taskRuns, runObjects)
+func updatePipelineRunStatusFromChildObjects(ctx context.Context, logger *zap.SugaredLogger, pr *v1beta1.PipelineRun, taskRuns []*v1beta1.TaskRun, customRuns []*v1beta1.CustomRun) error {
+	updatePipelineRunStatusFromChildRefs(logger, pr, taskRuns, customRuns)
 
 	return validateChildObjectsInPipelineRunStatus(ctx, pr.Status)
 }
@@ -1311,38 +1301,37 @@ func filterTaskRunsForPipelineRunStatus(logger *zap.SugaredLogger, pr *v1beta1.P
 	return ownedTaskRuns
 }
 
-// filterRunsForPipelineRunStatus filters the given slice of run objects, returning information only those owned by the given PipelineRun.
-func filterRunsForPipelineRunStatus(logger *zap.SugaredLogger, pr *v1beta1.PipelineRun, runObjects []v1beta1.RunObject) ([]string, []string, []schema.GroupVersionKind, []*v1beta1.CustomRunStatus) {
+// filterCustomRunsForPipelineRunStatus filters the given slice of customRuns, returning information only those owned by the given PipelineRun.
+func filterCustomRunsForPipelineRunStatus(logger *zap.SugaredLogger, pr *v1beta1.PipelineRun, customRuns []*v1beta1.CustomRun) ([]string, []string, []schema.GroupVersionKind, []*v1beta1.CustomRunStatus) {
 	var names []string
 	var taskLabels []string
 	var gvks []schema.GroupVersionKind
 	var statuses []*v1beta1.CustomRunStatus
 
-	// Loop over all the run objects associated to Tasks
-	for _, runObj := range runObjects {
-		// Only process run objects that are owned by this PipelineRun.
-		// This skips Runs that are indirectly created by the PipelineRun (e.g. by custom tasks).
-		if len(runObj.GetObjectMeta().GetOwnerReferences()) < 1 || runObj.GetObjectMeta().GetOwnerReferences()[0].UID != pr.ObjectMeta.UID {
-			logger.Debugf("Found a %s %s that is not owned by this PipelineRun", runObj.GetObjectKind().GroupVersionKind().Kind, runObj.GetObjectMeta().GetName())
+	// Loop over all the customRuns associated to Tasks
+	for _, cr := range customRuns {
+		// Only process customRuns that are owned by this PipelineRun.
+		// This skips customRuns that are indirectly created by the PipelineRun (e.g. by custom tasks).
+		if len(cr.GetObjectMeta().GetOwnerReferences()) < 1 || cr.GetObjectMeta().GetOwnerReferences()[0].UID != pr.ObjectMeta.UID {
+			logger.Debugf("Found a %s %s that is not owned by this PipelineRun", cr.GetObjectKind().GroupVersionKind().Kind, cr.GetObjectMeta().GetName())
 			continue
 		}
 
-		names = append(names, runObj.GetObjectMeta().GetName())
-		taskLabels = append(taskLabels, runObj.GetObjectMeta().GetLabels()[pipeline.PipelineTaskLabelKey])
+		names = append(names, cr.GetObjectMeta().GetName())
+		taskLabels = append(taskLabels, cr.GetObjectMeta().GetLabels()[pipeline.PipelineTaskLabelKey])
 
-		r := runObj.(*v1beta1.CustomRun)
-		statuses = append(statuses, &r.Status)
-		// We can't just get the gvk from the run's TypeMeta because that isn't populated for resources created through the fake client.
+		statuses = append(statuses, &cr.Status)
+		// We can't just get the gvk from the customRun's TypeMeta because that isn't populated for resources created through the fake client.
 		gvks = append(gvks, v1beta1.SchemeGroupVersion.WithKind(customRun))
 	}
 
 	return names, taskLabels, gvks, statuses
 }
 
-func updatePipelineRunStatusFromChildRefs(logger *zap.SugaredLogger, pr *v1beta1.PipelineRun, trs []*v1beta1.TaskRun, runObjects []v1beta1.RunObject) {
-	// If no TaskRun or RunObject was found, nothing to be done. We never remove child references from the status.
+func updatePipelineRunStatusFromChildRefs(logger *zap.SugaredLogger, pr *v1beta1.PipelineRun, trs []*v1beta1.TaskRun, customRuns []*v1beta1.CustomRun) {
+	// If no TaskRun or CustomRun was found, nothing to be done. We never remove child references from the status.
 	// We do still return an empty map of TaskRun/Run names keyed by PipelineTask name for later functions.
-	if len(trs) == 0 && len(runObjects) == 0 {
+	if len(trs) == 0 && len(customRuns) == 0 {
 		return
 	}
 
@@ -1378,7 +1367,7 @@ func updatePipelineRunStatusFromChildRefs(logger *zap.SugaredLogger, pr *v1beta1
 	}
 
 	// Get the names, their task label values, and their group/version/kind info for all CustomRuns or Runs associated with the PipelineRun
-	names, taskLabels, gvks, _ := filterRunsForPipelineRunStatus(logger, pr, runObjects)
+	names, taskLabels, gvks, _ := filterCustomRunsForPipelineRunStatus(logger, pr, customRuns)
 
 	// Loop over that data and populate the child references
 	for idx := range names {

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
@@ -43,7 +43,7 @@ import (
 	logtesting "knative.dev/pkg/logging/testing"
 )
 
-func nopGetRun(string) (v1beta1.RunObject, error) {
+func nopGetCustomRun(string) (*v1beta1.CustomRun, error) {
 	return nil, errors.New("GetRun should not be called")
 }
 func nopGetTask(context.Context, string) (*v1beta1.Task, *v1beta1.RefSource, *trustedresources.VerificationResult, error) {
@@ -479,49 +479,49 @@ var allFinishedState = PipelineRunState{{
 var noCustomRunStartedState = PipelineRunState{{
 	PipelineTask:   &pts[12],
 	CustomTask:     true,
-	RunObjectNames: []string{"pipelinerun-mytask13"},
-	RunObjects:     nil,
+	CustomRunNames: []string{"pipelinerun-mytask13"},
+	CustomRuns:     nil,
 }, {
 	PipelineTask:   &pts[13],
 	CustomTask:     true,
-	RunObjectNames: []string{"pipelinerun-mytask14"},
-	RunObjects:     nil,
+	CustomRunNames: []string{"pipelinerun-mytask14"},
+	CustomRuns:     nil,
 }}
 
 var oneCustomRunStartedState = PipelineRunState{{
 	PipelineTask:   &pts[12],
 	CustomTask:     true,
-	RunObjectNames: []string{"pipelinerun-mytask13"},
-	RunObjects:     []v1beta1.RunObject{makeCustomRunStarted(customRuns[0])},
+	CustomRunNames: []string{"pipelinerun-mytask13"},
+	CustomRuns:     []*v1beta1.CustomRun{makeCustomRunStarted(customRuns[0])},
 }, {
 	PipelineTask:   &pts[13],
 	CustomTask:     true,
-	RunObjectNames: []string{"pipelinerun-mytask14"},
-	RunObjects:     nil,
+	CustomRunNames: []string{"pipelinerun-mytask14"},
+	CustomRuns:     nil,
 }}
 
 var oneCustomRunFinishedState = PipelineRunState{{
 	PipelineTask:   &pts[12],
 	CustomTask:     true,
-	RunObjectNames: []string{"pipelinerun-mytask13"},
-	RunObjects:     []v1beta1.RunObject{makeCustomRunSucceeded(customRuns[0])},
+	CustomRunNames: []string{"pipelinerun-mytask13"},
+	CustomRuns:     []*v1beta1.CustomRun{makeCustomRunSucceeded(customRuns[0])},
 }, {
 	PipelineTask:   &pts[13],
 	CustomTask:     true,
-	RunObjectNames: []string{"pipelinerun-mytask14"},
-	RunObjects:     nil,
+	CustomRunNames: []string{"pipelinerun-mytask14"},
+	CustomRuns:     nil,
 }}
 
 var oneCustomRunFailedState = PipelineRunState{{
 	PipelineTask:   &pts[12],
 	CustomTask:     true,
-	RunObjectNames: []string{"pipelinerun-mytask13"},
-	RunObjects:     []v1beta1.RunObject{makeCustomRunFailed(customRuns[0])},
+	CustomRunNames: []string{"pipelinerun-mytask13"},
+	CustomRuns:     []*v1beta1.CustomRun{makeCustomRunFailed(customRuns[0])},
 }, {
 	PipelineTask:   &pts[13],
 	CustomTask:     true,
-	RunObjectNames: []string{"pipelinerun-mytask14"},
-	RunObjects:     nil,
+	CustomRunNames: []string{"pipelinerun-mytask14"},
+	CustomRuns:     nil,
 }}
 
 var taskCancelled = PipelineRunState{{
@@ -535,8 +535,8 @@ var taskCancelled = PipelineRunState{{
 
 var customRunCancelled = PipelineRunState{{
 	PipelineTask:   &pts[12],
-	RunObjectNames: []string{"pipelinerun-mytask13"},
-	RunObjects:     []v1beta1.RunObject{withCustomRunCancelled(newCustomRun(customRuns[0]))},
+	CustomRunNames: []string{"pipelinerun-mytask13"},
+	CustomRuns:     []*v1beta1.CustomRun{withCustomRunCancelled(newCustomRun(customRuns[0]))},
 }}
 
 var noneStartedStateMatrix = PipelineRunState{{
@@ -638,37 +638,37 @@ var allFinishedStateMatrix = PipelineRunState{{
 var noCustomRunStartedStateMatrix = PipelineRunState{{
 	PipelineTask:   &pts[18],
 	CustomTask:     true,
-	RunObjectNames: []string{"pipelinerun-mytask13"},
-	RunObjects:     nil,
+	CustomRunNames: []string{"pipelinerun-mytask13"},
+	CustomRuns:     nil,
 }, {
 	PipelineTask:   &pts[19],
 	CustomTask:     true,
-	RunObjectNames: []string{"pipelinerun-mytask13"},
-	RunObjects:     nil,
+	CustomRunNames: []string{"pipelinerun-mytask13"},
+	CustomRuns:     nil,
 }}
 
 var oneCustomRunStartedStateMatrix = PipelineRunState{{
 	PipelineTask:   &pts[18],
 	CustomTask:     true,
-	RunObjectNames: []string{"pipelinerun-mytask13"},
-	RunObjects:     []v1beta1.RunObject{makeCustomRunStarted(customRuns[0])},
+	CustomRunNames: []string{"pipelinerun-mytask13"},
+	CustomRuns:     []*v1beta1.CustomRun{makeCustomRunStarted(customRuns[0])},
 }, {
 	PipelineTask:   &pts[19],
 	CustomTask:     true,
-	RunObjectNames: []string{"pipelinerun-mytask14"},
-	RunObjects:     nil,
+	CustomRunNames: []string{"pipelinerun-mytask14"},
+	CustomRuns:     nil,
 }}
 
 var oneCustomRunFailedStateMatrix = PipelineRunState{{
 	PipelineTask:   &pts[18],
 	CustomTask:     true,
-	RunObjectNames: []string{"pipelinerun-mytask13"},
-	RunObjects:     []v1beta1.RunObject{makeCustomRunFailed(customRuns[0])},
+	CustomRunNames: []string{"pipelinerun-mytask13"},
+	CustomRuns:     []*v1beta1.CustomRun{makeCustomRunFailed(customRuns[0])},
 }, {
 	PipelineTask:   &pts[19],
 	CustomTask:     true,
-	RunObjectNames: []string{"pipelinerun-mytask14"},
-	RunObjects:     nil,
+	CustomRunNames: []string{"pipelinerun-mytask14"},
+	CustomRuns:     nil,
 }}
 
 var taskCancelledMatrix = PipelineRunState{{
@@ -1246,7 +1246,7 @@ func TestIsFailure(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
 			CustomTask:   true,
-			RunObjects:   []v1beta1.RunObject{makeCustomRunStarted(customRuns[0])},
+			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunStarted(customRuns[0])},
 		},
 		want: false,
 	}, {
@@ -1261,7 +1261,7 @@ func TestIsFailure(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
 			CustomTask:   true,
-			RunObjects:   []v1beta1.RunObject{makeCustomRunSucceeded(customRuns[0])},
+			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunSucceeded(customRuns[0])},
 		},
 		want: false,
 	}, {
@@ -1276,7 +1276,7 @@ func TestIsFailure(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
 			CustomTask:   true,
-			RunObjects:   []v1beta1.RunObject{makeCustomRunFailed(customRuns[0])},
+			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunFailed(customRuns[0])},
 		},
 		want: true,
 	}, {
@@ -1284,7 +1284,7 @@ func TestIsFailure(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task", Retries: 1},
 			CustomTask:   true,
-			RunObjects:   []v1beta1.RunObject{makeCustomRunFailed(customRuns[0])},
+			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunFailed(customRuns[0])},
 		},
 		want: true,
 	}, {
@@ -1299,7 +1299,7 @@ func TestIsFailure(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task", Retries: 1},
 			CustomTask:   true,
-			RunObjects:   []v1beta1.RunObject{withCustomRunRetries(makeCustomRunFailed(customRuns[0]))},
+			CustomRuns:   []*v1beta1.CustomRun{withCustomRunRetries(makeCustomRunFailed(customRuns[0]))},
 		},
 		want: true,
 	}, {
@@ -1327,7 +1327,7 @@ func TestIsFailure(t *testing.T) {
 		name: "customrun cancelled",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
-			RunObjects:   []v1beta1.RunObject{withCustomRunCancelled(makeCustomRunFailed(customRuns[0]))},
+			CustomRuns:   []*v1beta1.CustomRun{withCustomRunCancelled(makeCustomRunFailed(customRuns[0]))},
 			CustomTask:   true,
 		},
 		want: true,
@@ -1335,7 +1335,7 @@ func TestIsFailure(t *testing.T) {
 		name: "customrun cancelled for timeout",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
-			RunObjects:   []v1beta1.RunObject{withCustomRunCancelledForTimeout(makeCustomRunFailed(customRuns[0]))},
+			CustomRuns:   []*v1beta1.CustomRun{withCustomRunCancelledForTimeout(makeCustomRunFailed(customRuns[0]))},
 			CustomTask:   true,
 		},
 		want: true,
@@ -1343,7 +1343,7 @@ func TestIsFailure(t *testing.T) {
 		name: "customrun cancelled but not failed",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
-			RunObjects:   []v1beta1.RunObject{withCustomRunCancelled(newCustomRun(customRuns[0]))},
+			CustomRuns:   []*v1beta1.CustomRun{withCustomRunCancelled(newCustomRun(customRuns[0]))},
 			CustomTask:   true,
 		},
 		want: false,
@@ -1358,7 +1358,7 @@ func TestIsFailure(t *testing.T) {
 		name: "customrun cancelled: retries remaining",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task", Retries: 1},
-			RunObjects:   []v1beta1.RunObject{withCustomRunCancelled(makeCustomRunFailed(customRuns[0]))},
+			CustomRuns:   []*v1beta1.CustomRun{withCustomRunCancelled(makeCustomRunFailed(customRuns[0]))},
 			CustomTask:   true,
 		},
 		want: true,
@@ -1373,7 +1373,7 @@ func TestIsFailure(t *testing.T) {
 		name: "custom run cancelled: retried",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task", Retries: 1},
-			RunObjects:   []v1beta1.RunObject{withCustomRunCancelled(withCustomRunRetries(makeCustomRunFailed(customRuns[0])))},
+			CustomRuns:   []*v1beta1.CustomRun{withCustomRunCancelled(withCustomRunRetries(makeCustomRunFailed(customRuns[0])))},
 			CustomTask:   true,
 		},
 		want: true,
@@ -1402,7 +1402,7 @@ func TestIsFailure(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: matrixedPipelineTask,
-			RunObjects:   []v1beta1.RunObject{makeCustomRunStarted(customRuns[0]), makeCustomRunStarted(customRuns[1])},
+			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunStarted(customRuns[0]), makeCustomRunStarted(customRuns[1])},
 		},
 		want: false,
 	}, {
@@ -1417,7 +1417,7 @@ func TestIsFailure(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: matrixedPipelineTask,
-			RunObjects:   []v1beta1.RunObject{makeCustomRunStarted(customRuns[0]), makeCustomRunSucceeded(customRuns[1])},
+			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunStarted(customRuns[0]), makeCustomRunSucceeded(customRuns[1])},
 		},
 		want: false,
 	}, {
@@ -1439,7 +1439,7 @@ func TestIsFailure(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: matrixedPipelineTask,
-			RunObjects:   []v1beta1.RunObject{makeCustomRunSucceeded(customRuns[0]), makeCustomRunStarted(customRuns[1])},
+			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunSucceeded(customRuns[0]), makeCustomRunStarted(customRuns[1])},
 		},
 		want: false,
 	}, {
@@ -1454,7 +1454,7 @@ func TestIsFailure(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: matrixedPipelineTask,
-			RunObjects:   []v1beta1.RunObject{makeCustomRunFailed(customRuns[0]), makeCustomRunFailed(customRuns[1])},
+			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunFailed(customRuns[0]), makeCustomRunFailed(customRuns[1])},
 		},
 		want: true,
 	}, {
@@ -1469,7 +1469,7 @@ func TestIsFailure(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: matrixedPipelineTask,
-			RunObjects:   []v1beta1.RunObject{makeCustomRunFailed(customRuns[0]), makeCustomRunStarted(customRuns[1])},
+			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunFailed(customRuns[0]), makeCustomRunStarted(customRuns[1])},
 		},
 		want: false,
 	}, {
@@ -1484,7 +1484,7 @@ func TestIsFailure(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: withPipelineTaskRetries(*matrixedPipelineTask, 1),
-			RunObjects:   []v1beta1.RunObject{makeCustomRunFailed(customRuns[0]), makeCustomRunFailed(customRuns[1])},
+			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunFailed(customRuns[0]), makeCustomRunFailed(customRuns[1])},
 		},
 		want: true,
 	}, {
@@ -1499,7 +1499,7 @@ func TestIsFailure(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: withPipelineTaskRetries(*matrixedPipelineTask, 1),
-			RunObjects:   []v1beta1.RunObject{makeCustomRunFailed(customRuns[0]), withCustomRunRetries(makeCustomRunFailed(customRuns[1]))},
+			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunFailed(customRuns[0]), withCustomRunRetries(makeCustomRunFailed(customRuns[1]))},
 		},
 		want: true,
 	}, {
@@ -1507,7 +1507,7 @@ func TestIsFailure(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: withPipelineTaskRetries(*matrixedPipelineTask, 1),
-			RunObjects:   []v1beta1.RunObject{withCustomRunRetries(makeCustomRunFailed(customRuns[0])), withCustomRunRetries(makeCustomRunFailed(customRuns[1]))},
+			CustomRuns:   []*v1beta1.CustomRun{withCustomRunRetries(makeCustomRunFailed(customRuns[0])), withCustomRunRetries(makeCustomRunFailed(customRuns[1]))},
 		},
 		want: true,
 	}, {
@@ -1522,7 +1522,7 @@ func TestIsFailure(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: matrixedPipelineTask,
-			RunObjects:   []v1beta1.RunObject{withCustomRunCancelled(makeCustomRunFailed(customRuns[0])), withCustomRunCancelled(makeCustomRunFailed(customRuns[1]))},
+			CustomRuns:   []*v1beta1.CustomRun{withCustomRunCancelled(makeCustomRunFailed(customRuns[0])), withCustomRunCancelled(makeCustomRunFailed(customRuns[1]))},
 		},
 		want: true,
 	}, {
@@ -1537,7 +1537,7 @@ func TestIsFailure(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: matrixedPipelineTask,
-			RunObjects:   []v1beta1.RunObject{withCustomRunCancelled(makeCustomRunFailed(customRuns[0])), makeCustomRunStarted(customRuns[1])},
+			CustomRuns:   []*v1beta1.CustomRun{withCustomRunCancelled(makeCustomRunFailed(customRuns[0])), makeCustomRunStarted(customRuns[1])},
 		},
 		want: false,
 	}, {
@@ -1552,7 +1552,7 @@ func TestIsFailure(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: matrixedPipelineTask,
-			RunObjects:   []v1beta1.RunObject{withCustomRunCancelled(newCustomRun(customRuns[0])), withCustomRunCancelled(newCustomRun(customRuns[1]))},
+			CustomRuns:   []*v1beta1.CustomRun{withCustomRunCancelled(newCustomRun(customRuns[0])), withCustomRunCancelled(newCustomRun(customRuns[1]))},
 		},
 		want: false,
 	}, {
@@ -1567,7 +1567,7 @@ func TestIsFailure(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: matrixedPipelineTask,
-			RunObjects:   []v1beta1.RunObject{withCustomRunCancelled(newCustomRun(customRuns[0])), makeCustomRunStarted(customRuns[1])},
+			CustomRuns:   []*v1beta1.CustomRun{withCustomRunCancelled(newCustomRun(customRuns[0])), makeCustomRunStarted(customRuns[1])},
 		},
 		want: false,
 	}, {
@@ -1582,7 +1582,7 @@ func TestIsFailure(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: withPipelineTaskRetries(*matrixedPipelineTask, 1),
-			RunObjects:   []v1beta1.RunObject{withCustomRunCancelled(makeCustomRunFailed(customRuns[0])), withCustomRunCancelled(makeCustomRunFailed(customRuns[1]))},
+			CustomRuns:   []*v1beta1.CustomRun{withCustomRunCancelled(makeCustomRunFailed(customRuns[0])), withCustomRunCancelled(makeCustomRunFailed(customRuns[1]))},
 		},
 		want: true,
 	}, {
@@ -1597,7 +1597,7 @@ func TestIsFailure(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: withPipelineTaskRetries(*matrixedPipelineTask, 1),
-			RunObjects:   []v1beta1.RunObject{withCustomRunCancelled(makeCustomRunFailed(customRuns[0])), makeCustomRunStarted(customRuns[1])},
+			CustomRuns:   []*v1beta1.CustomRun{withCustomRunCancelled(makeCustomRunFailed(customRuns[0])), makeCustomRunStarted(customRuns[1])},
 		},
 		want: false,
 	}, {
@@ -1612,7 +1612,7 @@ func TestIsFailure(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: withPipelineTaskRetries(*matrixedPipelineTask, 1),
-			RunObjects:   []v1beta1.RunObject{withCustomRunCancelled(withCustomRunRetries(makeCustomRunFailed(customRuns[0]))), withCustomRunCancelled(withCustomRunRetries(makeCustomRunFailed(customRuns[1])))},
+			CustomRuns:   []*v1beta1.CustomRun{withCustomRunCancelled(withCustomRunRetries(makeCustomRunFailed(customRuns[0]))), withCustomRunCancelled(withCustomRunRetries(makeCustomRunFailed(customRuns[1])))},
 		},
 		want: true,
 	}, {
@@ -1627,7 +1627,7 @@ func TestIsFailure(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: withPipelineTaskRetries(*matrixedPipelineTask, 1),
-			RunObjects:   []v1beta1.RunObject{withCustomRunCancelled(withCustomRunRetries(makeCustomRunFailed(customRuns[0]))), makeCustomRunStarted(customRuns[1])},
+			CustomRuns:   []*v1beta1.CustomRun{withCustomRunCancelled(withCustomRunRetries(makeCustomRunFailed(customRuns[0]))), makeCustomRunStarted(customRuns[1])},
 		},
 		want: false,
 	}} {
@@ -1696,56 +1696,56 @@ func TestIsCancelled(t *testing.T) {
 		name: "customruns not started",
 		rpt: ResolvedPipelineTask{
 			CustomTask: true,
-			RunObjects: []v1beta1.RunObject{},
+			CustomRuns: []*v1beta1.CustomRun{},
 		},
 		want: false,
 	}, {
 		name: "customrun not done",
 		rpt: ResolvedPipelineTask{
 			CustomTask: true,
-			RunObjects: []v1beta1.RunObject{makeCustomRunStarted(customRuns[0])},
+			CustomRuns: []*v1beta1.CustomRun{makeCustomRunStarted(customRuns[0])},
 		},
 		want: false,
 	}, {
 		name: "customrun succeeded but not cancelled",
 		rpt: ResolvedPipelineTask{
 			CustomTask: true,
-			RunObjects: []v1beta1.RunObject{(makeCustomRunSucceeded(customRuns[0]))},
+			CustomRuns: []*v1beta1.CustomRun{(makeCustomRunSucceeded(customRuns[0]))},
 		},
 		want: false,
 	}, {
 		name: "customrun failed but not cancelled",
 		rpt: ResolvedPipelineTask{
 			CustomTask: true,
-			RunObjects: []v1beta1.RunObject{(makeCustomRunFailed(customRuns[0]))},
+			CustomRuns: []*v1beta1.CustomRun{(makeCustomRunFailed(customRuns[0]))},
 		},
 		want: false,
 	}, {
 		name: "customrun cancelled and failed",
 		rpt: ResolvedPipelineTask{
 			CustomTask: true,
-			RunObjects: []v1beta1.RunObject{withCustomRunCancelled(makeCustomRunFailed(customRuns[0]))},
+			CustomRuns: []*v1beta1.CustomRun{withCustomRunCancelled(makeCustomRunFailed(customRuns[0]))},
 		},
 		want: true,
 	}, {
 		name: "customrun cancelled but still running",
 		rpt: ResolvedPipelineTask{
 			CustomTask: true,
-			RunObjects: []v1beta1.RunObject{withCustomRunCancelled(makeCustomRunStarted(customRuns[0]))},
+			CustomRuns: []*v1beta1.CustomRun{withCustomRunCancelled(makeCustomRunStarted(customRuns[0]))},
 		},
 		want: false,
 	}, {
 		name: "one customrun cancelled, one not done",
 		rpt: ResolvedPipelineTask{
 			CustomTask: true,
-			RunObjects: []v1beta1.RunObject{withCustomRunCancelled(makeCustomRunFailed(customRuns[0])), makeCustomRunStarted(customRuns[1])},
+			CustomRuns: []*v1beta1.CustomRun{withCustomRunCancelled(makeCustomRunFailed(customRuns[0])), makeCustomRunStarted(customRuns[1])},
 		},
 		want: false,
 	}, {
 		name: "one customrun cancelled, one done but not cancelled",
 		rpt: ResolvedPipelineTask{
 			CustomTask: true,
-			RunObjects: []v1beta1.RunObject{withCustomRunCancelled(makeCustomRunFailed(customRuns[0])), makeCustomRunSucceeded(customRuns[1])},
+			CustomRuns: []*v1beta1.CustomRun{withCustomRunCancelled(makeCustomRunFailed(customRuns[0])), makeCustomRunSucceeded(customRuns[1])},
 		},
 		want: true,
 	}}
@@ -1821,63 +1821,63 @@ func TestIsCancelledForTimeout(t *testing.T) {
 		name: "customruns not started",
 		rpt: ResolvedPipelineTask{
 			CustomTask: true,
-			RunObjects: []v1beta1.RunObject{},
+			CustomRuns: []*v1beta1.CustomRun{},
 		},
 		want: false,
 	}, {
 		name: "customrun not done",
 		rpt: ResolvedPipelineTask{
 			CustomTask: true,
-			RunObjects: []v1beta1.RunObject{makeCustomRunStarted(customRuns[0])},
+			CustomRuns: []*v1beta1.CustomRun{makeCustomRunStarted(customRuns[0])},
 		},
 		want: false,
 	}, {
 		name: "customrun succeeded but not cancelled",
 		rpt: ResolvedPipelineTask{
 			CustomTask: true,
-			RunObjects: []v1beta1.RunObject{(makeCustomRunSucceeded(customRuns[0]))},
+			CustomRuns: []*v1beta1.CustomRun{(makeCustomRunSucceeded(customRuns[0]))},
 		},
 		want: false,
 	}, {
 		name: "customrun failed but not cancelled",
 		rpt: ResolvedPipelineTask{
 			CustomTask: true,
-			RunObjects: []v1beta1.RunObject{(makeCustomRunFailed(customRuns[0]))},
+			CustomRuns: []*v1beta1.CustomRun{(makeCustomRunFailed(customRuns[0]))},
 		},
 		want: false,
 	}, {
 		name: "customrun cancelled by spec and failed",
 		rpt: ResolvedPipelineTask{
 			CustomTask: true,
-			RunObjects: []v1beta1.RunObject{withCustomRunCancelledBySpec(makeCustomRunFailed(customRuns[0]))},
+			CustomRuns: []*v1beta1.CustomRun{withCustomRunCancelledBySpec(makeCustomRunFailed(customRuns[0]))},
 		},
 		want: false,
 	}, {
 		name: "customrun cancelled for timeout and failed",
 		rpt: ResolvedPipelineTask{
 			CustomTask: true,
-			RunObjects: []v1beta1.RunObject{withCustomRunCancelledForTimeout(makeCustomRunFailed(customRuns[0]))},
+			CustomRuns: []*v1beta1.CustomRun{withCustomRunCancelledForTimeout(makeCustomRunFailed(customRuns[0]))},
 		},
 		want: true,
 	}, {
 		name: "customrun cancelled for timeout but still running",
 		rpt: ResolvedPipelineTask{
 			CustomTask: true,
-			RunObjects: []v1beta1.RunObject{withCustomRunCancelledForTimeout(makeCustomRunStarted(customRuns[0]))},
+			CustomRuns: []*v1beta1.CustomRun{withCustomRunCancelledForTimeout(makeCustomRunStarted(customRuns[0]))},
 		},
 		want: false,
 	}, {
 		name: "one customrun cancelled for timeout, one not done",
 		rpt: ResolvedPipelineTask{
 			CustomTask: true,
-			RunObjects: []v1beta1.RunObject{withCustomRunCancelledForTimeout(makeCustomRunFailed(customRuns[0])), makeCustomRunStarted(customRuns[1])},
+			CustomRuns: []*v1beta1.CustomRun{withCustomRunCancelledForTimeout(makeCustomRunFailed(customRuns[0])), makeCustomRunStarted(customRuns[1])},
 		},
 		want: false,
 	}, {
 		name: "one customrun cancelled for timeout, one done but not cancelled",
 		rpt: ResolvedPipelineTask{
 			CustomTask: true,
-			RunObjects: []v1beta1.RunObject{withCustomRunCancelledForTimeout(makeCustomRunFailed(customRuns[0])), makeCustomRunSucceeded(customRuns[1])},
+			CustomRuns: []*v1beta1.CustomRun{withCustomRunCancelledForTimeout(makeCustomRunFailed(customRuns[0])), makeCustomRunSucceeded(customRuns[1])},
 		},
 		want: true,
 	}}
@@ -1972,7 +1972,7 @@ func TestHasTaskRunsStarted(t *testing.T) {
 	}
 }
 
-func TestHasRunObjectsStarted(t *testing.T) {
+func TestHasCustomRunsStarted(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		rpt  ResolvedPipelineTask
@@ -1989,7 +1989,7 @@ func TestHasRunObjectsStarted(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
 			CustomTask:   true,
-			RunObjects:   []v1beta1.RunObject{makeCustomRunStarted(customRuns[0])},
+			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunStarted(customRuns[0])},
 		},
 		want: true,
 	}, {
@@ -1997,7 +1997,7 @@ func TestHasRunObjectsStarted(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
 			CustomTask:   true,
-			RunObjects:   []v1beta1.RunObject{makeCustomRunSucceeded(customRuns[0])},
+			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunSucceeded(customRuns[0])},
 		},
 		want: true,
 	}, {
@@ -2005,7 +2005,7 @@ func TestHasRunObjectsStarted(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
 			CustomTask:   true,
-			RunObjects:   []v1beta1.RunObject{makeCustomRunFailed(customRuns[0])},
+			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunFailed(customRuns[0])},
 		},
 		want: true,
 	}, {
@@ -2020,7 +2020,7 @@ func TestHasRunObjectsStarted(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: matrixedPipelineTask,
-			RunObjects:   []v1beta1.RunObject{makeCustomRunStarted(customRuns[0]), makeCustomRunStarted(customRuns[1])},
+			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunStarted(customRuns[0]), makeCustomRunStarted(customRuns[1])},
 		},
 		want: true,
 	}, {
@@ -2028,7 +2028,7 @@ func TestHasRunObjectsStarted(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: matrixedPipelineTask,
-			RunObjects:   []v1beta1.RunObject{makeCustomRunStarted(customRuns[0]), makeCustomRunSucceeded(customRuns[1])},
+			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunStarted(customRuns[0]), makeCustomRunSucceeded(customRuns[1])},
 		},
 		want: true,
 	}, {
@@ -2036,7 +2036,7 @@ func TestHasRunObjectsStarted(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: matrixedPipelineTask,
-			RunObjects:   []v1beta1.RunObject{makeCustomRunSucceeded(customRuns[0]), makeCustomRunStarted(customRuns[1])},
+			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunSucceeded(customRuns[0]), makeCustomRunStarted(customRuns[1])},
 		},
 		want: true,
 	}, {
@@ -2044,19 +2044,19 @@ func TestHasRunObjectsStarted(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: matrixedPipelineTask,
-			RunObjects:   []v1beta1.RunObject{makeCustomRunFailed(customRuns[0]), makeCustomRunFailed(customRuns[1])},
+			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunFailed(customRuns[0]), makeCustomRunFailed(customRuns[1])},
 		},
 		want: true,
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := tc.rpt.hasRunObjectsStarted(); got != tc.want {
+			if got := tc.rpt.hasCustomRunsStarted(); got != tc.want {
 				t.Errorf("expected isStarted: %t but got %t", tc.want, got)
 			}
 		})
 	}
 }
 
-func TestAreRunObjectsConditionStatusFalse(t *testing.T) {
+func TestAreCustomRunsConditionStatusFalse(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		rpt  ResolvedPipelineTask
@@ -2073,7 +2073,7 @@ func TestAreRunObjectsConditionStatusFalse(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
 			CustomTask:   true,
-			RunObjects:   []v1beta1.RunObject{makeCustomRunStarted(customRuns[0])},
+			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunStarted(customRuns[0])},
 		},
 		want: false,
 	}, {
@@ -2081,7 +2081,7 @@ func TestAreRunObjectsConditionStatusFalse(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
 			CustomTask:   true,
-			RunObjects:   []v1beta1.RunObject{makeCustomRunSucceeded(customRuns[0])},
+			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunSucceeded(customRuns[0])},
 		},
 		want: false,
 	}, {
@@ -2089,14 +2089,14 @@ func TestAreRunObjectsConditionStatusFalse(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
 			CustomTask:   true,
-			RunObjects:   []v1beta1.RunObject{makeCustomRunFailed(customRuns[0])},
+			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunFailed(customRuns[0])},
 		},
 		want: true,
 	}, {
 		name: "customrun cancelled",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
-			RunObjects:   []v1beta1.RunObject{withCustomRunCancelled(makeCustomRunFailed(customRuns[0]))},
+			CustomRuns:   []*v1beta1.CustomRun{withCustomRunCancelled(makeCustomRunFailed(customRuns[0]))},
 			CustomTask:   true,
 		},
 		want: true,
@@ -2104,7 +2104,7 @@ func TestAreRunObjectsConditionStatusFalse(t *testing.T) {
 		name: "customrun cancelled for timeout",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
-			RunObjects:   []v1beta1.RunObject{withCustomRunCancelledForTimeout(makeCustomRunFailed(customRuns[0]))},
+			CustomRuns:   []*v1beta1.CustomRun{withCustomRunCancelledForTimeout(makeCustomRunFailed(customRuns[0]))},
 			CustomTask:   true,
 		},
 		want: true,
@@ -2112,7 +2112,7 @@ func TestAreRunObjectsConditionStatusFalse(t *testing.T) {
 		name: "customrun cancelled but not failed",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
-			RunObjects:   []v1beta1.RunObject{withCustomRunCancelled(newCustomRun(customRuns[0]))},
+			CustomRuns:   []*v1beta1.CustomRun{withCustomRunCancelled(newCustomRun(customRuns[0]))},
 			CustomTask:   true,
 		},
 		want: false,
@@ -2128,7 +2128,7 @@ func TestAreRunObjectsConditionStatusFalse(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: matrixedPipelineTask,
-			RunObjects:   []v1beta1.RunObject{makeCustomRunStarted(customRuns[0]), makeCustomRunStarted(customRuns[1])},
+			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunStarted(customRuns[0]), makeCustomRunStarted(customRuns[1])},
 		},
 		want: false,
 	}, {
@@ -2136,7 +2136,7 @@ func TestAreRunObjectsConditionStatusFalse(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: matrixedPipelineTask,
-			RunObjects:   []v1beta1.RunObject{makeCustomRunStarted(customRuns[0]), makeCustomRunSucceeded(customRuns[1])},
+			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunStarted(customRuns[0]), makeCustomRunSucceeded(customRuns[1])},
 		},
 		want: false,
 	}, {
@@ -2144,7 +2144,7 @@ func TestAreRunObjectsConditionStatusFalse(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: matrixedPipelineTask,
-			RunObjects:   []v1beta1.RunObject{makeCustomRunSucceeded(customRuns[0]), makeCustomRunStarted(customRuns[1])},
+			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunSucceeded(customRuns[0]), makeCustomRunStarted(customRuns[1])},
 		},
 		want: false,
 	}, {
@@ -2152,7 +2152,7 @@ func TestAreRunObjectsConditionStatusFalse(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: matrixedPipelineTask,
-			RunObjects:   []v1beta1.RunObject{makeCustomRunFailed(customRuns[0]), makeCustomRunFailed(customRuns[1])},
+			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunFailed(customRuns[0]), makeCustomRunFailed(customRuns[1])},
 		},
 		want: true,
 	}, {
@@ -2160,7 +2160,7 @@ func TestAreRunObjectsConditionStatusFalse(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: matrixedPipelineTask,
-			RunObjects:   []v1beta1.RunObject{makeCustomRunFailed(customRuns[0]), makeCustomRunStarted(customRuns[1])},
+			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunFailed(customRuns[0]), makeCustomRunStarted(customRuns[1])},
 		},
 		want: true,
 	}, {
@@ -2168,7 +2168,7 @@ func TestAreRunObjectsConditionStatusFalse(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: matrixedPipelineTask,
-			RunObjects:   []v1beta1.RunObject{withCustomRunCancelled(makeCustomRunFailed(customRuns[0])), withCustomRunCancelled(makeCustomRunFailed(customRuns[1]))},
+			CustomRuns:   []*v1beta1.CustomRun{withCustomRunCancelled(makeCustomRunFailed(customRuns[0])), withCustomRunCancelled(makeCustomRunFailed(customRuns[1]))},
 		},
 		want: true,
 	}, {
@@ -2176,7 +2176,7 @@ func TestAreRunObjectsConditionStatusFalse(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: matrixedPipelineTask,
-			RunObjects:   []v1beta1.RunObject{withCustomRunCancelled(makeCustomRunFailed(customRuns[0])), makeCustomRunStarted(customRuns[1])},
+			CustomRuns:   []*v1beta1.CustomRun{withCustomRunCancelled(makeCustomRunFailed(customRuns[0])), makeCustomRunStarted(customRuns[1])},
 		},
 		want: true,
 	}, {
@@ -2184,7 +2184,7 @@ func TestAreRunObjectsConditionStatusFalse(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: matrixedPipelineTask,
-			RunObjects:   []v1beta1.RunObject{withCustomRunCancelled(newCustomRun(customRuns[0])), withCustomRunCancelled(newCustomRun(customRuns[1]))},
+			CustomRuns:   []*v1beta1.CustomRun{withCustomRunCancelled(newCustomRun(customRuns[0])), withCustomRunCancelled(newCustomRun(customRuns[1]))},
 		},
 		want: false,
 	}, {
@@ -2192,13 +2192,13 @@ func TestAreRunObjectsConditionStatusFalse(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: matrixedPipelineTask,
-			RunObjects:   []v1beta1.RunObject{withCustomRunCancelled(newCustomRun(customRuns[0])), makeCustomRunStarted(customRuns[1])},
+			CustomRuns:   []*v1beta1.CustomRun{withCustomRunCancelled(newCustomRun(customRuns[0])), makeCustomRunStarted(customRuns[1])},
 		},
 		want: false,
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := tc.rpt.areRunObjectsConditionStatusFalse(); got != tc.want {
-				t.Errorf("expected areRunObjectsConditionStatusFalse: %t but got %t", tc.want, got)
+			if got := tc.rpt.areCustomRunsConditionStatusFalse(); got != tc.want {
+				t.Errorf("expected areCustomRunsConditionStatusFalse: %t but got %t", tc.want, got)
 			}
 		})
 	}
@@ -2501,7 +2501,7 @@ func TestResolvePipelineRun_CustomTask(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "pipelinerun"},
 	}
 	run := &v1beta1.CustomRun{ObjectMeta: metav1.ObjectMeta{Name: "run-exists-abcde"}}
-	getRun := func(name string) (v1beta1.RunObject, error) {
+	getRun := func(name string) (*v1beta1.CustomRun, error) {
 		if name == "pipelinerun-run-exists" {
 			return run, nil
 		}
@@ -2522,18 +2522,18 @@ func TestResolvePipelineRun_CustomTask(t *testing.T) {
 	expectedState := PipelineRunState{{
 		PipelineTask:   &pts[0],
 		CustomTask:     true,
-		RunObjectNames: []string{"pipelinerun-customtask"},
-		RunObjects:     nil,
+		CustomRunNames: []string{"pipelinerun-customtask"},
+		CustomRuns:     nil,
 	}, {
 		PipelineTask:   &pts[1],
 		CustomTask:     true,
-		RunObjectNames: []string{"pipelinerun-customtask-spec"},
-		RunObjects:     nil,
+		CustomRunNames: []string{"pipelinerun-customtask-spec"},
+		CustomRuns:     nil,
 	}, {
 		PipelineTask:   &pts[2],
 		CustomTask:     true,
-		RunObjectNames: []string{"pipelinerun-run-exists"},
-		RunObjects:     []v1beta1.RunObject{run},
+		CustomRunNames: []string{"pipelinerun-run-exists"},
+		CustomRuns:     []*v1beta1.CustomRun{run},
 	}}
 	if d := cmp.Diff(expectedState, pipelineState); d != "" {
 		t.Errorf("Unexpected pipeline state: %s", diff.PrintWantGot(d))
@@ -2563,7 +2563,7 @@ func TestResolvePipelineRun_PipelineTaskHasNoResources(t *testing.T) {
 	}
 	pipelineState := PipelineRunState{}
 	for _, task := range pts {
-		ps, err := ResolvePipelineTask(context.Background(), pr, getTask, getTaskRun, nopGetRun, task)
+		ps, err := ResolvePipelineTask(context.Background(), pr, getTask, getTaskRun, nopGetCustomRun, task)
 		if err != nil {
 			t.Errorf("Error getting tasks for fake pipeline %s: %s", p.ObjectMeta.Name, err)
 		}
@@ -2614,7 +2614,7 @@ func TestResolvePipelineRun_TaskDoesntExist(t *testing.T) {
 		},
 	}
 	for _, pt := range pts {
-		_, err := ResolvePipelineTask(context.Background(), pr, getTask, getTaskRun, nopGetRun, pt)
+		_, err := ResolvePipelineTask(context.Background(), pr, getTask, getTaskRun, nopGetCustomRun, pt)
 		var tnf *TaskNotFoundError
 		switch {
 		case err == nil:
@@ -2654,7 +2654,7 @@ func TestResolvePipelineRun_VerificationFailed(t *testing.T) {
 		},
 	}
 	for _, pt := range pts {
-		rt, _ := ResolvePipelineTask(context.Background(), pr, getTask, getTaskRun, nopGetRun, pt)
+		rt, _ := ResolvePipelineTask(context.Background(), pr, getTask, getTaskRun, nopGetCustomRun, pt)
 		if d := cmp.Diff(verificationResult, rt.ResolvedTask.VerificationResult, cmpopts.EquateErrors()); d != "" {
 			t.Errorf(diff.PrintWantGot(d))
 		}
@@ -2898,7 +2898,7 @@ func TestResolvePipeline_WhenExpressions(t *testing.T) {
 	}
 
 	t.Run("When Expressions exist", func(t *testing.T) {
-		_, err := ResolvePipelineTask(context.Background(), pr, getTask, getTaskRun, nopGetRun, pt)
+		_, err := ResolvePipelineTask(context.Background(), pr, getTask, getTaskRun, nopGetCustomRun, pt)
 		if err != nil {
 			t.Fatalf("Did not expect error when resolving PipelineRun: %v", err)
 		}
@@ -2915,7 +2915,7 @@ func TestIsCustomTask(t *testing.T) {
 		return task, nil, nil, nil
 	}
 	getTaskRun := func(name string) (*v1beta1.TaskRun, error) { return nil, nil } //nolint:nilnil
-	getRun := func(name string) (v1beta1.RunObject, error) { return nil, nil }
+	getRun := func(name string) (*v1beta1.CustomRun, error) { return nil, nil }   //nolint:nilnil
 
 	for _, tc := range []struct {
 		name string
@@ -3610,7 +3610,7 @@ func TestGetNamesOfRuns(t *testing.T) {
 			if tc.prName != "" {
 				testPrName = tc.prName
 			}
-			namesOfRunsFromChildRefs := getNamesOfRuns(childRefs, tc.ptName, testPrName, 2)
+			namesOfRunsFromChildRefs := getNamesOfCustomRuns(childRefs, tc.ptName, testPrName, 2)
 			sort.Strings(namesOfRunsFromChildRefs)
 			if d := cmp.Diff(tc.wantRunNames, namesOfRunsFromChildRefs); d != "" {
 				t.Errorf("getRunName: %s", diff.PrintWantGot(d))
@@ -3660,11 +3660,11 @@ func TestGetRunName(t *testing.T) {
 			if tc.prName != "" {
 				testPrName = tc.prName
 			}
-			rnFromChildRefs := getRunName(childRefs, tc.ptName, testPrName)
+			rnFromChildRefs := getCustomRunName(childRefs, tc.ptName, testPrName)
 			if d := cmp.Diff(tc.wantTrName, rnFromChildRefs); d != "" {
 				t.Errorf("GetTaskRunName: %s", diff.PrintWantGot(d))
 			}
-			rnFromBoth := getRunName(childRefs, tc.ptName, testPrName)
+			rnFromBoth := getCustomRunName(childRefs, tc.ptName, testPrName)
 			if d := cmp.Diff(tc.wantTrName, rnFromBoth); d != "" {
 				t.Errorf("GetTaskRunName: %s", diff.PrintWantGot(d))
 			}
@@ -3682,7 +3682,7 @@ func TestIsMatrixed(t *testing.T) {
 		return task, nil, nil, nil
 	}
 	getTaskRun := func(name string) (*v1beta1.TaskRun, error) { return &trs[0], nil }
-	getRun := func(name string) (v1beta1.RunObject, error) { return &customRuns[0], nil }
+	getRun := func(name string) (*v1beta1.CustomRun, error) { return &customRuns[0], nil }
 
 	for _, tc := range []struct {
 		name string
@@ -3816,7 +3816,7 @@ func TestResolvePipelineRunTask_WithMatrix(t *testing.T) {
 		return task, nil, nil, nil
 	}
 	getTaskRun := func(name string) (*v1beta1.TaskRun, error) { return taskRunsMap[name], nil }
-	getRun := func(name string) (v1beta1.RunObject, error) { return &customRuns[0], nil }
+	getRun := func(name string) (*v1beta1.CustomRun, error) { return &customRuns[0], nil }
 
 	for _, tc := range []struct {
 		name string
@@ -3872,7 +3872,7 @@ func TestResolvePipelineRunTask_WithMatrixedCustomTask(t *testing.T) {
 		},
 	}
 
-	var runs []v1beta1.RunObject
+	var runs []*v1beta1.CustomRun
 	var runNames []string
 	runsMap := map[string]*v1beta1.CustomRun{}
 	for i := 0; i < 9; i++ {
@@ -3920,7 +3920,7 @@ func TestResolvePipelineRunTask_WithMatrixedCustomTask(t *testing.T) {
 		return task, nil, nil, nil
 	}
 	getTaskRun := func(name string) (*v1beta1.TaskRun, error) { return &trs[0], nil }
-	getRun := func(name string) (v1beta1.RunObject, error) { return runsMap[name], nil }
+	getRun := func(name string) (*v1beta1.CustomRun, error) { return runsMap[name], nil }
 
 	for _, tc := range []struct {
 		name   string
@@ -3932,8 +3932,8 @@ func TestResolvePipelineRunTask_WithMatrixedCustomTask(t *testing.T) {
 		pt:   pts[0],
 		want: &ResolvedPipelineTask{
 			CustomTask:     true,
-			RunObjectNames: runNames[:3],
-			RunObjects:     runs[:3],
+			CustomRunNames: runNames[:3],
+			CustomRuns:     runs[:3],
 			PipelineTask:   &pts[0],
 		},
 	}, {
@@ -3941,20 +3941,20 @@ func TestResolvePipelineRunTask_WithMatrixedCustomTask(t *testing.T) {
 		pt:   pts[1],
 		want: &ResolvedPipelineTask{
 			CustomTask:     true,
-			RunObjectNames: runNames,
-			RunObjects:     runs,
+			CustomRunNames: runNames,
+			CustomRuns:     runs,
 			PipelineTask:   &pts[1],
 		},
 	}, {
 		name: "custom task with matrix - nil run",
 		pt:   pts[1],
-		getRun: func(name string) (v1beta1.RunObject, error) {
+		getRun: func(name string) (*v1beta1.CustomRun, error) {
 			return nil, kerrors.NewNotFound(v1beta1.Resource("run"), name)
 		},
 		want: &ResolvedPipelineTask{
 			CustomTask:     true,
-			RunObjectNames: runNames,
-			RunObjects:     nil,
+			CustomRunNames: runNames,
+			CustomRuns:     nil,
 			PipelineTask:   &pts[1],
 		},
 	}} {
@@ -4012,7 +4012,7 @@ func TestIsSuccessful(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
 			CustomTask:   true,
-			RunObjects:   []v1beta1.RunObject{makeCustomRunStarted(customRuns[0])},
+			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunStarted(customRuns[0])},
 		},
 		want: false,
 	}, {
@@ -4027,7 +4027,7 @@ func TestIsSuccessful(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
 			CustomTask:   true,
-			RunObjects:   []v1beta1.RunObject{makeCustomRunSucceeded(customRuns[0])},
+			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunSucceeded(customRuns[0])},
 		},
 		want: true,
 	}, {
@@ -4042,7 +4042,7 @@ func TestIsSuccessful(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
 			CustomTask:   true,
-			RunObjects:   []v1beta1.RunObject{makeCustomRunFailed(customRuns[0])},
+			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunFailed(customRuns[0])},
 		},
 		want: false,
 	}, {
@@ -4057,7 +4057,7 @@ func TestIsSuccessful(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task", Retries: 1},
 			CustomTask:   true,
-			RunObjects:   []v1beta1.RunObject{makeCustomRunFailed(customRuns[0])},
+			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunFailed(customRuns[0])},
 		},
 		want: false,
 	}, {
@@ -4065,7 +4065,7 @@ func TestIsSuccessful(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task", Retries: 1},
 			CustomTask:   true,
-			RunObjects:   []v1beta1.RunObject{withCustomRunRetries(makeCustomRunFailed(customRuns[0]))},
+			CustomRuns:   []*v1beta1.CustomRun{withCustomRunRetries(makeCustomRunFailed(customRuns[0]))},
 		},
 		want: false,
 	}, {
@@ -4086,7 +4086,7 @@ func TestIsSuccessful(t *testing.T) {
 		name: "run cancelled",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
-			RunObjects:   []v1beta1.RunObject{withCustomRunCancelled(makeCustomRunFailed(customRuns[0]))},
+			CustomRuns:   []*v1beta1.CustomRun{withCustomRunCancelled(makeCustomRunFailed(customRuns[0]))},
 			CustomTask:   true,
 		},
 		want: false,
@@ -4094,7 +4094,7 @@ func TestIsSuccessful(t *testing.T) {
 		name: "run cancelled but not failed",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
-			RunObjects:   []v1beta1.RunObject{withCustomRunCancelled(newCustomRun(customRuns[0]))},
+			CustomRuns:   []*v1beta1.CustomRun{withCustomRunCancelled(newCustomRun(customRuns[0]))},
 			CustomTask:   true,
 		},
 		want: false,
@@ -4109,7 +4109,7 @@ func TestIsSuccessful(t *testing.T) {
 		name: "run cancelled: retries remaining",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task", Retries: 1},
-			RunObjects:   []v1beta1.RunObject{withCustomRunCancelled(makeCustomRunFailed(customRuns[0]))},
+			CustomRuns:   []*v1beta1.CustomRun{withCustomRunCancelled(makeCustomRunFailed(customRuns[0]))},
 			CustomTask:   true,
 		},
 		want: false,
@@ -4124,7 +4124,7 @@ func TestIsSuccessful(t *testing.T) {
 		name: "run cancelled: retried",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task", Retries: 1},
-			RunObjects:   []v1beta1.RunObject{withCustomRunCancelled(withCustomRunRetries(makeCustomRunFailed(customRuns[0])))},
+			CustomRuns:   []*v1beta1.CustomRun{withCustomRunCancelled(withCustomRunRetries(makeCustomRunFailed(customRuns[0])))},
 			CustomTask:   true,
 		},
 		want: false,
@@ -4153,7 +4153,7 @@ func TestIsSuccessful(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: matrixedPipelineTask,
-			RunObjects:   []v1beta1.RunObject{makeCustomRunStarted(customRuns[0]), makeCustomRunStarted(customRuns[1])},
+			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunStarted(customRuns[0]), makeCustomRunStarted(customRuns[1])},
 		},
 		want: false,
 	}, {
@@ -4168,7 +4168,7 @@ func TestIsSuccessful(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: matrixedPipelineTask,
-			RunObjects:   []v1beta1.RunObject{makeCustomRunStarted(customRuns[0]), makeCustomRunSucceeded(customRuns[1])},
+			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunStarted(customRuns[0]), makeCustomRunSucceeded(customRuns[1])},
 		},
 		want: false,
 	}, {
@@ -4183,7 +4183,7 @@ func TestIsSuccessful(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: matrixedPipelineTask,
-			RunObjects:   []v1beta1.RunObject{makeCustomRunSucceeded(customRuns[0]), makeCustomRunSucceeded(customRuns[1])},
+			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunSucceeded(customRuns[0]), makeCustomRunSucceeded(customRuns[1])},
 		},
 		want: true,
 	}, {
@@ -4198,7 +4198,7 @@ func TestIsSuccessful(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: matrixedPipelineTask,
-			RunObjects:   []v1beta1.RunObject{makeCustomRunSucceeded(customRuns[0]), makeCustomRunStarted(customRuns[1])},
+			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunSucceeded(customRuns[0]), makeCustomRunStarted(customRuns[1])},
 		},
 		want: false,
 	}, {
@@ -4213,7 +4213,7 @@ func TestIsSuccessful(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: matrixedPipelineTask,
-			RunObjects:   []v1beta1.RunObject{makeCustomRunFailed(customRuns[0]), makeCustomRunFailed(customRuns[1])},
+			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunFailed(customRuns[0]), makeCustomRunFailed(customRuns[1])},
 		},
 		want: false,
 	}, {
@@ -4228,7 +4228,7 @@ func TestIsSuccessful(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: matrixedPipelineTask,
-			RunObjects:   []v1beta1.RunObject{makeCustomRunFailed(customRuns[0]), makeCustomRunStarted(customRuns[1])},
+			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunFailed(customRuns[0]), makeCustomRunStarted(customRuns[1])},
 		},
 		want: false,
 	}, {
@@ -4243,7 +4243,7 @@ func TestIsSuccessful(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: withPipelineTaskRetries(*matrixedPipelineTask, 1),
-			RunObjects:   []v1beta1.RunObject{makeCustomRunFailed(customRuns[0]), makeCustomRunFailed(customRuns[1])},
+			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunFailed(customRuns[0]), makeCustomRunFailed(customRuns[1])},
 		},
 		want: false,
 	}, {
@@ -4258,7 +4258,7 @@ func TestIsSuccessful(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: withPipelineTaskRetries(*matrixedPipelineTask, 1),
-			RunObjects:   []v1beta1.RunObject{makeCustomRunFailed(customRuns[0]), withCustomRunRetries(makeCustomRunFailed(customRuns[1]))},
+			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunFailed(customRuns[0]), withCustomRunRetries(makeCustomRunFailed(customRuns[1]))},
 		},
 		want: false,
 	}, {
@@ -4266,7 +4266,7 @@ func TestIsSuccessful(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: withPipelineTaskRetries(*matrixedPipelineTask, 1),
-			RunObjects:   []v1beta1.RunObject{withCustomRunRetries(makeCustomRunFailed(customRuns[0])), withCustomRunRetries(makeCustomRunFailed(customRuns[1]))},
+			CustomRuns:   []*v1beta1.CustomRun{withCustomRunRetries(makeCustomRunFailed(customRuns[0])), withCustomRunRetries(makeCustomRunFailed(customRuns[1]))},
 		},
 		want: false,
 	}, {
@@ -4281,7 +4281,7 @@ func TestIsSuccessful(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: matrixedPipelineTask,
-			RunObjects:   []v1beta1.RunObject{withCustomRunCancelled(makeCustomRunFailed(customRuns[0])), withCustomRunCancelled(makeCustomRunFailed(customRuns[1]))},
+			CustomRuns:   []*v1beta1.CustomRun{withCustomRunCancelled(makeCustomRunFailed(customRuns[0])), withCustomRunCancelled(makeCustomRunFailed(customRuns[1]))},
 		},
 		want: false,
 	}, {
@@ -4296,7 +4296,7 @@ func TestIsSuccessful(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: matrixedPipelineTask,
-			RunObjects:   []v1beta1.RunObject{withCustomRunCancelled(makeCustomRunFailed(customRuns[0])), makeCustomRunStarted(customRuns[1])},
+			CustomRuns:   []*v1beta1.CustomRun{withCustomRunCancelled(makeCustomRunFailed(customRuns[0])), makeCustomRunStarted(customRuns[1])},
 		},
 		want: false,
 	}, {
@@ -4311,7 +4311,7 @@ func TestIsSuccessful(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: matrixedPipelineTask,
-			RunObjects:   []v1beta1.RunObject{withCustomRunCancelled(newCustomRun(customRuns[0])), withCustomRunCancelled(newCustomRun(customRuns[1]))},
+			CustomRuns:   []*v1beta1.CustomRun{withCustomRunCancelled(newCustomRun(customRuns[0])), withCustomRunCancelled(newCustomRun(customRuns[1]))},
 		},
 		want: false,
 	}, {
@@ -4326,7 +4326,7 @@ func TestIsSuccessful(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: matrixedPipelineTask,
-			RunObjects:   []v1beta1.RunObject{withCustomRunCancelled(newCustomRun(customRuns[0])), makeCustomRunStarted(customRuns[1])},
+			CustomRuns:   []*v1beta1.CustomRun{withCustomRunCancelled(newCustomRun(customRuns[0])), makeCustomRunStarted(customRuns[1])},
 		},
 		want: false,
 	}, {
@@ -4341,7 +4341,7 @@ func TestIsSuccessful(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: withPipelineTaskRetries(*matrixedPipelineTask, 1),
-			RunObjects:   []v1beta1.RunObject{withCustomRunCancelled(makeCustomRunFailed(customRuns[0])), withCustomRunCancelled(makeCustomRunFailed(customRuns[1]))},
+			CustomRuns:   []*v1beta1.CustomRun{withCustomRunCancelled(makeCustomRunFailed(customRuns[0])), withCustomRunCancelled(makeCustomRunFailed(customRuns[1]))},
 		},
 		want: false,
 	}, {
@@ -4356,7 +4356,7 @@ func TestIsSuccessful(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: withPipelineTaskRetries(*matrixedPipelineTask, 1),
-			RunObjects:   []v1beta1.RunObject{withCustomRunCancelled(makeCustomRunFailed(customRuns[0])), makeCustomRunStarted(customRuns[1])},
+			CustomRuns:   []*v1beta1.CustomRun{withCustomRunCancelled(makeCustomRunFailed(customRuns[0])), makeCustomRunStarted(customRuns[1])},
 		},
 		want: false,
 	}, {
@@ -4371,7 +4371,7 @@ func TestIsSuccessful(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: withPipelineTaskRetries(*matrixedPipelineTask, 1),
-			RunObjects:   []v1beta1.RunObject{withCustomRunCancelled(withCustomRunRetries(makeCustomRunFailed(customRuns[0]))), withCustomRunCancelled(withCustomRunRetries(makeCustomRunFailed(customRuns[1])))},
+			CustomRuns:   []*v1beta1.CustomRun{withCustomRunCancelled(withCustomRunRetries(makeCustomRunFailed(customRuns[0]))), withCustomRunCancelled(withCustomRunRetries(makeCustomRunFailed(customRuns[1])))},
 		},
 		want: false,
 	}, {
@@ -4386,7 +4386,7 @@ func TestIsSuccessful(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: withPipelineTaskRetries(*matrixedPipelineTask, 1),
-			RunObjects:   []v1beta1.RunObject{withCustomRunCancelled(withCustomRunRetries(makeCustomRunFailed(customRuns[0]))), makeCustomRunStarted(customRuns[1])},
+			CustomRuns:   []*v1beta1.CustomRun{withCustomRunCancelled(withCustomRunRetries(makeCustomRunFailed(customRuns[0]))), makeCustomRunStarted(customRuns[1])},
 		},
 		want: false,
 	}} {
@@ -4428,7 +4428,7 @@ func TestIsRunning(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
 			CustomTask:   true,
-			RunObjects:   []v1beta1.RunObject{makeCustomRunStarted(customRuns[0])},
+			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunStarted(customRuns[0])},
 		},
 		want: true,
 	}, {
@@ -4443,7 +4443,7 @@ func TestIsRunning(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
 			CustomTask:   true,
-			RunObjects:   []v1beta1.RunObject{makeCustomRunSucceeded(customRuns[0])},
+			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunSucceeded(customRuns[0])},
 		},
 		want: false,
 	}, {
@@ -4458,7 +4458,7 @@ func TestIsRunning(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
 			CustomTask:   true,
-			RunObjects:   []v1beta1.RunObject{makeCustomRunFailed(customRuns[0])},
+			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunFailed(customRuns[0])},
 		},
 		want: false,
 	}, {
@@ -4473,7 +4473,7 @@ func TestIsRunning(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task", Retries: 1},
 			CustomTask:   true,
-			RunObjects:   []v1beta1.RunObject{makeCustomRunFailed(customRuns[0])},
+			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunFailed(customRuns[0])},
 		},
 		want: false,
 	}, {
@@ -4481,7 +4481,7 @@ func TestIsRunning(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task", Retries: 1},
 			CustomTask:   true,
-			RunObjects:   []v1beta1.RunObject{withCustomRunRetries(makeCustomRunFailed(customRuns[0]))},
+			CustomRuns:   []*v1beta1.CustomRun{withCustomRunRetries(makeCustomRunFailed(customRuns[0]))},
 		},
 		want: false,
 	}, {
@@ -4502,7 +4502,7 @@ func TestIsRunning(t *testing.T) {
 		name: "run cancelled",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
-			RunObjects:   []v1beta1.RunObject{withCustomRunCancelled(makeCustomRunFailed(customRuns[0]))},
+			CustomRuns:   []*v1beta1.CustomRun{withCustomRunCancelled(makeCustomRunFailed(customRuns[0]))},
 			CustomTask:   true,
 		},
 		want: false,
@@ -4510,7 +4510,7 @@ func TestIsRunning(t *testing.T) {
 		name: "run cancelled but not failed",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
-			RunObjects:   []v1beta1.RunObject{withCustomRunCancelled(newCustomRun(customRuns[0]))},
+			CustomRuns:   []*v1beta1.CustomRun{withCustomRunCancelled(newCustomRun(customRuns[0]))},
 			CustomTask:   true,
 		},
 		want: true,
@@ -4525,7 +4525,7 @@ func TestIsRunning(t *testing.T) {
 		name: "run cancelled: retries remaining",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task", Retries: 1},
-			RunObjects:   []v1beta1.RunObject{withCustomRunCancelled(makeCustomRunFailed(customRuns[0]))},
+			CustomRuns:   []*v1beta1.CustomRun{withCustomRunCancelled(makeCustomRunFailed(customRuns[0]))},
 			CustomTask:   true,
 		},
 		want: false,
@@ -4540,7 +4540,7 @@ func TestIsRunning(t *testing.T) {
 		name: "run cancelled: retried",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{Name: "task", Retries: 1},
-			RunObjects:   []v1beta1.RunObject{withCustomRunCancelled(withCustomRunRetries(makeCustomRunFailed(customRuns[0])))},
+			CustomRuns:   []*v1beta1.CustomRun{withCustomRunCancelled(withCustomRunRetries(makeCustomRunFailed(customRuns[0])))},
 			CustomTask:   true,
 		},
 		want: false,
@@ -4569,7 +4569,7 @@ func TestIsRunning(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: matrixedPipelineTask,
-			RunObjects:   []v1beta1.RunObject{makeCustomRunStarted(customRuns[0]), makeCustomRunStarted(customRuns[1])},
+			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunStarted(customRuns[0]), makeCustomRunStarted(customRuns[1])},
 		},
 		want: true,
 	}, {
@@ -4584,7 +4584,7 @@ func TestIsRunning(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: matrixedPipelineTask,
-			RunObjects:   []v1beta1.RunObject{makeCustomRunStarted(customRuns[0]), makeCustomRunSucceeded(customRuns[1])},
+			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunStarted(customRuns[0]), makeCustomRunSucceeded(customRuns[1])},
 		},
 		want: true,
 	}, {
@@ -4599,7 +4599,7 @@ func TestIsRunning(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: matrixedPipelineTask,
-			RunObjects:   []v1beta1.RunObject{makeCustomRunSucceeded(customRuns[0]), makeCustomRunSucceeded(customRuns[1])},
+			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunSucceeded(customRuns[0]), makeCustomRunSucceeded(customRuns[1])},
 		},
 		want: false,
 	}, {
@@ -4614,7 +4614,7 @@ func TestIsRunning(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: matrixedPipelineTask,
-			RunObjects:   []v1beta1.RunObject{makeCustomRunFailed(customRuns[0]), makeCustomRunFailed(customRuns[1])},
+			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunFailed(customRuns[0]), makeCustomRunFailed(customRuns[1])},
 		},
 		want: false,
 	}, {
@@ -4629,7 +4629,7 @@ func TestIsRunning(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: matrixedPipelineTask,
-			RunObjects:   []v1beta1.RunObject{makeCustomRunFailed(customRuns[0]), makeCustomRunStarted(customRuns[1])},
+			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunFailed(customRuns[0]), makeCustomRunStarted(customRuns[1])},
 		},
 		want: true,
 	}, {
@@ -4644,7 +4644,7 @@ func TestIsRunning(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: withPipelineTaskRetries(*matrixedPipelineTask, 1),
-			RunObjects:   []v1beta1.RunObject{makeCustomRunFailed(customRuns[0]), makeCustomRunFailed(customRuns[1])},
+			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunFailed(customRuns[0]), makeCustomRunFailed(customRuns[1])},
 		},
 		want: false,
 	}, {
@@ -4659,7 +4659,7 @@ func TestIsRunning(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: withPipelineTaskRetries(*matrixedPipelineTask, 1),
-			RunObjects:   []v1beta1.RunObject{makeCustomRunFailed(customRuns[0]), withCustomRunRetries(makeCustomRunFailed(customRuns[1]))},
+			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunFailed(customRuns[0]), withCustomRunRetries(makeCustomRunFailed(customRuns[1]))},
 		},
 		want: false,
 	}, {
@@ -4667,7 +4667,7 @@ func TestIsRunning(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: withPipelineTaskRetries(*matrixedPipelineTask, 1),
-			RunObjects:   []v1beta1.RunObject{withCustomRunRetries(makeCustomRunFailed(customRuns[0])), withCustomRunRetries(makeCustomRunFailed(customRuns[1]))},
+			CustomRuns:   []*v1beta1.CustomRun{withCustomRunRetries(makeCustomRunFailed(customRuns[0])), withCustomRunRetries(makeCustomRunFailed(customRuns[1]))},
 		},
 		want: false,
 	}, {
@@ -4682,7 +4682,7 @@ func TestIsRunning(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: matrixedPipelineTask,
-			RunObjects:   []v1beta1.RunObject{withCustomRunCancelled(makeCustomRunFailed(customRuns[0])), withCustomRunCancelled(makeCustomRunFailed(customRuns[1]))},
+			CustomRuns:   []*v1beta1.CustomRun{withCustomRunCancelled(makeCustomRunFailed(customRuns[0])), withCustomRunCancelled(makeCustomRunFailed(customRuns[1]))},
 		},
 		want: false,
 	}, {
@@ -4697,7 +4697,7 @@ func TestIsRunning(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: matrixedPipelineTask,
-			RunObjects:   []v1beta1.RunObject{withCustomRunCancelled(makeCustomRunFailed(customRuns[0])), makeCustomRunStarted(customRuns[1])},
+			CustomRuns:   []*v1beta1.CustomRun{withCustomRunCancelled(makeCustomRunFailed(customRuns[0])), makeCustomRunStarted(customRuns[1])},
 		},
 		want: true,
 	}, {
@@ -4712,7 +4712,7 @@ func TestIsRunning(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: matrixedPipelineTask,
-			RunObjects:   []v1beta1.RunObject{withCustomRunCancelled(newCustomRun(customRuns[0])), withCustomRunCancelled(newCustomRun(customRuns[1]))},
+			CustomRuns:   []*v1beta1.CustomRun{withCustomRunCancelled(newCustomRun(customRuns[0])), withCustomRunCancelled(newCustomRun(customRuns[1]))},
 		},
 		want: true,
 	}, {
@@ -4727,7 +4727,7 @@ func TestIsRunning(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: matrixedPipelineTask,
-			RunObjects:   []v1beta1.RunObject{withCustomRunCancelled(newCustomRun(customRuns[0])), makeCustomRunStarted(customRuns[1])},
+			CustomRuns:   []*v1beta1.CustomRun{withCustomRunCancelled(newCustomRun(customRuns[0])), makeCustomRunStarted(customRuns[1])},
 		},
 		want: true,
 	}, {
@@ -4742,7 +4742,7 @@ func TestIsRunning(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: withPipelineTaskRetries(*matrixedPipelineTask, 1),
-			RunObjects:   []v1beta1.RunObject{withCustomRunCancelled(makeCustomRunFailed(customRuns[0])), withCustomRunCancelled(makeCustomRunFailed(customRuns[1]))},
+			CustomRuns:   []*v1beta1.CustomRun{withCustomRunCancelled(makeCustomRunFailed(customRuns[0])), withCustomRunCancelled(makeCustomRunFailed(customRuns[1]))},
 		},
 		want: false,
 	}, {
@@ -4757,7 +4757,7 @@ func TestIsRunning(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: withPipelineTaskRetries(*matrixedPipelineTask, 1),
-			RunObjects:   []v1beta1.RunObject{withCustomRunCancelled(makeCustomRunFailed(customRuns[0])), makeCustomRunStarted(customRuns[1])},
+			CustomRuns:   []*v1beta1.CustomRun{withCustomRunCancelled(makeCustomRunFailed(customRuns[0])), makeCustomRunStarted(customRuns[1])},
 		},
 		want: true,
 	}, {
@@ -4772,7 +4772,7 @@ func TestIsRunning(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: withPipelineTaskRetries(*matrixedPipelineTask, 1),
-			RunObjects:   []v1beta1.RunObject{withCustomRunCancelled(withCustomRunRetries(makeCustomRunFailed(customRuns[0]))), withCustomRunCancelled(withCustomRunRetries(makeCustomRunFailed(customRuns[1])))},
+			CustomRuns:   []*v1beta1.CustomRun{withCustomRunCancelled(withCustomRunRetries(makeCustomRunFailed(customRuns[0]))), withCustomRunCancelled(withCustomRunRetries(makeCustomRunFailed(customRuns[1])))},
 		},
 		want: false,
 	}, {
@@ -4787,7 +4787,7 @@ func TestIsRunning(t *testing.T) {
 		rpt: ResolvedPipelineTask{
 			CustomTask:   true,
 			PipelineTask: withPipelineTaskRetries(*matrixedPipelineTask, 1),
-			RunObjects:   []v1beta1.RunObject{withCustomRunCancelled(withCustomRunRetries(makeCustomRunFailed(customRuns[0]))), makeCustomRunStarted(customRuns[1])},
+			CustomRuns:   []*v1beta1.CustomRun{withCustomRunCancelled(withCustomRunRetries(makeCustomRunFailed(customRuns[0]))), makeCustomRunStarted(customRuns[1])},
 		},
 		want: true,
 	}} {

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
@@ -110,22 +110,22 @@ func TestPipelineRunFacts_CheckDAGTasksDoneDone(t *testing.T) {
 	var customRunRunningState = PipelineRunState{{
 		PipelineTask:   &pts[12],
 		CustomTask:     true,
-		RunObjectNames: []string{"pipelinerun-mytask13"},
-		RunObjects:     []v1beta1.RunObject{makeCustomRunStarted(customRuns[0])},
+		CustomRunNames: []string{"pipelinerun-mytask13"},
+		CustomRuns:     []*v1beta1.CustomRun{makeCustomRunStarted(customRuns[0])},
 	}}
 
 	var customRunSucceededState = PipelineRunState{{
 		PipelineTask:   &pts[12],
 		CustomTask:     true,
-		RunObjectNames: []string{"pipelinerun-mytask13"},
-		RunObjects:     []v1beta1.RunObject{makeCustomRunSucceeded(customRuns[0])},
+		CustomRunNames: []string{"pipelinerun-mytask13"},
+		CustomRuns:     []*v1beta1.CustomRun{makeCustomRunSucceeded(customRuns[0])},
 	}}
 
 	var customRunFailedState = PipelineRunState{{
 		PipelineTask:   &pts[12],
 		CustomTask:     true,
-		RunObjectNames: []string{"pipelinerun-mytask13"},
-		RunObjects:     []v1beta1.RunObject{makeCustomRunFailed(customRuns[0])},
+		CustomRunNames: []string{"pipelinerun-mytask13"},
+		CustomRuns:     []*v1beta1.CustomRun{makeCustomRunFailed(customRuns[0])},
 	}}
 
 	var taskCancelledFailedWithRetries = PipelineRunState{{
@@ -626,8 +626,8 @@ func TestGetNextTaskWithRetries(t *testing.T) {
 
 	var customRunCancelledByStatusState = PipelineRunState{{
 		PipelineTask:   &pts[4], // 2 retries needed
-		RunObjectNames: []string{"pipelinerun-mytask1"},
-		RunObjects:     []v1beta1.RunObject{withCustomRunCancelled(withCustomRunRetries(newCustomRun(customRuns[0])))},
+		CustomRunNames: []string{"pipelinerun-mytask1"},
+		CustomRuns:     []*v1beta1.CustomRun{withCustomRunCancelled(withCustomRunRetries(newCustomRun(customRuns[0])))},
 		CustomTask:     true,
 		ResolvedTask: &resources.ResolvedTask{
 			TaskSpec: &task.Spec,
@@ -636,8 +636,8 @@ func TestGetNextTaskWithRetries(t *testing.T) {
 
 	var customRunCancelledBySpecState = PipelineRunState{{
 		PipelineTask:   &pts[4],
-		RunObjectNames: []string{"pipelinerun-mytask1"},
-		RunObjects:     []v1beta1.RunObject{withCustomRunCancelledBySpec(withCustomRunRetries(newCustomRun(customRuns[0])))},
+		CustomRunNames: []string{"pipelinerun-mytask1"},
+		CustomRuns:     []*v1beta1.CustomRun{withCustomRunCancelledBySpec(withCustomRunRetries(newCustomRun(customRuns[0])))},
 		CustomTask:     true,
 		ResolvedTask: &resources.ResolvedTask{
 			TaskSpec: &task.Spec,
@@ -646,8 +646,8 @@ func TestGetNextTaskWithRetries(t *testing.T) {
 
 	var customRunRunningState = PipelineRunState{{
 		PipelineTask:   &pts[4],
-		RunObjectNames: []string{"pipelinerun-mytask1"},
-		RunObjects:     []v1beta1.RunObject{makeCustomRunStarted(customRuns[0])},
+		CustomRunNames: []string{"pipelinerun-mytask1"},
+		CustomRuns:     []*v1beta1.CustomRun{makeCustomRunStarted(customRuns[0])},
 		CustomTask:     true,
 		ResolvedTask: &resources.ResolvedTask{
 			TaskSpec: &task.Spec,
@@ -656,8 +656,8 @@ func TestGetNextTaskWithRetries(t *testing.T) {
 
 	var customRunSucceededState = PipelineRunState{{
 		PipelineTask:   &pts[4],
-		RunObjectNames: []string{"pipelinerun-mytask1"},
-		RunObjects:     []v1beta1.RunObject{makeCustomRunSucceeded(customRuns[0])},
+		CustomRunNames: []string{"pipelinerun-mytask1"},
+		CustomRuns:     []*v1beta1.CustomRun{makeCustomRunSucceeded(customRuns[0])},
 		CustomTask:     true,
 		ResolvedTask: &resources.ResolvedTask{
 			TaskSpec: &task.Spec,
@@ -711,8 +711,8 @@ func TestGetNextTaskWithRetries(t *testing.T) {
 
 	var runCancelledByStatusStateMatrix = PipelineRunState{{
 		PipelineTask:   &pts[20], // 2 retries needed
-		RunObjectNames: []string{"pipelinerun-mytask1"},
-		RunObjects:     []v1beta1.RunObject{withCustomRunCancelled(withCustomRunRetries(newCustomRun(customRuns[0])))},
+		CustomRunNames: []string{"pipelinerun-mytask1"},
+		CustomRuns:     []*v1beta1.CustomRun{withCustomRunCancelled(withCustomRunRetries(newCustomRun(customRuns[0])))},
 		CustomTask:     true,
 		ResolvedTask: &resources.ResolvedTask{
 			TaskSpec: &task.Spec,
@@ -721,8 +721,8 @@ func TestGetNextTaskWithRetries(t *testing.T) {
 
 	var runCancelledBySpecStateMatrix = PipelineRunState{{
 		PipelineTask:   &pts[20], // 2 retries needed
-		RunObjectNames: []string{"pipelinerun-mytask1"},
-		RunObjects:     []v1beta1.RunObject{withCustomRunCancelledBySpec(withCustomRunRetries(newCustomRun(customRuns[0])))},
+		CustomRunNames: []string{"pipelinerun-mytask1"},
+		CustomRuns:     []*v1beta1.CustomRun{withCustomRunCancelledBySpec(withCustomRunRetries(newCustomRun(customRuns[0])))},
 		CustomTask:     true,
 		ResolvedTask: &resources.ResolvedTask{
 			TaskSpec: &task.Spec,
@@ -731,8 +731,8 @@ func TestGetNextTaskWithRetries(t *testing.T) {
 
 	var runRunningStateMatrix = PipelineRunState{{
 		PipelineTask:   &pts[20], // 2 retries needed
-		RunObjectNames: []string{"pipelinerun-mytask1"},
-		RunObjects:     []v1beta1.RunObject{makeCustomRunStarted(customRuns[0])},
+		CustomRunNames: []string{"pipelinerun-mytask1"},
+		CustomRuns:     []*v1beta1.CustomRun{makeCustomRunStarted(customRuns[0])},
 		CustomTask:     true,
 		ResolvedTask: &resources.ResolvedTask{
 			TaskSpec: &task.Spec,
@@ -741,8 +741,8 @@ func TestGetNextTaskWithRetries(t *testing.T) {
 
 	var customRunSucceededStateMatrix = PipelineRunState{{
 		PipelineTask:   &pts[20], // 2 retries needed
-		RunObjectNames: []string{"pipelinerun-mytask1"},
-		RunObjects:     []v1beta1.RunObject{makeCustomRunSucceeded(customRuns[0])},
+		CustomRunNames: []string{"pipelinerun-mytask1"},
+		CustomRuns:     []*v1beta1.CustomRun{makeCustomRunSucceeded(customRuns[0])},
 		CustomTask:     true,
 		ResolvedTask: &resources.ResolvedTask{
 			TaskSpec: &task.Spec,
@@ -751,8 +751,8 @@ func TestGetNextTaskWithRetries(t *testing.T) {
 
 	var customRunRetriedStateMatrix = PipelineRunState{{
 		PipelineTask:   &pts[17], // 1 retry needed
-		RunObjectNames: []string{"pipelinerun-mytask1"},
-		RunObjects:     []v1beta1.RunObject{withCustomRunCancelled(withCustomRunRetries(newCustomRun(customRuns[0])))},
+		CustomRunNames: []string{"pipelinerun-mytask1"},
+		CustomRuns:     []*v1beta1.CustomRun{withCustomRunCancelled(withCustomRunRetries(newCustomRun(customRuns[0])))},
 		CustomTask:     true,
 		ResolvedTask: &resources.ResolvedTask{
 			TaskSpec: &task.Spec,
@@ -892,7 +892,7 @@ func TestDAGExecutionQueue(t *testing.T) {
 			Name:    "createdrun",
 			TaskRef: &v1beta1.TaskRef{Name: "task"},
 		},
-		RunObjectNames: []string{"createdrun"},
+		CustomRunNames: []string{"createdrun"},
 		CustomTask:     true,
 	}
 	runningTask := ResolvedPipelineTask{
@@ -911,8 +911,8 @@ func TestDAGExecutionQueue(t *testing.T) {
 			Name:    "runningrun",
 			TaskRef: &v1beta1.TaskRef{Name: "task"},
 		},
-		RunObjectNames: []string{"runningrun"},
-		RunObjects:     []v1beta1.RunObject{newCustomRun(customRuns[0])},
+		CustomRunNames: []string{"runningrun"},
+		CustomRuns:     []*v1beta1.CustomRun{newCustomRun(customRuns[0])},
 		CustomTask:     true,
 	}
 	successfulTask := ResolvedPipelineTask{
@@ -931,8 +931,8 @@ func TestDAGExecutionQueue(t *testing.T) {
 			Name:    "successfulrun",
 			TaskRef: &v1beta1.TaskRef{Name: "task"},
 		},
-		RunObjectNames: []string{"successfulrun"},
-		RunObjects:     []v1beta1.RunObject{makeCustomRunSucceeded(customRuns[0])},
+		CustomRunNames: []string{"successfulrun"},
+		CustomRuns:     []*v1beta1.CustomRun{makeCustomRunSucceeded(customRuns[0])},
 		CustomTask:     true,
 	}
 	failedTask := ResolvedPipelineTask{
@@ -951,8 +951,8 @@ func TestDAGExecutionQueue(t *testing.T) {
 			Name:    "failedrun",
 			TaskRef: &v1beta1.TaskRef{Name: "task"},
 		},
-		RunObjectNames: []string{"failedrun"},
-		RunObjects:     []v1beta1.RunObject{makeCustomRunFailed(customRuns[0])},
+		CustomRunNames: []string{"failedrun"},
+		CustomRuns:     []*v1beta1.CustomRun{makeCustomRunFailed(customRuns[0])},
 		CustomTask:     true,
 	}
 	tcs := []struct {
@@ -1163,7 +1163,7 @@ func TestDAGExecutionQueueSequentialRuns(t *testing.T) {
 					Name:    "task-1",
 					TaskRef: &v1beta1.TaskRef{Name: "task"},
 				},
-				RunObjectNames: []string{"task-1"},
+				CustomRunNames: []string{"task-1"},
 				CustomTask:     true,
 			}
 			secondRun := ResolvedPipelineTask{
@@ -1172,14 +1172,14 @@ func TestDAGExecutionQueueSequentialRuns(t *testing.T) {
 					TaskRef:  &v1beta1.TaskRef{Name: "task"},
 					RunAfter: []string{"task-1"},
 				},
-				RunObjectNames: []string{"task-2"},
+				CustomRunNames: []string{"task-2"},
 				CustomTask:     true,
 			}
 			if tc.firstRun != nil {
-				firstRun.RunObjects = append(firstRun.RunObjects, tc.firstRun)
+				firstRun.CustomRuns = append(firstRun.CustomRuns, tc.firstRun)
 			}
 			if tc.secondRun != nil {
-				secondRun.RunObjects = append(secondRun.RunObjects, tc.secondRun)
+				secondRun.CustomRuns = append(secondRun.CustomRuns, tc.secondRun)
 			}
 			state := PipelineRunState{&firstRun, &secondRun}
 			d, err := dagFromState(state)
@@ -1586,9 +1586,9 @@ func TestGetPipelineConditionStatus(t *testing.T) {
 	var cancelledRun = PipelineRunState{{
 		PipelineTask:   &pts[12],
 		CustomTask:     true,
-		RunObjectNames: []string{"pipelinerun-mytask13"},
-		RunObjects: []v1beta1.RunObject{
-			&v1beta1.CustomRun{
+		CustomRunNames: []string{"pipelinerun-mytask13"},
+		CustomRuns: []*v1beta1.CustomRun{
+			{
 				Status: v1beta1.CustomRunStatus{
 					Status: duckv1.Status{Conditions: []apis.Condition{{
 						Type:   apis.ConditionSucceeded,
@@ -1602,9 +1602,9 @@ func TestGetPipelineConditionStatus(t *testing.T) {
 	var timedOutRun = PipelineRunState{{
 		PipelineTask:   &pts[12],
 		CustomTask:     true,
-		RunObjectNames: []string{"pipelinerun-mytask14"},
-		RunObjects: []v1beta1.RunObject{
-			&v1beta1.CustomRun{
+		CustomRunNames: []string{"pipelinerun-mytask14"},
+		CustomRuns: []*v1beta1.CustomRun{
+			{
 				Spec: v1beta1.CustomRunSpec{
 					StatusMessage: v1beta1.CustomRunCancelledByPipelineTimeoutMsg,
 				},
@@ -1621,7 +1621,7 @@ func TestGetPipelineConditionStatus(t *testing.T) {
 	var notRunningRun = PipelineRunState{{
 		PipelineTask:   &pts[12],
 		CustomTask:     true,
-		RunObjectNames: []string{"pipelinerun-mytask14"},
+		CustomRunNames: []string{"pipelinerun-mytask14"},
 	}}
 
 	// 6 Tasks, 4 that run in parallel in the beginning
@@ -2162,18 +2162,18 @@ func TestAdjustStartTime(t *testing.T) {
 	}, {
 		name: "multiple CustomRuns, some earlier",
 		prs: PipelineRunState{{
-			RunObjects: []v1beta1.RunObject{
-				&v1beta1.CustomRun{
+			CustomRuns: []*v1beta1.CustomRun{
+				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:              "blah1",
 						CreationTimestamp: metav1.Time{Time: baseline.Time.Add(-1 * time.Second)},
 					},
-				}, &v1beta1.CustomRun{
+				}, {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:              "blah2",
 						CreationTimestamp: metav1.Time{Time: baseline.Time.Add(-2 * time.Second)},
 					},
-				}, &v1beta1.CustomRun{
+				}, {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:              "blah3",
 						CreationTimestamp: metav1.Time{Time: baseline.Time.Add(2 * time.Second)},
@@ -2185,8 +2185,8 @@ func TestAdjustStartTime(t *testing.T) {
 	}, {
 		name: "CustomRun starts later",
 		prs: PipelineRunState{{
-			RunObjects: []v1beta1.RunObject{
-				&v1beta1.CustomRun{
+			CustomRuns: []*v1beta1.CustomRun{
+				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:              "blah",
 						CreationTimestamp: metav1.Time{Time: baseline.Time.Add(1 * time.Second)},
@@ -2198,8 +2198,8 @@ func TestAdjustStartTime(t *testing.T) {
 	}, {
 		name: "CustomRun starts earlier",
 		prs: PipelineRunState{{
-			RunObjects: []v1beta1.RunObject{
-				&v1beta1.CustomRun{
+			CustomRuns: []*v1beta1.CustomRun{
+				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:              "blah",
 						CreationTimestamp: metav1.Time{Time: baseline.Time.Add(-1 * time.Second)},
@@ -2585,13 +2585,13 @@ func TestPipelineRunState_GetResultsFuncs(t *testing.T) {
 			Name: "nil-taskrun-1",
 		},
 	}, {
-		RunObjectNames: []string{"successful-run-with-results"},
+		CustomRunNames: []string{"successful-run-with-results"},
 		CustomTask:     true,
 		PipelineTask: &v1beta1.PipelineTask{
 			Name: "successful-run-with-results-1",
 		},
-		RunObjects: []v1beta1.RunObject{
-			&v1beta1.CustomRun{
+		CustomRuns: []*v1beta1.CustomRun{
+			{
 				Status: v1beta1.CustomRunStatus{
 					Status: duckv1.Status{Conditions: []apis.Condition{{
 						Type:   apis.ConditionSucceeded,
@@ -2609,13 +2609,13 @@ func TestPipelineRunState_GetResultsFuncs(t *testing.T) {
 				},
 			}},
 	}, {
-		RunObjectNames: []string{"successful-run-without-results"},
+		CustomRunNames: []string{"successful-run-without-results"},
 		CustomTask:     true,
 		PipelineTask: &v1beta1.PipelineTask{
 			Name: "successful-run-without-results-1",
 		},
-		RunObjects: []v1beta1.RunObject{
-			&v1beta1.CustomRun{
+		CustomRuns: []*v1beta1.CustomRun{
+			{
 				Status: v1beta1.CustomRunStatus{
 					Status: duckv1.Status{Conditions: []apis.Condition{{
 						Type:   apis.ConditionSucceeded,
@@ -2625,12 +2625,12 @@ func TestPipelineRunState_GetResultsFuncs(t *testing.T) {
 				},
 			}},
 	}, {
-		RunObjectNames: []string{"failed-run"},
+		CustomRunNames: []string{"failed-run"},
 		PipelineTask: &v1beta1.PipelineTask{
 			Name: "failed-run-1",
 		},
-		RunObjects: []v1beta1.RunObject{
-			&v1beta1.CustomRun{
+		CustomRuns: []*v1beta1.CustomRun{
+			{
 				Status: v1beta1.CustomRunStatus{
 					Status: duckv1.Status{Conditions: []apis.Condition{{
 						Type:   apis.ConditionSucceeded,
@@ -2645,12 +2645,12 @@ func TestPipelineRunState_GetResultsFuncs(t *testing.T) {
 				}},
 		},
 	}, {
-		RunObjectNames: []string{"incomplete-run"},
+		CustomRunNames: []string{"incomplete-run"},
 		PipelineTask: &v1beta1.PipelineTask{
 			Name: "incomplete-run-1",
 		},
-		RunObjects: []v1beta1.RunObject{
-			&v1beta1.CustomRun{
+		CustomRuns: []*v1beta1.CustomRun{
+			{
 				Status: v1beta1.CustomRunStatus{
 					Status: duckv1.Status{Conditions: []apis.Condition{{
 						Type:   apis.ConditionSucceeded,
@@ -2665,7 +2665,7 @@ func TestPipelineRunState_GetResultsFuncs(t *testing.T) {
 				},
 			}},
 	}, {
-		RunObjectNames: []string{"nil-run"},
+		CustomRunNames: []string{"nil-run"},
 		CustomTask:     true,
 		PipelineTask: &v1beta1.PipelineTask{
 			Name: "nil-run-1",
@@ -2735,7 +2735,7 @@ func TestPipelineRunState_GetResultsFuncs(t *testing.T) {
 			},
 		}},
 	}, {
-		RunObjectNames: []string{
+		CustomRunNames: []string{
 			"matrixed-run-0",
 			"matrixed-run-1",
 			"matrixed-run-2",
@@ -2756,8 +2756,8 @@ func TestPipelineRunState_GetResultsFuncs(t *testing.T) {
 					Value: v1beta1.ParamValue{Type: v1beta1.ParamTypeArray, ArrayVal: []string{"qux", "baz"}},
 				}}},
 		},
-		RunObjects: []v1beta1.RunObject{
-			&v1beta1.CustomRun{
+		CustomRuns: []*v1beta1.CustomRun{
+			{
 				TypeMeta:   metav1.TypeMeta{APIVersion: "example.dev/v0"},
 				ObjectMeta: metav1.ObjectMeta{Name: "matrixed-run-0"},
 				Status: v1beta1.CustomRunStatus{
@@ -2775,7 +2775,7 @@ func TestPipelineRunState_GetResultsFuncs(t *testing.T) {
 						}},
 					},
 				},
-			}, &v1beta1.CustomRun{
+			}, {
 				TypeMeta:   metav1.TypeMeta{APIVersion: "example.dev/v0"},
 				ObjectMeta: metav1.ObjectMeta{Name: "matrixed-run-1"},
 				Status: v1beta1.CustomRunStatus{
@@ -2793,7 +2793,7 @@ func TestPipelineRunState_GetResultsFuncs(t *testing.T) {
 						}},
 					},
 				},
-			}, &v1beta1.CustomRun{
+			}, {
 				TypeMeta:   metav1.TypeMeta{APIVersion: "example.dev/v0"},
 				ObjectMeta: metav1.ObjectMeta{Name: "matrixed-run-2"},
 				Status: v1beta1.CustomRunStatus{
@@ -2811,7 +2811,7 @@ func TestPipelineRunState_GetResultsFuncs(t *testing.T) {
 						}},
 					},
 				},
-			}, &v1beta1.CustomRun{
+			}, {
 				TypeMeta:   metav1.TypeMeta{APIVersion: "example.dev/v0"},
 				ObjectMeta: metav1.ObjectMeta{Name: "matrixed-run-3"},
 				Status: v1beta1.CustomRunStatus{
@@ -2894,7 +2894,7 @@ func TestPipelineRunState_GetChildReferences(t *testing.T) {
 		{
 			name: "unresolved-custom-task",
 			state: PipelineRunState{{
-				RunObjectNames: []string{"unresolved-custom-task-run"},
+				CustomRunNames: []string{"unresolved-custom-task-run"},
 				CustomTask:     true,
 				PipelineTask: &v1beta1.PipelineTask{
 					Name: "unresolved-custom-task-1",
@@ -2946,7 +2946,7 @@ func TestPipelineRunState_GetChildReferences(t *testing.T) {
 		{
 			name: "single-custom-task",
 			state: PipelineRunState{{
-				RunObjectNames: []string{"single-custom-task-run"},
+				CustomRunNames: []string{"single-custom-task-run"},
 				CustomTask:     true,
 				PipelineTask: &v1beta1.PipelineTask{
 					Name: "single-custom-task-1",
@@ -2961,8 +2961,8 @@ func TestPipelineRunState_GetChildReferences(t *testing.T) {
 						Values:   []string{"foo", "bar"},
 					}},
 				},
-				RunObjects: []v1beta1.RunObject{
-					&v1beta1.CustomRun{
+				CustomRuns: []*v1beta1.CustomRun{
+					{
 						TypeMeta:   metav1.TypeMeta{APIVersion: "tekton.dev/v1beta1"},
 						ObjectMeta: metav1.ObjectMeta{Name: "single-custom-task-run"},
 					}},
@@ -2998,7 +2998,7 @@ func TestPipelineRunState_GetChildReferences(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Name: "single-task-run"},
 				}},
 			}, {
-				RunObjectNames: []string{"single-custom-task-run"},
+				CustomRunNames: []string{"single-custom-task-run"},
 				CustomTask:     true,
 				PipelineTask: &v1beta1.PipelineTask{
 					Name: "single-custom-task-1",
@@ -3008,8 +3008,8 @@ func TestPipelineRunState_GetChildReferences(t *testing.T) {
 						Name:       "single-custom-task",
 					},
 				},
-				RunObjects: []v1beta1.RunObject{
-					&v1beta1.CustomRun{
+				CustomRuns: []*v1beta1.CustomRun{
+					{
 						TypeMeta:   metav1.TypeMeta{APIVersion: "tekton.dev/v1beta1"},
 						ObjectMeta: metav1.ObjectMeta{Name: "single-custom-task-run"},
 					}},
@@ -3199,7 +3199,7 @@ func TestPipelineRunState_GetChildReferences(t *testing.T) {
 						}}},
 				},
 				CustomTask: true,
-				RunObjects: []v1beta1.RunObject{
+				CustomRuns: []*v1beta1.CustomRun{
 					customRunWithName("matrixed-run-0"),
 					customRunWithName("matrixed-run-1"),
 					customRunWithName("matrixed-run-2"),

--- a/pkg/reconciler/pipelinerun/resources/resultrefresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/resultrefresolution.go
@@ -130,12 +130,12 @@ func resolveResultRef(pipelineState PipelineRunState, resultRef *v1beta1.ResultR
 	var resultValue v1beta1.ResultValue
 	var err error
 	if referencedPipelineTask.IsCustomTask() {
-		if len(referencedPipelineTask.RunObjects) != 1 {
+		if len(referencedPipelineTask.CustomRuns) != 1 {
 			return nil, resultRef.PipelineTask, fmt.Errorf("referenced tasks can only have length of 1 since a matrixed task does not support producing results, but was length %d", len(referencedPipelineTask.TaskRuns))
 		}
-		runObject := referencedPipelineTask.RunObjects[0]
-		runName = runObject.GetObjectMeta().GetName()
-		runValue, err = findRunResultForParam(runObject, resultRef)
+		customRun := referencedPipelineTask.CustomRuns[0]
+		runName = customRun.GetObjectMeta().GetName()
+		runValue, err = findRunResultForParam(customRun, resultRef)
 		resultValue = *v1beta1.NewStructuredValues(runValue)
 		if err != nil {
 			return nil, resultRef.PipelineTask, err
@@ -161,9 +161,8 @@ func resolveResultRef(pipelineState PipelineRunState, resultRef *v1beta1.ResultR
 	}, "", nil
 }
 
-func findRunResultForParam(runObj v1beta1.RunObject, reference *v1beta1.ResultRef) (string, error) {
-	run := runObj.(*v1beta1.CustomRun)
-	for _, result := range run.Status.Results {
+func findRunResultForParam(customRun *v1beta1.CustomRun, reference *v1beta1.ResultRef) (string, error) {
+	for _, result := range customRun.Status.Results {
 		if result.Name == reference.Result {
 			return result.Value, nil
 		}

--- a/pkg/reconciler/pipelinerun/resources/resultrefresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/resultrefresolution_test.go
@@ -104,9 +104,9 @@ var pipelineRunState = PipelineRunState{{
 	},
 }, {
 	CustomTask:     true,
-	RunObjectNames: []string{"aRun"},
-	RunObjects: []v1beta1.RunObject{
-		&v1beta1.CustomRun{
+	CustomRunNames: []string{"aRun"},
+	CustomRuns: []*v1beta1.CustomRun{
+		{
 			ObjectMeta: metav1.ObjectMeta{Name: "aRun"},
 			Status: v1beta1.CustomRunStatus{
 				Status: duckv1.Status{
@@ -262,9 +262,9 @@ var pipelineRunState = PipelineRunState{{
 	},
 }, {
 	CustomTask:     true,
-	RunObjectNames: []string{"xRun"},
-	RunObjects: []v1beta1.RunObject{
-		&v1beta1.CustomRun{
+	CustomRunNames: []string{"xRun"},
+	CustomRuns: []*v1beta1.CustomRun{
+		{
 			ObjectMeta: metav1.ObjectMeta{Name: "xRun"},
 			Status: v1beta1.CustomRunStatus{
 				Status: duckv1.Status{
@@ -277,7 +277,7 @@ var pipelineRunState = PipelineRunState{{
 					}},
 				},
 			},
-		}, &v1beta1.CustomRun{
+		}, {
 			ObjectMeta: metav1.ObjectMeta{Name: "yRun"},
 			Status: v1beta1.CustomRunStatus{
 				Status: duckv1.Status{

--- a/pkg/reconciler/pipelinerun/resources/validate_dependencies_test.go
+++ b/pkg/reconciler/pipelinerun/resources/validate_dependencies_test.go
@@ -97,7 +97,7 @@ func TestValidatePipelineTaskResults_ValidStates(t *testing.T) {
 				Name: "pt1",
 			},
 			CustomTask:     true,
-			RunObjectNames: []string{"foo-run"},
+			CustomRunNames: []string{"foo-run"},
 		}, {
 			PipelineTask: &v1beta1.PipelineTask{
 				Name: "pt2",


### PR DESCRIPTION
v1alpha1 Runs are no longer supported by the PipelineRun reconciler. The PipelineRun reconciler currently operates on RunObjects (an interface which is implemented by v1alpha1.Run and v1beta1.CustomRun). However, this code is misleading, since retry behavior differs between v1alpha1.Run and v1beta1.CustomRun, but the controller only supports the behavior of v1beta1.CustomRuns. This commit replaces usages of RunObject with CustomRun, and renames references to runs/runObjects to customRuns for clarity. No functional changes.

/kind cleanup
Partially addresses https://github.com/tektoncd/pipeline/issues/6628

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- n/a Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- n/a Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- n/a Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
