### PR TITLE
Consolidate validation for Task/Pipeline beta features

### DIFF
--- a/pkg/apis/pipeline/v1/pipeline_types_test.go
+++ b/pkg/apis/pipeline/v1/pipeline_types_test.go
@@ -276,18 +276,6 @@ func TestPipelineTask_ValidateRegularTask_Failure(t *testing.T) {
 			Message: `invalid value: taskRef must specify name`,
 			Paths:   []string{"taskRef.name"},
 		},
-	}, {
-		name: "pipeline task - use of resolver without the feature flag set",
-		task: PipelineTask{
-			TaskRef: &TaskRef{Name: "boo", ResolverRef: ResolverRef{Resolver: "bar"}},
-		},
-		expectedError: *apis.ErrDisallowedFields("taskref.resolver"),
-	}, {
-		name: "pipeline task - use of resolver params without the feature flag set",
-		task: PipelineTask{
-			TaskRef: &TaskRef{Name: "boo", ResolverRef: ResolverRef{Params: Params{{}}}},
-		},
-		expectedError: *apis.ErrDisallowedFields("taskref.params"),
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/apis/pipeline/v1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1/pipeline_validation_test.go
@@ -3522,7 +3522,7 @@ func TestPipelineWithBetaFields(t *testing.T) {
 		name string
 		spec PipelineSpec
 	}{{
-		name: "array indexing",
+		name: "array indexing in Tasks",
 		spec: PipelineSpec{
 			Params: []ParamSpec{
 				{Name: "first-param", Type: ParamTypeArray, Default: NewStructuredValues("default-value", "default-value-again")},
@@ -3535,15 +3535,181 @@ func TestPipelineWithBetaFields(t *testing.T) {
 				TaskRef: &TaskRef{Name: "foo"},
 			}},
 		},
+	}, {
+		name: "array indexing in Finally",
+		spec: PipelineSpec{
+			Params: []ParamSpec{
+				{Name: "first-param", Type: ParamTypeArray, Default: NewStructuredValues("default-value", "default-value-again")},
+			},
+			Tasks: []PipelineTask{{
+				Name:    "foo",
+				TaskRef: &TaskRef{Name: "foo"},
+			}},
+			Finally: []PipelineTask{{
+				Name: "bar",
+				Params: Params{
+					{Name: "first-task-first-param", Value: *NewStructuredValues("$(params.first-param[0])")},
+				},
+				TaskRef: &TaskRef{Name: "bar"},
+			}},
+		},
+	}, {
+		name: "pipeline tasks - use of resolver without the feature flag set",
+		spec: PipelineSpec{
+			Tasks: []PipelineTask{{
+				Name:    "uses-resolver",
+				TaskRef: &TaskRef{Name: "boo", ResolverRef: ResolverRef{Resolver: "bar"}},
+			}},
+		},
+	}, {
+		name: "pipeline tasks - use of resolver params without the feature flag set",
+		spec: PipelineSpec{
+			Tasks: []PipelineTask{{
+				Name:    "uses-resolver-params",
+				TaskRef: &TaskRef{Name: "boo", ResolverRef: ResolverRef{Params: Params{{}}}},
+			}},
+		},
+	}, {
+		name: "finally tasks - use of resolver without the feature flag set",
+		spec: PipelineSpec{
+			Tasks: []PipelineTask{{
+				Name:    "valid-pipeline-task",
+				TaskRef: &TaskRef{Name: "foo-task"},
+			}},
+			Finally: []PipelineTask{{
+				Name:    "uses-resolver",
+				TaskRef: &TaskRef{Name: "boo", ResolverRef: ResolverRef{Resolver: "bar"}},
+			}},
+		},
+	}, {
+		name: "finally tasks - use of resolver params without the feature flag set",
+		spec: PipelineSpec{
+			Tasks: []PipelineTask{{
+				Name:    "valid-pipeline-task",
+				TaskRef: &TaskRef{Name: "foo-task"},
+			}},
+			Finally: []PipelineTask{{
+				Name:    "uses-resolver-params",
+				TaskRef: &TaskRef{Name: "boo", ResolverRef: ResolverRef{Params: Params{{}}}},
+			}},
+		},
+	}, {
+		name: "object params",
+		spec: PipelineSpec{
+			Params: []ParamSpec{
+				{Name: "first-param", Type: ParamTypeObject, Properties: map[string]PropertySpec{}},
+			},
+			Tasks: []PipelineTask{{
+				Name:    "foo",
+				TaskRef: &TaskRef{Name: "foo"},
+			}},
+		},
+	}, {
+		name: "object params in Tasks",
+		spec: PipelineSpec{
+			Tasks: []PipelineTask{{
+				Name: "valid-pipeline-task",
+				TaskSpec: &EmbeddedTask{TaskSpec: TaskSpec{
+					Steps:  []Step{{Image: "busybox", Script: "echo hello"}},
+					Params: []ParamSpec{{Name: "my-object-param", Type: ParamTypeObject, Properties: map[string]PropertySpec{}}},
+				}},
+			}},
+		},
+	}, {
+		name: "object params in Finally",
+		spec: PipelineSpec{
+			Tasks: []PipelineTask{{
+				Name:    "foo",
+				TaskRef: &TaskRef{Name: "foo"},
+			}},
+			Finally: []PipelineTask{{
+				Name: "valid-finally-task",
+				TaskSpec: &EmbeddedTask{TaskSpec: TaskSpec{
+					Steps:  []Step{{Image: "busybox", Script: "echo hello"}},
+					Params: []ParamSpec{{Name: "my-object-param", Type: ParamTypeObject, Properties: map[string]PropertySpec{}}},
+				}},
+			}},
+		},
+	}, {
+		name: "array results",
+		spec: PipelineSpec{
+			Tasks: []PipelineTask{{
+				Name:    "valid-pipeline-task",
+				TaskRef: &TaskRef{Name: "foo-task"},
+			}},
+			Results: []PipelineResult{{Name: "my-array-result", Type: ResultsTypeArray, Value: *NewStructuredValues("$(tasks.valid-pipeline-task.results.foo[*])")}},
+		},
+	}, {
+		name: "array results in Tasks",
+		spec: PipelineSpec{
+			Tasks: []PipelineTask{{
+				Name: "valid-pipeline-task",
+				TaskSpec: &EmbeddedTask{TaskSpec: TaskSpec{
+					Steps:   []Step{{Image: "busybox", Script: "echo hello"}},
+					Results: []TaskResult{{Name: "my-array-result", Type: ResultsTypeArray}},
+				}},
+			}},
+		},
+	}, {
+		name: "array results in Finally",
+		spec: PipelineSpec{
+			Tasks: []PipelineTask{{
+				Name:    "valid-pipeline-task",
+				TaskRef: &TaskRef{Name: "foo-task"},
+			}},
+			Finally: []PipelineTask{{
+				Name: "valid-finally-task",
+				TaskSpec: &EmbeddedTask{TaskSpec: TaskSpec{
+					Steps:   []Step{{Image: "busybox", Script: "echo hello"}},
+					Results: []TaskResult{{Name: "my-array-result", Type: ResultsTypeArray}},
+				}},
+			}},
+		},
+	}, {
+		name: "object results",
+		spec: PipelineSpec{
+			Tasks: []PipelineTask{{
+				Name:    "valid-pipeline-task",
+				TaskRef: &TaskRef{Name: "foo-task"},
+			}},
+			Results: []PipelineResult{{Name: "my-object-result", Type: ResultsTypeObject, Value: *NewStructuredValues("$(tasks.valid-pipeline-task.results.foo[*])")}},
+		},
+	}, {
+		name: "object results in Tasks",
+		spec: PipelineSpec{
+			Tasks: []PipelineTask{{
+				Name: "valid-pipeline-task",
+				TaskSpec: &EmbeddedTask{TaskSpec: TaskSpec{
+					Steps:   []Step{{Image: "busybox", Script: "echo hello"}},
+					Results: []TaskResult{{Name: "my-object-result", Type: ResultsTypeObject, Properties: map[string]PropertySpec{}}},
+				}},
+			}},
+		},
+	}, {
+		name: "object results in Finally",
+		spec: PipelineSpec{
+			Tasks: []PipelineTask{{
+				Name:    "valid-pipeline-task",
+				TaskRef: &TaskRef{Name: "foo-task"},
+			}},
+			Finally: []PipelineTask{{
+				Name: "valid-finally-task",
+				TaskSpec: &EmbeddedTask{TaskSpec: TaskSpec{
+					Steps:   []Step{{Image: "busybox", Script: "echo hello"}},
+					Results: []TaskResult{{Name: "my-object-result", Type: ResultsTypeObject, Properties: map[string]PropertySpec{}}},
+				}},
+			}},
+		},
 	}}
 	for _, tt := range tts {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := tt.spec.Validate(context.Background()); err == nil {
+			pipeline := Pipeline{ObjectMeta: metav1.ObjectMeta{Name: "foo"}, Spec: tt.spec}
+			if err := pipeline.Validate(context.Background()); err == nil {
 				t.Errorf("no error when using beta field when `enable-api-fields` is stable")
 			}
 
 			ctx := config.EnableBetaAPIFields(context.Background())
-			if err := tt.spec.Validate(ctx); err != nil {
+			if err := pipeline.Validate(ctx); err != nil {
 				t.Errorf("unexpected error when using beta field: %s", err)
 			}
 		})

--- a/pkg/apis/pipeline/v1/result_validation.go
+++ b/pkg/apis/pipeline/v1/result_validation.go
@@ -18,8 +18,6 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/tektoncd/pipeline/pkg/apis/config"
-	"github.com/tektoncd/pipeline/pkg/apis/version"
 	"knative.dev/pkg/apis"
 )
 
@@ -35,15 +33,11 @@ func (tr TaskResult) Validate(ctx context.Context) (errs *apis.FieldError) {
 	}
 
 	switch {
-	// Object results is beta feature - check if the feature flag is set to "beta" or "alpha"
 	case tr.Type == ResultsTypeObject:
 		errs := validateObjectResult(tr)
-		errs = errs.Also(version.ValidateEnabledAPIFields(ctx, "results type", config.BetaAPIFields))
 		return errs
-	// Array results is a beta feature - check if the feature flag is set to "beta" or "alpha"
 	case tr.Type == ResultsTypeArray:
-		errs = errs.Also(version.ValidateEnabledAPIFields(ctx, "results type", config.BetaAPIFields))
-		return errs
+		return nil
 	// Resources created before the result. Type was introduced may not have Type set
 	// and should be considered valid
 	case tr.Type == "":

--- a/pkg/apis/pipeline/v1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1/task_validation_test.go
@@ -1885,6 +1885,43 @@ func TestTaskSpecBetaFields(t *testing.T) {
 					echo $(params.foo[1])`,
 			}},
 		},
+	}, {
+		name: "object params",
+		spec: v1.TaskSpec{
+			Params: []v1.ParamSpec{{Name: "foo", Type: v1.ParamTypeObject, Properties: map[string]v1.PropertySpec{"bar": {Type: v1.ParamTypeString}}}},
+			Steps: []v1.Step{{
+				Name:  "my-step",
+				Image: "my-image",
+				Script: `
+					#!/usr/bin/env  bash
+					echo $(params.foo.bar)`,
+			}},
+		},
+	}, {
+		name: "array results",
+		spec: v1.TaskSpec{
+			Results: []v1.TaskResult{{Name: "array-result", Type: v1.ResultsTypeArray}},
+			Steps: []v1.Step{{
+				Name:  "my-step",
+				Image: "my-image",
+				Script: `
+					#!/usr/bin/env  bash
+					echo -n "[\"hello\",\"world\"]" | tee $(results.array-result.path)`,
+			}},
+		},
+	}, {
+		name: "object results",
+		spec: v1.TaskSpec{
+			Results: []v1.TaskResult{{Name: "object-result", Type: v1.ResultsTypeObject,
+				Properties: map[string]v1.PropertySpec{}}},
+			Steps: []v1.Step{{
+				Name:  "my-step",
+				Image: "my-image",
+				Script: `
+					#!/usr/bin/env  bash
+					echo -n "{\"hello\":\"world\"}" | tee $(results.object-result.path)`,
+			}},
+		},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Currently, the validation webhook includes code for validating that "enable-api-fields" is set to "beta" when a v1 object is created using beta features.

Validation of Task and Pipeline specs is currently applied in the reconciler as well, to referenced Tasks and Pipelines that are fetched remotely or from the cluster. This commit refactors validation of beta features in Tasks and Pipelines, so that it is all done in one place. There are no functional changes in this commit, but it will make it easier to fix issues related to versioned validation of referenced Tasks and Pipelines.

/kind cleanup
Part 1 of https://github.com/tektoncd/pipeline/issues/6616

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- n/a Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- n/a Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- n/a Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
