### PR TITLE
merge VerifyTask and VerifyPipeline into VerifyResource

### DIFF
--- a/pkg/reconciler/pipelinerun/resources/pipelineref.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelineref.go
@@ -151,7 +151,7 @@ func readRuntimeObjectAsPipeline(ctx context.Context, obj runtime.Object, k8s ku
 	switch obj := obj.(type) {
 	case *v1beta1.Pipeline:
 		// Verify the Pipeline once we fetch from the remote resolution, mutating, validation and conversion of the pipeline should happen after the verification, since signatures are based on the remote pipeline contents
-		vr := trustedresources.VerifyPipeline(ctx, obj, k8s, refSource, verificationPolicies)
+		vr := trustedresources.VerifyResource(ctx, obj, k8s, refSource, verificationPolicies)
 		if vr.VerificationResultType == trustedresources.VerificationError {
 			if vr.Err != nil {
 				return nil, fmt.Errorf("Pipeline verification failed for object %s: %w", obj.GetName(), vr.Err)

--- a/pkg/reconciler/taskrun/resources/taskref.go
+++ b/pkg/reconciler/taskrun/resources/taskref.go
@@ -174,7 +174,7 @@ func readRuntimeObjectAsTask(ctx context.Context, obj runtime.Object, k8s kubern
 	switch obj := obj.(type) {
 	case *v1beta1.Task:
 		// Verify the Task once we fetch from the remote resolution, mutating, validation and conversion of the task should happen after the verification, since signatures are based on the remote task contents
-		vr := trustedresources.VerifyTask(ctx, obj, k8s, refSource, verificationPolicies)
+		vr := trustedresources.VerifyResource(ctx, obj, k8s, refSource, verificationPolicies)
 		return obj, &vr, nil
 	case *v1beta1.ClusterTask:
 		return convertClusterTaskToTask(*obj), nil, nil

--- a/pkg/trustedresources/errors.go
+++ b/pkg/trustedresources/errors.go
@@ -24,4 +24,6 @@ var (
 	ErrNoMatchedPolicies = errors.New("no policies are matched")
 	// ErrRegexMatch is returned when regex match returns error
 	ErrRegexMatch = errors.New("regex failed to match")
+	// ErrResourceNotSupported is returned when the resource type is not supported
+	ErrResourceNotSupported = errors.New("resource type not supported")
 )


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This commit merges VerifyTask and VerifyPipeline into VerifyResource to reduce duplicate code.

/kind cleanup

Signed-off-by: Yongxuan Zhang yongxuanzhang@google.com

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
action required: VerifyTask and VerifyPipeline are now merged into 1 function VerifyResource, please update the usages if upgrade to the new release
```
