### PR TITLE
Add validation for beta features in v1 remote Tasks/Pipelines

### DIFF
--- a/pkg/apis/pipeline/v1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1/pipeline_validation.go
@@ -70,7 +70,7 @@ func (ps *PipelineSpec) Validate(ctx context.Context) (errs *apis.FieldError) {
 	errs = errs.Also(validatePipelineContextVariables(ps.Tasks).ViaField("tasks"))
 	errs = errs.Also(validatePipelineContextVariables(ps.Finally).ViaField("finally"))
 	errs = errs.Also(validateExecutionStatusVariables(ps.Tasks, ps.Finally))
-	errs = errs.Also(ps.validateBetaFields(ctx))
+	errs = errs.Also(ps.ValidateBetaFields(ctx))
 	// Validate the pipeline's workspaces.
 	errs = errs.Also(validatePipelineWorkspacesDeclarations(ps.Workspaces))
 	// Validate the pipeline's results
@@ -84,9 +84,9 @@ func (ps *PipelineSpec) Validate(ctx context.Context) (errs *apis.FieldError) {
 	return errs
 }
 
-// validateBetaFields returns an error if the Pipeline spec uses beta features but does not
+// ValidateBetaFields returns an error if the Pipeline spec uses beta features but does not
 // have "enable-api-fields" set to "alpha" or "beta".
-func (ps *PipelineSpec) validateBetaFields(ctx context.Context) *apis.FieldError {
+func (ps *PipelineSpec) ValidateBetaFields(ctx context.Context) *apis.FieldError {
 	var errs *apis.FieldError
 	// Object parameters
 	for i, p := range ps.Params {
@@ -133,7 +133,7 @@ func (pt *PipelineTask) validateBetaFields(ctx context.Context) *apis.FieldError
 			errs = errs.Also(version.ValidateEnabledAPIFields(ctx, "taskref.params", config.BetaAPIFields))
 		}
 	} else if pt.TaskSpec != nil {
-		errs = errs.Also(pt.TaskSpec.validateBetaFields(ctx))
+		errs = errs.Also(pt.TaskSpec.ValidateBetaFields(ctx))
 	}
 	return errs
 }

--- a/pkg/apis/pipeline/v1/task_validation.go
+++ b/pkg/apis/pipeline/v1/task_validation.go
@@ -90,16 +90,16 @@ func (ts *TaskSpec) Validate(ctx context.Context) (errs *apis.FieldError) {
 	errs = errs.Also(validateSidecarNames(ts.Sidecars))
 	errs = errs.Also(ValidateParameterTypes(ctx, ts.Params).ViaField("params"))
 	errs = errs.Also(ValidateParameterVariables(ctx, ts.Steps, ts.Params))
-	errs = errs.Also(ts.validateBetaFields(ctx))
+	errs = errs.Also(ts.ValidateBetaFields(ctx))
 	errs = errs.Also(validateTaskContextVariables(ctx, ts.Steps))
 	errs = errs.Also(validateTaskResultsVariables(ctx, ts.Steps, ts.Results))
 	errs = errs.Also(validateResults(ctx, ts.Results).ViaField("results"))
 	return errs
 }
 
-// validateBetaFields returns an error if the Task spec uses beta features but does not
+// ValidateBetaFields returns an error if the Task spec uses beta features but does not
 // have "enable-api-fields" set to "alpha" or "beta".
-func (ts *TaskSpec) validateBetaFields(ctx context.Context) *apis.FieldError {
+func (ts *TaskSpec) ValidateBetaFields(ctx context.Context) *apis.FieldError {
 	var errs *apis.FieldError
 	// Object parameters
 	for i, p := range ts.Params {


### PR DESCRIPTION
Currently, when a user creates a v1 Task or Pipeline using beta features on their cluster, we validate that "enable-api-fields" is set to "alpha" or "beta", and if not, reject the Task or Pipeline.

However, no such validation is done for v1 remote Tasks or Pipelines. This is because we validate remote Task and Pipeline specs in the reconciler after converting them to v1beta1. This commit adds the same validation to remote v1 Tasks and Pipelines that we are already performing for local v1 Tasks and Pipelines.

/kind bug
Partially addresses https://github.com/tektoncd/pipeline/issues/6616

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- n/a Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- n/a Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Bug fix: Apply validation for beta features for v1 remote pipelines and tasks in the same way as already exists for pipelines and tasks created directly on cluster
```
