### PR TITLE
Enable beta features by default

### DIFF
--- a/api_compatibility_policy.md
+++ b/api_compatibility_policy.md
@@ -70,14 +70,14 @@ and follows the [beta policy](#beta-crds) for backwards incompatible changes.
 
 - We will not make any backwards incompatible changes to fields that are stable without incrementing the api version.
 
-- Alpha and Beta features may be present within a stable API version. However, they will not be enabled by default and must be enabled by setting `enable-api-fields` to `alpha` or `beta`.
+- Alpha and Beta features may be present within a stable API version. Alpha features will not be enabled by default and must be enabled by setting `enable-api-fields` to `alpha`. To disable beta features as well, set `enable-api-fields` to `stable`.
 
 ## Feature Gates
 
 CRD API versions gate the overall stability of the CRD and its default behaviors. Within a particular CRD version, certain opt-in features may be at a lower stability level as described in [TEP-33](https://github.com/tektoncd/community/blob/main/teps/0033-tekton-feature-gates.md). These fields may be disabled by default and can be enabled by setting the right `enable-api-fields` feature-flag as described in TEP-33:
 
-* `stable` (default) - This value indicates that only fields of the highest stability level are enabled; For `beta` CRDs, this means only     beta stability fields are enabled, i.e. `alpha` fields are not enabled. For  `GA` CRDs, this means only `GA` fields are enabled by defaultd, i.e. `beta` and `alpha` fields would not be enabled.
-* `beta` - This value indicates that only fields which are of `beta` (or greater) stability are enabled, i.e. `alpha` fields are not enabled. 
+* `stable` - This value indicates that only fields of the highest stability level are enabled; For `beta` CRDs, this means only beta stability fields are enabled, i.e. `alpha` fields are not enabled. For `GA` CRDs, this means only `GA` fields are enabled, i.e. `beta` and `alpha` fields would not be enabled.
+* `beta` (default) - This value indicates that only fields which are of `beta` (or greater) stability are enabled, i.e. `alpha` fields are not enabled. 
 * `alpha` - This value indicates that fields of all stability levels are enabled, specifically `alpha`, `beta` and `GA`.
 
 
@@ -101,7 +101,7 @@ See the current list of [alpha features](https://github.com/tektoncd/pipeline/bl
 
 ### Beta features
 
-- Beta features in GA CRDs are disabled by default and must be enabled by [setting `enable-api-fields` to `beta`](https://github.com/tektoncd/pipeline/blob/main/docs/install.md#beta-features). In beta API versions, beta features are enabled by default.
+- Beta features are enabled by default and can be disabled by [setting `enable-api-fields` to `stable`](https://github.com/tektoncd/pipeline/blob/main/docs/install.md#beta-features).
 
 - Beta features may be deprecated or changed in a backwards incompatible way by following the same process as [Beta CRDs](#beta-crds) 
   i.e. by providing a 9 month support period.

--- a/config/config-feature-flags.yaml
+++ b/config/config-feature-flags.yaml
@@ -72,7 +72,7 @@ data:
   enable-tekton-oci-bundles: "false"
   # Setting this flag will determine which gated features are enabled.
   # Acceptable values are "stable", "beta", or "alpha".
-  enable-api-fields: "stable"
+  enable-api-fields: "beta"
   # Setting this flag to "true" enables CloudEvents for CustomRuns and Runs, as long as a
   # CloudEvents sink is configured in the config-defaults config map
   send-cloudevents-for-runs: "false"

--- a/docs/additional-configs.md
+++ b/docs/additional-configs.md
@@ -237,9 +237,10 @@ not running.
 and use Workspaces to mount credentials from Secrets instead.
 The default is `false`. For more information, see the [associated issue](https://github.com/tektoncd/pipeline/issues/3399).
 
-- `enable-api-fields`: set this flag to "stable" to allow only the
-most stable features to be used. Set it to "alpha" to allow [alpha
-features](#alpha-features) to be used.
+- `enable-api-fields`: When using v1beta1 APIs, setting this field to "stable" or "beta"
+enables [beta features](#beta-features). When using v1 APIs, setting this field to "stable"
+allows only stable features, and setting it to "beta" allows only beta features.
+Set this field to "alpha" to allow [alpha features](#alpha-features) to be used.
 
 - `trusted-resources-verification-no-match-policy`: Setting this flag to `fail` will fail the taskrun/pipelinerun if no matching policies found. Setting to `warn` will skip verification and log a warning if no matching policies are found, but not fail the taskrun/pipelinerun. Setting to `ignore` will skip verification if no matching policies found.
 Defaults to "ignore".

--- a/pkg/apis/config/feature_flags.go
+++ b/pkg/apis/config/feature_flags.go
@@ -59,7 +59,7 @@ const (
 	// DefaultEnableTektonOciBundles is the default value for "enable-tekton-oci-bundles".
 	DefaultEnableTektonOciBundles = false
 	// DefaultEnableAPIFields is the default value for "enable-api-fields".
-	DefaultEnableAPIFields = StableAPIFields
+	DefaultEnableAPIFields = BetaAPIFields
 	// DefaultSendCloudEventsForRuns is the default value for "send-cloudevents-for-runs".
 	DefaultSendCloudEventsForRuns = false
 	// EnforceNonfalsifiabilityWithSpire is the value used for  "enable-nonfalsifiability" when SPIRE is used to enable non-falsifiability.

--- a/pkg/apis/config/feature_flags_test.go
+++ b/pkg/apis/config/feature_flags_test.go
@@ -144,7 +144,7 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 		},
 		{
 			expectedConfig: &config.FeatureFlags{
-				EnableAPIFields:                  "stable",
+				EnableAPIFields:                  config.DefaultEnableAPIFields,
 				VerificationNoMatchPolicy:        config.DefaultNoMatchPolicyConfig,
 				RunningInEnvWithInjectedSidecars: config.DefaultRunningInEnvWithInjectedSidecars,
 				AwaitSidecarReadiness:            config.DefaultAwaitSidecarReadiness,

--- a/pkg/apis/pipeline/v1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1/pipeline_validation_test.go
@@ -3704,11 +3704,12 @@ func TestPipelineWithBetaFields(t *testing.T) {
 	for _, tt := range tts {
 		t.Run(tt.name, func(t *testing.T) {
 			pipeline := Pipeline{ObjectMeta: metav1.ObjectMeta{Name: "foo"}, Spec: tt.spec}
-			if err := pipeline.Validate(context.Background()); err == nil {
+			ctx := config.EnableStableAPIFields(context.Background())
+			if err := pipeline.Validate(ctx); err == nil {
 				t.Errorf("no error when using beta field when `enable-api-fields` is stable")
 			}
 
-			ctx := config.EnableBetaAPIFields(context.Background())
+			ctx = config.EnableBetaAPIFields(context.Background())
 			if err := pipeline.Validate(ctx); err != nil {
 				t.Errorf("unexpected error when using beta field: %s", err)
 			}

--- a/pkg/apis/pipeline/v1/pipelineref_validation_test.go
+++ b/pkg/apis/pipeline/v1/pipelineref_validation_test.go
@@ -44,7 +44,8 @@ func TestPipelineRef_Invalid(t *testing.T) {
 				Resolver: "foo",
 			},
 		},
-		wantErr: apis.ErrGeneric("resolver requires \"enable-api-fields\" feature gate to be \"alpha\" or \"beta\" but it is \"stable\""),
+		withContext: config.EnableStableAPIFields,
+		wantErr:     apis.ErrGeneric("resolver requires \"enable-api-fields\" feature gate to be \"alpha\" or \"beta\" but it is \"stable\""),
 	}, {
 		name: "pipelineref params disallowed without beta feature gate",
 		ref: &v1.PipelineRef{
@@ -52,7 +53,8 @@ func TestPipelineRef_Invalid(t *testing.T) {
 				Params: v1.Params{},
 			},
 		},
-		wantErr: apis.ErrMissingField("resolver").Also(apis.ErrGeneric("resolver params requires \"enable-api-fields\" feature gate to be \"alpha\" or \"beta\" but it is \"stable\"")),
+		withContext: config.EnableStableAPIFields,
+		wantErr:     apis.ErrMissingField("resolver").Also(apis.ErrGeneric("resolver params requires \"enable-api-fields\" feature gate to be \"alpha\" or \"beta\" but it is \"stable\"")),
 	}, {
 		name: "pipelineref params disallowed without resolver",
 		ref: &v1.PipelineRef{

--- a/pkg/apis/pipeline/v1/pipelinerun_validation_test.go
+++ b/pkg/apis/pipeline/v1/pipelinerun_validation_test.go
@@ -931,7 +931,8 @@ func TestPipelineRunSpec_Invalidate(t *testing.T) {
 				},
 			},
 		},
-		wantErr: apis.ErrGeneric("stepSpecs requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\"").ViaIndex(0).ViaField("taskRunSpecs"),
+		withContext: config.EnableStableAPIFields,
+		wantErr:     apis.ErrGeneric("stepSpecs requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\"").ViaIndex(0).ViaField("taskRunSpecs"),
 	}, {
 		name: "sidecarSpec disallowed without alpha feature gate",
 		spec: v1.PipelineRunSpec{
@@ -948,7 +949,8 @@ func TestPipelineRunSpec_Invalidate(t *testing.T) {
 				},
 			},
 		},
-		wantErr: apis.ErrGeneric("sidecarSpecs requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\"").ViaIndex(0).ViaField("taskRunSpecs"),
+		withContext: config.EnableStableAPIFields,
+		wantErr:     apis.ErrGeneric("sidecarSpecs requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\"").ViaIndex(0).ViaField("taskRunSpecs"),
 	}, {
 		name: "missing stepSpecs name",
 		spec: v1.PipelineRunSpec{
@@ -1035,7 +1037,8 @@ func TestPipelineRunSpec_Invalidate(t *testing.T) {
 				},
 			},
 		},
-		wantErr: apis.ErrGeneric("computeResources requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\"").ViaIndex(0).ViaField("taskRunSpecs"),
+		withContext: config.EnableStableAPIFields,
+		wantErr:     apis.ErrGeneric("computeResources requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\"").ViaIndex(0).ViaField("taskRunSpecs"),
 	}}
 
 	for _, ps := range tests {

--- a/pkg/apis/pipeline/v1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1/task_validation_test.go
@@ -1925,12 +1925,13 @@ func TestTaskBetaFields(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			ctx := config.EnableStableAPIFields(context.Background())
 			task := v1.Task{ObjectMeta: metav1.ObjectMeta{Name: "foo"}, Spec: tt.spec}
-			if err := task.Validate(context.Background()); err == nil {
+			if err := task.Validate(ctx); err == nil {
 				t.Errorf("no error when using beta field when `enable-api-fields` is stable")
 			}
 
-			ctx := config.EnableBetaAPIFields(context.Background())
+			ctx = config.EnableBetaAPIFields(context.Background())
 			if err := task.Validate(ctx); err != nil {
 				t.Errorf("unexpected error when using beta field: %s", err)
 			}

--- a/pkg/apis/pipeline/v1/taskref_validation_test.go
+++ b/pkg/apis/pipeline/v1/taskref_validation_test.go
@@ -92,6 +92,7 @@ func TestTaskRef_Invalid(t *testing.T) {
 				Resolver: "git",
 			},
 		},
+		wc:      config.EnableStableAPIFields,
 		wantErr: apis.ErrGeneric("resolver requires \"enable-api-fields\" feature gate to be \"alpha\" or \"beta\" but it is \"stable\""),
 	}, {
 		name: "taskref params disallowed without beta feature gate",
@@ -100,6 +101,7 @@ func TestTaskRef_Invalid(t *testing.T) {
 				Params: v1.Params{},
 			},
 		},
+		wc:      config.EnableStableAPIFields,
 		wantErr: apis.ErrMissingField("resolver").Also(apis.ErrGeneric("resolver params requires \"enable-api-fields\" feature gate to be \"alpha\" or \"beta\" but it is \"stable\"")),
 	}, {
 		name: "taskref params disallowed without resolver",

--- a/pkg/apis/pipeline/v1/taskrun_validation_test.go
+++ b/pkg/apis/pipeline/v1/taskrun_validation_test.go
@@ -640,6 +640,7 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 				Breakpoint: []string{"onFailure"},
 			},
 		},
+		wc:      config.EnableStableAPIFields,
 		wantErr: apis.ErrGeneric("debug requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\""),
 	}, {
 		name: "invalid breakpoint",
@@ -666,6 +667,7 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 				},
 			}},
 		},
+		wc:      config.EnableStableAPIFields,
 		wantErr: apis.ErrGeneric("stepSpecs requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\""),
 	}, {
 		name: "sidecarSpec disallowed without alpha feature gate",
@@ -680,6 +682,7 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 				},
 			}},
 		},
+		wc:      config.EnableStableAPIFields,
 		wantErr: apis.ErrGeneric("sidecarSpecs requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\""),
 	}, {
 		name: "duplicate stepSpecs names",
@@ -776,6 +779,7 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 				},
 			},
 		},
+		wc:      config.EnableStableAPIFields,
 		wantErr: apis.ErrGeneric("computeResources requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\""),
 	}}
 

--- a/pkg/apis/pipeline/v1/workspace_validation_test.go
+++ b/pkg/apis/pipeline/v1/workspace_validation_test.go
@@ -186,6 +186,7 @@ func TestWorkspaceBindingValidateInvalid(t *testing.T) {
 				Driver: "csi-driver",
 			},
 		},
+		wc: config.EnableStableAPIFields,
 	}, {
 		name: "Provide csi without a driver",
 		binding: &v1.WorkspaceBinding{

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_validation_test.go
@@ -1065,7 +1065,8 @@ func TestPipelineRunSpec_Invalidate(t *testing.T) {
 				},
 			},
 		},
-		wantErr: apis.ErrGeneric("stepOverrides requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\"").ViaIndex(0).ViaField("taskRunSpecs"),
+		withContext: config.EnableStableAPIFields,
+		wantErr:     apis.ErrGeneric("stepOverrides requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\"").ViaIndex(0).ViaField("taskRunSpecs"),
 	}, {
 		name: "sidecarOverride disallowed without alpha feature gate",
 		spec: v1beta1.PipelineRunSpec{
@@ -1082,7 +1083,8 @@ func TestPipelineRunSpec_Invalidate(t *testing.T) {
 				},
 			},
 		},
-		wantErr: apis.ErrGeneric("sidecarOverrides requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\"").ViaIndex(0).ViaField("taskRunSpecs"),
+		withContext: config.EnableStableAPIFields,
+		wantErr:     apis.ErrGeneric("sidecarOverrides requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\"").ViaIndex(0).ViaField("taskRunSpecs"),
 	}, {
 		name: "missing stepOverride name",
 		spec: v1beta1.PipelineRunSpec{
@@ -1169,7 +1171,8 @@ func TestPipelineRunSpec_Invalidate(t *testing.T) {
 				},
 			},
 		},
-		wantErr: apis.ErrGeneric("computeResources requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\"").ViaIndex(0).ViaField("taskRunSpecs"),
+		withContext: config.EnableStableAPIFields,
+		wantErr:     apis.ErrGeneric("computeResources requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\"").ViaIndex(0).ViaField("taskRunSpecs"),
 	}}
 
 	for _, ps := range tests {

--- a/pkg/apis/pipeline/v1beta1/taskrun_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_validation_test.go
@@ -628,6 +628,7 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 				Breakpoint: []string{"onFailure"},
 			},
 		},
+		wc:      config.EnableStableAPIFields,
 		wantErr: apis.ErrGeneric("debug requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\""),
 	}, {
 		name: "invalid breakpoint",
@@ -654,6 +655,7 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 				},
 			}},
 		},
+		wc:      config.EnableStableAPIFields,
 		wantErr: apis.ErrGeneric("stepOverrides requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\""),
 	}, {
 		name: "sidecarOverride disallowed without alpha feature gate",
@@ -668,6 +670,7 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 				},
 			}},
 		},
+		wc:      config.EnableStableAPIFields,
 		wantErr: apis.ErrGeneric("sidecarOverrides requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\""),
 	}, {
 		name: "duplicate stepOverride names",
@@ -764,6 +767,7 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 				},
 			},
 		},
+		wc:      config.EnableStableAPIFields,
 		wantErr: apis.ErrGeneric("computeResources requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\""),
 	}, {
 		name: "uses resources",

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -4597,7 +4597,7 @@ status:
   provenance:
     featureFlags:
       RunningInEnvWithInjectedSidecars: true
-      EnableAPIFields: "stable"
+      EnableAPIFields: "beta"
       AwaitSidecarReadiness: true
       VerificationNoMatchPolicy: "ignore"
       EnableProvenanceInStatus: true
@@ -4754,7 +4754,7 @@ status:
   provenance:
     featureFlags:
       RunningInEnvWithInjectedSidecars: true
-      EnableAPIFields: "stable"
+      EnableAPIFields: "beta"
       AwaitSidecarReadiness: true
       VerificationNoMatchPolicy: "ignore"
       EnableProvenanceInStatus: true

--- a/pkg/reconciler/pipelinerun/resources/pipelineref_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelineref_test.go
@@ -288,7 +288,7 @@ func TestGetPipelineFuncSpecAlreadyFetched(t *testing.T) {
 }
 
 func TestGetPipelineFunc_RemoteResolution(t *testing.T) {
-	ctx := context.Background()
+	ctx := config.EnableStableAPIFields(context.Background())
 	cfg := config.FromContextOrDefaults(ctx)
 	ctx = config.ToContext(ctx, cfg)
 	pipelineRef := &v1beta1.PipelineRef{ResolverRef: v1beta1.ResolverRef{Resolver: "git"}}

--- a/pkg/reconciler/taskrun/resources/taskref_test.go
+++ b/pkg/reconciler/taskrun/resources/taskref_test.go
@@ -548,7 +548,7 @@ echo hello
 }
 
 func TestGetTaskFunc_RemoteResolution(t *testing.T) {
-	ctx := context.Background()
+	ctx := config.EnableStableAPIFields(context.Background())
 	cfg := config.FromContextOrDefaults(ctx)
 	ctx = config.ToContext(ctx, cfg)
 	taskRef := &v1beta1.TaskRef{ResolverRef: v1beta1.ResolverRef{Resolver: "git"}}

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -1721,7 +1721,7 @@ status:
   provenance:
     featureFlags:
       RunningInEnvWithInjectedSidecars: true
-      EnableAPIFields: "stable"
+      EnableAPIFields: "beta"
       AwaitSidecarReadiness: true
       VerificationNoMatchPolicy: "ignore"
       EnableProvenanceInStatus: true

--- a/test/custom_task_test.go
+++ b/test/custom_task_test.go
@@ -721,16 +721,26 @@ func resetConfigMap(ctx context.Context, t *testing.T, c *clients, namespace, co
 
 func getFeatureFlagsBaseOnAPIFlag(t *testing.T) *config.FeatureFlags {
 	t.Helper()
-	alphaFeatureFlags, _ := config.NewFeatureFlagsFromMap(map[string]string{
+	alphaFeatureFlags, err := config.NewFeatureFlagsFromMap(map[string]string{
 		"enable-api-fields":         "alpha",
 		"results-from":              "sidecar-logs",
 		"enable-tekton-oci-bundles": "true",
 	})
-	betaFeatureFlags, _ := config.NewFeatureFlagsFromMap(map[string]string{
+	if err != nil {
+		t.Fatalf("error creating alpha feature flags configmap: %v", err)
+	}
+	betaFeatureFlags, err := config.NewFeatureFlagsFromMap(map[string]string{
 		"enable-api-fields": "beta",
 	})
-	stableFeatureFlags := config.DefaultFeatureFlags.DeepCopy()
-
+	if err != nil {
+		t.Fatalf("error creating beta feature flags configmap: %v", err)
+	}
+	stableFeatureFlags, err := config.NewFeatureFlagsFromMap(map[string]string{
+		"enable-api-fields": "stable",
+	})
+	if err != nil {
+		t.Fatalf("error creating stable feature flags configmap: %v", err)
+	}
 	enabledFeatureGate, err := getAPIFeatureGate()
 	if err != nil {
 		t.Fatalf("error reading enabled feature gate: %v", err)


### PR DESCRIPTION
When users decide to upgrade to v1 APIs, they may not be aware they are using beta features. If they are using the default value ("stable") of "enable-api-fields", any beta features they're using will work in beta APIs, but break when when move to v1 APIs.

This commit changes the default value of "enable-api-fields" to "beta", to ensure beta features continue to work by default when users change API versions. Independently, we plan to decouple API versioning from feature versioning (https://github.com/tektoncd/pipeline/issues/6592).

This commit will also help avoid breakages when swapping our storage version to v1 due to the issue described [here](https://github.com/tektoncd/pipeline/pull/6444#issuecomment-1580926707).

This commit is not backwards compatible.

Related: https://github.com/tektoncd/pipeline/issues/6616

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
action required: "enable-api-fields" is set to "beta" by default. If you are using v1 APIs and would like to use only stable features, modify the "feature-flags" configmap in the "tekton-pipelines" namespace to set "enable-api-fields" to "stable". Example command: kubectl patch cm feature-flags -n tekton-pipelines -p '{"data":{"enable-api-fields":"stable"}}'
If you are using v1beta1 APIs, no action is needed.
```
