### PR TITLE
add taskrun gauge metrics for k8s throttling because of defined resource quotas or k8s node constraints

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -20,6 +20,8 @@ We expose several kinds of exporters, including Prometheus, Google Stackdriver, 
 | `tekton_pipelines_controller_taskrun_duration_seconds_[bucket, sum, count]` | Histogram/LastValue(Gauge) | `status`=&lt;status&gt; <br> `*task`=&lt;task_name&gt; <br> `*taskrun`=&lt;taskrun_name&gt;<br> `namespace`=&lt;pipelineruns-taskruns-namespace&gt; | experimental |
 | `tekton_pipelines_controller_taskrun_count` | Counter | `status`=&lt;status&gt; | experimental |
 | `tekton_pipelines_controller_running_taskruns_count` | Gauge | | experimental |
+| `tekton_pipelines_controller_running_taskruns_throttled_by_quota_count` | Gauge | | experimental |
+| `tekton_pipelines_controller_running_taskruns_throttled_by_node_count`  | Gauge | | experimental |
 | `tekton_pipelines_controller_taskruns_pod_latency` | Gauge | `namespace`=&lt;taskruns-namespace&gt; <br> `pod`= &lt; taskrun_pod_name&gt; <br> `*task`=&lt;task_name&gt; <br> `*taskrun`=&lt;taskrun_name&gt;<br> | experimental |
 | `tekton_pipelines_controller_cloudevent_count` | Counter | `*pipeline`=&lt;pipeline_name&gt; <br> `*pipelinerun`=&lt;pipelinerun_name&gt; <br> `status`=&lt;status&gt; <br> `*task`=&lt;task_name&gt; <br> `*taskrun`=&lt;taskrun_name&gt;<br> `namespace`=&lt;pipelineruns-taskruns-namespace&gt;| experimental |
 | `tekton_pipelines_controller_client_latency_[bucket, sum, count]` | Histogram | | experimental |

--- a/pkg/taskrunmetrics/metrics.go
+++ b/pkg/taskrunmetrics/metrics.go
@@ -27,6 +27,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	listers "github.com/tektoncd/pipeline/pkg/client/listers/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/pkg/pod"
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
@@ -51,12 +52,14 @@ var (
 	statusTag      = tag.MustNewKey("status")
 	podTag         = tag.MustNewKey("pod")
 
-	trDurationView      *view.View
-	prTRDurationView    *view.View
-	trCountView         *view.View
-	runningTRsCountView *view.View
-	podLatencyView      *view.View
-	cloudEventsView     *view.View
+	trDurationView                      *view.View
+	prTRDurationView                    *view.View
+	trCountView                         *view.View
+	runningTRsCountView                 *view.View
+	runningTRsThrottledByQuotaCountView *view.View
+	runningTRsThrottledByNodeCountView  *view.View
+	podLatencyView                      *view.View
+	cloudEventsView                     *view.View
 
 	trDuration = stats.Float64(
 		"taskrun_duration_seconds",
@@ -74,6 +77,14 @@ var (
 
 	runningTRsCount = stats.Float64("running_taskruns_count",
 		"Number of taskruns executing currently",
+		stats.UnitDimensionless)
+
+	runningTRsThrottledByQuotaCount = stats.Float64("running_taskruns_throttled_by_quota_count",
+		"Number of taskruns executing currently, but whose underlying Pods or Containers are suspended by k8s because of defined ResourceQuotas.  Such suspensions can occur as part of initial scheduling of the Pod, or scheduling of any of the subsequent Container(s) in the Pod after the first Container is started",
+		stats.UnitDimensionless)
+
+	runningTRsThrottledByNodeCount = stats.Float64("running_taskruns_throttled_by_node_count",
+		"Number of taskruns executing currently, but whose underlying Pods or Containers are suspended by k8s because of Node level constraints. Such suspensions can occur as part of initial scheduling of the Pod, or scheduling of any of the subsequent Container(s) in the Pod after the first Container is started",
 		stats.UnitDimensionless)
 
 	podLatency = stats.Float64("taskruns_pod_latency",
@@ -203,6 +214,16 @@ func viewRegister(cfg *config.Metrics) error {
 		Measure:     runningTRsCount,
 		Aggregation: view.LastValue(),
 	}
+	runningTRsThrottledByQuotaCountView = &view.View{
+		Description: runningTRsThrottledByQuotaCount.Description(),
+		Measure:     runningTRsThrottledByQuotaCount,
+		Aggregation: view.LastValue(),
+	}
+	runningTRsThrottledByNodeCountView = &view.View{
+		Description: runningTRsThrottledByNodeCount.Description(),
+		Measure:     runningTRsThrottledByNodeCount,
+		Aggregation: view.LastValue(),
+	}
 	podLatencyView = &view.View{
 		Description: podLatency.Description(),
 		Measure:     podLatency,
@@ -220,6 +241,8 @@ func viewRegister(cfg *config.Metrics) error {
 		prTRDurationView,
 		trCountView,
 		runningTRsCountView,
+		runningTRsThrottledByQuotaCountView,
+		runningTRsThrottledByNodeCountView,
 		podLatencyView,
 		cloudEventsView,
 	)
@@ -231,6 +254,8 @@ func viewUnregister() {
 		prTRDurationView,
 		trCountView,
 		runningTRsCountView,
+		runningTRsThrottledByQuotaCountView,
+		runningTRsThrottledByNodeCountView,
 		podLatencyView,
 		cloudEventsView,
 	)
@@ -344,9 +369,21 @@ func (r *Recorder) RunningTaskRuns(ctx context.Context, lister listers.TaskRunLi
 	}
 
 	var runningTrs int
+	var trsThrottledByQuota int
+	var trsThrottledByNode int
 	for _, pr := range trs {
-		if !pr.IsDone() {
-			runningTrs++
+		if pr.IsDone() {
+			continue
+		}
+		runningTrs++
+		succeedCondition := pr.Status.GetCondition(apis.ConditionSucceeded)
+		if succeedCondition != nil && succeedCondition.Status == corev1.ConditionUnknown {
+			switch succeedCondition.Reason {
+			case pod.ReasonExceededResourceQuota:
+				trsThrottledByQuota++
+			case pod.ReasonExceededNodeResources:
+				trsThrottledByNode++
+			}
 		}
 	}
 
@@ -355,6 +392,8 @@ func (r *Recorder) RunningTaskRuns(ctx context.Context, lister listers.TaskRunLi
 		return err
 	}
 	metrics.Record(ctx, runningTRsCount.M(float64(runningTrs)))
+	metrics.Record(ctx, runningTRsThrottledByNodeCount.M(float64(trsThrottledByNode)))
+	metrics.Record(ctx, runningTRsThrottledByQuotaCount.M(float64(trsThrottledByQuota)))
 
 	return nil
 }
@@ -374,7 +413,7 @@ func (r *Recorder) ReportRunningTaskRuns(ctx context.Context, lister listers.Tas
 			return
 
 		case <-delay.C:
-			// Every 30s surface a metric for the number of running tasks.
+			// Every 30s surface a metric for the number of running tasks, as well as those running tasks that are currently throttled by k8s.
 			if err := r.RunningTaskRuns(ctx, lister); err != nil {
 				logger.Warnf("Failed to log the metrics : %v", err)
 			}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Fixes https://github.com/tektoncd/pipeline/issues/6631

/kind feature

This commit adds a new experimental gauge metrics that counts the number of TaskRuns whose
underlying Pods are currently not scheduled to run by Kubernetes:
 - one metric counts when Kubernetes ResourceQuota policies within a Namespace prevent scheduling
 - a second metric counts when underlying Node level CPU or Memory utilization are such that the underlying Pod
    cannot be scheduled


# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ /] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ /] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [/ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [/ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [/ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [n/a ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
A new gauge metric for both PipelineRun and TaskRun will indicate whether underlying Pods are being throttled by Kubernetes because of either ResourceQuota policies defined in the namespace, or because the underlying node is experiencing resource constraints.
```

@vdemeester @khrm ptal