### PR TITLE
Issue#6697 Fix tab formatting for documentation

### DIFF
--- a/docs/pipelineruns.md
+++ b/docs/pipelineruns.md
@@ -160,7 +160,7 @@ You can reference a `Tekton bundle` in a `TaskRef` in both `v1` and `v1beta1` us
 In `v1beta1`, you can also reference a `Tekton bundle` using OCI bundle syntax, which has been deprecated in favor of remote resolution. The example shown below for `v1beta1` uses OCI bundle syntax, and requires enabling `enable-tekton-oci-bundles: "true"` feature flag.
 
 {{< tabs >}}
-{{< tab "v1 & v1beta1" >}}
+{{% tab "v1 & v1beta1" %}}
 ```yaml
 spec:
   pipelineRef:
@@ -173,16 +173,16 @@ spec:
     - name: kind
       value: Pipeline
 ```
-{{< /tab >}}
+{{% /tab %}}
 
-{{< tab "v1beta1" >}}
+{{% tab "v1beta1" %}}
  ```yaml
  spec:
    pipelineRef:
      name: mypipeline
      bundle: docker.io/myrepo/mycatalog:v1.0
  ```
-{{< /tab >}}
+{{% /tab %}}
 {{< /tabs >}}
 
 The syntax and caveats are similar to using `Tekton Bundles` for  `Task` references
@@ -706,7 +706,7 @@ map a specific `serviceAccountName` value to a specific `Task` in the `Pipeline`
 For example, if you specify these mappings:
 
 {{< tabs >}}
-{{< tab "v1" >}}
+{{% tab "v1" %}}
 ```yaml
 spec:
   taskRunTemplate:
@@ -715,9 +715,9 @@ spec:
     - pipelineTaskName: build-task
       serviceAccountName: sa-for-build
 ```
-{{< /tab >}}
+{{% /tab %}}
 
-{{< tab "v1beta1" >}}
+{{% tab "v1beta1" %}}
 ```yaml
 spec:
   serviceAccountName: sa-1
@@ -725,7 +725,7 @@ spec:
     - pipelineTaskName: build-task
       taskServiceAccountName: sa-for-build
 ```
-{{< /tab >}}
+{{% /tab %}}
 {{< /tabs >}}
 
 for this `Pipeline`:
@@ -754,7 +754,7 @@ In the following example, the `Task` defines a `volumeMount` object named `my-ca
 provisions this object for the `Task` using a `persistentVolumeClaim` and executes it as user 1001.
 
 {{< tabs >}}
-{{< tab "v1" >}}
+{{% tab "v1" %}}
 ```yaml
 apiVersion: tekton.dev/v1
 kind: Task
@@ -797,9 +797,9 @@ spec:
           persistentVolumeClaim:
             claimName: my-volume-claim
 ```
-{{< /tab >}}
+{{% /tab %}}
 
-{{< tab "v1beta1" >}}
+{{% tab "v1beta1" %}}
 ```yaml
 apiVersion: tekton.dev/v1beta1
 kind: Task
@@ -841,7 +841,7 @@ spec:
         persistentVolumeClaim:
           claimName: my-volume-claim
 ```
-{{< /tab >}}
+{{% /tab %}}
 {{< /tabs >}}
 
 [`Custom tasks`](pipelines.md#using-custom-tasks) may or may not use a pod template.
@@ -856,7 +856,7 @@ wide `ServiceAccountName`  and [`podTemplate`](./podtemplates.md) configuration,
 for example:
 
 {{< tabs >}}
-{{< tab "v1" >}}
+{{% tab "v1" %}}
 ```yaml
 spec:
   podTemplate:
@@ -871,9 +871,9 @@ spec:
         nodeSelector:
           disktype: ssd
 ```
-{{< /tab >}}
+{{% /tab %}}
 
-{{< tab "v1beta1" >}}
+{{% tab "v1beta1" %}}
 ```yaml
 spec:
   podTemplate:
@@ -888,7 +888,7 @@ spec:
         nodeSelector:
           disktype: ssd
 ```
-{{< /tab >}}
+{{% /tab %}}
 {{< /tabs >}}
 
 If used with this `Pipeline`,  `build-task` will use the task specific `PodTemplate` (where `nodeSelector` has `disktype` equal to `ssd`).

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -395,7 +395,7 @@ In `v1beta1`, you can also reference a `Tekton bundle` using OCI bundle syntax, 
 
 
 {{< tabs >}}
-{{< tab "v1 & v1beta1" >}}
+{{% tab "v1 & v1beta1" %}}
 ```yaml
 spec:
   taskRef:
@@ -408,9 +408,9 @@ spec:
     - name: kind
       value: Task
 ```
-{{< /tab >}}
+{{% /tab %}}
 
-{{< tab "v1beta1" >}}
+{{% tab "v1beta1" %}}
 ```yaml
 spec:
   tasks:
@@ -419,7 +419,7 @@ spec:
         name: echo-task
         bundle: docker.com/myrepo/mycatalog
 ```
-{{< /tab >}}
+{{% /tab %}}
 {{< /tabs >}}
 
 Here, the `bundle` field is the full reference url to the artifact. The name is the
@@ -429,7 +429,7 @@ You may also specify a `tag` as you would with a Docker image which will give yo
 repeatable reference to a `Task`.
 
 {{< tabs >}}
-{{< tab "v1 & v1beta1" >}}
+{{% tab "v1 & v1beta1" %}}
 ```yaml
 spec:
   taskRef:
@@ -442,9 +442,9 @@ spec:
     - name: kind
       value: Task
 ```
-{{< /tab >}}
+{{% /tab %}}
 
-{{< tab "v1beta1" >}}
+{{% tab "v1beta1" %}}
 ```yaml
 spec:
   tasks:
@@ -453,13 +453,13 @@ spec:
         name: echo-task
         bundle: docker.com/myrepo/mycatalog:v1.0.1
 ```
-{{< /tab >}}
+{{% /tab %}}
 {{< /tabs >}}
 
 You may also specify a fixed digest instead of a tag.
 
 {{< tabs >}}
-{{< tab "v1 & v1beta1" >}}
+{{% tab "v1 & v1beta1" %}}
 ```yaml
 spec:
   taskRef:
@@ -472,9 +472,9 @@ spec:
     - name: kind
       value: Task
 ```
-{{< /tab >}}
+{{% /tab %}}
 
-{{< tab "v1beta1" >}}
+{{% tab "v1beta1" %}}
 ```yaml
 spec:
   tasks:
@@ -483,7 +483,7 @@ spec:
         name: echo-task
         bundle: docker.io/myrepo/mycatalog@sha256:abc123
 ```
-{{< /tab >}}
+{{% /tab %}}
 {{< /tabs >}}
 
 Any of the above options will fetch the image using the `ImagePullSecrets` attached to the

--- a/docs/taskruns.md
+++ b/docs/taskruns.md
@@ -121,7 +121,7 @@ You can reference a `Tekton bundle` in a `TaskRef` in both `v1` and `v1beta1` us
 In `v1beta1`, you can also reference a `Tekton bundle` using OCI bundle syntax, which has been deprecated in favor of remote resolution. The example shown below for `v1beta1` uses OCI bundle syntax, and requires enabling `enable-tekton-oci-bundles: "true"` feature flag.
 
 {{< tabs >}}
-{{< tab "v1 & v1beta1" >}}
+{{% tab "v1 & v1beta1" %}}
 ```yaml
 spec:
   taskRef:
@@ -134,16 +134,16 @@ spec:
     - name: kind
       value: Task
 ```
-{{< /tab >}}
+{{% /tab %}}
 
-{{< tab "v1beta1" >}}
+{{% tab "v1beta1" %}}
 ```yaml
 spec:
 taskRef:
   name: echo-task
   bundle: docker.io/myrepo/mycatalog
 ```
-{{< /tab >}}
+{{% /tab %}}
 {{< /tabs >}}
 
 Here, the `bundle` field is the full reference url to the artifact. The name is the
@@ -152,7 +152,7 @@ Here, the `bundle` field is the full reference url to the artifact. The name is 
 You may also specify a `tag` as you would with a Docker image which will give you a repeatable reference to a `Task`.
 
 {{< tabs >}}
-{{< tab "v1 & v1beta1" >}}
+{{% tab "v1 & v1beta1" %}}
 ```yaml
 spec:
   taskRef:
@@ -165,22 +165,22 @@ spec:
     - name: kind
       value: Task
 ```
-{{< /tab >}}
+{{% /tab %}}
 
-{{< tab "v1beta1" >}}
+{{% tab "v1beta1" %}}
 ```yaml
 spec:
 taskRef:
   name: echo-task
   bundle: docker.io/myrepo/mycatalog:v1.0.1
 ```
-{{< /tab >}}
+{{% /tab %}}
 {{< /tabs >}}
 
 You may also specify a fixed digest instead of a tag which ensures the referenced task is constant.
 
 {{< tabs >}}
-{{< tab "v1 & v1beta1" >}}
+{{% tab "v1 & v1beta1" %}}
 ```yaml
 spec:
   taskRef:
@@ -193,16 +193,16 @@ spec:
     - name: kind
       value: Task
 ```
-{{< /tab >}}
+{{% /tab %}}
 
-{{< tab "v1beta1" >}}
+{{% tab "v1beta1" %}}
 ```yaml
 spec:
 taskRef:
   name: echo-task
   bundle: docker.io/myrepo/mycatalog@sha256:abc123
 ```
-{{< /tab >}}
+{{% /tab %}}
 {{< /tabs >}}
 
 A working example can be found [here](../examples/v1beta1/taskruns/no-ci/tekton-bundles.yaml).
@@ -657,7 +657,7 @@ spec:
 An example TaskRun definition could look like:
 
 {{< tabs >}}
-{{< tab "v1" >}}
+{{% tab "v1" %}}
 ```yaml
 apiVersion: tekton.dev/v1
 kind: TaskRun
@@ -679,9 +679,9 @@ spec:
         limits:
           cpu: 500m
 ```
-{{< /tab>}}
+{{% /tab %}}
 
-{{< tab "v1beta1" >}}
+{{% tab "v1beta1" %}}
 ```yaml
 apiVersion: tekton.dev/v1beta1
 kind: TaskRun
@@ -703,7 +703,7 @@ spec:
         limits:
           cpu: 500m
 ```
-{{< /tab>}}
+{{% /tab %}}
 {{< /tabs >}}
 `StepSpecs` and `SidecarSpecs` must include the `name` field and may include `resources`.
 No other fields can be overridden.

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -137,7 +137,7 @@ Below is an example of a Pipeline declaration that uses a `ClusterTask`:
 - The cluster resolver syntax below can be used to reference any task, not just a clustertask.
 
 {{< tabs >}}
-{{< tab header="v1 & v1beta1" code=true lang="yaml" >}}
+{{% tab header="v1 & v1beta1" %}}
 ```yaml
 apiVersion: tekton.dev/v1
 kind: Pipeline
@@ -156,9 +156,9 @@ spec:
         - name: namespace
           value: default
 ```
-{{< /tab >}}
+{{% /tab %}}
 
-{{< tab header="v1beta1" code=true lang="yaml" >}}
+{{% tab header="v1beta1" %}}
 ```yaml
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline
@@ -173,7 +173,7 @@ spec:
         kind: ClusterTask
       params: ....
 ```
-{{< /tab >}}
+{{% /tab %}}
 {{< /tabs >}}
 
 ### Defining `Steps`
@@ -201,7 +201,7 @@ Below is an example of setting the resource requests and limits for a step:
 
 
 {{< tabs >}}
-{{< tab header="v1" code=true lang="yaml" >}}
+{{% tab header="v1" %}}
 ```yaml
 spec:
   steps:
@@ -214,9 +214,9 @@ spec:
           memory: 2Gi
           cpu: 800m
 ```
-{{< /tab >}}
+{{% /tab %}}
 
-{{< tab header="v1beta1" code=true lang="yaml" >}}
+{{% tab header="v1beta1" %}}
 ```yaml
 spec:
   steps:
@@ -229,7 +229,7 @@ spec:
           memory: 2Gi
           cpu: 800m
 ```
-{{< /tab >}}
+{{% /tab %}}
 {{< /tabs >}}
 
 #### Reserved directories
@@ -790,7 +790,7 @@ When this Task is executed in a TaskRun, the results will appear in the TaskRun'
 
 
 {{< tabs >}}
-{{< tab header="v1" code=true lang="yaml" >}}
+{{% tab header="v1" %}}
 ```yaml
 apiVersion: tekton.dev/v1
 kind: TaskRun
@@ -805,9 +805,9 @@ status:
       value: |
         1579722445
 ```
-{{< /tab >}}
+{{% /tab %}}
 
-{{< tab header="v1beta1" code=true lang="yaml" >}}
+{{% tab header="v1beta1" %}}
 ```yaml
 apiVersion: tekton.dev/v1beta1
 kind: TaskRun
@@ -822,7 +822,7 @@ status:
       value: |
         1579722445
 ```
-{{< /tab >}}
+{{% /tab %}}
 {{< /tabs >}}
 
 Tekton does not perform any processing on the contents of results; they are emitted


### PR DESCRIPTION
Prior to this, tabs were not rendered correctly as indicated in issue https://github.com/tektoncd/pipeline/issues/6697. This PR fixes the tab notation according to stype suggested in https://learn.netlify.app/en/shortcodes/tabs/.

This PR fixes https://github.com/tektoncd/pipeline/issues/6697 and https://github.com/tektoncd/website/issues/549

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
