### PR TITLE
[TEP-0091] update taskrun and pipelinerun condition based on VerificationResult

### DIFF
--- a/docs/trusted-resources.md
+++ b/docs/trusted-resources.md
@@ -73,6 +73,49 @@ Or patch the new values:
 kubectl patch configmap feature-flags -n tekton-pipelines -p='{"data":{"trusted-resources-verification-no-match-policy":"fail"}}
 ```
 
+ #### TaskRun and PipelineRun status update
+Trusted resources will update the taskrun's [condition](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties) to indicate if it passes verification or not.
+
+The following tables illustrate how the conditions are impacted by feature flag and verification result. Note that if not `true` or `false` means this case doesn't update the corresponding condition.
+**No Matching Policies:**
+|                             | `Conditions.TrustedResourcesVerified` | `Conditions.Succeeded` |
+|-----------------------------|---------------------------------------|------------------------|
+| `no-match-policy`: "ignore" |                                       |                        |
+| `no-match-policy`: "warn"   | False                                 |                        |
+| `no-match-policy`: "fail"   | False                                 | False                  |
+
+**Matching Policies(no matter what `trusted-resources-verification-no-match-policy` value is):**
+|                          | `Conditions.TrustedResourcesVerified` | `Conditions.Succeeded` |
+|--------------------------|---------------------------------------|------------------------|
+| all policies pass        | True                                  |                        |
+| any enforce policy fails | False                                 | False                  |
+| only warn policies fail  | False                                 |                        |
+
+
+A successful sample `TrustedResourcesVerified` condition is:
+```yaml
+status:
+  conditions:
+  - lastTransitionTime: "2023-03-01T18:17:05Z"
+    message: Trusted resource verification passed
+    status: "True"
+    type: TrustedResourcesVerified
+```
+
+Failed sample `TrustedResourcesVerified` and `Succeeded` conditions are:
+```yaml
+status:
+  conditions:
+  - lastTransitionTime: "2023-03-01T18:17:05Z"
+    message: resource verification failed # This will be filled with detailed error message.
+    status: "False"
+    type: TrustedResourcesVerified
+  - lastTransitionTime: "2023-03-01T18:17:10Z"
+    message: resource verification failed
+    status: "False"
+    type: Succeeded
+```
+
 #### Config key at VerificationPolicy
 VerificationPolicy supports SecretRef or encoded public key data.
 

--- a/pkg/trustedresources/verify.go
+++ b/pkg/trustedresources/verify.go
@@ -33,12 +33,15 @@ import (
 	"github.com/tektoncd/pipeline/pkg/trustedresources/verifier"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"knative.dev/pkg/apis"
 	"knative.dev/pkg/logging"
 )
 
 const (
 	// SignatureAnnotation is the key of signature in annotation map
 	SignatureAnnotation = "tekton.dev/signature"
+	// ConditionTrustedResourcesVerified specifies that the resources pass trusted resources verification or not.
+	ConditionTrustedResourcesVerified apis.ConditionType = "TrustedResourcesVerified"
 )
 
 const (
@@ -191,7 +194,7 @@ func verifyResource(ctx context.Context, resource metav1.Object, k8s kubernetes.
 	for _, p := range warnPolicies {
 		verifiers, err := verifier.FromPolicy(ctx, k8s, p)
 		if err != nil {
-			warn := fmt.Errorf("fails to get verifiers for resource %s from namespace %s: %w", resource.GetName(), resource.GetNamespace(), err)
+			warn := fmt.Errorf("failed to get verifiers for resource %s from namespace %s: %w", resource.GetName(), resource.GetNamespace(), err)
 			logger.Warnf(warn.Error())
 			return VerificationResult{VerificationResultType: VerificationWarn, Err: warn}
 		}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This commits updates taskrun and pipelinerun condition based on VerificationResult to add TrustedResourcesVerified condition. The condition will be marked as false if verification policy fails, or no matching policies when feature flag is set to fail. The condition will be set to true if verification passes. No condition is added when verification is skipped.

Last feature PR of https://github.com/tektoncd/pipeline/issues/6665

/kind feature

Signed-off-by: Yongxuan Zhang yongxuanzhang@google.com

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
TrustedResourcesVerified is added to TaskRun/PipelineRun status if trusted resources is enabled, the condition indicates the result of the verification.
```
