### PR TITLE
[TEP-0091] support remote v1 task verification

### DIFF
--- a/docs/trusted-resources.md
+++ b/docs/trusted-resources.md
@@ -14,7 +14,7 @@ weight: 312
 
 ## Overview
 
-Trusted Resources is a feature which can be used to sign Tekton Resources and verify them. Details of design can be found at [TEP--0091](https://github.com/tektoncd/community/blob/main/teps/0091-trusted-resources.md). This is an alpha feature and supports `v1beta1` version of  `Task` and `Pipeline`.
+Trusted Resources is a feature which can be used to sign Tekton Resources and verify them. Details of design can be found at [TEP--0091](https://github.com/tektoncd/community/blob/main/teps/0091-trusted-resources.md). This is an alpha feature and supports `v1beta1` version of  `Task` and `Pipeline` and `v1` `Task`.
 
 **Note**: Currently, trusted resources only support verifying Tekton resources that come from remote places i.e. git, OCI registry and Artifact Hub. To use [cluster resolver](./cluster-resolver.md) for in-cluster resources, make sure to set all default values for the resources before applied to cluster, because the mutating webhook will update the default fields if not given and fail the verification.
 

--- a/pkg/reconciler/taskrun/resources/taskref.go
+++ b/pkg/reconciler/taskrun/resources/taskref.go
@@ -177,7 +177,7 @@ func readRuntimeObjectAsTask(ctx context.Context, obj runtime.Object, k8s kubern
 	case *v1beta1.ClusterTask:
 		return convertClusterTaskToTask(*obj), nil, nil
 	case *v1.Task:
-		// TODO(#6356): Support V1 Task verification
+		vr := trustedresources.VerifyResource(ctx, obj, k8s, refSource, verificationPolicies)
 		// Validation of beta fields must happen before the V1 Task is converted into the storage version of the API.
 		// TODO(#6592): Decouple API versioning from feature versioning
 		if err := obj.Spec.ValidateBetaFields(ctx); err != nil {
@@ -192,7 +192,7 @@ func readRuntimeObjectAsTask(ctx context.Context, obj runtime.Object, k8s kubern
 		if err := t.ConvertFrom(ctx, obj); err != nil {
 			return nil, nil, fmt.Errorf("failed to convert obj %s into Task", obj.GetObjectKind().GroupVersionKind().String())
 		}
-		return t, nil, nil
+		return t, &vr, nil
 	}
 	return nil, nil, errors.New("resource is not a task")
 }

--- a/pkg/reconciler/taskrun/resources/taskref_test.go
+++ b/pkg/reconciler/taskrun/resources/taskref_test.go
@@ -17,7 +17,10 @@
 package resources_test
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -28,7 +31,9 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-containerregistry/pkg/registry"
+	"github.com/sigstore/sigstore/pkg/signature"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
+	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned/fake"
@@ -83,6 +88,24 @@ var (
 		},
 		EntryPoint: "foo/bar",
 	}
+	unsignedV1Task = pipelinev1.Task{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "tekton.dev/v1",
+			Kind:       "Task"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "task",
+			Annotations: map[string]string{"foo": "bar"},
+		},
+		Spec: pipelinev1.TaskSpec{
+			Steps: []pipelinev1.Step{{
+				Image: "ubuntu",
+				Name:  "echo",
+			}},
+		},
+	}
+	verificationResultCmp = cmp.Comparer(func(x, y trustedresources.VerificationResult) bool {
+		return x.VerificationResultType == y.VerificationResultType && (errors.Is(x.Err, y.Err) || errors.Is(y.Err, x.Err))
+	})
 )
 
 func TestGetTaskKind(t *testing.T) {
@@ -760,13 +783,8 @@ func TestGetTaskFunc_VerifyNoError(t *testing.T) {
 	}
 	noMatchPolicyRefSource := &v1beta1.RefSource{
 		URI: "abc.com",
-		Digest: map[string]string{
-			"sha1": "a123",
-		},
-		EntryPoint: "foo/bar",
 	}
-	resolvedUnmatched := test.NewResolvedResource(unsignedTaskBytes, nil, noMatchPolicyRefSource, nil)
-	requesterUnmatched := test.NewRequester(resolvedUnmatched, nil)
+	requesterUnmatched := bytesToRequester(unsignedTaskBytes, noMatchPolicyRefSource)
 
 	signedTask, err := test.GetSignedTask(unsignedTask, signer, "signed")
 	if err != nil {
@@ -778,19 +796,13 @@ func TestGetTaskFunc_VerifyNoError(t *testing.T) {
 	}
 	matchPolicyRefSource := &v1beta1.RefSource{
 		URI: "	https://github.com/tektoncd/catalog.git",
-		Digest: map[string]string{
-			"sha1": "a123",
-		},
-		EntryPoint: "foo/bar",
 	}
-	resolvedMatched := test.NewResolvedResource(signedTaskBytes, nil, matchPolicyRefSource, nil)
-	requesterMatched := test.NewRequester(resolvedMatched, nil)
+	requesterMatched := bytesToRequester(signedTaskBytes, matchPolicyRefSource)
 
 	warnPolicyRefSource := &v1beta1.RefSource{
 		URI: "	warnVP",
 	}
-	resolvedUnsignedMatched := test.NewResolvedResource(unsignedTaskBytes, nil, warnPolicyRefSource, nil)
-	requesterUnsignedMatched := test.NewRequester(resolvedUnsignedMatched, nil)
+	requesterUnsignedMatched := bytesToRequester(unsignedTaskBytes, warnPolicyRefSource)
 
 	taskRef := &v1beta1.TaskRef{ResolverRef: v1beta1.ResolverRef{Resolver: "git"}}
 
@@ -896,14 +908,8 @@ func TestGetTaskFunc_VerifyError(t *testing.T) {
 	}
 	matchPolicyRefSource := &v1beta1.RefSource{
 		URI: "https://github.com/tektoncd/catalog.git",
-		Digest: map[string]string{
-			"sha1": "a123",
-		},
-		EntryPoint: "foo/bar",
 	}
-
-	resolvedUnsigned := test.NewResolvedResource(unsignedTaskBytes, nil, matchPolicyRefSource, nil)
-	requesterUnsigned := test.NewRequester(resolvedUnsigned, nil)
+	requesterUnsigned := bytesToRequester(unsignedTaskBytes, matchPolicyRefSource)
 
 	signedTask, err := test.GetSignedTask(unsignedTask, signer, "signed")
 	if err != nil {
@@ -913,16 +919,10 @@ func TestGetTaskFunc_VerifyError(t *testing.T) {
 	if err != nil {
 		t.Fatal("fail to marshal task", err)
 	}
-
 	noMatchPolicyRefSource := &v1beta1.RefSource{
 		URI: "abc.com",
-		Digest: map[string]string{
-			"sha1": "a123",
-		},
-		EntryPoint: "foo/bar",
 	}
-	resolvedUnmatched := test.NewResolvedResource(signedTaskBytes, nil, noMatchPolicyRefSource, nil)
-	requesterUnmatched := test.NewRequester(resolvedUnmatched, nil)
+	requesterUnmatched := bytesToRequester(signedTaskBytes, noMatchPolicyRefSource)
 
 	modifiedTask := signedTask.DeepCopy()
 	modifiedTask.Annotations["random"] = "attack"
@@ -930,8 +930,7 @@ func TestGetTaskFunc_VerifyError(t *testing.T) {
 	if err != nil {
 		t.Fatal("fail to marshal task", err)
 	}
-	resolvedModified := test.NewResolvedResource(modifiedTaskBytes, nil, matchPolicyRefSource, nil)
-	requesterModified := test.NewRequester(resolvedModified, nil)
+	requesterModified := bytesToRequester(modifiedTaskBytes, matchPolicyRefSource)
 
 	taskRef := &v1beta1.TaskRef{ResolverRef: v1beta1.ResolverRef{Resolver: "git"}}
 
@@ -1011,6 +1010,264 @@ func TestGetTaskFunc_VerifyError(t *testing.T) {
 			}
 			if tc.expectedVerificationResultType != vr.VerificationResultType {
 				t.Errorf("VerificationResultType mismatch, want %d got %d", tc.expectedVerificationResultType, vr.VerificationResultType)
+			}
+		})
+	}
+}
+
+func TestGetTaskFunc_V1Task_VerifyNoError(t *testing.T) {
+	ctx := context.Background()
+	signer, _, k8sclient, vps := test.SetupVerificationPolicies(t)
+	tektonclient := fake.NewSimpleClientset()
+
+	v1beta1UnsignedTask := &v1beta1.Task{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Task",
+			APIVersion: "tekton.dev/v1beta1",
+		},
+	}
+	if err := v1beta1UnsignedTask.ConvertFrom(ctx, unsignedV1Task.DeepCopy()); err != nil {
+		t.Error(err)
+	}
+
+	unsignedTaskBytes, err := json.Marshal(unsignedV1Task)
+	if err != nil {
+		t.Fatal("fail to marshal task", err)
+	}
+	noMatchPolicyRefSource := &v1beta1.RefSource{
+		URI: "abc.com",
+	}
+	requesterUnmatched := bytesToRequester(unsignedTaskBytes, noMatchPolicyRefSource)
+
+	signedV1Task, err := getSignedV1Task(unsignedV1Task.DeepCopy(), signer, "signed")
+	if err != nil {
+		t.Fatal("fail to sign task", err)
+	}
+	v1beta1SignedTask := &v1beta1.Task{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Task",
+			APIVersion: "tekton.dev/v1beta1",
+		},
+	}
+	if err := v1beta1SignedTask.ConvertFrom(ctx, signedV1Task.DeepCopy()); err != nil {
+		t.Error(err)
+	}
+
+	signedTaskBytes, err := json.Marshal(signedV1Task)
+	if err != nil {
+		t.Fatal("fail to marshal task", err)
+	}
+	matchPolicyRefSource := &v1beta1.RefSource{
+		URI: "	https://github.com/tektoncd/catalog.git",
+	}
+	requesterMatched := bytesToRequester(signedTaskBytes, matchPolicyRefSource)
+
+	warnPolicyRefSource := &v1beta1.RefSource{
+		URI: "	warnVP",
+	}
+	requesterUnsignedMatched := bytesToRequester(unsignedTaskBytes, warnPolicyRefSource)
+
+	taskRef := &v1beta1.TaskRef{ResolverRef: v1beta1.ResolverRef{Resolver: "git"}}
+
+	testcases := []struct {
+		name                       string
+		requester                  *test.Requester
+		verificationNoMatchPolicy  string
+		policies                   []*v1alpha1.VerificationPolicy
+		expected                   runtime.Object
+		expectedRefSource          *v1beta1.RefSource
+		expectedVerificationResult *trustedresources.VerificationResult
+	}{{
+		name:                       "signed task with matching policy pass verification with enforce no match policy",
+		requester:                  requesterMatched,
+		verificationNoMatchPolicy:  config.FailNoMatchPolicy,
+		policies:                   vps,
+		expected:                   v1beta1SignedTask,
+		expectedRefSource:          matchPolicyRefSource,
+		expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationPass},
+	}, {
+		name:                       "signed task with matching policy pass verification with warn no match policy",
+		requester:                  requesterMatched,
+		verificationNoMatchPolicy:  config.WarnNoMatchPolicy,
+		policies:                   vps,
+		expected:                   v1beta1SignedTask,
+		expectedRefSource:          matchPolicyRefSource,
+		expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationPass},
+	}, {
+		name:                       "signed task with matching policy pass verification with ignore no match policy",
+		requester:                  requesterMatched,
+		verificationNoMatchPolicy:  config.IgnoreNoMatchPolicy,
+		policies:                   vps,
+		expected:                   v1beta1SignedTask,
+		expectedRefSource:          matchPolicyRefSource,
+		expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationPass},
+	}, {
+		name:                       "warn unsigned task without matching policies",
+		requester:                  requesterUnmatched,
+		verificationNoMatchPolicy:  config.WarnNoMatchPolicy,
+		policies:                   vps,
+		expected:                   v1beta1UnsignedTask,
+		expectedRefSource:          noMatchPolicyRefSource,
+		expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationWarn, Err: trustedresources.ErrNoMatchedPolicies},
+	}, {
+		name:                       "task fails warn mode policy return warn VerificationResult",
+		requester:                  requesterUnsignedMatched,
+		verificationNoMatchPolicy:  config.FailNoMatchPolicy,
+		policies:                   vps,
+		expected:                   v1beta1UnsignedTask,
+		expectedRefSource:          warnPolicyRefSource,
+		expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationWarn, Err: trustedresources.ErrResourceVerificationFailed},
+	}, {
+		name:                       "ignore unsigned task without matching policies",
+		requester:                  requesterUnmatched,
+		verificationNoMatchPolicy:  config.IgnoreNoMatchPolicy,
+		policies:                   vps,
+		expected:                   v1beta1UnsignedTask,
+		expectedRefSource:          noMatchPolicyRefSource,
+		expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationSkip},
+	},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx = test.SetupTrustedResourceConfig(ctx, tc.verificationNoMatchPolicy)
+			tr := &v1beta1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "trusted-resources"},
+				Spec: v1beta1.TaskRunSpec{
+					TaskRef:            taskRef,
+					ServiceAccountName: "default",
+				},
+			}
+			fn := resources.GetTaskFunc(ctx, k8sclient, tektonclient, tc.requester, tr, tr.Spec.TaskRef, "", "default", "default", tc.policies)
+
+			gotResolvedTask, gotRefSource, gotVerificationResult, err := fn(ctx, taskRef.Name)
+
+			if err != nil {
+				t.Fatalf("Received unexpected error ( %#v )", err)
+			}
+
+			if d := cmp.Diff(tc.expected, gotResolvedTask); d != "" {
+				t.Errorf("resolvedTask did not match: %s", diff.PrintWantGot(d))
+			}
+
+			if d := cmp.Diff(tc.expectedRefSource, gotRefSource); d != "" {
+				t.Errorf("configSources did not match: %s", diff.PrintWantGot(d))
+			}
+			if d := cmp.Diff(gotVerificationResult, tc.expectedVerificationResult, verificationResultCmp); d != "" {
+				t.Errorf("VerificationResult did not match:%s", diff.PrintWantGot(d))
+			}
+		})
+	}
+}
+
+func TestGetTaskFunc_V1Task_VerifyError(t *testing.T) {
+	ctx := context.Background()
+	signer, _, k8sclient, vps := test.SetupVerificationPolicies(t)
+	tektonclient := fake.NewSimpleClientset()
+
+	unsignedTaskBytes, err := json.Marshal(unsignedV1Task)
+	if err != nil {
+		t.Fatal("fail to marshal task", err)
+	}
+	matchPolicyRefSource := &v1beta1.RefSource{
+		URI: "https://github.com/tektoncd/catalog.git",
+	}
+
+	requesterUnsigned := bytesToRequester(unsignedTaskBytes, matchPolicyRefSource)
+
+	signedV1Task, err := getSignedV1Task(unsignedV1Task.DeepCopy(), signer, "signed")
+	if err != nil {
+		t.Fatal("fail to sign task", err)
+	}
+	signedTaskBytes, err := json.Marshal(signedV1Task)
+	if err != nil {
+		t.Fatal("fail to marshal task", err)
+	}
+	noMatchPolicyRefSource := &v1beta1.RefSource{
+		URI: "abc.com",
+	}
+	requesterUnmatched := bytesToRequester(signedTaskBytes, noMatchPolicyRefSource)
+
+	modifiedTask := signedV1Task.DeepCopy()
+	modifiedTask.Annotations["random"] = "attack"
+	modifiedTaskBytes, err := json.Marshal(modifiedTask)
+	if err != nil {
+		t.Fatal("fail to marshal task", err)
+	}
+	requesterModified := bytesToRequester(modifiedTaskBytes, matchPolicyRefSource)
+
+	taskRef := &v1beta1.TaskRef{ResolverRef: v1beta1.ResolverRef{Resolver: "git"}}
+
+	testcases := []struct {
+		name                       string
+		requester                  *test.Requester
+		verificationNoMatchPolicy  string
+		expected                   *v1beta1.Task
+		expectedErr                error
+		expectedVerificationResult *trustedresources.VerificationResult
+	}{{
+		name:                       "unsigned task fails verification with fail no match policy",
+		requester:                  requesterUnsigned,
+		verificationNoMatchPolicy:  config.FailNoMatchPolicy,
+		expected:                   nil,
+		expectedErr:                trustedresources.ErrResourceVerificationFailed,
+		expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationError, Err: trustedresources.ErrResourceVerificationFailed},
+	}, {
+		name:                       "unsigned task fails verification with warn no match policy",
+		requester:                  requesterUnsigned,
+		verificationNoMatchPolicy:  config.WarnNoMatchPolicy,
+		expected:                   nil,
+		expectedErr:                trustedresources.ErrResourceVerificationFailed,
+		expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationError, Err: trustedresources.ErrResourceVerificationFailed},
+	}, {
+		name:                       "unsigned task fails verification with ignore no match policy",
+		requester:                  requesterUnsigned,
+		verificationNoMatchPolicy:  config.IgnoreNoMatchPolicy,
+		expected:                   nil,
+		expectedErr:                trustedresources.ErrResourceVerificationFailed,
+		expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationError, Err: trustedresources.ErrResourceVerificationFailed},
+	}, {
+		name:                       "modified task fails verification with fail no match policy",
+		requester:                  requesterModified,
+		verificationNoMatchPolicy:  config.FailNoMatchPolicy,
+		expected:                   nil,
+		expectedErr:                trustedresources.ErrResourceVerificationFailed,
+		expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationError, Err: trustedresources.ErrResourceVerificationFailed},
+	}, {
+		name:                       "modified task fails verification with warn no match policy",
+		requester:                  requesterModified,
+		verificationNoMatchPolicy:  config.WarnNoMatchPolicy,
+		expected:                   nil,
+		expectedErr:                trustedresources.ErrResourceVerificationFailed,
+		expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationError, Err: trustedresources.ErrResourceVerificationFailed},
+	}, {
+		name:                       "modified task fails verification with ignore no match policy",
+		requester:                  requesterModified,
+		verificationNoMatchPolicy:  config.IgnoreNoMatchPolicy,
+		expected:                   nil,
+		expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationError, Err: trustedresources.ErrResourceVerificationFailed},
+	}, {
+		name:                       "unmatched task fails with verification fail no match policy",
+		requester:                  requesterUnmatched,
+		verificationNoMatchPolicy:  config.FailNoMatchPolicy,
+		expected:                   nil,
+		expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationError, Err: trustedresources.ErrNoMatchedPolicies},
+	},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx = test.SetupTrustedResourceConfig(ctx, tc.verificationNoMatchPolicy)
+			tr := &v1beta1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "trusted-resources"},
+				Spec: v1beta1.TaskRunSpec{
+					TaskRef:            taskRef,
+					ServiceAccountName: "default",
+				},
+			}
+			fn := resources.GetTaskFunc(ctx, k8sclient, tektonclient, tc.requester, tr, tr.Spec.TaskRef, "", "default", "default", vps)
+
+			_, _, gotVerificationResult, _ := fn(ctx, taskRef.Name)
+			if d := cmp.Diff(gotVerificationResult, tc.expectedVerificationResult, verificationResultCmp); d != "" {
+				t.Errorf("VerificationResult did not match:%s", diff.PrintWantGot(d))
 			}
 		})
 	}
@@ -1126,3 +1383,42 @@ spec:
   - name: array-result
     type: array
 `
+
+func bytesToRequester(data []byte, source *v1beta1.RefSource) *test.Requester {
+	resolved := test.NewResolvedResource(data, nil, source, nil)
+	requester := test.NewRequester(resolved, nil)
+	return requester
+}
+
+func getSignedV1Task(unsigned *pipelinev1.Task, signer signature.Signer, name string) (*pipelinev1.Task, error) {
+	signed := unsigned.DeepCopy()
+	signed.Name = name
+	if signed.Annotations == nil {
+		signed.Annotations = map[string]string{}
+	}
+	signature, err := signInterface(signer, signed)
+	if err != nil {
+		return nil, err
+	}
+	signed.Annotations[trustedresources.SignatureAnnotation] = base64.StdEncoding.EncodeToString(signature)
+	return signed, nil
+}
+
+func signInterface(signer signature.Signer, i interface{}) ([]byte, error) {
+	if signer == nil {
+		return nil, fmt.Errorf("signer is nil")
+	}
+	b, err := json.Marshal(i)
+	if err != nil {
+		return nil, err
+	}
+	h := sha256.New()
+	h.Write(b)
+
+	sig, err := signer.SignMessage(bytes.NewReader(h.Sum(nil)))
+	if err != nil {
+		return nil, err
+	}
+
+	return sig, nil
+}

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -17,8 +17,11 @@ limitations under the License.
 package taskrun
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http/httptest"
@@ -33,9 +36,11 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/go-containerregistry/pkg/registry"
+	"github.com/sigstore/sigstore/pkg/signature"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
+	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	resolutionv1beta1 "github.com/tektoncd/pipeline/pkg/apis/resolution/v1beta1"
@@ -4900,7 +4905,7 @@ status:
 	}
 }
 
-func TestReconcile_verifyResolvedTask_Success(t *testing.T) {
+func TestReconcile_verifyResolved_V1beta1Task_NoError(t *testing.T) {
 	resolverName := "foobar"
 	ts := parse.MustParseV1beta1Task(t, `
 metadata:
@@ -5047,7 +5052,7 @@ status:
 	}
 }
 
-func TestReconcile_verifyResolvedTask_Error(t *testing.T) {
+func TestReconcile_verifyResolved_V1beta1Task_Error(t *testing.T) {
 	resolverName := "foobar"
 	unsignedTask := parse.MustParseV1beta1Task(t, `
 metadata:
@@ -5155,6 +5160,261 @@ status:
 	}
 }
 
+func TestReconcile_verifyResolved_V1Task_NoError(t *testing.T) {
+	resolverName := "foobar"
+	ts := parse.MustParseV1Task(t, `
+metadata:
+  name: test-task
+  namespace: foo
+spec:
+  params:
+  - default: mydefault
+    name: myarg
+    type: string
+  steps:
+  - script: echo $(params.myarg)
+    image: myimage
+    name: mycontainer
+`)
+
+	signer, _, vps := test.SetupMatchAllVerificationPolicies(t, ts.Namespace)
+	signedTask, err := getSignedV1Task(ts, signer, "test-task")
+	if err != nil {
+		t.Fatal("fail to sign task", err)
+	}
+	signedTaskBytes, err := yaml.Marshal(signedTask)
+	if err != nil {
+		t.Fatal("fail to marshal task", err)
+	}
+
+	noMatchPolicy := []*v1alpha1.VerificationPolicy{{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "no-match",
+			Namespace: ts.Namespace,
+		},
+		Spec: v1alpha1.VerificationPolicySpec{
+			Resources: []v1alpha1.ResourcePattern{{Pattern: "no-match"}},
+		}}}
+	// warnPolicy doesn't contain keys so it will fail verification but doesn't fail the run
+	warnPolicy := []*v1alpha1.VerificationPolicy{{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "warn-policy",
+			Namespace: ts.Namespace,
+		},
+		Spec: v1alpha1.VerificationPolicySpec{
+			Resources: []v1alpha1.ResourcePattern{{Pattern: ".*"}},
+			Mode:      v1alpha1.ModeWarn,
+		}}}
+	tr := parse.MustParseV1beta1TaskRun(t, fmt.Sprintf(`
+metadata:
+  name: test-taskrun
+  namespace: foo
+spec:
+  params:
+  - name: myarg
+    value: foo
+  taskRef:
+    resolver: %s
+  serviceAccountName: default
+status:
+  podName: the-pod
+`, resolverName))
+
+	failNoMatchCondition := &apis.Condition{
+		Type:    trustedresources.ConditionTrustedResourcesVerified,
+		Status:  corev1.ConditionFalse,
+		Message: fmt.Sprintf("failed to get matched policies: %s: no matching policies are found for resource: %s against source: %s", trustedresources.ErrNoMatchedPolicies, ts.Name, ""),
+	}
+	passCondition := &apis.Condition{
+		Type:   trustedresources.ConditionTrustedResourcesVerified,
+		Status: corev1.ConditionTrue,
+	}
+	failNoKeysCondition := &apis.Condition{
+		Type:    trustedresources.ConditionTrustedResourcesVerified,
+		Status:  corev1.ConditionFalse,
+		Message: fmt.Sprintf("failed to get verifiers for resource %s from namespace %s: %s", ts.Name, ts.Namespace, verifier.ErrEmptyPublicKeys),
+	}
+	testCases := []struct {
+		name                          string
+		task                          []*v1beta1.Task
+		noMatchPolicy                 string
+		verificationPolicies          []*v1alpha1.VerificationPolicy
+		wantTrustedResourcesCondition *apis.Condition
+	}{{
+		name:                          "ignore no match policy",
+		noMatchPolicy:                 config.IgnoreNoMatchPolicy,
+		verificationPolicies:          noMatchPolicy,
+		wantTrustedResourcesCondition: nil,
+	}, {
+		name:                          "warn no match policy",
+		noMatchPolicy:                 config.WarnNoMatchPolicy,
+		verificationPolicies:          noMatchPolicy,
+		wantTrustedResourcesCondition: failNoMatchCondition,
+	}, {
+		name:                          "pass enforce policy",
+		noMatchPolicy:                 config.FailNoMatchPolicy,
+		verificationPolicies:          vps,
+		wantTrustedResourcesCondition: passCondition,
+	}, {
+		name:                          "only fail warn policy",
+		noMatchPolicy:                 config.FailNoMatchPolicy,
+		verificationPolicies:          warnPolicy,
+		wantTrustedResourcesCondition: failNoKeysCondition,
+	},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cms := []*corev1.ConfigMap{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: config.GetFeatureFlagsConfigName(), Namespace: system.Namespace()},
+					Data: map[string]string{
+						"trusted-resources-verification-no-match-policy": tc.noMatchPolicy,
+					},
+				},
+			}
+			rr := getResolvedResolutionRequest(t, resolverName, signedTaskBytes, tr.Namespace, tr.Name)
+			d := test.Data{
+				TaskRuns:             []*v1beta1.TaskRun{tr},
+				ConfigMaps:           cms,
+				VerificationPolicies: tc.verificationPolicies,
+				ResolutionRequests:   []*resolutionv1beta1.ResolutionRequest{&rr},
+			}
+
+			testAssets, cancel := getTaskRunController(t, d)
+			defer cancel()
+			createServiceAccount(t, testAssets, tr.Spec.ServiceAccountName, tr.Namespace)
+			err = testAssets.Controller.Reconciler.Reconcile(testAssets.Ctx, getRunName(tr))
+
+			if ok, _ := controller.IsRequeueKey(err); !ok {
+				t.Errorf("Error reconciling TaskRun. Got error %v", err)
+			}
+			reconciledRun, err := testAssets.Clients.Pipeline.TektonV1beta1().TaskRuns(tr.Namespace).Get(testAssets.Ctx, tr.Name, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("getting updated taskrun: %v", err)
+			}
+			condition := reconciledRun.Status.GetCondition(apis.ConditionSucceeded)
+			if condition == nil || condition.Status != corev1.ConditionUnknown {
+				t.Errorf("Expected fresh TaskRun to have in progress status, but had %v", condition)
+			}
+			if condition != nil && condition.Reason != v1beta1.TaskRunReasonRunning.String() {
+				t.Errorf("Expected reason %q but was %s", v1beta1.TaskRunReasonRunning.String(), condition.Reason)
+			}
+			gotVerificationCondition := reconciledRun.Status.GetCondition(trustedresources.ConditionTrustedResourcesVerified)
+			if d := cmp.Diff(tc.wantTrustedResourcesCondition, gotVerificationCondition, ignoreLastTransitionTime); d != "" {
+				t.Error(diff.PrintWantGot(d))
+			}
+		})
+	}
+}
+
+func TestReconcile_verifyResolved_V1Task_Error(t *testing.T) {
+	resolverName := "foobar"
+	unsignedTask := parse.MustParseV1Task(t, `
+metadata:
+  name: test-task
+  namespace: foo
+spec:
+  params:
+  - default: mydefault
+    name: myarg
+    type: string
+  steps:
+  - script: echo $(params.myarg)
+    image: myimage
+    name: mycontainer
+`)
+	unsignedTaskBytes, err := yaml.Marshal(unsignedTask)
+	if err != nil {
+		t.Fatal("fail to marshal task", err)
+	}
+
+	signer, _, vps := test.SetupMatchAllVerificationPolicies(t, unsignedTask.Namespace)
+	signedTask, err := getSignedV1Task(unsignedTask, signer, "test-task")
+	if err != nil {
+		t.Fatal("fail to sign task", err)
+	}
+
+	modifiedTask := signedTask.DeepCopy()
+	if modifiedTask.Annotations == nil {
+		modifiedTask.Annotations = make(map[string]string)
+	}
+	modifiedTask.Annotations["random"] = "attack"
+	modifiedTaskBytes, err := yaml.Marshal(modifiedTask)
+	if err != nil {
+		t.Fatal("fail to marshal task", err)
+	}
+
+	cms := []*corev1.ConfigMap{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: config.GetFeatureFlagsConfigName(), Namespace: system.Namespace()},
+			Data: map[string]string{
+				"trusted-resources-verification-no-match-policy": config.FailNoMatchPolicy,
+				"enable-tekton-oci-bundles":                      "true",
+			},
+		},
+	}
+	tr := parse.MustParseV1beta1TaskRun(t, fmt.Sprintf(`
+metadata:
+  name: test-taskrun
+  namespace: foo
+spec:
+  params:
+  - name: myarg
+    value: foo
+  taskRef:
+    resolver: %s
+    name: test-task
+status:
+  podName: the-pod
+`, resolverName))
+	testCases := []struct {
+		name      string
+		taskBytes []byte
+	}{
+		{
+			name:      "unsigned task fails verification",
+			taskBytes: unsignedTaskBytes,
+		},
+		{
+			name:      "modified task fails verification",
+			taskBytes: modifiedTaskBytes,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			rr := getResolvedResolutionRequest(t, resolverName, tc.taskBytes, tr.Namespace, tr.Name)
+			d := test.Data{
+				TaskRuns:             []*v1beta1.TaskRun{tr},
+				ConfigMaps:           cms,
+				VerificationPolicies: vps,
+				ResolutionRequests:   []*resolutionv1beta1.ResolutionRequest{&rr},
+			}
+
+			testAssets, cancel := getTaskRunController(t, d)
+			defer cancel()
+			createServiceAccount(t, testAssets, tr.Spec.ServiceAccountName, tr.Namespace)
+			err := testAssets.Controller.Reconciler.Reconcile(testAssets.Ctx, getRunName(tr))
+
+			if !errors.Is(err, trustedresources.ErrResourceVerificationFailed) {
+				t.Errorf("Reconcile got %v but want %v", err, trustedresources.ErrResourceVerificationFailed)
+			}
+			reconciledRun, err := testAssets.Clients.Pipeline.TektonV1beta1().TaskRuns(tr.Namespace).Get(testAssets.Ctx, tr.Name, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("getting updated taskrun: %v", err)
+			}
+			condition := reconciledRun.Status.GetCondition(apis.ConditionSucceeded)
+			if condition.Type != apis.ConditionSucceeded || condition.Status != corev1.ConditionFalse || condition.Reason != podconvert.ReasonResourceVerificationFailed {
+				t.Errorf("Expected TaskRun to fail with reason \"%s\" but it did not. Final conditions were:\n%#v", podconvert.ReasonResourceVerificationFailed, tr.Status.Conditions)
+			}
+			gotVerificationCondition := reconciledRun.Status.GetCondition(trustedresources.ConditionTrustedResourcesVerified)
+			if gotVerificationCondition == nil || gotVerificationCondition.Status != corev1.ConditionFalse {
+				t.Errorf("Expected to have false condition, but had %v", gotVerificationCondition)
+			}
+		})
+	}
+}
+
 // getResolvedResolutionRequest is a helper function to return the ResolutionRequest and the data is filled with resourceBytes,
 // the ResolutionRequest's name is generated by resolverName, namespace and runName.
 func getResolvedResolutionRequest(t *testing.T, resolverName string, resourceBytes []byte, namespace string, runName string) resolutionv1beta1.ResolutionRequest {
@@ -5173,4 +5433,37 @@ func getResolvedResolutionRequest(t *testing.T, resolverName string, resourceByt
 	rr.Status.ResolutionRequestStatusFields.Data = base64.StdEncoding.Strict().EncodeToString(resourceBytes)
 	rr.Status.MarkSucceeded()
 	return rr
+}
+
+func getSignedV1Task(unsigned *pipelinev1.Task, signer signature.Signer, name string) (*pipelinev1.Task, error) {
+	signed := unsigned.DeepCopy()
+	signed.Name = name
+	if signed.Annotations == nil {
+		signed.Annotations = map[string]string{}
+	}
+	signature, err := signInterface(signer, signed)
+	if err != nil {
+		return nil, err
+	}
+	signed.Annotations[trustedresources.SignatureAnnotation] = base64.StdEncoding.EncodeToString(signature)
+	return signed, nil
+}
+
+func signInterface(signer signature.Signer, i interface{}) ([]byte, error) {
+	if signer == nil {
+		return nil, fmt.Errorf("signer is nil")
+	}
+	b, err := json.Marshal(i)
+	if err != nil {
+		return nil, err
+	}
+	h := sha256.New()
+	h.Write(b)
+
+	sig, err := signer.SignMessage(bytes.NewReader(h.Sum(nil)))
+	if err != nil {
+		return nil, err
+	}
+
+	return sig, nil
 }


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This commit adds the support for v1 task verification. Previously we only support v1beta1 verification.

Part of https://github.com/tektoncd/pipeline/issues/6729

/kind feature

Signed-off-by: Yongxuan Zhang yongxuanzhang@google.com

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Trusted Resources supports v1 remote tasks verification
```
