### PR TITLE
[TEP-0089] Enable the signing and verification of TR results and the TR status

### DIFF
--- a/docs/spire.md
+++ b/docs/spire.md
@@ -6,13 +6,58 @@ weight: 1660
 -->
 ⚠️ This is a work in progress: SPIRE support is not yet functional
 
-TaskRun result attestations is currently an alpha experimental feature. Currently all that is implemented is support for configuring Tekton to connect to SPIRE. See TEP-0089 for details on the overall design and feature set.
+TaskRun result attestations is currently an alpha experimental feature. Currently all that is implemented is support for configuring Tekton to connect to SPIRE and enabling TaskRun to sign and verify the TaskRunStatus. See [TEP-0089](https://github.com/tektoncd/community/blob/main/teps/0089-nonfalsifiable-provenance-support.md) for details on the overall design and feature set.
 
 This being a large feature, this will be implemented in the following phases. This document will be updated as we implement new phases.
 1.  Add a client for SPIRE (done).
-2.  Add a configMap which initializes SPIRE (in progress).
-3.  Modify TaskRun to sign and verify TaskRun Results using SPIRE.
-4.  Modify Tekton Chains to verify the TaskRun Results.
+2.  Add a configMap which initializes SPIRE (done).
+3.  Modify TaskRun to sign and verify TaskRunStatus using SPIRE (done). 
+4.  Enabling Chains to verify the TaskRun Results.
+
+When the TaskRun result attestations feature is [enabled](./spire.md#enabling-taskrun-result-attestations) all TaskRuns will produce a signature alongside its results, which can then be used to validate its provenance. For example, a TaskRun result that creates user-specified results `commit` and `url` would look like the following. `SVID`, `RESULT_MANIFEST`, `RESULT_MANIFEST.sig`, `commit.sig` and `url.sig` are generated attestations by the integration of SPIRE and Tekton Controller.
+
+Parsed, the fields would be:
+```
+...
+<truncated>
+...
+📝 Results
+
+ NAME                    VALUE
+ ∙ RESULT_MANIFEST       commit,url,SVID,commit.sig,url.sig
+ ∙ RESULT_MANIFEST.sig   MEUCIQD55MMII9SEk/esQvwNLGC43y7efNGZ+7fsTdq+9vXYFAIgNoRW7cV9WKriZkcHETIaAKqfcZVJfsKbEmaDyohDSm4=
+ ∙ SVID                  -----BEGIN CERTIFICATE-----
+MIICGzCCAcGgAwIBAgIQH9VkLxKkYMidPIsofckRQTAKBggqhkjOPQQDAjAeMQsw
+CQYDVQQGEwJVUzEPMA0GA1UEChMGU1BJRkZFMB4XDTIyMDIxMTE2MzM1MFoXDTIy
+MDIxMTE3MzQwMFowHTELMAkGA1UEBhMCVVMxDjAMBgNVBAoTBVNQSVJFMFkwEwYH
+KoZIzj0CAQYIKoZIzj0DAQcDQgAEBRdg3LdxVAELeH+lq8wzdEJd4Gnt+m9G0Qhy
+NyWoPmFUaj9vPpvOyRgzxChYnW0xpcDWihJBkq/EbusPvQB8CKOB4TCB3jAOBgNV
+HQ8BAf8EBAMCA6gwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAwGA1Ud
+EwEB/wQCMAAwHQYDVR0OBBYEFID7ARM5+vwzvnLPMO7Icfnj7l7hMB8GA1UdIwQY
+MBaAFES3IzpGDqgV3QcQNgX8b/MBwyAtMF8GA1UdEQRYMFaGVHNwaWZmZTovL2V4
+YW1wbGUub3JnL25zL2RlZmF1bHQvdGFza3J1bi9jYWNoZS1pbWFnZS1waXBlbGlu
+ZXJ1bi04ZHE5Yy1mZXRjaC1mcm9tLWdpdDAKBggqhkjOPQQDAgNIADBFAiEAi+LR
+JkrZn93PZPslaFmcrQw3rVcEa4xKmPleSvQaBoACIF1QB+q1uwH6cNvWdbLK9g+W
+T9Np18bK0xc6p5SuTM2C
+-----END CERTIFICATE-----
+ ∙ commit       aa79de59c4bae24e32f15fda467d02ae9cd94b01
+ ∙ commit.sig   MEQCIEJHk+8B+mCFozp0F52TQ1AadlhEo1lZNOiOnb/ht71aAiBCE0otKB1R0BktlPvweFPldfZfjG0F+NUSc2gPzhErzg==
+ ∙ url          https://github.com/buildpacks/samples
+ ∙ url.sig      MEUCIF0Fuxr6lv1MmkreqDKcPH3m+eXp+gY++VcxWgGCx7T1AiEA9U/tROrKuCGfKApLq2A9EModbdoGXyQXFOpAa0aMpOg=
+```
+
+However, the verification materials are removed from the final results as part of the TaskRun status. It is stored in the termination messages (more details below):
+
+```
+$ tkn tr describe cache-image-pipelinerun-8dq9c-fetch-from-git
+...
+<truncated>
+...
+📝 Results
+ NAME                    VALUE
+ ∙ commit       aa79de59c4bae24e32f15fda467d02ae9cd94b01
+ ∙ url          https://github.com/buildpacks/samples
+```
 
 ## Architecture Overview
 
@@ -127,3 +172,204 @@ To enable TaskRun attestations:
       # spire-node-alias-prefix specifies the SPIRE node alias prefix to use.
       spire-node-alias-prefix: "/tekton-node/"
     ```
+
+## Sample TaskRun attestation
+
+The following example shows how this feature works:
+
+```yaml
+kind: TaskRun
+apiVersion: tekton.dev/v1beta1
+metadata:
+  name: non-falsifiable-provenance
+spec:
+  timeout: 60s
+  taskSpec:
+    steps:
+    - name: non-falsifiable
+      image: ubuntu
+      script: |
+        #!/usr/bin/env bash
+        printf "%s" "hello" > "$(results.foo.path)"
+        printf "%s" "world" > "$(results.bar.path)"
+    results:
+    - name: foo
+    - name: bar
+```
+
+
+The termination message is:
+```
+message: '[{"key":"RESULT_MANIFEST","value":"foo,bar","type":1},{"key":"RESULT_MANIFEST.sig","value":"MEQCIB4grfqBkcsGuVyoQd9KUVzNZaFGN6jQOKK90p5HWHqeAiB7yZerDA+YE3Af/ALG43DQzygiBpKhTt8gzWGmpvXJFw==","type":1},{"key":"SVID","value":"-----BEGIN
+        CERTIFICATE-----\nMIICCjCCAbCgAwIBAgIRALH94zAZZXdtPg97O5vG5M0wCgYIKoZIzj0EAwIwHjEL\nMAkGA1UEBhMCVVMxDzANBgNVBAoTBlNQSUZGRTAeFw0yMjAzMTQxNTUzNTlaFw0y\nMjAzMTQxNjU0MDlaMB0xCzAJBgNVBAYTAlVTMQ4wDAYDVQQKEwVTUElSRTBZMBMG\nByqGSM49AgEGCCqGSM49AwEHA0IABPLzFTDY0RDpjKb+eZCIWgUw9DViu8/pM8q7\nHMTKCzlyGqhaU80sASZfpkZvmi72w+gLszzwVI1ZNU5e7aCzbtSjgc8wgcwwDgYD\nVR0PAQH/BAQDAgOoMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAMBgNV\nHRMBAf8EAjAAMB0GA1UdDgQWBBSsUvspy+/Dl24pA1f+JuNVJrjgmTAfBgNVHSME\nGDAWgBSOMyOHnyLLGxPSD9RRFL+Yhm/6qzBNBgNVHREERjBEhkJzcGlmZmU6Ly9l\neGFtcGxlLm9yZy9ucy9kZWZhdWx0L3Rhc2tydW4vbm9uLWZhbHNpZmlhYmxlLXBy\nb3ZlbmFuY2UwCgYIKoZIzj0EAwIDSAAwRQIhAM4/bPAH9dyhBEj3DbwtJKMyEI56\n4DVrP97ps9QYQb23AiBiXWrQkvRYl0h4CX0lveND2yfqLrGdVL405O5NzCcUrA==\n-----END
+        CERTIFICATE-----\n","type":1},{"key":"bar","value":"world","type":1},{"key":"bar.sig","value":"MEUCIQDOtg+aEP1FCr6/FsHX+bY1d5abSQn2kTiUMg4Uic2lVQIgTVF5bbT/O77VxESSMtQlpBreMyw2GmKX2hYJlaOEH1M=","type":1},{"key":"foo","value":"hello","type":1},{"key":"foo.sig","value":"MEQCIBr+k0i7SRSyb4h96vQE9hhxBZiZb/2PXQqReOKJDl/rAiBrjgSsalwOvN0zgQay0xQ7PRbm5YSmI8tvKseLR8Ryww==","type":1}]'
+```
+
+Parsed, the fields are:
+- `RESULT_MANIFEST`: List of results that should be present, to prevent pick and choose attacks
+- `RESULT_MANIFEST.sig`: The signature of the result manifest
+- `SVID`: The x509 certificate that will be used to verify the signature trust chain to the authority
+- `*.sig`: The signature of each individual result output
+```
+ ∙ RESULT_MANIFEST       foo,bar
+ ∙ RESULT_MANIFEST.sig   MEQCIB4grfqBkcsGuVyoQd9KUVzNZaFGN6jQOKK90p5HWHqeAiB7yZerDA+YE3Af/ALG43DQzygiBpKhTt8gzWGmpvXJFw==
+ ∙ SVID                  -----BEGIN CERTIFICATE-----
+MIICCjCCAbCgAwIBAgIRALH94zAZZXdtPg97O5vG5M0wCgYIKoZIzj0EAwIwHjEL
+MAkGA1UEBhMCVVMxDzANBgNVBAoTBlNQSUZGRTAeFw0yMjAzMTQxNTUzNTlaFw0y
+MjAzMTQxNjU0MDlaMB0xCzAJBgNVBAYTAlVTMQ4wDAYDVQQKEwVTUElSRTBZMBMG
+ByqGSM49AgEGCCqGSM49AwEHA0IABPLzFTDY0RDpjKb+eZCIWgUw9DViu8/pM8q7
+HMTKCzlyGqhaU80sASZfpkZvmi72w+gLszzwVI1ZNU5e7aCzbtSjgc8wgcwwDgYD
+VR0PAQH/BAQDAgOoMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAMBgNV
+HRMBAf8EAjAAMB0GA1UdDgQWBBSsUvspy+/Dl24pA1f+JuNVJrjgmTAfBgNVHSME
+GDAWgBSOMyOHnyLLGxPSD9RRFL+Yhm/6qzBNBgNVHREERjBEhkJzcGlmZmU6Ly9l
+eGFtcGxlLm9yZy9ucy9kZWZhdWx0L3Rhc2tydW4vbm9uLWZhbHNpZmlhYmxlLXBy
+b3ZlbmFuY2UwCgYIKoZIzj0EAwIDSAAwRQIhAM4/bPAH9dyhBEj3DbwtJKMyEI56
+4DVrP97ps9QYQb23AiBiXWrQkvRYl0h4CX0lveND2yfqLrGdVL405O5NzCcUrA==
+-----END CERTIFICATE-----
+ ∙ bar       world
+ ∙ bar.sig   MEUCIQDOtg+aEP1FCr6/FsHX+bY1d5abSQn2kTiUMg4Uic2lVQIgTVF5bbT/O77VxESSMtQlpBreMyw2GmKX2hYJlaOEH1M=
+ ∙ foo       hello
+ ∙ foo.sig   MEQCIBr+k0i7SRSyb4h96vQE9hhxBZiZb/2PXQqReOKJDl/rAiBrjgSsalwOvN0zgQay0xQ7PRbm5YSmI8tvKseLR8Ryww==
+```
+
+
+However, the verification materials are removed from the results as part of the TaskRun status:
+```console
+$ tkn tr describe non-falsifiable-provenance
+Name:              non-falsifiable-provenance
+Namespace:         default
+Service Account:   default
+Timeout:           1m0s
+Labels:
+ app.kubernetes.io/managed-by=tekton-pipelines
+
+🌡️  Status
+
+STARTED          DURATION     STATUS
+38 seconds ago   36 seconds   Succeeded
+
+📝 Results
+
+ NAME        VALUE
+ ∙ bar       world
+ ∙ foo       hello
+
+🦶 Steps
+
+ NAME                STATUS
+ ∙ non-falsifiable   Completed
+```
+
+## How is the result being verified
+
+The signatures are being verified by the Tekton controller, the process of verification is as follows:
+
+- Verifying the SVID
+  - Obtain the trust bundle from the SPIRE server
+  - Verify the SVID with the trust bundle
+  - Verify that the SVID spiffe ID is for the correct TaskRun
+- Verifying the result manifest
+  - Verify the content of `RESULT_MANIFEST` with the field `RESULT_MANIFEST.sig` with the SVID public key
+  - Verify that there is a corresponding field for all items listed in `RESULT_MANIFEST` (besides SVID and `*.sig` fields)
+- Verify individual result fields
+  - For each of the items in the results, verify its content against its associated `.sig` field
+
+
+# TaskRun Status attestations
+
+Each TaskRun status that is written by the tekton-pipelines-controller will be signed to ensure that there is no external
+tampering of the TaskRun status. Upon each retrieval of the TaskRun, the tekton-pipelines-controller checks if the status is initialized,
+and that the signature validates the current status.
+The signature and SVID will be stored as annotations on the TaskRun Status field, and can be verified by a client.
+
+The verification is done on every consumption of the TaskRun except when the TaskRun is uninitialized. When uninitialized, the 
+tekton-pipelines-controller is not influenced by fields in the status and thus will not sign incorrect reflections of the TaskRun.
+
+The spec and TaskRun annotations/labels are not signed when there are valid interactions from other controllers or users (i.e. cancelling taskrun).
+Editing the object annotations/labels or spec will not result in any unverifiable outcome of the status field.
+
+As the TaskRun progresses, the Pipeline Controller will reconcile the TaskRun object and continually verify the current hash against the `tekton.dev/status-hash-sig` before updating the hash to match the new status and creating a new signature.
+
+An example TaskRun annotations would be:
+
+```console
+$ tkn tr describe non-falsifiable-provenance -oyaml
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  annotations:
+    pipeline.tekton.dev/release: 3ee99ec
+  creationTimestamp: "2022-03-04T19:10:46Z"
+  generation: 1
+  labels:
+    app.kubernetes.io/managed-by: tekton-pipelines
+  name: non-falsifiable-provenance
+  namespace: default
+  resourceVersion: "23088242"
+  uid: 548ebe99-d40b-4580-a9bc-afe80915e22e
+spec:
+  serviceAccountName: default
+  taskSpec:
+    results:
+    - description: ""
+      name: foo
+    - description: ""
+      name: bar
+    steps:
+    - image: ubuntu
+      name: non-falsifiable
+      resources: {}
+      script: |
+        #!/usr/bin/env bash
+        sleep 30
+        printf "%s" "hello" > "$(results.foo.path)"
+        printf "%s" "world" > "$(results.bar.path)"
+  timeout: 1m0s
+status:
+  annotations:
+    tekton.dev/controller-svid: |
+      -----BEGIN CERTIFICATE-----
+      MIIB7jCCAZSgAwIBAgIRAI8/08uXSn9tyv7cRN87uvgwCgYIKoZIzj0EAwIwHjEL
+      MAkGA1UEBhMCVVMxDzANBgNVBAoTBlNQSUZGRTAeFw0yMjAzMDQxODU0NTlaFw0y
+      MjAzMDQxOTU1MDlaMB0xCzAJBgNVBAYTAlVTMQ4wDAYDVQQKEwVTUElSRTBZMBMG
+      ByqGSM49AgEGCCqGSM49AwEHA0IABL+e9OjkMv+7XgMWYtrzq0ESzJi+znA/Pm8D
+      nvApAHg3/rEcNS8c5LgFFRzDfcs9fxGSSkL1JrELzoYul1Q13XejgbMwgbAwDgYD
+      VR0PAQH/BAQDAgOoMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAMBgNV
+      HRMBAf8EAjAAMB0GA1UdDgQWBBR+ma+yZfo092FKIM4F3yhEY8jgDDAfBgNVHSME
+      GDAWgBRKiCg5+YdTaQ+5gJmvt2QcDkQ6KjAxBgNVHREEKjAohiZzcGlmZmU6Ly9l
+      eGFtcGxlLm9yZy90ZWt0b24vY29udHJvbGxlcjAKBggqhkjOPQQDAgNIADBFAiEA
+      8xVWrQr8+i6yMLDm9IUjtvTbz9ofjSsWL6c/+rxmmRYCIBTiJ/HW7di3inSfxwqK
+      5DKyPrKoR8sq8Ne7flkhgbkg
+      -----END CERTIFICATE-----
+    tekton.dev/status-hash: 76692c9dcd362f8a6e4bda8ccb4c0937ad16b0d23149ae256049433192892511
+    tekton.dev/status-hash-sig: MEQCIFv2bW0k4g0Azx+qaeZjUulPD8Ma3uCUn0tXQuuR1FaEAiBHQwN4XobOXmC2nddYm04AZ74YubUyNl49/vnbnR/HcQ==
+  completionTime: "2022-03-04T19:11:22Z"
+  conditions:
+  - lastTransitionTime: "2022-03-04T19:11:22Z"
+    message: All Steps have completed executing
+    reason: Succeeded
+    status: "True"
+    type: Succeeded
+  - lastTransitionTime: "2022-03-04T19:11:22Z"
+    message: Spire verified
+    reason: TaskRunResultsVerified
+    status: "True"
+    type: SignedResultsVerified
+  podName: non-falsifiable-provenance-pod
+  startTime: "2022-03-04T19:10:46Z"
+  steps:
+  ...
+  <TRUNCATED>
+```
+
+## How is the status being verified
+
+The signature are being verified by the Tekton controller, the process of verification is as follows:
+
+- Verify status-hash fields
+  - verify `tekton.dev/status-hash` content against its associated `tekton.dev/status-hash-sig` field. If status hash does 
+    not match invalidate the `tekton.dev/verified = no` annotation will be added
+
+## Further Details
+
+To learn more about SPIRE attestations, check out the [TEP](https://github.com/tektoncd/community/blob/main/teps/0089-nonfalsifiable-provenance-support.md).

--- a/pkg/apis/pipeline/v1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1/taskrun_types.go
@@ -131,6 +131,19 @@ type TaskRunStatus struct {
 // reasons that emerge from underlying resources are not included here
 type TaskRunReason string
 
+// TaskRunConditionType is an enum used to store TaskRun custom
+// conditions such as one used in spire results verification
+type TaskRunConditionType string
+
+const (
+	// TaskRunConditionResultsVerified is a Condition Type that indicates that the results were verified by spire
+	TaskRunConditionResultsVerified TaskRunConditionType = "SignedResultsVerified"
+)
+
+func (t TaskRunConditionType) String() string {
+	return string(t)
+}
+
 const (
 	// TaskRunReasonStarted is the reason set when the TaskRun has just started
 	TaskRunReasonStarted TaskRunReason = "Started"
@@ -155,6 +168,12 @@ const (
 	TaskRunReasonResultLargerThanAllowedLimit TaskRunReason = "TaskRunResultLargerThanAllowedLimit"
 	// TaskRunReasonStopSidecarFailed indicates that the sidecar is not properly stopped.
 	TaskRunReasonStopSidecarFailed = "TaskRunStopSidecarFailed"
+	// TaskRunReasonResultsVerified is the reason set when the TaskRun results are verified by spire
+	TaskRunReasonResultsVerified TaskRunReason = "TaskRunResultsVerified"
+	// TaskRunReasonsResultsVerificationFailed is the reason set when the TaskRun results are failed to verify by spire
+	TaskRunReasonsResultsVerificationFailed TaskRunReason = "TaskRunResultsVerificationFailed"
+	// AwaitingTaskRunResults is the reason set when waiting upon `TaskRun` results and signatures to verify
+	AwaitingTaskRunResults TaskRunReason = "AwaitingTaskRunResults"
 )
 
 func (t TaskRunReason) String() string {
@@ -433,4 +452,14 @@ func (tr *TaskRun) HasVolumeClaimTemplate() bool {
 		}
 	}
 	return false
+}
+
+// IsTaskRunResultVerified returns true if the TaskRun's results have been validated by spire.
+func (tr *TaskRun) IsTaskRunResultVerified() bool {
+	return tr.Status.GetCondition(apis.ConditionType(TaskRunConditionResultsVerified.String())).IsTrue()
+}
+
+// IsTaskRunResultDone returns true if the TaskRun's results are available for verification
+func (tr *TaskRun) IsTaskRunResultDone() bool {
+	return !tr.Status.GetCondition(apis.ConditionType(TaskRunConditionResultsVerified.String())).IsUnknown()
 }

--- a/pkg/entrypoint/entrypointer_test.go
+++ b/pkg/entrypoint/entrypointer_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/result"
 	"github.com/tektoncd/pipeline/pkg/spire"
@@ -697,14 +698,14 @@ func createTmpDir(t *testing.T, name string) string {
 	return tmpDir
 }
 
-func getMockSpireClient(ctx context.Context) (spire.EntrypointerAPIClient, spire.ControllerAPIClient, *v1beta1.TaskRun) {
-	tr := &v1beta1.TaskRun{
+func getMockSpireClient(ctx context.Context) (spire.EntrypointerAPIClient, spire.ControllerAPIClient, *v1.TaskRun) {
+	tr := &v1.TaskRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "taskrun-example",
 			Namespace: "foo",
 		},
-		Spec: v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{
+		Spec: v1.TaskRunSpec{
+			TaskRef: &v1.TaskRef{
 				Name:       "taskname",
 				APIVersion: "a1",
 			},

--- a/pkg/pod/status_test.go
+++ b/pkg/pod/status_test.go
@@ -232,9 +232,9 @@ func TestMakeTaskRunStatusVerify(t *testing.T) {
 	statusSRVUnknown := func() duckv1.Status {
 		status := statusRunning()
 		status.Conditions = append(status.Conditions, apis.Condition{
-			Type:    apis.ConditionType(v1beta1.TaskRunConditionResultsVerified.String()),
+			Type:    apis.ConditionType(v1.TaskRunConditionResultsVerified.String()),
 			Status:  corev1.ConditionUnknown,
-			Reason:  v1beta1.AwaitingTaskRunResults.String(),
+			Reason:  v1.AwaitingTaskRunResults.String(),
 			Message: "Waiting upon TaskRun results and signatures to verify",
 		})
 		return status
@@ -242,9 +242,9 @@ func TestMakeTaskRunStatusVerify(t *testing.T) {
 	statusSRVVerified := func() duckv1.Status {
 		status := statusSuccess()
 		status.Conditions = append(status.Conditions, apis.Condition{
-			Type:    apis.ConditionType(v1beta1.TaskRunConditionResultsVerified.String()),
+			Type:    apis.ConditionType(v1.TaskRunConditionResultsVerified.String()),
 			Status:  corev1.ConditionTrue,
-			Reason:  v1beta1.TaskRunReasonResultsVerified.String(),
+			Reason:  v1.TaskRunReasonResultsVerified.String(),
 			Message: "Successfully verified all spire signed taskrun results",
 		})
 		return status
@@ -252,9 +252,9 @@ func TestMakeTaskRunStatusVerify(t *testing.T) {
 	statusSRVUnverified := func() duckv1.Status {
 		status := statusSuccess()
 		status.Conditions = append(status.Conditions, apis.Condition{
-			Type:    apis.ConditionType(v1beta1.TaskRunConditionResultsVerified.String()),
+			Type:    apis.ConditionType(v1.TaskRunConditionResultsVerified.String()),
 			Status:  corev1.ConditionFalse,
-			Reason:  v1beta1.TaskRunReasonsResultsVerificationFailed.String(),
+			Reason:  v1.TaskRunReasonsResultsVerificationFailed.String(),
 			Message: "",
 		})
 		return status
@@ -262,20 +262,20 @@ func TestMakeTaskRunStatusVerify(t *testing.T) {
 	for _, c := range []struct {
 		desc                 string
 		specifyTaskRunResult bool
-		resultOut            []v1beta1.PipelineResourceResult
+		resultOut            []result.RunResult
 		podStatus            corev1.PodStatus
 		pod                  corev1.Pod
-		want                 v1beta1.TaskRunStatus
+		want                 v1.TaskRunStatus
 	}{{
 		// test awaiting results
 		desc:      "running pod awaiting results",
 		podStatus: corev1.PodStatus{},
 
-		want: v1beta1.TaskRunStatus{
+		want: v1.TaskRunStatus{
 			Status: statusSRVUnknown(),
-			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
-				Steps:    []v1beta1.StepState{},
-				Sidecars: []v1beta1.SidecarState{},
+			TaskRunStatusFields: v1.TaskRunStatusFields{
+				Steps:    []v1.StepState{},
+				Sidecars: []v1.SidecarState{},
 			},
 		},
 	}, {
@@ -291,22 +291,22 @@ func TestMakeTaskRunStatusVerify(t *testing.T) {
 				},
 			}},
 		},
-		want: v1beta1.TaskRunStatus{
+		want: v1.TaskRunStatus{
 			Status: statusSRVUnverified(),
-			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
-				Steps: []v1beta1.StepState{{
+			TaskRunStatusFields: v1.TaskRunStatusFields{
+				Steps: []v1.StepState{{
 					ContainerState: corev1.ContainerState{
 						Terminated: &corev1.ContainerStateTerminated{
 							Message: `[{"key":"digest","value":"sha256:1234","type":1}]`,
 						}},
-					Name:          "bar",
-					ContainerName: "step-bar",
+					Name:      "bar",
+					Container: "step-bar",
 				}},
-				Sidecars: []v1beta1.SidecarState{},
-				TaskRunResults: []v1beta1.TaskRunResult{{
+				Sidecars: []v1.SidecarState{},
+				Results: []v1.TaskRunResult{{
 					Name:  "digest",
-					Type:  v1beta1.ResultsTypeString,
-					Value: *v1beta1.NewStructuredValues("sha256:1234"),
+					Type:  v1.ResultsTypeString,
+					Value: *v1.NewStructuredValues("sha256:1234"),
 				}},
 				// We don't actually care about the time, just that it's not nil
 				CompletionTime: &metav1.Time{Time: time.Now()},
@@ -332,22 +332,22 @@ func TestMakeTaskRunStatusVerify(t *testing.T) {
 				},
 			}},
 		},
-		want: v1beta1.TaskRunStatus{
+		want: v1.TaskRunStatus{
 			Status: statusSRVVerified(),
-			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
-				Steps: []v1beta1.StepState{{
+			TaskRunStatusFields: v1.TaskRunStatusFields{
+				Steps: []v1.StepState{{
 					ContainerState: corev1.ContainerState{
 						Terminated: &corev1.ContainerStateTerminated{
 							Message: `to be overridden by signing`,
 						}},
-					Name:          "bar",
-					ContainerName: "step-bar",
+					Name:      "bar",
+					Container: "step-bar",
 				}},
-				Sidecars: []v1beta1.SidecarState{},
-				TaskRunResults: []v1beta1.TaskRunResult{{
+				Sidecars: []v1.SidecarState{},
+				Results: []v1.TaskRunResult{{
 					Name:  "resultName",
-					Type:  v1beta1.ResultsTypeString,
-					Value: *v1beta1.NewStructuredValues("resultValue"),
+					Type:  v1.ResultsTypeString,
+					Value: *v1.NewStructuredValues("resultValue"),
 				}},
 				// We don't actually care about the time, just that it's not nil
 				CompletionTime: &metav1.Time{Time: time.Now()},
@@ -373,22 +373,22 @@ func TestMakeTaskRunStatusVerify(t *testing.T) {
 				},
 			}},
 		},
-		want: v1beta1.TaskRunStatus{
+		want: v1.TaskRunStatus{
 			Status: statusSRVVerified(),
-			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
-				Steps: []v1beta1.StepState{{
+			TaskRunStatusFields: v1.TaskRunStatusFields{
+				Steps: []v1.StepState{{
 					ContainerState: corev1.ContainerState{
 						Terminated: &corev1.ContainerStateTerminated{
 							Message: `to be overridden by signing`,
 						}},
-					Name:          "bar",
-					ContainerName: "step-bar",
+					Name:      "bar",
+					Container: "step-bar",
 				}},
-				Sidecars: []v1beta1.SidecarState{},
-				TaskRunResults: []v1beta1.TaskRunResult{{
+				Sidecars: []v1.SidecarState{},
+				Results: []v1.TaskRunResult{{
 					Name:  "resultName",
-					Type:  v1beta1.ResultsTypeArray,
-					Value: *v1beta1.NewStructuredValues("hello", "world"),
+					Type:  v1.ResultsTypeArray,
+					Value: *v1.NewStructuredValues("hello", "world"),
 				}},
 				// We don't actually care about the time, just that it's not nil
 				CompletionTime: &metav1.Time{Time: time.Now()},
@@ -396,7 +396,7 @@ func TestMakeTaskRunStatusVerify(t *testing.T) {
 		},
 	}, {
 		desc:      "test result with no result with signed termination message",
-		resultOut: []v1beta1.PipelineResourceResult{},
+		resultOut: []result.RunResult{},
 		podStatus: corev1.PodStatus{
 			Phase: corev1.PodSucceeded,
 			ContainerStatuses: []corev1.ContainerStatus{{
@@ -408,18 +408,18 @@ func TestMakeTaskRunStatusVerify(t *testing.T) {
 				},
 			}},
 		},
-		want: v1beta1.TaskRunStatus{
+		want: v1.TaskRunStatus{
 			Status: statusSRVVerified(),
-			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
-				Steps: []v1beta1.StepState{{
+			TaskRunStatusFields: v1.TaskRunStatusFields{
+				Steps: []v1.StepState{{
 					ContainerState: corev1.ContainerState{
 						Terminated: &corev1.ContainerStateTerminated{
 							Message: `to be overridden by signing`,
 						}},
-					Name:          "bar",
-					ContainerName: "step-bar",
+					Name:      "bar",
+					Container: "step-bar",
 				}},
-				Sidecars: []v1beta1.SidecarState{},
+				Sidecars: []v1.SidecarState{},
 				// We don't actually care about the time, just that it's not nil
 				CompletionTime: &metav1.Time{Time: time.Now()},
 			},
@@ -437,18 +437,18 @@ func TestMakeTaskRunStatusVerify(t *testing.T) {
 				},
 			}},
 		},
-		want: v1beta1.TaskRunStatus{
+		want: v1.TaskRunStatus{
 			Status: statusSRVVerified(),
-			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
-				Steps: []v1beta1.StepState{{
+			TaskRunStatusFields: v1.TaskRunStatusFields{
+				Steps: []v1.StepState{{
 					ContainerState: corev1.ContainerState{
 						Terminated: &corev1.ContainerStateTerminated{
 							Message: "[]",
 						}},
-					Name:          "bar",
-					ContainerName: "step-bar",
+					Name:      "bar",
+					Container: "step-bar",
 				}},
-				Sidecars: []v1beta1.SidecarState{},
+				Sidecars: []v1.SidecarState{},
 				// We don't actually care about the time, just that it's not nil
 				CompletionTime: &metav1.Time{Time: time.Now()},
 			},
@@ -467,18 +467,18 @@ func TestMakeTaskRunStatusVerify(t *testing.T) {
 				},
 			}},
 		},
-		want: v1beta1.TaskRunStatus{
+		want: v1.TaskRunStatus{
 			Status: statusSRVUnverified(),
-			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
-				Steps: []v1beta1.StepState{{
+			TaskRunStatusFields: v1.TaskRunStatusFields{
+				Steps: []v1.StepState{{
 					ContainerState: corev1.ContainerState{
 						Terminated: &corev1.ContainerStateTerminated{
 							Message: "[]",
 						}},
-					Name:          "bar",
-					ContainerName: "step-bar",
+					Name:      "bar",
+					Container: "step-bar",
 				}},
-				Sidecars: []v1beta1.SidecarState{},
+				Sidecars: []v1.SidecarState{},
 				// We don't actually care about the time, just that it's not nil
 				CompletionTime: &metav1.Time{Time: time.Now()},
 			},
@@ -503,21 +503,21 @@ func TestMakeTaskRunStatusVerify(t *testing.T) {
 			}
 
 			startTime := time.Date(2010, 1, 1, 1, 1, 1, 1, time.UTC)
-			tr := v1beta1.TaskRun{
+			tr := v1.TaskRun{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "task-run",
 					Namespace: "foo",
 				},
-				Status: v1beta1.TaskRunStatus{
-					TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+				Status: v1.TaskRunStatus{
+					TaskRunStatusFields: v1.TaskRunStatusFields{
 						StartTime: &metav1.Time{Time: startTime},
 					},
 				},
 			}
 			if c.specifyTaskRunResult {
 				// Specify result
-				tr.Status.TaskSpec = &v1beta1.TaskSpec{
-					Results: []v1beta1.TaskResult{{
+				tr.Status.TaskSpec = &v1.TaskSpec{
+					Results: []v1.TaskResult{{
 						Name: "some-task-result",
 					}},
 				}
@@ -550,7 +550,7 @@ func TestMakeTaskRunStatusVerify(t *testing.T) {
 
 			logger, _ := logging.NewLogger("", "status")
 			kubeclient := fakek8s.NewSimpleClientset()
-			got, err := MakeTaskRunStatus(ctx, logger, tr, &c.pod, kubeclient, &v1beta1.TaskSpec{}, sc)
+			got, err := MakeTaskRunStatus(ctx, logger, tr, &c.pod, kubeclient, &v1.TaskSpec{}, sc)
 			if err != nil {
 				t.Errorf("MakeTaskRunResult: %s", err)
 			}

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -1479,7 +1479,7 @@ spec:
 		t.Errorf("expected no error. Got error %v", err)
 	}
 
-	client := testAssets.Clients.ResolutionRequests.ResolutionV1().ResolutionRequests("default")
+	client := testAssets.Clients.ResolutionRequests.ResolutionV1beta1().ResolutionRequests("default")
 	resolutionrequests, err := client.List(testAssets.Ctx, metav1.ListOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error listing resource requests: %v", err)
@@ -1579,7 +1579,7 @@ spec:
 		t.Errorf("expected no error. Got error %v", err)
 	}
 
-	client := testAssets.Clients.ResolutionRequests.ResolutionV1().ResolutionRequests("default")
+	client := testAssets.Clients.ResolutionRequests.ResolutionV1beta1().ResolutionRequests("default")
 	resolutionrequests, err := client.List(testAssets.Ctx, metav1.ListOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error listing resource requests: %v", err)

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -53,6 +53,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/reconciler/volumeclaim"
 	resolutioncommon "github.com/tektoncd/pipeline/pkg/resolution/common"
 	remoteresource "github.com/tektoncd/pipeline/pkg/resolution/resource"
+	"github.com/tektoncd/pipeline/pkg/spire"
 	"github.com/tektoncd/pipeline/pkg/trustedresources"
 	"github.com/tektoncd/pipeline/pkg/trustedresources/verifier"
 	"github.com/tektoncd/pipeline/pkg/workspace"
@@ -73,6 +74,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	clock "k8s.io/utils/clock/testing"
 	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 	cminformer "knative.dev/pkg/configmap/informer"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/kmeta"
@@ -306,6 +308,7 @@ var (
 			EmptyDir: &corev1.EmptyDirVolumeSource{},
 		},
 	}
+	mockSpire = &spire.MockClient{}
 )
 
 const fakeVersion string = "unknown"
@@ -369,6 +372,7 @@ func initializeTaskRunControllerAssets(t *testing.T, d test.Data, opts pipeline.
 	t.Helper()
 	ctx, _ := ttesting.SetupFakeContext(t)
 	ctx = ttesting.SetupFakeCloudClientContext(ctx, d.ExpectedCloudEventCount)
+	ctx = spire.InjectClient(ctx, mockSpire)
 	ctx, cancel := context.WithCancel(ctx)
 	test.EnsureConfigurationConfigMapsExist(&d)
 	c, informers := test.SeedTestData(t, ctx, d)
@@ -439,7 +443,7 @@ spec:
 			image: "foo",
 			name:  "simple-step",
 			cmd:   "/mycmd",
-		}}),
+		}}, false),
 	}, {
 		name:    "serviceaccount",
 		taskRun: taskRunWithSaSuccess,
@@ -447,7 +451,7 @@ spec:
 			image: "foo",
 			name:  "sa-step",
 			cmd:   "/mycmd",
-		}}),
+		}}, false),
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			saName := tc.taskRun.Spec.ServiceAccountName
@@ -770,7 +774,7 @@ spec:
 			image: "foo",
 			name:  "simple-step",
 			cmd:   "/mycmd",
-		}}),
+		}}, false),
 	}, {
 		name:    "serviceaccount",
 		taskRun: taskRunWithSaSuccess,
@@ -782,7 +786,7 @@ spec:
 			image: "foo",
 			name:  "sa-step",
 			cmd:   "/mycmd",
-		}}),
+		}}, false),
 	}, {
 		name:    "params",
 		taskRun: taskRunSubstitution,
@@ -818,7 +822,7 @@ spec:
 				cmd:   "/mycmd",
 				args:  []string{"--my-other-arg=https://foo.git"},
 			},
-		}),
+		}, false),
 	}, {
 		name:    "taskrun-with-taskspec",
 		taskRun: taskRunWithTaskSpec,
@@ -832,7 +836,7 @@ spec:
 				image: "myimage",
 				cmd:   "/mycmd",
 			},
-		}),
+		}, false),
 	}, {
 		name:    "success-with-cluster-task",
 		taskRun: taskRunWithClusterTask,
@@ -844,7 +848,7 @@ spec:
 			name:  "simple-step",
 			image: "foo",
 			cmd:   "/mycmd",
-		}}),
+		}}, false),
 	}, {
 		name:    "taskrun-with-pod",
 		taskRun: taskRunWithPod,
@@ -856,7 +860,7 @@ spec:
 			name:  "simple-step",
 			image: "foo",
 			cmd:   "/mycmd",
-		}}),
+		}}, false),
 	}, {
 		name:    "taskrun-with-credentials-variable-default-tekton-creds",
 		taskRun: taskRunWithCredentialsVariable,
@@ -868,7 +872,7 @@ spec:
 			name:  "mycontainer",
 			image: "myimage",
 			cmd:   "/mycmd /tekton/creds",
-		}}),
+		}}, false),
 	}, {
 		name:    "remote-task",
 		taskRun: taskRunBundle,
@@ -880,7 +884,7 @@ spec:
 			name:  "simple-step",
 			image: "foo",
 			cmd:   "/mycmd",
-		}}),
+		}}, false),
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			testAssets, cancel := getTaskRunController(t, d)
@@ -942,6 +946,7 @@ spec:
 
 func TestAlphaReconcile(t *testing.T) {
 	names.TestingSeed()
+	readonly := true
 	taskRunWithOutputConfig := parse.MustParseV1TaskRun(t, `
 metadata:
   name: test-taskrun-with-output-config
@@ -984,7 +989,8 @@ spec:
 	cms := []*corev1.ConfigMap{{
 		ObjectMeta: metav1.ObjectMeta{Namespace: system.Namespace(), Name: config.GetFeatureFlagsConfigName()},
 		Data: map[string]string{
-			"enable-api-fields": config.AlphaAPIFields,
+			"enable-api-fields":         config.AlphaAPIFields,
+			"enforce-nonfalsifiability": config.EnforceNonfalsifiabilityWithSpire,
 		},
 	}}
 	d := test.Data{
@@ -1005,12 +1011,30 @@ spec:
 			"Normal Started ",
 			"Normal Running Not all Steps",
 		},
-		wantPod: expectedPod("test-taskrun-with-output-config-pod", "", "test-taskrun-with-output-config", "foo", config.DefaultServiceAccountValue, false, nil, []stepForExpectedPod{{
-			name:       "mycontainer",
-			image:      "myimage",
-			stdoutPath: "stdout.txt",
-			cmd:        "/mycmd",
-		}}),
+		wantPod: addVolumeMounts(expectedPod("test-taskrun-with-output-config-pod", "", "test-taskrun-with-output-config", "foo", config.DefaultServiceAccountValue, false,
+			[]corev1.Volume{
+				{
+					Name: spire.WorkloadAPI,
+					VolumeSource: corev1.VolumeSource{
+						CSI: &corev1.CSIVolumeSource{
+							Driver:   "csi.spiffe.io",
+							ReadOnly: &readonly,
+						},
+					},
+				}}, []stepForExpectedPod{{
+				name:       "mycontainer",
+				image:      "myimage",
+				stdoutPath: "stdout.txt",
+				cmd:        "/mycmd",
+			}}, true),
+			[]corev1.VolumeMount{
+				{
+					Name:      spire.WorkloadAPI,
+					MountPath: spire.VolumeMountPath,
+					ReadOnly:  true,
+				},
+			},
+		),
 	}, {
 		name:    "taskrun-with-output-config-ws",
 		taskRun: taskRunWithOutputConfigAndWorkspace,
@@ -1019,22 +1043,40 @@ spec:
 			"Normal Running Not all Steps",
 		},
 		wantPod: addVolumeMounts(expectedPod("test-taskrun-with-output-config-ws-pod", "", "test-taskrun-with-output-config-ws", "foo", config.DefaultServiceAccountValue, false,
-			[]corev1.Volume{{
-				Name: "ws-9l9zj",
-				VolumeSource: corev1.VolumeSource{
-					EmptyDir: &corev1.EmptyDirVolumeSource{},
+			[]corev1.Volume{
+				{
+					Name: "ws-9l9zj",
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{},
+					},
+				}, {
+					Name: spire.WorkloadAPI,
+					VolumeSource: corev1.VolumeSource{
+						CSI: &corev1.CSIVolumeSource{
+							Driver:   "csi.spiffe.io",
+							ReadOnly: &readonly,
+						},
+					},
 				},
-			}},
+			},
 			[]stepForExpectedPod{{
 				name:       "mycontainer",
 				image:      "myimage",
 				stdoutPath: "stdout.txt",
 				cmd:        "/mycmd",
-			}}),
-			[]corev1.VolumeMount{{
-				Name:      "ws-9l9zj",
-				MountPath: "/workspace/data",
-			}}),
+			}}, true),
+			[]corev1.VolumeMount{
+				{
+					Name:      "ws-9l9zj",
+					MountPath: "/workspace/data",
+				},
+				{
+					Name:      spire.WorkloadAPI,
+					MountPath: spire.VolumeMountPath,
+					ReadOnly:  true,
+				},
+			},
+		),
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			testAssets, cancel := getTaskRunController(t, d)
@@ -1095,10 +1137,304 @@ spec:
 }
 
 func addVolumeMounts(p *corev1.Pod, vms []corev1.VolumeMount) *corev1.Pod {
-	for i, vm := range vms {
-		p.Spec.Containers[i].VolumeMounts = append(p.Spec.Containers[i].VolumeMounts, vm)
+	for i := range p.Spec.Containers {
+		p.Spec.Containers[i].VolumeMounts = append(p.Spec.Containers[i].VolumeMounts, vms...)
 	}
 	return p
+}
+
+func TestSpireFlowReconcile(t *testing.T) {
+	names.TestingSeed()
+	readonly := true
+	taskRunWithOutputConfig := parse.MustParseV1TaskRun(t, `
+metadata:
+  name: test-taskrun-with-output-config
+  namespace: foo
+spec:
+  taskSpec:
+    steps:
+      - command:
+        - /mycmd
+        image: myimage
+        name: mycontainer
+        stdoutConfig:
+          path: stdout.txt
+`)
+	taskruns := []*v1.TaskRun{
+		taskRunWithOutputConfig,
+	}
+
+	cms := []*corev1.ConfigMap{{
+		ObjectMeta: metav1.ObjectMeta{Namespace: system.Namespace(), Name: config.GetFeatureFlagsConfigName()},
+		Data: map[string]string{
+			"enable-api-fields":         config.AlphaAPIFields,
+			"enforce-nonfalsifiability": config.EnforceNonfalsifiabilityWithSpire,
+		},
+	}}
+	d := test.Data{
+		ConfigMaps: cms,
+		TaskRuns:   taskruns,
+	}
+	for _, tc := range []struct {
+		name       string
+		taskRun    *v1.TaskRun
+		wantPod    *corev1.Pod
+		wantEvents []string
+	}{{
+		name:    "taskrun-with-output-config",
+		taskRun: taskRunWithOutputConfig,
+		wantEvents: []string{
+			"Normal Started ",
+			"Normal Running Not all Steps",
+		},
+		wantPod: addVolumeMounts(expectedPod("test-taskrun-with-output-config-pod", "", "test-taskrun-with-output-config", "foo", config.DefaultServiceAccountValue, false,
+			[]corev1.Volume{
+				{
+					Name: spire.WorkloadAPI,
+					VolumeSource: corev1.VolumeSource{
+						CSI: &corev1.CSIVolumeSource{
+							Driver:   "csi.spiffe.io",
+							ReadOnly: &readonly,
+						},
+					},
+				}}, []stepForExpectedPod{{
+				name:       "mycontainer",
+				image:      "myimage",
+				stdoutPath: "stdout.txt",
+				cmd:        "/mycmd",
+			}}, true),
+			[]corev1.VolumeMount{
+				{
+					Name:      spire.WorkloadAPI,
+					MountPath: spire.VolumeMountPath,
+					ReadOnly:  true,
+				},
+			},
+		),
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			testAssets, cancel := getTaskRunController(t, d)
+			defer cancel()
+			c := testAssets.Controller
+			clients := testAssets.Clients
+			saName := tc.taskRun.Spec.ServiceAccountName
+			createServiceAccount(t, testAssets, saName, tc.taskRun.Namespace)
+
+			if err := c.Reconciler.Reconcile(testAssets.Ctx, getRunName(tc.taskRun)); err == nil {
+				t.Error("Wanted a wrapped requeue error, but got nil.")
+			} else if ok, _ := controller.IsRequeueKey(err); !ok {
+				t.Errorf("expected no error. Got error %v", err)
+			}
+
+			tr, err := clients.Pipeline.TektonV1().TaskRuns(tc.taskRun.Namespace).Get(testAssets.Ctx, tc.taskRun.Name, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("getting updated taskrun: %v", err)
+			}
+
+			if err := spire.CheckStatusInternalAnnotation(tr); err != nil {
+				t.Fatalf("Error %s in checking internal status after first reconcile.", err)
+			}
+
+			if tr.Status.PodName == "" {
+				t.Fatalf("Reconcile didn't set pod name")
+			}
+			pod, err := clients.Kube.CoreV1().Pods(tr.Namespace).Get(testAssets.Ctx, tr.Status.PodName, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("Failed to fetch build pod: %v", err)
+			}
+			pod.Status = corev1.PodStatus{
+				Phase: corev1.PodRunning,
+			}
+			if _, err := clients.Kube.CoreV1().Pods(tr.Namespace).UpdateStatus(testAssets.Ctx, pod, metav1.UpdateOptions{}); err != nil {
+				t.Errorf("Unexpected error while updating build: %v", err)
+			}
+			// Before calling Reconcile again, we need to ensure that the informer's
+			// lister cache is update to reflect the result of the previous Reconcile.
+			testAssets.Informers.TaskRun.Informer().GetIndexer().Add(tr)
+
+			if err := c.Reconciler.Reconcile(testAssets.Ctx, getRunName(tr)); err == nil {
+				t.Error("Wanted a wrapped requeue error, but got nil.")
+			} else if ok, _ := controller.IsRequeueKey(err); !ok {
+				t.Fatalf("Unexpected error when Reconcile(): %v", err)
+			}
+
+			tr, err = clients.Pipeline.TektonV1().TaskRuns(tr.Namespace).Get(testAssets.Ctx, tr.Name, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("Expected TaskRun %s to exist but instead got error when getting it: %v", tr.Name, err)
+			}
+			if err := spire.CheckStatusInternalAnnotation(tr); err != nil {
+				t.Fatalf("Error %s in checking internal status after second reconcile.", err)
+			}
+
+			spireTaskRunEntryID := fmt.Sprintf("/ns/%v/taskrun/%v", tr.Namespace, tr.Name)
+			if _, err := mockSpire.Entries[spireTaskRunEntryID]; !err {
+				t.Fatalf("%s expected to be added as a SPIFFE id.", spireTaskRunEntryID)
+			}
+
+			pod.Status = corev1.PodStatus{
+				Phase: corev1.PodSucceeded,
+			}
+			if _, err := clients.Kube.CoreV1().Pods(tr.Namespace).UpdateStatus(testAssets.Ctx, pod, metav1.UpdateOptions{}); err != nil {
+				t.Errorf("Unexpected error while updating build: %v", err)
+			}
+			testAssets.Informers.TaskRun.Informer().GetIndexer().Add(tr)
+
+			if err := c.Reconciler.Reconcile(testAssets.Ctx, getRunName(tr)); err == nil {
+				t.Error("Wanted a wrapped requeue error, but got nil.")
+			} else if ok, _ := controller.IsRequeueKey(err); !ok {
+				t.Fatalf("Unexpected error when Reconcile(): %v", err)
+			}
+
+			tr, err = clients.Pipeline.TektonV1().TaskRuns(tr.Namespace).Get(testAssets.Ctx, tr.Name, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("Expected TaskRun %s to exist but instead got error when getting it: %v", tr.Name, err)
+			}
+			if err := spire.CheckStatusInternalAnnotation(tr); err != nil {
+				t.Fatalf("Error %s in checking internal status after third reconcile.", err)
+			}
+
+			if _, err := mockSpire.Entries[spireTaskRunEntryID]; err {
+				t.Fatalf("SPIFFE id %s expected to be deleted.", spireTaskRunEntryID)
+			}
+
+			if d := cmp.Diff(tc.wantPod.ObjectMeta, pod.ObjectMeta, ignoreRandomPodNameSuffix); d != "" {
+				t.Errorf("Pod metadata doesn't match %s", diff.PrintWantGot(d))
+			}
+
+			pod.Name = tc.wantPod.Name // Ignore pod name differences, the pod name is generated and tested in pod_test.go
+			if d := cmp.Diff(tc.wantPod.Spec, pod.Spec, resourceQuantityCmp, volumeSort, volumeMountSort, ignoreEnvVarOrdering); d != "" {
+				t.Errorf("Pod spec doesn't match %s", diff.PrintWantGot(d))
+			}
+			if d := cmp.Diff(&apis.Condition{
+				Type:    apis.ConditionSucceeded,
+				Status:  corev1.ConditionTrue,
+				Reason:  v1.TaskRunReasonSuccessful.String(),
+				Message: "All Steps have completed executing",
+			}, tr.Status.GetCondition(apis.ConditionSucceeded), ignoreLastTransitionTime); d != "" {
+				t.Errorf("Did not get expected condition %s", diff.PrintWantGot(d))
+			}
+		})
+	}
+}
+
+func TestReconcileOnTaskRunSign(t *testing.T) {
+	taskSt := &apis.Condition{
+		Type:    apis.ConditionSucceeded,
+		Status:  corev1.ConditionTrue,
+		Reason:  "Build succeeded",
+		Message: "Build succeeded",
+	}
+	taskRunStartedUnsigned := &v1.TaskRun{
+		ObjectMeta: objectMeta("taskrun-started-unsigned", "foo"),
+		Spec: v1.TaskRunSpec{
+			TaskRef: &v1.TaskRef{
+				Name: simpleTask.Name,
+			},
+		},
+		Status: v1.TaskRunStatus{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{
+					*taskSt,
+				},
+			},
+			TaskRunStatusFields: v1.TaskRunStatusFields{
+				StartTime: &metav1.Time{Time: now.Add(-15 * time.Second)},
+			},
+		},
+	}
+	taskRunUnstarted := &v1.TaskRun{
+		ObjectMeta: objectMeta("taskrun-unstarted", "foo"),
+		Spec: v1.TaskRunSpec{
+			TaskRef: &v1.TaskRef{
+				Name: simpleTask.Name,
+			},
+		},
+		Status: v1.TaskRunStatus{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{
+					*taskSt,
+				},
+			},
+		},
+	}
+	taskRunStartedSigned := &v1.TaskRun{
+		ObjectMeta: objectMeta("taskrun-started-signed", "foo"),
+		Spec: v1.TaskRunSpec{
+			TaskRef: &v1.TaskRef{
+				Name: simpleTask.Name,
+			},
+		},
+		Status: v1.TaskRunStatus{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{
+					*taskSt,
+				},
+			},
+			TaskRunStatusFields: v1.TaskRunStatusFields{
+				StartTime: &metav1.Time{Time: now.Add(-15 * time.Second)},
+			},
+		},
+	}
+	if err := mockSpire.AppendStatusInternalAnnotation(context.Background(), taskRunStartedSigned); err != nil {
+		t.Fatal("failed to sign test taskrun")
+	}
+
+	d := test.Data{
+		ConfigMaps: []*corev1.ConfigMap{{
+			ObjectMeta: metav1.ObjectMeta{Name: config.GetFeatureFlagsConfigName(), Namespace: system.Namespace()},
+			Data: map[string]string{
+				"enable-api-fields":         config.AlphaAPIFields,
+				"enforce-nonfalsifiability": config.EnforceNonfalsifiabilityWithSpire,
+			},
+		}},
+
+		TaskRuns: []*v1.TaskRun{
+			taskRunStartedUnsigned, taskRunUnstarted, taskRunStartedSigned,
+		},
+		Tasks: []*v1.Task{simpleTask},
+	}
+	testAssets, cancel := getTaskRunController(t, d)
+	defer cancel()
+	c := testAssets.Controller
+	clients := testAssets.Clients
+
+	testCases := []struct {
+		name       string
+		tr         *v1.TaskRun
+		verifiable bool
+	}{
+		{
+			name:       "sign/verify unstarted taskrun",
+			tr:         taskRunUnstarted,
+			verifiable: true,
+		},
+		{
+			name:       "sign/verify signed started taskrun",
+			tr:         taskRunStartedSigned,
+			verifiable: true,
+		},
+		{
+			name:       "sign/verify unsigned started taskrun should fail",
+			tr:         taskRunStartedUnsigned,
+			verifiable: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := c.Reconciler.Reconcile(testAssets.Ctx, getRunName(tc.tr)); err != nil {
+				t.Fatalf("Unexpected error when reconciling completed TaskRun : %v", err)
+			}
+			newTr, err := clients.Pipeline.TektonV1().TaskRuns(tc.tr.Namespace).Get(testAssets.Ctx, tc.tr.Name, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("Expected completed TaskRun %s to exist but instead got error when getting it: %v", tc.tr.Name, err)
+			}
+			verified := mockSpire.CheckSpireVerifiedFlag(newTr)
+			if verified != tc.verifiable {
+				t.Fatalf("expected verifiable: %v, got %v", tc.verifiable, verified)
+			}
+		})
+	}
 }
 
 // TestReconcileWithResolver checks that a TaskRun with a populated Resolver
@@ -1143,7 +1479,7 @@ spec:
 		t.Errorf("expected no error. Got error %v", err)
 	}
 
-	client := testAssets.Clients.ResolutionRequests.ResolutionV1beta1().ResolutionRequests("default")
+	client := testAssets.Clients.ResolutionRequests.ResolutionV1().ResolutionRequests("default")
 	resolutionrequests, err := client.List(testAssets.Ctx, metav1.ListOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error listing resource requests: %v", err)
@@ -1243,7 +1579,7 @@ spec:
 		t.Errorf("expected no error. Got error %v", err)
 	}
 
-	client := testAssets.Clients.ResolutionRequests.ResolutionV1beta1().ResolutionRequests("default")
+	client := testAssets.Clients.ResolutionRequests.ResolutionV1().ResolutionRequests("default")
 	resolutionrequests, err := client.List(testAssets.Ctx, metav1.ListOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error listing resource requests: %v", err)
@@ -4392,7 +4728,7 @@ func podVolumeMounts(idx, totalSteps int) []corev1.VolumeMount {
 	return mnts
 }
 
-func podArgs(cmd string, stdoutPath string, stderrPath string, additionalArgs []string, idx int) []string {
+func podArgs(cmd string, stdoutPath string, stderrPath string, additionalArgs []string, idx int, spireEnabled bool) []string {
 	args := []string{
 		"-wait_file",
 	}
@@ -4409,6 +4745,9 @@ func podArgs(cmd string, stdoutPath string, stderrPath string, additionalArgs []
 		"-step_metadata_dir",
 		fmt.Sprintf("/tekton/run/%d/status", idx),
 	)
+	if spireEnabled {
+		args = append(args, "-enable_spire")
+	}
 	if stdoutPath != "" {
 		args = append(args, "-stdout_path", stdoutPath)
 	}
@@ -4470,10 +4809,22 @@ type stepForExpectedPod struct {
 	stderrPath      string
 }
 
-func expectedPod(podName, taskName, taskRunName, ns, saName string, isClusterTask bool, extraVolumes []corev1.Volume, steps []stepForExpectedPod) *corev1.Pod {
+func expectedPod(podName, taskName, taskRunName, ns, saName string, isClusterTask bool, extraVolumes []corev1.Volume, steps []stepForExpectedPod, spireEnabled bool) *corev1.Pod {
 	stepNames := make([]string, 0, len(steps))
 	for _, s := range steps {
 		stepNames = append(stepNames, fmt.Sprintf("step-%s", s.name))
+	}
+
+	initContainers := []corev1.Container{placeToolsInitContainer(stepNames)}
+	if spireEnabled {
+		for i := range initContainers {
+			c := &initContainers[i]
+			c.VolumeMounts = append(c.VolumeMounts, corev1.VolumeMount{
+				Name:      spire.WorkloadAPI,
+				MountPath: spire.VolumeMountPath,
+				ReadOnly:  true,
+			})
+		}
 	}
 	p := &corev1.Pod{
 		ObjectMeta: podObjectMeta(podName, taskName, taskRunName, ns, isClusterTask),
@@ -4486,7 +4837,7 @@ func expectedPod(podName, taskName, taskRunName, ns, saName string, isClusterTas
 				binVolume,
 				downwardVolume,
 			},
-			InitContainers:        []corev1.Container{placeToolsInitContainer(stepNames)},
+			InitContainers:        initContainers,
 			RestartPolicy:         corev1.RestartPolicyNever,
 			ActiveDeadlineSeconds: &defaultActiveDeadlineSeconds,
 			ServiceAccountName:    saName,
@@ -4507,7 +4858,7 @@ func expectedPod(podName, taskName, taskRunName, ns, saName string, isClusterTas
 			VolumeMounts:           podVolumeMounts(idx, len(steps)),
 			TerminationMessagePath: "/tekton/termination",
 		}
-		stepContainer.Args = podArgs(s.cmd, s.stdoutPath, s.stderrPath, s.args, idx)
+		stepContainer.Args = podArgs(s.cmd, s.stdoutPath, s.stderrPath, s.args, idx, spireEnabled)
 
 		for k, v := range s.envVars {
 			stepContainer.Env = append(stepContainer.Env, corev1.EnvVar{

--- a/pkg/spire/controller.go
+++ b/pkg/spire/controller.go
@@ -28,7 +28,7 @@ import (
 	entryv1 "github.com/spiffe/spire-api-sdk/proto/spire/api/server/entry/v1"
 	spiffetypes "github.com/spiffe/spire-api-sdk/proto/spire/api/types"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	spireconfig "github.com/tektoncd/pipeline/pkg/spire/config"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
@@ -173,7 +173,7 @@ func (sc *spireControllerAPIClient) nodeEntry(nodeName string) *spiffetypes.Entr
 	}
 }
 
-func (sc *spireControllerAPIClient) workloadEntry(tr *v1beta1.TaskRun, pod *corev1.Pod, expiry int64) *spiffetypes.Entry {
+func (sc *spireControllerAPIClient) workloadEntry(tr *v1.TaskRun, pod *corev1.Pod, expiry int64) *spiffetypes.Entry {
 	// Note: We can potentially add attestation on the container images as well since
 	// the information is available here.
 	selectors := []*spiffetypes.Selector{
@@ -202,7 +202,7 @@ func (sc *spireControllerAPIClient) workloadEntry(tr *v1beta1.TaskRun, pod *core
 }
 
 // ttl is the TTL for the SPIRE entry in seconds, not the SVID TTL
-func (sc *spireControllerAPIClient) CreateEntries(ctx context.Context, tr *v1beta1.TaskRun, pod *corev1.Pod, ttl time.Duration) error {
+func (sc *spireControllerAPIClient) CreateEntries(ctx context.Context, tr *v1.TaskRun, pod *corev1.Pod, ttl time.Duration) error {
 	err := sc.setupClient(ctx)
 	if err != nil {
 		return err
@@ -244,7 +244,7 @@ func (sc *spireControllerAPIClient) CreateEntries(ctx context.Context, tr *v1bet
 	return nil
 }
 
-func (sc *spireControllerAPIClient) getEntries(ctx context.Context, tr *v1beta1.TaskRun, pod *corev1.Pod) ([]*spiffetypes.Entry, error) {
+func (sc *spireControllerAPIClient) getEntries(ctx context.Context, tr *v1.TaskRun, pod *corev1.Pod) ([]*spiffetypes.Entry, error) {
 	req := &entryv1.ListEntriesRequest{
 		Filter: &entryv1.ListEntriesRequest_Filter{
 			BySpiffeId: &spiffetypes.SPIFFEID{
@@ -273,7 +273,7 @@ func (sc *spireControllerAPIClient) getEntries(ctx context.Context, tr *v1beta1.
 	return entries, nil
 }
 
-func (sc *spireControllerAPIClient) DeleteEntry(ctx context.Context, tr *v1beta1.TaskRun, pod *corev1.Pod) error {
+func (sc *spireControllerAPIClient) DeleteEntry(ctx context.Context, tr *v1.TaskRun, pod *corev1.Pod) error {
 	entries, err := sc.getEntries(ctx, tr, pod)
 	if err != nil {
 		return err

--- a/pkg/spire/sign.go
+++ b/pkg/spire/sign.go
@@ -27,7 +27,7 @@ import (
 	"strings"
 
 	"github.com/spiffe/go-spiffe/v2/svid/x509svid"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/result"
 )
 
@@ -116,7 +116,7 @@ func getManifest(results []result.RunResult) string {
 }
 
 // AppendStatusInternalAnnotation creates the status annotations which are used by the controller to verify the status hash
-func (sc *spireControllerAPIClient) AppendStatusInternalAnnotation(ctx context.Context, tr *v1beta1.TaskRun) error {
+func (sc *spireControllerAPIClient) AppendStatusInternalAnnotation(ctx context.Context, tr *v1.TaskRun) error {
 	err := sc.setupClient(ctx)
 	if err != nil {
 		return err

--- a/pkg/spire/spire.go
+++ b/pkg/spire/spire.go
@@ -28,7 +28,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/result"
 	spireconfig "github.com/tektoncd/pipeline/pkg/spire/config"
 	"go.uber.org/zap"
@@ -59,13 +59,13 @@ const (
 
 // ControllerAPIClient interface maps to the spire controller API to interact with spire
 type ControllerAPIClient interface {
-	AppendStatusInternalAnnotation(ctx context.Context, tr *v1beta1.TaskRun) error
-	CheckSpireVerifiedFlag(tr *v1beta1.TaskRun) bool
+	AppendStatusInternalAnnotation(ctx context.Context, tr *v1.TaskRun) error
+	CheckSpireVerifiedFlag(tr *v1.TaskRun) bool
 	Close() error
-	CreateEntries(ctx context.Context, tr *v1beta1.TaskRun, pod *corev1.Pod, ttl time.Duration) error
-	DeleteEntry(ctx context.Context, tr *v1beta1.TaskRun, pod *corev1.Pod) error
-	VerifyStatusInternalAnnotation(ctx context.Context, tr *v1beta1.TaskRun, logger *zap.SugaredLogger) error
-	VerifyTaskRunResults(ctx context.Context, prs []result.RunResult, tr *v1beta1.TaskRun) error
+	CreateEntries(ctx context.Context, tr *v1.TaskRun, pod *corev1.Pod, ttl time.Duration) error
+	DeleteEntry(ctx context.Context, tr *v1.TaskRun, pod *corev1.Pod) error
+	VerifyStatusInternalAnnotation(ctx context.Context, tr *v1.TaskRun, logger *zap.SugaredLogger) error
+	VerifyTaskRunResults(ctx context.Context, prs []result.RunResult, tr *v1.TaskRun) error
 	SetConfig(c spireconfig.SpireConfig)
 }
 

--- a/pkg/spire/spire_mock.go
+++ b/pkg/spire/spire_mock.go
@@ -24,7 +24,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/result"
 	spireconfig "github.com/tektoncd/pipeline/pkg/spire/config"
 	"go.uber.org/zap"
@@ -67,16 +67,16 @@ type MockClient struct {
 	VerifyAlwaysReturns *bool
 
 	// VerifyStatusInternalAnnotationOverride contains the function to overwrite a call to VerifyStatusInternalAnnotation
-	VerifyStatusInternalAnnotationOverride func(ctx context.Context, tr *v1beta1.TaskRun, logger *zap.SugaredLogger) error
+	VerifyStatusInternalAnnotationOverride func(ctx context.Context, tr *v1.TaskRun, logger *zap.SugaredLogger) error
 
 	// VerifyTaskRunResultsOverride contains the function to overwrite a call to VerifyTaskRunResults
-	VerifyTaskRunResultsOverride func(ctx context.Context, prs []result.RunResult, tr *v1beta1.TaskRun) error
+	VerifyTaskRunResultsOverride func(ctx context.Context, prs []result.RunResult, tr *v1.TaskRun) error
 
 	// AppendStatusInternalAnnotationOverride  contains the function to overwrite a call to AppendStatusInternalAnnotation
-	AppendStatusInternalAnnotationOverride func(ctx context.Context, tr *v1beta1.TaskRun) error
+	AppendStatusInternalAnnotationOverride func(ctx context.Context, tr *v1.TaskRun) error
 
 	// CheckSpireVerifiedFlagOverride contains the function to overwrite a call to CheckSpireVerifiedFlag
-	CheckSpireVerifiedFlagOverride func(tr *v1beta1.TaskRun) bool
+	CheckSpireVerifiedFlagOverride func(tr *v1.TaskRun) bool
 
 	// SignOverride contains the function to overwrite a call to Sign
 	SignOverride func(ctx context.Context, results []result.RunResult) ([]result.RunResult, error)
@@ -96,12 +96,12 @@ func (sc *MockClient) mockVerify(content, sig, signedBy string) bool {
 }
 
 // GetIdentity get the taskrun namespace and taskrun name that is used for signing and verifying in mocked spire
-func (*MockClient) GetIdentity(tr *v1beta1.TaskRun) string {
+func (*MockClient) GetIdentity(tr *v1.TaskRun) string {
 	return fmt.Sprintf("/ns/%v/taskrun/%v", tr.Namespace, tr.Name)
 }
 
 // AppendStatusInternalAnnotation creates the status annotations which are used by the controller to verify the status hash
-func (sc *MockClient) AppendStatusInternalAnnotation(ctx context.Context, tr *v1beta1.TaskRun) error {
+func (sc *MockClient) AppendStatusInternalAnnotation(ctx context.Context, tr *v1.TaskRun) error {
 	if sc.AppendStatusInternalAnnotationOverride != nil {
 		return sc.AppendStatusInternalAnnotationOverride(ctx, tr)
 	}
@@ -121,7 +121,7 @@ func (sc *MockClient) AppendStatusInternalAnnotation(ctx context.Context, tr *v1
 }
 
 // CheckSpireVerifiedFlag checks if the verified status annotation is set which would result in spire verification failed
-func (sc *MockClient) CheckSpireVerifiedFlag(tr *v1beta1.TaskRun) bool {
+func (sc *MockClient) CheckSpireVerifiedFlag(tr *v1.TaskRun) bool {
 	if sc.CheckSpireVerifiedFlagOverride != nil {
 		return sc.CheckSpireVerifiedFlagOverride(tr)
 	}
@@ -131,7 +131,7 @@ func (sc *MockClient) CheckSpireVerifiedFlag(tr *v1beta1.TaskRun) bool {
 }
 
 // CreateEntries adds entries to the dictionary of entries that mock the SPIRE server datastore
-func (sc *MockClient) CreateEntries(ctx context.Context, tr *v1beta1.TaskRun, pod *corev1.Pod, ttl time.Duration) error {
+func (sc *MockClient) CreateEntries(ctx context.Context, tr *v1.TaskRun, pod *corev1.Pod, ttl time.Duration) error {
 	id := fmt.Sprintf("/ns/%v/taskrun/%v", tr.Namespace, tr.Name)
 	if sc.Entries == nil {
 		sc.Entries = map[string]bool{}
@@ -141,7 +141,7 @@ func (sc *MockClient) CreateEntries(ctx context.Context, tr *v1beta1.TaskRun, po
 }
 
 // DeleteEntry removes the entry from the dictionary of entries that mock the SPIRE server datastore
-func (sc *MockClient) DeleteEntry(ctx context.Context, tr *v1beta1.TaskRun, pod *corev1.Pod) error {
+func (sc *MockClient) DeleteEntry(ctx context.Context, tr *v1.TaskRun, pod *corev1.Pod) error {
 	id := fmt.Sprintf("/ns/%v/taskrun/%v", tr.Namespace, tr.Name)
 	if sc.Entries != nil {
 		delete(sc.Entries, id)
@@ -150,7 +150,7 @@ func (sc *MockClient) DeleteEntry(ctx context.Context, tr *v1beta1.TaskRun, pod 
 }
 
 // VerifyStatusInternalAnnotation checks that the internal status annotations are valid by the mocked spire client
-func (sc *MockClient) VerifyStatusInternalAnnotation(ctx context.Context, tr *v1beta1.TaskRun, logger *zap.SugaredLogger) error {
+func (sc *MockClient) VerifyStatusInternalAnnotation(ctx context.Context, tr *v1.TaskRun, logger *zap.SugaredLogger) error {
 	if sc.VerifyStatusInternalAnnotationOverride != nil {
 		return sc.VerifyStatusInternalAnnotationOverride(ctx, tr, logger)
 	}
@@ -187,7 +187,7 @@ func (sc *MockClient) VerifyStatusInternalAnnotation(ctx context.Context, tr *v1
 }
 
 // VerifyTaskRunResults checks that all the TaskRun results are valid by the mocked spire client
-func (sc *MockClient) VerifyTaskRunResults(ctx context.Context, prs []result.RunResult, tr *v1beta1.TaskRun) error {
+func (sc *MockClient) VerifyTaskRunResults(ctx context.Context, prs []result.RunResult, tr *v1.TaskRun) error {
 	if sc.VerifyTaskRunResultsOverride != nil {
 		return sc.VerifyTaskRunResultsOverride(ctx, prs, tr)
 	}

--- a/pkg/spire/spire_mock.go
+++ b/pkg/spire/spire_mock.go
@@ -38,7 +38,12 @@ func init() {
 }
 
 func withFakeControllerClient(ctx context.Context, cfg *rest.Config) context.Context {
-	return context.WithValue(ctx, controllerKey{}, &spireControllerAPIClient{})
+	return context.WithValue(ctx, controllerKey{}, &MockClient{})
+}
+
+// InjectClient injects MockClient into the given context as SpireControllerApiClient.
+func InjectClient(ctx context.Context, spireMock *MockClient) context.Context {
+	return context.WithValue(ctx, controllerKey{}, spireMock)
 }
 
 // MockClient is a client used for mocking the this package for unit testing

--- a/pkg/spire/spire_mock_test.go
+++ b/pkg/spire/spire_mock_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/result"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -55,7 +55,7 @@ func TestMock_TaskRunSign(t *testing.T) {
 	}
 }
 
-// test CheckSpireVerifiedFlag(tr *v1beta1.TaskRun) bool
+// test CheckSpireVerifiedFlag(tr *v1.TaskRun) bool
 func TestMock_CheckSpireVerifiedFlag(t *testing.T) {
 	spireMockClient := &MockClient{}
 	var (
@@ -95,7 +95,7 @@ func TestMock_CheckHashSimilarities(t *testing.T) {
 
 	tr2c.Status.Status.Annotations = map[string]string{"new": "value"}
 
-	signTrs := []*v1beta1.TaskRun{tr1, tr1c, tr2, tr2c}
+	signTrs := []*v1.TaskRun{tr1, tr1c, tr2, tr2c}
 
 	for _, tr := range signTrs {
 		err := cc.AppendStatusInternalAnnotation(ctx, tr)
@@ -220,7 +220,7 @@ func TestMock_CheckTamper(t *testing.T) {
 			}
 
 			if tt.modifyStatus {
-				tr.Status.TaskRunStatusFields.Steps = append(tr.Status.TaskRunStatusFields.Steps, v1beta1.StepState{
+				tr.Status.TaskRunStatusFields.Steps = append(tr.Status.TaskRunStatusFields.Steps, v1.StepState{
 					ContainerState: corev1.ContainerState{
 						Terminated: &corev1.ContainerStateTerminated{ExitCode: int32(54321)},
 					}})
@@ -545,13 +545,13 @@ func objectMeta(name, ns string) metav1.ObjectMeta {
 	}
 }
 
-func testTaskRuns() []*v1beta1.TaskRun {
-	return []*v1beta1.TaskRun{
+func testTaskRuns() []*v1.TaskRun {
+	return []*v1.TaskRun{
 		// taskRun 1
 		{
 			ObjectMeta: objectMeta("taskrun-example", "foo"),
-			Spec: v1beta1.TaskRunSpec{
-				TaskRef: &v1beta1.TaskRef{
+			Spec: v1.TaskRunSpec{
+				TaskRef: &v1.TaskRef{
 					Name:       "taskname",
 					APIVersion: "a1",
 				},
@@ -561,14 +561,14 @@ func testTaskRuns() []*v1beta1.TaskRun {
 		// taskRun 2
 		{
 			ObjectMeta: objectMeta("taskrun-example-populated", "foo"),
-			Spec: v1beta1.TaskRunSpec{
-				TaskRef:            &v1beta1.TaskRef{Name: "unit-test-task"},
+			Spec: v1.TaskRunSpec{
+				TaskRef:            &v1.TaskRef{Name: "unit-test-task"},
 				ServiceAccountName: "test-sa",
 				Timeout:            &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
 			},
-			Status: v1beta1.TaskRunStatus{
-				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
-					Steps: []v1beta1.StepState{{
+			Status: v1.TaskRunStatus{
+				TaskRunStatusFields: v1.TaskRunStatusFields{
+					Steps: []v1.StepState{{
 						ContainerState: corev1.ContainerState{
 							Terminated: &corev1.ContainerStateTerminated{ExitCode: int32(0)},
 						},
@@ -579,12 +579,12 @@ func testTaskRuns() []*v1beta1.TaskRun {
 		// taskRun 3
 		{
 			ObjectMeta: objectMeta("taskrun-example-with-objmeta", "foo"),
-			Spec: v1beta1.TaskRunSpec{
-				TaskRef:            &v1beta1.TaskRef{Name: "unit-test-task"},
+			Spec: v1.TaskRunSpec{
+				TaskRef:            &v1.TaskRef{Name: "unit-test-task"},
 				ServiceAccountName: "test-sa",
 				Timeout:            &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
 			},
-			Status: v1beta1.TaskRunStatus{
+			Status: v1.TaskRunStatus{
 				Status: duckv1.Status{
 					Conditions: duckv1.Conditions{
 						apis.Condition{
@@ -592,8 +592,8 @@ func testTaskRuns() []*v1beta1.TaskRun {
 						},
 					},
 				},
-				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
-					Steps: []v1beta1.StepState{{
+				TaskRunStatusFields: v1.TaskRunStatusFields{
+					Steps: []v1.StepState{{
 						ContainerState: corev1.ContainerState{
 							Terminated: &corev1.ContainerStateTerminated{ExitCode: int32(0)},
 						},
@@ -603,12 +603,12 @@ func testTaskRuns() []*v1beta1.TaskRun {
 		},
 		{
 			ObjectMeta: objectMeta("taskrun-example-with-objmeta-annotations", "foo"),
-			Spec: v1beta1.TaskRunSpec{
-				TaskRef:            &v1beta1.TaskRef{Name: "unit-test-task"},
+			Spec: v1.TaskRunSpec{
+				TaskRef:            &v1.TaskRef{Name: "unit-test-task"},
 				ServiceAccountName: "test-sa",
 				Timeout:            &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
 			},
-			Status: v1beta1.TaskRunStatus{
+			Status: v1.TaskRunStatus{
 				Status: duckv1.Status{
 					Conditions: duckv1.Conditions{
 						apis.Condition{
@@ -620,8 +620,8 @@ func testTaskRuns() []*v1beta1.TaskRun {
 						"annotation2": "a2value",
 					},
 				},
-				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
-					Steps: []v1beta1.StepState{{
+				TaskRunStatusFields: v1.TaskRunStatusFields{
+					Steps: []v1.StepState{{
 						ContainerState: corev1.ContainerState{
 							Terminated: &corev1.ContainerStateTerminated{ExitCode: int32(0)},
 						},
@@ -716,11 +716,11 @@ func testRunResults() [][]result.RunResult {
 	}
 }
 
-func getHash(tr *v1beta1.TaskRun) string {
+func getHash(tr *v1.TaskRun) string {
 	return tr.Status.Status.Annotations[TaskRunStatusHashAnnotation]
 }
 
-func genPodObj(tr *v1beta1.TaskRun, uid string) *corev1.Pod {
+func genPodObj(tr *v1.TaskRun, uid string) *corev1.Pod {
 	if uid == "" {
 		uid = uuid.NewString()
 	}

--- a/pkg/spire/spire_test.go
+++ b/pkg/spire/spire_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/go-spiffe/v2/svid/x509svid"
 	pconf "github.com/tektoncd/pipeline/pkg/apis/config"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	ttesting "github.com/tektoncd/pipeline/pkg/reconciler/testing"
 	"github.com/tektoncd/pipeline/pkg/result"
 	"github.com/tektoncd/pipeline/pkg/spire/config"
@@ -169,7 +169,7 @@ func TestCheckHashSimilarities(t *testing.T) {
 
 	tr2c.Status.Status.Annotations = map[string]string{"new": "value"}
 
-	signTrs := []*v1beta1.TaskRun{tr1, tr1c, tr2, tr2c}
+	signTrs := []*v1.TaskRun{tr1, tr1c, tr2, tr2c}
 
 	for _, tr := range signTrs {
 		err := cc.AppendStatusInternalAnnotation(ctx, tr)
@@ -329,7 +329,7 @@ func TestCheckTamper(t *testing.T) {
 			}
 
 			if tt.modifyStatus {
-				tr.Status.TaskRunStatusFields.Steps = append(tr.Status.TaskRunStatusFields.Steps, v1beta1.StepState{
+				tr.Status.TaskRunStatusFields.Steps = append(tr.Status.TaskRunStatusFields.Steps, v1.StepState{
 					ContainerState: corev1.ContainerState{
 						Terminated: &corev1.ContainerStateTerminated{ExitCode: int32(54321)},
 					}})
@@ -701,6 +701,6 @@ func x509svids(ca *test.CA, ids ...spiffeid.ID) []*x509svid.SVID {
 	return svids
 }
 
-func taskrunPath(tr *v1beta1.TaskRun) string {
+func taskrunPath(tr *v1.TaskRun) string {
 	return fmt.Sprintf("/ns/%v/taskrun/%v", tr.Namespace, tr.Name)
 }

--- a/test/taskrun_test.go
+++ b/test/taskrun_test.go
@@ -31,8 +31,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/pod"
 	"github.com/tektoncd/pipeline/test/parse"
 	corev1 "k8s.io/api/core/v1"
@@ -324,8 +324,8 @@ spec:
 				Reason:   "Error",
 			},
 		},
-		Name:          "unnamed-0",
-		ContainerName: "step-unnamed-0",
+		Name:      "unnamed-0",
+		Container: "step-unnamed-0",
 	}}
 
 	ignoreTerminatedFields := cmpopts.IgnoreFields(corev1.ContainerStateTerminated{}, "StartedAt", "FinishedAt", "ContainerID")
@@ -410,8 +410,8 @@ spec:
 				Reason:   "Completed",
 			},
 		},
-		Name:          "unnamed-0",
-		ContainerName: "step-unnamed-0",
+		Name:      "unnamed-0",
+		Container: "step-unnamed-0",
 	}}
 
 	ignoreTerminatedFields := cmpopts.IgnoreFields(corev1.ContainerStateTerminated{}, "StartedAt", "FinishedAt", "ContainerID")

--- a/test/taskrun_test.go
+++ b/test/taskrun_test.go
@@ -21,18 +21,24 @@ package test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"strings"
 	"testing"
 
+	jsonpatch "gomodules.xyz/jsonpatch/v2"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/pod"
 	"github.com/tektoncd/pipeline/test/parse"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"knative.dev/pkg/system"
 	knativetest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/helpers"
 )
@@ -90,6 +96,11 @@ spec:
 	taskrun, err := c.V1TaskRunClient.Get(ctx, taskRunName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't get expected TaskRun %s: %s", taskRunName, err)
+	}
+
+	if isSpireEnabled(ctx, t, c, namespace) {
+		spireShouldFailTaskRunResultsVerify(t, taskrun)
+		spireShouldPassSpireAnnotation(t, taskrun)
 	}
 
 	expectedStepState := []v1.StepState{{
@@ -184,6 +195,11 @@ spec:
 		t.Fatalf("Couldn't get expected TaskRun %s: %s", taskRunName, err)
 	}
 
+	if isSpireEnabled(ctx, t, c, namespace) {
+		spireShouldPassTaskRunResultsVerify(t, taskrun)
+		spireShouldPassSpireAnnotation(t, taskrun)
+	}
+
 	expectedStepState := []v1.StepState{{
 		ContainerState: corev1.ContainerState{
 			Terminated: &corev1.ContainerStateTerminated{
@@ -207,5 +223,220 @@ spec:
 
 	if d := cmp.Diff(taskrun.Status.TaskSpec, &task.Spec); d != "" {
 		t.Fatalf("-got, +want: %v", d)
+	}
+}
+
+// TestTaskRunModificationSpire is an exclusive test for SPIRE integration into taskrun.
+// The test starts a taskrun which has a sleep. While the taskrun is "sleep"ing,
+// the text modifies the taskrun results.
+// This change is caught by the taskrun reconciler when it tries to verify the results.
+func TestTaskRunModificationSpire(t *testing.T) {
+	ctx := context.Background()
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	var c *clients
+	var namespace string
+	var oldConfigMap map[string]string
+	var configSpire = map[string]string{
+		"results-from":              "termination-message",
+		"enforce-nonfalsifiability": "spire",
+	}
+
+	c, namespace, oldConfigMap = setupWithFlags(ctx, t, configSpire, requireAllGates(spireFeatureGates))
+	defer resetFlags(ctx, t, c, oldConfigMap)
+
+	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
+	defer tearDown(ctx, t, c, namespace)
+
+	taskRunName := "non-falsifiable-provenance-fail"
+
+	t.Logf("Creating Task and TaskRun in namespace %s", namespace)
+	task := parse.MustParseV1Task(t, fmt.Sprintf(`
+metadata:
+  name: non-falsifiable
+  namespace: %s
+spec:
+  results:
+  - name: foo
+  - name: bar
+  steps:
+  - image: ubuntu
+    script: |
+      #!/usr/bin/env bash
+      sleep 20
+      printf "hello" > "$(results.foo.path)"
+      printf "world" > "$(results.bar.path)"
+`, namespace))
+	if _, err := c.V1TaskClient.Create(ctx, task, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Failed to create Task: %s", err)
+	}
+	taskRun := parse.MustParseV1TaskRun(t, fmt.Sprintf(`
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  taskRef:
+    name: non-falsifiable
+`, taskRunName, namespace))
+	if _, err := c.V1TaskRunClient.Create(ctx, taskRun, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Failed to create TaskRun: %s", err)
+	}
+
+	t.Logf("Waiting for TaskRun in namespace %s to be in running state", namespace)
+	if err := WaitForTaskRunState(ctx, c, taskRunName, Running(taskRunName), "TaskRunRunning", v1Version); err != nil {
+		t.Errorf("Error waiting for TaskRun to start running: %s", err)
+	}
+
+	patches := []jsonpatch.JsonPatchOperation{{
+		Operation: "replace",
+		Path:      "/status/taskSpec/steps/0/image",
+		Value:     "not-ubuntu",
+	}}
+	patchBytes, err := json.Marshal(patches)
+	if err != nil {
+		t.Fatalf("failed to marshal patch bytes in order to stop")
+	}
+	t.Logf("Patching TaskRun %s in namespace %s mid run for spire to catch the un-authorized changed", taskRunName, namespace)
+	if _, err := c.V1TaskRunClient.Patch(ctx, taskRunName, types.JSONPatchType, patchBytes, metav1.PatchOptions{}, "status"); err != nil {
+		t.Fatalf("Failed to patch taskrun `%s`: %s", taskRunName, err)
+	}
+
+	t.Logf("Waiting for TaskRun %s in namespace %s to succeed", taskRunName, namespace)
+	if err := WaitForTaskRunState(ctx, c, taskRunName, TaskRunFailed(taskRunName), "TaskRunFailed", v1Version); err != nil {
+		t.Errorf("Error waiting for TaskRun to finish: %s", err)
+	}
+
+	taskrun, err := c.V1TaskRunClient.Get(ctx, taskRunName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't get expected TaskRun %s: %s", taskRunName, err)
+	}
+
+	if isSpireEnabled(ctx, t, c, namespace) {
+		spireShouldFailTaskRunResultsVerify(t, taskrun)
+		spireShouldFailSpireAnnotation(t, taskrun)
+	}
+
+	expectedStepState := []v1.StepState{{
+		ContainerState: corev1.ContainerState{
+			Terminated: &corev1.ContainerStateTerminated{
+				ExitCode: 1,
+				Reason:   "Error",
+			},
+		},
+		Name:          "unnamed-0",
+		ContainerName: "step-unnamed-0",
+	}}
+
+	ignoreTerminatedFields := cmpopts.IgnoreFields(corev1.ContainerStateTerminated{}, "StartedAt", "FinishedAt", "ContainerID")
+	ignoreStepFields := cmpopts.IgnoreFields(v1.StepState{}, "ImageID")
+	if d := cmp.Diff(taskrun.Status.Steps, expectedStepState, ignoreTerminatedFields, ignoreStepFields); d != "" {
+		t.Fatalf("-got, +want: %v", d)
+	}
+}
+
+func TestTaskRunSpire(t *testing.T) {
+	ctx := context.Background()
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	var c *clients
+	var namespace string
+	var oldConfigMap map[string]string
+	var configSpire = map[string]string{
+		"results-from":              "termination-message",
+		"enforce-nonfalsifiability": "spire",
+	}
+
+	c, namespace, oldConfigMap = setupWithFlags(ctx, t, configSpire, requireAllGates(spireFeatureGates))
+	defer resetFlags(ctx, t, c, oldConfigMap)
+
+	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
+	defer tearDown(ctx, t, c, namespace)
+
+	taskRunName := "non-falsifiable-provenance-pass"
+
+	t.Logf("Creating Task and TaskRun in namespace %s", namespace)
+	task := parse.MustParseV1Task(t, fmt.Sprintf(`
+metadata:
+  name: non-falsifiable
+  namespace: %s
+spec:
+  results:
+  - name: foo
+  - name: bar
+  steps:
+  - image: ubuntu
+    script: |
+      #!/usr/bin/env bash
+      sleep 20
+      printf "hello" > "$(results.foo.path)"
+      printf "world" > "$(results.bar.path)"
+`, namespace))
+	if _, err := c.V1TaskClient.Create(ctx, task, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Failed to create Task: %s", err)
+	}
+	taskRun := parse.MustParseV1TaskRun(t, fmt.Sprintf(`
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  taskRef:
+    name: non-falsifiable
+`, taskRunName, namespace))
+	if _, err := c.V1TaskRunClient.Create(ctx, taskRun, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Failed to create TaskRun: %s", err)
+	}
+
+	t.Logf("Waiting for TaskRun %s in namespace %s to succeed", taskRunName, namespace)
+	if err := WaitForTaskRunState(ctx, c, taskRunName, TaskRunSucceed(taskRunName), "TaskRunSucceed", v1Version); err != nil {
+		t.Errorf("Error waiting for TaskRun to finish: %s", err)
+	}
+
+	taskrun, err := c.V1TaskRunClient.Get(ctx, taskRunName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't get expected TaskRun %s: %s", taskRunName, err)
+	}
+
+	if isSpireEnabled(ctx, t, c, namespace) {
+		spireShouldPassTaskRunResultsVerify(t, taskrun)
+		spireShouldPassSpireAnnotation(t, taskrun)
+	}
+
+	expectedStepState := []v1.StepState{{
+		ContainerState: corev1.ContainerState{
+			Terminated: &corev1.ContainerStateTerminated{
+				ExitCode: 0,
+				Reason:   "Completed",
+			},
+		},
+		Name:          "unnamed-0",
+		ContainerName: "step-unnamed-0",
+	}}
+
+	ignoreTerminatedFields := cmpopts.IgnoreFields(corev1.ContainerStateTerminated{}, "StartedAt", "FinishedAt", "ContainerID")
+	ignoreStepFields := cmpopts.IgnoreFields(v1.StepState{}, "ImageID")
+	if d := cmp.Diff(taskrun.Status.Steps, expectedStepState, ignoreTerminatedFields, ignoreStepFields); d != "" {
+		t.Fatalf("-got, +want: %v", d)
+	}
+}
+
+func setupWithFlags(ctx context.Context, t *testing.T, configMapData map[string]string, fn ...func(context.Context, *testing.T, *clients, string)) (*clients, string, map[string]string) {
+	t.Helper()
+	c, ns := setup(ctx, t, fn...)
+	featureFlagsCM, err := c.KubeClient.CoreV1().ConfigMaps(system.Namespace()).Get(ctx, config.GetFeatureFlagsConfigName(), metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get ConfigMap `%s`: %s", config.GetFeatureFlagsConfigName(), err)
+	}
+	if err := updateConfigMap(ctx, c.KubeClient, system.Namespace(), config.GetFeatureFlagsConfigName(), configMapData); err != nil {
+		t.Fatal(err)
+	}
+	return c, ns, featureFlagsCM.Data
+}
+
+func resetFlags(ctx context.Context, t *testing.T, c *clients, configMapData map[string]string) {
+	t.Helper()
+	if err := updateConfigMap(ctx, c.KubeClient, system.Namespace(), config.GetFeatureFlagsConfigName(), configMapData); err != nil {
+		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
Enable the signing and verification of TR results and the TR status.

This PR enables the signing and verification of TR results and TR status.

Before this change the spireAPIController object was injected into the TR reconciler but it was not used.

After this change,
- At the start of every reconcile run, the reconciler will verify if the signature on the status can be verified, else it will error out.
- At the end of every reconcile run, the reconciler will sign the status and add it as an annotation.
- When TR results are read from the termination message and converted into TR results, they will be verified.

This commit is part of a series of PRs to implement TEP-0089. The implementation of TEP-0089 is tracked in the issue #6597 SPIRE for non-falsifiable provenance.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [X] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [X] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [X] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [X] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [X] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
* Added TaskRun Status annotations to track the validity of the signed TaskRun
* Utilizes pipeline controller spire SVID, status hash and signature
* Pipeline controller continuously validates the TaskRun Status for any modifications
* Tekton Chains will validate the results and status of the TaskRun after completion
```
