### PR TITLE
Fix apiVersion of Task to v1 in v1 examples

### DIFF
--- a/examples/v1/pipelineruns/pipelinerun.yaml
+++ b/examples/v1/pipelineruns/pipelinerun.yaml
@@ -101,7 +101,7 @@ spec:
 # Using the catalog fails for unknown reasons, so we're keeping this here.
 # Adding `--ignore-path=/product_uuid` EXTRA_ARGS is a workaround for the 'build unlinkat
 # //product_uuid' error filed at https://github.com/GoogleContainerTools/kaniko/issues/2164.
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: kaniko

--- a/examples/v1/taskruns/beta/bundles-resolver.yaml
+++ b/examples/v1/taskruns/beta/bundles-resolver.yaml
@@ -1,4 +1,4 @@
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
   generateName: bundles-resolver-

--- a/examples/v1/taskruns/beta/git-resolver.yaml
+++ b/examples/v1/taskruns/beta/git-resolver.yaml
@@ -1,4 +1,4 @@
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
   generateName: git-resolver-

--- a/examples/v1/taskruns/beta/hub-resolver.yaml
+++ b/examples/v1/taskruns/beta/hub-resolver.yaml
@@ -1,4 +1,4 @@
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
   generateName: hub-resolver-simple-semver-
@@ -26,7 +26,7 @@ spec:
       - name: version
         value: "0.6"
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
   generateName: hub-resolver-semver-required-fields-only-


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This commit changes the apiVersion of the v1beta1 Task used in v1 examples.

/kind cleanup
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [n/a] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [n/a] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [n/a] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
