### PR TITLE
 Remove logic setting resolvers feature flag in e2e tests

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -55,24 +55,14 @@ function add_spire() {
 
 function set_feature_gate() {
   local gate="$1"
-  local resolver="false"
   if [ "$gate" != "alpha" ] && [ "$gate" != "stable" ] && [ "$gate" != "beta" ] ; then
     printf "Invalid gate %s\n" ${gate}
     exit 255
-  fi
-  if [ "$gate" == "alpha" ]; then
-    resolver="true"
   fi
   printf "Setting feature gate to %s\n", ${gate}
   jsonpatch=$(printf "{\"data\": {\"enable-api-fields\": \"%s\"}}" $1)
   echo "feature-flags ConfigMap patch: ${jsonpatch}"
   kubectl patch configmap feature-flags -n tekton-pipelines -p "$jsonpatch"
-  if [ "$gate" == "alpha" ]; then
-    printf "enabling resolvers\n"
-    jsonpatch=$(printf "{\"data\": {\"enable-git-resolver\": \"true\", \"enable-hub-resolver\": \"true\", \"enable-bundles-resolver\": \"true\", \"enable-cluster-resolver\": \"true\"}}")
-    echo "resolvers-feature-flags ConfigMap patch: ${jsonpatch}"
-    kubectl patch configmap resolvers-feature-flags -n tekton-pipelines-resolvers -p "$jsonpatch"
-  fi
 }
 
 function set_result_extraction_method() {


### PR DESCRIPTION
Resolution is a beta feature, and resolvers are now enabled by default.
Therefore, there is no logic needed to patch the resolvers configmap when "enable-api-fields" is set to "stable".
In addition, we don't gate installation of resolvers on the "enable-api-fields" feature flag,
and doing so in tests isn't representative of how users install resolvers.

This commit removes logic patching the resolvers configmap.

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- n/a Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- n/a Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- n/a Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
