### PR TITLE
TEP-0135: Introduce coschedule feature flags

### DIFF
--- a/config/config-feature-flags.yaml
+++ b/config/config-feature-flags.yaml
@@ -30,6 +30,18 @@ data:
   # https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md#affinity-assistant-and-specifying-workspace-order-in-a-pipeline
   # or https://github.com/tektoncd/pipeline/pull/2630 for more info.
   disable-affinity-assistant: "false"
+  # Setting this flag will determine how PipelineRun Pods are scheduled with Affinity Assistant.
+  # Acceptable values are "workspaces" (default), "pipelineruns", "isolate-pipelinerun", or "disabled".
+  #
+  # Setting it to "workspaces" will schedule all the taskruns sharing the same PVC-based workspace in a pipelinerun to the same node.
+  # Setting it to "pipelineruns" will schedule all the taskruns in a pipelinerun to the same node.
+  # Setting it to "isolate-pipelinerun" will schedule all the taskruns in a pipelinerun to the same node,
+  # and only allows one pipelinerun to run on a node at a time.
+  # Setting it to "disabled" will not apply any coschedule policy.
+  #
+  # TODO: add links to documentation and migration strategy
+  # NOTE: this feature is still under development and not yet functional.
+  coschedule: "workspaces"
   # Setting this flag to "true" will prevent Tekton scanning attached
   # service accounts and injecting any credentials it finds into your
   # Steps.

--- a/pkg/apis/config/feature_flags_test.go
+++ b/pkg/apis/config/feature_flags_test.go
@@ -52,6 +52,7 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 				ResultExtractionMethod:    config.DefaultResultExtractionMethod,
 				MaxResultSize:             config.DefaultMaxResultSize,
 				SetSecurityContext:        config.DefaultSetSecurityContext,
+				Coschedule:                config.DefaultCoschedule,
 			},
 			fileName: config.GetFeatureFlagsConfigName(),
 		},
@@ -70,6 +71,7 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 				ResultExtractionMethod:           "termination-message",
 				MaxResultSize:                    4096,
 				SetSecurityContext:               true,
+				Coschedule:                       config.CoscheduleDisabled,
 			},
 			fileName: "feature-flags-all-flags-set",
 		},
@@ -91,6 +93,7 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 				ResultExtractionMethod:           config.DefaultResultExtractionMethod,
 				MaxResultSize:                    config.DefaultMaxResultSize,
 				SetSecurityContext:               config.DefaultSetSecurityContext,
+				Coschedule:                       config.DefaultCoschedule,
 			},
 			fileName: "feature-flags-enable-api-fields-overrides-bundles-and-custom-tasks",
 		},
@@ -110,6 +113,7 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 				ResultExtractionMethod:           config.DefaultResultExtractionMethod,
 				MaxResultSize:                    config.DefaultMaxResultSize,
 				SetSecurityContext:               config.DefaultSetSecurityContext,
+				Coschedule:                       config.DefaultCoschedule,
 			},
 			fileName: "feature-flags-bundles-and-custom-tasks",
 		},
@@ -129,6 +133,7 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 				ResultExtractionMethod:           config.DefaultResultExtractionMethod,
 				MaxResultSize:                    config.DefaultMaxResultSize,
 				SetSecurityContext:               config.DefaultSetSecurityContext,
+				Coschedule:                       config.DefaultCoschedule,
 			},
 			fileName: "feature-flags-beta-api-fields",
 		},
@@ -144,6 +149,7 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 				ResultExtractionMethod:           config.DefaultResultExtractionMethod,
 				MaxResultSize:                    config.DefaultMaxResultSize,
 				SetSecurityContext:               config.DefaultSetSecurityContext,
+				Coschedule:                       config.DefaultCoschedule,
 			},
 			fileName: "feature-flags-enforce-nonfalsifiability-spire",
 		},
@@ -157,6 +163,7 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 				ResultExtractionMethod:           config.ResultExtractionMethodSidecarLogs,
 				MaxResultSize:                    8192,
 				SetSecurityContext:               config.DefaultSetSecurityContext,
+				Coschedule:                       config.DefaultCoschedule,
 			},
 			fileName: "feature-flags-results-via-sidecar-logs",
 		},
@@ -188,6 +195,7 @@ func TestNewFeatureFlagsFromEmptyConfigMap(t *testing.T) {
 		ResultExtractionMethod:           config.DefaultResultExtractionMethod,
 		MaxResultSize:                    config.DefaultMaxResultSize,
 		SetSecurityContext:               config.DefaultSetSecurityContext,
+		Coschedule:                       config.DefaultCoschedule,
 	}
 	verifyConfigFileWithExpectedFeatureFlagsConfig(t, FeatureFlagsConfigEmptyName, expectedConfig)
 }
@@ -247,6 +255,12 @@ func TestNewFeatureFlagsConfigMapErrors(t *testing.T) {
 	}, {
 		fileName: "feature-flags-spire-with-stable",
 		want:     `"enforce-nonfalsifiability" can be set to non-default values ("spire") only in alpha`,
+	}, {
+		fileName: "feature-flags-invalid-coschedule-affinity-assistant-comb",
+		want:     `coschedule value pipelineruns is incompatible with disable-affinity-assistant setting to false`,
+	}, {
+		fileName: "feature-flags-invalid-coschedule",
+		want:     `invalid value for feature flag "coschedule": "invalid"`,
 	}} {
 		t.Run(tc.fileName, func(t *testing.T) {
 			cm := test.ConfigMapFromTestFile(t, tc.fileName)

--- a/pkg/apis/config/testdata/feature-flags-invalid-coschedule-affinity-assistant-comb.yaml
+++ b/pkg/apis/config/testdata/feature-flags-invalid-coschedule-affinity-assistant-comb.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 The Tekton Authors
+# Copyright 2023 The Tekton Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,16 +18,5 @@ metadata:
   name: feature-flags
   namespace: tekton-pipelines
 data:
-  disable-affinity-assistant: "true"
-  coschedule: "disabled"
-  running-in-environment-with-injected-sidecars: "false"
-  await-sidecar-readiness: "false"
-  require-git-ssh-secret-known-hosts: "true"
-  enable-tekton-oci-bundles: "true"
-  enable-custom-tasks: "true"
-  enable-api-fields: "alpha"
-  send-cloudevents-for-runs: "true"
-  enforce-nonfalsifiability: "spire"
-  trusted-resources-verification-no-match-policy: "fail"
-  enable-provenance-in-status: "false"
-  set-security-context: "true"
+  coschedule: "pipelineruns"
+  disable-affinity-assistant: "false"

--- a/pkg/apis/config/testdata/feature-flags-invalid-coschedule.yaml
+++ b/pkg/apis/config/testdata/feature-flags-invalid-coschedule.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 The Tekton Authors
+# Copyright 2023 The Tekton Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,16 +18,4 @@ metadata:
   name: feature-flags
   namespace: tekton-pipelines
 data:
-  disable-affinity-assistant: "true"
-  coschedule: "disabled"
-  running-in-environment-with-injected-sidecars: "false"
-  await-sidecar-readiness: "false"
-  require-git-ssh-secret-known-hosts: "true"
-  enable-tekton-oci-bundles: "true"
-  enable-custom-tasks: "true"
-  enable-api-fields: "alpha"
-  send-cloudevents-for-runs: "true"
-  enforce-nonfalsifiability: "spire"
-  trusted-resources-verification-no-match-policy: "fail"
-  enable-provenance-in-status: "false"
-  set-security-context: "true"
+  coschedule: "invalid"

--- a/pkg/apis/config/testing/featureflags.go
+++ b/pkg/apis/config/testing/featureflags.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2023 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tektoncd/pipeline/pkg/apis/config"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/logging"
+)
+
+// SetFeatureFlags sets the feature-flags ConfigMap values in an existing context (for use in testing)
+func SetFeatureFlags(ctx context.Context, t *testing.T, data map[string]string) context.Context {
+	t.Helper()
+	s := config.NewStore(logging.FromContext(ctx).Named("config-store"))
+	s.OnConfigChanged(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: config.GetFeatureFlagsConfigName(),
+		},
+		Data: data,
+	})
+	return s.ToContext(ctx)
+}

--- a/pkg/internal/affinityassistant/affinityassistant_types.go
+++ b/pkg/internal/affinityassistant/affinityassistant_types.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2023 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package affinityassistant
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/tektoncd/pipeline/pkg/apis/config"
+)
+
+type AffinityAssitantBehavior string
+
+const (
+	AffinityAssistantDisabled                    = AffinityAssitantBehavior("AffinityAssistantDisabled")
+	AffinityAssistantPerWorkspace                = AffinityAssitantBehavior("AffinityAssistantPerWorkspace")
+	AffinityAssistantPerPipelineRun              = AffinityAssitantBehavior("AffinityAssistantPerPipelineRun")
+	AffinityAssistantPerPipelineRunWithIsolation = AffinityAssitantBehavior("AffinityAssistantPerPipelineRunWithIsolation")
+)
+
+// GetAffinityAssistantBehavior returns an AffinityAssitantBehavior based on the
+// combination of "disable-affinity-assistant" and "coschedule" feature flags
+// TODO(#6740)(WIP): consume this function in the PipelineRun reconciler to determine Affinity Assistant behavior.
+func GetAffinityAssistantBehavior(ctx context.Context) (AffinityAssitantBehavior, error) {
+	cfg := config.FromContextOrDefaults(ctx)
+	disableAA := cfg.FeatureFlags.DisableAffinityAssistant
+	coschedule := cfg.FeatureFlags.Coschedule
+
+	// at this point, we have validated that "coschedule" can only be "workspaces"
+	// when "disable-affinity-assistant" is false
+	if !disableAA {
+		return AffinityAssistantPerWorkspace, nil
+	}
+
+	switch coschedule {
+	case config.CoschedulePipelineRuns:
+		return AffinityAssistantPerPipelineRun, nil
+	case config.CoscheduleIsolatePipelineRun:
+		return AffinityAssistantPerPipelineRunWithIsolation, nil
+	case config.CoscheduleDisabled, config.CoscheduleWorkspaces:
+		return AffinityAssistantDisabled, nil
+	}
+
+	return "", fmt.Errorf("unknown combination of disable-affinity-assistant: %v and coschedule: %v", disableAA, coschedule)
+}

--- a/pkg/internal/affinityassistant/affinityassistant_types_test.go
+++ b/pkg/internal/affinityassistant/affinityassistant_types_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2023 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package affinityassistant
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	cfgtesting "github.com/tektoncd/pipeline/pkg/apis/config/testing"
+	"github.com/tektoncd/pipeline/test/diff"
+
+	"github.com/tektoncd/pipeline/pkg/apis/config"
+)
+
+func Test_GetAffinityAssistantBehavior(t *testing.T) {
+	tcs := []struct {
+		name      string
+		configMap map[string]string
+		expect    AffinityAssitantBehavior
+	}{{
+		name: "affinity-assistant-enabled",
+		configMap: map[string]string{
+			"disable-affinity-assistant": "false",
+		},
+		expect: AffinityAssistantPerWorkspace,
+	}, {
+		name: "affinity-assistant-disabled-coschedule-workspaces",
+		configMap: map[string]string{
+			"disable-affinity-assistant": "true",
+			"coschedule":                 config.CoscheduleWorkspaces,
+		},
+		expect: AffinityAssistantDisabled,
+	}, {
+		name: "affinity-assistant-disabled-coschedule-pipelineruns",
+		configMap: map[string]string{
+			"disable-affinity-assistant": "true",
+			"coschedule":                 config.CoschedulePipelineRuns,
+		},
+		expect: AffinityAssistantPerPipelineRun,
+	}, {
+		name: "affinity-assistant-disabled-coschedule-isolate-pipelinerun",
+		configMap: map[string]string{
+			"disable-affinity-assistant": "true",
+			"coschedule":                 config.CoscheduleIsolatePipelineRun,
+		},
+		expect: AffinityAssistantPerPipelineRunWithIsolation,
+	}, {
+		name: "affinity-assistant-disabled-coschedule-disabled",
+		configMap: map[string]string{
+			"disable-affinity-assistant": "true",
+			"coschedule":                 config.CoscheduleDisabled,
+		},
+		expect: AffinityAssistantDisabled,
+	}}
+
+	for _, tc := range tcs {
+		ctx := cfgtesting.SetFeatureFlags(context.Background(), t, tc.configMap)
+		get, err := GetAffinityAssistantBehavior(ctx)
+		if err != nil {
+			t.Fatalf("unexpected error when getting affinity assistant behavior: %v", err)
+		}
+
+		if d := cmp.Diff(tc.expect, get); d != "" {
+			t.Errorf("AffinityAssitantBehavior mismatch: %v", diff.PrintWantGot(d))
+		}
+	}
+}

--- a/pkg/reconciler/pipelinerun/affinity_assistant.go
+++ b/pkg/reconciler/pipelinerun/affinity_assistant.go
@@ -278,6 +278,8 @@ func affinityAssistantStatefulSet(name string, pr *v1.PipelineRun, claimTemplate
 // be created for each PipelineRun that use workspaces with PersistentVolumeClaims
 // as volume source. The default behaviour is to enable the Affinity Assistant to
 // provide Node Affinity for TaskRuns that share a PVC workspace.
+//
+// TODO(#6740)(WIP): replace this function with GetAffinityAssistantBehavior
 func (c *Reconciler) isAffinityAssistantDisabled(ctx context.Context) bool {
 	cfg := config.FromContextOrDefaults(ctx)
 	return cfg.FeatureFlags.DisableAffinityAssistant

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -1200,6 +1200,7 @@ status:
       EnableProvenanceInStatus: true
       ResultExtractionMethod: "termination-message"
       MaxResultSize: 4096
+      Coschedule: "workspaces" 
 `)
 	d := test.Data{
 		PipelineRuns: prs,
@@ -4753,6 +4754,7 @@ status:
       EnableProvenanceInStatus: true
       ResultExtractionMethod: "termination-message"
       MaxResultSize: 4096
+      Coschedule: "workspaces"
 `)
 
 	expectedPr := expectedPrStatus
@@ -4910,6 +4912,7 @@ status:
       EnableProvenanceInStatus: true
       ResultExtractionMethod: "termination-message"
       MaxResultSize: 4096
+      Coschedule: "workspaces"
 `)
 
 	expectedPr := expectedPrStatus
@@ -8174,6 +8177,7 @@ status:
       EnableProvenanceInStatus: true
       ResultExtractionMethod: "termination-message"
       MaxResultSize: 4096
+      Coschedule: "workspaces"
 `),
 	}, {
 		name:     "p-finally",
@@ -8339,6 +8343,8 @@ status:
       EnableProvenanceInStatus: true
       ResultExtractionMethod: "termination-message"
       MaxResultSize: 4096
+      Coschedule: "workspaces"
+
 `),
 	}}
 	for _, tt := range tests {
@@ -8548,6 +8554,7 @@ status:
       EnableProvenanceInStatus: true
       ResultExtractionMethod: "termination-message"
       MaxResultSize: 4096
+      Coschedule: "workspaces"
 `),
 	}}
 	for _, tt := range tests {
@@ -8958,6 +8965,7 @@ status:
       EnableProvenanceInStatus: true
       ResultExtractionMethod: "termination-message"
       MaxResultSize: 4096
+      Coschedule: "workspaces"
 `),
 	}, {
 		name:     "p-finally",
@@ -9161,6 +9169,7 @@ status:
       EnableProvenanceInStatus: true
       ResultExtractionMethod: "termination-message"
       MaxResultSize: 4096
+      Coschedule: "workspaces"
 `),
 	}}
 	for _, tt := range tests {
@@ -9395,6 +9404,7 @@ status:
       EnableProvenanceInStatus: true
       ResultExtractionMethod: "termination-message"
       MaxResultSize: 4096
+      Coschedule: "workspaces"
 `),
 	},
 	}
@@ -9837,6 +9847,7 @@ status:
       EnableProvenanceInStatus: true
       ResultExtractionMethod: "termination-message"
       MaxResultSize: 4096
+      Coschedule: "workspaces"
 `),
 	}, {
 		name:     "p-finally",
@@ -10013,6 +10024,7 @@ status:
       EnableProvenanceInStatus: true
       ResultExtractionMethod: "termination-message"
       MaxResultSize: 4096
+      Coschedule: "workspaces"
 `),
 	}}
 	for _, tt := range tests {
@@ -10237,6 +10249,7 @@ status:
       EnableProvenanceInStatus: true
       ResultExtractionMethod: "termination-message"
       MaxResultSize: 4096
+      Coschedule: "workspaces"
 `),
 	}, {
 		name:  "indexing results in matrix.params",
@@ -10400,6 +10413,7 @@ status:
       EnableProvenanceInStatus: true
       ResultExtractionMethod: "termination-message"
       MaxResultSize: 4096
+      Coschedule: "workspaces"
 `),
 	}, {
 		name:  "whole array result replacements in matrix.params",
@@ -10783,6 +10797,7 @@ status:
       EnableProvenanceInStatus: true
       ResultExtractionMethod: "termination-message"
       MaxResultSize: 4096
+      Coschedule: "workspaces"
 `),
 	}}
 	for _, tt := range tests {
@@ -11007,6 +11022,7 @@ status:
       EnableProvenanceInStatus: true
       ResultExtractionMethod: "termination-message"
       MaxResultSize: 4096
+      Coschedule: "workspaces"
 `),
 		expectedTaskRuns: []*v1.TaskRun{
 			mustParseTaskRunWithObjectMeta(t,
@@ -11203,6 +11219,7 @@ status:
       EnableProvenanceInStatus: true
       ResultExtractionMethod: "termination-message"
       MaxResultSize: 4096
+      Coschedule: "workspaces"
 `),
 		expectedTaskRuns: []*v1.TaskRun{
 			mustParseTaskRunWithObjectMeta(t,
@@ -11617,6 +11634,7 @@ status:
       EnableProvenanceInStatus: true
       ResultExtractionMethod: "termination-message"
       MaxResultSize: 4096
+      Coschedule: "workspaces"
 `),
 	}, {
 		name:     "p-finally",
@@ -11783,6 +11801,7 @@ status:
       EnableProvenanceInStatus: true
       ResultExtractionMethod: "termination-message"
       MaxResultSize: 4096
+      Coschedule: "workspaces"
 `),
 	}}
 	for _, tt := range tests {

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -1676,6 +1676,7 @@ status:
         EnableProvenanceInStatus: true
         ResultExtractionMethod: "termination-message"
         MaxResultSize: 4096
+        Coschedule: "workspaces"
   provenance:
     featureFlags:
       RunningInEnvWithInjectedSidecars: true
@@ -1686,6 +1687,7 @@ status:
       EnableProvenanceInStatus: true
       ResultExtractionMethod: "termination-message"
       MaxResultSize: 4096
+      Coschedule: "workspaces"
 `)
 		reconciliatonError = fmt.Errorf("1 error occurred:\n\t* Provided results don't match declared results; may be invalid JSON or missing result declaration:  \"aResult\": task result is expected to be \"array\" type but was initialized to a different type \"string\"")
 		toBeRetriedTaskRun = parse.MustParseV1TaskRun(t, `
@@ -1737,6 +1739,7 @@ status:
       EnableProvenanceInStatus: true
       ResultExtractionMethod: "termination-message"
       MaxResultSize: 4096
+      Coschedule: "workspaces"
 `)
 	)
 


### PR DESCRIPTION
Part of [#6740][#6740]. [TEP-0135][tep-0135] introduces a feature that allows a cluster operator to ensure that all of a PipelineRun's pods are scheduled to the same node.

This commit introduces a new feature flag `coschedule` which works together with the `disable-affinity-assistant` feature flag to determine the Affinity Assistant behavior. The usage of the new feature flag will be added in the follow-up PRs.

The details of the `coschedule` feature flag can be found in the [Configuration][configuration] section of TEP-0135. The details of the `disable-affinity-assistant` feature flag can be found in the [Upgrade and Migration Strategy][strategy] section of TEP-0135.

NOTE: this feature is WIP, please do not use on this feature.

/kind feature

[#6740]: https://github.com/tektoncd/pipeline/issues/6740
[tep-0135]: https://github.com/tektoncd/community/blob/main/teps/0135-coscheduling-pipelinerun-pods.md
[configuration]: https://github.com/tektoncd/community/blob/main/teps/0135-coscheduling-pipelinerun-pods.md#configuration
[strategy]: https://github.com/tektoncd/community/blob/main/teps/0135-coscheduling-pipelinerun-pods.md#configuration

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
tep-0135: introduce `coschedule` feature flag
```
