### PR TITLE
Change ordering of ResolveResultRefs/ApplyTaskResults

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -1089,7 +1089,7 @@ spec:
         - name: foo
           image: busybox
           script: 'exit 0'
- `)}
+`)}
 
 	trs := []*v1.TaskRun{mustParseTaskRunWithObjectMeta(t,
 		taskRunObjectMeta("test-pipeline-missing-results-task1", "foo",
@@ -1181,7 +1181,7 @@ status:
           image: busybox
           script: 'exit 0'
   conditions:
-  - message: "Could not find result with name result2 for task task1"
+  - message: "Invalid task result reference: Could not find result with name result2 for task task1"
     reason: InvalidTaskResultReference
     status: "False"
     type: Succeeded

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -542,14 +542,25 @@ func ResolvePipelineTask(
 	getTaskRun resources.GetTaskRun,
 	getRun GetRun,
 	pipelineTask v1.PipelineTask,
+	pst PipelineRunState,
 ) (*ResolvedPipelineTask, error) {
 	rpt := ResolvedPipelineTask{
 		PipelineTask: &pipelineTask,
 	}
 	rpt.CustomTask = rpt.PipelineTask.TaskRef.IsCustomTask() || rpt.PipelineTask.TaskSpec.IsCustomTask()
 	numCombinations := 1
+	// We want to resolve all of the result references and ignore any errors at this point since there could be
+	// instances where result references are missing here, but will be later skipped or resolved in a subsequent
+	// TaskRun. The final validation is handled in skipBecauseResultReferencesAreMissing.
+	resolvedResultRefs, _, _ := ResolveResultRefs(pst, PipelineRunState{&rpt})
+	if err := validateArrayResultsIndex(resolvedResultRefs); err != nil {
+		return nil, err
+	}
+
+	ApplyTaskResults(PipelineRunState{&rpt}, resolvedResultRefs)
+
 	if rpt.PipelineTask.IsMatrixed() {
-		numCombinations = pipelineTask.Matrix.CountCombinations()
+		numCombinations = rpt.PipelineTask.Matrix.CountCombinations()
 	}
 	if rpt.IsCustomTask() {
 		rpt.CustomRunNames = getNamesOfCustomRuns(pipelineRun.Status.ChildReferences, pipelineTask.Name, pipelineRun.Name, numCombinations)
@@ -747,4 +758,29 @@ func (t *ResolvedPipelineTask) hasResultReferences() bool {
 
 func isCustomRunCancelledByPipelineRunTimeout(cr *v1beta1.CustomRun) bool {
 	return cr.Spec.StatusMessage == v1beta1.CustomRunCancelledByPipelineTimeoutMsg
+}
+
+// CheckMissingResultReferences returns an error if it is missing any result references.
+// Missing result references can occur if task fails to produce a result but has
+// OnError: continue (ie TestMissingResultWhenStepErrorIsIgnored)
+func CheckMissingResultReferences(pipelineRunState PipelineRunState, targets PipelineRunState) error {
+	for _, target := range targets {
+		for _, resultRef := range v1.PipelineTaskResultRefs(target.PipelineTask) {
+			referencedPipelineTask := pipelineRunState.ToMap()[resultRef.PipelineTask]
+			if referencedPipelineTask.IsCustomTask() {
+				customRun := referencedPipelineTask.CustomRuns[0]
+				_, err := findRunResultForParam(customRun, resultRef)
+				if err != nil {
+					return err
+				}
+			} else {
+				taskRun := referencedPipelineTask.TaskRuns[0]
+				_, err := findTaskResultForParam(taskRun, resultRef)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
 }

--- a/pkg/reconciler/pipelinerun/resources/resultrefresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/resultrefresolution_test.go
@@ -106,21 +106,20 @@ var pipelineRunState = PipelineRunState{{
 }, {
 	CustomTask:     true,
 	CustomRunNames: []string{"aRun"},
-	CustomRuns: []*v1beta1.CustomRun{
-		{
-			ObjectMeta: metav1.ObjectMeta{Name: "aRun"},
-			Status: v1beta1.CustomRunStatus{
-				Status: duckv1.Status{
-					Conditions: []apis.Condition{successCondition},
-				},
-				CustomRunStatusFields: v1beta1.CustomRunStatusFields{
-					Results: []v1beta1.CustomRunResult{{
-						Name:  "aResult",
-						Value: "aResultValue",
-					}},
-				},
+	CustomRuns: []*v1beta1.CustomRun{{
+		ObjectMeta: metav1.ObjectMeta{Name: "aRun"},
+		Status: v1beta1.CustomRunStatus{
+			Status: duckv1.Status{
+				Conditions: []apis.Condition{successCondition},
 			},
-		}},
+			CustomRunStatusFields: v1beta1.CustomRunStatusFields{
+				Results: []v1beta1.CustomRunResult{{
+					Name:  "aResult",
+					Value: "aResultValue",
+				}},
+			},
+		},
+	}},
 	PipelineTask: &v1.PipelineTask{
 		Name:    "aCustomPipelineTask",
 		TaskRef: &v1.TaskRef{APIVersion: "example.dev/v0", Kind: "Example", Name: "aTask"},
@@ -216,92 +215,51 @@ var pipelineRunState = PipelineRunState{{
 		}},
 	},
 }, {
-	TaskRunNames: []string{"xTaskRun"},
-	TaskRuns: []*v1.TaskRun{{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "xTaskRun",
-		},
-		Status: v1.TaskRunStatus{
-			Status: duckv1.Status{
-				Conditions: duckv1.Conditions{successCondition},
-			},
-			TaskRunStatusFields: v1.TaskRunStatusFields{
-				Results: []v1.TaskRunResult{{
-					Name:  "xResult",
-					Value: *v1.NewStructuredValues("arrayResultOne", "arrayResultTwo"),
-				}},
-			},
-		},
-	}, {
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "yTaskRun",
-		},
-		Status: v1.TaskRunStatus{
-			Status: duckv1.Status{
-				Conditions: duckv1.Conditions{successCondition},
-			},
-			TaskRunStatusFields: v1.TaskRunStatusFields{
-				Results: []v1.TaskRunResult{{
-					Name:  "yResult",
-					Value: *v1.NewStructuredValues("arrayResultOne", "arrayResultTwo"),
-				}},
-			},
-		},
-	}},
 	PipelineTask: &v1.PipelineTask{
-		Name:    "xTask",
-		TaskRef: &v1.TaskRef{Name: "xTask"},
+		Name:    "gTask",
+		TaskRef: &v1.TaskRef{Name: "gTask"},
 		Matrix: &v1.Matrix{
 			Params: v1.Params{{
-				Name:  "xParam",
-				Value: *v1.NewStructuredValues("$(tasks.xTask.results.xResult[*])"),
+				Name:  "dResults",
+				Value: *v1.NewStructuredValues("$(tasks.dTask.results.dResult[0])"),
 			}, {
-				Name:  "yParam",
-				Value: *v1.NewStructuredValues("$(tasks.yTask.results.yResult[*])"),
+				Name:  "cResults",
+				Value: *v1.NewStructuredValues("$(tasks.cTask.results.cResult[1])"),
 			}},
 		},
 	},
 }, {
-	CustomTask:     true,
-	CustomRunNames: []string{"xRun"},
-	CustomRuns: []*v1beta1.CustomRun{
-		{
-			ObjectMeta: metav1.ObjectMeta{Name: "xRun"},
-			Status: v1beta1.CustomRunStatus{
-				Status: duckv1.Status{
-					Conditions: []apis.Condition{successCondition},
-				},
-				CustomRunStatusFields: v1beta1.CustomRunStatusFields{
-					Results: []v1beta1.CustomRunResult{{
-						Name:  "xResult",
-						Value: "xResultValue",
-					}},
-				},
-			},
-		}, {
-			ObjectMeta: metav1.ObjectMeta{Name: "yRun"},
-			Status: v1beta1.CustomRunStatus{
-				Status: duckv1.Status{
-					Conditions: []apis.Condition{successCondition},
-				},
-				CustomRunStatusFields: v1beta1.CustomRunStatusFields{
-					Results: []v1beta1.CustomRunResult{{
-						Name:  "yResult",
-						Value: "yResultValue",
-					}},
-				},
-			},
-		}},
+	CustomTask: true,
 	PipelineTask: &v1.PipelineTask{
-		Name:    "xTask",
-		TaskRef: &v1.TaskRef{Name: "xTask"},
+		Name:    "hTask",
+		TaskRef: &v1.TaskRef{Name: "hTask"},
 		Matrix: &v1.Matrix{
 			Params: v1.Params{{
-				Name:  "xParam",
-				Value: *v1.NewStructuredValues("$(tasks.xCustomPipelineTask.results.xResult[*])"),
-			}, {
-				Name:  "yParam",
-				Value: *v1.NewStructuredValues("$(tasks.yCustomPipelineTask.results.yResult[*])"),
+				Name:  "aResult",
+				Value: *v1.NewStructuredValues("$(tasks.aCustomPipelineTask.results.aResult)"),
+			}},
+		},
+	},
+}, {
+	PipelineTask: &v1.PipelineTask{
+		Name:    "iTask",
+		TaskRef: &v1.TaskRef{Name: "iTask"},
+		Matrix: &v1.Matrix{
+			Params: v1.Params{{
+				Name:  "iDoNotExist",
+				Value: *v1.NewStructuredValues("$(tasks.dTask.results.iDoNotExist[0])"),
+			}},
+		},
+	},
+}, {
+	CustomTask: true,
+	PipelineTask: &v1.PipelineTask{
+		Name:    "jTask",
+		TaskRef: &v1.TaskRef{Name: "jTask"},
+		Matrix: &v1.Matrix{
+			Params: v1.Params{{
+				Name:  "iDoNotExist",
+				Value: *v1.NewStructuredValues("$(tasks.aCustomPipelineTask.results.iDoNotExist)"),
 			}},
 		},
 	},
@@ -347,31 +305,38 @@ func TestResolveResultRefs(t *testing.T) {
 		}},
 		wantErr: false,
 	}, {
-		name:             "Test unsuccessful matrix array result references resolution",
-		pipelineRunState: pipelineRunState,
-		targets: PipelineRunState{
-			pipelineRunState[11],
-		},
-		want:    nil,
-		wantErr: true,
-		wantPt:  "xTask",
-	}, {
-		name:             "Test unsuccessful result references resolution - params",
-		pipelineRunState: pipelineRunState,
-		targets: PipelineRunState{
-			pipelineRunState[8],
-		},
-		want:    nil,
-		wantErr: true,
-	}, {
-		name:             "Test unsuccessful matrix array result references resolution - customrun",
+		name:             "Test successful matrix result references resolution - customrun",
 		pipelineRunState: pipelineRunState,
 		targets: PipelineRunState{
 			pipelineRunState[12],
 		},
+		want: ResolvedResultRefs{{
+			Value: *v1.NewStructuredValues("aResultValue"),
+			ResultReference: v1.ResultRef{
+				PipelineTask: "aCustomPipelineTask",
+				Result:       "aResult",
+			},
+			FromRun: "aRun",
+		}},
+		wantErr: false,
+	}, {
+		name:             "Test unsuccessful matrix array result references resolution",
+		pipelineRunState: pipelineRunState,
+		targets: PipelineRunState{
+			pipelineRunState[13],
+		},
 		want:    nil,
 		wantErr: true,
-		wantPt:  "xCustomPipelineTask",
+		wantPt:  "dTask",
+	}, {
+		name:             "Test unsuccessful matrix array result references resolution custom run",
+		pipelineRunState: pipelineRunState,
+		targets: PipelineRunState{
+			pipelineRunState[14],
+		},
+		want:    nil,
+		wantErr: true,
+		wantPt:  "aCustomPipelineTask",
 	}, {
 		name:             "Test successful result references resolution - when expressions",
 		pipelineRunState: pipelineRunState,
@@ -553,4 +518,190 @@ func lessResolvedResultRefs(i, j *ResolvedResultRef) bool {
 		fromJ = j.FromRun
 	}
 	return strings.Compare(fromI, fromJ) < 0
+}
+
+func TestCheckMissingResultReferences(t *testing.T) {
+	for _, tt := range []struct {
+		name             string
+		pipelineRunState PipelineRunState
+		targets          PipelineRunState
+		wantErr          string
+	}{{
+		name:             "Valid: successful result references resolution - params",
+		pipelineRunState: pipelineRunState,
+		targets: PipelineRunState{
+			pipelineRunState[1],
+		},
+	}, {
+		name:             "Valid: Test successful array result references resolution - params",
+		pipelineRunState: pipelineRunState,
+		targets: PipelineRunState{
+			pipelineRunState[7],
+		},
+	}, {
+		name:             "Valid: Test successful result references resolution - when expressions",
+		pipelineRunState: pipelineRunState,
+		targets: PipelineRunState{
+			pipelineRunState[2],
+		},
+	}, {
+		name:             "Invalid: Test unsuccessful result references resolution - when expression",
+		pipelineRunState: pipelineRunState,
+		targets: PipelineRunState{
+			pipelineRunState[3],
+		},
+		wantErr: "Invalid task result reference: Could not find result with name missingResult for task aTask",
+	}, {
+		name:             "Test unsuccessful result references resolution - params",
+		pipelineRunState: pipelineRunState,
+		targets: PipelineRunState{
+			pipelineRunState[4],
+		},
+		wantErr: "Invalid task result reference: Could not find result with name missingResult for task aTask",
+	}, {
+		name:             "Valid: Test successful result references resolution - params - Run",
+		pipelineRunState: pipelineRunState,
+		targets: PipelineRunState{
+			pipelineRunState[6],
+		},
+	}, {
+		name:             "Valid: Test successful result references resolution non result references",
+		pipelineRunState: pipelineRunState,
+		targets: PipelineRunState{
+			pipelineRunState[0],
+		},
+	}, {
+		name:             "Valid: Test successful result references resolution - params - failed taskrun",
+		pipelineRunState: pipelineRunState,
+		targets: PipelineRunState{
+			pipelineRunState[10],
+		},
+	}, {
+		name:             "Valid: Test successful result references resolution - matrix - array indexing",
+		pipelineRunState: pipelineRunState,
+		targets: PipelineRunState{
+			pipelineRunState[11],
+		},
+	}, {
+		name:             "Valid: Test successful result references resolution - matrix custom task - string replacements",
+		pipelineRunState: pipelineRunState,
+		targets: PipelineRunState{
+			pipelineRunState[12],
+		},
+	}, {
+		name:             "Invalid: Test result references resolution - matrix - missing references to array replacements",
+		pipelineRunState: pipelineRunState,
+		targets: PipelineRunState{
+			pipelineRunState[13],
+		},
+		wantErr: "Invalid task result reference: Could not find result with name iDoNotExist for task dTask",
+	}, {
+		name:             "Invalid: Test result references resolution - matrix custom task - missing references to string replacements",
+		pipelineRunState: pipelineRunState,
+		targets: PipelineRunState{
+			pipelineRunState[14],
+		},
+		wantErr: "Invalid task result reference: Could not find result with name iDoNotExist for task aCustomPipelineTask",
+	}} {
+		t.Run(tt.name, func(t *testing.T) {
+			err := CheckMissingResultReferences(tt.pipelineRunState, tt.targets)
+			if (err != nil) && err.Error() != tt.wantErr {
+				t.Errorf("CheckMissingResultReferences() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err == nil && tt.wantErr != "" {
+				t.Fatalf("Expecting error %v, but did not get an error", tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateArrayResultsIndex(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		refs    ResolvedResultRefs
+		wantErr string
+	}{{
+		name: "Empty Array",
+		refs: ResolvedResultRefs{{
+			Value: v1.ResultValue{
+				Type:     "array",
+				ArrayVal: []string{},
+			},
+			ResultReference: v1.ResultRef{
+				PipelineTask: "aTask",
+				Result:       "aResult",
+				ResultsIndex: 1,
+			},
+			FromTaskRun: "aTaskRun",
+		}},
+		wantErr: "Array Result Index 1 for Task aTask Result aResult is out of bound of size 0",
+	}, {
+		name: "In Bounds Array",
+		refs: ResolvedResultRefs{{
+			Value: v1.ResultValue{
+				Type:     "array",
+				ArrayVal: []string{"a", "b", "c"},
+			},
+			ResultReference: v1.ResultRef{
+				PipelineTask: "aTask",
+				Result:       "aResult",
+				ResultsIndex: 1,
+			},
+			FromTaskRun: "aTaskRun",
+		}},
+		wantErr: "",
+	}, {
+		name: "Out Of Bounds Array",
+		refs: ResolvedResultRefs{{
+			Value: v1.ResultValue{
+				Type:     "array",
+				ArrayVal: []string{"a", "b", "c"},
+			},
+			ResultReference: v1.ResultRef{
+				PipelineTask: "aTask",
+				Result:       "aResult",
+				ResultsIndex: 3,
+			},
+			FromTaskRun: "aTaskRun",
+		}},
+		wantErr: "Array Result Index 3 for Task aTask Result aResult is out of bound of size 3",
+	}, {
+		name: "In Bounds and Out of Bounds Array",
+		refs: ResolvedResultRefs{{
+			Value: v1.ResultValue{
+				Type:     "array",
+				ArrayVal: []string{"a", "b", "c"},
+			},
+			ResultReference: v1.ResultRef{
+				PipelineTask: "aTask",
+				Result:       "aResult",
+				ResultsIndex: 1,
+			},
+			FromTaskRun: "aTaskRun",
+		}, {
+			Value: v1.ResultValue{
+				Type:     "array",
+				ArrayVal: []string{"a", "b", "c"},
+			},
+			ResultReference: v1.ResultRef{
+				PipelineTask: "aTask",
+				Result:       "aResult",
+				ResultsIndex: 3,
+			},
+			FromTaskRun: "aTaskRun",
+		}},
+		wantErr: "Array Result Index 3 for Task aTask Result aResult is out of bound of size 3",
+	}} {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateArrayResultsIndex(tt.refs)
+			if (err != nil) && err.Error() != tt.wantErr {
+				t.Errorf("validateArrayResultsIndex() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err == nil && tt.wantErr != "" {
+				t.Fatalf("Expecting error %v, but did not get an error", tt.wantErr)
+			}
+		})
+	}
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
This refactor changes the ordering of when we resolve references to results and apply task results within the reconciler. Prior to this change, we were waiting until `RunNextScheduableTask()` to resolve and apply task results. This becomes an issue when trying to consume whole array results in a Matrix since the TaskRuns are created prior to `RunNextScheduableTask()` and the number of TaskRuns before resolving references is nondeterministic [*]. Consuming whole array results is a feature required in order to promote Matrix to beta and will be implemented in a subsequent PR #6603.

In this PR, we move this logic before `RunNextScheduableTask()` into `ResolvePipelineTask()` and resolve and apply the task results upfront so that by the time we go to create the TaskRuns, all of the replacements have been applied and we know exactly how many TaskRuns to create. Changing the ordering of the reconciler logic means we also have to change some of the error handling with ResolveResultRefs because we currently fail a PipelineRun if any of the result values are missing, however this could be a valid PipelineRun if it's a skipped Task due to `MissingResultsSkip`. This PR removes some of the initial errors that would cause the PipelineRun to fail the first time we ResolveResultRefs since some tasks could be missing result references, yet are valid at this point in time and need to be marked as "skipBecauseResultReferencesAreMissing". This enables us to mark all of the task that are supposed to be skipped as "skipBecauseResultReferencesAreMissing" rather than failing the pipelinerun immediately.

We later check for any actual missing result references in the Skipped Tasks and fail the PipelineRun in RunNextSchedulableTask().
An example of this is in TestMissingResultWhenStepErrorIsIgnored()when Task 1 produces Result A successfully and fails to produce Result B, but has onError continue. Task 2 consumes the results from Task 1, which results in the Failed PipelineRun because Task2 cannot reference Result B that was never produced in Task 1. However because On Error: Continue was used, Task 1 succeeded and the PipelineRun needs to now be marked as failed due to "ReasonInvalidTaskResultReference".

For more information on why this is necessary please see the discussion here: https://github.com/tektoncd/pipeline/pull/6056#issuecomment-1406928173

/kind feature

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
