### PR TITLE
Add pod name to build_logs test output

### DIFF
--- a/test/build_logs.go
+++ b/test/build_logs.go
@@ -45,7 +45,7 @@ func getContainersLogsFromPod(ctx context.Context, c kubernetes.Interface, pod, 
 
 	sb := strings.Builder{}
 	for _, container := range p.Spec.Containers {
-		sb.WriteString(fmt.Sprintf("\n>>> Container %s:\n", container.Name))
+		sb.WriteString(fmt.Sprintf("\n>>> Pod %s Container %s:\n", p.Name, container.Name))
 		logs, err := getContainerLogsFromPod(ctx, c, pod, container.Name, namespace)
 		if err != nil {
 			return "", err


### PR DESCRIPTION
When integration tests fail, logs are printed from failed pods. This commit adds the pod name to the output, in addition to the container name, to make debugging easier in scenarios where multiple pods have the same container name. (This is common with unnamed steps.)

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- n/a Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- n/a Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- n/a Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- n/a Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
