### PR TITLE
remove GetUnsignedTask helper function and use var in each file

### DIFF
--- a/pkg/reconciler/taskrun/resources/taskref_test.go
+++ b/pkg/reconciler/taskrun/resources/taskref_test.go
@@ -87,6 +87,22 @@ var (
 		},
 		EntryPoint: "foo/bar",
 	}
+	unsignedV1beta1Task = &v1beta1.Task{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "tekton.dev/v1beta1",
+			Kind:       "Task"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test-task",
+			Namespace:   "trusted-resources",
+			Annotations: map[string]string{"foo": "bar"},
+		},
+		Spec: v1beta1.TaskSpec{
+			Steps: []v1beta1.Step{{
+				Image: "ubuntu",
+				Name:  "echo",
+			}},
+		},
+	}
 	unsignedV1Task = v1.Task{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "tekton.dev/v1",
@@ -738,7 +754,7 @@ func TestGetTaskFunc_V1beta1Task_VerifyNoError(t *testing.T) {
 	signer, _, k8sclient, vps := test.SetupVerificationPolicies(t)
 	tektonclient := fake.NewSimpleClientset()
 
-	unsignedTask := test.GetUnsignedTask("test-task")
+	unsignedTask := unsignedV1beta1Task
 	unsignedTaskBytes, err := json.Marshal(unsignedTask)
 	unsignedV1Task := &v1.Task{}
 	unsignedTask.ConvertTo(ctx, unsignedV1Task)
@@ -872,7 +888,7 @@ func TestGetTaskFunc_V1beta1Task_VerifyError(t *testing.T) {
 	signer, _, k8sclient, vps := test.SetupVerificationPolicies(t)
 	tektonclient := fake.NewSimpleClientset()
 
-	unsignedTask := test.GetUnsignedTask("test-task")
+	unsignedTask := unsignedV1beta1Task
 	unsignedTaskBytes, err := json.Marshal(unsignedTask)
 	if err != nil {
 		t.Fatal("fail to marshal task", err)
@@ -1249,7 +1265,7 @@ func TestGetTaskFunc_GetFuncError(t *testing.T) {
 	_, k8sclient, vps := test.SetupMatchAllVerificationPolicies(t, "trusted-resources")
 	tektonclient := fake.NewSimpleClientset()
 
-	unsignedTask := test.GetUnsignedTask("test-task")
+	unsignedTask := unsignedV1beta1Task
 	unsignedTaskBytes, err := json.Marshal(unsignedTask)
 	if err != nil {
 		t.Fatal("fail to marshal task", err)

--- a/pkg/trustedresources/verify_test.go
+++ b/pkg/trustedresources/verify_test.go
@@ -45,6 +45,22 @@ const (
 )
 
 var (
+	unsignedV1beta1Task = &v1beta1.Task{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "tekton.dev/v1beta1",
+			Kind:       "Task"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test-task",
+			Namespace:   "trusted-resources",
+			Annotations: map[string]string{"foo": "bar"},
+		},
+		Spec: v1beta1.TaskSpec{
+			Steps: []v1beta1.Step{{
+				Image: "ubuntu",
+				Name:  "echo",
+			}},
+		},
+	}
 	unsignedV1Task = v1.Task{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "tekton.dev/v1",
@@ -97,7 +113,7 @@ var (
 
 func TestVerifyResource_Task_Success(t *testing.T) {
 	signer256, _, k8sclient, vps := test.SetupVerificationPolicies(t)
-	unsignedTask := test.GetUnsignedTask("test-task")
+	unsignedTask := unsignedV1beta1Task
 	signedTask, err := test.GetSignedV1beta1Task(unsignedTask, signer256, "signed")
 	if err != nil {
 		t.Fatal("fail to sign task", err)
@@ -265,7 +281,7 @@ func TestVerifyResource_Task_Error(t *testing.T) {
 	ctx = test.SetupTrustedResourceConfig(ctx, config.FailNoMatchPolicy)
 	sv, _, k8sclient, vps := test.SetupVerificationPolicies(t)
 
-	unsignedTask := test.GetUnsignedTask("test-task")
+	unsignedTask := unsignedV1beta1Task
 
 	signedTask, err := test.GetSignedV1beta1Task(unsignedTask, sv, "signed")
 	if err != nil {

--- a/test/trustedresources.go
+++ b/test/trustedresources.go
@@ -54,26 +54,6 @@ var (
 	read = readPasswordFn
 )
 
-// GetUnsignedTask returns unsigned task with given name
-func GetUnsignedTask(name string) *v1beta1.Task {
-	return &v1beta1.Task{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "tekton.dev/v1beta1",
-			Kind:       "Task"},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        name,
-			Namespace:   namespace,
-			Annotations: map[string]string{"foo": "bar"},
-		},
-		Spec: v1beta1.TaskSpec{
-			Steps: []v1beta1.Step{{
-				Image: "ubuntu",
-				Name:  "echo",
-			}},
-		},
-	}
-}
-
 // SetupTrustedResourceConfig configures the trusted-resources-verification-no-match-policy feature flag with the given mode for testing
 func SetupTrustedResourceConfig(ctx context.Context, verificationNoMatchPolicy string) context.Context {
 	store := config.NewStore(logging.FromContext(ctx).Named("config-store"))

--- a/test/trustedresources_test.go
+++ b/test/trustedresources_test.go
@@ -26,8 +26,27 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/sigstore/sigstore/pkg/signature"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/test/diff"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+var unsignedV1beta1Task = &v1beta1.Task{
+	TypeMeta: metav1.TypeMeta{
+		APIVersion: "tekton.dev/v1beta1",
+		Kind:       "Task"},
+	ObjectMeta: metav1.ObjectMeta{
+		Name:        "test-task",
+		Namespace:   "trusted-resources",
+		Annotations: map[string]string{"foo": "bar"},
+	},
+	Spec: v1beta1.TaskSpec{
+		Steps: []v1beta1.Step{{
+			Image: "ubuntu",
+			Name:  "echo",
+		}},
+	},
+}
 
 func TestSignInterface(t *testing.T) {
 	sv, _, err := signature.NewDefaultECDSASignerVerifier()
@@ -46,7 +65,7 @@ func TestSignInterface(t *testing.T) {
 	}{{
 		name:    "Sign Task",
 		signer:  sv,
-		target:  GetUnsignedTask("unsigned"),
+		target:  unsignedV1beta1Task,
 		wantErr: false,
 	}, {
 		name:    "Sign String with cosign signer",
@@ -61,7 +80,7 @@ func TestSignInterface(t *testing.T) {
 	}, {
 		name:    "Empty Signer",
 		signer:  nil,
-		target:  GetUnsignedTask("unsigned"),
+		target:  unsignedV1beta1Task,
 		wantErr: true,
 	}, {
 		name:     "Sign String with mock signer",


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This commit is part of #5820. It removes the GetUnsignedTask helper function and use a var in each test file instead to improve the readability for developers.

No functional change in this PR.

/kind cleanup

Signed-off-by: Yongxuan Zhang yongxuanzhang@google.com

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
