### PR TITLE
remove GetUnsignedPipeline helper function and use var in each file

### DIFF
--- a/pkg/reconciler/pipelinerun/resources/pipelineref_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelineref_test.go
@@ -65,6 +65,23 @@ var (
 		},
 		EntryPoint: "foo/bar",
 	}
+	unsignedV1beta1Pipeline = &v1beta1.Pipeline{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "tekton.dev/v1beta1",
+			Kind:       "Pipeline"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test-pipeline",
+			Namespace:   "trusted-resources",
+			Annotations: map[string]string{"foo": "bar"},
+		},
+		Spec: v1beta1.PipelineSpec{
+			Tasks: []v1beta1.PipelineTask{
+				{
+					Name: "task",
+				},
+			},
+		},
+	}
 
 	unsignedV1Pipeline = &v1.Pipeline{
 		TypeMeta: metav1.TypeMeta{
@@ -485,7 +502,7 @@ func TestGetPipelineFunc_V1beta1Pipeline_VerifyNoError(t *testing.T) {
 	signer, _, k8sclient, vps := test.SetupVerificationPolicies(t)
 	tektonclient := fake.NewSimpleClientset()
 
-	unsignedPipeline := test.GetUnsignedPipeline("test-pipeline")
+	unsignedPipeline := unsignedV1beta1Pipeline
 	unsignedV1Pipeline := &v1.Pipeline{}
 	unsignedPipeline.ConvertTo(ctx, unsignedV1Pipeline)
 	unsignedV1Pipeline.APIVersion = "tekton.dev/v1"
@@ -688,7 +705,7 @@ func TestGetPipelineFunc_V1beta1Pipeline_VerifyError(t *testing.T) {
 	tektonclient := fake.NewSimpleClientset()
 	signer, _, k8sclient, vps := test.SetupVerificationPolicies(t)
 
-	unsignedPipeline := test.GetUnsignedPipeline("test-pipeline")
+	unsignedPipeline := unsignedV1beta1Pipeline
 	unsignedPipelineBytes, err := json.Marshal(unsignedPipeline)
 	if err != nil {
 		t.Fatal("fail to marshal pipeline", err)
@@ -1134,7 +1151,7 @@ func TestGetPipelineFunc_GetFuncError(t *testing.T) {
 	tektonclient := fake.NewSimpleClientset()
 	_, k8sclient, vps := test.SetupMatchAllVerificationPolicies(t, "trusted-resources")
 
-	unsignedPipeline := test.GetUnsignedPipeline("test-pipeline")
+	unsignedPipeline := unsignedV1beta1Pipeline
 	unsignedPipelineBytes, err := json.Marshal(unsignedPipeline)
 	if err != nil {
 		t.Fatal("fail to marshal pipeline", err)

--- a/pkg/trustedresources/verify_test.go
+++ b/pkg/trustedresources/verify_test.go
@@ -46,38 +46,56 @@ const (
 	namespace = "trusted-resources"
 )
 
-var unsignedTask = v1.Task{
-	TypeMeta: metav1.TypeMeta{
-		APIVersion: "tekton.dev/v1",
-		Kind:       "Task"},
-	ObjectMeta: metav1.ObjectMeta{
-		Name:        "task",
-		Annotations: map[string]string{"foo": "bar"},
-	},
-	Spec: v1.TaskSpec{
-		Steps: []v1.Step{{
-			Image: "ubuntu",
-			Name:  "echo",
-		}},
-	},
-}
-
-var unsignedPipeline = v1.Pipeline{
-	TypeMeta: metav1.TypeMeta{
-		APIVersion: "tekton.dev/v1",
-		Kind:       "Pipeline"},
-	ObjectMeta: metav1.ObjectMeta{
-		Name:        "pipeline",
-		Annotations: map[string]string{"foo": "bar"},
-	},
-	Spec: v1.PipelineSpec{
-		Tasks: []v1.PipelineTask{
-			{
-				Name: "task",
+var (
+	unsignedV1Task = v1.Task{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "tekton.dev/v1",
+			Kind:       "Task"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "task",
+			Annotations: map[string]string{"foo": "bar"},
+		},
+		Spec: v1.TaskSpec{
+			Steps: []v1.Step{{
+				Image: "ubuntu",
+				Name:  "echo",
+			}},
+		},
+	}
+	unsignedV1beta1Pipeline = &v1beta1.Pipeline{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "tekton.dev/v1beta1",
+			Kind:       "Pipeline"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test-pipeline",
+			Namespace:   "trusted-resources",
+			Annotations: map[string]string{"foo": "bar"},
+		},
+		Spec: v1beta1.PipelineSpec{
+			Tasks: []v1beta1.PipelineTask{
+				{
+					Name: "task",
+				},
 			},
 		},
-	},
-}
+	}
+	unsignedV1Pipeline = v1.Pipeline{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "tekton.dev/v1",
+			Kind:       "Pipeline"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "pipeline",
+			Annotations: map[string]string{"foo": "bar"},
+		},
+		Spec: v1.PipelineSpec{
+			Tasks: []v1.PipelineTask{
+				{
+					Name: "task",
+				},
+			},
+		},
+	}
+)
 
 func TestVerifyInterface_Task_Success(t *testing.T) {
 	sv, _, err := signature.NewDefaultECDSASignerVerifier()
@@ -429,7 +447,7 @@ func TestVerifyResource_Task_Error(t *testing.T) {
 
 func TestVerifyResource_Pipeline_Success(t *testing.T) {
 	sv, _, k8sclient, vps := test.SetupVerificationPolicies(t)
-	unsignedPipeline := test.GetUnsignedPipeline("test-pipeline")
+	unsignedPipeline := unsignedV1beta1Pipeline
 	signedPipeline, err := test.GetSignedV1beta1Pipeline(unsignedPipeline, sv, "signed")
 	if err != nil {
 		t.Fatal("fail to sign task", err)
@@ -483,7 +501,7 @@ func TestVerifyResource_Pipeline_Error(t *testing.T) {
 	ctx = test.SetupTrustedResourceConfig(ctx, config.FailNoMatchPolicy)
 	sv, _, k8sclient, vps := test.SetupVerificationPolicies(t)
 
-	unsignedPipeline := test.GetUnsignedPipeline("test-pipeline")
+	unsignedPipeline := unsignedV1beta1Pipeline
 
 	signedPipeline, err := test.GetSignedV1beta1Pipeline(unsignedPipeline, sv, "signed")
 	if err != nil {
@@ -542,7 +560,7 @@ func TestVerifyResource_Pipeline_Error(t *testing.T) {
 
 func TestVerifyResource_V1Task_Success(t *testing.T) {
 	signer, _, k8sclient, vps := test.SetupVerificationPolicies(t)
-	signedTask, err := getSignedV1Task(unsignedTask.DeepCopy(), signer, "signed")
+	signedTask, err := getSignedV1Task(unsignedV1Task.DeepCopy(), signer, "signed")
 	if err != nil {
 		t.Error(err)
 	}
@@ -553,7 +571,7 @@ func TestVerifyResource_V1Task_Success(t *testing.T) {
 }
 func TestVerifyResource_V1Task_Error(t *testing.T) {
 	signer, _, k8sclient, vps := test.SetupVerificationPolicies(t)
-	signedTask, err := getSignedV1Task(unsignedTask.DeepCopy(), signer, "signed")
+	signedTask, err := getSignedV1Task(unsignedV1Task.DeepCopy(), signer, "signed")
 	if err != nil {
 		t.Error(err)
 	}
@@ -567,7 +585,7 @@ func TestVerifyResource_V1Task_Error(t *testing.T) {
 
 func TestVerifyResource_V1Pipeline_Success(t *testing.T) {
 	signer, _, k8sclient, vps := test.SetupVerificationPolicies(t)
-	signed, err := getSignedV1Pipeline(unsignedPipeline.DeepCopy(), signer, "signed")
+	signed, err := getSignedV1Pipeline(unsignedV1Pipeline.DeepCopy(), signer, "signed")
 	if err != nil {
 		t.Error(err)
 	}
@@ -579,7 +597,7 @@ func TestVerifyResource_V1Pipeline_Success(t *testing.T) {
 
 func TestVerifyResource_V1Pipeline_Error(t *testing.T) {
 	signer, _, k8sclient, vps := test.SetupVerificationPolicies(t)
-	signed, err := getSignedV1Pipeline(unsignedPipeline.DeepCopy(), signer, "signed")
+	signed, err := getSignedV1Pipeline(unsignedV1Pipeline.DeepCopy(), signer, "signed")
 	if err != nil {
 		t.Error(err)
 	}

--- a/test/trustedresources.go
+++ b/test/trustedresources.go
@@ -74,27 +74,6 @@ func GetUnsignedTask(name string) *v1beta1.Task {
 	}
 }
 
-// GetUnsignedPipeline returns unsigned pipeline with given name
-func GetUnsignedPipeline(name string) *v1beta1.Pipeline {
-	return &v1beta1.Pipeline{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "tekton.dev/v1beta1",
-			Kind:       "Pipeline"},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        name,
-			Namespace:   namespace,
-			Annotations: map[string]string{"foo": "bar"},
-		},
-		Spec: v1beta1.PipelineSpec{
-			Tasks: []v1beta1.PipelineTask{
-				{
-					Name: "task",
-				},
-			},
-		},
-	}
-}
-
 // SetupTrustedResourceConfig configures the trusted-resources-verification-no-match-policy feature flag with the given mode for testing
 func SetupTrustedResourceConfig(ctx context.Context, verificationNoMatchPolicy string) context.Context {
 	store := config.NewStore(logging.FromContext(ctx).Named("config-store"))


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This commit is part of #5820. It removes the GetUnsignedPipeline helper function and use a var in each test file instead to improve the readability for developers.

No functional change.

/kind cleanup

Signed-off-by: Yongxuan Zhang yongxuanzhang@google.com

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
