### PR TITLE
Refactor failure logic in pipelinerun resolution

### DIFF
--- a/pkg/apis/pipeline/v1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1/taskrun_types.go
@@ -380,9 +380,14 @@ func (tr *TaskRun) HasStarted() bool {
 	return tr.Status.StartTime != nil && !tr.Status.StartTime.IsZero()
 }
 
-// IsSuccessful returns true if the TaskRun's status indicates that it is done.
+// IsSuccessful returns true if the TaskRun's status indicates that it has succeeded.
 func (tr *TaskRun) IsSuccessful() bool {
 	return tr != nil && tr.Status.GetCondition(apis.ConditionSucceeded).IsTrue()
+}
+
+// IsFailure returns true if the TaskRun's status indicates that it has failed.
+func (tr *TaskRun) IsFailure() bool {
+	return tr != nil && tr.Status.GetCondition(apis.ConditionSucceeded).IsFalse()
 }
 
 // IsCancelled returns true if the TaskRun's spec status is set to Cancelled state

--- a/pkg/apis/pipeline/v1/taskrun_types_test.go
+++ b/pkg/apis/pipeline/v1/taskrun_types_test.go
@@ -127,6 +127,82 @@ func TestTaskRunIsDone(t *testing.T) {
 	}
 }
 
+func TestIsSuccessful(t *testing.T) {
+	tcs := []struct {
+		name    string
+		taskRun *v1.TaskRun
+		want    bool
+	}{{
+		name: "nil taskrun",
+		want: false,
+	}, {
+		name: "still running",
+		taskRun: &v1.TaskRun{Status: v1.TaskRunStatus{Status: duckv1.Status{Conditions: []apis.Condition{{
+			Type:   apis.ConditionSucceeded,
+			Status: corev1.ConditionUnknown,
+		}}}}},
+		want: false,
+	}, {
+		name: "succeeded",
+		taskRun: &v1.TaskRun{Status: v1.TaskRunStatus{Status: duckv1.Status{Conditions: []apis.Condition{{
+			Type:   apis.ConditionSucceeded,
+			Status: corev1.ConditionTrue,
+		}}}}},
+		want: true,
+	}, {
+		name: "failed",
+		taskRun: &v1.TaskRun{Status: v1.TaskRunStatus{Status: duckv1.Status{Conditions: []apis.Condition{{
+			Type:   apis.ConditionSucceeded,
+			Status: corev1.ConditionFalse,
+		}}}}},
+		want: false,
+	}}
+	for _, tc := range tcs {
+		got := tc.taskRun.IsSuccessful()
+		if tc.want != got {
+			t.Errorf("wanted isSuccessful to be %t but was %t", tc.want, got)
+		}
+	}
+}
+
+func TestIsFailure(t *testing.T) {
+	tcs := []struct {
+		name    string
+		taskRun *v1.TaskRun
+		want    bool
+	}{{
+		name: "nil taskrun",
+		want: false,
+	}, {
+		name: "still running",
+		taskRun: &v1.TaskRun{Status: v1.TaskRunStatus{Status: duckv1.Status{Conditions: []apis.Condition{{
+			Type:   apis.ConditionSucceeded,
+			Status: corev1.ConditionUnknown,
+		}}}}},
+		want: false,
+	}, {
+		name: "succeeded",
+		taskRun: &v1.TaskRun{Status: v1.TaskRunStatus{Status: duckv1.Status{Conditions: []apis.Condition{{
+			Type:   apis.ConditionSucceeded,
+			Status: corev1.ConditionTrue,
+		}}}}},
+		want: false,
+	}, {
+		name: "failed",
+		taskRun: &v1.TaskRun{Status: v1.TaskRunStatus{Status: duckv1.Status{Conditions: []apis.Condition{{
+			Type:   apis.ConditionSucceeded,
+			Status: corev1.ConditionFalse,
+		}}}}},
+		want: true,
+	}}
+	for _, tc := range tcs {
+		got := tc.taskRun.IsFailure()
+		if tc.want != got {
+			t.Errorf("wanted isFailure to be %t but was %t", tc.want, got)
+		}
+	}
+}
+
 func TestTaskRunIsCancelled(t *testing.T) {
 	tr := &v1.TaskRun{
 		Spec: v1.TaskRunSpec{

--- a/pkg/apis/pipeline/v1alpha1/run_types.go
+++ b/pkg/apis/pipeline/v1alpha1/run_types.go
@@ -230,7 +230,7 @@ func (r *Run) HasStarted() bool {
 	return r.Status.StartTime != nil && !r.Status.StartTime.IsZero()
 }
 
-// IsSuccessful returns true if the Run's status indicates that it is done.
+// IsSuccessful returns true if the Run's status indicates that it has succeeded.
 func (r *Run) IsSuccessful() bool {
 	return r != nil && r.Status.GetCondition(apis.ConditionSucceeded).IsTrue()
 }

--- a/pkg/apis/pipeline/v1alpha1/run_types_test.go
+++ b/pkg/apis/pipeline/v1alpha1/run_types_test.go
@@ -163,6 +163,44 @@ func TestRunIsDone(t *testing.T) {
 	}
 }
 
+func TestRunIsSuccessful(t *testing.T) {
+	tcs := []struct {
+		name string
+		run  *v1alpha1.Run
+		want bool
+	}{{
+		name: "nil taskrun",
+		want: false,
+	}, {
+		name: "still running",
+		run: &v1alpha1.Run{Status: v1alpha1.RunStatus{Status: duckv1.Status{Conditions: []apis.Condition{{
+			Type:   apis.ConditionSucceeded,
+			Status: corev1.ConditionUnknown,
+		}}}}},
+		want: false,
+	}, {
+		name: "succeeded",
+		run: &v1alpha1.Run{Status: v1alpha1.RunStatus{Status: duckv1.Status{Conditions: []apis.Condition{{
+			Type:   apis.ConditionSucceeded,
+			Status: corev1.ConditionTrue,
+		}}}}},
+		want: true,
+	}, {
+		name: "failed",
+		run: &v1alpha1.Run{Status: v1alpha1.RunStatus{Status: duckv1.Status{Conditions: []apis.Condition{{
+			Type:   apis.ConditionSucceeded,
+			Status: corev1.ConditionFalse,
+		}}}}},
+		want: false,
+	}}
+	for _, tc := range tcs {
+		got := tc.run.IsSuccessful()
+		if tc.want != got {
+			t.Errorf("wanted isSuccessful to be %t but was %t", tc.want, got)
+		}
+	}
+}
+
 func TestRunIsCancelled(t *testing.T) {
 	run := v1alpha1.Run{
 		Spec: v1alpha1.RunSpec{

--- a/pkg/apis/pipeline/v1beta1/customrun_types.go
+++ b/pkg/apis/pipeline/v1beta1/customrun_types.go
@@ -223,9 +223,14 @@ func (r *CustomRun) HasStarted() bool {
 	return r.Status.StartTime != nil && !r.Status.StartTime.IsZero()
 }
 
-// IsSuccessful returns true if the CustomRun's status indicates that it is done.
+// IsSuccessful returns true if the CustomRun's status indicates that it has succeeded.
 func (r *CustomRun) IsSuccessful() bool {
 	return r != nil && r.Status.GetCondition(apis.ConditionSucceeded).IsTrue()
+}
+
+// IsFailure returns true if the CustomRun's status indicates that it has failed.
+func (r *CustomRun) IsFailure() bool {
+	return r != nil && r.Status.GetCondition(apis.ConditionSucceeded).IsFalse()
 }
 
 // GetCustomRunKey return the customrun's key for timeout handler map

--- a/pkg/apis/pipeline/v1beta1/customrun_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/customrun_types_test.go
@@ -158,6 +158,82 @@ func TestRunIsDone(t *testing.T) {
 	}
 }
 
+func TestCustomRunIsSuccessful(t *testing.T) {
+	tcs := []struct {
+		name      string
+		customRun *v1beta1.CustomRun
+		want      bool
+	}{{
+		name: "nil taskrun",
+		want: false,
+	}, {
+		name: "still running",
+		customRun: &v1beta1.CustomRun{Status: v1beta1.CustomRunStatus{Status: duckv1.Status{Conditions: []apis.Condition{{
+			Type:   apis.ConditionSucceeded,
+			Status: corev1.ConditionUnknown,
+		}}}}},
+		want: false,
+	}, {
+		name: "succeeded",
+		customRun: &v1beta1.CustomRun{Status: v1beta1.CustomRunStatus{Status: duckv1.Status{Conditions: []apis.Condition{{
+			Type:   apis.ConditionSucceeded,
+			Status: corev1.ConditionTrue,
+		}}}}},
+		want: true,
+	}, {
+		name: "failed",
+		customRun: &v1beta1.CustomRun{Status: v1beta1.CustomRunStatus{Status: duckv1.Status{Conditions: []apis.Condition{{
+			Type:   apis.ConditionSucceeded,
+			Status: corev1.ConditionFalse,
+		}}}}},
+		want: false,
+	}}
+	for _, tc := range tcs {
+		got := tc.customRun.IsSuccessful()
+		if tc.want != got {
+			t.Errorf("wanted isSuccessful to be %t but was %t", tc.want, got)
+		}
+	}
+}
+
+func TestCustomRunIsFailure(t *testing.T) {
+	tcs := []struct {
+		name    string
+		taskRun *v1beta1.TaskRun
+		want    bool
+	}{{
+		name: "nil taskrun",
+		want: false,
+	}, {
+		name: "still running",
+		taskRun: &v1beta1.TaskRun{Status: v1beta1.TaskRunStatus{Status: duckv1.Status{Conditions: []apis.Condition{{
+			Type:   apis.ConditionSucceeded,
+			Status: corev1.ConditionUnknown,
+		}}}}},
+		want: false,
+	}, {
+		name: "succeeded",
+		taskRun: &v1beta1.TaskRun{Status: v1beta1.TaskRunStatus{Status: duckv1.Status{Conditions: []apis.Condition{{
+			Type:   apis.ConditionSucceeded,
+			Status: corev1.ConditionTrue,
+		}}}}},
+		want: false,
+	}, {
+		name: "failed",
+		taskRun: &v1beta1.TaskRun{Status: v1beta1.TaskRunStatus{Status: duckv1.Status{Conditions: []apis.Condition{{
+			Type:   apis.ConditionSucceeded,
+			Status: corev1.ConditionFalse,
+		}}}}},
+		want: true,
+	}}
+	for _, tc := range tcs {
+		got := tc.taskRun.IsFailure()
+		if tc.want != got {
+			t.Errorf("wanted isFailure to be %t but was %t", tc.want, got)
+		}
+	}
+}
+
 func TestRunIsCancelled(t *testing.T) {
 	customRun := v1beta1.CustomRun{
 		Spec: v1beta1.CustomRunSpec{

--- a/pkg/apis/pipeline/v1beta1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_types.go
@@ -449,9 +449,14 @@ func (tr *TaskRun) HasStarted() bool {
 	return tr.Status.StartTime != nil && !tr.Status.StartTime.IsZero()
 }
 
-// IsSuccessful returns true if the TaskRun's status indicates that it is done.
+// IsSuccessful returns true if the TaskRun's status indicates that it has succeeded.
 func (tr *TaskRun) IsSuccessful() bool {
 	return tr != nil && tr.Status.GetCondition(apis.ConditionSucceeded).IsTrue()
+}
+
+// IsFailure returns true if the TaskRun's status indicates that it has failed.
+func (tr *TaskRun) IsFailure() bool {
+	return tr != nil && tr.Status.GetCondition(apis.ConditionSucceeded).IsFalse()
 }
 
 // IsCancelled returns true if the TaskRun's spec status is set to Cancelled state

--- a/pkg/apis/pipeline/v1beta1/taskrun_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_types_test.go
@@ -280,6 +280,82 @@ func TestTaskRunHasStarted(t *testing.T) {
 	}
 }
 
+func TestIsSuccessful(t *testing.T) {
+	tcs := []struct {
+		name    string
+		taskRun *v1beta1.TaskRun
+		want    bool
+	}{{
+		name: "nil taskrun",
+		want: false,
+	}, {
+		name: "still running",
+		taskRun: &v1beta1.TaskRun{Status: v1beta1.TaskRunStatus{Status: duckv1.Status{Conditions: []apis.Condition{{
+			Type:   apis.ConditionSucceeded,
+			Status: corev1.ConditionUnknown,
+		}}}}},
+		want: false,
+	}, {
+		name: "succeeded",
+		taskRun: &v1beta1.TaskRun{Status: v1beta1.TaskRunStatus{Status: duckv1.Status{Conditions: []apis.Condition{{
+			Type:   apis.ConditionSucceeded,
+			Status: corev1.ConditionTrue,
+		}}}}},
+		want: true,
+	}, {
+		name: "failed",
+		taskRun: &v1beta1.TaskRun{Status: v1beta1.TaskRunStatus{Status: duckv1.Status{Conditions: []apis.Condition{{
+			Type:   apis.ConditionSucceeded,
+			Status: corev1.ConditionFalse,
+		}}}}},
+		want: false,
+	}}
+	for _, tc := range tcs {
+		got := tc.taskRun.IsSuccessful()
+		if tc.want != got {
+			t.Errorf("wanted isSuccessful to be %t but was %t", tc.want, got)
+		}
+	}
+}
+
+func TestIsFailure(t *testing.T) {
+	tcs := []struct {
+		name    string
+		taskRun *v1beta1.TaskRun
+		want    bool
+	}{{
+		name: "nil taskrun",
+		want: false,
+	}, {
+		name: "still running",
+		taskRun: &v1beta1.TaskRun{Status: v1beta1.TaskRunStatus{Status: duckv1.Status{Conditions: []apis.Condition{{
+			Type:   apis.ConditionSucceeded,
+			Status: corev1.ConditionUnknown,
+		}}}}},
+		want: false,
+	}, {
+		name: "succeeded",
+		taskRun: &v1beta1.TaskRun{Status: v1beta1.TaskRunStatus{Status: duckv1.Status{Conditions: []apis.Condition{{
+			Type:   apis.ConditionSucceeded,
+			Status: corev1.ConditionTrue,
+		}}}}},
+		want: false,
+	}, {
+		name: "failed",
+		taskRun: &v1beta1.TaskRun{Status: v1beta1.TaskRunStatus{Status: duckv1.Status{Conditions: []apis.Condition{{
+			Type:   apis.ConditionSucceeded,
+			Status: corev1.ConditionFalse,
+		}}}}},
+		want: true,
+	}}
+	for _, tc := range tcs {
+		got := tc.taskRun.IsFailure()
+		if tc.want != got {
+			t.Errorf("wanted isFailure to be %t but was %t", tc.want, got)
+		}
+	}
+}
+
 func TestHasTimedOut(t *testing.T) {
 	// IsZero reports whether t represents the zero time instant, January 1, year 1, 00:00:00 UTC
 	zeroTime := time.Date(1, 1, 1, 0, 0, 0, 0, time.UTC)

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
@@ -1891,173 +1891,7 @@ func TestIsCancelledForTimeout(t *testing.T) {
 	}
 }
 
-func TestHasTaskRunsStarted(t *testing.T) {
-	for _, tc := range []struct {
-		name string
-		rpt  ResolvedPipelineTask
-		want bool
-	}{{
-		name: "taskrun not started",
-		rpt: ResolvedPipelineTask{
-			PipelineTask: &v1.PipelineTask{Name: "task"},
-		},
-		want: false,
-	}, {
-		name: "taskrun running",
-		rpt: ResolvedPipelineTask{
-			PipelineTask: &v1.PipelineTask{Name: "task"},
-			TaskRuns:     []*v1.TaskRun{makeStarted(trs[0])},
-		},
-		want: true,
-	}, {
-		name: "taskrun succeeded",
-		rpt: ResolvedPipelineTask{
-			PipelineTask: &v1.PipelineTask{Name: "task"},
-			TaskRuns:     []*v1.TaskRun{makeSucceeded(trs[0])},
-		},
-		want: true,
-	}, {
-		name: "taskrun failed",
-		rpt: ResolvedPipelineTask{
-			PipelineTask: &v1.PipelineTask{Name: "task"},
-			TaskRuns:     []*v1.TaskRun{makeFailed(trs[0])},
-		},
-		want: true,
-	}, {
-		name: "matrixed taskruns not started",
-		rpt: ResolvedPipelineTask{
-			PipelineTask: matrixedPipelineTask,
-		},
-		want: false,
-	}, {
-		name: "matrixed taskruns running",
-		rpt: ResolvedPipelineTask{
-			PipelineTask: matrixedPipelineTask,
-			TaskRuns:     []*v1.TaskRun{makeStarted(trs[0]), makeStarted(trs[1])},
-		},
-		want: true,
-	}, {
-		name: "one matrixed taskrun running",
-		rpt: ResolvedPipelineTask{
-			PipelineTask: matrixedPipelineTask,
-			TaskRuns:     []*v1.TaskRun{makeStarted(trs[0]), makeSucceeded(trs[1])},
-		},
-		want: true,
-	}, {
-		name: "matrixed taskruns succeeded",
-		rpt: ResolvedPipelineTask{
-			PipelineTask: matrixedPipelineTask,
-			TaskRuns:     []*v1.TaskRun{makeSucceeded(trs[0]), makeSucceeded(trs[1])},
-		},
-		want: true,
-	}, {
-		name: "one matrixed taskrun succeeded",
-		rpt: ResolvedPipelineTask{
-			PipelineTask: matrixedPipelineTask,
-			TaskRuns:     []*v1.TaskRun{makeSucceeded(trs[0]), makeStarted(trs[1])},
-		},
-		want: true,
-	}, {
-		name: "matrixed taskruns failed",
-		rpt: ResolvedPipelineTask{
-			PipelineTask: matrixedPipelineTask,
-			TaskRuns:     []*v1.TaskRun{makeFailed(trs[0]), makeFailed(trs[1])},
-		},
-		want: true,
-	}} {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := tc.rpt.hasTaskRunsStarted(); got != tc.want {
-				t.Errorf("expected isStarted: %t but got %t", tc.want, got)
-			}
-		})
-	}
-}
-
-func TestHasCustomRunsStarted(t *testing.T) {
-	for _, tc := range []struct {
-		name string
-		rpt  ResolvedPipelineTask
-		want bool
-	}{{
-		name: "run not started",
-		rpt: ResolvedPipelineTask{
-			PipelineTask: &v1.PipelineTask{Name: "task"},
-			CustomTask:   true,
-		},
-		want: false,
-	}, {
-		name: "run running",
-		rpt: ResolvedPipelineTask{
-			PipelineTask: &v1.PipelineTask{Name: "task"},
-			CustomTask:   true,
-			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunStarted(customRuns[0])},
-		},
-		want: true,
-	}, {
-		name: "run succeeded",
-		rpt: ResolvedPipelineTask{
-			PipelineTask: &v1.PipelineTask{Name: "task"},
-			CustomTask:   true,
-			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunSucceeded(customRuns[0])},
-		},
-		want: true,
-	}, {
-		name: "run failed",
-		rpt: ResolvedPipelineTask{
-			PipelineTask: &v1.PipelineTask{Name: "task"},
-			CustomTask:   true,
-			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunFailed(customRuns[0])},
-		},
-		want: true,
-	}, {
-		name: "matrixed runs not started",
-		rpt: ResolvedPipelineTask{
-			CustomTask:   true,
-			PipelineTask: matrixedPipelineTask,
-		},
-		want: false,
-	}, {
-		name: "matrixed runs running",
-		rpt: ResolvedPipelineTask{
-			CustomTask:   true,
-			PipelineTask: matrixedPipelineTask,
-			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunStarted(customRuns[0]), makeCustomRunStarted(customRuns[1])},
-		},
-		want: true,
-	}, {
-		name: "one matrixed run running",
-		rpt: ResolvedPipelineTask{
-			CustomTask:   true,
-			PipelineTask: matrixedPipelineTask,
-			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunStarted(customRuns[0]), makeCustomRunSucceeded(customRuns[1])},
-		},
-		want: true,
-	}, {
-		name: "one matrixed run succeeded",
-		rpt: ResolvedPipelineTask{
-			CustomTask:   true,
-			PipelineTask: matrixedPipelineTask,
-			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunSucceeded(customRuns[0]), makeCustomRunStarted(customRuns[1])},
-		},
-		want: true,
-	}, {
-		name: "matrixed runs failed",
-		rpt: ResolvedPipelineTask{
-			CustomTask:   true,
-			PipelineTask: matrixedPipelineTask,
-			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunFailed(customRuns[0]), makeCustomRunFailed(customRuns[1])},
-		},
-		want: true,
-	}} {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := tc.rpt.hasCustomRunsStarted(); got != tc.want {
-				t.Errorf("expected isStarted: %t but got %t", tc.want, got)
-			}
-		})
-	}
-}
-
-func TestIsConditionStatusFalse(t *testing.T) {
+func TestHaveAnyCustomRunsFailed(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		rpt  ResolvedPipelineTask
@@ -2196,7 +2030,21 @@ func TestIsConditionStatusFalse(t *testing.T) {
 			CustomRuns:   []*v1beta1.CustomRun{withCustomRunCancelled(newCustomRun(customRuns[0])), makeCustomRunStarted(customRuns[1])},
 		},
 		want: false,
-	}, {
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.rpt.haveAnyCustomRunsFailed(); got != tc.want {
+				t.Errorf("expected haveAnyCustomRunsFailed: %t but got %t", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestHaveAnyTaskRunsFailed(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		rpt  ResolvedPipelineTask
+		want bool
+	}{{
 		name: "taskrun not started",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1.PipelineTask{Name: "task"},
@@ -2322,8 +2170,8 @@ func TestIsConditionStatusFalse(t *testing.T) {
 		want: false,
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := tc.rpt.isConditionStatusFalse(); got != tc.want {
-				t.Errorf("expected isConditionStatusFalse: %t but got %t", tc.want, got)
+			if got := tc.rpt.haveAnyTaskRunsFailed(); got != tc.want {
+				t.Errorf("expected haveAnyTaskRunsFailed: %t but got %t", tc.want, got)
 			}
 		})
 	}

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
@@ -478,7 +478,7 @@ func (facts *PipelineRunFacts) GetPipelineTaskStatus() map[string]string {
 			case t.isSuccessful():
 				s = v1.TaskRunReasonSuccessful.String()
 			// execution status is Failed when a task has succeeded condition with status set to false
-			case t.isConditionStatusFalse():
+			case t.haveAnyRunsFailed():
 				s = v1.TaskRunReasonFailed.String()
 			default:
 				// None includes skipped as well
@@ -496,7 +496,7 @@ func (facts *PipelineRunFacts) GetPipelineTaskStatus() map[string]string {
 		for _, t := range facts.State {
 			if facts.isDAGTask(t.PipelineTask.Name) {
 				// if any of the dag task failed, change the aggregate status to failed and return
-				if !t.IsCustomTask() && t.areTaskRunsConditionStatusFalse() || t.IsCustomTask() && t.areCustomRunsConditionStatusFalse() {
+				if !t.IsCustomTask() && t.haveAnyTaskRunsFailed() || t.IsCustomTask() && t.haveAnyCustomRunsFailed() {
 					aggregateStatus = v1beta1.PipelineRunReasonFailed.String()
 					break
 				}


### PR DESCRIPTION
This commit simplifies logic for determining which child TaskRuns/CustomRuns in a PipelineRun have failed, based on whether they have condition status false. Previously, v1alpha1 Runs had different logic to determine whether they had failed, based on whether they had retries remaining. Now that we don't support v1alpha1 Runs, failure status is based entirely on the value of ConditionSucceeded, for both CustomRuns and TaskRuns. This commit simplifies the member function isFailure for ResolvedPipelineTask to reflect this.

It also updates the RunObject interface to have a new IsFailure function, meaning that v1alpha1 Runs no longer implement RunObject. RunObject is retained because it may be useful for eventually migrating v1beta1 CustomRuns to v1 CustomRuns.

Lastly, it adds tests for the member function IsSuccessful for Runs, CustomRuns, and TaskRuns. No functional changes expected.

/kind cleanup
Fixes https://github.com/tektoncd/pipeline/issues/6628

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- n/a Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- n/a Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- n/a Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
