### PR TITLE
Add apiVersions to TrustedResources Verification Helper Functions

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -11628,7 +11628,7 @@ spec:
 `)
 
 	signer, _, vps := test.SetupMatchAllVerificationPolicies(t, ts.Namespace)
-	signedTask, err := test.GetSignedTask(ts, signer, "test-task")
+	signedTask, err := test.GetSignedV1beta1Task(ts, signer, "test-task")
 	if err != nil {
 		t.Fatal("fail to sign task", err)
 	}
@@ -11648,7 +11648,7 @@ spec:
         resolver: %s
 `, resolverName))
 
-	signedPipeline, err := test.GetSignedPipeline(ps, signer, "test-pipeline")
+	signedPipeline, err := test.GetSignedV1beta1Pipeline(ps, signer, "test-pipeline")
 	if err != nil {
 		t.Fatal("fail to sign pipeline", err)
 	}
@@ -11800,7 +11800,7 @@ spec:
 
 	// Case2: signed Pipeline refers to unsigned Task
 	signer, _, vps := test.SetupMatchAllVerificationPolicies(t, unsignedTask.Namespace)
-	signedPipelineWithUnsignedTask, err := test.GetSignedPipeline(unsignedPipeline, signer, "test-pipeline")
+	signedPipelineWithUnsignedTask, err := test.GetSignedV1beta1Pipeline(unsignedPipeline, signer, "test-pipeline")
 	if err != nil {
 		t.Fatal("fail to sign pipeline", err)
 	}
@@ -11810,7 +11810,7 @@ spec:
 	}
 
 	// Case3: signed Pipeline refers to modified Task
-	signedTask, err := test.GetSignedTask(unsignedTask, signer, "test-task")
+	signedTask, err := test.GetSignedV1beta1Task(unsignedTask, signer, "test-task")
 	if err != nil {
 		t.Fatal("fail to sign task", err)
 	}
@@ -11838,7 +11838,7 @@ spec:
       taskRef:
         resolver: %s
 `, resolverName))
-	signedPipelineWithModifiedTask, err := test.GetSignedPipeline(ps, signer, "test-pipeline")
+	signedPipelineWithModifiedTask, err := test.GetSignedV1beta1Pipeline(ps, signer, "test-pipeline")
 	if err != nil {
 		t.Fatal("fail to sign pipeline", err)
 	}
@@ -11858,7 +11858,7 @@ spec:
       taskRef:
         resolver: %s
 `, resolverName))
-	signedPipeline, err := test.GetSignedPipeline(ps, signer, "test-pipeline")
+	signedPipeline, err := test.GetSignedV1beta1Pipeline(ps, signer, "test-pipeline")
 	if err != nil {
 		t.Fatal("fail to sign pipeline", err)
 	}
@@ -12135,7 +12135,7 @@ spec:
 
 	// Case2: signed Pipeline refers to unsigned Task
 	signer, _, vps := test.SetupMatchAllVerificationPolicies(t, unsignedTask.Namespace)
-	signedPipelineWithUnsignedTask, err := test.GetSignedPipeline(unsignedPipeline, signer, "test-pipeline")
+	signedPipelineWithUnsignedTask, err := test.GetSignedV1beta1Pipeline(unsignedPipeline, signer, "test-pipeline")
 	if err != nil {
 		t.Fatal("fail to sign pipeline", err)
 	}
@@ -12145,7 +12145,7 @@ spec:
 	}
 
 	// Case3: signed Pipeline refers to modified Task
-	signedTask, err := test.GetSignedTask(unsignedTask, signer, "test-task")
+	signedTask, err := test.GetSignedV1beta1Task(unsignedTask, signer, "test-task")
 	if err != nil {
 		t.Fatal("fail to sign task", err)
 	}
@@ -12173,7 +12173,7 @@ spec:
       taskRef:
         resolver: %s
 `, resolverName))
-	signedPipelineWithModifiedTask, err := test.GetSignedPipeline(ps, signer, "test-pipeline")
+	signedPipelineWithModifiedTask, err := test.GetSignedV1beta1Pipeline(ps, signer, "test-pipeline")
 	if err != nil {
 		t.Fatal("fail to sign pipeline", err)
 	}
@@ -12193,7 +12193,7 @@ spec:
       taskRef:
         resolver: %s
 `, resolverName))
-	signedPipeline, err := test.GetSignedPipeline(ps, signer, "test-pipeline")
+	signedPipeline, err := test.GetSignedV1beta1Pipeline(ps, signer, "test-pipeline")
 	if err != nil {
 		t.Fatal("fail to sign pipeline", err)
 	}

--- a/pkg/reconciler/pipelinerun/resources/pipelineref_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelineref_test.go
@@ -512,7 +512,7 @@ func TestGetPipelineFunc_RemoteResolutionInvalidData(t *testing.T) {
 	}
 }
 
-func TestGetPipelineFunc_VerifyNoError(t *testing.T) {
+func TestGetPipelineFunc_V1beta1Pipeline_VerifyNoError(t *testing.T) {
 	ctx := context.Background()
 	signer, _, k8sclient, vps := test.SetupVerificationPolicies(t)
 	tektonclient := fake.NewSimpleClientset()
@@ -532,7 +532,7 @@ func TestGetPipelineFunc_VerifyNoError(t *testing.T) {
 	resolvedUnmatched := test.NewResolvedResource(unsignedPipelineBytes, nil, noMatchPolicyRefSource, nil)
 	requesterUnmatched := test.NewRequester(resolvedUnmatched, nil)
 
-	signedPipeline, err := test.GetSignedPipeline(unsignedPipeline, signer, "signed")
+	signedPipeline, err := test.GetSignedV1beta1Pipeline(unsignedPipeline, signer, "signed")
 	if err != nil {
 		t.Fatal("fail to sign pipeline", err)
 	}
@@ -699,7 +699,7 @@ func TestGetPipelineFunc_VerifyNoError(t *testing.T) {
 	}
 }
 
-func TestGetPipelineFunc_VerifyError(t *testing.T) {
+func TestGetPipelineFunc_V1beta1Pipeline_VerifyError(t *testing.T) {
 	ctx := context.Background()
 	tektonclient := fake.NewSimpleClientset()
 	signer, _, k8sclient, vps := test.SetupVerificationPolicies(t)
@@ -720,7 +720,7 @@ func TestGetPipelineFunc_VerifyError(t *testing.T) {
 	resolvedUnsigned := test.NewResolvedResource(unsignedPipelineBytes, nil, matchPolicyRefSource, nil)
 	requesterUnsigned := test.NewRequester(resolvedUnsigned, nil)
 
-	signedPipeline, err := test.GetSignedPipeline(unsignedPipeline, signer, "signed")
+	signedPipeline, err := test.GetSignedV1beta1Pipeline(unsignedPipeline, signer, "signed")
 	if err != nil {
 		t.Fatal("fail to sign pipeline", err)
 	}

--- a/pkg/reconciler/taskrun/resources/taskref_test.go
+++ b/pkg/reconciler/taskrun/resources/taskref_test.go
@@ -760,7 +760,7 @@ func TestGetPipelineFunc_RemoteResolutionInvalidData(t *testing.T) {
 	}
 }
 
-func TestGetTaskFunc_VerifyNoError(t *testing.T) {
+func TestGetTaskFunc_V1beta1Task_VerifyNoError(t *testing.T) {
 	ctx := context.Background()
 	signer, _, k8sclient, vps := test.SetupVerificationPolicies(t)
 	tektonclient := fake.NewSimpleClientset()
@@ -775,7 +775,7 @@ func TestGetTaskFunc_VerifyNoError(t *testing.T) {
 	}
 	requesterUnmatched := bytesToRequester(unsignedTaskBytes, noMatchPolicyRefSource)
 
-	signedTask, err := test.GetSignedTask(unsignedTask, signer, "signed")
+	signedTask, err := test.GetSignedV1beta1Task(unsignedTask, signer, "signed")
 	if err != nil {
 		t.Fatal("fail to sign task", err)
 	}
@@ -885,7 +885,7 @@ func TestGetTaskFunc_VerifyNoError(t *testing.T) {
 	}
 }
 
-func TestGetTaskFunc_VerifyError(t *testing.T) {
+func TestGetTaskFunc_V1beta1Task_VerifyError(t *testing.T) {
 	ctx := context.Background()
 	signer, _, k8sclient, vps := test.SetupVerificationPolicies(t)
 	tektonclient := fake.NewSimpleClientset()
@@ -900,7 +900,7 @@ func TestGetTaskFunc_VerifyError(t *testing.T) {
 	}
 	requesterUnsigned := bytesToRequester(unsignedTaskBytes, matchPolicyRefSource)
 
-	signedTask, err := test.GetSignedTask(unsignedTask, signer, "signed")
+	signedTask, err := test.GetSignedV1beta1Task(unsignedTask, signer, "signed")
 	if err != nil {
 		t.Fatal("fail to sign task", err)
 	}

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -4919,7 +4919,7 @@ spec:
 `)
 
 	signer, _, vps := test.SetupMatchAllVerificationPolicies(t, ts.Namespace)
-	signedTask, err := test.GetSignedTask(ts, signer, "test-task")
+	signedTask, err := test.GetSignedV1beta1Task(ts, signer, "test-task")
 	if err != nil {
 		t.Fatal("fail to sign task", err)
 	}
@@ -5070,7 +5070,7 @@ spec:
 	}
 
 	signer, _, vps := test.SetupMatchAllVerificationPolicies(t, unsignedTask.Namespace)
-	signedTask, err := test.GetSignedTask(unsignedTask, signer, "test-task")
+	signedTask, err := test.GetSignedV1beta1Task(unsignedTask, signer, "test-task")
 	if err != nil {
 		t.Fatal("fail to sign task", err)
 	}

--- a/pkg/trustedresources/verify_test.go
+++ b/pkg/trustedresources/verify_test.go
@@ -86,7 +86,7 @@ func TestVerifyInterface_Task_Success(t *testing.T) {
 	}
 
 	unsignedTask := test.GetUnsignedTask("test-task")
-	signedTask, err := test.GetSignedTask(unsignedTask, sv, "signed")
+	signedTask, err := test.GetSignedV1beta1Task(unsignedTask, sv, "signed")
 	if err != nil {
 		t.Fatalf("Failed to get signed task %v", err)
 	}
@@ -115,7 +115,7 @@ func TestVerifyInterface_Task_Error(t *testing.T) {
 
 	unsignedTask := test.GetUnsignedTask("test-task")
 
-	signedTask, err := test.GetSignedTask(unsignedTask, sv, "signed")
+	signedTask, err := test.GetSignedV1beta1Task(unsignedTask, sv, "signed")
 	if err != nil {
 		t.Fatalf("Failed to get signed task %v", err)
 	}
@@ -165,7 +165,7 @@ func TestVerifyInterface_Task_Error(t *testing.T) {
 func TestVerifyResource_Task_Success(t *testing.T) {
 	signer256, _, k8sclient, vps := test.SetupVerificationPolicies(t)
 	unsignedTask := test.GetUnsignedTask("test-task")
-	signedTask, err := test.GetSignedTask(unsignedTask, signer256, "signed")
+	signedTask, err := test.GetSignedV1beta1Task(unsignedTask, signer256, "signed")
 	if err != nil {
 		t.Fatal("fail to sign task", err)
 	}
@@ -246,7 +246,7 @@ func TestVerifyResource_Task_Success(t *testing.T) {
 		},
 	}
 
-	signedTask384, err := test.GetSignedTask(unsignedTask, signer384, "signed384")
+	signedTask384, err := test.GetSignedV1beta1Task(unsignedTask, signer384, "signed384")
 	if err != nil {
 		t.Fatal("fail to sign task", err)
 	}
@@ -334,7 +334,7 @@ func TestVerifyResource_Task_Error(t *testing.T) {
 
 	unsignedTask := test.GetUnsignedTask("test-task")
 
-	signedTask, err := test.GetSignedTask(unsignedTask, sv, "signed")
+	signedTask, err := test.GetSignedV1beta1Task(unsignedTask, sv, "signed")
 	if err != nil {
 		t.Fatal("fail to sign task", err)
 	}
@@ -430,7 +430,7 @@ func TestVerifyResource_Task_Error(t *testing.T) {
 func TestVerifyResource_Pipeline_Success(t *testing.T) {
 	sv, _, k8sclient, vps := test.SetupVerificationPolicies(t)
 	unsignedPipeline := test.GetUnsignedPipeline("test-pipeline")
-	signedPipeline, err := test.GetSignedPipeline(unsignedPipeline, sv, "signed")
+	signedPipeline, err := test.GetSignedV1beta1Pipeline(unsignedPipeline, sv, "signed")
 	if err != nil {
 		t.Fatal("fail to sign task", err)
 	}
@@ -485,7 +485,7 @@ func TestVerifyResource_Pipeline_Error(t *testing.T) {
 
 	unsignedPipeline := test.GetUnsignedPipeline("test-pipeline")
 
-	signedPipeline, err := test.GetSignedPipeline(unsignedPipeline, sv, "signed")
+	signedPipeline, err := test.GetSignedV1beta1Pipeline(unsignedPipeline, sv, "signed")
 	if err != nil {
 		t.Fatal("fail to sign task", err)
 	}

--- a/test/trusted_resources_test.go
+++ b/test/trusted_resources_test.go
@@ -96,7 +96,7 @@ spec:
     args: ['-c', 'echo hello']
 `, helpers.ObjectNameForTest(t), namespace, fqImageName))
 
-	signedTask, err := GetSignedTask(task, signer, "signedtask")
+	signedTask, err := GetSignedV1beta1Task(task, signer, "signedtask")
 	if err != nil {
 		t.Errorf("error getting signed task: %v", err)
 	}
@@ -123,7 +123,7 @@ spec:
         value: %s
 `, helpers.ObjectNameForTest(t), namespace, signedTask.Name, namespace))
 
-	signedPipeline, err := GetSignedPipeline(pipeline, signer, "signedpipeline")
+	signedPipeline, err := GetSignedV1beta1Pipeline(pipeline, signer, "signedpipeline")
 	if err != nil {
 		t.Errorf("error getting signed pipeline: %v", err)
 	}
@@ -210,7 +210,7 @@ spec:
     args: ['-c', 'echo hello']
 `, helpers.ObjectNameForTest(t), namespace, fqImageName))
 
-	signedTask, err := GetSignedTask(task, signer, "signedtask")
+	signedTask, err := GetSignedV1beta1Task(task, signer, "signedtask")
 	if err != nil {
 		t.Errorf("error getting signed task: %v", err)
 	}
@@ -239,7 +239,7 @@ spec:
         value: %s
 `, helpers.ObjectNameForTest(t), namespace, signedTask.Name, namespace))
 
-	signedPipeline, err := GetSignedPipeline(pipeline, signer, "signedpipeline")
+	signedPipeline, err := GetSignedV1beta1Pipeline(pipeline, signer, "signedpipeline")
 	if err != nil {
 		t.Errorf("error getting signed pipeline: %v", err)
 	}

--- a/test/trustedresources.go
+++ b/test/trustedresources.go
@@ -324,8 +324,8 @@ func signInterface(signer signature.Signer, i interface{}) ([]byte, error) {
 	return sig, nil
 }
 
-// GetSignedPipeline signed the given pipeline and rename it with given name
-func GetSignedPipeline(unsigned *v1beta1.Pipeline, signer signature.Signer, name string) (*v1beta1.Pipeline, error) {
+// GetSignedV1beta1Pipeline signed the given pipeline and rename it with given name
+func GetSignedV1beta1Pipeline(unsigned *v1beta1.Pipeline, signer signature.Signer, name string) (*v1beta1.Pipeline, error) {
 	signedPipeline := unsigned.DeepCopy()
 	signedPipeline.Name = name
 	if signedPipeline.Annotations == nil {
@@ -339,8 +339,8 @@ func GetSignedPipeline(unsigned *v1beta1.Pipeline, signer signature.Signer, name
 	return signedPipeline, nil
 }
 
-// GetSignedTask signed the given task and rename it with given name
-func GetSignedTask(unsigned *v1beta1.Task, signer signature.Signer, name string) (*v1beta1.Task, error) {
+// GetSignedV1beta1Task signed the given task and rename it with given name
+func GetSignedV1beta1Task(unsigned *v1beta1.Task, signer signature.Signer, name string) (*v1beta1.Task, error) {
 	signedTask := unsigned.DeepCopy()
 	signedTask.Name = name
 	if signedTask.Annotations == nil {


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This commit adds the apiVersions to the TrustedResources Verification helpers so as to clarify the test class responsibilities. This also helps break changes in v1 swap down.

/kind misc
related #6444 

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [n/a] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [n/a] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
