### PR TITLE
[release v0.41.x] Fix v1beta1 pipelineref bundle conversion to resolver

### DIFF
--- a/pkg/apis/pipeline/v1beta1/pipelineref_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/pipelineref_conversion.go
@@ -38,7 +38,7 @@ func (pr PipelineRef) convertBundleToResolver(sink *v1.PipelineRef) {
 				Value: v1.ParamValue{StringVal: pr.Name, Type: v1.ParamTypeString},
 			}, {
 				Name:  "kind",
-				Value: v1.ParamValue{StringVal: "Task", Type: v1.ParamTypeString},
+				Value: v1.ParamValue{StringVal: "Pipeline", Type: v1.ParamTypeString},
 			}},
 		}
 	}

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_conversion_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_conversion_test.go
@@ -258,7 +258,7 @@ func TestPipelineRunConversionFromDeprecated(t *testing.T) {
 						Params: []v1beta1.Param{
 							{Name: "bundle", Value: v1beta1.ParamValue{StringVal: "test-bundle", Type: "string"}},
 							{Name: "name", Value: v1beta1.ParamValue{StringVal: "test-bundle-name", Type: "string"}},
-							{Name: "kind", Value: v1beta1.ParamValue{StringVal: "Task", Type: "string"}},
+							{Name: "kind", Value: v1beta1.ParamValue{StringVal: "Pipeline", Type: "string"}},
 						},
 					},
 				},

--- a/test/tektonbundles_test.go
+++ b/test/tektonbundles_test.go
@@ -75,11 +75,6 @@ func TestTektonBundlesSimpleWorkingExample(t *testing.T) {
 	pipelineRunName := helpers.ObjectNameForTest(t)
 	repo := fmt.Sprintf("%s:5000/tektonbundlessimple", getRegistryServiceIP(ctx, t, c, namespace))
 
-	ref, err := name.ParseReference(repo)
-	if err != nil {
-		t.Fatalf("Failed to parse %s as an OCI reference: %s", repo, err)
-	}
-
 	task := parse.MustParseTask(t, fmt.Sprintf(`
 metadata:
   name: %s
@@ -276,11 +271,6 @@ func TestTektonBundlesUsingRegularImage(t *testing.T) {
 	pipelineName := helpers.ObjectNameForTest(t)
 	pipelineRunName := helpers.ObjectNameForTest(t)
 	repo := fmt.Sprintf("%s:5000/tektonbundlesregularimage", getRegistryServiceIP(ctx, t, c, namespace))
-
-	ref, err := name.ParseReference(repo)
-	if err != nil {
-		t.Fatalf("Failed to parse %s as an OCI reference: %s", repo, err)
-	}
 
 	pipeline := parse.MustParsePipeline(t, fmt.Sprintf(`
 metadata:


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This is a cherry-pick of https://github.com/tektoncd/pipeline/pull/6791

This commit fixes the bundle conversion for PipelineRef which should be converting to the bundle Resolver with a Pipeline kind. It also adds the conversion integration tests for the bundle logics to prevent such error. It extracts the setup for bundle and makes it into a helper function.

/kind bug
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [n/a] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [n/a] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
bug fix: bundle resolver type param value for pipelineRef conversion
```
