### PR TITLE
[release-v0.44.x] Fix v1beta1 pipelineref bundle conversion to resolver

### DIFF
--- a/pkg/apis/pipeline/v1beta1/pipelineref_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/pipelineref_conversion.go
@@ -40,7 +40,7 @@ func (pr PipelineRef) convertBundleToResolver(sink *v1.PipelineRef) {
 				Value: v1.ParamValue{StringVal: pr.Name, Type: v1.ParamTypeString},
 			}, {
 				Name:  "kind",
-				Value: v1.ParamValue{StringVal: "Task", Type: v1.ParamTypeString},
+				Value: v1.ParamValue{StringVal: "Pipeline", Type: v1.ParamTypeString},
 			}},
 		}
 	}

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_conversion_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_conversion_test.go
@@ -429,7 +429,7 @@ func TestPipelineRunConversionFromDeprecated(t *testing.T) {
 						Params: []v1beta1.Param{
 							{Name: "bundle", Value: v1beta1.ParamValue{StringVal: "test-bundle", Type: "string"}},
 							{Name: "name", Value: v1beta1.ParamValue{StringVal: "test-bundle-name", Type: "string"}},
-							{Name: "kind", Value: v1beta1.ParamValue{StringVal: "Task", Type: "string"}},
+							{Name: "kind", Value: v1beta1.ParamValue{StringVal: "Pipeline", Type: "string"}},
 						},
 					},
 				},

--- a/test/tektonbundles_test.go
+++ b/test/tektonbundles_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/layout"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/pod"
 	"github.com/tektoncd/pipeline/pkg/reconciler/pipelinerun"
 	corev1 "k8s.io/api/core/v1"
@@ -48,7 +49,7 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-var requireFeatureFlags = requireAnyGate(map[string]string{
+var bundleFeatureFlags = requireAnyGate(map[string]string{
 	"enable-tekton-oci-bundles": "true",
 	"enable-api-fields":         "alpha",
 })
@@ -61,7 +62,7 @@ var resolverFeatureFlags = requireAnyGate(map[string]string{
 // images.
 func TestTektonBundlesSimpleWorkingExample(t *testing.T) {
 	ctx := context.Background()
-	c, namespace := setup(ctx, t, withRegistry, requireFeatureFlags)
+	c, namespace := setup(ctx, t, withRegistry, bundleFeatureFlags)
 
 	t.Parallel()
 
@@ -72,12 +73,6 @@ func TestTektonBundlesSimpleWorkingExample(t *testing.T) {
 	pipelineName := helpers.ObjectNameForTest(t)
 	pipelineRunName := helpers.ObjectNameForTest(t)
 	repo := fmt.Sprintf("%s:5000/tektonbundlessimple", getRegistryServiceIP(ctx, t, c, namespace))
-
-	ref, err := name.ParseReference(repo)
-	if err != nil {
-		t.Fatalf("Failed to parse %s as an OCI reference: %s", repo, err)
-	}
-
 	task := parse.MustParseV1beta1Task(t, fmt.Sprintf(`
 metadata:
   name: %s
@@ -101,47 +96,7 @@ spec:
       bundle: %s
 `, pipelineName, namespace, taskName, repo))
 
-	// Write the task and pipeline into an image to the registry in the proper format.
-	rawTask, err := yaml.Marshal(task)
-	if err != nil {
-		t.Fatalf("Failed to marshal task to yaml: %s", err)
-	}
-
-	rawPipeline, err := yaml.Marshal(pipeline)
-	if err != nil {
-		t.Fatalf("Failed to marshal task to yaml: %s", err)
-	}
-
-	img := empty.Image
-	taskLayer, err := tarball.LayerFromReader(bytes.NewBuffer(rawTask))
-	if err != nil {
-		t.Fatalf("Failed to create oci layer from task: %s", err)
-	}
-	pipelineLayer, err := tarball.LayerFromReader(bytes.NewBuffer(rawPipeline))
-	if err != nil {
-		t.Fatalf("Failed to create oci layer from pipeline: %s", err)
-	}
-	img, err = mutate.Append(img, mutate.Addendum{
-		Layer: taskLayer,
-		Annotations: map[string]string{
-			"dev.tekton.image.name":       taskName,
-			"dev.tekton.image.kind":       strings.ToLower(task.Kind),
-			"dev.tekton.image.apiVersion": task.APIVersion,
-		},
-	}, mutate.Addendum{
-		Layer: pipelineLayer,
-		Annotations: map[string]string{
-			"dev.tekton.image.name":       pipelineName,
-			"dev.tekton.image.kind":       strings.ToLower(pipeline.Kind),
-			"dev.tekton.image.apiVersion": pipeline.APIVersion,
-		},
-	})
-	if err != nil {
-		t.Fatalf("Failed to create an oci image from the task and pipeline layers: %s", err)
-	}
-
-	// Publish this image to the in-cluster registry.
-	publishImg(ctx, t, c, namespace, img, ref)
+	setupBundle(ctx, t, c, namespace, repo, task, pipeline)
 
 	// Now generate a PipelineRun to invoke this pipeline and task.
 	pr := parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
@@ -211,10 +166,6 @@ func TestTektonBundlesResolver(t *testing.T) {
 	pipelineName := helpers.ObjectNameForTest(t)
 	pipelineRunName := helpers.ObjectNameForTest(t)
 	repo := fmt.Sprintf("%s:5000/tektonbundlesresolver", getRegistryServiceIP(ctx, t, c, namespace))
-	ref, err := name.ParseReference(repo)
-	if err != nil {
-		t.Fatalf("Failed to parse %s as an OCI reference: %s", repo, err)
-	}
 
 	task := parse.MustParseV1beta1Task(t, fmt.Sprintf(`
 metadata:
@@ -243,47 +194,7 @@ spec:
         value: %s
 `, pipelineName, namespace, repo, taskName))
 
-	// Write the task and pipeline into an image to the registry in the proper format.
-	rawTask, err := yaml.Marshal(task)
-	if err != nil {
-		t.Fatalf("Failed to marshal task to yaml: %s", err)
-	}
-
-	rawPipeline, err := yaml.Marshal(pipeline)
-	if err != nil {
-		t.Fatalf("Failed to marshal task to yaml: %s", err)
-	}
-
-	img := empty.Image
-	taskLayer, err := tarball.LayerFromReader(bytes.NewBuffer(rawTask))
-	if err != nil {
-		t.Fatalf("Failed to create oci layer from task: %s", err)
-	}
-	pipelineLayer, err := tarball.LayerFromReader(bytes.NewBuffer(rawPipeline))
-	if err != nil {
-		t.Fatalf("Failed to create oci layer from pipeline: %s", err)
-	}
-	img, err = mutate.Append(img, mutate.Addendum{
-		Layer: taskLayer,
-		Annotations: map[string]string{
-			"dev.tekton.image.name":       taskName,
-			"dev.tekton.image.kind":       strings.ToLower(task.Kind),
-			"dev.tekton.image.apiVersion": task.APIVersion,
-		},
-	}, mutate.Addendum{
-		Layer: pipelineLayer,
-		Annotations: map[string]string{
-			"dev.tekton.image.name":       pipelineName,
-			"dev.tekton.image.kind":       strings.ToLower(pipeline.Kind),
-			"dev.tekton.image.apiVersion": pipeline.APIVersion,
-		},
-	})
-	if err != nil {
-		t.Fatalf("Failed to create an oci image from the task and pipeline layers: %s", err)
-	}
-
-	// Publish this image to the in-cluster registry.
-	publishImg(ctx, t, c, namespace, img, ref)
+	setupBundle(ctx, t, c, namespace, repo, task, pipeline)
 
 	// Now generate a PipelineRun to invoke this pipeline and task.
 	pr := parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
@@ -347,7 +258,7 @@ spec:
 // TestTektonBundlesUsingRegularImage is an integration test which passes a non-Tekton bundle as a task reference.
 func TestTektonBundlesUsingRegularImage(t *testing.T) {
 	ctx := context.Background()
-	c, namespace := setup(ctx, t, withRegistry, requireFeatureFlags)
+	c, namespace := setup(ctx, t, withRegistry, bundleFeatureFlags)
 
 	t.Parallel()
 
@@ -358,11 +269,6 @@ func TestTektonBundlesUsingRegularImage(t *testing.T) {
 	pipelineName := helpers.ObjectNameForTest(t)
 	pipelineRunName := helpers.ObjectNameForTest(t)
 	repo := fmt.Sprintf("%s:5000/tektonbundlesregularimage", getRegistryServiceIP(ctx, t, c, namespace))
-
-	ref, err := name.ParseReference(repo)
-	if err != nil {
-		t.Fatalf("Failed to parse %s as an OCI reference: %s", repo, err)
-	}
 
 	pipeline := parse.MustParseV1beta1Pipeline(t, fmt.Sprintf(`
 metadata:
@@ -376,32 +282,7 @@ spec:
       bundle: registry
 `, pipelineName, namespace, taskName))
 
-	// Write the pipeline into an image to the registry in the proper format. We don't write the task because we are
-	// using an non Tekton Bundle.
-	rawPipeline, err := yaml.Marshal(pipeline)
-	if err != nil {
-		t.Fatalf("Failed to marshal task to yaml: %s", err)
-	}
-
-	img := empty.Image
-	pipelineLayer, err := tarball.LayerFromReader(bytes.NewBuffer(rawPipeline))
-	if err != nil {
-		t.Fatalf("Failed to create oci layer from pipeline: %s", err)
-	}
-	img, err = mutate.Append(img, mutate.Addendum{
-		Layer: pipelineLayer,
-		Annotations: map[string]string{
-			"dev.tekton.image.name":       pipelineName,
-			"dev.tekton.image.kind":       strings.ToLower(pipeline.Kind),
-			"dev.tekton.image.apiVersion": pipeline.APIVersion,
-		},
-	})
-	if err != nil {
-		t.Fatalf("Failed to create an oci image from the task and pipeline layers: %s", err)
-	}
-
-	// Publish this image to the in-cluster registry.
-	publishImg(ctx, t, c, namespace, img, ref)
+	setupBundle(ctx, t, c, namespace, repo, nil, pipeline)
 
 	// Now generate a PipelineRun to invoke this pipeline and task.
 	pr := parse.MustParseV1beta1PipelineRun(t, fmt.Sprintf(`
@@ -430,7 +311,7 @@ spec:
 // task reference.
 func TestTektonBundlesUsingImproperFormat(t *testing.T) {
 	ctx := context.Background()
-	c, namespace := setup(ctx, t, withRegistry, requireFeatureFlags)
+	c, namespace := setup(ctx, t, withRegistry, bundleFeatureFlags)
 
 	t.Parallel()
 
@@ -669,4 +550,63 @@ func publishImg(ctx context.Context, t *testing.T, c *clients, namespace string,
 			t.Fatalf("Failed to create image. Pod logs are: \n%s", string(logs))
 		}
 	}
+}
+
+// setupBundle creates an empty image, provides a reference to the fake registry and pushes the
+// bundled task and pipeline within an image into the registry
+func setupBundle(ctx context.Context, t *testing.T, c *clients, namespace, repo string, task *v1beta1.Task, pipeline *v1beta1.Pipeline) {
+	t.Helper()
+	img := empty.Image
+	ref, err := name.ParseReference(repo)
+	if err != nil {
+		t.Fatalf("Failed to parse %s as an OCI reference: %s", repo, err)
+	}
+
+	var rawTask, rawPipeline []byte
+	var taskLayer, pipelineLayer v1.Layer
+	// Write the task and pipeline into an image to the registry in the proper format.
+	if task != nil {
+		rawTask, err = yaml.Marshal(task)
+		if err != nil {
+			t.Fatalf("Failed to marshal task to yaml: %s", err)
+		}
+		taskLayer, err = tarball.LayerFromReader(bytes.NewBuffer(rawTask))
+		if err != nil {
+			t.Fatalf("Failed to create oci layer from task: %s", err)
+		}
+		img, err = mutate.Append(img, mutate.Addendum{
+			Layer: taskLayer,
+			Annotations: map[string]string{
+				"dev.tekton.image.name":       task.Name,
+				"dev.tekton.image.kind":       strings.ToLower(task.Kind),
+				"dev.tekton.image.apiVersion": task.APIVersion,
+			},
+		})
+	}
+
+	if pipeline != nil {
+		rawPipeline, err = yaml.Marshal(pipeline)
+		if err != nil {
+			t.Fatalf("Failed to marshal task to yaml: %s", err)
+		}
+		pipelineLayer, err = tarball.LayerFromReader(bytes.NewBuffer(rawPipeline))
+		if err != nil {
+			t.Fatalf("Failed to create oci layer from pipeline: %s", err)
+		}
+		img, err = mutate.Append(img, mutate.Addendum{
+			Layer: pipelineLayer,
+			Annotations: map[string]string{
+				"dev.tekton.image.name":       pipeline.Name,
+				"dev.tekton.image.kind":       strings.ToLower(pipeline.Kind),
+				"dev.tekton.image.apiVersion": pipeline.APIVersion,
+			},
+		})
+	}
+
+	if err != nil {
+		t.Fatalf("Failed to create an oci image from the task and pipeline layers: %s", err)
+	}
+
+	// Publish this image to the in-cluster registry.
+	publishImg(ctx, t, c, namespace, img, ref)
 }


### PR DESCRIPTION
This commit fixes the bundle conversion for PipelineRef which should be converting to the bundle Resolver with a Pipeline kind. It also adds the conversion integration tests for the bundle logics to prevent such error. It extracts the setup for bundle and makes it into a helper function.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This is a cherry-pick of https://github.com/tektoncd/pipeline/pull/6791

This commit fixes the bundle conversion for PipelineRef which should be converting to the bundle Resolver with a Pipeline kind. It also adds the conversion integration tests for the bundle logics to prevent such error. It extracts the setup for bundle and makes it into a helper function.

/kind bug
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [n/a] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [n/a] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
bug fix: bundle resolver type param value for pipelineRef conversion
```
