### PR TITLE
Use apiVersion declarative naming in pipelineRef and taskRef test for…

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -11783,7 +11783,7 @@ spec:
 		t.Fatal("fail to marshal task", err)
 	}
 
-	unsignedPipeline := parse.MustParseV1beta1Pipeline(t, fmt.Sprintf(`
+	unsignedV1beta1Pipeline := parse.MustParseV1beta1Pipeline(t, fmt.Sprintf(`
 metadata:
   name: test-pipeline
   namespace: foo
@@ -11793,14 +11793,14 @@ spec:
       taskRef:
         resolver: %s
 `, resolverName))
-	unsignedPipelineBytes, err := yaml.Marshal(unsignedPipeline)
+	unsignedV1beta1PipelineBytes, err := yaml.Marshal(unsignedV1beta1Pipeline)
 	if err != nil {
 		t.Fatal("fail to marshal task", err)
 	}
 
 	// Case2: signed Pipeline refers to unsigned Task
 	signer, _, vps := test.SetupMatchAllVerificationPolicies(t, unsignedTask.Namespace)
-	signedPipelineWithUnsignedTask, err := test.GetSignedV1beta1Pipeline(unsignedPipeline, signer, "test-pipeline")
+	signedPipelineWithUnsignedTask, err := test.GetSignedV1beta1Pipeline(unsignedV1beta1Pipeline, signer, "test-pipeline")
 	if err != nil {
 		t.Fatal("fail to sign pipeline", err)
 	}
@@ -11901,7 +11901,7 @@ spec:
 	}{
 		{
 			name:          "unsigned pipeline fails verification",
-			pipelineBytes: unsignedPipelineBytes,
+			pipelineBytes: unsignedV1beta1PipelineBytes,
 			taskBytes:     unsignedTaskBytes,
 		},
 		{
@@ -12118,7 +12118,7 @@ spec:
 		t.Fatal("fail to marshal task", err)
 	}
 
-	unsignedPipeline := parse.MustParseV1beta1Pipeline(t, fmt.Sprintf(`
+	unsignedV1beta1Pipeline := parse.MustParseV1beta1Pipeline(t, fmt.Sprintf(`
 metadata:
   name: test-pipeline
   namespace: foo
@@ -12128,14 +12128,14 @@ spec:
       taskRef:
         resolver: %s
 `, resolverName))
-	unsignedPipelineBytes, err := yaml.Marshal(unsignedPipeline)
+	unsignedV1beta1PipelineBytes, err := yaml.Marshal(unsignedV1beta1Pipeline)
 	if err != nil {
 		t.Fatal("fail to marshal task", err)
 	}
 
 	// Case2: signed Pipeline refers to unsigned Task
 	signer, _, vps := test.SetupMatchAllVerificationPolicies(t, unsignedTask.Namespace)
-	signedPipelineWithUnsignedTask, err := test.GetSignedV1beta1Pipeline(unsignedPipeline, signer, "test-pipeline")
+	signedPipelineWithUnsignedTask, err := test.GetSignedV1beta1Pipeline(unsignedV1beta1Pipeline, signer, "test-pipeline")
 	if err != nil {
 		t.Fatal("fail to sign pipeline", err)
 	}
@@ -12236,7 +12236,7 @@ spec:
 	}{
 		{
 			name:          "unsigned pipeline fails verification",
-			pipelineBytes: unsignedPipelineBytes,
+			pipelineBytes: unsignedV1beta1PipelineBytes,
 			taskBytes:     unsignedTaskBytes,
 		},
 		{

--- a/pkg/reconciler/pipelinerun/resources/pipelineref_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelineref_test.go
@@ -517,8 +517,8 @@ func TestGetPipelineFunc_V1beta1Pipeline_VerifyNoError(t *testing.T) {
 	signer, _, k8sclient, vps := test.SetupVerificationPolicies(t)
 	tektonclient := fake.NewSimpleClientset()
 
-	unsignedPipeline := test.GetUnsignedPipeline("test-pipeline")
-	unsignedPipelineBytes, err := json.Marshal(unsignedPipeline)
+	unsignedV1beta1Pipeline := test.GetUnsignedV1beta1Pipeline("test-pipeline")
+	unsignedV1beta1PipelineBytes, err := json.Marshal(unsignedV1beta1Pipeline)
 	if err != nil {
 		t.Fatal("fail to marshal pipeline", err)
 	}
@@ -529,10 +529,10 @@ func TestGetPipelineFunc_V1beta1Pipeline_VerifyNoError(t *testing.T) {
 		},
 		EntryPoint: "foo/bar",
 	}
-	resolvedUnmatched := test.NewResolvedResource(unsignedPipelineBytes, nil, noMatchPolicyRefSource, nil)
+	resolvedUnmatched := test.NewResolvedResource(unsignedV1beta1PipelineBytes, nil, noMatchPolicyRefSource, nil)
 	requesterUnmatched := test.NewRequester(resolvedUnmatched, nil)
 
-	signedPipeline, err := test.GetSignedV1beta1Pipeline(unsignedPipeline, signer, "signed")
+	signedPipeline, err := test.GetSignedV1beta1Pipeline(unsignedV1beta1Pipeline, signer, "signed")
 	if err != nil {
 		t.Fatal("fail to sign pipeline", err)
 	}
@@ -588,7 +588,7 @@ func TestGetPipelineFunc_V1beta1Pipeline_VerifyNoError(t *testing.T) {
 	warnPolicyRefSource := &v1beta1.RefSource{
 		URI: "	warnVP",
 	}
-	resolvedUnsignedMatched := test.NewResolvedResource(unsignedPipelineBytes, nil, warnPolicyRefSource, nil)
+	resolvedUnsignedMatched := test.NewResolvedResource(unsignedV1beta1PipelineBytes, nil, warnPolicyRefSource, nil)
 	requesterUnsignedMatched := test.NewRequester(resolvedUnsignedMatched, nil)
 
 	testcases := []struct {
@@ -633,7 +633,7 @@ func TestGetPipelineFunc_V1beta1Pipeline_VerifyNoError(t *testing.T) {
 		verificationNoMatchPolicy:  config.WarnNoMatchPolicy,
 		pipelinerun:                pr,
 		policies:                   vps,
-		expected:                   unsignedPipeline,
+		expected:                   unsignedV1beta1Pipeline,
 		expectedRefSource:          noMatchPolicyRefSource,
 		expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationWarn, Err: trustedresources.ErrNoMatchedPolicies},
 	}, {
@@ -642,7 +642,7 @@ func TestGetPipelineFunc_V1beta1Pipeline_VerifyNoError(t *testing.T) {
 		verificationNoMatchPolicy:  config.FailNoMatchPolicy,
 		pipelinerun:                pr,
 		policies:                   vps,
-		expected:                   unsignedPipeline,
+		expected:                   unsignedV1beta1Pipeline,
 		expectedRefSource:          warnPolicyRefSource,
 		expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationWarn, Err: trustedresources.ErrResourceVerificationFailed},
 	}, {
@@ -651,7 +651,7 @@ func TestGetPipelineFunc_V1beta1Pipeline_VerifyNoError(t *testing.T) {
 		verificationNoMatchPolicy:  config.IgnoreNoMatchPolicy,
 		pipelinerun:                pr,
 		policies:                   vps,
-		expected:                   unsignedPipeline,
+		expected:                   unsignedV1beta1Pipeline,
 		expectedRefSource:          noMatchPolicyRefSource,
 		expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationSkip},
 	}, {
@@ -704,8 +704,8 @@ func TestGetPipelineFunc_V1beta1Pipeline_VerifyError(t *testing.T) {
 	tektonclient := fake.NewSimpleClientset()
 	signer, _, k8sclient, vps := test.SetupVerificationPolicies(t)
 
-	unsignedPipeline := test.GetUnsignedPipeline("test-pipeline")
-	unsignedPipelineBytes, err := json.Marshal(unsignedPipeline)
+	unsignedV1beta1Pipeline := test.GetUnsignedV1beta1Pipeline("test-pipeline")
+	unsignedV1beta1PipelineBytes, err := json.Marshal(unsignedV1beta1Pipeline)
 	if err != nil {
 		t.Fatal("fail to marshal pipeline", err)
 	}
@@ -717,10 +717,10 @@ func TestGetPipelineFunc_V1beta1Pipeline_VerifyError(t *testing.T) {
 		EntryPoint: "foo/bar",
 	}
 
-	resolvedUnsigned := test.NewResolvedResource(unsignedPipelineBytes, nil, matchPolicyRefSource, nil)
+	resolvedUnsigned := test.NewResolvedResource(unsignedV1beta1PipelineBytes, nil, matchPolicyRefSource, nil)
 	requesterUnsigned := test.NewRequester(resolvedUnsigned, nil)
 
-	signedPipeline, err := test.GetSignedV1beta1Pipeline(unsignedPipeline, signer, "signed")
+	signedPipeline, err := test.GetSignedV1beta1Pipeline(unsignedV1beta1Pipeline, signer, "signed")
 	if err != nil {
 		t.Fatal("fail to sign pipeline", err)
 	}
@@ -821,17 +821,17 @@ func TestGetPipelineFunc_V1Pipeline_VerifyNoError(t *testing.T) {
 	signer, _, k8sclient, vps := test.SetupVerificationPolicies(t)
 	tektonclient := fake.NewSimpleClientset()
 
-	v1beta1UnsignedPipeline := &v1beta1.Pipeline{
+	v1beta1UnsignedV1beta1Pipeline := &v1beta1.Pipeline{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Pipeline",
 			APIVersion: "tekton.dev/v1beta1",
 		},
 	}
-	if err := v1beta1UnsignedPipeline.ConvertFrom(ctx, unsignedV1Pipeline.DeepCopy()); err != nil {
+	if err := v1beta1UnsignedV1beta1Pipeline.ConvertFrom(ctx, unsignedV1Pipeline.DeepCopy()); err != nil {
 		t.Error(err)
 	}
 
-	unsignedPipelineBytes, err := json.Marshal(unsignedV1Pipeline)
+	unsignedV1beta1PipelineBytes, err := json.Marshal(unsignedV1Pipeline)
 	if err != nil {
 		t.Fatal("fail to marshal pipeline", err)
 	}
@@ -842,7 +842,7 @@ func TestGetPipelineFunc_V1Pipeline_VerifyNoError(t *testing.T) {
 		},
 		EntryPoint: "foo/bar",
 	}
-	resolvedUnmatched := test.NewResolvedResource(unsignedPipelineBytes, nil, noMatchPolicyRefSource, nil)
+	resolvedUnmatched := test.NewResolvedResource(unsignedV1beta1PipelineBytes, nil, noMatchPolicyRefSource, nil)
 	requesterUnmatched := test.NewRequester(resolvedUnmatched, nil)
 
 	signedPipeline, err := getSignedV1Pipeline(unsignedV1Pipeline, signer, "signed")
@@ -912,7 +912,7 @@ func TestGetPipelineFunc_V1Pipeline_VerifyNoError(t *testing.T) {
 	warnPolicyRefSource := &v1beta1.RefSource{
 		URI: "	warnVP",
 	}
-	resolvedUnsignedMatched := test.NewResolvedResource(unsignedPipelineBytes, nil, warnPolicyRefSource, nil)
+	resolvedUnsignedMatched := test.NewResolvedResource(unsignedV1beta1PipelineBytes, nil, warnPolicyRefSource, nil)
 	requesterUnsignedMatched := test.NewRequester(resolvedUnsignedMatched, nil)
 
 	testcases := []struct {
@@ -957,7 +957,7 @@ func TestGetPipelineFunc_V1Pipeline_VerifyNoError(t *testing.T) {
 		verificationNoMatchPolicy:  config.WarnNoMatchPolicy,
 		pipelinerun:                pr,
 		policies:                   vps,
-		expected:                   v1beta1UnsignedPipeline,
+		expected:                   v1beta1UnsignedV1beta1Pipeline,
 		expectedRefSource:          noMatchPolicyRefSource,
 		expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationWarn, Err: trustedresources.ErrNoMatchedPolicies},
 	}, {
@@ -966,7 +966,7 @@ func TestGetPipelineFunc_V1Pipeline_VerifyNoError(t *testing.T) {
 		verificationNoMatchPolicy:  config.FailNoMatchPolicy,
 		pipelinerun:                pr,
 		policies:                   vps,
-		expected:                   v1beta1UnsignedPipeline,
+		expected:                   v1beta1UnsignedV1beta1Pipeline,
 		expectedRefSource:          warnPolicyRefSource,
 		expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationWarn, Err: trustedresources.ErrResourceVerificationFailed},
 	}, {
@@ -975,7 +975,7 @@ func TestGetPipelineFunc_V1Pipeline_VerifyNoError(t *testing.T) {
 		verificationNoMatchPolicy:  config.IgnoreNoMatchPolicy,
 		pipelinerun:                pr,
 		policies:                   vps,
-		expected:                   v1beta1UnsignedPipeline,
+		expected:                   v1beta1UnsignedV1beta1Pipeline,
 		expectedRefSource:          noMatchPolicyRefSource,
 		expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationSkip},
 	}, {
@@ -1028,7 +1028,7 @@ func TestGetPipelineFunc_V1Pipeline_VerifyError(t *testing.T) {
 	tektonclient := fake.NewSimpleClientset()
 	signer, _, k8sclient, vps := test.SetupVerificationPolicies(t)
 
-	unsignedPipelineBytes, err := json.Marshal(unsignedV1Pipeline)
+	unsignedV1beta1PipelineBytes, err := json.Marshal(unsignedV1Pipeline)
 	if err != nil {
 		t.Fatal("fail to marshal pipeline", err)
 	}
@@ -1040,7 +1040,7 @@ func TestGetPipelineFunc_V1Pipeline_VerifyError(t *testing.T) {
 		EntryPoint: "foo/bar",
 	}
 
-	resolvedUnsigned := test.NewResolvedResource(unsignedPipelineBytes, nil, matchPolicyRefSource, nil)
+	resolvedUnsigned := test.NewResolvedResource(unsignedV1beta1PipelineBytes, nil, matchPolicyRefSource, nil)
 	requesterUnsigned := test.NewRequester(resolvedUnsigned, nil)
 
 	signedPipeline, err := getSignedV1Pipeline(unsignedV1Pipeline, signer, "signed")
@@ -1144,13 +1144,13 @@ func TestGetPipelineFunc_GetFuncError(t *testing.T) {
 	tektonclient := fake.NewSimpleClientset()
 	_, k8sclient, vps := test.SetupMatchAllVerificationPolicies(t, "trusted-resources")
 
-	unsignedPipeline := test.GetUnsignedPipeline("test-pipeline")
-	unsignedPipelineBytes, err := json.Marshal(unsignedPipeline)
+	unsignedV1beta1Pipeline := test.GetUnsignedV1beta1Pipeline("test-pipeline")
+	unsignedV1beta1PipelineBytes, err := json.Marshal(unsignedV1beta1Pipeline)
 	if err != nil {
 		t.Fatal("fail to marshal pipeline", err)
 	}
 
-	resolvedUnsigned := test.NewResolvedResource(unsignedPipelineBytes, nil, sampleRefSource.DeepCopy(), nil)
+	resolvedUnsigned := test.NewResolvedResource(unsignedV1beta1PipelineBytes, nil, sampleRefSource.DeepCopy(), nil)
 	requesterUnsigned := test.NewRequester(resolvedUnsigned, nil)
 	resolvedUnsigned.DataErr = fmt.Errorf("resolution error")
 

--- a/pkg/reconciler/taskrun/resources/taskref_test.go
+++ b/pkg/reconciler/taskrun/resources/taskref_test.go
@@ -765,8 +765,8 @@ func TestGetTaskFunc_V1beta1Task_VerifyNoError(t *testing.T) {
 	signer, _, k8sclient, vps := test.SetupVerificationPolicies(t)
 	tektonclient := fake.NewSimpleClientset()
 
-	unsignedTask := test.GetUnsignedTask("test-task")
-	unsignedTaskBytes, err := json.Marshal(unsignedTask)
+	unsignedV1beta1Task := test.GetUnsignedV1beta1Task("test-task")
+	unsignedTaskBytes, err := json.Marshal(unsignedV1beta1Task)
 	if err != nil {
 		t.Fatal("fail to marshal task", err)
 	}
@@ -775,7 +775,7 @@ func TestGetTaskFunc_V1beta1Task_VerifyNoError(t *testing.T) {
 	}
 	requesterUnmatched := bytesToRequester(unsignedTaskBytes, noMatchPolicyRefSource)
 
-	signedTask, err := test.GetSignedV1beta1Task(unsignedTask, signer, "signed")
+	signedTask, err := test.GetSignedV1beta1Task(unsignedV1beta1Task, signer, "signed")
 	if err != nil {
 		t.Fatal("fail to sign task", err)
 	}
@@ -832,7 +832,7 @@ func TestGetTaskFunc_V1beta1Task_VerifyNoError(t *testing.T) {
 		requester:                  requesterUnmatched,
 		verificationNoMatchPolicy:  config.WarnNoMatchPolicy,
 		policies:                   vps,
-		expected:                   unsignedTask,
+		expected:                   unsignedV1beta1Task,
 		expectedRefSource:          noMatchPolicyRefSource,
 		expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationWarn, Err: trustedresources.ErrNoMatchedPolicies},
 	}, {
@@ -840,7 +840,7 @@ func TestGetTaskFunc_V1beta1Task_VerifyNoError(t *testing.T) {
 		requester:                  requesterUnsignedMatched,
 		verificationNoMatchPolicy:  config.FailNoMatchPolicy,
 		policies:                   vps,
-		expected:                   unsignedTask,
+		expected:                   unsignedV1beta1Task,
 		expectedRefSource:          warnPolicyRefSource,
 		expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationWarn, Err: trustedresources.ErrResourceVerificationFailed},
 	}, {
@@ -848,7 +848,7 @@ func TestGetTaskFunc_V1beta1Task_VerifyNoError(t *testing.T) {
 		requester:                  requesterUnmatched,
 		verificationNoMatchPolicy:  config.IgnoreNoMatchPolicy,
 		policies:                   vps,
-		expected:                   unsignedTask,
+		expected:                   unsignedV1beta1Task,
 		expectedRefSource:          noMatchPolicyRefSource,
 		expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationSkip},
 	},
@@ -890,8 +890,8 @@ func TestGetTaskFunc_V1beta1Task_VerifyError(t *testing.T) {
 	signer, _, k8sclient, vps := test.SetupVerificationPolicies(t)
 	tektonclient := fake.NewSimpleClientset()
 
-	unsignedTask := test.GetUnsignedTask("test-task")
-	unsignedTaskBytes, err := json.Marshal(unsignedTask)
+	unsignedV1beta1Task := test.GetUnsignedV1beta1Task("test-task")
+	unsignedTaskBytes, err := json.Marshal(unsignedV1beta1Task)
 	if err != nil {
 		t.Fatal("fail to marshal task", err)
 	}
@@ -900,7 +900,7 @@ func TestGetTaskFunc_V1beta1Task_VerifyError(t *testing.T) {
 	}
 	requesterUnsigned := bytesToRequester(unsignedTaskBytes, matchPolicyRefSource)
 
-	signedTask, err := test.GetSignedV1beta1Task(unsignedTask, signer, "signed")
+	signedTask, err := test.GetSignedV1beta1Task(unsignedV1beta1Task, signer, "signed")
 	if err != nil {
 		t.Fatal("fail to sign task", err)
 	}
@@ -1267,8 +1267,8 @@ func TestGetTaskFunc_GetFuncError(t *testing.T) {
 	_, k8sclient, vps := test.SetupMatchAllVerificationPolicies(t, "trusted-resources")
 	tektonclient := fake.NewSimpleClientset()
 
-	unsignedTask := test.GetUnsignedTask("test-task")
-	unsignedTaskBytes, err := json.Marshal(unsignedTask)
+	unsignedV1beta1Task := test.GetUnsignedV1beta1Task("test-task")
+	unsignedTaskBytes, err := json.Marshal(unsignedV1beta1Task)
 	if err != nil {
 		t.Fatal("fail to marshal task", err)
 	}

--- a/pkg/trustedresources/verify_test.go
+++ b/pkg/trustedresources/verify_test.go
@@ -62,7 +62,7 @@ var unsignedTask = v1.Task{
 	},
 }
 
-var unsignedPipeline = v1.Pipeline{
+var unsignedV1Pipeline = v1.Pipeline{
 	TypeMeta: metav1.TypeMeta{
 		APIVersion: "tekton.dev/v1",
 		Kind:       "Pipeline"},
@@ -85,7 +85,7 @@ func TestVerifyInterface_Task_Success(t *testing.T) {
 		t.Fatalf("failed to get signerverifier %v", err)
 	}
 
-	unsignedTask := test.GetUnsignedTask("test-task")
+	unsignedTask := test.GetUnsignedV1beta1Task("test-task")
 	signedTask, err := test.GetSignedV1beta1Task(unsignedTask, sv, "signed")
 	if err != nil {
 		t.Fatalf("Failed to get signed task %v", err)
@@ -113,7 +113,7 @@ func TestVerifyInterface_Task_Error(t *testing.T) {
 		t.Fatalf("failed to get signerverifier %v", err)
 	}
 
-	unsignedTask := test.GetUnsignedTask("test-task")
+	unsignedTask := test.GetUnsignedV1beta1Task("test-task")
 
 	signedTask, err := test.GetSignedV1beta1Task(unsignedTask, sv, "signed")
 	if err != nil {
@@ -164,7 +164,7 @@ func TestVerifyInterface_Task_Error(t *testing.T) {
 
 func TestVerifyResource_Task_Success(t *testing.T) {
 	signer256, _, k8sclient, vps := test.SetupVerificationPolicies(t)
-	unsignedTask := test.GetUnsignedTask("test-task")
+	unsignedTask := test.GetUnsignedV1beta1Task("test-task")
 	signedTask, err := test.GetSignedV1beta1Task(unsignedTask, signer256, "signed")
 	if err != nil {
 		t.Fatal("fail to sign task", err)
@@ -332,7 +332,7 @@ func TestVerifyResource_Task_Error(t *testing.T) {
 	ctx = test.SetupTrustedResourceConfig(ctx, config.FailNoMatchPolicy)
 	sv, _, k8sclient, vps := test.SetupVerificationPolicies(t)
 
-	unsignedTask := test.GetUnsignedTask("test-task")
+	unsignedTask := test.GetUnsignedV1beta1Task("test-task")
 
 	signedTask, err := test.GetSignedV1beta1Task(unsignedTask, sv, "signed")
 	if err != nil {
@@ -429,7 +429,7 @@ func TestVerifyResource_Task_Error(t *testing.T) {
 
 func TestVerifyResource_Pipeline_Success(t *testing.T) {
 	sv, _, k8sclient, vps := test.SetupVerificationPolicies(t)
-	unsignedPipeline := test.GetUnsignedPipeline("test-pipeline")
+	unsignedPipeline := test.GetUnsignedV1beta1Pipeline("test-pipeline")
 	signedPipeline, err := test.GetSignedV1beta1Pipeline(unsignedPipeline, sv, "signed")
 	if err != nil {
 		t.Fatal("fail to sign task", err)
@@ -483,9 +483,9 @@ func TestVerifyResource_Pipeline_Error(t *testing.T) {
 	ctx = test.SetupTrustedResourceConfig(ctx, config.FailNoMatchPolicy)
 	sv, _, k8sclient, vps := test.SetupVerificationPolicies(t)
 
-	unsignedPipeline := test.GetUnsignedPipeline("test-pipeline")
+	unsignedV1beta1Pipeline := test.GetUnsignedV1beta1Pipeline("test-pipeline")
 
-	signedPipeline, err := test.GetSignedV1beta1Pipeline(unsignedPipeline, sv, "signed")
+	signedPipeline, err := test.GetSignedV1beta1Pipeline(unsignedV1beta1Pipeline, sv, "signed")
 	if err != nil {
 		t.Fatal("fail to sign task", err)
 	}
@@ -567,7 +567,7 @@ func TestVerifyResource_V1Task_Error(t *testing.T) {
 
 func TestVerifyResource_V1Pipeline_Success(t *testing.T) {
 	signer, _, k8sclient, vps := test.SetupVerificationPolicies(t)
-	signed, err := getSignedV1Pipeline(unsignedPipeline.DeepCopy(), signer, "signed")
+	signed, err := getSignedV1Pipeline(unsignedV1Pipeline.DeepCopy(), signer, "signed")
 	if err != nil {
 		t.Error(err)
 	}
@@ -579,7 +579,7 @@ func TestVerifyResource_V1Pipeline_Success(t *testing.T) {
 
 func TestVerifyResource_V1Pipeline_Error(t *testing.T) {
 	signer, _, k8sclient, vps := test.SetupVerificationPolicies(t)
-	signed, err := getSignedV1Pipeline(unsignedPipeline.DeepCopy(), signer, "signed")
+	signed, err := getSignedV1Pipeline(unsignedV1Pipeline.DeepCopy(), signer, "signed")
 	if err != nil {
 		t.Error(err)
 	}
@@ -602,7 +602,7 @@ func TestVerifyResource_TypeNotSupported(t *testing.T) {
 }
 
 func TestPrepareObjectMeta(t *testing.T) {
-	unsigned := test.GetUnsignedTask("test-task").ObjectMeta
+	unsigned := test.GetUnsignedV1beta1Task("test-task").ObjectMeta
 
 	signed := unsigned.DeepCopy()
 	sig := "tY805zV53PtwDarK3VD6dQPx5MbIgctNcg/oSle+MG0="

--- a/test/trustedresources.go
+++ b/test/trustedresources.go
@@ -54,8 +54,8 @@ var (
 	read = readPasswordFn
 )
 
-// GetUnsignedTask returns unsigned task with given name
-func GetUnsignedTask(name string) *v1beta1.Task {
+// GetUnsignedV1beta1Task returns unsigned task with given name
+func GetUnsignedV1beta1Task(name string) *v1beta1.Task {
 	return &v1beta1.Task{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "tekton.dev/v1beta1",
@@ -74,8 +74,8 @@ func GetUnsignedTask(name string) *v1beta1.Task {
 	}
 }
 
-// GetUnsignedPipeline returns unsigned pipeline with given name
-func GetUnsignedPipeline(name string) *v1beta1.Pipeline {
+// GetUnsignedV1beta1Pipeline returns unsigned pipeline with given name
+func GetUnsignedV1beta1Pipeline(name string) *v1beta1.Pipeline {
 	return &v1beta1.Pipeline{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "tekton.dev/v1beta1",

--- a/test/trustedresources_test.go
+++ b/test/trustedresources_test.go
@@ -46,7 +46,7 @@ func TestSignInterface(t *testing.T) {
 	}{{
 		name:    "Sign Task",
 		signer:  sv,
-		target:  GetUnsignedTask("unsigned"),
+		target:  GetUnsignedV1beta1Task("unsigned"),
 		wantErr: false,
 	}, {
 		name:    "Sign String with cosign signer",
@@ -61,7 +61,7 @@ func TestSignInterface(t *testing.T) {
 	}, {
 		name:    "Empty Signer",
 		signer:  nil,
-		target:  GetUnsignedTask("unsigned"),
+		target:  GetUnsignedV1beta1Task("unsigned"),
 		wantErr: true,
 	}, {
 		name:     "Sign String with mock signer",


### PR DESCRIPTION



<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This commit adds apiVersion to the unsigned Tasks and Pipelines ie. unsignedV1beta1Task so as to be declarative when we are swapping to v1 storage version. No function change.

/kind misc
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [n/a] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [n/a] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
