### PR TITLE
Add apiVersion to trustedResources helper

### DIFF
--- a/pkg/reconciler/pipelinerun/resources/pipelineref_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelineref_test.go
@@ -491,7 +491,7 @@ func TestGetPipelineFunc_V1beta1Pipeline_VerifyNoError(t *testing.T) {
 	unsignedV1Pipeline.APIVersion = "tekton.dev/v1"
 	unsignedV1Pipeline.Kind = "Pipeline"
 
-	unsignedPipelineBytes, err := json.Marshal(unsignedPipeline)
+	unsignedV1PipelineBytes, err := json.Marshal(unsignedV1Pipeline)
 	if err != nil {
 		t.Fatal("fail to marshal pipeline", err)
 	}
@@ -502,19 +502,19 @@ func TestGetPipelineFunc_V1beta1Pipeline_VerifyNoError(t *testing.T) {
 		},
 		EntryPoint: "foo/bar",
 	}
-	resolvedUnmatched := test.NewResolvedResource(unsignedPipelineBytes, nil, noMatchPolicyRefSource, nil)
+	resolvedUnmatched := test.NewResolvedResource(unsignedV1PipelineBytes, nil, noMatchPolicyRefSource, nil)
 	requesterUnmatched := test.NewRequester(resolvedUnmatched, nil)
 
-	signedPipeline, err := test.GetSignedV1beta1Pipeline(unsignedPipeline, signer, "signed")
+	signedV1beta1Pipeline, err := test.GetSignedPipeline(unsignedPipeline, signer, "signed", "v1beta1")
 	if err != nil {
 		t.Fatal("fail to sign pipeline", err)
 	}
 	signedV1Pipeline := &v1.Pipeline{}
-	signedPipeline.ConvertTo(ctx, signedV1Pipeline)
+	signedV1beta1Pipeline.(*v1beta1.Pipeline).ConvertTo(ctx, signedV1Pipeline)
 	signedV1Pipeline.APIVersion = "tekton.dev/v1"
 	signedV1Pipeline.Kind = "Pipeline"
 
-	signedPipelineBytes, err := json.Marshal(signedPipeline)
+	signedV1beta1PipelineBytes, err := json.Marshal(signedV1beta1Pipeline)
 	if err != nil {
 		t.Fatal("fail to marshal pipeline", err)
 	}
@@ -525,11 +525,11 @@ func TestGetPipelineFunc_V1beta1Pipeline_VerifyNoError(t *testing.T) {
 		},
 		EntryPoint: "foo/bar",
 	}
-	resolvedMatched := test.NewResolvedResource(signedPipelineBytes, nil, matchPolicyRefSource, nil)
+	resolvedMatched := test.NewResolvedResource(signedV1beta1PipelineBytes, nil, matchPolicyRefSource, nil)
 	requesterMatched := test.NewRequester(resolvedMatched, nil)
 
 	pipelineRef := &v1.PipelineRef{
-		Name: signedPipeline.Name,
+		Name: signedV1beta1Pipeline.(*v1beta1.Pipeline).Name,
 		ResolverRef: v1.ResolverRef{
 			Resolver: "git",
 		},
@@ -572,7 +572,7 @@ func TestGetPipelineFunc_V1beta1Pipeline_VerifyNoError(t *testing.T) {
 	warnPolicyRefSource := &v1.RefSource{
 		URI: "	warnVP",
 	}
-	resolvedUnsignedMatched := test.NewResolvedResource(unsignedPipelineBytes, nil, warnPolicyRefSource, nil)
+	resolvedUnsignedMatched := test.NewResolvedResource(unsignedV1PipelineBytes, nil, warnPolicyRefSource, nil)
 	requesterUnsignedMatched := test.NewRequester(resolvedUnsignedMatched, nil)
 
 	testcases := []struct {
@@ -688,8 +688,8 @@ func TestGetPipelineFunc_V1beta1Pipeline_VerifyError(t *testing.T) {
 	tektonclient := fake.NewSimpleClientset()
 	signer, _, k8sclient, vps := test.SetupVerificationPolicies(t)
 
-	unsignedPipeline := test.GetUnsignedPipeline("test-pipeline")
-	unsignedPipelineBytes, err := json.Marshal(unsignedPipeline)
+	unsignedV1beta1Pipeline := test.GetUnsignedPipeline("test-pipeline")
+	unsignedV1beta1PipelineBytes, err := json.Marshal(unsignedV1beta1Pipeline)
 	if err != nil {
 		t.Fatal("fail to marshal pipeline", err)
 	}
@@ -701,10 +701,10 @@ func TestGetPipelineFunc_V1beta1Pipeline_VerifyError(t *testing.T) {
 		EntryPoint: "foo/bar",
 	}
 
-	resolvedUnsigned := test.NewResolvedResource(unsignedPipelineBytes, nil, matchPolicyRefSource, nil)
+	resolvedUnsigned := test.NewResolvedResource(unsignedV1beta1PipelineBytes, nil, matchPolicyRefSource, nil)
 	requesterUnsigned := test.NewRequester(resolvedUnsigned, nil)
 
-	signedPipeline, err := test.GetSignedV1beta1Pipeline(unsignedPipeline, signer, "signed")
+	signedPipeline, err := test.GetSignedPipeline(unsignedV1beta1Pipeline, signer, "signed", "v1beta1")
 	if err != nil {
 		t.Fatal("fail to sign pipeline", err)
 	}
@@ -723,7 +723,7 @@ func TestGetPipelineFunc_V1beta1Pipeline_VerifyError(t *testing.T) {
 	resolvedUnmatched := test.NewResolvedResource(signedPipelineBytes, nil, noMatchPolicyRefSource, nil)
 	requesterUnmatched := test.NewRequester(resolvedUnmatched, nil)
 
-	modifiedPipeline := signedPipeline.DeepCopy()
+	modifiedPipeline := signedPipeline.(*v1beta1.Pipeline).DeepCopy()
 	modifiedPipeline.Annotations["random"] = "attack"
 	modifiedPipelineBytes, err := json.Marshal(modifiedPipeline)
 	if err != nil {
@@ -817,7 +817,7 @@ func TestGetPipelineFunc_V1Pipeline_VerifyNoError(t *testing.T) {
 		t.Error(err)
 	}
 
-	unsignedPipelineBytes, err := json.Marshal(unsignedV1Pipeline)
+	unsignedV1beta1PipelineBytes, err := json.Marshal(unsignedV1Pipeline)
 	if err != nil {
 		t.Fatal("fail to marshal pipeline", err)
 	}
@@ -828,7 +828,7 @@ func TestGetPipelineFunc_V1Pipeline_VerifyNoError(t *testing.T) {
 		},
 		EntryPoint: "foo/bar",
 	}
-	resolvedUnmatched := test.NewResolvedResource(unsignedPipelineBytes, nil, noMatchPolicyRefSource, nil)
+	resolvedUnmatched := test.NewResolvedResource(unsignedV1beta1PipelineBytes, nil, noMatchPolicyRefSource, nil)
 	requesterUnmatched := test.NewRequester(resolvedUnmatched, nil)
 
 	signedPipeline, err := getSignedV1Pipeline(unsignedV1Pipeline, signer, "signed")
@@ -902,7 +902,7 @@ func TestGetPipelineFunc_V1Pipeline_VerifyNoError(t *testing.T) {
 	warnPolicyRefSource := &v1.RefSource{
 		URI: "	warnVP",
 	}
-	resolvedUnsignedMatched := test.NewResolvedResource(unsignedPipelineBytes, nil, warnPolicyRefSource, nil)
+	resolvedUnsignedMatched := test.NewResolvedResource(unsignedV1beta1PipelineBytes, nil, warnPolicyRefSource, nil)
 	requesterUnsignedMatched := test.NewRequester(resolvedUnsignedMatched, nil)
 
 	testcases := []struct {
@@ -1018,7 +1018,7 @@ func TestGetPipelineFunc_V1Pipeline_VerifyError(t *testing.T) {
 	tektonclient := fake.NewSimpleClientset()
 	signer, _, k8sclient, vps := test.SetupVerificationPolicies(t)
 
-	unsignedPipelineBytes, err := json.Marshal(unsignedV1Pipeline)
+	unsignedV1beta1PipelineBytes, err := json.Marshal(unsignedV1Pipeline)
 	if err != nil {
 		t.Fatal("fail to marshal pipeline", err)
 	}
@@ -1030,7 +1030,7 @@ func TestGetPipelineFunc_V1Pipeline_VerifyError(t *testing.T) {
 		EntryPoint: "foo/bar",
 	}
 
-	resolvedUnsigned := test.NewResolvedResource(unsignedPipelineBytes, nil, matchPolicyRefSource, nil)
+	resolvedUnsigned := test.NewResolvedResource(unsignedV1beta1PipelineBytes, nil, matchPolicyRefSource, nil)
 	requesterUnsigned := test.NewRequester(resolvedUnsigned, nil)
 
 	signedPipeline, err := getSignedV1Pipeline(unsignedV1Pipeline, signer, "signed")
@@ -1134,13 +1134,13 @@ func TestGetPipelineFunc_GetFuncError(t *testing.T) {
 	tektonclient := fake.NewSimpleClientset()
 	_, k8sclient, vps := test.SetupMatchAllVerificationPolicies(t, "trusted-resources")
 
-	unsignedPipeline := test.GetUnsignedPipeline("test-pipeline")
-	unsignedPipelineBytes, err := json.Marshal(unsignedPipeline)
+	unsignedV1beta1Pipeline := test.GetUnsignedPipeline("test-pipeline")
+	unsignedV1beta1PipelineBytes, err := json.Marshal(unsignedV1beta1Pipeline)
 	if err != nil {
 		t.Fatal("fail to marshal pipeline", err)
 	}
 
-	resolvedUnsigned := test.NewResolvedResource(unsignedPipelineBytes, nil, sampleRefSource.DeepCopy(), nil)
+	resolvedUnsigned := test.NewResolvedResource(unsignedV1beta1PipelineBytes, nil, sampleRefSource.DeepCopy(), nil)
 	requesterUnsigned := test.NewRequester(resolvedUnsigned, nil)
 	resolvedUnsigned.DataErr = fmt.Errorf("resolution error")
 

--- a/pkg/reconciler/taskrun/resources/taskref_test.go
+++ b/pkg/reconciler/taskrun/resources/taskref_test.go
@@ -651,10 +651,10 @@ func TestGetTaskFunc_V1beta1Task_VerifyNoError(t *testing.T) {
 	signer, _, k8sclient, vps := test.SetupVerificationPolicies(t)
 	tektonclient := fake.NewSimpleClientset()
 
-	unsignedTask := test.GetUnsignedTask("test-task")
-	unsignedTaskBytes, err := json.Marshal(unsignedTask)
+	unsignedV1beta1Task := test.GetUnsignedTask("test-task")
+	unsignedTaskBytes, err := json.Marshal(unsignedV1beta1Task)
 	unsignedV1Task := &v1.Task{}
-	unsignedTask.ConvertTo(ctx, unsignedV1Task)
+	unsignedV1beta1Task.ConvertTo(ctx, unsignedV1Task)
 	unsignedV1Task.APIVersion = "tekton.dev/v1"
 	unsignedV1Task.Kind = "Task"
 
@@ -666,15 +666,15 @@ func TestGetTaskFunc_V1beta1Task_VerifyNoError(t *testing.T) {
 	}
 	requesterUnmatched := bytesToRequester(unsignedTaskBytes, noMatchPolicyRefSource)
 
-	signedTask, err := test.GetSignedV1beta1Task(unsignedTask, signer, "signed")
+	signedV1beta1Task, err := test.GetSignedTask(unsignedV1beta1Task, signer, "signed", "v1beta1")
 	if err != nil {
 		t.Fatal("fail to sign task", err)
 	}
 	signedV1Task := &v1.Task{}
-	signedTask.ConvertTo(ctx, signedV1Task)
+	signedV1beta1Task.(*v1beta1.Task).ConvertTo(ctx, signedV1Task)
 	signedV1Task.APIVersion = "tekton.dev/v1"
 	signedV1Task.Kind = "Task"
-	signedTaskBytes, err := json.Marshal(signedTask)
+	signedTaskBytes, err := json.Marshal(signedV1Task)
 	if err != nil {
 		t.Fatal("fail to marshal task", err)
 	}
@@ -785,8 +785,8 @@ func TestGetTaskFunc_V1beta1Task_VerifyError(t *testing.T) {
 	signer, _, k8sclient, vps := test.SetupVerificationPolicies(t)
 	tektonclient := fake.NewSimpleClientset()
 
-	unsignedTask := test.GetUnsignedTask("test-task")
-	unsignedTaskBytes, err := json.Marshal(unsignedTask)
+	unsignedV1beta1Task := test.GetUnsignedTask("test-task")
+	unsignedTaskBytes, err := json.Marshal(unsignedV1beta1Task)
 	if err != nil {
 		t.Fatal("fail to marshal task", err)
 	}
@@ -795,10 +795,11 @@ func TestGetTaskFunc_V1beta1Task_VerifyError(t *testing.T) {
 	}
 	requesterUnsigned := bytesToRequester(unsignedTaskBytes, matchPolicyRefSource)
 
-	signedTask, err := test.GetSignedV1beta1Task(unsignedTask, signer, "signed")
+	signedTask, err := test.GetSignedTask(unsignedV1beta1Task, signer, "signed", "v1beta1")
 	if err != nil {
 		t.Fatal("fail to sign task", err)
 	}
+	signedV1beta1Task := signedTask.(*v1beta1.Task)
 	signedTaskBytes, err := json.Marshal(signedTask)
 	if err != nil {
 		t.Fatal("fail to marshal task", err)
@@ -808,7 +809,7 @@ func TestGetTaskFunc_V1beta1Task_VerifyError(t *testing.T) {
 	}
 	requesterUnmatched := bytesToRequester(signedTaskBytes, noMatchPolicyRefSource)
 
-	modifiedTask := signedTask.DeepCopy()
+	modifiedTask := signedV1beta1Task.DeepCopy()
 	modifiedTask.Annotations["random"] = "attack"
 	modifiedTaskBytes, err := json.Marshal(modifiedTask)
 	if err != nil {
@@ -1162,8 +1163,8 @@ func TestGetTaskFunc_GetFuncError(t *testing.T) {
 	_, k8sclient, vps := test.SetupMatchAllVerificationPolicies(t, "trusted-resources")
 	tektonclient := fake.NewSimpleClientset()
 
-	unsignedTask := test.GetUnsignedTask("test-task")
-	unsignedTaskBytes, err := json.Marshal(unsignedTask)
+	unsignedV1beta1Task := test.GetUnsignedTask("test-task")
+	unsignedTaskBytes, err := json.Marshal(unsignedV1beta1Task)
 	if err != nil {
 		t.Fatal("fail to marshal task", err)
 	}

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -84,6 +84,8 @@ import (
 )
 
 const (
+	v1Version          = "v1"
+	v1beta1Version     = "v1beta1"
 	entrypointLocation = "/tekton/bin/entrypoint"
 	workspaceDir       = "/workspace"
 	currentAPIVersion  = "tekton.dev/v1"
@@ -2837,7 +2839,7 @@ status:
 		expectedReason string
 	}{{
 		description:    "ResourceQuotaConflictError does not fail taskrun",
-		err:            k8sapierrors.NewConflict(k8sruntimeschema.GroupResource{Group: "v1", Resource: "resourcequotas"}, "dummy", errors.New("operation cannot be fulfilled on resourcequotas dummy the object has been modified please apply your changes to the latest version and try again")),
+		err:            k8sapierrors.NewConflict(k8sruntimeschema.GroupResource{Group: v1Version, Resource: "resourcequotas"}, "dummy", errors.New("operation cannot be fulfilled on resourcequotas dummy the object has been modified please apply your changes to the latest version and try again")),
 		expectedType:   apis.ConditionSucceeded,
 		expectedStatus: corev1.ConditionUnknown,
 		expectedReason: podconvert.ReasonPending,
@@ -4605,7 +4607,7 @@ status:
 			pod := &corev1.Pod{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "Pod",
-					APIVersion: "v1",
+					APIVersion: v1Version,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-taskrun-larger-results-sidecar-logs-pod",
@@ -4921,7 +4923,7 @@ spec:
 `)
 
 	signer, _, vps := test.SetupMatchAllVerificationPolicies(t, ts.Namespace)
-	signedTask, err := test.GetSignedV1beta1Task(ts, signer, "test-task")
+	signedTask, err := test.GetSignedTask(ts, signer, "test-task", v1beta1Version)
 	if err != nil {
 		t.Fatal("fail to sign task", err)
 	}
@@ -5072,12 +5074,12 @@ spec:
 	}
 
 	signer, _, vps := test.SetupMatchAllVerificationPolicies(t, unsignedTask.Namespace)
-	signedTask, err := test.GetSignedV1beta1Task(unsignedTask, signer, "test-task")
+	signedTask, err := test.GetSignedTask(unsignedTask, signer, "test-task", v1beta1Version)
 	if err != nil {
 		t.Fatal("fail to sign task", err)
 	}
-
-	modifiedTask := signedTask.DeepCopy()
+	signedV1beta1Task := signedTask.(*v1beta1.Task)
+	modifiedTask := signedV1beta1Task.DeepCopy()
 	if modifiedTask.Annotations == nil {
 		modifiedTask.Annotations = make(map[string]string)
 	}


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This commit adds the apiVersion to the trustedResources helper which now allows the getSignedTask and etc helpers to return verified CRDs with the accepted apiVersions. This could help avoid confusions when we are adding v1 CRDs to be verified in the test cases.

/kind misc
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
