### PR TITLE
Updating release doc with recent releases

### DIFF
--- a/releases.md
+++ b/releases.md
@@ -41,35 +41,42 @@ Further documentation available:
 
 ## Release
 
+### v0.48
+
+- **Latest Release**: [v0.48.0][v0-48-0] (2023-03-17) ([docs][v0-48-0-docs], [examples][v0-48-0-examples])
+- **Initial Release**: [v0.48.0][v0-48-0] (2023-03-17)
+- **Estimated End of Life**: 2023-04-17
+- **Patch Releases**: [v0.48.0][v0-48-0]
+
+### v0.47 (LTS)
+
+- **Latest Release**: [v0.47.0][v0-47-1] (2023-03-17) ([docs][v0-47-1-docs], [examples][v0-47-1-examples])
+- **Initial Release**: [v0.47.0][v0-47-0] (2023-03-17)
+- **Estimated End of Life**: 2023-04-17
+- **Patch Releases**: [v0.47.0][v0-47-0], [v0.47.1][v0-47-1]
+
+### v0.44 (LTS)
+
+- **Latest Release**: [v0.44.3][v0-44-3] (2023-01-24) ([docs][v0-44-3-docs], [examples][v0-44-3-examples])
+- **Initial Release**: [v0.44.0][v0-44-0] (2023-01-24)
+- **Estimated End of Life**: 2024-01-24
+- **Patch Releases**: [v0.44.0][v0-44-0], [v0.44.2][v0-44-2], [v0.44.3][v0-44-3]
+ 
+### v0.41 (LTS)
+
+- **Latest Release**: [0.41.3][v0-41-3] (2023-04-06) ([docs][v0-41-3-docs], [examples][v0-41-3-examples])
+- **Initial Release**: [v0.41.0][v0-41-0] (2022-10-31)
+- **Estimated End of Life**: 2023-10-30
+- **Patch Releases**: [v0.41.0][v0-41-0], [v0.41.1][v0-41-1], [v0.41.2][v0-41-2], [v0.41.3][v0-41-3]
+
+## End of Life Releases
+
 ### v0.46
 
 - **Latest Release**: [v0.46.0][v0-46-0] (2023-03-17) ([docs][v0-46-0-docs], [examples][v0-46-0-examples])
 - **Initial Release**: [v0.46.0][v0-46-0] (2023-03-17)
-- **Estimated End of Life**: 2023-04-17
+- **End of Life**: 2023-04-17
 - **Patch Releases**: [v0.46.0][v0-46-0]
-
-### v0.44 (LTS)
-
-- **Latest Release**: [v0.44.0][v0-44-0] (2023-01-24) ([docs][v0-44-0-docs], [examples][v0-44-0-examples])
-- **Initial Release**: [v0.44.0][v0-44-0] (2023-01-24)
-- **Estimated End of Life**: 2024-01-24
-- **Patch Releases**: [v0.44.0][v0-44-0]
-
-### v0.43
-
-- **Latest Release**: [v0.43.2][v0-43-2] (2023-01-10) ([docs][v0-43-2-docs], [examples][v0-43-2-examples])
-- **Initial Release**: [v0.43.0][v0-43-0] (2022-12-22)
-- **Estimated End of Life**: 2023-04-22
-- **Patch Releases**: [v0.43.0][v0-43-0], [v0.43.1][v0-43-1], [v0.43.2][v0-43-2]
- 
-### v0.41 (LTS)
-
-- **Latest Release**: [0.41.2][v0-41-2] (2023-04-06) ([docs][v0-41-2-docs], [examples][v0-41-2-examples])
-- **Initial Release**: [v0.41.0][v0-41-0] (2022-10-31)
-- **Estimated End of Life**: 2023-10-30
-- **Patch Releases**: [v0.41.0][v0-41-0], [v0.41.1][v0-41-1], [v0.41.2][v0-41-2]
-
-## End of Life Releases
 
 ### v0.45
 
@@ -77,6 +84,13 @@ Further documentation available:
 - **Initial Release**: [v0.45.0][v0-45-0] (2023-02-17)
 - **End of Life**: 2023-03-17
 - **Patch Releases**: [v0.45.0][v0-45-0]
+
+### v0.43
+
+- **Latest Release**: [v0.43.2][v0-43-2] (2023-01-10) ([docs][v0-43-2-docs], [examples][v0-43-2-examples])
+- **Initial Release**: [v0.43.0][v0-43-0] (2022-12-22)
+- **End of Life**: 2023-04-22
+- **Patch Releases**: [v0.43.0][v0-43-0], [v0.43.1][v0-43-1], [v0.43.2][v0-43-2]
 
 ### v0.42
 
@@ -124,13 +138,18 @@ Older releases are EOL and available on [GitHub][tekton-pipeline-releases].
 [release-notes-standards]:
     https://github.com/tektoncd/community/blob/main/standards.md#release-notes
 
+[v0-48-0]: https://github.com/tektoncd/pipeline/releases/tag/v0.48.0
+[v0-47-1]: https://github.com/tektoncd/pipeline/releases/tag/v0.47.1
+[v0-47-0]: https://github.com/tektoncd/pipeline/releases/tag/v0.47.0
 [v0-46-0]: https://github.com/tektoncd/pipeline/releases/tag/v0.46.0
 [v0-45-0]: https://github.com/tektoncd/pipeline/releases/tag/v0.45.0
+[v0-44-3]: https://github.com/tektoncd/pipeline/releases/tag/v0.44.3
 [v0-44-0]: https://github.com/tektoncd/pipeline/releases/tag/v0.44.0
 [v0-43-0]: https://github.com/tektoncd/pipeline/releases/tag/v0.43.0
 [v0-43-1]: https://github.com/tektoncd/pipeline/releases/tag/v0.43.1
 [v0-43-2]: https://github.com/tektoncd/pipeline/releases/tag/v0.43.2
 [v0-42-0]: https://github.com/tektoncd/pipeline/releases/tag/v0.42.0
+[v0-41-3]: https://github.com/tektoncd/pipeline/releases/tag/v0.41.3
 [v0-41-2]: https://github.com/tektoncd/pipeline/releases/tag/v0.41.2
 [v0-41-1]: https://github.com/tektoncd/pipeline/releases/tag/v0.41.1
 [v0-41-0]: https://github.com/tektoncd/pipeline/releases/tag/v0.41.0
@@ -146,27 +165,31 @@ Older releases are EOL and available on [GitHub][tekton-pipeline-releases].
 [v0-37-5]: https://github.com/tektoncd/pipeline/releases/tag/v0.37.5
 [v0-37-0]: https://github.com/tektoncd/pipeline/releases/tag/v0.37.0
 
+[v0-48-0-docs]: https://github.com/tektoncd/pipeline/tree/v0.48.0/docs#tekton-pipelines
+[v0-47-1-docs]: https://github.com/tektoncd/pipeline/tree/v0.47.1/docs#tekton-pipelines
 [v0-46-0-docs]: https://github.com/tektoncd/pipeline/tree/v0.46.0/docs#tekton-pipelines
 [v0-45-0-docs]: https://github.com/tektoncd/pipeline/tree/v0.45.0/docs#tekton-pipelines
-[v0-44-0-docs]: https://github.com/tektoncd/pipeline/tree/v0.44.0/docs#tekton-pipelines
+[v0-44-3-docs]: https://github.com/tektoncd/pipeline/tree/v0.44.3/docs#tekton-pipelines
 [v0-43-0-docs]: https://github.com/tektoncd/pipeline/tree/v0.43.0/docs#tekton-pipelines
 [v0-43-1-docs]: https://github.com/tektoncd/pipeline/tree/v0.43.1/docs#tekton-pipelines
 [v0-43-2-docs]: https://github.com/tektoncd/pipeline/tree/v0.43.2/docs#tekton-pipelines
 [v0-42-0-docs]: https://github.com/tektoncd/pipeline/tree/v0.42.0/docs#tekton-pipelines
-[v0-41-2-docs]: https://github.com/tektoncd/pipeline/tree/v0.41.2/docs#tekton-pipelines
+[v0-41-3-docs]: https://github.com/tektoncd/pipeline/tree/v0.41.3/docs#tekton-pipelines
 [v0-40-2-docs]: https://github.com/tektoncd/pipeline/tree/v0.40.2/docs#tekton-pipelines
 [v0-39-0-docs]: https://github.com/tektoncd/pipeline/tree/v0.39.0/docs#tekton-pipelines
 [v0-38-4-docs]: https://github.com/tektoncd/pipeline/tree/v0.38.4/docs#tekton-pipelines
 [v0-37-5-docs]: https://github.com/tektoncd/pipeline/tree/v0.37.5/docs#tekton-pipelines
 
+[v0-48-0-examples]: https://github.com/tektoncd/pipeline/tree/v0.48.0/examples#examples
+[v0-47-1-examples]: https://github.com/tektoncd/pipeline/tree/v0.47.1/examples#examples
 [v0-46-0-examples]: https://github.com/tektoncd/pipeline/tree/v0.46.0/examples#examples
 [v0-45-0-examples]: https://github.com/tektoncd/pipeline/tree/v0.45.0/examples#examples
-[v0-44-0-examples]: https://github.com/tektoncd/pipeline/tree/v0.44.0/examples#examples
+[v0-44-3-examples]: https://github.com/tektoncd/pipeline/tree/v0.44.3/examples#examples
 [v0-43-0-examples]: https://github.com/tektoncd/pipeline/tree/v0.43.0/examples#examples
 [v0-43-1-examples]: https://github.com/tektoncd/pipeline/tree/v0.43.1/examples#examples
 [v0-43-2-examples]: https://github.com/tektoncd/pipeline/tree/v0.43.2/examples#examples
 [v0-42-0-examples]: https://github.com/tektoncd/pipeline/tree/v0.42.0/examples#examples
-[v0-41-2-examples]: https://github.com/tektoncd/pipeline/tree/v0.41.2/examples#examples
+[v0-41-3-examples]: https://github.com/tektoncd/pipeline/tree/v0.41.3/examples#examples
 [v0-40-2-examples]: https://github.com/tektoncd/pipeline/tree/v0.40.2/examples#examples
 [v0-39-0-examples]: https://github.com/tektoncd/pipeline/tree/v0.39.0/examples#examples
 [v0-38-4-examples]: https://github.com/tektoncd/pipeline/tree/v0.38.4/examples#examples


### PR DESCRIPTION

# Changes

This updates the release.md document with the most recent versions.

This should probably be generated (and auto-updated as well) as it seems a bit tedious to maintain — probably why it was not up-to-date 🙃 @tektoncd/core-maintainers 

/kind docs

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
