### PR TITLE
Conversion webhook fix for tasks with nil StepTemplate

### DIFF
--- a/pkg/apis/pipeline/v1beta1/task_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/task_conversion.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"reflect"
 
 	"github.com/tektoncd/pipeline/pkg/apis/version"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -293,21 +292,21 @@ func retrieveTaskDeprecation(spec *TaskSpec) *taskDeprecation {
 			DeprecatedTTY:                      s.DeprecatedTTY,
 		})
 	}
-	dst := &StepTemplate{
-		DeprecatedName:                     spec.StepTemplate.DeprecatedName,
-		DeprecatedPorts:                    spec.StepTemplate.DeprecatedPorts,
-		DeprecatedLivenessProbe:            spec.StepTemplate.DeprecatedLivenessProbe,
-		DeprecatedReadinessProbe:           spec.StepTemplate.DeprecatedReadinessProbe,
-		DeprecatedStartupProbe:             spec.StepTemplate.DeprecatedStartupProbe,
-		DeprecatedLifecycle:                spec.StepTemplate.DeprecatedLifecycle,
-		DeprecatedTerminationMessagePath:   spec.StepTemplate.DeprecatedTerminationMessagePath,
-		DeprecatedTerminationMessagePolicy: spec.StepTemplate.DeprecatedTerminationMessagePolicy,
-		DeprecatedStdin:                    spec.StepTemplate.DeprecatedStdin,
-		DeprecatedStdinOnce:                spec.StepTemplate.DeprecatedStdinOnce,
-		DeprecatedTTY:                      spec.StepTemplate.DeprecatedTTY,
-	}
-	if reflect.DeepEqual(dst, &StepTemplate{}) {
-		dst = nil
+	var dst *StepTemplate
+	if spec.StepTemplate != nil {
+		dst = &StepTemplate{
+			DeprecatedName:                     spec.StepTemplate.DeprecatedName,
+			DeprecatedPorts:                    spec.StepTemplate.DeprecatedPorts,
+			DeprecatedLivenessProbe:            spec.StepTemplate.DeprecatedLivenessProbe,
+			DeprecatedReadinessProbe:           spec.StepTemplate.DeprecatedReadinessProbe,
+			DeprecatedStartupProbe:             spec.StepTemplate.DeprecatedStartupProbe,
+			DeprecatedLifecycle:                spec.StepTemplate.DeprecatedLifecycle,
+			DeprecatedTerminationMessagePath:   spec.StepTemplate.DeprecatedTerminationMessagePath,
+			DeprecatedTerminationMessagePolicy: spec.StepTemplate.DeprecatedTerminationMessagePolicy,
+			DeprecatedStdin:                    spec.StepTemplate.DeprecatedStdin,
+			DeprecatedStdinOnce:                spec.StepTemplate.DeprecatedStdinOnce,
+			DeprecatedTTY:                      spec.StepTemplate.DeprecatedTTY,
+		}
 	}
 	return &taskDeprecation{
 		DeprecatedSteps:        ds,


### PR DESCRIPTION
Prior to this, the conversion of task spec from v1beta1 was panicing when the step template was nil since it could not access the underlying deprecated fields. This PR fixes that bug. Related issue: https://github.com/tektoncd/pipeline/issues/6823

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Conversion webhook fix for tasks with nil StepTemplate
```
/kind bug