### PR TITLE
Fix release pipeline

### DIFF
--- a/tekton/release-pipeline.yaml
+++ b/tekton/release-pipeline.yaml
@@ -53,15 +53,12 @@ spec:
   tasks:
     - name: git-clone
       taskRef:
-        name: git-clone
-        resolver: bundles
+        resolver: hub
         params:
-          - name: bundle
-            value: gcr.io/tekton-releases/catalog/upstream/git-clone:0.9
           - name: name
             value: git-clone
-          - name: kind
-            value: task
+          - name: version
+            value: "0.7"
       workspaces:
         - name: output
           workspace: workarea
@@ -74,7 +71,6 @@ spec:
     - name: precheck
       runAfter: [git-clone]
       taskRef:
-        name: prerelease-checks
         resolver: git
         params:
           - name: repo
@@ -99,7 +95,6 @@ spec:
     - name: unit-tests
       runAfter: [precheck]
       taskRef:
-        name: golang-test
         resolver: bundles
         params:
           - name: bundle
@@ -120,7 +115,6 @@ spec:
     - name: build
       runAfter: [precheck]
       taskRef:
-        name: golang-build
         resolver: bundles
         params:
           - name: bundle
@@ -207,7 +201,6 @@ spec:
           operator: in
           values: ["true"]
       taskRef:
-        name: gcs-upload
         resolver: bundles
         params:
           - name: bundle


### PR DESCRIPTION
This commit fixes the syntax of the release pipeline task refs. We don't allow taskref.name along with taskref.resolver. Running into https://github.com/tektoncd/pipeline/issues/5673.

In addition, it downgrades the version of the git-clone catalog task to 0.7, as the version 0.9 requires setting a security context on the pipelinerun, and our current release process, which uses tkn, doesn't provide a good way to set the security context for a single pipeline task.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- n/a Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- n/a Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- n/a Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- n/a Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
