### PR TITLE
merge podTemplates instead of overriding

### DIFF
--- a/docs/pipelineruns.md
+++ b/docs/pipelineruns.md
@@ -891,7 +891,8 @@ spec:
 {{% /tab %}}
 {{< /tabs >}}
 
-If used with this `Pipeline`,  `build-task` will use the task specific `PodTemplate` (where `nodeSelector` has `disktype` equal to `ssd`).
+If used with this `Pipeline`,  `build-task` will use the task specific `PodTemplate` (where `nodeSelector` has `disktype` equal to `ssd`)
+along with `securityContext` from the `pipelineRun.spec.podTemplate`.
 `PipelineTaskRunSpec` may also contain `StepSpecs` and `SidecarSpecs`; see
 [Overriding `Task` `Steps` and `Sidecars`](./taskruns.md#overriding-task-steps-and-sidecars) for more information.
 

--- a/pkg/apis/pipeline/v1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1/pipelinerun_types.go
@@ -585,9 +585,9 @@ func (pr *PipelineRun) GetTaskRunSpec(pipelineTaskName string) PipelineTaskRunSp
 	}
 	for _, task := range pr.Spec.TaskRunSpecs {
 		if task.PipelineTaskName == pipelineTaskName {
-			if task.PodTemplate != nil {
-				s.PodTemplate = task.PodTemplate
-			}
+			// merge podTemplates specified in pipelineRun.spec.taskRunSpecs[].podTemplate and pipelineRun.spec.podTemplate
+			// with taskRunSpecs taking higher precedence
+			s.PodTemplate = pod.MergePodTemplateWithDefault(task.PodTemplate, s.PodTemplate)
 			if task.ServiceAccountName != "" {
 				s.ServiceAccountName = task.ServiceAccountName
 			}

--- a/pkg/apis/pipeline/v1/pipelinerun_types_test.go
+++ b/pkg/apis/pipeline/v1/pipelinerun_types_test.go
@@ -624,3 +624,78 @@ func TestPipelineRunGetPodSpec(t *testing.T) {
 		}
 	}
 }
+
+func TestPipelineRun_GetTaskRunSpec(t *testing.T) {
+	user := int64(1000)
+	group := int64(2000)
+	fsGroup := int64(3000)
+	for _, tt := range []struct {
+		name                 string
+		pr                   *v1.PipelineRun
+		expectedPodTemplates map[string]*pod.PodTemplate
+	}{
+		{
+			name: "pipelineRun Spec podTemplate and taskRunSpec pipelineTask podTemplate",
+			pr: &v1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{Name: "pr"},
+				Spec: v1.PipelineRunSpec{
+					TaskRunTemplate: v1.PipelineTaskRunTemplate{
+						PodTemplate: &pod.Template{
+							SecurityContext: &corev1.PodSecurityContext{
+								RunAsUser:  &user,
+								RunAsGroup: &group,
+								FSGroup:    &fsGroup,
+							},
+						},
+						ServiceAccountName: "defaultSA",
+					},
+					PipelineRef: &v1.PipelineRef{Name: "prs"},
+					TaskRunSpecs: []v1.PipelineTaskRunSpec{{
+						PipelineTaskName:   "task-1",
+						ServiceAccountName: "task-1-service-account",
+						PodTemplate: &pod.Template{
+							NodeSelector: map[string]string{
+								"diskType": "ssd",
+							},
+						},
+					}, {
+						PipelineTaskName:   "task-2",
+						ServiceAccountName: "task-2-service-account",
+						PodTemplate: &pod.Template{
+							SchedulerName: "task-2-schedule",
+						},
+					}},
+				},
+			},
+			expectedPodTemplates: map[string]*pod.PodTemplate{
+				"task-1": {
+					SecurityContext: &corev1.PodSecurityContext{
+						RunAsUser:  &user,
+						RunAsGroup: &group,
+						FSGroup:    &fsGroup,
+					},
+					NodeSelector: map[string]string{
+						"diskType": "ssd",
+					},
+				},
+				"task-2": {
+					SecurityContext: &corev1.PodSecurityContext{
+						RunAsUser:  &user,
+						RunAsGroup: &group,
+						FSGroup:    &fsGroup,
+					},
+					SchedulerName: "task-2-schedule",
+				},
+			},
+		},
+	} {
+		for taskName := range tt.expectedPodTemplates {
+			t.Run(tt.name, func(t *testing.T) {
+				s := tt.pr.GetTaskRunSpec(taskName)
+				if d := cmp.Diff(tt.expectedPodTemplates[taskName], s.PodTemplate); d != "" {
+					t.Error(diff.PrintWantGot(d))
+				}
+			})
+		}
+	}
+}

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
@@ -618,9 +618,9 @@ func (pr *PipelineRun) GetTaskRunSpec(pipelineTaskName string) PipelineTaskRunSp
 	}
 	for _, task := range pr.Spec.TaskRunSpecs {
 		if task.PipelineTaskName == pipelineTaskName {
-			if task.TaskPodTemplate != nil {
-				s.TaskPodTemplate = task.TaskPodTemplate
-			}
+			// merge podTemplates specified in pipelineRun.spec.taskRunSpecs[].podTemplate and pipelineRun.spec.podTemplate
+			// with taskRunSpecs taking higher precedence
+			s.TaskPodTemplate = pod.MergePodTemplateWithDefault(task.TaskPodTemplate, s.TaskPodTemplate)
 			if task.TaskServiceAccountName != "" {
 				s.TaskServiceAccountName = task.TaskServiceAccountName
 			}

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_types_test.go
@@ -662,3 +662,76 @@ func TestPipelineRunGetPodSpec(t *testing.T) {
 		}
 	}
 }
+
+func TestPipelineRun_GetTaskRunSpec(t *testing.T) {
+	user := int64(1000)
+	group := int64(2000)
+	fsGroup := int64(3000)
+	for _, tt := range []struct {
+		name                 string
+		pr                   *v1beta1.PipelineRun
+		expectedPodTemplates map[string]*pod.PodTemplate
+	}{
+		{
+			name: "pipelineRun Spec podTemplate and taskRunSpec pipelineTask podTemplate",
+			pr: &v1beta1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{Name: "pr"},
+				Spec: v1beta1.PipelineRunSpec{
+					PodTemplate: &pod.Template{
+						SecurityContext: &corev1.PodSecurityContext{
+							RunAsUser:  &user,
+							RunAsGroup: &group,
+							FSGroup:    &fsGroup,
+						},
+					},
+					PipelineRef:        &v1beta1.PipelineRef{Name: "prs"},
+					ServiceAccountName: "defaultSA",
+					TaskRunSpecs: []v1beta1.PipelineTaskRunSpec{{
+						PipelineTaskName:       "task-1",
+						TaskServiceAccountName: "task-1-service-account",
+						TaskPodTemplate: &pod.Template{
+							NodeSelector: map[string]string{
+								"diskType": "ssd",
+							},
+						},
+					}, {
+						PipelineTaskName:       "task-2",
+						TaskServiceAccountName: "task-2-service-account",
+						TaskPodTemplate: &pod.Template{
+							SchedulerName: "task-2-schedule",
+						},
+					}},
+				},
+			},
+			expectedPodTemplates: map[string]*pod.PodTemplate{
+				"task-1": {
+					SecurityContext: &corev1.PodSecurityContext{
+						RunAsUser:  &user,
+						RunAsGroup: &group,
+						FSGroup:    &fsGroup,
+					},
+					NodeSelector: map[string]string{
+						"diskType": "ssd",
+					},
+				},
+				"task-2": {
+					SecurityContext: &corev1.PodSecurityContext{
+						RunAsUser:  &user,
+						RunAsGroup: &group,
+						FSGroup:    &fsGroup,
+					},
+					SchedulerName: "task-2-schedule",
+				},
+			},
+		},
+	} {
+		for taskName := range tt.expectedPodTemplates {
+			t.Run(tt.name, func(t *testing.T) {
+				s := tt.pr.GetTaskRunSpec(taskName)
+				if d := cmp.Diff(tt.expectedPodTemplates[taskName], s.TaskPodTemplate); d != "" {
+					t.Error(diff.PrintWantGot(d))
+				}
+			})
+		}
+	}
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

The podTemplate can be specified for any given pipelineTask at the pipelineRun.spec.taskRunSpecs.

The podTemplate can also be specified for the entire pipeline at the pipelineRun.spec.podTemplate.

Before this commit, the podTemplates at the pipelineRun level were ignored if it was specified at the taskRunSpecs. This resulted in the settings specified at the pipelineRun level not included along with the pipelineTask specific configuration. For example, there could be a common setting at the pipelineRun level to set the User and Group for all the pipelineTasks and a pipelineTask can have its own diskType. Without this commit, the taskRun runs with a podTemplate with the specified diskType but no user or group configurations.

Fixes https://github.com/tektoncd/pipeline/issues/6846 

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Merge podTemplate specified in pipelineRun.spec.taskRunSpecs[].podTemplate along with pipelineRun.spec.podTemplate instead of only considering the one specified at the taskRunSpecs. 
```
