### PR TITLE
Restore Upgrade Test Scenario2 by creating simple Task and Pipeline resources 

### DIFF
--- a/test/e2e-tests-upgrade.sh
+++ b/test/e2e-tests-upgrade.sh
@@ -66,17 +66,31 @@ uninstall_pipeline_crd_version $PREVIOUS_PIPELINE_VERSION
 header "Install the previous release of Tekton pipeline $PREVIOUS_PIPELINE_VERSION"
 install_pipeline_crd_version $PREVIOUS_PIPELINE_VERSION
 
+header "Create resources at previous release version"
+kubectl create namespace upgrade
+trap "kubectl delete namespace upgrade" EXIT
+kubectl create -f ./test/upgrade/simpleResources.yaml || fail_test
+
 # Upgrade to the current release.
 header "Upgrade to the current release of Tekton pipeline"
 install_pipeline_crd
 
-# Run the integration tests.
-go_test_e2e -timeout=20m ./test || failed=1
+# Create runs from the Task and Pipeline resources created at the previous release version
+header "Creating TaskRuns and PipelineRuns referencing existing Tasks and Pipelines"
+kubectl create -f ./test/upgrade/simpleRuns.yaml || fail_test
 
 # Run the post-integration tests. We do not need to install the resources again, since
 # they are installed before the upgrade. We verify if they still work, after going through
 # the upgrade.
-go_test_e2e -tags=examples -timeout=20m ./test/ || failed=1
+for test in taskrun pipelinerun; do
+  header "Running YAML e2e tests for ${test}s"
+  if ! run_tests ${test}; then
+    echo "ERROR: one or more YAML tests failed"
+    output_yaml_test_results ${test}
+    output_pods_logs ${test}
+    failed=1
+  fi
+done
 
 (( failed )) && fail_test
 

--- a/test/upgrade/simpleResources.yaml
+++ b/test/upgrade/simpleResources.yaml
@@ -1,0 +1,67 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: simple-task
+  namespace: upgrade
+spec:
+  params:
+    - name: rsp
+      type: string
+      default: "response"
+  steps:
+  - name: echo-param
+    image: alpine
+    script: |
+      echo "$(params.rsp)"
+  - name: check-workspace
+    image: alpine
+    script: |
+      if [ "$(workspaces.workspace.bound)" == "true" ]; then
+        echo "Workspace provided"
+      fi
+  sidecars:
+  - name: server
+    image: alpine:3.12.0
+    command: ['/bin/bash']
+    workingDir: /foo
+    script: echo server
+  workspaces:
+  - name: workspace
+    mountPath: /foo
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: simple-pipeline
+  namespace: upgrade
+spec:
+  description: foo
+  tasks:
+  - name: check-workspace
+    taskSpec:
+      params:
+        - name: task1-param
+          type: string
+          default: "1"
+      steps:
+        - image: alpine
+          name: check-workspace
+          script: |
+            if [ "$(workspaces.workspace.bound)" == "true" ]; then
+              echo "Workspace provided \n"
+              echo $(params.task1-param)
+            fi
+    timeout: 180s
+  workspaces:
+  - name: workspace
+  finally:
+  - name: echo-status
+    taskSpec:
+      params:
+        - name: echoStatus
+          type: string
+          default: "Succeeded"
+      steps:
+        - name: verify-status
+          image: ubuntu
+          script: echo $(params.echoStatus)

--- a/test/upgrade/simpleRuns.yaml
+++ b/test/upgrade/simpleRuns.yaml
@@ -1,0 +1,23 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: simple-pipelinerun
+  namespace: upgrade
+spec:
+  pipelineRef:
+    name: simple-pipeline
+  workspaces:
+    - name: workspace
+      emptyDir: {}
+---
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  name: simple-taskrun
+  namespace: upgrade
+spec:
+  taskRef:
+    name: simple-task
+  workspaces:
+    - name: workspace
+      emptyDir: {}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Scenario 2 of the upgrade test aims to install pipeline server from the
preivous release, create resources from that version and test on those
resources against the client of the current release.

This commit restores the resources creation of simple Task and Pipeline
resources to enable the 2nd scenario of the upgrade test to work by
applying the resources from the old server version of pipeline. It was
preivously renamed in https://github.com/tektoncd/pipeline/pull/1351 and then removed in https://github.com/tektoncd/pipeline/pull/2685.

It fixes the missing piece where the required resources from the previous
release have not been created to accomplish scenario 2 of the upgrade
test. More specifically, it creates a simple Task and Pipeline resources
and then runs the two simple resources with a TaskRun and PipelineRun
created after upgrading to the current version and verify that they both
run successfully.

/kind misc
Closes https://github.com/tektoncd/pipeline/issues/6868
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
