### PR TITLE
Fix filtering of Results Summary Annotation during Creation

### DIFF
--- a/pkg/apis/pipeline/constant.go
+++ b/pkg/apis/pipeline/constant.go
@@ -19,4 +19,13 @@ package pipeline
 const (
 	// TektonReservedAnnotationExpr is the expression we use to filter out reserved key in annotation
 	TektonReservedAnnotationExpr = "(results.tekton.dev|chains.tekton.dev)/.*"
+	// Integrators add this Result annotation to objects in order to store
+	// arbitrary keys/values into the Result.Annotations field.
+	// Need to ignore this annotation during filtering,
+	ResultsAnnotations = "results.tekton.dev/resultAnnotations"
+
+	// Integrators add this Results annotation to objects in order to store
+	// arbitrary keys/values into the Result.Summary.Annotations field.
+	// Need to ignore this annotation during filtering,
+	ResultsRecordSummaryAnnotations = "results.tekton.dev/recordSummaryAnnotations"
 )

--- a/pkg/apis/pipeline/filter_annotation.go
+++ b/pkg/apis/pipeline/filter_annotation.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2023 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package pipeline
+
+import (
+	"regexp"
+	"strings"
+)
+
+var (
+	filterReservedAnnotationRegexp = regexp.MustCompile(TektonReservedAnnotationExpr)
+	FilterReservedAnnotation       = func(s string) bool {
+		return filterReservedAnnotationRegexp.MatchString(s) && !strings.Contains(s, ResultsAnnotations) && !strings.Contains(s, ResultsRecordSummaryAnnotations)
+	}
+)

--- a/pkg/apis/pipeline/v1/pipelinerun_defaults.go
+++ b/pkg/apis/pipeline/v1/pipelinerun_defaults.go
@@ -18,7 +18,6 @@ package v1
 
 import (
 	"context"
-	"regexp"
 	"time"
 
 	"github.com/tektoncd/pipeline/pkg/apis/config"
@@ -30,8 +29,7 @@ import (
 )
 
 var (
-	_                              apis.Defaultable = (*PipelineRun)(nil)
-	filterReservedAnnotationRegexp                  = regexp.MustCompile(pipeline.TektonReservedAnnotationExpr)
+	_ apis.Defaultable = (*PipelineRun)(nil)
 )
 
 // SetDefaults implements apis.Defaultable
@@ -40,9 +38,7 @@ func (pr *PipelineRun) SetDefaults(ctx context.Context) {
 
 	// Silently filtering out Tekton Reserved annotations at creation
 	if apis.IsInCreate(ctx) {
-		pr.ObjectMeta.Annotations = kmap.Filter(pr.ObjectMeta.Annotations, func(s string) bool {
-			return filterReservedAnnotationRegexp.MatchString(s)
-		})
+		pr.ObjectMeta.Annotations = kmap.Filter(pr.ObjectMeta.Annotations, pipeline.FilterReservedAnnotation)
 	}
 }
 

--- a/pkg/apis/pipeline/v1/taskrun_defaults.go
+++ b/pkg/apis/pipeline/v1/taskrun_defaults.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/tektoncd/pipeline/pkg/apis/config"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	pod "github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
@@ -39,9 +40,7 @@ func (tr *TaskRun) SetDefaults(ctx context.Context) {
 
 	// Silently filtering out Tekton Reserved annotations at creation
 	if apis.IsInCreate(ctx) {
-		tr.ObjectMeta.Annotations = kmap.Filter(tr.ObjectMeta.Annotations, func(s string) bool {
-			return filterReservedAnnotationRegexp.MatchString(s)
-		})
+		tr.ObjectMeta.Annotations = kmap.Filter(tr.ObjectMeta.Annotations, pipeline.FilterReservedAnnotation)
 	}
 
 	// If the TaskRun doesn't have a managed-by label, apply the default

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_defaults.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_defaults.go
@@ -18,7 +18,6 @@ package v1beta1
 
 import (
 	"context"
-	"regexp"
 	"time"
 
 	"github.com/tektoncd/pipeline/pkg/apis/config"
@@ -30,8 +29,7 @@ import (
 )
 
 var (
-	_                              apis.Defaultable = (*PipelineRun)(nil)
-	filterReservedAnnotationRegexp                  = regexp.MustCompile(pipeline.TektonReservedAnnotationExpr)
+	_ apis.Defaultable = (*PipelineRun)(nil)
 )
 
 // SetDefaults implements apis.Defaultable
@@ -40,9 +38,7 @@ func (pr *PipelineRun) SetDefaults(ctx context.Context) {
 
 	// Silently filtering out Tekton Reserved annotations at creation
 	if apis.IsInCreate(ctx) {
-		pr.ObjectMeta.Annotations = kmap.Filter(pr.ObjectMeta.Annotations, func(s string) bool {
-			return filterReservedAnnotationRegexp.MatchString(s)
-		})
+		pr.ObjectMeta.Annotations = kmap.Filter(pr.ObjectMeta.Annotations, pipeline.FilterReservedAnnotation)
 	}
 }
 

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_defaults_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_defaults_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	cfgtesting "github.com/tektoncd/pipeline/pkg/apis/config/testing"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/test/diff"
@@ -410,7 +411,7 @@ func TestPipelineRunDefaultingOnCreate(t *testing.T) {
 		name: "Reserved Tekton annotations are filtered on create",
 		in: &v1beta1.PipelineRun{
 			ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{"chains.tekton.dev/signed": "true", "results.tekton.dev/hello": "world", "tekton.dev/foo": "bar", "foo": "bar"},
+				Annotations: map[string]string{"chains.tekton.dev/signed": "true", "results.tekton.dev/hello": "world", "results.tekton.dev/recordSummaryAnnotations": "test", "results.tekton.dev/resultAnnotations": "resTest", "tekton.dev/foo": "bar", "foo": "bar"},
 			},
 			Spec: v1beta1.PipelineRunSpec{
 				PipelineRef: &v1beta1.PipelineRef{
@@ -420,7 +421,7 @@ func TestPipelineRunDefaultingOnCreate(t *testing.T) {
 		},
 		want: &v1beta1.PipelineRun{
 			ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{"tekton.dev/foo": "bar", "foo": "bar"},
+				Annotations: map[string]string{"tekton.dev/foo": "bar", "foo": "bar", pipeline.ResultsAnnotations: "resTest", pipeline.ResultsRecordSummaryAnnotations: "test"},
 			},
 			Spec: v1beta1.PipelineRunSpec{
 				ServiceAccountName: config.DefaultServiceAccountValue,

--- a/pkg/apis/pipeline/v1beta1/taskrun_defaults.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_defaults.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/tektoncd/pipeline/pkg/apis/config"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	pod "github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
@@ -39,9 +40,7 @@ func (tr *TaskRun) SetDefaults(ctx context.Context) {
 
 	// Silently filtering out Tekton Reserved annotations at creation
 	if apis.IsInCreate(ctx) {
-		tr.ObjectMeta.Annotations = kmap.Filter(tr.ObjectMeta.Annotations, func(s string) bool {
-			return filterReservedAnnotationRegexp.MatchString(s)
-		})
+		tr.ObjectMeta.Annotations = kmap.Filter(tr.ObjectMeta.Annotations, pipeline.FilterReservedAnnotation)
 	}
 
 	// If the TaskRun doesn't have a managed-by label, apply the default

--- a/pkg/apis/pipeline/v1beta1/taskrun_defaults_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_defaults_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	cfgtesting "github.com/tektoncd/pipeline/pkg/apis/config/testing"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/test/diff"
@@ -424,7 +425,7 @@ func TestTaskRunDefaultingOnCreate(t *testing.T) {
 		name: "Reserved Tekton annotations are filtered on create",
 		in: &v1beta1.TaskRun{
 			ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{"chains.tekton.dev/signed": "true", "results.tekton.dev/hello": "world", "tekton.dev/foo": "bar", "foo": "bar"},
+				Annotations: map[string]string{"chains.tekton.dev/signed": "true", "results.tekton.dev/hello": "world", "results.tekton.dev/recordSummaryAnnotations": "test", "results.tekton.dev/resultAnnotations": "resTest", "tekton.dev/foo": "bar", "foo": "bar"},
 			},
 			Spec: v1beta1.TaskRunSpec{
 				TaskRef: &v1beta1.TaskRef{
@@ -435,7 +436,7 @@ func TestTaskRunDefaultingOnCreate(t *testing.T) {
 		want: &v1beta1.TaskRun{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels:      map[string]string{"app.kubernetes.io/managed-by": "tekton-pipelines"},
-				Annotations: map[string]string{"tekton.dev/foo": "bar", "foo": "bar"},
+				Annotations: map[string]string{"tekton.dev/foo": "bar", "foo": "bar", pipeline.ResultsAnnotations: "resTest", pipeline.ResultsRecordSummaryAnnotations: "test"},
 			},
 			Spec: v1beta1.TaskRunSpec{
 				TaskRef: &v1beta1.TaskRef{

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"path/filepath"
 	"reflect"
-	"regexp"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
@@ -164,8 +163,7 @@ type Reconciler struct {
 
 var (
 	// Check that our Reconciler implements pipelinerunreconciler.Interface
-	_                              pipelinerunreconciler.Interface = (*Reconciler)(nil)
-	filterReservedAnnotationRegexp                                 = regexp.MustCompile(pipeline.TektonReservedAnnotationExpr)
+	_ pipelinerunreconciler.Interface = (*Reconciler)(nil)
 )
 
 // ReconcileKind compares the actual state with the desired, and attempts to
@@ -1122,9 +1120,7 @@ func getTaskrunAnnotations(pr *v1.PipelineRun) map[string]string {
 	for key, val := range pr.ObjectMeta.Annotations {
 		annotations[key] = val
 	}
-	return kmap.Filter(annotations, func(s string) bool {
-		return filterReservedAnnotationRegexp.MatchString(s)
-	})
+	return kmap.Filter(annotations, pipeline.FilterReservedAnnotation)
 }
 
 func propagatePipelineNameLabelToPipelineRun(pr *v1.PipelineRun) error {


### PR DESCRIPTION
Results Record and Summary Annotation shouldn't be filtered during the Creation. Integrators like Triggers specify these annotations during creation.
Fixes https://github.com/tektoncd/pipeline/issues/6857
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
