### PR TITLE
Add compatibility policy for ResolutionRequests

### DIFF
--- a/api_compatibility_policy.md
+++ b/api_compatibility_policy.md
@@ -37,11 +37,15 @@ alpha or beta:
 - `v1.Pipeline`
 - `v1.PipelineRun`
 
-`v1beta1.CustomRun` is considered a beta CRD. Adding new fields to `CustomRun`
+`v1beta1.CustomRun` is a beta CRD. Adding new fields to `CustomRun`
 that all `CustomRun` controllers are required to support is considered a [backwards incompatible change](#backwards-incompatible-changes),
 and follows the [beta policy](#beta-crds) for backwards incompatible changes.
 
 `v1beta1.ClusterTask` is a deprecated beta CRD. New features will not be added to `ClusterTask`.
+
+`v1beta1.ResolutionRequest` is a beta CRD. Adding new fields to `ResolutionRequest`
+that all resolvers are required to support is considered a [backwards incompatible change](#backwards-incompatible-changes),
+and follows the [beta policy](#beta-crds) for backwards incompatible changes.
 
 ### Alpha CRDs
 
@@ -141,7 +145,8 @@ spec. These changes will mean that folks using a previous version of the API wil
 to adjust their usage in order to use the new version.
 Adding a new field to the CustomRun API that all CustomRun controllers are expected to support
 is also a backwards incompatible change, as CustomRun controllers that were valid before the change
-would be invalid after the change.
+would be invalid after the change. Similarly, adding a new field to the ResolutionRequest API that
+all resolvers are expected to support is also a backwards incompatible change.
 
 These changes must be approved by [more than half of the project OWNERS](OWNERS)
 (i.e. 50% + 1).


### PR DESCRIPTION
The ResolutionRequest CRD is similar to the CustomRun CRD, in that out-of-tree controllers are expected to implement support for it. Like CustomRuns, adding a new field to ResolutionRequest that all resolvers must support is not a backwards compatible change. (Removing a field is of course also backwards incompatible, as with all Tekton APIs.) This commit updates the compatibility policy to clarify this.

/kind documentation

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- n/a Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- n/a Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- n/a Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
