### PR TITLE
Add set-security-context to feature flags docs

### DIFF
--- a/docs/additional-configs.md
+++ b/docs/additional-configs.md
@@ -242,6 +242,17 @@ enables [beta features](#beta-features). When using v1 APIs, setting this field 
 allows only stable features, and setting it to "beta" allows only beta features.
 Set this field to "alpha" to allow [alpha features](#alpha-features) to be used.
 
+For example:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: feature-flags
+data:
+  enable-api-fields: "alpha" # Allow alpha fields to be used in Tasks and Pipelines.
+```
+
 - `trusted-resources-verification-no-match-policy`: Setting this flag to `fail` will fail the taskrun/pipelinerun if no matching policies found. Setting to `warn` will skip verification and log a warning if no matching policies are found, but not fail the taskrun/pipelinerun. Setting to `ignore` will skip verification if no matching policies found.
 Defaults to "ignore".
 
@@ -253,16 +264,8 @@ Defaults to "ignore".
   source from where a remote Task/Pipeline definition was fetched. By default, this is set to `true`.
   To disable populating this field, set this flag to `"false"`.
 
-For example:
-
-```yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: feature-flags
-data:
-  enable-api-fields: "alpha" # Allow alpha fields to be used in Tasks and Pipelines.
-```
+- `set-security-context`: Set this flag to `true` to set a security context for containers injected by Tekton that will allow TaskRun pods
+to run in namespaces with `restricted` pod security admission. By default, this is set to `false`.
 
 ### Alpha Features
 


### PR DESCRIPTION
Prior to this commit, the set-security-context feature flag was documented in the feature flags configmap and installation instructions, but not listed under config options in "customizing the pipelines controller behavior". This commit adds this flag to the list of feature flags in this doc.

/kind documentation

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- n/a Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- n/a Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- n/a Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
