### PR TITLE
Fail upgrade tests when test script fails

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -113,7 +113,7 @@ function patch_pipeline_spire() {
 
 function verify_pipeline_installation() {
   # Make sure that everything is cleaned up in the current namespace.
-  delete_pipeline_resources
+  delete_tekton_resources
 
   # Wait for pods to be running in the namespaces we are deploying to
   wait_until_pods_running tekton-pipelines || fail_test "Tekton Pipeline did not come up"
@@ -143,25 +143,20 @@ function verify_log_access_enabled() {
 function uninstall_pipeline_crd() {
   echo ">> Uninstalling Tekton Pipelines"
   ko delete --ignore-not-found=true -R -f config/
-
-  # Make sure that everything is cleaned up in the current namespace.
-  delete_pipeline_resources
 }
 
 function uninstall_pipeline_crd_version() {
   echo ">> Uninstalling Tekton Pipelines of version $1"
   kubectl delete --ignore-not-found=true -f "https://github.com/tektoncd/pipeline/releases/download/$1/release.yaml"
 
-  if [ "${PIPELINE_FEATURE_GATE}" == "alpha" ]; then
+  if [ -v ${PIPELINE_FEATURE_GATE+x} && "${PIPELINE_FEATURE_GATE}" == "alpha" ]; then
     kubectl delete --ignore-not-found=true -f "https://github.com/tektoncd/pipeline/releases/download/$1/resolvers.yaml"
   fi
-
-  # Make sure that everything is cleaned up in the current namespace.
-  delete_pipeline_resources
 }
 
-function delete_pipeline_resources() {
+function delete_tekton_resources() {
   for res in tasks clustertasks pipelines taskruns pipelineruns; do
+    echo ">> Deleting ${res}"
     kubectl delete --ignore-not-found=true ${res}.tekton.dev --all
   done
 }

--- a/test/e2e-tests-upgrade.sh
+++ b/test/e2e-tests-upgrade.sh
@@ -37,9 +37,10 @@ fi
 
 header "Setting up environment"
 
-# Handle failures ourselves, so we can dump useful info.
-set +o errexit
-set +o pipefail
+# Exit if any failures occur or any unbound variables are referenced
+set -o errexit
+set -o pipefail
+set -o nounset
 
 # First, we will verify if Scenario 1 works.
 # Install the previous release.
@@ -58,6 +59,7 @@ go_test_e2e -timeout=20m ./test || failed=1
 go_test_e2e -tags=examples -timeout=20m ./test/ || failed=1
 
 # Remove all the pipeline CRDs, and clean up the environment for next Scenario.
+delete_tekton_resources
 uninstall_pipeline_crd
 uninstall_pipeline_crd_version $PREVIOUS_PIPELINE_VERSION
 


### PR DESCRIPTION
Prior to this commit, if any lines in the upgrade testing script that didn't have special error handling failed, the script would continue to run, making it very hard to debug.

This commit fails the script if any lines fail, and doesn't prevent lines with special error handling (i.e. `fail_test`) from performing their own cleanup steps.

In addition, prior to this commit, lines deleting Tekton CRDs were run after the pipelines webhook and CRD definitions were deleted. This commit moves deletion of resources to happen before Tekton is uninstalled, so deletion can happen successfully.

Lastly, this commit handles cases where the variable PIPELINE_FEATURE_GATE is not set, and causes the script to fail if any unbound variables are referenced.

/kind bug
closes https://github.com/tektoncd/pipeline/issues/6869

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- n/a Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- n/a Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- n/a Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
