### PR TITLE
Reduce spam in integration test logs

### DIFF
--- a/test/init_test.go
+++ b/test/init_test.go
@@ -102,20 +102,11 @@ func tearDown(ctx context.Context, t *testing.T, cs *clients, namespace string) 
 			t.Log(string(bs))
 		}
 		header(t, fmt.Sprintf("Dumping logs from Pods in the %s", namespace))
-		v1beta1Taskruns, err := cs.V1beta1TaskRunClient.List(ctx, metav1.ListOptions{})
+		taskRuns, err := cs.V1TaskRunClient.List(ctx, metav1.ListOptions{})
 		if err != nil {
-			t.Errorf("Error getting v1beta1TaskRun list %s", err)
+			t.Errorf("Error listing TaskRuns: %s", err)
 		}
-		for _, tr := range v1beta1Taskruns.Items {
-			if tr.Status.PodName != "" {
-				CollectPodLogs(ctx, cs, tr.Status.PodName, namespace, t.Logf)
-			}
-		}
-		v1Taskruns, err := cs.V1TaskRunClient.List(ctx, metav1.ListOptions{})
-		if err != nil {
-			t.Errorf("Error getting v1TaskRun list %s", err)
-		}
-		for _, tr := range v1Taskruns.Items {
+		for _, tr := range taskRuns.Items {
 			if tr.Status.PodName != "" {
 				CollectPodLogs(ctx, cs, tr.Status.PodName, namespace, t.Logf)
 			}
@@ -210,47 +201,11 @@ func getCRDYaml(ctx context.Context, cs *clients, ns string) ([]byte, error) {
 		output = append(output, bs...)
 	}
 
-	v1beta1Pipelines, err := cs.V1beta1PipelineClient.List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("could not get v1beta1 pipeline: %w", err)
-	}
-	for _, i := range v1beta1Pipelines.Items {
-		i.SetManagedFields(nil)
-		printOrAdd(i)
-	}
-
-	v1beta1PipelineRuns, err := cs.V1beta1PipelineRunClient.List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("could not get v1beta1 pipelinerun: %w", err)
-	}
-	for _, i := range v1beta1PipelineRuns.Items {
-		i.SetManagedFields(nil)
-		printOrAdd(i)
-	}
-
-	v1beta1Tasks, err := cs.V1beta1TaskClient.List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("could not get v1beta1 tasks: %w", err)
-	}
-	for _, i := range v1beta1Tasks.Items {
-		i.SetManagedFields(nil)
-		printOrAdd(i)
-	}
-
 	v1beta1ClusterTasks, err := cs.V1beta1ClusterTaskClient.List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("could not get v1beta1 clustertasks: %w", err)
 	}
 	for _, i := range v1beta1ClusterTasks.Items {
-		i.SetManagedFields(nil)
-		printOrAdd(i)
-	}
-
-	v1beta1TaskRuns, err := cs.V1beta1TaskRunClient.List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("could not get v1beta1 taskruns: %w", err)
-	}
-	for _, i := range v1beta1TaskRuns.Items {
 		i.SetManagedFields(nil)
 		printOrAdd(i)
 	}


### PR DESCRIPTION
Prior to this commit, integration tests printed any Tekton objects from failed tests in both v1beta1 and v1 form. They also retrieved TaskRuns from both the v1 client and the v1beta1 client and printed logs for all of them. This resulted in every Tekton object being printed twice in the test output yaml, and every set of failed pod logs printed twice as well. This commit removes these duplicated checks so failure information is printed only once.
Note: conversion tests use cmp.Diff to compare yaml differences between API versions, so these extra logs are not necessary for conversion tests.

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- n/a Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- n/a Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- n/a Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
