### PR TITLE
updating releases with 0.47.3

### DIFF
--- a/releases.md
+++ b/releases.md
@@ -50,10 +50,10 @@ Further documentation available:
 
 ### v0.47 (LTS)
 
-- **Latest Release**: [v0.47.2][v0-47-2] (2023-06-13) ([docs][v0-47-2-docs], [examples][v0-47-2-examples])
+- **Latest Release**: [v0.47.3][v0-47-3] (2023-06-26) ([docs][v0-47-3-docs], [examples][v0-47-3-examples])
 - **Initial Release**: [v0.47.0][v0-47-0] (2023-03-17)
-- **Estimated End of Life**: 2023-04-17
-- **Patch Releases**: [v0.47.0][v0-47-0], [v0.47.1][v0-47-1], [v0.47.2][v0-47-2] 
+- **Estimated End of Life**: 2024-04-17
+- **Patch Releases**: [v0.47.0][v0-47-0], [v0.47.1][v0-47-1], [v0.47.2][v0-47-2], [v0.47.3][v0-47-3]
 
 ### v0.44 (LTS)
 
@@ -147,6 +147,7 @@ Older releases are EOL and available on [GitHub][tekton-pipeline-releases].
 
 [v0-49-0]: https://github.com/tektoncd/pipeline/releases/tag/v0.49.0
 [v0-48-0]: https://github.com/tektoncd/pipeline/releases/tag/v0.48.0
+[v0-47-3]: https://github.com/tektoncd/pipeline/releases/tag/v0.47.3
 [v0-47-2]: https://github.com/tektoncd/pipeline/releases/tag/v0.47.2
 [v0-47-1]: https://github.com/tektoncd/pipeline/releases/tag/v0.47.1
 [v0-47-0]: https://github.com/tektoncd/pipeline/releases/tag/v0.47.0
@@ -176,7 +177,7 @@ Older releases are EOL and available on [GitHub][tekton-pipeline-releases].
 
 [v0-49-0-docs]: https://github.com/tektoncd/pipeline/tree/v0.49.0/docs#tekton-pipelines
 [v0-48-0-docs]: https://github.com/tektoncd/pipeline/tree/v0.48.0/docs#tekton-pipelines
-[v0-47-2-docs]: https://github.com/tektoncd/pipeline/tree/v0.47.2/docs#tekton-pipelines
+[v0-47-3-docs]: https://github.com/tektoncd/pipeline/tree/v0.47.3/docs#tekton-pipelines
 [v0-46-0-docs]: https://github.com/tektoncd/pipeline/tree/v0.46.0/docs#tekton-pipelines
 [v0-45-0-docs]: https://github.com/tektoncd/pipeline/tree/v0.45.0/docs#tekton-pipelines
 [v0-44-3-docs]: https://github.com/tektoncd/pipeline/tree/v0.44.3/docs#tekton-pipelines
@@ -192,7 +193,7 @@ Older releases are EOL and available on [GitHub][tekton-pipeline-releases].
 
 [v0-49-0-examples]: https://github.com/tektoncd/pipeline/tree/v0.49.0/examples#examples
 [v0-48-0-examples]: https://github.com/tektoncd/pipeline/tree/v0.48.0/examples#examples
-[v0-47-2-examples]: https://github.com/tektoncd/pipeline/tree/v0.47.2/examples#examples
+[v0-47-3-examples]: https://github.com/tektoncd/pipeline/tree/v0.47.3/examples#examples
 [v0-46-0-examples]: https://github.com/tektoncd/pipeline/tree/v0.46.0/examples#examples
 [v0-45-0-examples]: https://github.com/tektoncd/pipeline/tree/v0.45.0/examples#examples
 [v0-44-3-examples]: https://github.com/tektoncd/pipeline/tree/v0.44.3/examples#examples


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

* Adding links to the docs/examples/announcements for 0.47.3.
* Also, fixing the end of the life estimation from 2023-04-17 to 2024-04-17. 0.47 was released on 2023-03-17 so the end of life should be 2024/04 and cannot be 2023/04.

/kind documentation

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
