### PR TITLE
[TEP-0135] Revert PVC creation

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -605,27 +605,30 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1.PipelineRun, getPipel
 			return controller.NewPermanentError(err)
 		}
 
-		// Make an attempt to create Affinity Assistant if it does not exist
-		// if the Affinity Assistant already exists, handle the possibility of assigned node becoming unschedulable by deleting the pod
-		if !c.isAffinityAssistantDisabled(ctx) {
-			// create Affinity Assistant (StatefulSet) so that taskRun pods that share workspace PVC achieve Node Affinity
-			// TODO(#6740)(WIP): We only support AffinityAssistantPerWorkspace at the point. Implement different AffinityAssitantBehaviors based on `coscheduling` feature flag when adding end-to-end support.
-			if err = c.createOrUpdateAffinityAssistantsPerAABehavior(ctx, pr, affinityassistant.AffinityAssistantPerWorkspace); err != nil {
-				logger.Errorf("Failed to create affinity assistant StatefulSet for PipelineRun %s: %v", pr.Name, err)
-				pr.Status.MarkFailed(ReasonCouldntCreateOrUpdateAffinityAssistantStatefulSetPerWorkspace,
-					"Failed to create StatefulSet for PipelineRun %s/%s correctly: %s",
-					pr.Namespace, pr.Name, err)
+		aaBehavior, err := affinityassistant.GetAffinityAssistantBehavior(ctx)
+		if err != nil {
+			return controller.NewPermanentError(err)
+		}
+
+		switch aaBehavior {
+		case affinityassistant.AffinityAssistantPerWorkspace, affinityassistant.AffinityAssistantDisabled:
+			if err = c.createOrUpdateAffinityAssistantsAndPVCs(ctx, pr, aaBehavior); err != nil {
+				logger.Errorf("Failed to create PVC or affinity assistant StatefulSet for PipelineRun %s: %v", pr.Name, err)
+				if aaBehavior == affinityassistant.AffinityAssistantPerWorkspace {
+					pr.Status.MarkFailed(ReasonCouldntCreateOrUpdateAffinityAssistantStatefulSetPerWorkspace,
+						"Failed to create StatefulSet for PipelineRun %s/%s correctly: %s",
+						pr.Namespace, pr.Name, err)
+				} else {
+					pr.Status.MarkFailed(volumeclaim.ReasonCouldntCreateWorkspacePVC,
+						"Failed to create PVC for PipelineRun %s/%s Workspaces correctly: %s",
+						pr.Namespace, pr.Name, err)
+				}
+
 				return controller.NewPermanentError(err)
 			}
-		} else if pr.HasVolumeClaimTemplate() {
-			// create workspace PVC from template
-			if err = c.pvcHandler.CreatePVCsForWorkspacesWithoutAffinityAssistant(ctx, pr.Spec.Workspaces, *kmeta.NewControllerRef(pr), pr.Namespace); err != nil {
-				logger.Errorf("Failed to create PVC for PipelineRun %s: %v", pr.Name, err)
-				pr.Status.MarkFailed(volumeclaim.ReasonCouldntCreateWorkspacePVC,
-					"Failed to create PVC for PipelineRun %s/%s Workspaces correctly: %s",
-					pr.Namespace, pr.Name, err)
-				return controller.NewPermanentError(err)
-			}
+		case affinityassistant.AffinityAssistantPerPipelineRun, affinityassistant.AffinityAssistantPerPipelineRunWithIsolation:
+			// TODO(#6740)(WIP): implement end-to-end support for AffinityAssistantPerPipelineRun and AffinityAssistantPerPipelineRunWithIsolation modes
+			return controller.NewPermanentError(fmt.Errorf("affinity assistant behavior: %v is not implemented", aaBehavior))
 		}
 	}
 
@@ -879,7 +882,7 @@ func (c *Reconciler) createTaskRun(ctx context.Context, taskRunName string, para
 	}
 
 	if !c.isAffinityAssistantDisabled(ctx) && pipelinePVCWorkspaceName != "" {
-		tr.Annotations[workspace.AnnotationAffinityAssistantName] = getAffinityAssistantName(pipelinePVCWorkspaceName, pr.Name)
+		tr.Annotations[workspace.AnnotationAffinityAssistantName] = GetAffinityAssistantName(pipelinePVCWorkspaceName, pr.Name)
 	}
 
 	logger.Infof("Creating a new TaskRun object %s for pipeline task %s", taskRunName, rpt.PipelineTask.Name)
@@ -987,7 +990,7 @@ func (c *Reconciler) createCustomRun(ctx context.Context, runName string, params
 	// Set the affinity assistant annotation in case the custom task creates TaskRuns or Pods
 	// that can take advantage of it.
 	if !c.isAffinityAssistantDisabled(ctx) && pipelinePVCWorkspaceName != "" {
-		r.Annotations[workspace.AnnotationAffinityAssistantName] = getAffinityAssistantName(pipelinePVCWorkspaceName, pr.Name)
+		r.Annotations[workspace.AnnotationAffinityAssistantName] = GetAffinityAssistantName(pipelinePVCWorkspaceName, pr.Name)
 	}
 
 	logger.Infof("Creating a new CustomRun object %s", runName)
@@ -1049,7 +1052,12 @@ func (c *Reconciler) getTaskrunWorkspaces(ctx context.Context, pr *v1.PipelineRu
 				pipelinePVCWorkspaceName = pipelineWorkspace
 			}
 
-			workspace := c.taskWorkspaceByWorkspaceVolumeSource(ctx, pipelinePVCWorkspaceName, pr.Name, b, taskWorkspaceName, pipelineTaskSubPath, *kmeta.NewControllerRef(pr))
+			aaBehavior, err := affinityassistant.GetAffinityAssistantBehavior(ctx)
+			if err != nil {
+				return nil, "", err
+			}
+
+			workspace := c.taskWorkspaceByWorkspaceVolumeSource(ctx, pipelinePVCWorkspaceName, pr.Name, b, taskWorkspaceName, pipelineTaskSubPath, *kmeta.NewControllerRef(pr), aaBehavior)
 			workspaces = append(workspaces, workspace)
 		} else {
 			workspaceIsOptional := false
@@ -1084,7 +1092,7 @@ func (c *Reconciler) getTaskrunWorkspaces(ctx context.Context, pr *v1.PipelineRu
 // taskWorkspaceByWorkspaceVolumeSource returns the WorkspaceBinding to be bound to each TaskRun in the Pipeline Task.
 // If the PipelineRun WorkspaceBinding is a volumeClaimTemplate, the returned WorkspaceBinding references a PersistentVolumeClaim created for the PipelineRun WorkspaceBinding based on the PipelineRun as OwnerReference.
 // Otherwise, the returned WorkspaceBinding references the same volume as the PipelineRun WorkspaceBinding, with the file path joined with pipelineTaskSubPath as the binding subpath.
-func (c *Reconciler) taskWorkspaceByWorkspaceVolumeSource(ctx context.Context, pipelineWorkspaceName string, prName string, wb v1.WorkspaceBinding, taskWorkspaceName string, pipelineTaskSubPath string, owner metav1.OwnerReference) v1.WorkspaceBinding {
+func (c *Reconciler) taskWorkspaceByWorkspaceVolumeSource(ctx context.Context, pipelineWorkspaceName string, prName string, wb v1.WorkspaceBinding, taskWorkspaceName string, pipelineTaskSubPath string, owner metav1.OwnerReference, aaBehavior affinityassistant.AffinityAssitantBehavior) v1.WorkspaceBinding {
 	if wb.VolumeClaimTemplate == nil {
 		binding := *wb.DeepCopy()
 		binding.Name = taskWorkspaceName
@@ -1098,9 +1106,8 @@ func (c *Reconciler) taskWorkspaceByWorkspaceVolumeSource(ctx context.Context, p
 	}
 	binding.Name = taskWorkspaceName
 
-	if !c.isAffinityAssistantDisabled(ctx) {
-		binding.PersistentVolumeClaim.ClaimName = getPersistentVolumeClaimNameWithAffinityAssistant(pipelineWorkspaceName, prName, wb, owner)
-	} else {
+	// TODO(#6740)(WIP): get binding for AffinityAssistantPerPipelineRun and AffinityAssistantPerPipelineRunWithIsolation mode
+	if aaBehavior == affinityassistant.AffinityAssistantDisabled || aaBehavior == affinityassistant.AffinityAssistantPerWorkspace {
 		binding.PersistentVolumeClaim.ClaimName = volumeclaim.GetPVCNameWithoutAffinityAssistant(wb.VolumeClaimTemplate.Name, wb, owner)
 	}
 

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -484,7 +484,7 @@ func (c *Reconciler) reconcile(ctx context.Context, tr *v1.TaskRun, rtr *resourc
 	// Please note that this block is required to run before `applyParamsContextsResultsAndWorkspaces` is called the first time,
 	// and that `applyParamsContextsResultsAndWorkspaces` _must_ be called on every reconcile.
 	if pod == nil && tr.HasVolumeClaimTemplate() {
-		if err := c.pvcHandler.CreatePVCsForWorkspacesWithoutAffinityAssistant(ctx, tr.Spec.Workspaces, *kmeta.NewControllerRef(tr), tr.Namespace); err != nil {
+		if err := c.pvcHandler.CreatePVCsForWorkspaces(ctx, tr.Spec.Workspaces, *kmeta.NewControllerRef(tr), tr.Namespace); err != nil {
 			logger.Errorf("Failed to create PVC for TaskRun %s: %v", tr.Name, err)
 			tr.Status.MarkResourceFailed(volumeclaim.ReasonCouldntCreateWorkspacePVC,
 				fmt.Errorf("Failed to create PVC for TaskRun %s workspaces correctly: %w",

--- a/pkg/reconciler/volumeclaim/pvchandler.go
+++ b/pkg/reconciler/volumeclaim/pvchandler.go
@@ -38,7 +38,7 @@ const (
 
 // PvcHandler is used to create PVCs for workspaces
 type PvcHandler interface {
-	CreatePVCsForWorkspacesWithoutAffinityAssistant(ctx context.Context, wb []v1.WorkspaceBinding, ownerReference metav1.OwnerReference, namespace string) error
+	CreatePVCsForWorkspaces(ctx context.Context, wb []v1.WorkspaceBinding, ownerReference metav1.OwnerReference, namespace string) error
 }
 
 type defaultPVCHandler struct {
@@ -51,13 +51,11 @@ func NewPVCHandler(clientset clientset.Interface, logger *zap.SugaredLogger) Pvc
 	return &defaultPVCHandler{clientset, logger}
 }
 
-// CreatePVCsForWorkspacesWithoutAffinityAssistant checks if a PVC named <claim-name>-<workspace-name>-<owner-name> exists;
+// CreatePVCsForWorkspaces checks if a PVC named <claim-name>-<workspace-name>-<owner-name> exists;
 // where claim-name is provided by the user in the volumeClaimTemplate, and owner-name is the name of the
 // resource with the volumeClaimTemplate declared, a PipelineRun or TaskRun. If the PVC did not exist, a new PVC
 // with that name is created with the provided OwnerReference.
-// This function is only called when Affinity Assistant is disabled.
-// When Affinity Assistant is enabled, the PersistentVolumeClaims will be created by the Affinity Assistant StatefulSet VolumeClaimTemplate instead.
-func (c *defaultPVCHandler) CreatePVCsForWorkspacesWithoutAffinityAssistant(ctx context.Context, wb []v1.WorkspaceBinding, ownerReference metav1.OwnerReference, namespace string) error {
+func (c *defaultPVCHandler) CreatePVCsForWorkspaces(ctx context.Context, wb []v1.WorkspaceBinding, ownerReference metav1.OwnerReference, namespace string) error {
 	var errs []error
 	for _, claim := range getPVCsWithoutAffinityAssistant(wb, ownerReference, namespace) {
 		_, err := c.clientset.CoreV1().PersistentVolumeClaims(claim.Namespace).Get(ctx, claim.Name, metav1.GetOptions{})

--- a/pkg/reconciler/volumeclaim/pvchandler_test.go
+++ b/pkg/reconciler/volumeclaim/pvchandler_test.go
@@ -83,7 +83,7 @@ func TestCreatePersistentVolumeClaimsForWorkspaces(t *testing.T) {
 
 	// when
 
-	err := pvcHandler.CreatePVCsForWorkspacesWithoutAffinityAssistant(ctx, workspaces, ownerRef, namespace)
+	err := pvcHandler.CreatePVCsForWorkspaces(ctx, workspaces, ownerRef, namespace)
 	if err != nil {
 		t.Fatalf("unexpexted error: %v", err)
 	}
@@ -147,7 +147,7 @@ func TestCreatePersistentVolumeClaimsForWorkspacesWithoutMetadata(t *testing.T) 
 
 	// when
 
-	err := pvcHandler.CreatePVCsForWorkspacesWithoutAffinityAssistant(ctx, workspaces, ownerRef, namespace)
+	err := pvcHandler.CreatePVCsForWorkspaces(ctx, workspaces, ownerRef, namespace)
 	if err != nil {
 		t.Fatalf("unexpexted error: %v", err)
 	}
@@ -205,7 +205,7 @@ func TestCreateExistPersistentVolumeClaims(t *testing.T) {
 	}
 	fakekubeclient.Fake.PrependReactor(actionGet, "*", fn)
 
-	err := pvcHandler.CreatePVCsForWorkspacesWithoutAffinityAssistant(ctx, workspaces, ownerRef, namespace)
+	err := pvcHandler.CreatePVCsForWorkspaces(ctx, workspaces, ownerRef, namespace)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/test/affinity_assistant_test.go
+++ b/test/affinity_assistant_test.go
@@ -1,0 +1,140 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2023 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/tektoncd/pipeline/pkg/reconciler/pipelinerun"
+	"github.com/tektoncd/pipeline/test/parse"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	knativetest "knative.dev/pkg/test"
+)
+
+// TestAffinityAssistant_PerWorkspace tests the lifecycle status of Affinity Assistant and PVCs
+// from the start to the deletion of a PipelineRun
+func TestAffinityAssistant_PerWorkspace(t *testing.T) {
+	ctx := context.Background()
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	c, namespace := setup(ctx, t)
+	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
+	defer tearDown(ctx, t, c, namespace)
+	prName := "my-pipelinerun"
+	pr := parse.MustParseV1PipelineRun(t, fmt.Sprintf(`
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  pipelineSpec:
+    workspaces:
+    - name: my-workspace
+    tasks:
+    - name: foo
+      workspaces:
+      - name: my-workspace
+      taskSpec:
+        steps:
+        - image: busybox
+          script: echo hello foo
+    - name: bar
+      workspaces:
+      - name: my-workspace
+      taskSpec:
+        steps:
+        - image: busybox
+          script: echo hello bar
+  workspaces:
+  - name: my-workspace
+    volumeClaimTemplate:
+      metadata:
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 16Mi
+`, prName, namespace))
+
+	if _, err := c.V1PipelineRunClient.Create(ctx, pr, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Failed to create PipelineRun: %s", err)
+	}
+	t.Logf("Waiting for PipelineRun in namespace %s to run", namespace)
+	if err := WaitForPipelineRunState(ctx, c, prName, timeout, Running(prName), "PipelineRun Running", v1Version); err != nil {
+		t.Fatalf("Error waiting for PipelineRun to run: %s", err)
+	}
+
+	// validate SS and PVC are created
+	ssName := pipelinerun.GetAffinityAssistantName("my-workspace", pr.Name)
+	ss, err := c.KubeClient.AppsV1().StatefulSets(namespace).Get(ctx, ssName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't get expected Affinity Assistant StatefulSet %s, err: %s", ss, err)
+	}
+	pvcList, err := c.KubeClient.CoreV1().PersistentVolumeClaims(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't get expected PVCs: %s", err)
+	}
+	if len(pvcList.Items) != 1 {
+		t.Fatalf("Unexpected PVC created, expecting 1 but got: %v", len(pvcList.Items))
+	}
+	pvcName := pvcList.Items[0].Name
+
+	// wait for PipelineRun to finish
+	t.Logf("Waiting for PipelineRun in namespace %s to finish", namespace)
+	if err := WaitForPipelineRunState(ctx, c, prName, timeout, PipelineRunSucceed(prName), "PipelineRunSucceeded", v1Version); err != nil {
+		t.Errorf("Error waiting for PipelineRun to finish: %s", err)
+	}
+
+	// validate Affinity Assistant is cleaned up
+	ss, err = c.KubeClient.AppsV1().StatefulSets(namespace).Get(ctx, ssName, metav1.GetOptions{})
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("Failed to cleanup Affinity Assistant StatefulSet: %v, err: %v", ssName, err)
+	}
+
+	// validate PipelineRun pods sharing the same PVC are scheduled to the same node
+	podFoo, err := c.KubeClient.CoreV1().Pods(namespace).Get(ctx, fmt.Sprintf("%v-foo-pod", prName), metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get pod: %v-foo-pod, err: %v", prName, err)
+	}
+	podBar, err := c.KubeClient.CoreV1().Pods(namespace).Get(ctx, fmt.Sprintf("%v-bar-pod", prName), metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get pod: %v-bar-pod, err: %v", prName, err)
+	}
+	if podFoo.Spec.NodeName != podBar.Spec.NodeName {
+		t.Errorf("pods are not scheduled to same node: %v and %v", podFoo.Spec.NodeName, podBar.Spec.NodeName)
+	}
+
+	// delete PipelineRun
+	if err = c.V1PipelineRunClient.Delete(ctx, prName, metav1.DeleteOptions{}); err != nil {
+		t.Fatalf("failed to delete PipelineRun: %s", err)
+	}
+
+	// validate PVC is in bounded state
+	pvc, err := c.KubeClient.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, pvcName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get PVC %v after PipelineRun is deleted, err: %v", pvcName, err)
+	}
+	if pvc.Status.Phase != "Bound" {
+		t.Fatalf("expect PVC %s to be in bounded state but got %v", pvcName, pvc.Status.Phase)
+	}
+}


### PR DESCRIPTION
Part of [#6740] and unblocks [#6635]. `PVCs` are created if a user specifies `VolumeClaimTemplate` as the source of a `pipelinerun workspace`. Prior to this change, such `pvcs` are created via `affinity assistant statefulset` when `affinity assistant` is enabled (in both `workspaces` or `pipelineruns` coschedule mode).

To delete such pvcs when the owning `pipelinerun` is completed, we must explicitly delete those pvcs in the reconciler since the owner of such pvcs is the `affinity assistant statefulset` instead of the `pipelinerun`. The problem of such deletion mechanism is that such `pvcs` are left in `terminating` state when the owning `pipelinerun` is `completed` but not `deleted`. This is because the pvcs are protected by `kubernetes.io/pvc-protection` `finalizer`, which does not allow the `pvcs` to be deleted until the `pipelinerun` consuming the `pvc` is deleted. Leaving pvcs in `terminating` state is confusing to cluster operators. Instead of changing the pvc deletion behavior in such backward incompatible way, it is better to make it configurable so that it is backward compatible, as prototyped in [#6635].

This commit reverts the pvc creation behavior `per-workspace` coschedule mode, which changes the owner of the `pvcs` back to the `pipelinerun` instead of the `affinity assistant statefulset`. After the commit, the pvcs created by specifying `VolumeClaimTemplate` are left in `bounded` state instead of `terminating`. This commit is the prerequisite of [#6635].

This commit does NOT reverts the pvc creation behavior `per-pipelinerun` coschedule mode as we will enforce the deletion of pvcs when the owning `pipelinerun` is completed. This is a better practice and there is no backward compatability concern since `per-pipelinerun` coschedule mode is a new feature.

[#6740]: https://github.com/tektoncd/pipeline/issues/6740
[#6635]: https://github.com/tektoncd/pipeline/pull/6635

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
TEP-0135: Revert the owner of `PVCs` created by `pipelinerun VolumeClaimTemplate` back to `pipelinerun`. The `PVCs` bounded to the `pipelinerun` is now in `bounded` state when the `pipelinerun` is completed but not deleted.
```
