### PR TITLE
Ignore SA in assertion

### DIFF
--- a/test/custom_task_test.go
+++ b/test/custom_task_test.go
@@ -685,6 +685,8 @@ func TestWaitCustomTask_V1_PipelineRun(t *testing.T) {
 				filterCondition,
 				filterCustomRunStatus,
 				filterPipelineRunStatus,
+				// ignore serviceaccount field also, because it can be different based on the value in config-defaults
+				ignoreSAPipelineRunSpec,
 			); d != "" {
 				t.Errorf("-want, +got: %v", d)
 			}


### PR DESCRIPTION
This removes SA in assertion as this value can
be changes based on the configmap value

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
