### PR TITLE
Document that Workspaces can be unused

### DIFF
--- a/docs/pipelineruns.md
+++ b/docs/pipelineruns.md
@@ -946,6 +946,33 @@ workspaces:
 `workspaces[].subPath` can be an absolute value or can reference `pipelineRun` context variables, such as,
 `$(context.pipelineRun.name)` or `$(context.pipelineRun.uid)`.
 
+You can pass in extra `Workspaces` if needed depending on your use cases. An example use
+case is when your CI system autogenerates `PipelineRuns` and it has `Workspaces` it wants to
+provide to all `PipelineRuns`. Because you can pass in extra `Workspaces`, you don't have to
+go through the complexity of checking each `Pipeline` and providing only the required `Workspaces`:
+
+```yaml
+apiVersion: tekton.dev/v1 # or tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: pipeline
+spec:
+  tasks:
+    - name: task
+---
+apiVersion: tekton.dev/v1 # or tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: pipelinerun
+spec:
+  pipelineRef:
+    name: pipeline
+  workspaces:
+    - name: unusedworkspace
+      persistentVolumeClaim:
+        claimName: mypvc
+```
+
 For more information, see the following topics:
 - For information on mapping `Workspaces` to `Volumes`, see [Specifying `Workspaces` in `PipelineRuns`](workspaces.md#specifying-workspaces-in-pipelineruns).
 - For a list of supported `Volume` types, see [Specifying `VolumeSources` in `Workspaces`](workspaces.md#specifying-volumesources-in-workspaces).

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -402,6 +402,11 @@ The entry must also include one `VolumeSource`. See [Using `VolumeSources` with 
 
 **Note:** If the `Workspaces` specified by a `Pipeline` are not provided at runtime by a `PipelineRun`, that `PipelineRun` will fail.
 
+You can pass in extra `Workspaces` if needed depending on your use cases. An example use
+case is when your CI system autogenerates `PipelineRuns` and it has `Workspaces` it wants to
+provide to all `PipelineRuns`. Because you can pass in extra `Workspaces`, you don't have to
+go through the complexity of checking each `Pipeline` and providing only the required `Workspaces`.
+
 #### Example `PipelineRun` definition using `Workspaces`
 
 In the example below, a `volumeClaimTemplate` is provided for how a `PersistentVolumeClaim` should be created for a workspace named


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Document that Workspaces in a PipelineRun can be unused, as per discussion on #6856
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [X] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [X] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [X] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
