### PR TITLE
[RFC] Increase support window for v1beta1 CRDs to 1 year

### DIFF
--- a/api_compatibility_policy.md
+++ b/api_compatibility_policy.md
@@ -62,6 +62,8 @@ and follows the [beta policy](#beta-crds) for backwards incompatible changes.
 - Any [backwards incompatible changes](#backwards-incompatible-changes) must be introduced in a backwards compatible manner first, with a deprecation warning in the release notes and migration instructions.
 
 - Users will be given at least 9 months to migrate before a backward incompatible change is made. This means an older beta API version will continue to be supported in new releases for a period of at least 9 months from the time a newer version is made available.
+  - As a special case, the `v1beta1` CRDs will not be removed until 1 year after they are deprecated,
+  because no stable API was available when they were created. The 9 month policy will apply to future beta APIs.
 
 - Alpha features may be present within a beta API version. However, they will not be enabled by default and must be enabled by setting `enable-api-fields` to `alpha`.
 


### PR DESCRIPTION
This commit updates the support policy for v1beta1 CRDs to 1 year, to give users more time to migrate off of the v1beta1 API.

v1beta1 is considered a special case because there were no stable APIs available when it was created. To avoid users becoming dependent on future unstable APIs and inhibiting development, the existing policy of 9 months will apply to future beta CRDs.

/kind documentation

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- n/a Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- n/a Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Support window for beta CRDs increased to 1 year
```
