### PR TITLE
[TEP-0135] Coschedule per (Isolated) PipelineRun e2e support

### DIFF
--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -418,7 +418,11 @@ func (c *Reconciler) prepare(ctx context.Context, tr *v1.TaskRun) (*v1.TaskSpec,
 		return nil, nil, controller.NewPermanentError(err)
 	}
 
-	if _, usesAssistant := tr.Annotations[workspace.AnnotationAffinityAssistantName]; usesAssistant {
+	aaBehavior, err := affinityassistant.GetAffinityAssistantBehavior(ctx)
+	if err != nil {
+		return nil, nil, controller.NewPermanentError(err)
+	}
+	if aaBehavior == affinityassistant.AffinityAssistantPerWorkspace {
 		if err := workspace.ValidateOnlyOnePVCIsUsed(tr.Spec.Workspaces); err != nil {
 			logger.Errorf("TaskRun %q workspaces incompatible with Affinity Assistant: %v", tr.Name, err)
 			tr.Status.MarkResourceFailed(podconvert.ReasonFailedValidation, err)

--- a/test/affinity_assistant_test.go
+++ b/test/affinity_assistant_test.go
@@ -22,10 +22,14 @@ package test
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"testing"
 
+	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/test/parse"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"knative.dev/pkg/system"
 	knativetest "knative.dev/pkg/test"
 )
 
@@ -94,17 +98,8 @@ spec:
 	pvcName := pvcList.Items[0].Name
 
 	// validate PipelineRun pods sharing the same PVC are scheduled to the same node
-	podFoo, err := c.KubeClient.CoreV1().Pods(namespace).Get(ctx, fmt.Sprintf("%v-foo-pod", prName), metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("Failed to get pod: %v-foo-pod, err: %v", prName, err)
-	}
-	podBar, err := c.KubeClient.CoreV1().Pods(namespace).Get(ctx, fmt.Sprintf("%v-bar-pod", prName), metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("Failed to get pod: %v-bar-pod, err: %v", prName, err)
-	}
-	if podFoo.Spec.NodeName != podBar.Spec.NodeName {
-		t.Errorf("pods are not scheduled to same node: %v and %v", podFoo.Spec.NodeName, podBar.Spec.NodeName)
-	}
+	podNames := []string{fmt.Sprintf("%v-foo-pod", prName), fmt.Sprintf("%v-bar-pod", prName)}
+	validatePodAffinity(t, ctx, podNames, namespace, c.KubeClient)
 
 	// delete PipelineRun
 	if err = c.V1PipelineRunClient.Delete(ctx, prName, metav1.DeleteOptions{}); err != nil {
@@ -119,4 +114,128 @@ spec:
 	if pvc.Status.Phase != "Bound" {
 		t.Fatalf("expect PVC %s to be in bounded state but got %v", pvcName, pvc.Status.Phase)
 	}
+}
+
+// TestAffinityAssistant_PerPipelineRun tests that mounting multiple PVC based workspaces to a pipeline task is allowed and
+// all the pods are scheduled to the same node in AffinityAssistantPerPipelineRuns mode
+func TestAffinityAssistant_PerPipelineRun(t *testing.T) {
+	ctx := context.Background()
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	c, namespace := setup(ctx, t)
+	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
+	defer resetFeatureFlagAndCleanup(ctx, t, c, namespace)
+
+	// update feature flag
+	configMapData := map[string]string{
+		"coschedule":                 config.CoschedulePipelineRuns,
+		"disable-affinity-assistant": "true",
+	}
+	if err := updateConfigMap(ctx, c.KubeClient, system.Namespace(), config.GetFeatureFlagsConfigName(), configMapData); err != nil {
+		t.Fatal(err)
+	}
+
+	prName := "my-pipelinerun"
+	pr := parse.MustParseV1PipelineRun(t, fmt.Sprintf(`
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  pipelineSpec:
+    workspaces:
+    - name: my-workspace
+    - name: my-workspace2
+    tasks:
+    - name: foo
+      workspaces:
+      - name: my-workspace
+      taskSpec:
+        steps:
+        - image: busybox
+          script: echo hello foo
+    - name: bar
+      workspaces:
+      - name: my-workspace2
+      taskSpec:
+        steps:
+        - image: busybox
+          script: echo hello bar
+    - name: double-ws
+      workspaces:
+      - name: my-workspace
+      - name: my-workspace2
+      taskSpec:
+        steps:
+        - image: busybox
+          script: echo double-ws
+    - name: no-ws
+      taskSpec:
+        steps:
+        - image: busybox
+        script: echo no-ws
+  workspaces:
+  - name: my-workspace
+    volumeClaimTemplate:
+      metadata:
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 16Mi
+  - name: my-workspace2
+    volumeClaimTemplate:
+      metadata:
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 16Mi
+`, prName, namespace))
+
+	// create PipelineRun
+	if _, err := c.V1PipelineRunClient.Create(ctx, pr, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Failed to create PipelineRun: %s", err)
+	}
+
+	// wait for PipelineRun to finish
+	t.Logf("Waiting for PipelineRun in namespace %s to finish", namespace)
+	if err := WaitForPipelineRunState(ctx, c, prName, timeout, PipelineRunSucceed(prName), "PipelineRunSucceeded", v1Version); err != nil {
+		t.Errorf("Error waiting for PipelineRun to finish: %s", err)
+	}
+
+	// validate PipelineRun pods sharing the same PVC are scheduled to the same node
+	podNames := []string{fmt.Sprintf("%v-foo-pod", prName), fmt.Sprintf("%v-bar-pod", prName), fmt.Sprintf("%v-double-ws-pod", prName), fmt.Sprintf("%v-no-ws-pod", prName)}
+	validatePodAffinity(t, ctx, podNames, namespace, c.KubeClient)
+}
+
+// validatePodAffinity checks if all the given pods are scheduled to the same node
+func validatePodAffinity(t *testing.T, ctx context.Context, podNames []string, namespace string, client kubernetes.Interface) {
+	t.Helper()
+	nodeName := ""
+	for _, podName := range podNames {
+		pod, err := client.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("Failed to get pod: %v, err: %v", podName, err)
+		}
+
+		if nodeName == "" {
+			nodeName = pod.Spec.NodeName
+		} else if pod.Spec.NodeName != nodeName {
+			t.Errorf("pods are not scheduled to the same node as expected %v vs %v", nodeName, pod.Spec.NodeName)
+		}
+	}
+}
+
+func resetFeatureFlagAndCleanup(ctx context.Context, t *testing.T, c *clients, namespace string) {
+	t.Helper()
+	configMapData := map[string]string{
+		"coschedule":                 config.DefaultCoschedule,
+		"disable-affinity-assistant": strconv.FormatBool(config.DefaultDisableAffinityAssistant),
+	}
+	if err := updateConfigMap(ctx, c.KubeClient, system.Namespace(), config.GetFeatureFlagsConfigName(), configMapData); err != nil {
+		t.Fatal(err)
+	}
+	tearDown(ctx, t, c, namespace)
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Part of [#6740]. [TEP-0135][tep-0135] introduces a feature that allows a cluster operator to ensure that all of a PipelineRun's pods are scheduled to the same node.

This commit consumes the functions added in [#6819] and implements end to end support of `coschedule:pipelineruns` coscheduling mode, where all the `PipelineRun pods` are scheduled to the same node.

/kind feature

[#6819]: https://github.com/tektoncd/pipeline/pull/6819
[#6740]: https://github.com/tektoncd/pipeline/issues/6740
[tep-0135]: https://github.com/tektoncd/community/blob/main/teps/0135-coscheduling-pipelinerun-pods.md
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
[TEP-0135]: Support `coschedule: pipelineruns` and `coschedule: isolate-pipelinerun` coschedule modes.
Users can now opt in this new feature to schedule all the pods in the same node and to optionally enforce one running pipelinerun in a node at the same time.
```
