### PR TITLE
Fix typo in AffinityAssistantBehavior

### DIFF
--- a/pkg/internal/affinityassistant/affinityassistant_types.go
+++ b/pkg/internal/affinityassistant/affinityassistant_types.go
@@ -20,19 +20,19 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 )
 
-type AffinityAssitantBehavior string
+type AffinityAssistantBehavior string
 
 const (
-	AffinityAssistantDisabled                    = AffinityAssitantBehavior("AffinityAssistantDisabled")
-	AffinityAssistantPerWorkspace                = AffinityAssitantBehavior("AffinityAssistantPerWorkspace")
-	AffinityAssistantPerPipelineRun              = AffinityAssitantBehavior("AffinityAssistantPerPipelineRun")
-	AffinityAssistantPerPipelineRunWithIsolation = AffinityAssitantBehavior("AffinityAssistantPerPipelineRunWithIsolation")
+	AffinityAssistantDisabled                    = AffinityAssistantBehavior("AffinityAssistantDisabled")
+	AffinityAssistantPerWorkspace                = AffinityAssistantBehavior("AffinityAssistantPerWorkspace")
+	AffinityAssistantPerPipelineRun              = AffinityAssistantBehavior("AffinityAssistantPerPipelineRun")
+	AffinityAssistantPerPipelineRunWithIsolation = AffinityAssistantBehavior("AffinityAssistantPerPipelineRunWithIsolation")
 )
 
-// GetAffinityAssistantBehavior returns an AffinityAssitantBehavior based on the
+// GetAffinityAssistantBehavior returns an AffinityAssistantBehavior based on the
 // combination of "disable-affinity-assistant" and "coschedule" feature flags
 // TODO(#6740)(WIP): consume this function in the PipelineRun reconciler to determine Affinity Assistant behavior.
-func GetAffinityAssistantBehavior(ctx context.Context) (AffinityAssitantBehavior, error) {
+func GetAffinityAssistantBehavior(ctx context.Context) (AffinityAssistantBehavior, error) {
 	cfg := config.FromContextOrDefaults(ctx)
 	disableAA := cfg.FeatureFlags.DisableAffinityAssistant
 	coschedule := cfg.FeatureFlags.Coschedule

--- a/pkg/internal/affinityassistant/affinityassistant_types_test.go
+++ b/pkg/internal/affinityassistant/affinityassistant_types_test.go
@@ -28,7 +28,7 @@ func Test_GetAffinityAssistantBehavior(t *testing.T) {
 	tcs := []struct {
 		name      string
 		configMap map[string]string
-		expect    AffinityAssitantBehavior
+		expect    AffinityAssistantBehavior
 	}{{
 		name: "affinity-assistant-enabled",
 		configMap: map[string]string{
@@ -73,7 +73,7 @@ func Test_GetAffinityAssistantBehavior(t *testing.T) {
 		}
 
 		if d := cmp.Diff(tc.expect, get); d != "" {
-			t.Errorf("AffinityAssitantBehavior mismatch: %v", diff.PrintWantGot(d))
+			t.Errorf("AffinityAssistantBehavior mismatch: %v", diff.PrintWantGot(d))
 		}
 	}
 }

--- a/pkg/reconciler/pipelinerun/affinity_assistant.go
+++ b/pkg/reconciler/pipelinerun/affinity_assistant.go
@@ -49,11 +49,11 @@ const (
 
 // createOrUpdateAffinityAssistantsAndPVCs creates Affinity Assistant StatefulSets and PVCs based on AffinityAssistantBehavior.
 // This is done to achieve Node Affinity for taskruns in a pipelinerun, and make it possible for the taskruns to execute parallel while sharing volume.
-// If the AffinityAssitantBehavior is AffinityAssistantPerWorkspace, it creates an Affinity Assistant for
+// If the AffinityAssistantBehavior is AffinityAssistantPerWorkspace, it creates an Affinity Assistant for
 // every taskrun in the pipelinerun that use the same PVC based volume.
-// If the AffinityAssitantBehavior is AffinityAssistantPerPipelineRun or AffinityAssistantPerPipelineRunWithIsolation,
+// If the AffinityAssistantBehavior is AffinityAssistantPerPipelineRun or AffinityAssistantPerPipelineRunWithIsolation,
 // it creates one Affinity Assistant for the pipelinerun.
-func (c *Reconciler) createOrUpdateAffinityAssistantsAndPVCs(ctx context.Context, pr *v1.PipelineRun, aaBehavior aa.AffinityAssitantBehavior) error {
+func (c *Reconciler) createOrUpdateAffinityAssistantsAndPVCs(ctx context.Context, pr *v1.PipelineRun, aaBehavior aa.AffinityAssistantBehavior) error {
 	var errs []error
 	var unschedulableNodes sets.Set[string] = nil
 

--- a/pkg/reconciler/pipelinerun/affinity_assistant_test.go
+++ b/pkg/reconciler/pipelinerun/affinity_assistant_test.go
@@ -190,7 +190,7 @@ func TestCreateAndDeleteOfAffinityAssistantPerWorkspaceOrDisabled(t *testing.T) 
 		name, expectedPVCName string
 		pr                    *v1.PipelineRun
 		expectStatefulSetSpec []*appsv1.StatefulSetSpec
-		aaBehavior            aa.AffinityAssitantBehavior
+		aaBehavior            aa.AffinityAssistantBehavior
 	}{{
 		name:       "PersistentVolumeClaim Workspace type",
 		aaBehavior: aa.AffinityAssistantPerWorkspace,

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -1102,7 +1102,7 @@ func (c *Reconciler) getTaskrunWorkspaces(ctx context.Context, pr *v1.PipelineRu
 // taskWorkspaceByWorkspaceVolumeSource returns the WorkspaceBinding to be bound to each TaskRun in the Pipeline Task.
 // If the PipelineRun WorkspaceBinding is a volumeClaimTemplate, the returned WorkspaceBinding references a PersistentVolumeClaim created for the PipelineRun WorkspaceBinding based on the PipelineRun as OwnerReference.
 // Otherwise, the returned WorkspaceBinding references the same volume as the PipelineRun WorkspaceBinding, with the file path joined with pipelineTaskSubPath as the binding subpath.
-func (c *Reconciler) taskWorkspaceByWorkspaceVolumeSource(ctx context.Context, pipelineWorkspaceName string, prName string, wb v1.WorkspaceBinding, taskWorkspaceName string, pipelineTaskSubPath string, owner metav1.OwnerReference, aaBehavior affinityassistant.AffinityAssitantBehavior) v1.WorkspaceBinding {
+func (c *Reconciler) taskWorkspaceByWorkspaceVolumeSource(ctx context.Context, pipelineWorkspaceName string, prName string, wb v1.WorkspaceBinding, taskWorkspaceName string, pipelineTaskSubPath string, owner metav1.OwnerReference, aaBehavior affinityassistant.AffinityAssistantBehavior) v1.WorkspaceBinding {
 	if wb.VolumeClaimTemplate == nil {
 		binding := *wb.DeepCopy()
 		binding.Name = taskWorkspaceName

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -7676,7 +7676,7 @@ func Test_taskWorkspaceByWorkspaceVolumeSource(t *testing.T) {
 		name, taskWorkspaceName, pipelineWorkspaceName, prName string
 		wb                                                     v1.WorkspaceBinding
 		expectedBinding                                        v1.WorkspaceBinding
-		aaBehavior                                             affinityassistant.AffinityAssitantBehavior
+		aaBehavior                                             affinityassistant.AffinityAssistantBehavior
 	}{
 		{
 			name:                  "PVC Workspace with Affinity Assistant",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This commit fixes the typo in `AffinityAssitantBehavior` to `AffinityAssistantBehavior`.

/kind cleanup

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
