### PR TITLE
Delete .ko.yaml

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,5 +1,0 @@
-defaultBaseImage: cgr.dev/chainguard/static
-baseImageOverrides:
-  # git-init uses a base image that includes Git, and supports running either
-  # as root or as user nonroot with UID 65532.
-  github.com/tektoncd/pipeline/cmd/git-init: cgr.dev/chainguard/git


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

/kind cleanup

Deletes `.ko.yaml` from the repo

This file isn't necessary anymore, since:

1. `./cmd/git-init` is no longer defined
2. the default base image for the latest versions of `ko` is already `cgr.dev/chainguard/static`

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```

Friction log:
- despite adding `/kind cleanup` in the PR description, and the label being added, `check-pr-has-kind-label` [failed](https://github.com/tektoncd/pipeline/pull/6931#issuecomment-1638486868) adding two PR comments
- Invoking the suggested command to re-run it resulted in "The specified target(s) for /test were not found."