### PR TITLE
Move feature flags testing functions into testing package

### DIFF
--- a/pkg/apis/config/feature_flags.go
+++ b/pkg/apis/config/feature_flags.go
@@ -334,21 +334,6 @@ func NewFeatureFlagsFromConfigMap(config *corev1.ConfigMap) (*FeatureFlags, erro
 	return NewFeatureFlagsFromMap(config.Data)
 }
 
-// EnableAlphaAPIFields enables alpha features in an existing context (for use in testing)
-func EnableAlphaAPIFields(ctx context.Context) context.Context {
-	return setEnableAPIFields(ctx, AlphaAPIFields)
-}
-
-// EnableBetaAPIFields enables beta features in an existing context (for use in testing)
-func EnableBetaAPIFields(ctx context.Context) context.Context {
-	return setEnableAPIFields(ctx, BetaAPIFields)
-}
-
-// EnableStableAPIFields enables stable features in an existing context (for use in testing)
-func EnableStableAPIFields(ctx context.Context) context.Context {
-	return setEnableAPIFields(ctx, StableAPIFields)
-}
-
 // GetVerificationNoMatchPolicy returns the "trusted-resources-verification-no-match-policy" value
 func GetVerificationNoMatchPolicy(ctx context.Context) string {
 	return FromContextOrDefaults(ctx).FeatureFlags.VerificationNoMatchPolicy
@@ -357,17 +342,4 @@ func GetVerificationNoMatchPolicy(ctx context.Context) string {
 // IsSpireEnabled checks if non-falsifiable provenance is enforced through SPIRE
 func IsSpireEnabled(ctx context.Context) bool {
 	return FromContextOrDefaults(ctx).FeatureFlags.EnforceNonfalsifiability == EnforceNonfalsifiabilityWithSpire
-}
-
-func setEnableAPIFields(ctx context.Context, want string) context.Context {
-	featureFlags, _ := NewFeatureFlagsFromMap(map[string]string{
-		"enable-api-fields": want,
-	})
-	cfg := &Config{
-		Defaults: &Defaults{
-			DefaultTimeoutMinutes: 60,
-		},
-		FeatureFlags: featureFlags,
-	}
-	return ToContext(ctx, cfg)
 }

--- a/pkg/apis/config/testing/featureflags.go
+++ b/pkg/apis/config/testing/featureflags.go
@@ -38,3 +38,31 @@ func SetFeatureFlags(ctx context.Context, t *testing.T, data map[string]string) 
 	})
 	return s.ToContext(ctx)
 }
+
+// EnableAlphaAPIFields enables alpha features in an existing context (for use in testing)
+func EnableAlphaAPIFields(ctx context.Context) context.Context {
+	return setEnableAPIFields(ctx, config.AlphaAPIFields)
+}
+
+// EnableBetaAPIFields enables beta features in an existing context (for use in testing)
+func EnableBetaAPIFields(ctx context.Context) context.Context {
+	return setEnableAPIFields(ctx, config.BetaAPIFields)
+}
+
+// EnableStableAPIFields enables stable features in an existing context (for use in testing)
+func EnableStableAPIFields(ctx context.Context) context.Context {
+	return setEnableAPIFields(ctx, config.StableAPIFields)
+}
+
+func setEnableAPIFields(ctx context.Context, want string) context.Context {
+	featureFlags, _ := config.NewFeatureFlagsFromMap(map[string]string{
+		"enable-api-fields": want,
+	})
+	cfg := &config.Config{
+		Defaults: &config.Defaults{
+			DefaultTimeoutMinutes: 60,
+		},
+		FeatureFlags: featureFlags,
+	}
+	return config.ToContext(ctx, cfg)
+}

--- a/pkg/apis/pipeline/v1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1/pipeline_validation_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
+	cfgtesting "github.com/tektoncd/pipeline/pkg/apis/config/testing"
 	"github.com/tektoncd/pipeline/test/diff"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -1341,7 +1342,7 @@ func TestValidatePipelineParameterVariables_Success(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := config.EnableAlphaAPIFields(context.Background())
+			ctx := cfgtesting.EnableAlphaAPIFields(context.Background())
 			err := ValidatePipelineParameterVariables(ctx, tt.tasks, tt.params)
 			if err != nil {
 				t.Errorf("Pipeline.ValidatePipelineParameterVariables() returned error for valid pipeline parameters: %v", err)
@@ -3537,12 +3538,12 @@ func TestPipelineWithBetaFields(t *testing.T) {
 	for _, tt := range tts {
 		t.Run(tt.name, func(t *testing.T) {
 			pipeline := Pipeline{ObjectMeta: metav1.ObjectMeta{Name: "foo"}, Spec: tt.spec}
-			ctx := config.EnableStableAPIFields(context.Background())
+			ctx := cfgtesting.EnableStableAPIFields(context.Background())
 			if err := pipeline.Validate(ctx); err == nil {
 				t.Errorf("no error when using beta field when `enable-api-fields` is stable")
 			}
 
-			ctx = config.EnableBetaAPIFields(context.Background())
+			ctx = cfgtesting.EnableBetaAPIFields(context.Background())
 			if err := pipeline.Validate(ctx); err != nil {
 				t.Errorf("unexpected error when using beta field: %s", err)
 			}

--- a/pkg/apis/pipeline/v1/pipelineref_validation_test.go
+++ b/pkg/apis/pipeline/v1/pipelineref_validation_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/tektoncd/pipeline/pkg/apis/config"
+	cfgtesting "github.com/tektoncd/pipeline/pkg/apis/config/testing"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/test/diff"
 	"knative.dev/pkg/apis"
@@ -44,7 +44,7 @@ func TestPipelineRef_Invalid(t *testing.T) {
 				Resolver: "foo",
 			},
 		},
-		withContext: config.EnableStableAPIFields,
+		withContext: cfgtesting.EnableStableAPIFields,
 		wantErr:     apis.ErrGeneric("resolver requires \"enable-api-fields\" feature gate to be \"alpha\" or \"beta\" but it is \"stable\""),
 	}, {
 		name: "pipelineref params disallowed without beta feature gate",
@@ -53,7 +53,7 @@ func TestPipelineRef_Invalid(t *testing.T) {
 				Params: v1.Params{},
 			},
 		},
-		withContext: config.EnableStableAPIFields,
+		withContext: cfgtesting.EnableStableAPIFields,
 		wantErr:     apis.ErrMissingField("resolver").Also(apis.ErrGeneric("resolver params requires \"enable-api-fields\" feature gate to be \"alpha\" or \"beta\" but it is \"stable\"")),
 	}, {
 		name: "pipelineref params disallowed without resolver",
@@ -63,7 +63,7 @@ func TestPipelineRef_Invalid(t *testing.T) {
 			},
 		},
 		wantErr:     apis.ErrMissingField("resolver"),
-		withContext: config.EnableBetaAPIFields,
+		withContext: cfgtesting.EnableBetaAPIFields,
 	}, {
 		name: "pipelineref resolver disallowed in conjunction with pipelineref name",
 		ref: &v1.PipelineRef{
@@ -73,7 +73,7 @@ func TestPipelineRef_Invalid(t *testing.T) {
 			},
 		},
 		wantErr:     apis.ErrMultipleOneOf("name", "resolver"),
-		withContext: config.EnableBetaAPIFields,
+		withContext: cfgtesting.EnableBetaAPIFields,
 	}, {
 		name: "pipelineref params disallowed in conjunction with pipelineref name",
 		ref: &v1.PipelineRef{
@@ -89,7 +89,7 @@ func TestPipelineRef_Invalid(t *testing.T) {
 			},
 		},
 		wantErr:     apis.ErrMultipleOneOf("name", "params").Also(apis.ErrMissingField("resolver")),
-		withContext: config.EnableBetaAPIFields,
+		withContext: cfgtesting.EnableBetaAPIFields,
 	}, {
 		name: "pipelineref param object not allowed in stable",
 		ref: &v1.PipelineRef{
@@ -107,7 +107,7 @@ func TestPipelineRef_Invalid(t *testing.T) {
 		wantErr: apis.ErrGeneric("resolver requires \"enable-api-fields\" feature gate to be \"alpha\" or \"beta\" but it is \"stable\"").Also(
 			apis.ErrGeneric("resolver params requires \"enable-api-fields\" feature gate to be \"alpha\" or \"beta\" but it is \"stable\"")).Also(
 			apis.ErrGeneric("object type parameter requires \"enable-api-fields\" feature gate to be \"alpha\" or \"beta\" but it is \"stable\"")),
-		withContext: config.EnableStableAPIFields,
+		withContext: cfgtesting.EnableStableAPIFields,
 	}}
 
 	for _, tc := range tests {
@@ -135,11 +135,11 @@ func TestPipelineRef_Valid(t *testing.T) {
 	}, {
 		name: "beta feature: valid resolver",
 		ref:  &v1.PipelineRef{ResolverRef: v1.ResolverRef{Resolver: "git"}},
-		wc:   config.EnableBetaAPIFields,
+		wc:   cfgtesting.EnableBetaAPIFields,
 	}, {
 		name: "beta feature: valid resolver with alpha flag",
 		ref:  &v1.PipelineRef{ResolverRef: v1.ResolverRef{Resolver: "git"}},
-		wc:   config.EnableAlphaAPIFields,
+		wc:   cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "alpha feature: valid resolver with params",
 		ref: &v1.PipelineRef{ResolverRef: v1.ResolverRef{Resolver: "git", Params: v1.Params{{
@@ -155,7 +155,7 @@ func TestPipelineRef_Valid(t *testing.T) {
 				StringVal: "baz",
 			},
 		}}}},
-		wc: config.EnableAlphaAPIFields,
+		wc: cfgtesting.EnableAlphaAPIFields,
 	}}
 
 	for _, ts := range tests {

--- a/pkg/apis/pipeline/v1/pipelinerun_validation_test.go
+++ b/pkg/apis/pipeline/v1/pipelinerun_validation_test.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/tektoncd/pipeline/pkg/apis/config"
+	cfgtesting "github.com/tektoncd/pipeline/pkg/apis/config/testing"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/test/diff"
@@ -140,7 +140,7 @@ func TestPipelineRun_Invalid(t *testing.T) {
 			Message: `non-existent variable in "$(params.pipeline-words.not-hello)"`,
 			Paths:   []string{"spec.steps[0].args[0]"},
 		},
-		wc: config.EnableAlphaAPIFields,
+		wc: cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "propagating object params with pipelinespec and taskspec params not provided",
 		pr: v1.PipelineRun{
@@ -178,7 +178,7 @@ func TestPipelineRun_Invalid(t *testing.T) {
 			Message: `non-existent variable in "$(params.pipeline-words.not-hello)"`,
 			Paths:   []string{"spec.steps[0].args[0]"},
 		},
-		wc: config.EnableAlphaAPIFields,
+		wc: cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "propagating object params with pipelinespec and taskspec params provided in taskrun",
 		pr: v1.PipelineRun{
@@ -223,7 +223,7 @@ func TestPipelineRun_Invalid(t *testing.T) {
 			Message: `non-existent variable in "$(params.pipeline-words.not-hello)"`,
 			Paths:   []string{"spec.steps[0].args[0]"},
 		},
-		wc: config.EnableAlphaAPIFields,
+		wc: cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "propagating params with pipelinespec and taskspec",
 		pr: v1.PipelineRun{
@@ -319,7 +319,7 @@ func TestPipelineRun_Invalid(t *testing.T) {
 			Message: `non-existent variable in "$(params.pipeline-words.not-hello)"`,
 			Paths:   []string{"spec.steps[0].args[0]"},
 		},
-		wc: config.EnableAlphaAPIFields,
+		wc: cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "pipelinerun pending while running",
 		pr: v1.PipelineRun{
@@ -446,7 +446,7 @@ func TestPipelineRun_Validate(t *testing.T) {
 				},
 			},
 		},
-		wc: config.EnableAlphaAPIFields,
+		wc: cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "propagating params with pipelinespec and taskspec",
 		pr: v1.PipelineRun{
@@ -476,7 +476,7 @@ func TestPipelineRun_Validate(t *testing.T) {
 				},
 			},
 		},
-		wc: config.EnableAlphaAPIFields,
+		wc: cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "propagating object params with pipelinespec and taskspec",
 		pr: v1.PipelineRun{
@@ -506,7 +506,7 @@ func TestPipelineRun_Validate(t *testing.T) {
 				},
 			},
 		},
-		wc: config.EnableAlphaAPIFields,
+		wc: cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "propagating object params no value in params but value in default",
 		pr: v1.PipelineRun{
@@ -546,7 +546,7 @@ func TestPipelineRun_Validate(t *testing.T) {
 				},
 			},
 		},
-		wc: config.EnableAlphaAPIFields,
+		wc: cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "propagating object params with some params defined in taskspec only",
 		pr: v1.PipelineRun{
@@ -587,7 +587,7 @@ func TestPipelineRun_Validate(t *testing.T) {
 				},
 			},
 		},
-		wc: config.EnableAlphaAPIFields,
+		wc: cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "propagating workspaces",
 		pr: v1.PipelineRun{
@@ -625,7 +625,7 @@ func TestPipelineRun_Validate(t *testing.T) {
 				},
 			},
 		},
-		wc: config.EnableAlphaAPIFields,
+		wc: cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "propagating workspaces partially defined",
 		pr: v1.PipelineRun{
@@ -666,7 +666,7 @@ func TestPipelineRun_Validate(t *testing.T) {
 				},
 			},
 		},
-		wc: config.EnableAlphaAPIFields,
+		wc: cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "propagating workspaces fully defined",
 		pr: v1.PipelineRun{
@@ -721,7 +721,7 @@ func TestPipelineRun_Validate(t *testing.T) {
 				},
 			},
 		},
-		wc: config.EnableAlphaAPIFields,
+		wc: cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "pipelinerun pending",
 		pr: v1.PipelineRun{
@@ -801,7 +801,7 @@ func TestPipelineRun_Validate(t *testing.T) {
 				},
 			},
 		},
-		wc: config.EnableAlphaAPIFields,
+		wc: cfgtesting.EnableAlphaAPIFields,
 	}}
 
 	for _, ts := range tests {
@@ -914,7 +914,7 @@ func TestPipelineRunSpec_Invalidate(t *testing.T) {
 			},
 		},
 		wantErr:     apis.ErrMultipleOneOf("taskRunSpecs[0].stepSpecs[1].name"),
-		withContext: config.EnableAlphaAPIFields,
+		withContext: cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "stepSpecs disallowed without alpha feature gate",
 		spec: v1.PipelineRunSpec{
@@ -931,7 +931,7 @@ func TestPipelineRunSpec_Invalidate(t *testing.T) {
 				},
 			},
 		},
-		withContext: config.EnableStableAPIFields,
+		withContext: cfgtesting.EnableStableAPIFields,
 		wantErr:     apis.ErrGeneric("stepSpecs requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\"").ViaIndex(0).ViaField("taskRunSpecs"),
 	}, {
 		name: "sidecarSpec disallowed without alpha feature gate",
@@ -949,7 +949,7 @@ func TestPipelineRunSpec_Invalidate(t *testing.T) {
 				},
 			},
 		},
-		withContext: config.EnableStableAPIFields,
+		withContext: cfgtesting.EnableStableAPIFields,
 		wantErr:     apis.ErrGeneric("sidecarSpecs requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\"").ViaIndex(0).ViaField("taskRunSpecs"),
 	}, {
 		name: "missing stepSpecs name",
@@ -967,7 +967,7 @@ func TestPipelineRunSpec_Invalidate(t *testing.T) {
 			},
 		},
 		wantErr:     apis.ErrMissingField("taskRunSpecs[0].stepSpecs[0].name"),
-		withContext: config.EnableAlphaAPIFields,
+		withContext: cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "duplicate sidecarSpec names",
 		spec: v1.PipelineRunSpec{
@@ -982,7 +982,7 @@ func TestPipelineRunSpec_Invalidate(t *testing.T) {
 			},
 		},
 		wantErr:     apis.ErrMultipleOneOf("taskRunSpecs[0].sidecarSpecs[1].name"),
-		withContext: config.EnableAlphaAPIFields,
+		withContext: cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "missing sidecarSpec name",
 		spec: v1.PipelineRunSpec{
@@ -999,7 +999,7 @@ func TestPipelineRunSpec_Invalidate(t *testing.T) {
 			},
 		},
 		wantErr:     apis.ErrMissingField("taskRunSpecs[0].sidecarSpecs[0].name"),
-		withContext: config.EnableAlphaAPIFields,
+		withContext: cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "invalid both step-level (stepSpecs.resources) and task-level (taskRunSpecs.resources) resource requirements configured",
 		spec: v1.PipelineRunSpec{
@@ -1023,7 +1023,7 @@ func TestPipelineRunSpec_Invalidate(t *testing.T) {
 			"taskRunSpecs[0].stepSpecs.resources",
 			"taskRunSpecs[0].computeResources",
 		),
-		withContext: config.EnableAlphaAPIFields,
+		withContext: cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "computeResources disallowed without alpha feature gate",
 		spec: v1.PipelineRunSpec{
@@ -1037,7 +1037,7 @@ func TestPipelineRunSpec_Invalidate(t *testing.T) {
 				},
 			},
 		},
-		withContext: config.EnableStableAPIFields,
+		withContext: cfgtesting.EnableStableAPIFields,
 		wantErr:     apis.ErrGeneric("computeResources requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\"").ViaIndex(0).ViaField("taskRunSpecs"),
 	}}
 
@@ -1086,7 +1086,7 @@ func TestPipelineRunSpec_Validate(t *testing.T) {
 				},
 			}},
 		},
-		withContext: config.EnableAlphaAPIFields,
+		withContext: cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "valid sidecar and task-level (taskRunSpecs.resources) resource requirements configured",
 		spec: v1.PipelineRunSpec{
@@ -1109,7 +1109,7 @@ func TestPipelineRunSpec_Validate(t *testing.T) {
 				}},
 			}},
 		},
-		withContext: config.EnableAlphaAPIFields,
+		withContext: cfgtesting.EnableAlphaAPIFields,
 	}}
 
 	for _, ps := range tests {

--- a/pkg/apis/pipeline/v1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1/task_validation_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/tektoncd/pipeline/pkg/apis/config"
+	cfgtesting "github.com/tektoncd/pipeline/pkg/apis/config/testing"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/test/diff"
@@ -138,7 +138,7 @@ func TestTaskSpecValidatePropagatedParamsAndWorkspaces(t *testing.T) {
 				Workspaces:   tt.fields.Workspaces,
 				Results:      tt.fields.Results,
 			}
-			ctx := config.EnableBetaAPIFields(context.Background())
+			ctx := cfgtesting.EnableBetaAPIFields(context.Background())
 			ts.SetDefaults(ctx)
 			if err := ts.Validate(ctx); err != nil {
 				t.Errorf("TaskSpec.Validate() = %v", err)
@@ -511,7 +511,7 @@ func TestTaskSpecValidate(t *testing.T) {
 				Workspaces:   tt.fields.Workspaces,
 				Results:      tt.fields.Results,
 			}
-			ctx := config.EnableAlphaAPIFields(context.Background())
+			ctx := cfgtesting.EnableAlphaAPIFields(context.Background())
 			ts.SetDefaults(ctx)
 			if err := ts.Validate(ctx); err != nil {
 				t.Errorf("TaskSpec.Validate() = %v", err)
@@ -714,7 +714,7 @@ func TestTaskValidateError(t *testing.T) {
 					Params: tt.fields.Params,
 					Steps:  tt.fields.Steps,
 				}}
-			ctx := config.EnableAlphaAPIFields(context.Background())
+			ctx := cfgtesting.EnableAlphaAPIFields(context.Background())
 			task.SetDefaults(ctx)
 			err := task.Validate(ctx)
 			if err == nil {
@@ -1357,7 +1357,7 @@ func TestTaskSpecValidateError(t *testing.T) {
 				Workspaces:   tt.fields.Workspaces,
 				Results:      tt.fields.Results,
 			}
-			ctx := config.EnableAlphaAPIFields(context.Background())
+			ctx := cfgtesting.EnableAlphaAPIFields(context.Background())
 			ts.SetDefaults(ctx)
 			err := ts.Validate(ctx)
 			if err == nil {
@@ -1440,7 +1440,7 @@ func TestStepAndSidecarWorkspaces(t *testing.T) {
 				Sidecars:   tt.fields.Sidecars,
 				Workspaces: tt.fields.Workspaces,
 			}
-			ctx := config.EnableAlphaAPIFields(context.Background())
+			ctx := cfgtesting.EnableAlphaAPIFields(context.Background())
 			ts.SetDefaults(ctx)
 			if err := ts.Validate(ctx); err != nil {
 				t.Errorf("TaskSpec.Validate() = %v", err)
@@ -1497,7 +1497,7 @@ func TestStepAndSidecarWorkspacesErrors(t *testing.T) {
 				Sidecars: tt.fields.Sidecars,
 			}
 
-			ctx := config.EnableAlphaAPIFields(context.Background())
+			ctx := cfgtesting.EnableAlphaAPIFields(context.Background())
 			ts.SetDefaults(ctx)
 			err := ts.Validate(ctx)
 			if err == nil {
@@ -1670,13 +1670,13 @@ func TestIncompatibleAPIVersions(t *testing.T) {
 				ts := tt.spec
 				ctx := context.Background()
 				if version == "alpha" {
-					ctx = config.EnableAlphaAPIFields(ctx)
+					ctx = cfgtesting.EnableAlphaAPIFields(ctx)
 				}
 				if version == "beta" {
-					ctx = config.EnableBetaAPIFields(ctx)
+					ctx = cfgtesting.EnableBetaAPIFields(ctx)
 				}
 				if version == "stable" {
-					ctx = config.EnableStableAPIFields(ctx)
+					ctx = cfgtesting.EnableStableAPIFields(ctx)
 				}
 				ts.SetDefaults(ctx)
 				err := ts.Validate(ctx)
@@ -1751,13 +1751,13 @@ func TestTaskBetaFields(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := config.EnableStableAPIFields(context.Background())
+			ctx := cfgtesting.EnableStableAPIFields(context.Background())
 			task := v1.Task{ObjectMeta: metav1.ObjectMeta{Name: "foo"}, Spec: tt.spec}
 			if err := task.Validate(ctx); err == nil {
 				t.Errorf("no error when using beta field when `enable-api-fields` is stable")
 			}
 
-			ctx = config.EnableBetaAPIFields(context.Background())
+			ctx = cfgtesting.EnableBetaAPIFields(context.Background())
 			if err := task.Validate(ctx); err != nil {
 				t.Errorf("unexpected error when using beta field: %s", err)
 			}

--- a/pkg/apis/pipeline/v1/taskref_validation_test.go
+++ b/pkg/apis/pipeline/v1/taskref_validation_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/tektoncd/pipeline/pkg/apis/config"
+	cfgtesting "github.com/tektoncd/pipeline/pkg/apis/config/testing"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/test/diff"
 	"knative.dev/pkg/apis"
@@ -40,11 +40,11 @@ func TestTaskRef_Valid(t *testing.T) {
 	}, {
 		name:    "beta feature: valid resolver",
 		taskRef: &v1.TaskRef{ResolverRef: v1.ResolverRef{Resolver: "git"}},
-		wc:      config.EnableBetaAPIFields,
+		wc:      cfgtesting.EnableBetaAPIFields,
 	}, {
 		name:    "beta feature: valid resolver with alpha flag",
 		taskRef: &v1.TaskRef{ResolverRef: v1.ResolverRef{Resolver: "git"}},
-		wc:      config.EnableAlphaAPIFields,
+		wc:      cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "beta feature: valid resolver with params",
 		taskRef: &v1.TaskRef{ResolverRef: v1.ResolverRef{Resolver: "git", Params: v1.Params{{
@@ -60,7 +60,7 @@ func TestTaskRef_Valid(t *testing.T) {
 				StringVal: "baz",
 			},
 		}}}},
-		wc: config.EnableBetaAPIFields,
+		wc: cfgtesting.EnableBetaAPIFields,
 	}}
 	for _, ts := range tests {
 		t.Run(ts.name, func(t *testing.T) {
@@ -99,7 +99,7 @@ func TestTaskRef_Invalid(t *testing.T) {
 				Resolver: "git",
 			},
 		},
-		wc:      config.EnableStableAPIFields,
+		wc:      cfgtesting.EnableStableAPIFields,
 		wantErr: apis.ErrGeneric("resolver requires \"enable-api-fields\" feature gate to be \"alpha\" or \"beta\" but it is \"stable\""),
 	}, {
 		name: "taskref params disallowed without beta feature gate",
@@ -108,7 +108,7 @@ func TestTaskRef_Invalid(t *testing.T) {
 				Params: v1.Params{},
 			},
 		},
-		wc:      config.EnableStableAPIFields,
+		wc:      cfgtesting.EnableStableAPIFields,
 		wantErr: apis.ErrMissingField("resolver").Also(apis.ErrGeneric("resolver params requires \"enable-api-fields\" feature gate to be \"alpha\" or \"beta\" but it is \"stable\"")),
 	}, {
 		name: "taskref params disallowed without resolver",
@@ -118,7 +118,7 @@ func TestTaskRef_Invalid(t *testing.T) {
 			},
 		},
 		wantErr: apis.ErrMissingField("resolver"),
-		wc:      config.EnableBetaAPIFields,
+		wc:      cfgtesting.EnableBetaAPIFields,
 	}, {
 		name: "taskref resolver disallowed in conjunction with taskref name",
 		taskRef: &v1.TaskRef{
@@ -128,7 +128,7 @@ func TestTaskRef_Invalid(t *testing.T) {
 			},
 		},
 		wantErr: apis.ErrMultipleOneOf("name", "resolver"),
-		wc:      config.EnableBetaAPIFields,
+		wc:      cfgtesting.EnableBetaAPIFields,
 	}, {
 		name: "taskref params disallowed in conjunction with taskref name",
 		taskRef: &v1.TaskRef{
@@ -144,7 +144,7 @@ func TestTaskRef_Invalid(t *testing.T) {
 			},
 		},
 		wantErr: apis.ErrMultipleOneOf("name", "params").Also(apis.ErrMissingField("resolver")),
-		wc:      config.EnableBetaAPIFields,
+		wc:      cfgtesting.EnableBetaAPIFields,
 	}, {
 		name: "taskref param object requires beta",
 		taskRef: &v1.TaskRef{
@@ -159,7 +159,7 @@ func TestTaskRef_Invalid(t *testing.T) {
 				}},
 			},
 		},
-		wc: config.EnableStableAPIFields,
+		wc: cfgtesting.EnableStableAPIFields,
 		wantErr: apis.ErrGeneric("resolver requires \"enable-api-fields\" feature gate to be \"alpha\" or \"beta\" but it is \"stable\"").Also(
 			apis.ErrGeneric("resolver params requires \"enable-api-fields\" feature gate to be \"alpha\" or \"beta\" but it is \"stable\"")).Also(
 			apis.ErrGeneric("object type parameter requires \"enable-api-fields\" feature gate to be \"alpha\" or \"beta\" but it is \"stable\"")),

--- a/pkg/apis/pipeline/v1/taskrun_validation_test.go
+++ b/pkg/apis/pipeline/v1/taskrun_validation_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
+	cfgtesting "github.com/tektoncd/pipeline/pkg/apis/config/testing"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/test/diff"
@@ -63,7 +64,7 @@ func TestTaskRun_Invalidate(t *testing.T) {
 			Message: `non-existent variable in "$(params.task-words[*])"`,
 			Paths:   []string{"spec.steps[0].args[0]"},
 		},
-		wc: config.EnableBetaAPIFields,
+		wc: cfgtesting.EnableBetaAPIFields,
 	}, {
 		name: "propagating object params not provided but used by step",
 		taskRun: &v1.TaskRun{
@@ -83,7 +84,7 @@ func TestTaskRun_Invalidate(t *testing.T) {
 			Message: `non-existent variable in "$(params.task-words.hello)"`,
 			Paths:   []string{"spec.steps[0].args[0]"},
 		},
-		wc: config.EnableAlphaAPIFields,
+		wc: cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "propagating object properties not provided",
 		taskRun: &v1.TaskRun{
@@ -118,7 +119,7 @@ func TestTaskRun_Invalidate(t *testing.T) {
 			Message: `missing field(s)`,
 			Paths:   []string{"spec.task-words.properties"},
 		},
-		wc: config.EnableAlphaAPIFields,
+		wc: cfgtesting.EnableAlphaAPIFields,
 	}}
 	for _, ts := range tests {
 		t.Run(ts.name, func(t *testing.T) {
@@ -161,7 +162,7 @@ func TestTaskRun_Validate(t *testing.T) {
 				},
 			},
 		},
-		wc: config.EnableBetaAPIFields,
+		wc: cfgtesting.EnableBetaAPIFields,
 	}, {
 		name: "propagating object params from taskrun to steps",
 		taskRun: &v1.TaskRun{
@@ -184,7 +185,7 @@ func TestTaskRun_Validate(t *testing.T) {
 				},
 			},
 		},
-		wc: config.EnableAlphaAPIFields,
+		wc: cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "propagating object params with taskrun mixing value types",
 		taskRun: &v1.TaskRun{
@@ -217,7 +218,7 @@ func TestTaskRun_Validate(t *testing.T) {
 				},
 			},
 		},
-		wc: config.EnableAlphaAPIFields,
+		wc: cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "propagating partial params with different provided and default names",
 		taskRun: &v1.TaskRun{
@@ -249,7 +250,7 @@ func TestTaskRun_Validate(t *testing.T) {
 				},
 			},
 		},
-		wc: config.EnableBetaAPIFields,
+		wc: cfgtesting.EnableBetaAPIFields,
 	}, {
 		name: "propagating object params with one declared in taskspec and other provided by taskrun",
 		taskRun: &v1.TaskRun{
@@ -283,7 +284,7 @@ func TestTaskRun_Validate(t *testing.T) {
 				},
 			},
 		},
-		wc: config.EnableAlphaAPIFields,
+		wc: cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "propagating partial params in taskrun",
 		taskRun: &v1.TaskRun{
@@ -318,7 +319,7 @@ func TestTaskRun_Validate(t *testing.T) {
 				},
 			},
 		},
-		wc: config.EnableBetaAPIFields,
+		wc: cfgtesting.EnableBetaAPIFields,
 	}, {
 		name: "propagating partial object params with multiple keys",
 		taskRun: &v1.TaskRun{
@@ -353,7 +354,7 @@ func TestTaskRun_Validate(t *testing.T) {
 				},
 			},
 		},
-		wc: config.EnableAlphaAPIFields,
+		wc: cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "propagating params with taskrun same names",
 		taskRun: &v1.TaskRun{
@@ -380,7 +381,7 @@ func TestTaskRun_Validate(t *testing.T) {
 				},
 			},
 		},
-		wc: config.EnableBetaAPIFields,
+		wc: cfgtesting.EnableBetaAPIFields,
 	}, {
 		name: "object params without propagation",
 		taskRun: &v1.TaskRun{
@@ -414,7 +415,7 @@ func TestTaskRun_Validate(t *testing.T) {
 				},
 			},
 		},
-		wc: config.EnableAlphaAPIFields,
+		wc: cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "alpha feature: valid step and sidecar specs",
 		taskRun: &v1.TaskRun{
@@ -435,7 +436,7 @@ func TestTaskRun_Validate(t *testing.T) {
 				}},
 			},
 		},
-		wc: config.EnableAlphaAPIFields,
+		wc: cfgtesting.EnableAlphaAPIFields,
 	}}
 	for _, ts := range tests {
 		t.Run(ts.name, func(t *testing.T) {
@@ -499,7 +500,7 @@ func TestTaskRun_Workspaces_Invalid(t *testing.T) {
 }
 
 func EnableForbiddenEnv(ctx context.Context) context.Context {
-	ctx = config.EnableAlphaAPIFields(ctx)
+	ctx = cfgtesting.EnableAlphaAPIFields(ctx)
 	c := config.FromContext(ctx)
 	c.Defaults.DefaultForbiddenEnv = []string{"TEST_ENV"}
 	return config.ToContext(ctx, c)
@@ -629,7 +630,7 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 			TaskRef: &v1.TaskRef{Name: "mytask"},
 		},
 		wantErr: apis.ErrMultipleOneOf("params[myobjectparam].name"),
-		wc:      config.EnableAlphaAPIFields,
+		wc:      cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "using debug when apifields stable",
 		spec: v1.TaskRunSpec{
@@ -640,7 +641,7 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 				Breakpoint: []string{"onFailure"},
 			},
 		},
-		wc:      config.EnableStableAPIFields,
+		wc:      cfgtesting.EnableStableAPIFields,
 		wantErr: apis.ErrGeneric("debug requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\""),
 	}, {
 		name: "invalid breakpoint",
@@ -653,7 +654,7 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 			},
 		},
 		wantErr: apis.ErrInvalidValue("breakito is not a valid breakpoint. Available valid breakpoints include [onFailure]", "debug.breakpoint"),
-		wc:      config.EnableAlphaAPIFields,
+		wc:      cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "stepSpecs disallowed without alpha feature gate",
 		spec: v1.TaskRunSpec{
@@ -667,7 +668,7 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 				},
 			}},
 		},
-		wc:      config.EnableStableAPIFields,
+		wc:      cfgtesting.EnableStableAPIFields,
 		wantErr: apis.ErrGeneric("stepSpecs requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\""),
 	}, {
 		name: "sidecarSpec disallowed without alpha feature gate",
@@ -682,7 +683,7 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 				},
 			}},
 		},
-		wc:      config.EnableStableAPIFields,
+		wc:      cfgtesting.EnableStableAPIFields,
 		wantErr: apis.ErrGeneric("sidecarSpecs requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\""),
 	}, {
 		name: "duplicate stepSpecs names",
@@ -701,7 +702,7 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 			}},
 		},
 		wantErr: apis.ErrMultipleOneOf("stepSpecs[1].name"),
-		wc:      config.EnableAlphaAPIFields,
+		wc:      cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "missing stepSpecs names",
 		spec: v1.TaskRunSpec{
@@ -713,7 +714,7 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 			}},
 		},
 		wantErr: apis.ErrMissingField("stepSpecs[0].name"),
-		wc:      config.EnableAlphaAPIFields,
+		wc:      cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "duplicate sidecarSpecs names",
 		spec: v1.TaskRunSpec{
@@ -731,7 +732,7 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 			}},
 		},
 		wantErr: apis.ErrMultipleOneOf("sidecarSpecs[1].name"),
-		wc:      config.EnableAlphaAPIFields,
+		wc:      cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "missing sidecarSpecs names",
 		spec: v1.TaskRunSpec{
@@ -743,7 +744,7 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 			}},
 		},
 		wantErr: apis.ErrMissingField("sidecarSpecs[0].name"),
-		wc:      config.EnableAlphaAPIFields,
+		wc:      cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "invalid both step-level (stepSpecs.resources) and task-level (spec.computeResources) resource requirements",
 		spec: v1.TaskRunSpec{
@@ -766,7 +767,7 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 			"stepSpecs.resources",
 			"computeResources",
 		),
-		wc: config.EnableAlphaAPIFields,
+		wc: cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "computeResources disallowed without alpha feature gate",
 		spec: v1.TaskRunSpec{
@@ -779,7 +780,7 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 				},
 			},
 		},
-		wc:      config.EnableStableAPIFields,
+		wc:      cfgtesting.EnableStableAPIFields,
 		wantErr: apis.ErrGeneric("computeResources requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\""),
 	}}
 
@@ -859,7 +860,7 @@ func TestTaskRunSpec_Validate(t *testing.T) {
 				},
 			},
 		},
-		wc: config.EnableAlphaAPIFields,
+		wc: cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "valid sidecar and task-level (spec.resources) resource requirements",
 		spec: v1.TaskRunSpec{
@@ -878,7 +879,7 @@ func TestTaskRunSpec_Validate(t *testing.T) {
 				},
 			}},
 		},
-		wc: config.EnableAlphaAPIFields,
+		wc: cfgtesting.EnableAlphaAPIFields,
 	}}
 
 	for _, ts := range tests {

--- a/pkg/apis/pipeline/v1/workspace_validation_test.go
+++ b/pkg/apis/pipeline/v1/workspace_validation_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/tektoncd/pipeline/pkg/apis/config"
+	cfgtesting "github.com/tektoncd/pipeline/pkg/apis/config/testing"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -169,7 +169,7 @@ func TestWorkspaceBindingValidateInvalid(t *testing.T) {
 			Name:      "beth",
 			Projected: &corev1.ProjectedVolumeSource{},
 		},
-		wc: config.EnableBetaAPIFields,
+		wc: cfgtesting.EnableBetaAPIFields,
 	}, {
 		name: "Provide csi without a driver",
 		binding: &v1.WorkspaceBinding{
@@ -178,7 +178,7 @@ func TestWorkspaceBindingValidateInvalid(t *testing.T) {
 				Driver: "",
 			},
 		},
-		wc: config.EnableBetaAPIFields,
+		wc: cfgtesting.EnableBetaAPIFields,
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_validation_test.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/tektoncd/pipeline/pkg/apis/config"
+	cfgtesting "github.com/tektoncd/pipeline/pkg/apis/config/testing"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/test/diff"
@@ -783,7 +783,7 @@ func TestPipelineRun_Validate(t *testing.T) {
 				},
 			},
 		},
-		wc: config.EnableAlphaAPIFields,
+		wc: cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "propagating workspaces partially defined",
 		pr: v1beta1.PipelineRun{
@@ -824,7 +824,7 @@ func TestPipelineRun_Validate(t *testing.T) {
 				},
 			},
 		},
-		wc: config.EnableAlphaAPIFields,
+		wc: cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "propagating workspaces fully defined",
 		pr: v1beta1.PipelineRun{
@@ -879,7 +879,7 @@ func TestPipelineRun_Validate(t *testing.T) {
 				},
 			},
 		},
-		wc: config.EnableAlphaAPIFields,
+		wc: cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "pipelinerun pending",
 		pr: v1beta1.PipelineRun{
@@ -959,7 +959,7 @@ func TestPipelineRun_Validate(t *testing.T) {
 				},
 			},
 		},
-		wc: config.EnableAlphaAPIFields,
+		wc: cfgtesting.EnableAlphaAPIFields,
 	}}
 
 	for _, ts := range tests {
@@ -1048,7 +1048,7 @@ func TestPipelineRunSpec_Invalidate(t *testing.T) {
 			},
 		},
 		wantErr:     apis.ErrMultipleOneOf("taskRunSpecs[0].stepOverrides[1].name"),
-		withContext: config.EnableAlphaAPIFields,
+		withContext: cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "stepOverride disallowed without alpha feature gate",
 		spec: v1beta1.PipelineRunSpec{
@@ -1065,7 +1065,7 @@ func TestPipelineRunSpec_Invalidate(t *testing.T) {
 				},
 			},
 		},
-		withContext: config.EnableStableAPIFields,
+		withContext: cfgtesting.EnableStableAPIFields,
 		wantErr:     apis.ErrGeneric("stepOverrides requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\"").ViaIndex(0).ViaField("taskRunSpecs"),
 	}, {
 		name: "sidecarOverride disallowed without alpha feature gate",
@@ -1083,7 +1083,7 @@ func TestPipelineRunSpec_Invalidate(t *testing.T) {
 				},
 			},
 		},
-		withContext: config.EnableStableAPIFields,
+		withContext: cfgtesting.EnableStableAPIFields,
 		wantErr:     apis.ErrGeneric("sidecarOverrides requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\"").ViaIndex(0).ViaField("taskRunSpecs"),
 	}, {
 		name: "missing stepOverride name",
@@ -1101,7 +1101,7 @@ func TestPipelineRunSpec_Invalidate(t *testing.T) {
 			},
 		},
 		wantErr:     apis.ErrMissingField("taskRunSpecs[0].stepOverrides[0].name"),
-		withContext: config.EnableAlphaAPIFields,
+		withContext: cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "duplicate sidecarOverride names",
 		spec: v1beta1.PipelineRunSpec{
@@ -1116,7 +1116,7 @@ func TestPipelineRunSpec_Invalidate(t *testing.T) {
 			},
 		},
 		wantErr:     apis.ErrMultipleOneOf("taskRunSpecs[0].sidecarOverrides[1].name"),
-		withContext: config.EnableAlphaAPIFields,
+		withContext: cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "missing sidecarOverride name",
 		spec: v1beta1.PipelineRunSpec{
@@ -1133,7 +1133,7 @@ func TestPipelineRunSpec_Invalidate(t *testing.T) {
 			},
 		},
 		wantErr:     apis.ErrMissingField("taskRunSpecs[0].sidecarOverrides[0].name"),
-		withContext: config.EnableAlphaAPIFields,
+		withContext: cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "invalid both step-level (stepOverrides.resources) and task-level (taskRunSpecs.resources) resource requirements configured",
 		spec: v1beta1.PipelineRunSpec{
@@ -1157,7 +1157,7 @@ func TestPipelineRunSpec_Invalidate(t *testing.T) {
 			"taskRunSpecs[0].stepOverrides.resources",
 			"taskRunSpecs[0].computeResources",
 		),
-		withContext: config.EnableAlphaAPIFields,
+		withContext: cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "computeResources disallowed without alpha feature gate",
 		spec: v1beta1.PipelineRunSpec{
@@ -1171,7 +1171,7 @@ func TestPipelineRunSpec_Invalidate(t *testing.T) {
 				},
 			},
 		},
-		withContext: config.EnableStableAPIFields,
+		withContext: cfgtesting.EnableStableAPIFields,
 		wantErr:     apis.ErrGeneric("computeResources requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\"").ViaIndex(0).ViaField("taskRunSpecs"),
 	}}
 
@@ -1220,7 +1220,7 @@ func TestPipelineRunSpec_Validate(t *testing.T) {
 				},
 			}},
 		},
-		withContext: config.EnableAlphaAPIFields,
+		withContext: cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "valid sidecar and task-level (taskRunSpecs.resources) resource requirements configured",
 		spec: v1beta1.PipelineRunSpec{
@@ -1243,7 +1243,7 @@ func TestPipelineRunSpec_Validate(t *testing.T) {
 				}},
 			}},
 		},
-		withContext: config.EnableAlphaAPIFields,
+		withContext: cfgtesting.EnableAlphaAPIFields,
 	}}
 
 	for _, ps := range tests {

--- a/pkg/apis/pipeline/v1beta1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation_test.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/tektoncd/pipeline/pkg/apis/config"
+	cfgtesting "github.com/tektoncd/pipeline/pkg/apis/config/testing"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/test/diff"
@@ -717,7 +717,7 @@ func TestTaskValidateError(t *testing.T) {
 					Params: tt.fields.Params,
 					Steps:  tt.fields.Steps,
 				}}
-			ctx := config.EnableAlphaAPIFields(context.Background())
+			ctx := cfgtesting.EnableAlphaAPIFields(context.Background())
 			task.SetDefaults(ctx)
 			err := task.Validate(ctx)
 			if err == nil {
@@ -1452,7 +1452,7 @@ func TestStepAndSidecarWorkspaces(t *testing.T) {
 				Sidecars:   tt.fields.Sidecars,
 				Workspaces: tt.fields.Workspaces,
 			}
-			ctx := config.EnableAlphaAPIFields(context.Background())
+			ctx := cfgtesting.EnableAlphaAPIFields(context.Background())
 			ts.SetDefaults(ctx)
 			if err := ts.Validate(ctx); err != nil {
 				t.Errorf("TaskSpec.Validate() = %v", err)
@@ -1509,7 +1509,7 @@ func TestStepAndSidecarWorkspacesErrors(t *testing.T) {
 				Sidecars: tt.fields.Sidecars,
 			}
 
-			ctx := config.EnableAlphaAPIFields(context.Background())
+			ctx := cfgtesting.EnableAlphaAPIFields(context.Background())
 			ts.SetDefaults(ctx)
 			err := ts.Validate(ctx)
 			if err == nil {
@@ -1682,13 +1682,13 @@ func TestIncompatibleAPIVersions(t *testing.T) {
 				ts := tt.spec
 				ctx := context.Background()
 				if version == "alpha" {
-					ctx = config.EnableAlphaAPIFields(ctx)
+					ctx = cfgtesting.EnableAlphaAPIFields(ctx)
 				}
 				if version == "beta" {
-					ctx = config.EnableBetaAPIFields(ctx)
+					ctx = cfgtesting.EnableBetaAPIFields(ctx)
 				}
 				if version == "stable" {
-					ctx = config.EnableStableAPIFields(ctx)
+					ctx = cfgtesting.EnableStableAPIFields(ctx)
 				}
 				ts.SetDefaults(ctx)
 				err := ts.Validate(ctx)

--- a/pkg/apis/pipeline/v1beta1/taskrun_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_validation_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
+	cfgtesting "github.com/tektoncd/pipeline/pkg/apis/config/testing"
 	pod "github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/test/diff"
@@ -449,7 +450,7 @@ func TestTaskRun_Validate(t *testing.T) {
 				}},
 			},
 		},
-		wc: config.EnableAlphaAPIFields,
+		wc: cfgtesting.EnableAlphaAPIFields,
 	}}
 	for _, ts := range tests {
 		t.Run(ts.name, func(t *testing.T) {
@@ -628,7 +629,7 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 				Breakpoint: []string{"onFailure"},
 			},
 		},
-		wc:      config.EnableStableAPIFields,
+		wc:      cfgtesting.EnableStableAPIFields,
 		wantErr: apis.ErrGeneric("debug requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\""),
 	}, {
 		name: "invalid breakpoint",
@@ -641,7 +642,7 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 			},
 		},
 		wantErr: apis.ErrInvalidValue("breakito is not a valid breakpoint. Available valid breakpoints include [onFailure]", "debug.breakpoint"),
-		wc:      config.EnableAlphaAPIFields,
+		wc:      cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "stepOverride disallowed without alpha feature gate",
 		spec: v1beta1.TaskRunSpec{
@@ -655,7 +656,7 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 				},
 			}},
 		},
-		wc:      config.EnableStableAPIFields,
+		wc:      cfgtesting.EnableStableAPIFields,
 		wantErr: apis.ErrGeneric("stepOverrides requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\""),
 	}, {
 		name: "sidecarOverride disallowed without alpha feature gate",
@@ -670,7 +671,7 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 				},
 			}},
 		},
-		wc:      config.EnableStableAPIFields,
+		wc:      cfgtesting.EnableStableAPIFields,
 		wantErr: apis.ErrGeneric("sidecarOverrides requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\""),
 	}, {
 		name: "duplicate stepOverride names",
@@ -689,7 +690,7 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 			}},
 		},
 		wantErr: apis.ErrMultipleOneOf("stepOverrides[1].name"),
-		wc:      config.EnableAlphaAPIFields,
+		wc:      cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "missing stepOverride names",
 		spec: v1beta1.TaskRunSpec{
@@ -701,7 +702,7 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 			}},
 		},
 		wantErr: apis.ErrMissingField("stepOverrides[0].name"),
-		wc:      config.EnableAlphaAPIFields,
+		wc:      cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "duplicate sidecarOverride names",
 		spec: v1beta1.TaskRunSpec{
@@ -719,7 +720,7 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 			}},
 		},
 		wantErr: apis.ErrMultipleOneOf("sidecarOverrides[1].name"),
-		wc:      config.EnableAlphaAPIFields,
+		wc:      cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "missing sidecarOverride names",
 		spec: v1beta1.TaskRunSpec{
@@ -731,7 +732,7 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 			}},
 		},
 		wantErr: apis.ErrMissingField("sidecarOverrides[0].name"),
-		wc:      config.EnableAlphaAPIFields,
+		wc:      cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "invalid both step-level (stepOverrides.resources) and task-level (spec.computeResources) resource requirements",
 		spec: v1beta1.TaskRunSpec{
@@ -754,7 +755,7 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 			"stepOverrides.resources",
 			"computeResources",
 		),
-		wc: config.EnableAlphaAPIFields,
+		wc: cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "computeResources disallowed without alpha feature gate",
 		spec: v1beta1.TaskRunSpec{
@@ -767,7 +768,7 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 				},
 			},
 		},
-		wc:      config.EnableStableAPIFields,
+		wc:      cfgtesting.EnableStableAPIFields,
 		wantErr: apis.ErrGeneric("computeResources requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\""),
 	}, {
 		name: "uses resources",
@@ -865,7 +866,7 @@ func TestTaskRunSpec_Validate(t *testing.T) {
 				},
 			},
 		},
-		wc: config.EnableAlphaAPIFields,
+		wc: cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "valid sidecar and task-level (spec.resources) resource requirements",
 		spec: v1beta1.TaskRunSpec{
@@ -884,7 +885,7 @@ func TestTaskRunSpec_Validate(t *testing.T) {
 				},
 			}},
 		},
-		wc: config.EnableAlphaAPIFields,
+		wc: cfgtesting.EnableAlphaAPIFields,
 	}}
 
 	for _, ts := range tests {

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/sigstore/sigstore/pkg/signature"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
+	cfgtesting "github.com/tektoncd/pipeline/pkg/apis/config/testing"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
@@ -7701,7 +7702,7 @@ spec:
 			expectedError: `expected workspace "not-source" to be provided by pipelinerun for pipeline task "resolved-pipelinetask"`,
 		},
 	}
-	ctx := config.EnableAlphaAPIFields(context.Background())
+	ctx := cfgtesting.EnableAlphaAPIFields(context.Background())
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := Reconciler{

--- a/pkg/reconciler/pipelinerun/resources/apply_test.go
+++ b/pkg/reconciler/pipelinerun/resources/apply_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/tektoncd/pipeline/pkg/apis/config"
+	cfgtesting "github.com/tektoncd/pipeline/pkg/apis/config/testing"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	resources "github.com/tektoncd/pipeline/pkg/reconciler/pipelinerun/resources"
@@ -212,7 +212,7 @@ func TestApplyParameters(t *testing.T) {
 				},
 			}},
 		},
-		wc: config.EnableAlphaAPIFields,
+		wc: cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "parameter propagation object finally task",
 		original: v1.PipelineSpec{
@@ -242,7 +242,7 @@ func TestApplyParameters(t *testing.T) {
 				},
 			}},
 		},
-		wc: config.EnableAlphaAPIFields,
+		wc: cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "parameter propagation with task default but no task winner pipeline",
 		original: v1.PipelineSpec{
@@ -617,7 +617,7 @@ func TestApplyParameters(t *testing.T) {
 				},
 			}},
 		},
-		wc: config.EnableAlphaAPIFields,
+		wc: cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "Finally task parameter propagation object with task default but no task winner pipeline",
 		original: v1.PipelineSpec{
@@ -672,7 +672,7 @@ func TestApplyParameters(t *testing.T) {
 				},
 			}},
 		},
-		wc: config.EnableAlphaAPIFields,
+		wc: cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "parameter propagation object with task default and task winner task",
 		original: v1.PipelineSpec{
@@ -736,7 +736,7 @@ func TestApplyParameters(t *testing.T) {
 				},
 			}},
 		},
-		wc: config.EnableAlphaAPIFields,
+		wc: cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "Finally task parameter propagation object with task default and task winner task",
 		original: v1.PipelineSpec{
@@ -800,7 +800,7 @@ func TestApplyParameters(t *testing.T) {
 				},
 			}},
 		},
-		wc: config.EnableAlphaAPIFields,
+		wc: cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "single parameter with when expression",
 		original: v1.PipelineSpec{
@@ -1409,7 +1409,7 @@ func TestApplyParameters(t *testing.T) {
 				},
 			}},
 		},
-		wc: config.EnableAlphaAPIFields,
+		wc: cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "single parameter in finally workspace subpath",
 		original: v1.PipelineSpec{

--- a/pkg/reconciler/pipelinerun/resources/pipelineref_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelineref_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/sigstore/sigstore/pkg/signature"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
+	cfgtesting "github.com/tektoncd/pipeline/pkg/apis/config/testing"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -279,7 +280,7 @@ func TestGetPipelineFuncSpecAlreadyFetched(t *testing.T) {
 
 func TestGetPipelineFunc_RemoteResolution(t *testing.T) {
 	ctx, clients := getFakePipelineClient(t)
-	ctx = config.EnableStableAPIFields(ctx)
+	ctx = cfgtesting.EnableStableAPIFields(ctx)
 	cfg := config.FromContextOrDefaults(ctx)
 	ctx = config.ToContext(ctx, cfg)
 	pipelineRef := &v1.PipelineRef{ResolverRef: v1.ResolverRef{Resolver: "git"}}
@@ -345,7 +346,7 @@ func TestGetPipelineFunc_RemoteResolution(t *testing.T) {
 
 func TestGetPipelineFunc_RemoteResolution_ValidationFailure(t *testing.T) {
 	ctx, clients := getFakePipelineClient(t)
-	ctx = config.EnableStableAPIFields(ctx)
+	ctx = cfgtesting.EnableStableAPIFields(ctx)
 	cfg := config.FromContextOrDefaults(ctx)
 	ctx = config.ToContext(ctx, cfg)
 	pipelineRef := &v1.PipelineRef{ResolverRef: v1.ResolverRef{Resolver: "git"}}

--- a/pkg/reconciler/taskrun/resources/taskref_test.go
+++ b/pkg/reconciler/taskrun/resources/taskref_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/sigstore/sigstore/pkg/signature"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
+	cfgtesting "github.com/tektoncd/pipeline/pkg/apis/config/testing"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -466,7 +467,7 @@ echo hello
 }
 
 func TestGetTaskFunc_RemoteResolution(t *testing.T) {
-	ctx := config.EnableStableAPIFields(context.Background())
+	ctx := cfgtesting.EnableStableAPIFields(context.Background())
 	cfg := config.FromContextOrDefaults(ctx)
 	ctx = config.ToContext(ctx, cfg)
 	taskRef := &v1.TaskRef{ResolverRef: v1.ResolverRef{Resolver: "git"}}

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/registry"
 	"github.com/sigstore/sigstore/pkg/signature"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
+	cfgtesting "github.com/tektoncd/pipeline/pkg/apis/config/testing"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
@@ -2675,7 +2676,7 @@ spec:
 		Kind:     "Task",
 		TaskSpec: &v1.TaskSpec{Steps: simpleTask.Spec.Steps, Workspaces: simpleTask.Spec.Workspaces},
 	}
-	ctx := config.EnableAlphaAPIFields(context.Background())
+	ctx := cfgtesting.EnableAlphaAPIFields(context.Background())
 	workspaceVolumes := workspace.CreateVolumes(taskRun.Spec.Workspaces)
 	taskSpec, err := applyParamsContextsResultsAndWorkspaces(ctx, taskRun, rtr, workspaceVolumes)
 	if err != nil {
@@ -2786,7 +2787,7 @@ spec:
 	}
 
 	workspaceVolumes := workspace.CreateVolumes(taskRun.Spec.Workspaces)
-	ctx := config.EnableAlphaAPIFields(context.Background())
+	ctx := cfgtesting.EnableAlphaAPIFields(context.Background())
 	taskSpec, err := applyParamsContextsResultsAndWorkspaces(ctx, taskRun, rtr, workspaceVolumes)
 	if err != nil {
 		t.Errorf("update task spec threw an error: %v", err)


### PR DESCRIPTION
Several functions in the config package are used to set the values of feature flags in tests. This commit moves them into an existing package used only in testing, to help ensure that these functions will only be used in testing contexts.

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- n/a Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- n/a Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Some exported functions moved from pkg/apis/config to pkg/apis/config/testing
```
