### PR TITLE
Replace redundant function CheckAlphaOrBetaFields

### DIFF
--- a/pkg/apis/config/feature_flags.go
+++ b/pkg/apis/config/feature_flags.go
@@ -365,12 +365,6 @@ func GetVerificationNoMatchPolicy(ctx context.Context) string {
 	return FromContextOrDefaults(ctx).FeatureFlags.VerificationNoMatchPolicy
 }
 
-// CheckAlphaOrBetaAPIFields return true if the enable-api-fields is either set to alpha or set to beta
-func CheckAlphaOrBetaAPIFields(ctx context.Context) bool {
-	cfg := FromContextOrDefaults(ctx)
-	return cfg.FeatureFlags.EnableAPIFields == AlphaAPIFields || cfg.FeatureFlags.EnableAPIFields == BetaAPIFields
-}
-
 // IsSpireEnabled checks if non-falsifiable provenance is enforced through SPIRE
 func IsSpireEnabled(ctx context.Context) bool {
 	return FromContextOrDefaults(ctx).FeatureFlags.EnforceNonfalsifiability == EnforceNonfalsifiabilityWithSpire

--- a/pkg/apis/config/feature_flags_test.go
+++ b/pkg/apis/config/feature_flags_test.go
@@ -311,37 +311,6 @@ func TestGetVerificationNoMatchPolicy(t *testing.T) {
 	}
 }
 
-// TestCheckAlphaOrBetaAPIFields validates CheckAlphaOrBetaAPIFields for alpha, beta, and stable context
-func TestCheckAlphaOrBetaAPIFields(t *testing.T) {
-	ctx := context.Background()
-	type testCase struct {
-		name           string
-		c              context.Context
-		expectedResult bool
-	}
-	testCases := []testCase{{
-		name:           "when enable-api-fields is set to alpha",
-		c:              config.EnableAlphaAPIFields(ctx),
-		expectedResult: true,
-	}, {
-		name:           "when enable-api-fields is set to beta",
-		c:              config.EnableBetaAPIFields(ctx),
-		expectedResult: true,
-	}, {
-		name:           "when enable-api-fields is set to stable",
-		c:              config.EnableStableAPIFields(ctx),
-		expectedResult: false,
-	}}
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			e := config.CheckAlphaOrBetaAPIFields(tc.c)
-			if (tc.expectedResult && !e) || (!tc.expectedResult && e) {
-				t.Errorf("Failed to validate CheckAlphaOrBetaAPIFields for \"%v\", expected \"%v\" but got \"%v\"", tc.name, tc.expectedResult, e)
-			}
-		})
-	}
-}
-
 func TestIsSpireEnabled(t *testing.T) {
 	testCases := []struct {
 		name      string

--- a/pkg/apis/pipeline/v1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1/pipeline_validation.go
@@ -101,8 +101,8 @@ func (ps *PipelineSpec) ValidateBetaFields(ctx context.Context) *apis.FieldError
 	}
 	// Indexing into array parameters
 	arrayParamIndexingRefs := ps.GetIndexingReferencesToArrayParams()
-	if len(arrayParamIndexingRefs) != 0 && !config.CheckAlphaOrBetaAPIFields(ctx) {
-		errs = errs.Also(apis.ErrGeneric(fmt.Sprintf("cannot index into array parameters when 'enable-api-fields' is 'stable', but found indexing references: %s", arrayParamIndexingRefs)))
+	if len(arrayParamIndexingRefs) != 0 {
+		errs = errs.Also(version.ValidateEnabledAPIFields(ctx, "indexing into array parameters", config.BetaAPIFields))
 	}
 	// array and object results
 	for i, result := range ps.Results {

--- a/pkg/apis/pipeline/v1/task_validation.go
+++ b/pkg/apis/pipeline/v1/task_validation.go
@@ -114,8 +114,8 @@ func (ts *TaskSpec) ValidateBetaFields(ctx context.Context) *apis.FieldError {
 	}
 	// Indexing into array parameters
 	arrayIndexParamRefs := ts.GetIndexingReferencesToArrayParams()
-	if len(arrayIndexParamRefs) != 0 && !config.CheckAlphaOrBetaAPIFields(ctx) {
-		errs = errs.Also(apis.ErrGeneric(fmt.Sprintf("cannot index into array parameters when 'enable-api-fields' is 'stable', but found indexing references: %s", arrayIndexParamRefs)))
+	if len(arrayIndexParamRefs) != 0 {
+		errs = errs.Also(version.ValidateEnabledAPIFields(ctx, "indexing into array parameters", config.BetaAPIFields))
 	}
 	// Array and object results
 	for i, result := range ts.Results {


### PR DESCRIPTION
Most existing validation code uses `version.ValidateEnabledAPIFields` to validate that "enable-api-fields" is set to the correct value for the feature in question. This commit removes the few usages of config.CheckAlphaOrBetaFields in favor of version.ValidateEnabledAPIFields, which provides the same functionality.

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- n/a Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- n/a Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- n/a Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
