### PR TITLE
Do not require enable-api-fields=alpha for spire

### DIFF
--- a/docs/spire.md
+++ b/docs/spire.md
@@ -64,7 +64,7 @@ When a TaskRun is created:
 ## Enabling TaskRun result attestations
 
 To enable TaskRun attestations:
-1. Make sure `enforce-nonfalsifiability` is set to `"spire"` and `enable-api-fields` is set to `"alpha"` in the `feature-flags` configmap, see [`install.md`](./install.md#customizing-the-pipelines-controller-behavior) for details
+1. Make sure `enforce-nonfalsifiability` is set to `"spire"`. See [`additional-configs.md`](./additional-configs.md#customizing-the-pipelines-controller-behavior) for details
 1. Create a SPIRE deployment containing a SPIRE server, SPIRE agents and the SPIRE CSI driver, for convenience, [this sample single cluster deployment](https://github.com/spiffe/spiffe-csi/tree/main/example/config) can be used.
 1. Register the SPIRE workload entry for Tekton with the "Admin" flag, which will allow the Tekton controller to communicate with the SPIRE server to manage the TaskRun identities dynamically.
     ```

--- a/pkg/apis/config/feature_flags.go
+++ b/pkg/apis/config/feature_flags.go
@@ -271,22 +271,11 @@ func setEnforceNonFalsifiability(cfgMap map[string]string, enableAPIFields strin
 	// validate that "enforce-nonfalsifiability" is set to a valid value
 	switch value {
 	case EnforceNonfalsifiabilityNone, EnforceNonfalsifiabilityWithSpire:
-		break
+		*feature = value
+		return nil
 	default:
 		return fmt.Errorf("invalid value for feature flag %q: %q", enforceNonfalsifiability, value)
 	}
-
-	// validate that "enforce-nonfalsifiability" is set to allowed values for stability level
-	switch enableAPIFields {
-	case AlphaAPIFields:
-		*feature = value
-	default:
-		// Do not consider any form of non-falsifiability enforcement in non-alpha mode
-		if value != DefaultEnforceNonfalsifiability {
-			return fmt.Errorf("%q can be set to non-default values (%q) only in alpha", enforceNonfalsifiability, value)
-		}
-	}
-	return nil
 }
 
 // setResultExtractionMethod sets the "results-from" flag based on the content of a given map.

--- a/pkg/apis/config/feature_flags_test.go
+++ b/pkg/apis/config/feature_flags_test.go
@@ -41,18 +41,18 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 				DisableAffinityAssistant:         false,
 				RunningInEnvWithInjectedSidecars: true,
 				RequireGitSSHSecretKnownHosts:    false,
-
-				DisableCredsInit:          config.DefaultDisableCredsInit,
-				AwaitSidecarReadiness:     config.DefaultAwaitSidecarReadiness,
-				EnableTektonOCIBundles:    config.DefaultEnableTektonOciBundles,
-				EnableAPIFields:           config.DefaultEnableAPIFields,
-				SendCloudEventsForRuns:    config.DefaultSendCloudEventsForRuns,
-				VerificationNoMatchPolicy: config.DefaultNoMatchPolicyConfig,
-				EnableProvenanceInStatus:  config.DefaultEnableProvenanceInStatus,
-				ResultExtractionMethod:    config.DefaultResultExtractionMethod,
-				MaxResultSize:             config.DefaultMaxResultSize,
-				SetSecurityContext:        config.DefaultSetSecurityContext,
-				Coschedule:                config.DefaultCoschedule,
+				DisableCredsInit:                 config.DefaultDisableCredsInit,
+				AwaitSidecarReadiness:            config.DefaultAwaitSidecarReadiness,
+				EnableTektonOCIBundles:           config.DefaultEnableTektonOciBundles,
+				EnableAPIFields:                  config.DefaultEnableAPIFields,
+				SendCloudEventsForRuns:           config.DefaultSendCloudEventsForRuns,
+				VerificationNoMatchPolicy:        config.DefaultNoMatchPolicyConfig,
+				EnableProvenanceInStatus:         config.DefaultEnableProvenanceInStatus,
+				ResultExtractionMethod:           config.DefaultResultExtractionMethod,
+				MaxResultSize:                    config.DefaultMaxResultSize,
+				SetSecurityContext:               config.DefaultSetSecurityContext,
+				Coschedule:                       config.DefaultCoschedule,
+				EnforceNonfalsifiability:         config.DefaultEnforceNonfalsifiability,
 			},
 			fileName: config.GetFeatureFlagsConfigName(),
 		},
@@ -139,9 +139,9 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 		},
 		{
 			expectedConfig: &config.FeatureFlags{
-				EnableAPIFields:                  "alpha",
-				EnforceNonfalsifiability:         "spire",
-				EnableTektonOCIBundles:           true,
+				EnableAPIFields:                  config.DefaultEnableAPIFields,
+				EnforceNonfalsifiability:         config.EnforceNonfalsifiabilityWithSpire,
+				EnableTektonOCIBundles:           config.DefaultEnableTektonOciBundles,
 				VerificationNoMatchPolicy:        config.DefaultNoMatchPolicyConfig,
 				RunningInEnvWithInjectedSidecars: config.DefaultRunningInEnvWithInjectedSidecars,
 				AwaitSidecarReadiness:            config.DefaultAwaitSidecarReadiness,
@@ -253,9 +253,6 @@ func TestNewFeatureFlagsConfigMapErrors(t *testing.T) {
 		fileName: "feature-flags-enforce-nonfalsifiability-bad-flag",
 		want:     `invalid value for feature flag "enforce-nonfalsifiability": "bad-value"`,
 	}, {
-		fileName: "feature-flags-spire-with-stable",
-		want:     `"enforce-nonfalsifiability" can be set to non-default values ("spire") only in alpha`,
-	}, {
 		fileName: "feature-flags-invalid-coschedule-affinity-assistant-comb",
 		want:     `coschedule value pipelineruns is incompatible with disable-affinity-assistant setting to false`,
 	}, {
@@ -360,7 +357,7 @@ func TestIsSpireEnabled(t *testing.T) {
 			"enable-api-fields":         "beta",
 			"enforce-nonfalsifiability": config.EnforceNonfalsifiabilityWithSpire,
 		},
-		want: false,
+		want: true,
 	}, {
 		name: "when enable-api-fields is set to alpha and non-falsifiability is not set",
 		configmap: map[string]string{

--- a/pkg/apis/config/testdata/feature-flags-enforce-nonfalsifiability-bad-flag.yaml
+++ b/pkg/apis/config/testdata/feature-flags-enforce-nonfalsifiability-bad-flag.yaml
@@ -5,4 +5,3 @@ metadata:
   namespace: tekton-pipelines
 data:
   enforce-nonfalsifiability: "bad-value"
-  enable-api-fields: "alpha"

--- a/pkg/apis/config/testdata/feature-flags-enforce-nonfalsifiability-spire.yaml
+++ b/pkg/apis/config/testdata/feature-flags-enforce-nonfalsifiability-spire.yaml
@@ -5,4 +5,3 @@ metadata:
   namespace: tekton-pipelines
 data:
   enforce-nonfalsifiability: "spire"
-  enable-api-fields: "alpha"

--- a/pkg/apis/config/testdata/feature-flags-spire-with-stable.yaml
+++ b/pkg/apis/config/testdata/feature-flags-spire-with-stable.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: feature-flags
-  namespace: tekton-pipelines
-data:
-  enforce-nonfalsifiability: "spire"


### PR DESCRIPTION
Prior to this commit, enabling spire support also required setting "enable-api-fields" to alpha. "enforce-nonfalsifiability" is the only behavioral feature flag that also requires setting "enable-api-fields" to alpha, even though it is not the only behavioral feature flag in an alpha state.

This commit removes the requirement that cluster operators set enable-api-fields to alpha in order to use spire.
In addition to creating a consistent approach among behavioral feature flags, this will allow cluster operators to opt into spire without having to opt into all alpha API fields.

Note: Spire support is not yet functional.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- n/a Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- n/a Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
