### PR TITLE
Fix logger Fatalf message

### DIFF
--- a/pkg/termination/write_test.go
+++ b/pkg/termination/write_test.go
@@ -47,7 +47,7 @@ func TestExistingFile(t *testing.T) {
 	}}
 
 	if err := termination.WriteMessage(tmpFile.Name(), output); err != nil {
-		logger.Fatalf("Errot while writing message: %s", err)
+		logger.Fatalf("Error while writing message: %s", err)
 	}
 
 	output = []result.RunResult{{
@@ -56,7 +56,7 @@ func TestExistingFile(t *testing.T) {
 	}}
 
 	if err := termination.WriteMessage(tmpFile.Name(), output); err != nil {
-		logger.Fatalf("Errot while writing message: %s", err)
+		logger.Fatalf("Error while writing message: %s", err)
 	}
 
 	if fileContents, err := os.ReadFile(tmpFile.Name()); err != nil {


### PR DESCRIPTION
This commit fixes the typos in the package termination_test where the fix is transforming Errot to Error

/kind cleanup

*Sidenote*: Working with @pritidesai at IBM, towards contributing to TektonCD Pipeline and as part of this am using this trivial cosmetic change PR to iron out issues pertinent to opensource contribution

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [X] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [X] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [X] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [X] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
