### PR TITLE
Fix flake of TestPipelineTaskTimeout

### DIFF
--- a/test/timeout_test.go
+++ b/test/timeout_test.go
@@ -364,7 +364,7 @@ spec:
   - name: pipelinetask1
     taskRef:
       name: %s
-    timeout: 60s
+    timeout: 0s
   - name: pipelinetask2
     taskRef:
       name: %s


### PR DESCRIPTION
Prior to this commit, TestPipelineTaskTimeout was flaky because a Pipeline task that was supposed to succeed timed out. This can happen when the time to create a pod exceeds the timeout, which was 60s.
This commit removes the timeout for that pipeline task, removing this cause of flakes.

/kind flake
closes https://github.com/tektoncd/pipeline/issues/6943

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- n/a Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- n/a Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- n/a Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
