### PR TITLE
fix: refine error resean with invalid pipelinename in taskrunspecs

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -83,8 +83,9 @@ const (
 	// ReasonInvalidWorkspaceBinding indicates that a Pipeline expects a workspace but a
 	// PipelineRun has provided an invalid binding.
 	ReasonInvalidWorkspaceBinding = "InvalidWorkspaceBindings"
-	// ReasonInvalidServiceAccountMapping indicates that PipelineRun.Spec.TaskRunSpecs[].TaskServiceAccountName is defined with a wrong taskName
-	ReasonInvalidServiceAccountMapping = "InvalidServiceAccountMappings"
+	// ReasonInvalidTaskRunSpec indicates that PipelineRun.Spec.TaskRunSpecs[].PipelineTaskName is defined with
+	// a not exist taskName in pipelineSpec.
+	ReasonInvalidTaskRunSpec = "InvalidTaskRunSpecs"
 	// ReasonParameterTypeMismatch indicates that the reason for the failure status is that
 	// parameter(s) declared in the PipelineRun do not have the some declared type as the
 	// parameters(s) declared in the Pipeline that they are supposed to override.
@@ -506,7 +507,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1.PipelineRun, getPipel
 
 	// Ensure that the TaskRunSpecs defined are correct.
 	if err := resources.ValidateTaskRunSpecs(pipelineSpec, pr); err != nil {
-		pr.Status.MarkFailed(ReasonInvalidServiceAccountMapping,
+		pr.Status.MarkFailed(ReasonInvalidTaskRunSpec,
 			"PipelineRun %s/%s doesn't define taskRunSpecs correctly: %s",
 			pr.Namespace, pr.Name, err)
 		return controller.NewPermanentError(err)

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -6885,6 +6885,24 @@ spec:
           - name: platform
             value: linux
 `),
+		parse.MustParseV1PipelineRun(t, `
+metadata:
+  name: pipelinerun-with-invalid-taskrunspecs
+  namespace: foo
+spec:
+  taskRunSpecs:
+  - metadata:
+      annotations:
+        env: test
+    pipelineTaskName: invalid-task-name
+  pipelineSpec:
+    tasks:
+    - name: pt0
+      taskSpec:
+        steps:
+        - image: foo:latest
+  serviceAccountName: test-sa
+`),
 	}
 
 	cms := []*corev1.ConfigMap{withEnabledAlphaAPIFields(newFeatureFlagsConfigMap())}
@@ -6915,6 +6933,9 @@ spec:
 		}, {
 			name:   "pipelinerun-matrix-param-invalid-type",
 			reason: ReasonInvalidMatrixParameterTypes,
+		}, {
+			name:   "pipelinerun-with-invalid-taskrunspecs",
+			reason: ReasonInvalidTaskRunSpec,
 		},
 	}
 	for _, tc := range testCases {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR tries to modify the scene where the pipelineRun containing an invalid pipeline name in taskRunSpecs displays an error mismatch.

fix:  #6956 

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
When the taskRunSpecs of the pipelineRun contains an invalid pipeline task name, the cause of the `InvalidTaskRunSpecs` error is displayed.
```
