### PR TITLE
Compress Runs' data before adding to annotations

### DIFF
--- a/pkg/apis/pipeline/v1beta1/pipelinerun_conversion_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_conversion_test.go
@@ -18,9 +18,10 @@ package v1beta1_test
 
 import (
 	"context"
-	"github.com/tektoncd/pipeline/pkg/apis/version"
 	"testing"
 	"time"
+
+	"github.com/tektoncd/pipeline/pkg/apis/version"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_conversion_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_conversion_test.go
@@ -18,6 +18,7 @@ package v1beta1_test
 
 import (
 	"context"
+	"github.com/tektoncd/pipeline/pkg/apis/version"
 	"testing"
 	"time"
 
@@ -656,9 +657,19 @@ func TestPipelineRunConversionEmbeddedStatusConvertFrom(t *testing.T) {
 		PipelineTaskName: "ptn-0",
 		WhenExpressions:  []v1.WhenExpression{{Input: "default-value-0", Operator: "in", Values: []string{"val-0", "val-1"}}},
 	}}
+
+	v1beta1RunsAnnotation, err := version.CompressAndEncode([]byte(`{"r-0":{"pipelineTaskName":"ptn-0","status":{"results":[{"name":"foo","value":"bar"}],"extraFields":null},"whenExpressions":[{"input":"default-value-0","operator":"in","values":["val-0","val-1"]}]}}`))
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	v1beta1TaskRunsAnnotation, err := version.CompressAndEncode([]byte(`{"tr-0":{"pipelineTaskName":"ptn","status":{"podName":"pod-name","steps":[{"running":{"startedAt":null},"name":"running-step","container":"step-running-step"}],"cloudEvents":[{"target":"http//sink1","status":{"condition":"Unknown","message":"","retryCount":0}},{"target":"http//sink2","status":{"condition":"Unknown","message":"","retryCount":0}}],"retriesStatus":[{"conditions":[{"type":"Succeeded","status":"False","lastTransitionTime":null}],"podName":""}],"resourcesResult":[{"key":"digest","value":"sha256:1234","resourceName":"source-image"}],"sidecars":[{"terminated":{"exitCode":1,"reason":"Error","message":"Error","startedAt":null,"finishedAt":null},"name":"error","container":"sidecar-error","imageID":"image-id"}]},"whenExpressions":[{"input":"default-value","operator":"in","values":["val"]}]}}`))
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
 	annotations := map[string]string{
-		"tekton.dev/v1beta1Runs":     `{"r-0":{"pipelineTaskName":"ptn-0","status":{"results":[{"name":"foo","value":"bar"}],"extraFields":null},"whenExpressions":[{"input":"default-value-0","operator":"in","values":["val-0","val-1"]}]}}`,
-		"tekton.dev/v1beta1TaskRuns": `{"tr-0":{"pipelineTaskName":"ptn","status":{"podName":"pod-name","steps":[{"running":{"startedAt":null},"name":"running-step","container":"step-running-step"}],"cloudEvents":[{"target":"http//sink1","status":{"condition":"Unknown","message":"","retryCount":0}},{"target":"http//sink2","status":{"condition":"Unknown","message":"","retryCount":0}}],"retriesStatus":[{"conditions":[{"type":"Succeeded","status":"False","lastTransitionTime":null}],"podName":""}],"resourcesResult":[{"key":"digest","value":"sha256:1234","resourceName":"source-image"}],"sidecars":[{"terminated":{"exitCode":1,"reason":"Error","message":"Error","startedAt":null,"finishedAt":null},"name":"error","container":"sidecar-error","imageID":"image-id"}]},"whenExpressions":[{"input":"default-value","operator":"in","values":["val"]}]}}`,
+		"tekton.dev/v1beta1Runs":     v1beta1RunsAnnotation,
+		"tekton.dev/v1beta1TaskRuns": v1beta1TaskRunsAnnotation,
 	}
 
 	tests := []struct {

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_conversion_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_conversion_test.go
@@ -603,8 +603,8 @@ func TestPipelineRunConversionEmbeddedStatusConvertTo(t *testing.T) {
 				Name:      "foo",
 				Namespace: "bar",
 				Annotations: map[string]string{
-					"tekton.dev/v1beta1Runs":     `{"r-0":{"pipelineTaskName":"ptn-0","status":{"results":[{"name":"foo","value":"bar"}],"extraFields":null},"whenExpressions":[{"input":"default-value-0","operator":"in","values":["val-0","val-1"]}]}}`,
-					"tekton.dev/v1beta1TaskRuns": `{"tr-0":{"pipelineTaskName":"ptn","status":{"podName":"pod-name","steps":[{"running":{"startedAt":null},"name":"running-step","container":"step-running-step"}],"cloudEvents":[{"target":"http//sink1","status":{"condition":"Unknown","message":"","retryCount":0}},{"target":"http//sink2","status":{"condition":"Unknown","message":"","retryCount":0}}],"retriesStatus":[{"conditions":[{"type":"Succeeded","status":"False","lastTransitionTime":null}],"podName":""}],"resourcesResult":[{"key":"digest","value":"sha256:1234","resourceName":"source-image"}],"sidecars":[{"terminated":{"exitCode":1,"reason":"Error","message":"Error","startedAt":null,"finishedAt":null},"name":"error","container":"sidecar-error","imageID":"image-id"}]},"whenExpressions":[{"input":"default-value","operator":"in","values":["val"]}]}}`,
+					"tekton.dev/v1beta1Runs":     "H4sIAAAAAAAA/zSNQQvCMAxG/8t37mBee9ejJ2+yQ2QZFmtamlQHo/9duuEpCby8t6EMI/yGHDLHIHwjfV3pzfDIJsMIBzWyqh0qrDWawt83yAEtKcHhQ7H260EFbXLg1QpdAsdZ4aXG2By+T5bzmgurhiSHJEiuBo+ZF6rRht2zR1PmQpYKPIL8C/2pbzvR5wlTm1r7BQAA//8hZzWqxgAAAA==",
+					"tekton.dev/v1beta1TaskRuns": "H4sIAAAAAAAA/6RSPW8bMQz9L2/WIbH7MWgrUhfo0qFxp+AG4cTYhM/UQaSSGMb990J359YusnWjRL7Hx0eeYbm5hz9j4IF6FtoGPfwIR4LHYAIHtWBFp5IUL5kUG6lhTdOg8E9n5CLCsquVaiEbxS8GL6XvRweZgUtNU1Fw6JJYYKEMPxE1N/mxdej6VOLmhcTmJhbyjgwee7Ph7k5ZDqsbkV2SyMZJ4PFLDpJe6xBHUg27qgAOmSyfHlIRg78fR/cu6/o/Wdv5h0kfF5anK5plmNNQwY+l64gixauW+BZ6rf72QW2bg+iE23K1cfK0dVcLwdxPU8kd6U/S0tvU4kAneETekRocXkJfar3uw/rTZ79af/iIv8CFbH40fKyzVWLlSF3Ii2jKR5ZgFKsx9Mb2kCLBrypP0MmiTc4p3xh0+fnnMhyeWVj3790KLZCbI5mVNJfcpPH7V/g5ajhibEeH1z3J5m3IpPrHbZah1B1Heg6lt2b2wiENlIOlSs9y8ahCaoR2bMfxdwAAAP//JmZFBycDAAA=",
 				},
 			},
 			Spec: v1.PipelineRunSpec{

--- a/pkg/apis/version/conversion.go
+++ b/pkg/apis/version/conversion.go
@@ -83,6 +83,10 @@ func DeserializeFromMetadata(meta *metav1.ObjectMeta, to interface{}, key string
 	return nil
 }
 
+// CompressAndEncode takes in a byte array, compresses it (gzip) and then encodes
+// (base64) it and returns the resulting string.
+// This is mainly used when large data needs to be compressed and stored in fields
+// such as annotations to mitigate annotations getting too large to store.
 func CompressAndEncode(data []byte) (string, error) {
 	// Compressing input data
 	var compressed bytes.Buffer
@@ -98,6 +102,10 @@ func CompressAndEncode(data []byte) (string, error) {
 	return base64.StdEncoding.EncodeToString(compressed.Bytes()), nil
 }
 
+// DecodeAndDecompress takes in a string and then decodes (base64) and then
+// decompresses (gzip) it and returns the raw byte array.
+// This is mainly used while converting Tekton resources to an older version
+// for fields such as annotations.
 func DecodeAndDecompress(data string) ([]byte, error) {
 	decoded, err := base64.StdEncoding.DecodeString(data)
 	if err != nil {

--- a/pkg/apis/version/conversion.go
+++ b/pkg/apis/version/conversion.go
@@ -17,23 +17,49 @@ limitations under the License.
 package version
 
 import (
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 
+	"k8s.io/apimachinery/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // SerializeToMetadata serializes the input field and adds it as an annotation to
 // the metadata under the input key.
 func SerializeToMetadata(meta *metav1.ObjectMeta, field interface{}, key string) error {
-	bytes, err := json.Marshal(field)
+	data, err := json.Marshal(field)
 	if err != nil {
 		return fmt.Errorf("error serializing field: %s", err)
 	}
+
+	// The data coming from TaskRun and PipelineRun workloads can be really huge
+	// and can result in inflated annotations which exceed the maximum allowed size
+	// for annotations of 256 kB, so we will be compressing and encoding the data.
+	var b bytes.Buffer
+	gz := gzip.NewWriter(&b)
+	if _, err := gz.Write(data); err != nil {
+		return err
+	}
+	if err := gz.Close(); err != nil {
+		return err
+	}
+
+	// Encoding to normalize the data for annotations
+	compressedAndEncoded := base64.StdEncoding.EncodeToString(b.Bytes())
 	if meta.Annotations == nil {
 		meta.Annotations = make(map[string]string)
 	}
-	meta.Annotations[key] = string(bytes)
+	meta.Annotations[key] = compressedAndEncoded
+
+	// While we have compressed the payload, we can still not guarantee that the
+	// maximum allowed annotation size (256 kB) is not exceeded :(
+	if err := validation.ValidateAnnotationsSize(meta.Annotations); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -45,8 +71,24 @@ func DeserializeFromMetadata(meta *metav1.ObjectMeta, to interface{}, key string
 		return nil
 	}
 	if str, ok := meta.Annotations[key]; ok {
-		if err := json.Unmarshal([]byte(str), to); err != nil {
-			return fmt.Errorf("error deserializing key %s from metadata: %s", key, err)
+		// This data needs to be first decoded and then decompressed.
+		decoded, err := base64.StdEncoding.DecodeString(str)
+		if err != nil {
+			return err
+		}
+		gz, err := gzip.NewReader(bytes.NewReader(decoded))
+		if err != nil {
+			return fmt.Errorf("error decoding string from encoded marshalled bytes %w", err)
+		}
+		data, err := io.ReadAll(gz)
+		if err != nil {
+			return err
+		}
+		if err := gz.Close(); err != nil {
+			return err
+		}
+		if err := json.Unmarshal(data, to); err != nil {
+			return fmt.Errorf("error deserializing key %s from metadata: %w", key, err)
 		}
 		delete(meta.Annotations, key)
 		if len(meta.Annotations) == 0 {


### PR DESCRIPTION
# Changes

When `embedded-status` is set to `both` or `full`, then TaskRun and PipelineRun payload JSON is added to annotations to facilitate conversion. This JSON payload is occasionally too large to fit into annotations and the maximum size limit of annotations (256 kB, combined limit for all annotations) is exceeded leading to errors while fetching Tekton workloads.

Example:
```
$ tkn pr ls
Failed to list objects from pipelines-ci namespace
Error: failed to list PipelineRuns from namespace pipelines-ci: conversion webhook for tekton.dev/v1beta1, Kind=PipelineRun returned invalid metadata: metadata.annotation: Too long: must have at most 262144 bytes
```

This commit mitigates this in 2 ways:
- The JSON payload is compressed before adding to the annotations. This helps in reducing the size footprint of the annotations quite a bit. The data is further encoded after compression so as to sanitize the compressed data which is in binary.
- Once the annotations are added, the size is validated and an error is returned if the annotions size limit is exceeded.

Fix #6561 

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
