### PR TITLE
[TEP-0135] Validate multiple PVC-based Workspaces in TaskRuns

### DIFF
--- a/pkg/workspace/affinity_assistant_names.go
+++ b/pkg/workspace/affinity_assistant_names.go
@@ -22,6 +22,7 @@ const (
 
 	// LabelComponent is used to configure PodAntiAffinity to other Affinity Assistants
 	LabelComponent = "app.kubernetes.io/component"
+
 	// ComponentNameAffinityAssistant is the component name for an Affinity Assistant
 	ComponentNameAffinityAssistant = "affinity-assistant"
 


### PR DESCRIPTION
Prior to this commit, we only validate that 1 `PVC` is allowed to be binded to a `TaskRun` in `AffinityAssistantPerWorkspace` coschedule mode. The validation was skipped when there is no affinity assistant presents in the `TaskRun` (i.e. in standalone `TaskRun` or in `AffinityAssistantDisabled` coschedule mode). This commit adds the missing validation.

This commit also updates workspace related documentation.

/kind bug

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
