### PR TITLE
[cherry-pick release-v0.47.x] Fix PipelineRun reconciler panic for computed timeouts

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -547,10 +547,12 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1beta1.PipelineRun, get
 	if pr.Status.FinallyStartTime != nil {
 		pipelineRunFacts.TimeoutsState.FinallyStartTime = &pr.Status.FinallyStartTime.Time
 	}
-	if tasksTimeout := pr.TasksTimeout(); tasksTimeout != nil {
+	tasksTimeout := pr.TasksTimeout()
+	if tasksTimeout != nil {
 		pipelineRunFacts.TimeoutsState.TasksTimeout = &tasksTimeout.Duration
 	}
-	if finallyTimeout := pr.FinallyTimeout(); finallyTimeout != nil {
+	finallyTimeout := pr.FinallyTimeout()
+	if finallyTimeout != nil {
 		pipelineRunFacts.TimeoutsState.FinallyTimeout = &finallyTimeout.Duration
 	}
 	if pipelineTimeout := pr.PipelineTimeout(ctx); pipelineTimeout != 0 {
@@ -631,7 +633,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1beta1.PipelineRun, get
 				}
 			}
 			if tasksToTimeOut.Len() > 0 {
-				logger.Infof("PipelineRun tasks timeout of %s reached, cancelling tasks", pr.Spec.Timeouts.Tasks.Duration.String())
+				logger.Debugf("PipelineRun tasks timeout of %s reached, cancelling tasks", tasksTimeout)
 				errs := timeoutPipelineTasksForTaskNames(ctx, logger, pr, c.PipelineClientSet, tasksToTimeOut)
 				if len(errs) > 0 {
 					errString := strings.Join(errs, "\n")
@@ -648,7 +650,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1beta1.PipelineRun, get
 			}
 		}
 		if tasksToTimeOut.Len() > 0 {
-			logger.Infof("PipelineRun finally timeout of %s reached, cancelling finally tasks", pr.Spec.Timeouts.Finally.Duration.String())
+			logger.Debugf("PipelineRun finally timeout of %s reached, cancelling finally tasks", finallyTimeout)
 			errs := timeoutPipelineTasksForTaskNames(ctx, logger, pr, c.PipelineClientSet, tasksToTimeOut)
 			if len(errs) > 0 {
 				errString := strings.Join(errs, "\n")


### PR DESCRIPTION
Cherry-pick of https://github.com/tektoncd/pipeline/pull/6886

Prior to this commit, log lines in the pipelinerun reconciler assumed that if a pipelineRun had reached its tasks timeout, `spec.timeouts.tasks` was set, rather than computed from `spec.timeouts.pipeline` and `spec.timeouts.finally`, and likewise for the finally timeout.

This commit updates log messages to avoid the controller panic, and adds tests for this fix.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- n/a Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- n/a Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
bug fix: Avoid controller panics for computed timeouts
```
