### PR TITLE
Update Matrix Documentation for Results

### DIFF
--- a/docs/matrix.md
+++ b/docs/matrix.md
@@ -358,11 +358,10 @@ tasks:
           value: $(tasks.task-2.results.duh.key) # string replacement from object result
 ```
 
-### Results from fanned out PipelineTasks
+### Results from fanned out Matrixed PipelineTasks
 
-Consuming `Results` from fanned out `PipelineTasks` will not be in the supported in the initial iteration
-of `Matrix`. Supporting consuming `Results` from fanned out `PipelineTasks` will be revisited after array
-and object `Results` are supported.
+Emitting `Results` from fanned out `PipelineTasks`  is not currently supported.
+We plan to support emitting `Results` from fanned out `PipelineTasks` in the near future.
 
 
 ## Retries

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -921,8 +921,6 @@ Array and Object result is a beta feature and can be enabled by setting `enable-
 
 **Note:** Whole Array and Object `Results` (using star notation) cannot be referred in `script`.
 
-**Note:** `Matrix` does not support `object` and `array` results.
-
 When one `Task` receives the `Results` of another, there is a dependency created between those
 two `Tasks`. In order for the receiving `Task` to get data from another `Task's` `Result`,
 the `Task` producing the `Result` must run first. Tekton enforces this `Task` ordering


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

This PR updates the documentation for Matrix to accurately reflect what is and is not currently supported.

Consuming results in a matrixed PipelineTask is supported for object, array and string results. 

Emitting results in a matrixed PipelineTask is not yet supported.

/kind documentation

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
