### PR TITLE
Create a separate role for Events Controller

### DIFF
--- a/config/200-role.yaml
+++ b/config/200-role.yaml
@@ -63,6 +63,25 @@ rules:
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
+  name: tekton-pipelines-events-controller
+  namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/component: events
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["list", "watch"]
+  # The controller needs access to these configmaps for logging information and runtime configuration.
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get"]
+    resourceNames: ["config-logging", "config-observability", "feature-flags", "config-leader-election", "config-registry-cert"]
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
   name: tekton-pipelines-leader-election
   namespace: tekton-pipelines
   labels:

--- a/config/201-rolebinding.yaml
+++ b/config/201-rolebinding.yaml
@@ -106,7 +106,7 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: tekton-events-controller
+  name: tekton-pipelines-events-controller
   namespace: tekton-pipelines
   labels:
     app.kubernetes.io/component: events
@@ -118,7 +118,7 @@ subjects:
     namespace: tekton-pipelines
 roleRef:
   kind: Role
-  name: tekton-pipelines-controller
+  name: tekton-pipelines-events-controller
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Before this, pipelines-controller role is being used. We would need to modify pipelines-controller role.
When setting up configmaps for the events controller different from the pipelines controller,  before this fix, it is also necessary to grant permissions to the role added to the pipelines controller. 

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
The role for Events Controller is now `tekton-events-controller`,  and the Rolebinding is now `tekton-pipelines-events-controller.`
```

/kind bug
