### PR TITLE
Make sure we use the correct namespace for remote Pipeline validation

### DIFF
--- a/pkg/reconciler/pipelinerun/resources/pipelineref.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelineref.go
@@ -37,9 +37,11 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-var ErrReferencedPipelineValidationFailed = errors.New("validation failed for referenced Pipeline")
-var ErrCouldntValidatePipelineRetryable = errors.New("retryable error validating referenced Pipeline")
-var ErrCouldntValidatePipelinePermanent = errors.New("permanent error validating referenced Pipeline")
+var (
+	ErrReferencedPipelineValidationFailed = errors.New("validation failed for referenced Pipeline")
+	ErrCouldntValidatePipelineRetryable   = errors.New("retryable error validating referenced Pipeline")
+	ErrCouldntValidatePipelinePermanent   = errors.New("permanent error validating referenced Pipeline")
+)
 
 // GetPipelineFunc is a factory function that will use the given PipelineRef to return a valid GetPipeline function that
 // looks up the pipeline. It uses as context a k8s client, tekton client, namespace, and service account name to return
@@ -150,6 +152,7 @@ func readRuntimeObjectAsPipeline(ctx context.Context, namespace string, obj runt
 		// TODO(#6592): Decouple API versioning from feature versioning
 		dryRunObj := obj.DeepCopy()
 		dryRunObj.Name = uuid.NewString() // Use a randomized name for the Pipeline in case there is already another Pipeline of the same name
+		dryRunObj.Namespace = namespace   // Make sure the namespace is the same as the PipelineRun
 		if _, err := tekton.TektonV1beta1().Pipelines(namespace).Create(ctx, dryRunObj, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}}); err != nil {
 			return nil, nil, handleDryRunCreateErr(err, obj.Name)
 		}
@@ -169,6 +172,7 @@ func readRuntimeObjectAsPipeline(ctx context.Context, namespace string, obj runt
 		// without actually creating the Pipeline on the cluster
 		dryRunObj := obj.DeepCopy()
 		dryRunObj.Name = uuid.NewString() // Use a randomized name for the Pipeline in case there is already another Pipeline of the same name
+		dryRunObj.Namespace = namespace   // Make sure the namespace is the same as the PipelineRun
 		if _, err := tekton.TektonV1().Pipelines(namespace).Create(ctx, dryRunObj, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}}); err != nil {
 			return nil, nil, handleDryRunCreateErr(err, obj.Name)
 		}

--- a/pkg/reconciler/pipelinerun/resources/pipelineref_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelineref_test.go
@@ -74,7 +74,8 @@ var (
 	unsignedV1Pipeline = &v1.Pipeline{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "tekton.dev/v1",
-			Kind:       "Pipeline"},
+			Kind:       "Pipeline",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "pipeline",
 			Namespace:   "trusted-resources",
@@ -313,6 +314,14 @@ func TestGetPipelineFunc_RemoteResolution(t *testing.T) {
 			pipelineYAMLStringWithoutDefaults,
 		}, "\n"),
 		wantPipeline: parse.MustParseV1Pipeline(t, pipelineYAMLStringWithoutDefaults),
+	}, {
+		name: "v1 remote pipeline with different namespace",
+		pipelineYAML: strings.Join([]string{
+			"kind: Pipeline",
+			"apiVersion: tekton.dev/v1",
+			pipelineYAMLStringNamespaceFoo,
+		}, "\n"),
+		wantPipeline: parse.MustParseV1Pipeline(t, pipelineYAMLStringNamespaceFoo),
 	}}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1301,6 +1310,21 @@ spec:
   params:
   - name: foo
     type: ""
+`
+
+var pipelineYAMLStringNamespaceFoo = `
+metadata:
+  name: foo
+  namespace: foo
+spec:
+  tasks:
+  - name: task1
+    taskSpec:
+      steps:
+      - name: step1
+        image: ubuntu
+        script: |
+          echo "hello world!"
 `
 
 func getSignedV1Pipeline(unsigned *v1.Pipeline, signer signature.Signer, name string) (*v1.Pipeline, error) {


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

In the case of using the cluster resolver, the fetched `Pipeline` will
have a namespace attached to it, which **will** be different from the
current namespace (where the `PipelineRun` is applied). This causes
the following error when using the cluster resolver:

```
validation failed for referenced Pipeline pipeline-name: the namespace of the provided object does not match the namespace sent on the request
```

This make sure we ignore that "fetched" namespace when doing the
remote `Pipeline` validation.

This fixes https://github.com/tektoncd/pipeline/issues/7015.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Fix validation errors when using the cluster resolver
```
