### PR TITLE
[TEP-0056]: Initial set of API refactors pertinent to Pipelines in Pipelines

### DIFF
--- a/docs/pipeline-api.md
+++ b/docs/pipeline-api.md
@@ -1797,7 +1797,7 @@ map[string]string
 <h3 id="tekton.dev/v1.PipelineRef">PipelineRef
 </h3>
 <p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineRunSpec">PipelineRunSpec</a>)
+(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineRunSpec">PipelineRunSpec</a>, <a href="#tekton.dev/v1.PipelineTask">PipelineTask</a>)
 </p>
 <div>
 <p>PipelineRef can be used to refer to a specific instance of a Pipeline.</p>
@@ -2453,7 +2453,7 @@ TaskRunStatus
 <h3 id="tekton.dev/v1.PipelineSpec">PipelineSpec
 </h3>
 <p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.Pipeline">Pipeline</a>, <a href="#tekton.dev/v1.PipelineRunSpec">PipelineRunSpec</a>, <a href="#tekton.dev/v1.PipelineRunStatusFields">PipelineRunStatusFields</a>)
+(<em>Appears on:</em><a href="#tekton.dev/v1.Pipeline">Pipeline</a>, <a href="#tekton.dev/v1.PipelineRunSpec">PipelineRunSpec</a>, <a href="#tekton.dev/v1.PipelineRunStatusFields">PipelineRunStatusFields</a>, <a href="#tekton.dev/v1.PipelineTask">PipelineTask</a>)
 </p>
 <div>
 <p>PipelineSpec defines the desired state of Pipeline.</p>
@@ -2744,6 +2744,36 @@ Kubernetes meta/v1.Duration
 <em>(Optional)</em>
 <p>Time after which the TaskRun times out. Defaults to 1 hour.
 Refer Go&rsquo;s ParseDuration documentation for expected format: <a href="https://golang.org/pkg/time/#ParseDuration">https://golang.org/pkg/time/#ParseDuration</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>pipelineRef</code><br/>
+<em>
+<a href="#tekton.dev/v1.PipelineRef">
+PipelineRef
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>PipelineRef is a reference to a pipeline definition
+Note: PipelineRef is in preview mode and not yet supported</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>pipelineSpec</code><br/>
+<em>
+<a href="#tekton.dev/v1.PipelineSpec">
+PipelineSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>PipelineSpec is a specification of a pipeline
+Note: PipelineSpec is in preview mode and not yet supported</p>
 </td>
 </tr>
 </tbody>
@@ -9631,7 +9661,7 @@ optional: false - the resource is considered required (default/equivalent of not
 <h3 id="tekton.dev/v1beta1.PipelineRef">PipelineRef
 </h3>
 <p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineRunSpec">PipelineRunSpec</a>)
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineRunSpec">PipelineRunSpec</a>, <a href="#tekton.dev/v1beta1.PipelineTask">PipelineTask</a>)
 </p>
 <div>
 <p>PipelineRef can be used to refer to a specific instance of a Pipeline.</p>
@@ -10445,7 +10475,7 @@ TaskRunStatus
 <h3 id="tekton.dev/v1beta1.PipelineSpec">PipelineSpec
 </h3>
 <p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.Pipeline">Pipeline</a>, <a href="#tekton.dev/v1beta1.PipelineRunSpec">PipelineRunSpec</a>, <a href="#tekton.dev/v1beta1.PipelineRunStatusFields">PipelineRunStatusFields</a>)
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.Pipeline">Pipeline</a>, <a href="#tekton.dev/v1beta1.PipelineRunSpec">PipelineRunSpec</a>, <a href="#tekton.dev/v1beta1.PipelineRunStatusFields">PipelineRunStatusFields</a>, <a href="#tekton.dev/v1beta1.PipelineTask">PipelineTask</a>)
 </p>
 <div>
 <p>PipelineSpec defines the desired state of Pipeline.</p>
@@ -10763,6 +10793,36 @@ Kubernetes meta/v1.Duration
 <em>(Optional)</em>
 <p>Time after which the TaskRun times out. Defaults to 1 hour.
 Refer Go&rsquo;s ParseDuration documentation for expected format: <a href="https://golang.org/pkg/time/#ParseDuration">https://golang.org/pkg/time/#ParseDuration</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>pipelineRef</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.PipelineRef">
+PipelineRef
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>PipelineRef is a reference to a pipeline definition
+Note: PipelineRef is in preview mode and not yet supported</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>pipelineSpec</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.PipelineSpec">
+PipelineSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>PipelineSpec is a specification of a pipeline
+Note: PipelineSpec is in preview mode and not yet supported</p>
 </td>
 </tr>
 </tbody>

--- a/docs/pipelines-in-pipelines.md
+++ b/docs/pipelines-in-pipelines.md
@@ -1,0 +1,115 @@
+<!--
+---
+linkTitle: "Pipelines in Pipelines"
+weight: 406
+---
+-->
+
+# Pipelines in Pipelines
+
+- [Overview](#overview)
+- [Specifying `pipelineRef` in `Tasks`](#specifying-pipelineref-in-pipelinetasks)
+- [Specifying `pipelineSpec` in `Tasks`](#specifying-pipelinespec-in-pipelinetasks)
+- [Specifying `Parameters`](#specifying-parameters)
+
+## Overview
+
+A mechanism to define and execute Pipelines in Pipelines, alongside Tasks and Custom Tasks, for a more in-depth background and inspiration, refer to the proposal [TEP-0056](https://github.com/tektoncd/community/blob/main/teps/0056-pipelines-in-pipelines.md "Proposal").
+
+> :seedling: **Pipelines in Pipelines is an  [alpha](additional-configs.md#alpha-features) feature.**
+> The `enable-api-fields` feature flag must be set to `"alpha"` to specify `pipelineRef` or `pipelineSpec` in a `pipelineTask`.
+> This feature is in Preview Only mode and not yet supported/implemented.
+
+## Specifying `pipelineRef` in `pipelineTasks`
+
+Defining Pipelines in Pipelines at authoring time, by either specifying `PipelineRef` or `PipelineSpec` fields to a `PipelineTask` alongside `TaskRef` and `TaskSpec`.
+
+For example, a Pipeline named security-scans which is run within a Pipeline named clone-scan-notify where the PipelineRef is used:
+
+```
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: security-scans
+spec:
+  tasks:
+    - name: scorecards
+      taskRef:
+        name: scorecards
+    - name: codeql
+      taskRef:
+        name: codeql
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: clone-scan-notify
+spec:
+  tasks:
+    - name: git-clone
+      taskRef:
+        name: git-clone
+    - name: security-scans
+      pipelineRef:
+        name: security-scans
+    - name: notification
+      taskRef:
+        name: notification
+```
+
+## Specifying `pipelineSpec` in `pipelineTasks`
+
+The `pipelineRef` [example](#specifying-pipelineref-in-pipelinetasks) can be modified to use PipelineSpec instead of PipelineRef to instead embed the Pipeline specification:
+```
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: clone-scan-notify
+spec:
+  tasks:
+    - name: git-clone
+      taskRef:
+        name: git-clone
+    - name: security-scans
+      pipelineSpec:
+        tasks:
+          - name: scorecards
+            taskRef:
+              name: scorecards
+          - name: codeql
+            taskRef:
+              name: codeql
+    - name: notification
+      taskRef:
+        name: notification
+```
+
+## Specifying `Parameters`
+
+Pipelines in Pipelines consume Parameters in the same way as Tasks in Pipelines
+```
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: clone-scan-notify
+spec:
+  params:
+    - name: repo
+      value: $(params.repo)
+  tasks:
+    - name: git-clone
+      params:
+        - name: repo
+          value: $(params.repo)      
+      taskRef:
+        name: git-clone
+    - name: security-scans
+      params:
+        - name: repo
+          value: $(params.repo)
+      pipelineRef:
+        name: security-scans
+    - name: notification
+      taskRef:
+        name: notification
+```

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -14,6 +14,7 @@ weight: 203
   - [Specifying `Parameters`](#specifying-parameters)
   - [Adding `Tasks` to the `Pipeline`](#adding-tasks-to-the-pipeline)
     - [Specifying Remote Tasks](#specifying-remote-tasks)
+    - [Specifying `Pipelines` in `PipelineTasks`](#specifying-pipelines-in-pipelinetasks)
     - [Specifying `Parameters` in `PipelineTasks`](#specifying-parameters-in-pipelinetasks)
     - [Specifying `Matrix` in `PipelineTasks`](#specifying-matrix-in-pipelinetasks)
     - [Specifying `Workspaces` in `PipelineTasks`](#specifying-workspaces-in-pipelinetasks)
@@ -316,6 +317,59 @@ tasks:
     - name: pathInRepo
       value: task/golang-build/0.3/golang-build.yaml
 ```
+
+### Specifying `Pipelines` in `PipelineTasks`
+
+> :seedling: **Specifying `pipelines` in `PipelineTasks` is an [alpha](additional-configs.md#alpha-features) feature.**
+> The `enable-api-fields` feature flag must be set to `"alpha"` to specify `PipelineRef` or `PipelineSpec` in a `PipelineTask`.
+> This feature is in **Preview Only** mode and not yet supported/implemented.
+
+Apart from `taskRef` and `taskSpec`, `pipelineRef` and `pipelineSpec` allows you to specify a `pipeline`  in `pipelineTask`.
+This allows you to generate a child `pipelineRun` which is inherited by the parent `pipelineRun`.
+
+```
+kind: Pipeline
+metadata:
+  name: security-scans
+spec:
+  tasks:
+    - name: scorecards
+      taskSpec:
+        steps:
+          - image: alpine
+            name: step-1
+            script: |
+              echo "Generating scorecard report ..."
+    - name: codeql
+      taskSpec:
+        steps:
+          - image: alpine
+            name: step-1
+            script: |
+              echo "Generating codeql report ..."
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: clone-scan-notify
+spec:
+  tasks:
+    - name: git-clone
+      taskSpec:
+        steps:
+          - image: alpine
+            name: step-1
+            script: |
+              echo "Cloning a repo to run security scans ..."
+    - name: security-scans
+      runAfter:
+        - git-clone
+      pipelineRef:
+        name: security-scans
+---
+```
+For further information read [Pipelines in Pipelines](./pipelines-in-pipelines.md)
+
 
 ### Specifying `Parameters` in `PipelineTasks`
 

--- a/pkg/apis/pipeline/v1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1/openapi_generated.go
@@ -1879,11 +1879,23 @@ func schema_pkg_apis_pipeline_v1_PipelineTask(ref common.ReferenceCallback) comm
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Duration"),
 						},
 					},
+					"pipelineRef": {
+						SchemaProps: spec.SchemaProps{
+							Description: "PipelineRef is a reference to a pipeline definition Note: PipelineRef is in preview mode and not yet supported",
+							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineRef"),
+						},
+					},
+					"pipelineSpec": {
+						SchemaProps: spec.SchemaProps{
+							Description: "PipelineSpec is a specification of a pipeline Note: PipelineSpec is in preview mode and not yet supported",
+							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineSpec"),
+						},
+					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.EmbeddedTask", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Matrix", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Param", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskRef", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.WhenExpression", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.WorkspacePipelineTaskBinding", "k8s.io/apimachinery/pkg/apis/meta/v1.Duration"},
+			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.EmbeddedTask", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Matrix", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Param", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineRef", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineSpec", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskRef", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.WhenExpression", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.WorkspacePipelineTaskBinding", "k8s.io/apimachinery/pkg/apis/meta/v1.Duration"},
 	}
 }
 

--- a/pkg/apis/pipeline/v1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1/pipeline_types.go
@@ -228,6 +228,16 @@ type PipelineTask struct {
 	// Refer Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration
 	// +optional
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
+
+	// PipelineRef is a reference to a pipeline definition
+	// Note: PipelineRef is in preview mode and not yet supported
+	// +optional
+	PipelineRef *PipelineRef `json:"pipelineRef,omitempty"`
+
+	// PipelineSpec is a specification of a pipeline
+	// Note: PipelineSpec is in preview mode and not yet supported
+	// +optional
+	PipelineSpec *PipelineSpec `json:"pipelineSpec,omitempty"`
 }
 
 // IsCustomTask checks whether an embedded TaskSpec is a Custom Task

--- a/pkg/apis/pipeline/v1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1/pipeline_validation.go
@@ -37,6 +37,13 @@ import (
 var _ apis.Validatable = (*Pipeline)(nil)
 var _ resourcesemantics.VerbLimited = (*Pipeline)(nil)
 
+const (
+	taskRef      = "taskRef"
+	taskSpec     = "taskSpec"
+	pipelineRef  = "pipelineRef"
+	pipelineSpec = "pipelineSpec"
+)
+
 // SupportedVerbs returns the operations that validation should be called for
 func (p *Pipeline) SupportedVerbs() []admissionregistrationv1.OperationType {
 	return []admissionregistrationv1.OperationType{admissionregistrationv1.Create, admissionregistrationv1.Update}
@@ -195,7 +202,7 @@ func (pt PipelineTask) ValidateName() *apis.FieldError {
 // Validate classifies whether a task is a custom task or a regular task(dag/final)
 // calls the validation routine based on the type of the task
 func (pt PipelineTask) Validate(ctx context.Context) (errs *apis.FieldError) {
-	errs = errs.Also(pt.validateRefOrSpec())
+	errs = errs.Also(pt.validateRefOrSpec(ctx))
 
 	errs = errs.Also(pt.validateEmbeddedOrType())
 	// taskKinds contains the kinds when the apiVersion is not set, they are not custom tasks,
@@ -289,15 +296,39 @@ func (pt *PipelineTask) validateWorkspaces(workspaceNames sets.String) (errs *ap
 	return errs
 }
 
-// validateRefOrSpec validates at least one of taskRef or taskSpec is specified
-func (pt PipelineTask) validateRefOrSpec() (errs *apis.FieldError) {
-	// can't have both taskRef and taskSpec at the same time
-	if pt.TaskRef != nil && pt.TaskSpec != nil {
-		errs = errs.Also(apis.ErrMultipleOneOf("taskRef", "taskSpec"))
+// validateRefOrSpec validates at least one of taskRef or taskSpec or pipelineRef or pipelineSpec is specified
+func (pt PipelineTask) validateRefOrSpec(ctx context.Context) (errs *apis.FieldError) {
+	// collect all the specified specifications
+	nonNilFields := []string{}
+	if pt.TaskRef != nil {
+		nonNilFields = append(nonNilFields, taskRef)
 	}
-	// Check that one of TaskRef and TaskSpec is present
-	if pt.TaskRef == nil && pt.TaskSpec == nil {
-		errs = errs.Also(apis.ErrMissingOneOf("taskRef", "taskSpec"))
+	if pt.TaskSpec != nil {
+		nonNilFields = append(nonNilFields, taskSpec)
+	}
+	if pt.PipelineRef != nil {
+		errs = errs.Also(version.ValidateEnabledAPIFields(ctx, pipelineRef, config.AlphaAPIFields))
+		nonNilFields = append(nonNilFields, pipelineRef)
+	}
+	if pt.PipelineSpec != nil {
+		errs = errs.Also(version.ValidateEnabledAPIFields(ctx, pipelineSpec, config.AlphaAPIFields))
+		nonNilFields = append(nonNilFields, pipelineSpec)
+	}
+
+	// check the length of nonNilFields
+	// if one of taskRef or taskSpec or pipelineRef or pipelineSpec is specified,
+	// the length of nonNilFields should exactly be 1
+	if len(nonNilFields) > 1 {
+		errs = errs.Also(apis.ErrGeneric("expected exactly one, got multiple", nonNilFields...))
+	} else if len(nonNilFields) == 0 {
+		cfg := config.FromContextOrDefaults(ctx)
+		// check for TaskRef or TaskSpec or PipelineRef or PipelineSpec with alpha feature flag
+		if cfg.FeatureFlags.EnableAPIFields == config.AlphaAPIFields {
+			errs = errs.Also(apis.ErrMissingOneOf(taskRef, taskSpec, pipelineRef, pipelineSpec))
+		} else {
+			// check for taskRef and taskSpec with beta/stable feature flag
+			errs = errs.Also(apis.ErrMissingOneOf(taskRef, taskSpec))
+		}
 	}
 	return errs
 }
@@ -323,10 +354,16 @@ func (pt PipelineTask) validateCustomTask() (errs *apis.FieldError) {
 func (pt PipelineTask) validateTask(ctx context.Context) (errs *apis.FieldError) {
 	// Validate TaskSpec if it's present
 	if pt.TaskSpec != nil {
-		errs = errs.Also(pt.TaskSpec.Validate(ctx).ViaField("taskSpec"))
+		errs = errs.Also(pt.TaskSpec.Validate(ctx).ViaField(taskSpec))
 	}
 	if pt.TaskRef != nil {
-		errs = errs.Also(pt.TaskRef.Validate(ctx).ViaField("taskRef"))
+		errs = errs.Also(pt.TaskRef.Validate(ctx).ViaField(taskRef))
+	}
+	if pt.PipelineRef != nil {
+		errs = errs.Also(pt.PipelineRef.Validate(ctx).ViaField(pipelineRef))
+	}
+	if pt.PipelineSpec != nil {
+		errs = errs.Also(pt.PipelineSpec.Validate(ctx).ViaField(pipelineSpec))
 	}
 	return errs
 }

--- a/pkg/apis/pipeline/v1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1/pipeline_validation_test.go
@@ -87,6 +87,34 @@ func TestPipeline_Validate_Success(t *testing.T) {
 				Tasks: []PipelineTask{{Name: "foo", TaskRef: &TaskRef{Name: "bar", Kind: ClusterTaskRefKind}}},
 			},
 		},
+	}, {
+		name: "valid task with pipelineRef",
+		wc:   cfgtesting.EnableAlphaAPIFields,
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Tasks: []PipelineTask{
+					{
+						Name:        "foo",
+						PipelineRef: &PipelineRef{Name: "foo-pipeline"},
+					},
+				},
+			},
+		},
+	}, {
+		name: "valid task with pipelineSpec",
+		wc:   cfgtesting.EnableAlphaAPIFields,
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Tasks: []PipelineTask{
+					{
+						Name:         "foo",
+						PipelineSpec: &PipelineSpec{Description: "foo-pipeline-description"},
+					},
+				},
+			},
+		},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -193,6 +221,25 @@ func TestPipeline_Validate_Failure(t *testing.T) {
 			Message: `non-existent variable in "$(params.doesnotexist)"`,
 			Paths:   []string{"spec.finally[0].steps[0].script"},
 		},
+	}, {
+		name: "invalid task with pipelineRef and pipelineSpec",
+		wc:   cfgtesting.EnableAlphaAPIFields,
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Tasks: []PipelineTask{
+					{
+						Name:         "foo",
+						PipelineRef:  &PipelineRef{Name: "foo-pipeline"},
+						PipelineSpec: &PipelineSpec{Description: "foo-pipeline-description"},
+					},
+				},
+			},
+		},
+		expectedError: apis.FieldError{
+			Message: `expected exactly one, got multiple`,
+			Paths:   []string{"spec.tasks[0].pipelineRef, spec.tasks[0].pipelineSpec"},
+		},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -216,8 +263,9 @@ func TestPipelineSpec_Validate_Failure(t *testing.T) {
 		name          string
 		ps            *PipelineSpec
 		expectedError apis.FieldError
+		wc            func(context.Context) context.Context
 	}{{
-		name: "invalid pipeline with one pipeline task having taskRef and taskSpec both",
+		name: "invalid pipeline with one pipeline task having taskRef and taskSpec",
 		ps: &PipelineSpec{
 			Description: "this is an invalid pipeline with invalid pipeline task",
 			Tasks: []PipelineTask{{
@@ -230,9 +278,195 @@ func TestPipelineSpec_Validate_Failure(t *testing.T) {
 			}},
 		},
 		expectedError: apis.FieldError{
-			Message: `expected exactly one, got both`,
+			Message: `expected exactly one, got multiple`,
 			Paths:   []string{"tasks[1].taskRef", "tasks[1].taskSpec"},
 		},
+	}, {
+		name: "invalid pipeline with one pipeline task having taskRef and pipelineRef",
+		ps: &PipelineSpec{
+			Description: "this is an invalid pipeline with invalid pipeline task",
+			Tasks: []PipelineTask{{
+				Name:    "valid-pipeline-task",
+				TaskRef: &TaskRef{Name: "foo-task"},
+			}, {
+				Name:        "invalid-pipeline-task",
+				TaskRef:     &TaskRef{Name: "foo-task"},
+				PipelineRef: &PipelineRef{Name: "foo-pipeline"},
+			}},
+		},
+		expectedError: apis.FieldError{
+			Message: `expected exactly one, got multiple`,
+			Paths:   []string{"tasks[1].taskRef", "tasks[1].pipelineRef"},
+		},
+		wc: cfgtesting.EnableAlphaAPIFields,
+	}, {
+		name: "invalid pipeline with one pipeline task having taskRef and pipelineSpec",
+		ps: &PipelineSpec{
+			Description: "this is an invalid pipeline with invalid pipeline task",
+			Tasks: []PipelineTask{{
+				Name:    "valid-pipeline-task",
+				TaskRef: &TaskRef{Name: "foo-task"},
+			}, {
+				Name:         "invalid-pipeline-task",
+				TaskRef:      &TaskRef{Name: "foo-task"},
+				PipelineSpec: &PipelineSpec{Description: "foo-pipeline-description"},
+			}},
+		},
+		expectedError: apis.FieldError{
+			Message: `expected exactly one, got multiple`,
+			Paths:   []string{"tasks[1].taskRef", "tasks[1].pipelineSpec"},
+		},
+		wc: cfgtesting.EnableAlphaAPIFields,
+	}, {
+		name: "invalid pipeline with one pipeline task having taskSpec and pipelineRef",
+		ps: &PipelineSpec{
+			Description: "this is an invalid pipeline with invalid pipeline task",
+			Tasks: []PipelineTask{{
+				Name:    "valid-pipeline-task",
+				TaskRef: &TaskRef{Name: "foo-task"},
+			}, {
+				Name:        "invalid-pipeline-task",
+				TaskSpec:    &EmbeddedTask{TaskSpec: getTaskSpec()},
+				PipelineRef: &PipelineRef{Name: "foo-pipeline"},
+			}},
+		},
+		expectedError: apis.FieldError{
+			Message: `expected exactly one, got multiple`,
+			Paths:   []string{"tasks[1].taskSpec", "tasks[1].pipelineRef"},
+		},
+		wc: cfgtesting.EnableAlphaAPIFields,
+	}, {
+		name: "invalid pipeline with one pipeline task having taskSpec and pipelineSpec",
+		ps: &PipelineSpec{
+			Description: "this is an invalid pipeline with invalid pipeline task",
+			Tasks: []PipelineTask{{
+				Name:    "valid-pipeline-task",
+				TaskRef: &TaskRef{Name: "foo-task"},
+			}, {
+				Name:         "invalid-pipeline-task",
+				TaskSpec:     &EmbeddedTask{TaskSpec: getTaskSpec()},
+				PipelineSpec: &PipelineSpec{Description: "foo-pipeline-description"},
+			}},
+		},
+		expectedError: apis.FieldError{
+			Message: `expected exactly one, got multiple`,
+			Paths:   []string{"tasks[1].taskSpec", "tasks[1].pipelineSpec"},
+		},
+		wc: cfgtesting.EnableAlphaAPIFields,
+	}, {
+		name: "invalid pipeline with one pipeline task having pipelineRef and pipelineSpec",
+		ps: &PipelineSpec{
+			Description: "this is an invalid pipeline with invalid pipeline task",
+			Tasks: []PipelineTask{{
+				Name:    "valid-pipeline-task",
+				TaskRef: &TaskRef{Name: "foo-task"},
+			}, {
+				Name:         "invalid-pipeline-task",
+				PipelineRef:  &PipelineRef{Name: "foo-pipeline"},
+				PipelineSpec: &PipelineSpec{Description: "foo-pipeline-description"},
+			}},
+		},
+		expectedError: apis.FieldError{
+			Message: `expected exactly one, got multiple`,
+			Paths:   []string{"tasks[1].pipelineRef", "tasks[1].pipelineSpec"},
+		},
+		wc: cfgtesting.EnableAlphaAPIFields,
+	}, {
+		name: "invalid pipeline with one pipeline task having taskRef, taskSpec and pipelineRef",
+		ps: &PipelineSpec{
+			Description: "this is an invalid pipeline with invalid pipeline task",
+			Tasks: []PipelineTask{{
+				Name:    "valid-pipeline-task",
+				TaskRef: &TaskRef{Name: "foo-task"},
+			}, {
+				Name:        "invalid-pipeline-task",
+				TaskRef:     &TaskRef{Name: "foo-task"},
+				TaskSpec:    &EmbeddedTask{TaskSpec: getTaskSpec()},
+				PipelineRef: &PipelineRef{Name: "foo-pipeline"},
+			}},
+		},
+		expectedError: apis.FieldError{
+			Message: `expected exactly one, got multiple`,
+			Paths:   []string{"tasks[1].taskRef", "tasks[1].taskSpec", "tasks[1].pipelineRef"},
+		},
+		wc: cfgtesting.EnableAlphaAPIFields,
+	}, {
+		name: "invalid pipeline with one pipeline task having taskRef, taskSpec and pipelineSpec",
+		ps: &PipelineSpec{
+			Description: "this is an invalid pipeline with invalid pipeline task",
+			Tasks: []PipelineTask{{
+				Name:    "valid-pipeline-task",
+				TaskRef: &TaskRef{Name: "foo-task"},
+			}, {
+				Name:         "invalid-pipeline-task",
+				TaskRef:      &TaskRef{Name: "foo-task"},
+				TaskSpec:     &EmbeddedTask{TaskSpec: getTaskSpec()},
+				PipelineSpec: &PipelineSpec{Description: "foo-pipeline-description"},
+			}},
+		},
+		expectedError: apis.FieldError{
+			Message: `expected exactly one, got multiple`,
+			Paths:   []string{"tasks[1].taskRef", "tasks[1].taskSpec", "tasks[1].pipelineSpec"},
+		},
+		wc: cfgtesting.EnableAlphaAPIFields,
+	}, {
+		name: "invalid pipeline with one pipeline task having taskRef, pipelineRef and pipelineSpec",
+		ps: &PipelineSpec{
+			Description: "this is an invalid pipeline with invalid pipeline task",
+			Tasks: []PipelineTask{{
+				Name:    "valid-pipeline-task",
+				TaskRef: &TaskRef{Name: "foo-task"},
+			}, {
+				Name:         "invalid-pipeline-task",
+				TaskRef:      &TaskRef{Name: "foo-task"},
+				PipelineRef:  &PipelineRef{Name: "foo-pipeline"},
+				PipelineSpec: &PipelineSpec{Description: "foo-pipeline-description"},
+			}},
+		},
+		expectedError: apis.FieldError{
+			Message: `expected exactly one, got multiple`,
+			Paths:   []string{"tasks[1].taskRef", "tasks[1].pipelineRef", "tasks[1].pipelineSpec"},
+		},
+		wc: cfgtesting.EnableAlphaAPIFields,
+	}, {
+		name: "invalid pipeline with one pipeline task having taskSpec, pipelineRef and pipelineSpec",
+		ps: &PipelineSpec{
+			Description: "this is an invalid pipeline with invalid pipeline task",
+			Tasks: []PipelineTask{{
+				Name:    "valid-pipeline-task",
+				TaskRef: &TaskRef{Name: "foo-task"},
+			}, {
+				Name:         "invalid-pipeline-task",
+				TaskSpec:     &EmbeddedTask{TaskSpec: getTaskSpec()},
+				PipelineRef:  &PipelineRef{Name: "foo-pipeline"},
+				PipelineSpec: &PipelineSpec{Description: "foo-pipeline-description"},
+			}},
+		},
+		expectedError: apis.FieldError{
+			Message: `expected exactly one, got multiple`,
+			Paths:   []string{"tasks[1].taskSpec", "tasks[1].pipelineRef", "tasks[1].pipelineSpec"},
+		},
+		wc: cfgtesting.EnableAlphaAPIFields,
+	}, {
+		name: "invalid pipeline with one pipeline task having taskRef and taskSpec and pipelineRef and pipelineSpec",
+		ps: &PipelineSpec{
+			Description: "this is an invalid pipeline with invalid pipeline task",
+			Tasks: []PipelineTask{{
+				Name:    "valid-pipeline-task",
+				TaskRef: &TaskRef{Name: "foo-task"},
+			}, {
+				Name:         "invalid-pipeline-task",
+				TaskRef:      &TaskRef{Name: "foo-task"},
+				TaskSpec:     &EmbeddedTask{TaskSpec: getTaskSpec()},
+				PipelineRef:  &PipelineRef{Name: "foo-pipeline"},
+				PipelineSpec: &PipelineSpec{Description: "foo-pipeline-description"},
+			}},
+		},
+		expectedError: apis.FieldError{
+			Message: `expected exactly one, got multiple`,
+			Paths:   []string{"tasks[1].taskRef", "tasks[1].taskSpec", "tasks[1].pipelineRef", "tasks[1].pipelineSpec"},
+		},
+		wc: cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "invalid pipeline with one pipeline task having when expression with invalid operator (not In/NotIn)",
 		ps: &PipelineSpec{
@@ -667,7 +901,11 @@ func TestPipelineSpec_Validate_Failure(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.ps.Validate(context.Background())
+			ctx := context.Background()
+			if tt.wc != nil {
+				ctx = tt.wc(ctx)
+			}
+			err := tt.ps.Validate(ctx)
 			if err == nil {
 				t.Errorf("PipelineSpec.Validate() did not return error for invalid pipelineSpec")
 			}
@@ -2069,8 +2307,10 @@ func TestValidatePipelineWithFinalTasks_Success(t *testing.T) {
 	tests := []struct {
 		name string
 		p    *Pipeline
+		wc   func(context.Context) context.Context
 	}{{
 		name: "valid pipeline with final tasks",
+		wc:   cfgtesting.EnableAlphaAPIFields,
 		p: &Pipeline{
 			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
 			Spec: PipelineSpec{
@@ -2084,6 +2324,12 @@ func TestValidatePipelineWithFinalTasks_Success(t *testing.T) {
 				}, {
 					Name:     "final-task-2",
 					TaskSpec: &EmbeddedTask{TaskSpec: getTaskSpec()},
+				}, {
+					Name:        "final-task-3",
+					PipelineRef: &PipelineRef{Name: "foo-pipeline"},
+				}, {
+					Name:         "final-task-4",
+					PipelineSpec: &PipelineSpec{Description: "foo-pipeline-description"},
 				}},
 			},
 		},
@@ -2126,7 +2372,11 @@ func TestValidatePipelineWithFinalTasks_Success(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.p.Validate(context.Background())
+			ctx := context.Background()
+			if tt.wc != nil {
+				ctx = tt.wc(ctx)
+			}
+			err := tt.p.Validate(ctx)
 			if err != nil {
 				t.Errorf("Pipeline.Validate() returned error for valid pipeline with finally: %v", err)
 			}
@@ -2139,6 +2389,7 @@ func TestValidatePipelineWithFinalTasks_Failure(t *testing.T) {
 		name          string
 		p             *Pipeline
 		expectedError apis.FieldError
+		wc            func(context.Context) context.Context
 	}{{
 		name: "invalid pipeline without any non-final task (tasks set to nil) but at least one final task",
 		p: &Pipeline{
@@ -2235,7 +2486,7 @@ func TestValidatePipelineWithFinalTasks_Failure(t *testing.T) {
 			Paths:   []string{"spec.finally[0].name"},
 		},
 	}, {
-		name: "final task missing taskref and taskspec",
+		name: "final task missing taskref or taskspec",
 		p: &Pipeline{
 			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
 			Spec: PipelineSpec{
@@ -2253,7 +2504,26 @@ func TestValidatePipelineWithFinalTasks_Failure(t *testing.T) {
 			Paths:   []string{"spec.finally[0].taskRef", "spec.finally[0].taskSpec"},
 		},
 	}, {
-		name: "final task with both tasfref and taskspec",
+		name: "final task missing taskref or taskspec or pipelineSpec(alpha) or pipelineRef(alpha)",
+		wc:   cfgtesting.EnableAlphaAPIFields,
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Tasks: []PipelineTask{{
+					Name:    "non-final-task",
+					TaskRef: &TaskRef{Name: "non-final-task"},
+				}},
+				Finally: []PipelineTask{{
+					Name: "final-task",
+				}},
+			},
+		},
+		expectedError: apis.FieldError{
+			Message: `expected exactly one, got neither`,
+			Paths:   []string{"spec.finally[0].taskRef", "spec.finally[0].taskSpec", "spec.finally[0].pipelineRef", "spec.finally[0].pipelineSpec"},
+		},
+	}, {
+		name: "final task with both taskref and taskspec",
 		p: &Pipeline{
 			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
 			Spec: PipelineSpec{
@@ -2269,8 +2539,203 @@ func TestValidatePipelineWithFinalTasks_Failure(t *testing.T) {
 			},
 		},
 		expectedError: apis.FieldError{
-			Message: `expected exactly one, got both`,
+			Message: `expected exactly one, got multiple`,
 			Paths:   []string{"spec.finally[0].taskRef", "spec.finally[0].taskSpec"},
+		},
+	}, {
+		name: "final task with taskref and pipelineRef",
+		wc:   cfgtesting.EnableAlphaAPIFields,
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Tasks: []PipelineTask{{
+					Name:    "non-final-task",
+					TaskRef: &TaskRef{Name: "non-final-task"},
+				}},
+				Finally: []PipelineTask{{
+					Name:        "final-task",
+					TaskRef:     &TaskRef{Name: "non-final-task"},
+					PipelineRef: &PipelineRef{Name: "foo-pipeline"},
+				}},
+			},
+		},
+		expectedError: apis.FieldError{
+			Message: `expected exactly one, got multiple`,
+			Paths:   []string{"spec.finally[0].taskRef", "spec.finally[0].pipelineRef"},
+		},
+	}, {
+		name: "final task with taskref and pipelineSpec",
+		wc:   cfgtesting.EnableAlphaAPIFields,
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Tasks: []PipelineTask{{
+					Name:    "non-final-task",
+					TaskRef: &TaskRef{Name: "non-final-task"},
+				}},
+				Finally: []PipelineTask{{
+					Name:         "final-task",
+					TaskRef:      &TaskRef{Name: "non-final-task"},
+					PipelineSpec: &PipelineSpec{Description: "foo-pipeline-description"},
+				}},
+			},
+		},
+		expectedError: apis.FieldError{
+			Message: `expected exactly one, got multiple`,
+			Paths:   []string{"spec.finally[0].taskRef", "spec.finally[0].pipelineSpec"},
+		},
+	}, {
+		name: "final task with taskspec and pipelineRef",
+		wc:   cfgtesting.EnableAlphaAPIFields,
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Tasks: []PipelineTask{{
+					Name:    "non-final-task",
+					TaskRef: &TaskRef{Name: "non-final-task"},
+				}},
+				Finally: []PipelineTask{{
+					Name:        "final-task",
+					TaskSpec:    &EmbeddedTask{TaskSpec: getTaskSpec()},
+					PipelineRef: &PipelineRef{Name: "foo-pipeline"},
+				}},
+			},
+		},
+		expectedError: apis.FieldError{
+			Message: `expected exactly one, got multiple`,
+			Paths:   []string{"spec.finally[0].taskSpec", "spec.finally[0].pipelineRef"},
+		},
+	}, {
+		name: "final task with taskspec and pipelineSpec",
+		wc:   cfgtesting.EnableAlphaAPIFields,
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Tasks: []PipelineTask{{
+					Name:    "non-final-task",
+					TaskRef: &TaskRef{Name: "non-final-task"},
+				}},
+				Finally: []PipelineTask{{
+					Name:         "final-task",
+					TaskSpec:     &EmbeddedTask{TaskSpec: getTaskSpec()},
+					PipelineSpec: &PipelineSpec{Description: "foo-pipeline-description"},
+				}},
+			},
+		},
+		expectedError: apis.FieldError{
+			Message: `expected exactly one, got multiple`,
+			Paths:   []string{"spec.finally[0].taskSpec", "spec.finally[0].pipelineSpec"},
+		},
+	}, {
+		name: "final task with taskref, taskspec and pipelineRef",
+		wc:   cfgtesting.EnableAlphaAPIFields,
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Tasks: []PipelineTask{{
+					Name:    "non-final-task",
+					TaskRef: &TaskRef{Name: "non-final-task"},
+				}},
+				Finally: []PipelineTask{{
+					Name:        "final-task",
+					TaskRef:     &TaskRef{Name: "non-final-task"},
+					TaskSpec:    &EmbeddedTask{TaskSpec: getTaskSpec()},
+					PipelineRef: &PipelineRef{Name: "foo-pipeline"},
+				}},
+			},
+		},
+		expectedError: apis.FieldError{
+			Message: `expected exactly one, got multiple`,
+			Paths:   []string{"spec.finally[0].taskRef", "spec.finally[0].taskSpec", "spec.finally[0].pipelineRef"},
+		},
+	}, {
+		name: "final task with taskref, taskspec and pipelineSpec",
+		wc:   cfgtesting.EnableAlphaAPIFields,
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Tasks: []PipelineTask{{
+					Name:    "non-final-task",
+					TaskRef: &TaskRef{Name: "non-final-task"},
+				}},
+				Finally: []PipelineTask{{
+					Name:         "final-task",
+					TaskRef:      &TaskRef{Name: "non-final-task"},
+					TaskSpec:     &EmbeddedTask{TaskSpec: getTaskSpec()},
+					PipelineSpec: &PipelineSpec{Description: "foo-pipeline-description"},
+				}},
+			},
+		},
+		expectedError: apis.FieldError{
+			Message: `expected exactly one, got multiple`,
+			Paths:   []string{"spec.finally[0].taskRef", "spec.finally[0].taskSpec", "spec.finally[0].pipelineSpec"},
+		},
+	}, {
+		name: "final task with taskref, pipelineRef and pipelineSpec",
+		wc:   cfgtesting.EnableAlphaAPIFields,
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Tasks: []PipelineTask{{
+					Name:    "non-final-task",
+					TaskRef: &TaskRef{Name: "non-final-task"},
+				}},
+				Finally: []PipelineTask{{
+					Name:         "final-task",
+					TaskRef:      &TaskRef{Name: "non-final-task"},
+					PipelineRef:  &PipelineRef{Name: "foo-pipeline"},
+					PipelineSpec: &PipelineSpec{Description: "foo-pipeline-description"},
+				}},
+			},
+		},
+		expectedError: apis.FieldError{
+			Message: `expected exactly one, got multiple`,
+			Paths:   []string{"spec.finally[0].taskRef", "spec.finally[0].pipelineRef", "spec.finally[0].pipelineSpec"},
+		},
+	}, {
+		name: "final task with taskspec, pipelineRef and pipelineSpec",
+		wc:   cfgtesting.EnableAlphaAPIFields,
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Tasks: []PipelineTask{{
+					Name:    "non-final-task",
+					TaskRef: &TaskRef{Name: "non-final-task"},
+				}},
+				Finally: []PipelineTask{{
+					Name:         "final-task",
+					TaskSpec:     &EmbeddedTask{TaskSpec: getTaskSpec()},
+					PipelineRef:  &PipelineRef{Name: "foo-pipeline"},
+					PipelineSpec: &PipelineSpec{Description: "foo-pipeline-description"},
+				}},
+			},
+		},
+		expectedError: apis.FieldError{
+			Message: `expected exactly one, got multiple`,
+			Paths:   []string{"spec.finally[0].taskSpec", "spec.finally[0].pipelineRef", "spec.finally[0].pipelineSpec"},
+		},
+	}, {
+		name: "final task with taskref, taskspec, pipelineRef and pipelineSpec",
+		wc:   cfgtesting.EnableAlphaAPIFields,
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Tasks: []PipelineTask{{
+					Name:    "non-final-task",
+					TaskRef: &TaskRef{Name: "non-final-task"},
+				}},
+				Finally: []PipelineTask{{
+					Name:         "final-task",
+					TaskRef:      &TaskRef{Name: "non-final-task"},
+					TaskSpec:     &EmbeddedTask{TaskSpec: getTaskSpec()},
+					PipelineRef:  &PipelineRef{Name: "foo-pipeline"},
+					PipelineSpec: &PipelineSpec{Description: "foo-pipeline-description"},
+				}},
+			},
+		},
+		expectedError: apis.FieldError{
+			Message: `expected exactly one, got multiple`,
+			Paths:   []string{"spec.finally[0].taskRef", "spec.finally[0].taskSpec", "spec.finally[0].pipelineRef", "spec.finally[0].pipelineSpec"},
 		},
 	}, {
 		name: "extra parameter called final-param provided to final task which is not specified in the Pipeline",
@@ -2375,7 +2840,11 @@ func TestValidatePipelineWithFinalTasks_Failure(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.p.Validate(context.Background())
+			ctx := context.Background()
+			if tt.wc != nil {
+				ctx = tt.wc(ctx)
+			}
+			err := tt.p.Validate(ctx)
 			if err == nil {
 				t.Errorf("Pipeline.Validate() did not return error for invalid pipeline with finally")
 			}

--- a/pkg/apis/pipeline/v1/swagger.json
+++ b/pkg/apis/pipeline/v1/swagger.json
@@ -894,6 +894,14 @@
           },
           "x-kubernetes-list-type": "atomic"
         },
+        "pipelineRef": {
+          "description": "PipelineRef is a reference to a pipeline definition Note: PipelineRef is in preview mode and not yet supported",
+          "$ref": "#/definitions/v1.PipelineRef"
+        },
+        "pipelineSpec": {
+          "description": "PipelineSpec is a specification of a pipeline Note: PipelineSpec is in preview mode and not yet supported",
+          "$ref": "#/definitions/v1.PipelineSpec"
+        },
         "retries": {
           "description": "Retries represents how many times this task should be retried in case of task failure: ConditionSucceeded set to False",
           "type": "integer",

--- a/pkg/apis/pipeline/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/pipeline/v1/zz_generated.deepcopy.go
@@ -777,6 +777,16 @@ func (in *PipelineTask) DeepCopyInto(out *PipelineTask) {
 		*out = new(metav1.Duration)
 		**out = **in
 	}
+	if in.PipelineRef != nil {
+		in, out := &in.PipelineRef, &out.PipelineRef
+		*out = new(PipelineRef)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.PipelineSpec != nil {
+		in, out := &in.PipelineSpec, &out.PipelineSpec
+		*out = new(PipelineSpec)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/pkg/apis/pipeline/v1beta1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1beta1/openapi_generated.go
@@ -2636,11 +2636,23 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineTask(ref common.ReferenceCallback)
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Duration"),
 						},
 					},
+					"pipelineRef": {
+						SchemaProps: spec.SchemaProps{
+							Description: "PipelineRef is a reference to a pipeline definition Note: PipelineRef is in preview mode and not yet supported",
+							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineRef"),
+						},
+					},
+					"pipelineSpec": {
+						SchemaProps: spec.SchemaProps{
+							Description: "PipelineSpec is a specification of a pipeline Note: PipelineSpec is in preview mode and not yet supported",
+							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineSpec"),
+						},
+					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.EmbeddedTask", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Matrix", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Param", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineTaskResources", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskRef", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.WhenExpression", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.WorkspacePipelineTaskBinding", "k8s.io/apimachinery/pkg/apis/meta/v1.Duration"},
+			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.EmbeddedTask", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Matrix", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Param", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineRef", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineSpec", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineTaskResources", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskRef", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.WhenExpression", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.WorkspacePipelineTaskBinding", "k8s.io/apimachinery/pkg/apis/meta/v1.Duration"},
 	}
 }
 

--- a/pkg/apis/pipeline/v1beta1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types.go
@@ -242,6 +242,16 @@ type PipelineTask struct {
 	// Refer Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration
 	// +optional
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
+
+	// PipelineRef is a reference to a pipeline definition
+	// Note: PipelineRef is in preview mode and not yet supported
+	// +optional
+	PipelineRef *PipelineRef `json:"pipelineRef,omitempty"`
+
+	// PipelineSpec is a specification of a pipeline
+	// Note: PipelineSpec is in preview mode and not yet supported
+	// +optional
+	PipelineSpec *PipelineSpec `json:"pipelineSpec,omitempty"`
 }
 
 // IsCustomTask checks whether an embedded TaskSpec is a Custom Task

--- a/pkg/apis/pipeline/v1beta1/pipeline_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
+	cfgtesting "github.com/tektoncd/pipeline/pkg/apis/config/testing"
 	"github.com/tektoncd/pipeline/test/diff"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -77,6 +78,7 @@ func TestPipelineTask_ValidateRefOrSpec(t *testing.T) {
 		name          string
 		p             PipelineTask
 		expectedError *apis.FieldError
+		wc            func(ctx context.Context) context.Context
 	}{{
 		name: "valid pipeline task - with taskRef only",
 		p: PipelineTask{
@@ -90,13 +92,37 @@ func TestPipelineTask_ValidateRefOrSpec(t *testing.T) {
 			TaskSpec: &EmbeddedTask{},
 		},
 	}, {
-		name: "invalid pipeline task missing taskRef and taskSpec",
+		name: "valid pipeline task - with pipelineRef only",
+		wc:   cfgtesting.EnableAlphaAPIFields,
+		p: PipelineTask{
+			Name:        "foo",
+			PipelineRef: &PipelineRef{},
+		},
+	}, {
+		name: "valid pipeline task - with pipelineSpec only",
+		wc:   cfgtesting.EnableAlphaAPIFields,
+		p: PipelineTask{
+			Name:         "foo",
+			PipelineSpec: &PipelineSpec{},
+		},
+	}, {
+		name: "invalid pipeline task missing taskRef or taskSpec",
 		p: PipelineTask{
 			Name: "foo",
 		},
 		expectedError: &apis.FieldError{
 			Message: `expected exactly one, got neither`,
 			Paths:   []string{"taskRef", "taskSpec"},
+		},
+	}, {
+		name: "invalid pipeline task missing taskRef or taskSpec or pipelineRef(alpha api) or pipelineSpec(alpha api)",
+		wc:   cfgtesting.EnableAlphaAPIFields,
+		p: PipelineTask{
+			Name: "foo",
+		},
+		expectedError: &apis.FieldError{
+			Message: `expected exactly one, got neither`,
+			Paths:   []string{"taskRef", "taskSpec", "pipelineRef", "pipelineSpec"},
 		},
 	}, {
 		name: "invalid pipeline task with both taskRef and taskSpec",
@@ -106,13 +132,143 @@ func TestPipelineTask_ValidateRefOrSpec(t *testing.T) {
 			TaskSpec: &EmbeddedTask{TaskSpec: getTaskSpec()},
 		},
 		expectedError: &apis.FieldError{
-			Message: `expected exactly one, got both`,
+			Message: `expected exactly one, got multiple`,
 			Paths:   []string{"taskRef", "taskSpec"},
+		},
+	}, {
+		name: "invalid pipeline task with both taskRef and pipelineRef",
+		wc:   cfgtesting.EnableAlphaAPIFields,
+		p: PipelineTask{
+			Name:        "foo",
+			TaskRef:     &TaskRef{Name: "foo-task"},
+			PipelineRef: &PipelineRef{Name: "foo-pipeline"},
+		},
+		expectedError: &apis.FieldError{
+			Message: `expected exactly one, got multiple`,
+			Paths:   []string{"taskRef", "pipelineRef"},
+		},
+	}, {
+		name: "invalid pipeline task with both taskRef and pipelineSpec",
+		wc:   cfgtesting.EnableAlphaAPIFields,
+		p: PipelineTask{
+			Name:         "foo",
+			TaskRef:      &TaskRef{Name: "foo-task"},
+			PipelineSpec: &PipelineSpec{Description: "description"},
+		},
+		expectedError: &apis.FieldError{
+			Message: `expected exactly one, got multiple`,
+			Paths:   []string{"taskRef", "pipelineSpec"},
+		},
+	}, {
+		name: "invalid pipeline task with both taskSpec and pipelineRef",
+		wc:   cfgtesting.EnableAlphaAPIFields,
+		p: PipelineTask{
+			Name:        "foo",
+			TaskSpec:    &EmbeddedTask{TaskSpec: getTaskSpec()},
+			PipelineRef: &PipelineRef{Name: "foo-pipeline"},
+		},
+		expectedError: &apis.FieldError{
+			Message: `expected exactly one, got multiple`,
+			Paths:   []string{"taskSpec", "pipelineRef"},
+		},
+	}, {
+		name: "invalid pipeline task with both taskSpec and pipelineSpec",
+		wc:   cfgtesting.EnableAlphaAPIFields,
+		p: PipelineTask{
+			Name:         "foo",
+			TaskSpec:     &EmbeddedTask{TaskSpec: getTaskSpec()},
+			PipelineSpec: &PipelineSpec{Description: "description"},
+		},
+		expectedError: &apis.FieldError{
+			Message: `expected exactly one, got multiple`,
+			Paths:   []string{"taskSpec", "pipelineSpec"},
+		},
+	}, {
+		name: "invalid pipeline task with both pipelineRef and pipelineSpec",
+		wc:   cfgtesting.EnableAlphaAPIFields,
+		p: PipelineTask{
+			Name:         "foo",
+			PipelineRef:  &PipelineRef{Name: "foo-pipeline"},
+			PipelineSpec: &PipelineSpec{Description: "description"},
+		},
+		expectedError: &apis.FieldError{
+			Message: `expected exactly one, got multiple`,
+			Paths:   []string{"pipelineRef", "pipelineSpec"},
+		},
+	}, {
+		name: "invalid pipeline task with taskRef and taskSpec and pipelineRef",
+		wc:   cfgtesting.EnableAlphaAPIFields,
+		p: PipelineTask{
+			Name:        "foo",
+			TaskRef:     &TaskRef{Name: "foo-task"},
+			TaskSpec:    &EmbeddedTask{TaskSpec: getTaskSpec()},
+			PipelineRef: &PipelineRef{Name: "foo-pipeline"},
+		},
+		expectedError: &apis.FieldError{
+			Message: `expected exactly one, got multiple`,
+			Paths:   []string{"taskRef", "taskSpec", "pipelineRef"},
+		},
+	}, {
+		name: "invalid pipeline task with taskRef and taskSpec and pipelineSpec",
+		wc:   cfgtesting.EnableAlphaAPIFields,
+		p: PipelineTask{
+			Name:         "foo",
+			TaskRef:      &TaskRef{Name: "foo-task"},
+			TaskSpec:     &EmbeddedTask{TaskSpec: getTaskSpec()},
+			PipelineSpec: &PipelineSpec{Description: "description"},
+		},
+		expectedError: &apis.FieldError{
+			Message: `expected exactly one, got multiple`,
+			Paths:   []string{"taskRef", "taskSpec", "pipelineSpec"},
+		},
+	}, {
+		name: "invalid pipeline task with taskRef and pipelineRef and pipelineSpec",
+		wc:   cfgtesting.EnableAlphaAPIFields,
+		p: PipelineTask{
+			Name:         "foo",
+			TaskRef:      &TaskRef{Name: "foo-task"},
+			PipelineRef:  &PipelineRef{Name: "foo-pipeline"},
+			PipelineSpec: &PipelineSpec{Description: "description"},
+		},
+		expectedError: &apis.FieldError{
+			Message: `expected exactly one, got multiple`,
+			Paths:   []string{"taskRef", "pipelineRef", "pipelineSpec"},
+		},
+	}, {
+		name: "invalid pipeline task with taskSpec and pipelineRef and pipelineSpec",
+		wc:   cfgtesting.EnableAlphaAPIFields,
+		p: PipelineTask{
+			Name:         "foo",
+			TaskSpec:     &EmbeddedTask{TaskSpec: getTaskSpec()},
+			PipelineRef:  &PipelineRef{Name: "foo-pipeline"},
+			PipelineSpec: &PipelineSpec{Description: "description"},
+		},
+		expectedError: &apis.FieldError{
+			Message: `expected exactly one, got multiple`,
+			Paths:   []string{"taskSpec", "pipelineRef", "pipelineSpec"},
+		},
+	}, {
+		name: "invalid pipeline task with taskRef and taskSpec and pipelineRef and pipelineSpec",
+		wc:   cfgtesting.EnableAlphaAPIFields,
+		p: PipelineTask{
+			Name:         "foo",
+			TaskRef:      &TaskRef{Name: "foo-task"},
+			TaskSpec:     &EmbeddedTask{TaskSpec: getTaskSpec()},
+			PipelineRef:  &PipelineRef{Name: "foo-pipeline"},
+			PipelineSpec: &PipelineSpec{Description: "description"},
+		},
+		expectedError: &apis.FieldError{
+			Message: `expected exactly one, got multiple`,
+			Paths:   []string{"taskRef", "taskSpec", "pipelineRef", "pipelineSpec"},
 		},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.p.validateRefOrSpec()
+			ctx := context.Background()
+			if tt.wc != nil {
+				ctx = tt.wc(ctx)
+			}
+			err := tt.p.validateRefOrSpec(ctx)
 			if tt.expectedError == nil {
 				if err != nil {
 					t.Error("PipelineTask.validateRefOrSpec() returned error for valid pipeline task")
@@ -123,6 +279,78 @@ func TestPipelineTask_ValidateRefOrSpec(t *testing.T) {
 				}
 				if d := cmp.Diff(tt.expectedError.Error(), err.Error(), cmpopts.IgnoreUnexported(apis.FieldError{})); d != "" {
 					t.Errorf("PipelineTask.validateRefOrSpec() errors diff %s", diff.PrintWantGot(d))
+				}
+			}
+		})
+	}
+}
+
+// TestPipelineTask_ValidateRefOrSpec_APIVersionsCompatibility validates `pipelineRef` and `pipelineSpec`
+// are guarded behind the appropriate feature flags i.e. alpha for now.
+func TestPipelineTask_ValidateRefOrSpec_APIVersionsCompatibility(t *testing.T) {
+	tests := []struct {
+		name    string
+		pt      PipelineTask
+		wc      func(ctx context.Context) context.Context
+		wantErr *apis.FieldError
+	}{
+		{
+			name: "pipelineRef requires alpha version",
+			pt: PipelineTask{
+				PipelineRef: &PipelineRef{},
+			},
+			wc: cfgtesting.EnableAlphaAPIFields,
+		}, {
+			name: "pipelineSpec requires alpha version",
+			pt: PipelineTask{
+				PipelineSpec: &PipelineSpec{},
+			},
+			wc: cfgtesting.EnableAlphaAPIFields,
+		}, {
+			name: "pipelineRef not allowed with beta version",
+			pt: PipelineTask{
+				PipelineRef: &PipelineRef{},
+			},
+			wc:      cfgtesting.EnableBetaAPIFields,
+			wantErr: apis.ErrGeneric("pipelineRef requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"beta\""),
+		}, {
+			name: "pipelineSpec not allowed with beta version",
+			pt: PipelineTask{
+				PipelineSpec: &PipelineSpec{},
+			},
+			wc:      cfgtesting.EnableBetaAPIFields,
+			wantErr: apis.ErrGeneric("pipelineSpec requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"beta\""),
+		}, {
+			name: "pipelineRef not allowed with stable version",
+			pt: PipelineTask{
+				PipelineRef: &PipelineRef{},
+			},
+			wc:      cfgtesting.EnableStableAPIFields,
+			wantErr: apis.ErrGeneric("pipelineRef requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\""),
+		}, {
+			name: "pipelineSpec not allowed with beta version",
+			pt: PipelineTask{
+				PipelineSpec: &PipelineSpec{},
+			},
+			wc:      cfgtesting.EnableStableAPIFields,
+			wantErr: apis.ErrGeneric("pipelineSpec requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\""),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			if test.wc != nil {
+				ctx = test.wc(ctx)
+			}
+			err := test.pt.validateRefOrSpec(ctx)
+			if test.wantErr != nil {
+				if d := cmp.Diff(test.wantErr.Error(), err.Error()); d != "" {
+					t.Error(diff.PrintWantGot(d))
+				}
+			} else {
+				if err := test.pt.validateRefOrSpec(ctx); err != nil {
+					t.Fatalf("pipelineTask.validateRefOrSpec() error = %v", err)
 				}
 			}
 		})

--- a/pkg/apis/pipeline/v1beta1/swagger.json
+++ b/pkg/apis/pipeline/v1beta1/swagger.json
@@ -1287,6 +1287,14 @@
           },
           "x-kubernetes-list-type": "atomic"
         },
+        "pipelineRef": {
+          "description": "PipelineRef is a reference to a pipeline definition Note: PipelineRef is in preview mode and not yet supported",
+          "$ref": "#/definitions/v1beta1.PipelineRef"
+        },
+        "pipelineSpec": {
+          "description": "PipelineSpec is a specification of a pipeline Note: PipelineSpec is in preview mode and not yet supported",
+          "$ref": "#/definitions/v1beta1.PipelineSpec"
+        },
         "resources": {
           "description": "Deprecated: Unused, preserved only for backwards compatibility",
           "$ref": "#/definitions/v1beta1.PipelineTaskResources"

--- a/pkg/apis/pipeline/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/pipeline/v1beta1/zz_generated.deepcopy.go
@@ -1175,6 +1175,16 @@ func (in *PipelineTask) DeepCopyInto(out *PipelineTask) {
 		*out = new(v1.Duration)
 		**out = **in
 	}
+	if in.PipelineRef != nil {
+		in, out := &in.PipelineRef, &out.PipelineRef
+		*out = new(PipelineRef)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.PipelineSpec != nil {
+		in, out := &in.PipelineSpec, &out.PipelineSpec
+		*out = new(PipelineSpec)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 


### PR DESCRIPTION
# Changes
This is the first of many pull requests to begin implementing [TEP-0056](https://github.com/tektoncd/community/blob/main/teps/0056-pipelines-in-pipelines.md)

1. Added `PipelineRef` and `PipelineSpec` to `PipelineTask`
2. Updated and added pipeline validation tests to reflect the above additions
3. Updated and added pipeline type tests to reflect the above additions
4. Added a initial set of docs and examples using the existing proposal

The changes in this PR does not change existing behavior and merely introduces fields to existing types

_Note: Pipelines in Pipelines is not yet implemented_

Co-authored-by: pritidesai [pdesai@us.ibm.com](mailto:pdesai@us.ibm.com)

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [X] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [X] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [X] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [X] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Added PipelineRef and PipelineSpec fields to PipelineTask, in lieu of TEP-0056
```
