### PR TITLE
fix an issue with `InvalidMatrixParameterTypes` along with updating the matrix example with additional validations

### DIFF
--- a/examples/v1/pipelineruns/alpha/pipelinerun-with-matrix.yaml
+++ b/examples/v1/pipelineruns/alpha/pipelinerun-with-matrix.yaml
@@ -64,6 +64,46 @@ spec:
             - name: echo
               image: ubuntu
               script: exit 1
+      - name: matrix-with-task-using-onerror
+        matrix:
+          params:
+            - name: version
+              value:
+                - "1"
+                - "2"
+        taskSpec:
+          params:
+            - name: version
+          steps:
+            - name: echo
+              image: ubuntu
+              onError: continue
+              script: exit 1
+      - name: matrix-with-task-retries
+        retries: 1
+        params:
+          - name: pipelineTask-retries
+            value: $(context.pipelineTask.retries)
+        matrix:
+          params:
+            - name: version
+              value:
+                - "1"
+                - "2"
+        taskSpec:
+          params:
+            - name: version
+            - name: pipelineTask-retries
+          steps:
+            - image: alpine
+              script: |
+                #!/usr/bin/env sh
+                if [ "$(context.task.retry-count)" == "$(params.pipelineTask-retries)" ]; then
+                  echo "This is the last retry."
+                  exit 0;
+                fi
+                echo "The PipelineTask has retried $(context.task.retry-count) times."
+                exit 1
     finally:
       - name: matrix-params-with-empty-array-skipped-in-finally
         matrix:

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -121,7 +121,7 @@ const (
 	// all of the running TaskRuns as timed out failed.
 	ReasonCouldntTimeOut = "PipelineRunCouldntTimeOut"
 	// ReasonInvalidMatrixParameterTypes indicates a matrix contains invalid parameter types
-	ReasonInvalidMatrixParameterTypes = "ReasonInvalidMatrixParameterTypes"
+	ReasonInvalidMatrixParameterTypes = "InvalidMatrixParameterTypes"
 	// ReasonInvalidTaskResultReference indicates a task result was declared
 	// but was not initialized by that task
 	ReasonInvalidTaskResultReference = "InvalidTaskResultReference"

--- a/pkg/reconciler/pipelinerun/resources/apply.go
+++ b/pkg/reconciler/pipelinerun/resources/apply.go
@@ -159,7 +159,7 @@ func ApplyPipelineTaskContexts(pt *v1.PipelineTask) *v1.PipelineTask {
 	}
 	pt.Params = pt.Params.ReplaceVariables(replacements, map[string][]string{}, map[string]map[string]string{})
 	if pt.IsMatrixed() {
-		pt.Matrix.Params = pt.Params.ReplaceVariables(replacements, map[string][]string{}, map[string]map[string]string{})
+		pt.Matrix.Params = pt.Matrix.Params.ReplaceVariables(replacements, map[string][]string{}, map[string]map[string]string{})
 		for i := range pt.Matrix.Include {
 			pt.Matrix.Include[i].Params = pt.Matrix.Include[i].Params.ReplaceVariables(replacements, map[string][]string{}, map[string]map[string]string{})
 		}

--- a/pkg/reconciler/pipelinerun/resources/validate_params.go
+++ b/pkg/reconciler/pipelinerun/resources/validate_params.go
@@ -96,7 +96,8 @@ func ValidateParameterTypesInMatrix(state PipelineRunState) error {
 			for _, include := range m.Include {
 				for _, param := range include.Params {
 					if param.Value.Type != v1.ParamTypeString {
-						return fmt.Errorf("parameters of type string only are allowed, but param %s has type %s", param.Name, string(param.Value.Type))
+						return fmt.Errorf("parameters of type string only are allowed, but param \"%s\" has type \"%s\" in pipelineTask \"%s\"",
+							param.Name, string(param.Value.Type), rpt.PipelineTask.Name)
 					}
 				}
 			}
@@ -104,7 +105,8 @@ func ValidateParameterTypesInMatrix(state PipelineRunState) error {
 		if m.HasParams() {
 			for _, param := range m.Params {
 				if param.Value.Type != v1.ParamTypeArray {
-					return fmt.Errorf("parameters of type array only are allowed, but param %s has type %s", param.Name, string(param.Value.Type))
+					return fmt.Errorf("parameters of type array only are allowed, but param \"%s\" has type \"%s\" in pipelineTask \"%s\"",
+						param.Name, string(param.Value.Type), rpt.PipelineTask.Name)
 				}
 			}
 		}

--- a/pkg/reconciler/pipelinerun/resources/validate_params_test.go
+++ b/pkg/reconciler/pipelinerun/resources/validate_params_test.go
@@ -355,7 +355,7 @@ func TestValidatePipelineParameterTypes(t *testing.T) {
 					}}},
 			},
 		}},
-		wantErrs: "parameters of type array only are allowed, but param foo has type string",
+		wantErrs: "parameters of type array only are allowed, but param \"foo\" has type \"string\" in pipelineTask \"task\"",
 	}, {
 		desc: "parameters in include matrix are strings",
 		state: resources.PipelineRunState{{
@@ -386,7 +386,7 @@ func TestValidatePipelineParameterTypes(t *testing.T) {
 					}}},
 			},
 		}},
-		wantErrs: "parameters of type string only are allowed, but param foobar has type array",
+		wantErrs: "parameters of type string only are allowed, but param \"foobar\" has type \"array\" in pipelineTask \"task\"",
 	}, {
 		desc: "parameters in include matrix are objects",
 		state: resources.PipelineRunState{{
@@ -409,7 +409,7 @@ func TestValidatePipelineParameterTypes(t *testing.T) {
 					}}},
 			},
 		}},
-		wantErrs: "parameters of type string only are allowed, but param barfoo has type object",
+		wantErrs: "parameters of type string only are allowed, but param \"barfoo\" has type \"object\" in pipelineTask \"task\"",
 	}} {
 		t.Run(tc.desc, func(t *testing.T) {
 			err := resources.ValidateParameterTypesInMatrix(tc.state)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

- Fixing an issue where the `ApplyPipelineTaskContexts` had bug in `ReplaceVariables` with replacing `matrix.params` with just `params` instead of `matrix.params`

- Adding two new validations:

    - **onError with matrix:** when a task fan out for a given number of instances, pipeline controller must apply the onError to each running instance.

    - **retry with matrix:** when a task has specified retry, that specification must apply to all the instances of fanned out task.

- Being consistent with the rest of the reasons, dropping "Reason" from "ReasonInvalidMatrixParameterTypes".

- Updated the error reported in "ValidateParameterTypesInMatrix" to include name of the pipelineTask.

Co-authored-by: EmmaMunley <emmamunley@google.com>

Closes #7070 

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
