### PR TITLE
Fix the link to alpha-features in docs #7074

### DIFF
--- a/docs/compute-resources.md
+++ b/docs/compute-resources.md
@@ -44,7 +44,7 @@ Therefore, the pod will have no effective CPU limit.
 
 ## Task-level Compute Resources Configuration
 
-**([alpha only](https://github.com/tektoncd/pipeline/blob/main/docs/install.md#alpha-features))**
+**([alpha only](https://github.com/tektoncd/pipeline/blob/main/docs/additional-configs.md#alpha-features))**
 
 Tekton allows users to specify resource requirements of [`Steps`](./tasks.md#defining-steps),
 which run sequentially. However, the pod's effective resource requirements are still the

--- a/docs/matrix.md
+++ b/docs/matrix.md
@@ -39,7 +39,7 @@ Documentation for specifying `Matrix` in a `Pipeline`:
 - [Specifying `Matrix` in `Finally Tasks`](pipelines.md#specifying-matrix-in-finally-tasks)
 - [Specifying `Matrix` in `Custom Tasks`](pipelines.md#specifying-matrix)
 
-> :seedling: **`Matrix` is an [alpha](install.md#alpha-features) feature.**
+> :seedling: **`Matrix` is an [alpha](additional-configs.md#alpha-features) feature.**
 > The `enable-api-fields` feature flag must be set to `"alpha"` to specify `Matrix` in a `PipelineTask`.
 
 ## Configuring a Matrix

--- a/docs/pipelineruns.md
+++ b/docs/pipelineruns.md
@@ -215,7 +215,7 @@ spec:
 
 ### Specifying Task-level `ComputeResources`
 
-**([alpha only](https://github.com/tektoncd/pipeline/blob/main/docs/install.md#alpha-features))**
+**([alpha only](https://github.com/tektoncd/pipeline/blob/main/docs/additional-configs.md#alpha-features))**
 
 Task-level compute resources can be configured in `PipelineRun.TaskRunSpecs.ComputeResources` or `TaskRun.ComputeResources`.
 

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -336,7 +336,7 @@ spec:
 
 ### Specifying `Matrix` in `PipelineTasks`
 
-> :seedling: **`Matrix` is an [alpha](install.md#alpha-features) feature.**
+> :seedling: **`Matrix` is an [alpha](additional-configs.md#alpha-features) feature.**
 > The `enable-api-fields` feature flag must be set to `"alpha"` to specify `Matrix` in a `PipelineTask`.
 
 You can also provide [`Parameters`](tasks.md#specifying-parameters) through the `matrix` field:
@@ -1195,7 +1195,7 @@ spec:
 
 ### Specifying `matrix` in `finally` tasks
 
-> :seedling: **`Matrix` is an [alpha](install.md#alpha-features) feature.**
+> :seedling: **`Matrix` is an [alpha](additional-configs.md#alpha-features) feature.**
 > The `enable-api-fields` feature flag must be set to `"alpha"` to specify `Matrix` in a `PipelineTask`.
 
 Similar to `tasks`, you can also provide [`Parameters`](tasks.md#specifying-parameters) through `matrix`
@@ -1648,7 +1648,7 @@ spec:
 
 ### Specifying matrix
 
-> :seedling: **`Matrix` is an [alpha](install.md#alpha-features) feature.**
+> :seedling: **`Matrix` is an [alpha](additional-configs.md#alpha-features) feature.**
 > The `enable-api-fields` feature flag must be set to `"alpha"` to specify `Matrix` in a `PipelineTask`.
 
 If a custom task supports [`parameters`](tasks.md#specifying-parameters), you can use the

--- a/docs/taskruns.md
+++ b/docs/taskruns.md
@@ -393,7 +393,7 @@ status:
 
 #### Extra Parameters
 
-**([alpha only](https://github.com/tektoncd/pipeline/blob/main/docs/install.md#alpha-features))**
+**([alpha only](https://github.com/tektoncd/pipeline/blob/main/docs/additional-configs.md#alpha-features))**
 
 You can pass in extra `Parameters` if needed depending on your use cases. An example use
 case is when your CI system autogenerates `TaskRuns` and it has `Parameters` it wants to
@@ -408,7 +408,7 @@ may be overridden by a TaskRun's StepSpecs and SidecarSpecs.
 
 ### Specifying Task-level `ComputeResources`
 
-**([alpha only](https://github.com/tektoncd/pipeline/blob/main/docs/install.md#alpha-features))**
+**([alpha only](https://github.com/tektoncd/pipeline/blob/main/docs/additional-configs.md#alpha-features))**
 
 Task-level compute resources can be configured in `TaskRun.ComputeResources`, or `PipelineRun.TaskRunSpecs.ComputeResources`.
 
@@ -633,7 +633,7 @@ and reasons.
 
 ### Configuring Task Steps and Sidecars in a TaskRun
 
-**([alpha only](https://github.com/tektoncd/pipeline/blob/main/docs/install.md#alpha-features))**
+**([alpha only](https://github.com/tektoncd/pipeline/blob/main/docs/additional-configs.md#alpha-features))**
 
 A TaskRun can specify `StepSpecs` or `SidecarSpecs` to configure Step or Sidecar
 specified in a Task. Only named Steps and Sidecars may be configured.


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
