### PR TITLE
[TEP0138] RFC: Add feature graduation process documentation

### DIFF
--- a/api_compatibility_policy.md
+++ b/api_compatibility_policy.md
@@ -136,6 +136,21 @@ See the current list of [alpha features](https://github.com/tektoncd/pipeline/bl
 
 - GA/Stable features will not be removed or changed in a backwards incompatible manner without incrementing the API Version.
 
+### Feature Graduation Process
+Features are first released as experimental in alpha, refined in beta, and finalized in stable releases.
+
+#### Introducing an `alpha` feature
+- When a feature is first introduced to Tekton, it will have the `alpha` stability level and be disabled by default. 
+- At this stage, users could choose to experiment with the feature. Feedback will be collected from users and it will help maintainers to determine whether to promote the feature to higher stability level or deprecate it.
+
+#### Promoting a feature to `beta`
+- After feedback of the usage of the alpha features, once the needs and motivations are validated, a feature could be promoted to `beta`. This stage is where features are further tested and refined.
+- The dedicated feature flag for this feature will change the stability level for validation to `beta`. It will continue to be disabled by default.
+
+#### Graduating a feature to `stable`
+- This is the final stage of feature graduation process, where features are considered to be complete and ready to be released for the public.
+- Once a feature has graduated to `stable`, it will be turned on by default.
+
 ## Approving API changes
 
 API changes must be approved by [OWNERS](OWNERS). The policy is slightly different


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This commit adds the feature graduation process documentation to the API compatibility policy. It aims to mitigate the confusions of API versioning that was coupled with feature versioning as in #6592. The graduation process clarifies the independence of feature versions from API versions.

part of: #7177 
related: TEP0138
/kind documentation
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
