### PR TITLE
Add taskrun/pipelinerun gauge metrics around resolving respective tasks/pipelines

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -11,19 +11,22 @@ The following pipeline metrics are available at `controller-service` on port `90
 
 We expose several kinds of exporters, including Prometheus, Google Stackdriver, and many others. You can set them up using [observability configuration](../config/config-observability.yaml).
 
-|  Name | Type | Labels/Tags | Status |
-| ---------- | ----------- | ----------- | ----------- |
-| `tekton_pipelines_controller_pipelinerun_duration_seconds_[bucket, sum, count]` | Histogram/LastValue(Gauge) | `*pipeline`=&lt;pipeline_name&gt; <br> `*pipelinerun`=&lt;pipelinerun_name&gt; <br> `status`=&lt;status&gt; <br> `namespace`=&lt;pipelinerun-namespace&gt; | experimental |
+| Name                                                                                    | Type | Labels/Tags | Status |
+|-----------------------------------------------------------------------------------------| ----------- | ----------- | ----------- |
+| `tekton_pipelines_controller_pipelinerun_duration_seconds_[bucket, sum, count]`         | Histogram/LastValue(Gauge) | `*pipeline`=&lt;pipeline_name&gt; <br> `*pipelinerun`=&lt;pipelinerun_name&gt; <br> `status`=&lt;status&gt; <br> `namespace`=&lt;pipelinerun-namespace&gt; | experimental |
 | `tekton_pipelines_controller_pipelinerun_taskrun_duration_seconds_[bucket, sum, count]` | Histogram/LastValue(Gauge) | `*pipeline`=&lt;pipeline_name&gt; <br> `*pipelinerun`=&lt;pipelinerun_name&gt; <br> `status`=&lt;status&gt; <br> `*task`=&lt;task_name&gt; <br> `*taskrun`=&lt;taskrun_name&gt;<br> `namespace`=&lt;pipelineruns-taskruns-namespace&gt;| experimental |
-| `tekton_pipelines_controller_pipelinerun_count` | Counter | `status`=&lt;status&gt; | experimental |
-| `tekton_pipelines_controller_running_pipelineruns_count` | Gauge | | experimental |
-| `tekton_pipelines_controller_taskrun_duration_seconds_[bucket, sum, count]` | Histogram/LastValue(Gauge) | `status`=&lt;status&gt; <br> `*task`=&lt;task_name&gt; <br> `*taskrun`=&lt;taskrun_name&gt;<br> `namespace`=&lt;pipelineruns-taskruns-namespace&gt; | experimental |
-| `tekton_pipelines_controller_taskrun_count` | Counter | `status`=&lt;status&gt; | experimental |
-| `tekton_pipelines_controller_running_taskruns_count` | Gauge | | experimental |
-| `tekton_pipelines_controller_running_taskruns_throttled_by_quota_count` | Gauge | | experimental |
-| `tekton_pipelines_controller_running_taskruns_throttled_by_node_count`  | Gauge | | experimental |
-| `tekton_pipelines_controller_taskruns_pod_latency_milliseconds` | Gauge | `namespace`=&lt;taskruns-namespace&gt; <br> `pod`= &lt; taskrun_pod_name&gt; <br> `*task`=&lt;task_name&gt; <br> `*taskrun`=&lt;taskrun_name&gt;<br> | experimental |
-| `tekton_pipelines_controller_client_latency_[bucket, sum, count]` | Histogram | | experimental |
+| `tekton_pipelines_controller_pipelinerun_count`                                         | Counter | `status`=&lt;status&gt; | experimental |
+| `tekton_pipelines_controller_running_pipelineruns_count`                                | Gauge | | experimental |
+| `tekton_pipelines_controller_taskrun_duration_seconds_[bucket, sum, count]`             | Histogram/LastValue(Gauge) | `status`=&lt;status&gt; <br> `*task`=&lt;task_name&gt; <br> `*taskrun`=&lt;taskrun_name&gt;<br> `namespace`=&lt;pipelineruns-taskruns-namespace&gt; | experimental |
+| `tekton_pipelines_controller_taskrun_count`                                             | Counter | `status`=&lt;status&gt; | experimental |
+| `tekton_pipelines_controller_running_taskruns_count`                                    | Gauge | | experimental |
+| `tekton_pipelines_controller_running_taskruns_throttled_by_quota_count`                 | Gauge | | experimental |
+| `tekton_pipelines_controller_running_taskruns_throttled_by_node_count`                  | Gauge | | experimental |
+| `tekton_pipelines_controller_running_taskruns_waiting_on_task_resolution_count`         | Gauge | | experimental |
+| `tekton_pipelines_controller_running_pipelineruns_waiting_on_pipeline_resolution_count` | Gauge | | experimental |
+| `tekton_pipelines_controller_running_pipelineruns_waiting_on_task_resolution_count`     | Gauge | | experimental |
+| `tekton_pipelines_controller_taskruns_pod_latency_milliseconds`                         | Gauge | `namespace`=&lt;taskruns-namespace&gt; <br> `pod`= &lt; taskrun_pod_name&gt; <br> `*task`=&lt;task_name&gt; <br> `*taskrun`=&lt;taskrun_name&gt;<br> | experimental |
+| `tekton_pipelines_controller_client_latency_[bucket, sum, count]`                       | Histogram | | experimental |
 
 The Labels/Tag marked as "*" are optional. And there's a choice between Histogram and LastValue(Gauge) for pipelinerun and taskrun duration metrics.
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

/kind feature

This commit adds new experimental gauge metrics that count the number of TaskRuns who are waiting for resolution of any Tasks they reference, as well as count the number of PipelineRuns waiting on Pipeline resolution, and lastly count the number of PipelineRuns waiting on Task resolution for their underlying TaskRuns.

This change's motivation is similar to https://github.com/tektoncd/pipeline/pull/6744 and stems from the same deployment of tekton that motivated the https://github.com/tektoncd/pipeline/pull/6744 changes I submitted back in May of this year.  In particular, questions around "how much time is spent resolving bundles" have arisen with a fair amount of frequency from various stakeholders of our deployment.

Getting some precise data on bundle wait times could also help lend priority to features like https://github.com/tektoncd/pipeline/issues/6385

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ /] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ /] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ /] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [/ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ /] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [/ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
New gauge metrics are introduced that count the number of TaskRuns waiting for resolution of any Tasks they reference, as well as count the number of PipelineRuns waiting on Pipeline resolution, and lastly count the number of PipelineRuns waiting on Task resolution for their underlying TaskRuns.
```

@vdemeester @khrm @lbernick PTAL if you all have sufficient time to do so - thanks !!