### PR TITLE
[WIP] Fix the naming as per convention for Metrics

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -15,14 +15,24 @@ We expose several kinds of exporters, including Prometheus, Google Stackdriver, 
 | ---------- | ----------- | ----------- | ----------- |
 | `tekton_pipelines_controller_pipelinerun_duration_seconds_[bucket, sum, count]` | Histogram/LastValue(Gauge) | `*pipeline`=&lt;pipeline_name&gt; <br> `*pipelinerun`=&lt;pipelinerun_name&gt; <br> `status`=&lt;status&gt; <br> `namespace`=&lt;pipelinerun-namespace&gt; | experimental |
 | `tekton_pipelines_controller_pipelinerun_taskrun_duration_seconds_[bucket, sum, count]` | Histogram/LastValue(Gauge) | `*pipeline`=&lt;pipeline_name&gt; <br> `*pipelinerun`=&lt;pipelinerun_name&gt; <br> `status`=&lt;status&gt; <br> `*task`=&lt;task_name&gt; <br> `*taskrun`=&lt;taskrun_name&gt;<br> `namespace`=&lt;pipelineruns-taskruns-namespace&gt;| experimental |
-| `tekton_pipelines_controller_pipelinerun_count` | Counter | `status`=&lt;status&gt; | experimental |
-| `tekton_pipelines_controller_running_pipelineruns_count` | Gauge | | experimental |
+| `tekton_pipelines_controller_pipelinerun_count` | Counter | `status`=&lt;status&gt; | deprecate |
+| `tekton_pipelines_controller_pipelinerun_total` | Counter | `status`=&lt;status&gt; | experimental |
+| `tekton_pipelines_controller_running_pipelineruns_count` | Gauge | | deprecate |
+| `tekton_pipelines_controller_running_pipelineruns` | Gauge | | experimental |
 | `tekton_pipelines_controller_taskrun_duration_seconds_[bucket, sum, count]` | Histogram/LastValue(Gauge) | `status`=&lt;status&gt; <br> `*task`=&lt;task_name&gt; <br> `*taskrun`=&lt;taskrun_name&gt;<br> `namespace`=&lt;pipelineruns-taskruns-namespace&gt; | experimental |
 | `tekton_pipelines_controller_taskrun_count` | Counter | `status`=&lt;status&gt; | experimental |
 | `tekton_pipelines_controller_running_taskruns_count` | Gauge | | experimental |
 | `tekton_pipelines_controller_running_taskruns_throttled_by_quota_count` | Gauge | | experimental |
 | `tekton_pipelines_controller_running_taskruns_throttled_by_node_count`  | Gauge | | experimental |
 | `tekton_pipelines_controller_taskruns_pod_latency_milliseconds` | Gauge | `namespace`=&lt;taskruns-namespace&gt; <br> `pod`= &lt; taskrun_pod_name&gt; <br> `*task`=&lt;task_name&gt; <br> `*taskrun`=&lt;taskrun_name&gt;<br> | experimental |
+| `tekton_pipelines_controller_taskrun_count` | Counter | `status`=&lt;status&gt; | deprecate |
+| `tekton_pipelines_controller_taskrun_total` | Counter | `status`=&lt;status&gt; | experimental |
+| `tekton_pipelines_controller_running_taskruns_count` | Gauge | | deprecate |
+| `tekton_pipelines_controller_running_taskruns` | Gauge | | experimental |
+| `tekton_pipelines_controller_running_taskruns_throttled_by_quota_count` | Gauge | | deprecate |
+| `tekton_pipelines_controller_running_taskruns_throttled_by_node_count`  | Gauge | | deprecate |
+| `tekton_pipelines_controller_running_taskruns_throttled_by_quota` | Gauge | | experimental |
+| `tekton_pipelines_controller_running_taskruns_throttled_by_node`  | Gauge | | experimental |
 | `tekton_pipelines_controller_client_latency_[bucket, sum, count]` | Histogram | | experimental |
 
 The Labels/Tag marked as "*" are optional. And there's a choice between Histogram and LastValue(Gauge) for pipelinerun and taskrun duration metrics.

--- a/pkg/taskrunmetrics/metrics.go
+++ b/pkg/taskrunmetrics/metrics.go
@@ -55,9 +55,13 @@ var (
 	trDurationView                      *view.View
 	prTRDurationView                    *view.View
 	trCountView                         *view.View
+	trTotalView                         *view.View
 	runningTRsCountView                 *view.View
+	runningTRsView                      *view.View
 	runningTRsThrottledByQuotaCountView *view.View
 	runningTRsThrottledByNodeCountView  *view.View
+	runningTRsThrottledByQuotaView      *view.View
+	runningTRsThrottledByNodeView       *view.View
 	podLatencyView                      *view.View
 
 	trDuration = stats.Float64(
@@ -74,7 +78,15 @@ var (
 		"number of taskruns",
 		stats.UnitDimensionless)
 
+	trTotal = stats.Float64("taskrun_total",
+		"Number of taskruns",
+		stats.UnitDimensionless)
+
 	runningTRsCount = stats.Float64("running_taskruns_count",
+		"Number of taskruns executing currently",
+		stats.UnitDimensionless)
+
+	runningTRs = stats.Float64("running_taskruns",
 		"Number of taskruns executing currently",
 		stats.UnitDimensionless)
 
@@ -86,7 +98,15 @@ var (
 		"Number of taskruns executing currently, but whose underlying Pods or Containers are suspended by k8s because of Node level constraints. Such suspensions can occur as part of initial scheduling of the Pod, or scheduling of any of the subsequent Container(s) in the Pod after the first Container is started",
 		stats.UnitDimensionless)
 
-	podLatency = stats.Float64("taskruns_pod_latency_milliseconds",
+	runningTRsThrottledByQuota = stats.Float64("running_taskruns_throttled_by_quota",
+		"Number of taskruns executing currently, but whose underlying Pods or Containers are suspended by k8s because of defined ResourceQuotas.  Such suspensions can occur as part of initial scheduling of the Pod, or scheduling of any of the subsequent Container(s) in the Pod after the first Container is started",
+		stats.UnitDimensionless)
+
+	runningTRsThrottledByNode = stats.Float64("running_taskruns_throttled_by_node",
+		"Number of taskruns executing currently, but whose underlying Pods or Containers are suspended by k8s because of Node level constraints. Such suspensions can occur as part of initial scheduling of the Pod, or scheduling of any of the subsequent Container(s) in the Pod after the first Container is started",
+		stats.UnitDimensionless)
+
+	podLatency = stats.Float64("taskruns_pod_latency",
 		"scheduling latency for the taskruns pods",
 		stats.UnitMilliseconds)
 )
@@ -204,9 +224,20 @@ func viewRegister(cfg *config.Metrics) error {
 		Aggregation: view.Count(),
 		TagKeys:     []tag.Key{statusTag},
 	}
+	trTotalView = &view.View{
+		Description: trTotal.Description(),
+		Measure:     trTotal,
+		Aggregation: view.Count(),
+		TagKeys:     []tag.Key{statusTag},
+	}
 	runningTRsCountView = &view.View{
 		Description: runningTRsCount.Description(),
 		Measure:     runningTRsCount,
+		Aggregation: view.LastValue(),
+	}
+	runningTRsView = &view.View{
+		Description: runningTRs.Description(),
+		Measure:     runningTRs,
 		Aggregation: view.LastValue(),
 	}
 	runningTRsThrottledByQuotaCountView = &view.View{
@@ -219,6 +250,16 @@ func viewRegister(cfg *config.Metrics) error {
 		Measure:     runningTRsThrottledByNodeCount,
 		Aggregation: view.LastValue(),
 	}
+	runningTRsThrottledByQuotaView = &view.View{
+		Description: runningTRsThrottledByQuota.Description(),
+		Measure:     runningTRsThrottledByQuota,
+		Aggregation: view.LastValue(),
+	}
+	runningTRsThrottledByNodeView = &view.View{
+		Description: runningTRsThrottledByNode.Description(),
+		Measure:     runningTRsThrottledByNode,
+		Aggregation: view.LastValue(),
+	}
 	podLatencyView = &view.View{
 		Description: podLatency.Description(),
 		Measure:     podLatency,
@@ -229,9 +270,13 @@ func viewRegister(cfg *config.Metrics) error {
 		trDurationView,
 		prTRDurationView,
 		trCountView,
+		trTotalView,
 		runningTRsCountView,
+		runningTRsView,
 		runningTRsThrottledByQuotaCountView,
 		runningTRsThrottledByNodeCountView,
+		runningTRsThrottledByQuotaView,
+		runningTRsThrottledByNodeView,
 		podLatencyView,
 	)
 }
@@ -241,9 +286,13 @@ func viewUnregister() {
 		trDurationView,
 		prTRDurationView,
 		trCountView,
+		trTotalView,
 		runningTRsCountView,
+		runningTRsView,
 		runningTRsThrottledByQuotaCountView,
 		runningTRsThrottledByNodeCountView,
+		runningTRsThrottledByQuotaView,
+		runningTRsThrottledByNodeView,
 		podLatencyView,
 	)
 }
@@ -336,6 +385,7 @@ func (r *Recorder) DurationAndCount(ctx context.Context, tr *v1.TaskRun, beforeC
 
 	metrics.Record(ctx, durationStat.M(duration.Seconds()))
 	metrics.Record(ctx, trCount.M(1))
+	metrics.Record(ctx, trTotal.M(1))
 
 	return nil
 }
@@ -379,8 +429,11 @@ func (r *Recorder) RunningTaskRuns(ctx context.Context, lister listers.TaskRunLi
 		return err
 	}
 	metrics.Record(ctx, runningTRsCount.M(float64(runningTrs)))
+	metrics.Record(ctx, runningTRs.M(float64(runningTrs)))
 	metrics.Record(ctx, runningTRsThrottledByNodeCount.M(float64(trsThrottledByNode)))
 	metrics.Record(ctx, runningTRsThrottledByQuotaCount.M(float64(trsThrottledByQuota)))
+	metrics.Record(ctx, runningTRsThrottledByNode.M(float64(trsThrottledByNode)))
+	metrics.Record(ctx, runningTRsThrottledByQuota.M(float64(trsThrottledByQuota)))
 
 	return nil
 }


### PR DESCRIPTION
Some metrics aren't as per convention. This fixes it in a backward compatible way.
Fixes #7096 
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
