### PR TITLE
Cleanup: Move PipelineRun Reasons to pkg/apis

### DIFF
--- a/docs/pipeline-api.md
+++ b/docs/pipeline-api.md
@@ -1944,11 +1944,86 @@ and no new Tasks will be scheduled by the controller, but final tasks are now ru
 </tr><tr><td><p>&#34;Completed&#34;</p></td>
 <td><p>PipelineRunReasonCompleted is the reason set when the PipelineRun completed successfully with one or more skipped Tasks</p>
 </td>
+</tr><tr><td><p>&#34;PipelineRunCouldntCancel&#34;</p></td>
+<td><p>ReasonCouldntCancel indicates that a PipelineRun was cancelled but attempting to update
+all of the running TaskRuns as cancelled failed.</p>
+</td>
+</tr><tr><td><p>&#34;CouldntGetPipeline&#34;</p></td>
+<td><p>ReasonCouldntGetPipeline indicates that the reason for the failure status is that the
+associated Pipeline couldn&rsquo;t be retrieved</p>
+</td>
+</tr><tr><td><p>&#34;CouldntGetTask&#34;</p></td>
+<td><p>ReasonCouldntGetTask indicates that the reason for the failure status is that the
+associated Pipeline&rsquo;s Tasks couldn&rsquo;t all be retrieved</p>
+</td>
+</tr><tr><td><p>&#34;PipelineRunCouldntTimeOut&#34;</p></td>
+<td><p>ReasonCouldntTimeOut indicates that a PipelineRun was timed out but attempting to update
+all of the running TaskRuns as timed out failed.</p>
+</td>
+</tr><tr><td><p>&#34;CreateRunFailed&#34;</p></td>
+<td><p>ReasonCreateRunFailed indicates that the pipeline fails to create the taskrun or other run resources</p>
+</td>
 </tr><tr><td><p>&#34;Failed&#34;</p></td>
 <td><p>PipelineRunReasonFailed is the reason set when the PipelineRun completed with a failure</p>
 </td>
+</tr><tr><td><p>&#34;PipelineValidationFailed&#34;</p></td>
+<td><p>ReasonFailedValidation indicates that the reason for failure status is
+that pipelinerun failed runtime validation</p>
+</td>
+</tr><tr><td><p>&#34;InvalidPipelineResourceBindings&#34;</p></td>
+<td><p>ReasonInvalidBindings indicates that the reason for the failure status is that the
+PipelineResources bound in the PipelineRun didn&rsquo;t match those declared in the Pipeline</p>
+</td>
+</tr><tr><td><p>&#34;PipelineInvalidGraph&#34;</p></td>
+<td><p>ReasonInvalidGraph indicates that the reason for the failure status is that the
+associated Pipeline is an invalid graph (a.k.a wrong order, cycle, …)</p>
+</td>
+</tr><tr><td><p>&#34;InvalidMatrixParameterTypes&#34;</p></td>
+<td><p>ReasonInvalidMatrixParameterTypes indicates a matrix contains invalid parameter types</p>
+</td>
+</tr><tr><td><p>&#34;InvalidTaskResultReference&#34;</p></td>
+<td><p>ReasonInvalidTaskResultReference indicates a task result was declared
+but was not initialized by that task</p>
+</td>
+</tr><tr><td><p>&#34;InvalidTaskRunSpecs&#34;</p></td>
+<td><p>ReasonInvalidTaskRunSpec indicates that PipelineRun.Spec.TaskRunSpecs[].PipelineTaskName is defined with
+a not exist taskName in pipelineSpec.</p>
+</td>
+</tr><tr><td><p>&#34;InvalidWorkspaceBindings&#34;</p></td>
+<td><p>ReasonInvalidWorkspaceBinding indicates that a Pipeline expects a workspace but a
+PipelineRun has provided an invalid binding.</p>
+</td>
+</tr><tr><td><p>&#34;ObjectParameterMissKeys&#34;</p></td>
+<td><p>ReasonObjectParameterMissKeys indicates that the object param value provided from PipelineRun spec
+misses some keys required for the object param declared in Pipeline spec.</p>
+</td>
+</tr><tr><td><p>&#34;ParamArrayIndexingInvalid&#34;</p></td>
+<td><p>ReasonParamArrayIndexingInvalid indicates that the use of param array indexing is not under correct api fields feature gate
+or the array is out of bound.</p>
+</td>
+</tr><tr><td><p>&#34;ParameterMissing&#34;</p></td>
+<td><p>ReasonParameterMissing indicates that the reason for the failure status is that the
+associated PipelineRun didn&rsquo;t provide all the required parameters</p>
+</td>
+</tr><tr><td><p>&#34;ParameterTypeMismatch&#34;</p></td>
+<td><p>ReasonParameterTypeMismatch indicates that the reason for the failure status is that
+parameter(s) declared in the PipelineRun do not have the some declared type as the
+parameters(s) declared in the Pipeline that they are supposed to override.</p>
+</td>
 </tr><tr><td><p>&#34;PipelineRunPending&#34;</p></td>
 <td><p>PipelineRunReasonPending is the reason set when the PipelineRun is in the pending state</p>
+</td>
+</tr><tr><td><p>&#34;RequiredWorkspaceMarkedOptional&#34;</p></td>
+<td><p>ReasonRequiredWorkspaceMarkedOptional indicates an optional workspace
+has been passed to a Task that is expecting a non-optional workspace</p>
+</td>
+</tr><tr><td><p>&#34;ResolvingPipelineRef&#34;</p></td>
+<td><p>ReasonResolvingPipelineRef indicates that the PipelineRun is waiting for
+its pipelineRef to be asynchronously resolved.</p>
+</td>
+</tr><tr><td><p>&#34;ResourceVerificationFailed&#34;</p></td>
+<td><p>ReasonResourceVerificationFailed indicates that the pipeline fails the trusted resource verification,
+it could be the content has changed, signature is invalid or public key is invalid</p>
 </td>
 </tr><tr><td><p>&#34;Running&#34;</p></td>
 <td><p>PipelineRunReasonRunning is the reason set when the PipelineRun is running</p>

--- a/pkg/apis/pipeline/v1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1/pipelinerun_types.go
@@ -351,6 +351,62 @@ const (
 	// PipelineRunReasonStoppedRunningFinally indicates that pipeline has been gracefully stopped
 	// and no new Tasks will be scheduled by the controller, but final tasks are now running
 	PipelineRunReasonStoppedRunningFinally PipelineRunReason = "StoppedRunningFinally"
+	// ReasonCouldntGetPipeline indicates that the reason for the failure status is that the
+	// associated Pipeline couldn't be retrieved
+	PipelineRunReasonCouldntGetPipeline PipelineRunReason = "CouldntGetPipeline"
+	// ReasonInvalidBindings indicates that the reason for the failure status is that the
+	// PipelineResources bound in the PipelineRun didn't match those declared in the Pipeline
+	PipelineRunReasonInvalidBindings PipelineRunReason = "InvalidPipelineResourceBindings"
+	// ReasonInvalidWorkspaceBinding indicates that a Pipeline expects a workspace but a
+	// PipelineRun has provided an invalid binding.
+	PipelineRunReasonInvalidWorkspaceBinding PipelineRunReason = "InvalidWorkspaceBindings"
+	// ReasonInvalidTaskRunSpec indicates that PipelineRun.Spec.TaskRunSpecs[].PipelineTaskName is defined with
+	// a not exist taskName in pipelineSpec.
+	PipelineRunReasonInvalidTaskRunSpec PipelineRunReason = "InvalidTaskRunSpecs"
+	// ReasonParameterTypeMismatch indicates that the reason for the failure status is that
+	// parameter(s) declared in the PipelineRun do not have the some declared type as the
+	// parameters(s) declared in the Pipeline that they are supposed to override.
+	PipelineRunReasonParameterTypeMismatch PipelineRunReason = "ParameterTypeMismatch"
+	// ReasonObjectParameterMissKeys indicates that the object param value provided from PipelineRun spec
+	// misses some keys required for the object param declared in Pipeline spec.
+	PipelineRunReasonObjectParameterMissKeys PipelineRunReason = "ObjectParameterMissKeys"
+	// ReasonParamArrayIndexingInvalid indicates that the use of param array indexing is not under correct api fields feature gate
+	// or the array is out of bound.
+	PipelineRunReasonParamArrayIndexingInvalid PipelineRunReason = "ParamArrayIndexingInvalid"
+	// ReasonCouldntGetTask indicates that the reason for the failure status is that the
+	// associated Pipeline's Tasks couldn't all be retrieved
+	PipelineRunReasonCouldntGetTask PipelineRunReason = "CouldntGetTask"
+	// ReasonParameterMissing indicates that the reason for the failure status is that the
+	// associated PipelineRun didn't provide all the required parameters
+	PipelineRunReasonParameterMissing PipelineRunReason = "ParameterMissing"
+	// ReasonFailedValidation indicates that the reason for failure status is
+	// that pipelinerun failed runtime validation
+	PipelineRunReasonFailedValidation PipelineRunReason = "PipelineValidationFailed"
+	// ReasonInvalidGraph indicates that the reason for the failure status is that the
+	// associated Pipeline is an invalid graph (a.k.a wrong order, cycle, …)
+	PipelineRunReasonInvalidGraph PipelineRunReason = "PipelineInvalidGraph"
+	// ReasonCouldntCancel indicates that a PipelineRun was cancelled but attempting to update
+	// all of the running TaskRuns as cancelled failed.
+	PipelineRunReasonCouldntCancel PipelineRunReason = "PipelineRunCouldntCancel"
+	// ReasonCouldntTimeOut indicates that a PipelineRun was timed out but attempting to update
+	// all of the running TaskRuns as timed out failed.
+	PipelineRunReasonCouldntTimeOut PipelineRunReason = "PipelineRunCouldntTimeOut"
+	// ReasonInvalidMatrixParameterTypes indicates a matrix contains invalid parameter types
+	PipelineRunReasonInvalidMatrixParameterTypes PipelineRunReason = "InvalidMatrixParameterTypes"
+	// ReasonInvalidTaskResultReference indicates a task result was declared
+	// but was not initialized by that task
+	PipelineRunReasonInvalidTaskResultReference PipelineRunReason = "InvalidTaskResultReference"
+	// ReasonRequiredWorkspaceMarkedOptional indicates an optional workspace
+	// has been passed to a Task that is expecting a non-optional workspace
+	PipelineRunReasonRequiredWorkspaceMarkedOptional PipelineRunReason = "RequiredWorkspaceMarkedOptional"
+	// ReasonResolvingPipelineRef indicates that the PipelineRun is waiting for
+	// its pipelineRef to be asynchronously resolved.
+	PipelineRunReasonResolvingPipelineRef PipelineRunReason = "ResolvingPipelineRef"
+	// ReasonResourceVerificationFailed indicates that the pipeline fails the trusted resource verification,
+	// it could be the content has changed, signature is invalid or public key is invalid
+	PipelineRunReasonResourceVerificationFailed PipelineRunReason = "ResourceVerificationFailed"
+	// ReasonCreateRunFailed indicates that the pipeline fails to create the taskrun or other run resources
+	PipelineRunReasonCreateRunFailed PipelineRunReason = "CreateRunFailed"
 )
 
 func (t PipelineRunReason) String() string {

--- a/pkg/pipelinerunmetrics/metrics.go
+++ b/pkg/pipelinerunmetrics/metrics.go
@@ -63,7 +63,8 @@ var (
 
 const (
 	// ReasonCancelled indicates that a PipelineRun was cancelled.
-	ReasonCancelled = "Cancelled"
+	// Aliased for backwards compatibility; additional reasons should not be added here.
+	ReasonCancelled = v1.PipelineRunReasonCancelled
 )
 
 // Recorder holds keys for Tekton metrics
@@ -233,7 +234,7 @@ func (r *Recorder) DurationAndCount(pr *v1.PipelineRun, beforeCondition *apis.Co
 	status := "success"
 	if cond := pr.Status.GetCondition(apis.ConditionSucceeded); cond.Status == corev1.ConditionFalse {
 		status = "failed"
-		if cond.Reason == ReasonCancelled {
+		if cond.Reason == v1.PipelineRunReasonCancelled.String() {
 			status = "cancelled"
 		}
 	}

--- a/pkg/pipelinerunmetrics/metrics_test.go
+++ b/pkg/pipelinerunmetrics/metrics_test.go
@@ -224,7 +224,7 @@ func TestRecordPipelineRunDurationCount(t *testing.T) {
 					Conditions: duckv1.Conditions{{
 						Type:   apis.ConditionSucceeded,
 						Status: corev1.ConditionFalse,
-						Reason: ReasonCancelled,
+						Reason: v1.PipelineRunReasonCancelled.String(),
 					}},
 				},
 				PipelineRunStatusFields: v1.PipelineRunStatusFields{

--- a/pkg/reconciler/pipelinerun/cancel.go
+++ b/pkg/reconciler/pipelinerun/cancel.go
@@ -97,12 +97,12 @@ func cancelPipelineRun(ctx context.Context, logger *zap.SugaredLogger, pr *v1.Pi
 
 	// If we successfully cancelled all the TaskRuns and Runs, we can consider the PipelineRun cancelled.
 	if len(errs) == 0 {
-		reason := ReasonCancelled
+		reason := v1.PipelineRunReasonCancelled
 
 		pr.Status.SetCondition(&apis.Condition{
 			Type:    apis.ConditionSucceeded,
 			Status:  corev1.ConditionFalse,
-			Reason:  reason,
+			Reason:  reason.String(),
 			Message: fmt.Sprintf("PipelineRun %q was cancelled", pr.Name),
 		})
 		// update pr completed time
@@ -113,7 +113,7 @@ func cancelPipelineRun(ctx context.Context, logger *zap.SugaredLogger, pr *v1.Pi
 		pr.Status.SetCondition(&apis.Condition{
 			Type:    apis.ConditionSucceeded,
 			Status:  corev1.ConditionUnknown,
-			Reason:  ReasonCouldntCancel,
+			Reason:  v1.PipelineRunReasonCouldntCancel.String(),
 			Message: fmt.Sprintf("PipelineRun %q was cancelled but had errors trying to cancel TaskRuns and/or Runs: %s", pr.Name, e),
 		})
 		return fmt.Errorf("error(s) from cancelling TaskRun(s) from PipelineRun %s: %s", pr.Name, e)
@@ -194,7 +194,7 @@ func gracefullyCancelPipelineRun(ctx context.Context, logger *zap.SugaredLogger,
 		pr.Status.SetCondition(&apis.Condition{
 			Type:    apis.ConditionSucceeded,
 			Status:  corev1.ConditionUnknown,
-			Reason:  ReasonCouldntCancel,
+			Reason:  v1.PipelineRunReasonCouldntCancel.String(),
 			Message: fmt.Sprintf("PipelineRun %q was cancelled but had errors trying to cancel TaskRuns and/or Runs: %s", pr.Name, e),
 		})
 		return fmt.Errorf("error(s) from cancelling TaskRun(s) from PipelineRun %s: %s", pr.Name, e)

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -75,67 +75,68 @@ import (
 	pkgreconciler "knative.dev/pkg/reconciler"
 )
 
-const (
+// Aliased for backwards compatibility; do not add additional reasons here
+var (
 	// ReasonCouldntGetPipeline indicates that the reason for the failure status is that the
 	// associated Pipeline couldn't be retrieved
-	ReasonCouldntGetPipeline = "CouldntGetPipeline"
+	ReasonCouldntGetPipeline = v1.PipelineRunReasonCouldntGetPipeline.String()
 	// ReasonInvalidBindings indicates that the reason for the failure status is that the
 	// PipelineResources bound in the PipelineRun didn't match those declared in the Pipeline
-	ReasonInvalidBindings = "InvalidPipelineResourceBindings"
+	ReasonInvalidBindings = v1.PipelineRunReasonInvalidBindings.String()
 	// ReasonInvalidWorkspaceBinding indicates that a Pipeline expects a workspace but a
 	// PipelineRun has provided an invalid binding.
-	ReasonInvalidWorkspaceBinding = "InvalidWorkspaceBindings"
+	ReasonInvalidWorkspaceBinding = v1.PipelineRunReasonInvalidWorkspaceBinding.String()
 	// ReasonInvalidTaskRunSpec indicates that PipelineRun.Spec.TaskRunSpecs[].PipelineTaskName is defined with
 	// a not exist taskName in pipelineSpec.
-	ReasonInvalidTaskRunSpec = "InvalidTaskRunSpecs"
+	ReasonInvalidTaskRunSpec = v1.PipelineRunReasonInvalidTaskRunSpec.String()
 	// ReasonParameterTypeMismatch indicates that the reason for the failure status is that
 	// parameter(s) declared in the PipelineRun do not have the some declared type as the
 	// parameters(s) declared in the Pipeline that they are supposed to override.
-	ReasonParameterTypeMismatch = "ParameterTypeMismatch"
+	ReasonParameterTypeMismatch = v1.PipelineRunReasonParameterTypeMismatch.String()
 	// ReasonObjectParameterMissKeys indicates that the object param value provided from PipelineRun spec
 	// misses some keys required for the object param declared in Pipeline spec.
-	ReasonObjectParameterMissKeys = "ObjectParameterMissKeys"
+	ReasonObjectParameterMissKeys = v1.PipelineRunReasonObjectParameterMissKeys.String()
 	// ReasonParamArrayIndexingInvalid indicates that the use of param array indexing is not under correct api fields feature gate
 	// or the array is out of bound.
-	ReasonParamArrayIndexingInvalid = "ParamArrayIndexingInvalid"
+	ReasonParamArrayIndexingInvalid = v1.PipelineRunReasonParamArrayIndexingInvalid.String()
 	// ReasonCouldntGetTask indicates that the reason for the failure status is that the
 	// associated Pipeline's Tasks couldn't all be retrieved
-	ReasonCouldntGetTask = "CouldntGetTask"
+	ReasonCouldntGetTask = v1.PipelineRunReasonCouldntGetTask.String()
 	// ReasonParameterMissing indicates that the reason for the failure status is that the
 	// associated PipelineRun didn't provide all the required parameters
-	ReasonParameterMissing = "ParameterMissing"
+	ReasonParameterMissing = v1.PipelineRunReasonParameterMissing.String()
 	// ReasonFailedValidation indicates that the reason for failure status is
 	// that pipelinerun failed runtime validation
-	ReasonFailedValidation = "PipelineValidationFailed"
+	ReasonFailedValidation = v1.PipelineRunReasonFailedValidation.String()
 	// ReasonInvalidGraph indicates that the reason for the failure status is that the
 	// associated Pipeline is an invalid graph (a.k.a wrong order, cycle, …)
-	ReasonInvalidGraph = "PipelineInvalidGraph"
+	ReasonInvalidGraph = v1.PipelineRunReasonInvalidGraph.String()
 	// ReasonCancelled indicates that a PipelineRun was cancelled.
-	ReasonCancelled = pipelinerunmetrics.ReasonCancelled
+	ReasonCancelled = v1.PipelineRunReasonCancelled.String()
 	// ReasonPending indicates that a PipelineRun is pending.
-	ReasonPending = "PipelineRunPending"
+	ReasonPending = v1.PipelineRunReasonPending.String()
 	// ReasonCouldntCancel indicates that a PipelineRun was cancelled but attempting to update
 	// all of the running TaskRuns as cancelled failed.
-	ReasonCouldntCancel = "PipelineRunCouldntCancel"
+	ReasonCouldntCancel = v1.PipelineRunReasonCouldntCancel.String()
 	// ReasonCouldntTimeOut indicates that a PipelineRun was timed out but attempting to update
 	// all of the running TaskRuns as timed out failed.
-	ReasonCouldntTimeOut = "PipelineRunCouldntTimeOut"
+	ReasonCouldntTimeOut = v1.PipelineRunReasonCouldntTimeOut.String()
 	// ReasonInvalidMatrixParameterTypes indicates a matrix contains invalid parameter types
-	ReasonInvalidMatrixParameterTypes = "InvalidMatrixParameterTypes"
+	ReasonInvalidMatrixParameterTypes = v1.PipelineRunReasonInvalidMatrixParameterTypes.String()
 	// ReasonInvalidTaskResultReference indicates a task result was declared
 	// but was not initialized by that task
-	ReasonInvalidTaskResultReference = "InvalidTaskResultReference"
+	ReasonInvalidTaskResultReference = v1.PipelineRunReasonInvalidTaskResultReference.String()
 	// ReasonRequiredWorkspaceMarkedOptional indicates an optional workspace
 	// has been passed to a Task that is expecting a non-optional workspace
-	ReasonRequiredWorkspaceMarkedOptional = "RequiredWorkspaceMarkedOptional"
+	ReasonRequiredWorkspaceMarkedOptional = v1.PipelineRunReasonRequiredWorkspaceMarkedOptional.String()
 	// ReasonResolvingPipelineRef indicates that the PipelineRun is waiting for
 	// its pipelineRef to be asynchronously resolved.
-	ReasonResolvingPipelineRef = "ResolvingPipelineRef"
+	ReasonResolvingPipelineRef = v1.PipelineRunReasonResolvingPipelineRef.String()
 	// ReasonResourceVerificationFailed indicates that the pipeline fails the trusted resource verification,
 	// it could be the content has changed, signature is invalid or public key is invalid
-	ReasonResourceVerificationFailed = "ResourceVerificationFailed"
+	ReasonResourceVerificationFailed = v1.PipelineRunReasonResourceVerificationFailed.String()
 	// ReasonCreateRunFailed indicates that the pipeline fails to create the taskrun or other run resources
-	ReasonCreateRunFailed = "CreateRunFailed"
+	ReasonCreateRunFailed = v1.PipelineRunReasonCreateRunFailed.String()
 )
 
 // constants used as kind descriptors for various types of runs; these constants
@@ -368,11 +369,11 @@ func (c *Reconciler) resolvePipelineState(
 			}
 			var nfErr *resources.TaskNotFoundError
 			if errors.As(err, &nfErr) {
-				pr.Status.MarkFailed(ReasonCouldntGetTask,
+				pr.Status.MarkFailed(v1.PipelineRunReasonCouldntGetTask.String(),
 					"Pipeline %s/%s can't be Run; it contains Tasks that don't exist: %s",
 					pipelineMeta.Namespace, pipelineMeta.Name, nfErr)
 			} else {
-				pr.Status.MarkFailed(ReasonFailedValidation,
+				pr.Status.MarkFailed(v1.PipelineRunReasonFailedValidation.String(),
 					"PipelineRun %s/%s can't be Run; couldn't resolve all references: %s",
 					pipelineMeta.Namespace, pr.Name, err)
 			}
@@ -382,7 +383,7 @@ func (c *Reconciler) resolvePipelineState(
 			cond, err := conditionFromVerificationResult(resolvedTask.ResolvedTask.VerificationResult, pr, task.Name)
 			pr.Status.SetCondition(cond)
 			if err != nil {
-				pr.Status.MarkFailed(ReasonResourceVerificationFailed, err.Error())
+				pr.Status.MarkFailed(v1.PipelineRunReasonResourceVerificationFailed.String(), err.Error())
 				return nil, controller.NewPermanentError(err)
 			}
 		}
@@ -400,7 +401,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1.PipelineRun, getPipel
 
 	// When pipeline run is pending, return to avoid creating the task
 	if pr.IsPending() {
-		pr.Status.MarkRunning(ReasonPending, fmt.Sprintf("PipelineRun %q is pending", pr.Name))
+		pr.Status.MarkRunning(v1.PipelineRunReasonPending.String(), fmt.Sprintf("PipelineRun %q is pending", pr.Name))
 		return nil
 	}
 
@@ -408,16 +409,16 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1.PipelineRun, getPipel
 	switch {
 	case errors.Is(err, remote.ErrRequestInProgress):
 		message := fmt.Sprintf("PipelineRun %s/%s awaiting remote resource", pr.Namespace, pr.Name)
-		pr.Status.MarkRunning(ReasonResolvingPipelineRef, message)
+		pr.Status.MarkRunning(v1.PipelineRunReasonResolvingPipelineRef.String(), message)
 		return nil
 	case errors.Is(err, apiserver.ErrReferencedObjectValidationFailed), errors.Is(err, apiserver.ErrCouldntValidateObjectPermanent):
-		pr.Status.MarkFailed(ReasonFailedValidation, err.Error())
+		pr.Status.MarkFailed(v1.PipelineRunReasonFailedValidation.String(), err.Error())
 		return controller.NewPermanentError(err)
 	case errors.Is(err, apiserver.ErrCouldntValidateObjectRetryable):
 		return err
 	case err != nil:
 		logger.Errorf("Failed to determine Pipeline spec to use for pipelinerun %s: %v", pr.Name, err)
-		pr.Status.MarkFailed(ReasonCouldntGetPipeline,
+		pr.Status.MarkFailed(v1.PipelineRunReasonCouldntGetPipeline.String(),
 			"Error retrieving pipeline for pipelinerun %s/%s: %s",
 			pr.Namespace, pr.Name, err)
 		return controller.NewPermanentError(err)
@@ -432,7 +433,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1.PipelineRun, getPipel
 		cond, err := conditionFromVerificationResult(pipelineMeta.VerificationResult, pr, pipelineMeta.Name)
 		pr.Status.SetCondition(cond)
 		if err != nil {
-			pr.Status.MarkFailed(ReasonResourceVerificationFailed, err.Error())
+			pr.Status.MarkFailed(v1.PipelineRunReasonResourceVerificationFailed.String(), err.Error())
 			return controller.NewPermanentError(err)
 		}
 	}
@@ -440,7 +441,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1.PipelineRun, getPipel
 	d, err := dag.Build(v1.PipelineTaskList(pipelineSpec.Tasks), v1.PipelineTaskList(pipelineSpec.Tasks).Deps())
 	if err != nil {
 		// This Run has failed, so we need to mark it as failed and stop reconciling it
-		pr.Status.MarkFailed(ReasonInvalidGraph,
+		pr.Status.MarkFailed(v1.PipelineRunReasonInvalidGraph.String(),
 			"PipelineRun %s/%s's Pipeline DAG is invalid: %s",
 			pr.Namespace, pr.Name, err)
 		return controller.NewPermanentError(err)
@@ -453,7 +454,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1.PipelineRun, getPipel
 	dfinally, err := dag.Build(v1.PipelineTaskList(pipelineSpec.Finally), map[string][]string{})
 	if err != nil {
 		// This Run has failed, so we need to mark it as failed and stop reconciling it
-		pr.Status.MarkFailed(ReasonInvalidGraph,
+		pr.Status.MarkFailed(v1.PipelineRunReasonInvalidGraph.String(),
 			"PipelineRun %s's Pipeline DAG is invalid for finally clause: %s",
 			pr.Namespace, pr.Name, err)
 		return controller.NewPermanentError(err)
@@ -461,7 +462,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1.PipelineRun, getPipel
 
 	if err := pipelineSpec.Validate(ctx); err != nil {
 		// This Run has failed, so we need to mark it as failed and stop reconciling it
-		pr.Status.MarkFailed(ReasonFailedValidation,
+		pr.Status.MarkFailed(v1.PipelineRunReasonFailedValidation.String(),
 			"Pipeline %s/%s can't be Run; it has an invalid spec: %s",
 			pipelineMeta.Namespace, pipelineMeta.Name, err)
 		return controller.NewPermanentError(err)
@@ -470,7 +471,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1.PipelineRun, getPipel
 	// Ensure that the PipelineRun provides all the parameters required by the Pipeline
 	if err := resources.ValidateRequiredParametersProvided(&pipelineSpec.Params, &pr.Spec.Params); err != nil {
 		// This Run has failed, so we need to mark it as failed and stop reconciling it
-		pr.Status.MarkFailed(ReasonParameterMissing,
+		pr.Status.MarkFailed(v1.PipelineRunReasonParameterMissing.String(),
 			"PipelineRun %s parameters is missing some parameters required by Pipeline %s's parameters: %s",
 			pr.Namespace, pr.Name, err)
 		return controller.NewPermanentError(err)
@@ -480,7 +481,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1.PipelineRun, getPipel
 	// Weird substitution issues can occur if this is not validated (ApplyParameters() does not verify type).
 	if err = resources.ValidateParamTypesMatching(pipelineSpec, pr); err != nil {
 		// This Run has failed, so we need to mark it as failed and stop reconciling it
-		pr.Status.MarkFailed(ReasonParameterTypeMismatch,
+		pr.Status.MarkFailed(v1.PipelineRunReasonParameterTypeMismatch.String(),
 			"PipelineRun %s/%s parameters have mismatching types with Pipeline %s/%s's parameters: %s",
 			pr.Namespace, pr.Name, pr.Namespace, pipelineMeta.Name, err)
 		return controller.NewPermanentError(err)
@@ -489,7 +490,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1.PipelineRun, getPipel
 	// Ensure that the keys of an object param declared in PipelineSpec are not missed in the PipelineRunSpec
 	if err = resources.ValidateObjectParamRequiredKeys(pipelineSpec.Params, pr.Spec.Params); err != nil {
 		// This Run has failed, so we need to mark it as failed and stop reconciling it
-		pr.Status.MarkFailed(ReasonObjectParameterMissKeys,
+		pr.Status.MarkFailed(v1.PipelineRunReasonObjectParameterMissKeys.String(),
 			"PipelineRun %s/%s parameters is missing object keys required by Pipeline %s/%s's parameters: %s",
 			pr.Namespace, pr.Name, pr.Namespace, pipelineMeta.Name, err)
 		return controller.NewPermanentError(err)
@@ -498,7 +499,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1.PipelineRun, getPipel
 	// Ensure that the array reference is not out of bound
 	if err := resources.ValidateParamArrayIndex(pipelineSpec, pr.Spec.Params); err != nil {
 		// This Run has failed, so we need to mark it as failed and stop reconciling it
-		pr.Status.MarkFailed(ReasonParamArrayIndexingInvalid,
+		pr.Status.MarkFailed(v1.PipelineRunReasonParamArrayIndexingInvalid.String(),
 			"PipelineRun %s/%s failed validation: failed to validate Pipeline %s/%s's parameter which has an invalid index while referring to an array: %s",
 			pr.Namespace, pr.Name, pr.Namespace, pipelineMeta.Name, err)
 		return controller.NewPermanentError(err)
@@ -506,7 +507,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1.PipelineRun, getPipel
 
 	// Ensure that the workspaces expected by the Pipeline are provided by the PipelineRun.
 	if err := resources.ValidateWorkspaceBindings(pipelineSpec, pr); err != nil {
-		pr.Status.MarkFailed(ReasonInvalidWorkspaceBinding,
+		pr.Status.MarkFailed(v1.PipelineRunReasonInvalidWorkspaceBinding.String(),
 			"PipelineRun %s/%s doesn't bind Pipeline %s/%s's Workspaces correctly: %s",
 			pr.Namespace, pr.Name, pr.Namespace, pipelineMeta.Name, err)
 		return controller.NewPermanentError(err)
@@ -514,7 +515,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1.PipelineRun, getPipel
 
 	// Ensure that the TaskRunSpecs defined are correct.
 	if err := resources.ValidateTaskRunSpecs(pipelineSpec, pr); err != nil {
-		pr.Status.MarkFailed(ReasonInvalidTaskRunSpec,
+		pr.Status.MarkFailed(v1.PipelineRunReasonInvalidTaskRunSpec.String(),
 			"PipelineRun %s/%s doesn't define taskRunSpecs correctly: %s",
 			pr.Namespace, pr.Name, err)
 		return controller.NewPermanentError(err)
@@ -580,7 +581,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1.PipelineRun, getPipel
 			err := taskrun.ValidateResolvedTask(ctx, rpt.PipelineTask.Params, rpt.PipelineTask.Matrix, rpt.ResolvedTask)
 			if err != nil {
 				logger.Errorf("Failed to validate pipelinerun %q with error %v", pr.Name, err)
-				pr.Status.MarkFailed(ReasonFailedValidation, err.Error())
+				pr.Status.MarkFailed(v1.PipelineRunReasonFailedValidation.String(), err.Error())
 				return controller.NewPermanentError(err)
 			}
 		}
@@ -599,19 +600,19 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1.PipelineRun, getPipel
 	if pipelineRunFacts.State.IsBeforeFirstTaskRun() {
 		if err := resources.ValidatePipelineTaskResults(pipelineRunFacts.State); err != nil {
 			logger.Errorf("Failed to resolve task result reference for %q with error %v", pr.Name, err)
-			pr.Status.MarkFailed(ReasonInvalidTaskResultReference, err.Error())
+			pr.Status.MarkFailed(v1.PipelineRunReasonInvalidTaskResultReference.String(), err.Error())
 			return controller.NewPermanentError(err)
 		}
 
 		if err := resources.ValidatePipelineResults(pipelineSpec, pipelineRunFacts.State); err != nil {
 			logger.Errorf("Failed to resolve task result reference for %q with error %v", pr.Name, err)
-			pr.Status.MarkFailed(ReasonInvalidTaskResultReference, err.Error())
+			pr.Status.MarkFailed(v1.PipelineRunReasonInvalidTaskResultReference.String(), err.Error())
 			return controller.NewPermanentError(err)
 		}
 
 		if err := resources.ValidateOptionalWorkspaces(pipelineSpec.Workspaces, pipelineRunFacts.State); err != nil {
 			logger.Errorf("Optional workspace not supported by task: %v", err)
-			pr.Status.MarkFailed(ReasonRequiredWorkspaceMarkedOptional, err.Error())
+			pr.Status.MarkFailed(v1.PipelineRunReasonRequiredWorkspaceMarkedOptional.String(), err.Error())
 			return controller.NewPermanentError(err)
 		}
 
@@ -706,7 +707,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1.PipelineRun, getPipel
 		pr.Status.Results, err = resources.ApplyTaskResultsToPipelineResults(ctx, pipelineSpec.Results,
 			pipelineRunFacts.State.GetTaskRunsResults(), pipelineRunFacts.State.GetRunsResults(), pipelineRunFacts.GetPipelineTaskStatus())
 		if err != nil {
-			pr.Status.MarkFailed(ReasonFailedValidation, err.Error())
+			pr.Status.MarkFailed(v1.PipelineRunReasonFailedValidation.String(), err.Error())
 			return err
 		}
 	}
@@ -736,7 +737,7 @@ func (c *Reconciler) runNextSchedulableTask(ctx context.Context, pr *v1.Pipeline
 	err = resources.CheckMissingResultReferences(pipelineRunFacts.State, nextRpts)
 	if err != nil {
 		logger.Infof("Failed to resolve task result reference for %q with error %v", pr.Name, err)
-		pr.Status.MarkFailed(ReasonInvalidTaskResultReference, err.Error())
+		pr.Status.MarkFailed(v1.PipelineRunReasonInvalidTaskResultReference.String(), err.Error())
 		return controller.NewPermanentError(err)
 	}
 
@@ -772,7 +773,7 @@ func (c *Reconciler) runNextSchedulableTask(ctx context.Context, pr *v1.Pipeline
 		if rpt.PipelineTask.IsMatrixed() {
 			if err := resources.ValidateParameterTypesInMatrix(pipelineRunFacts.State); err != nil {
 				logger.Errorf("Failed to validate matrix %q with error %v", pr.Name, err)
-				pr.Status.MarkFailed(ReasonInvalidMatrixParameterTypes, err.Error())
+				pr.Status.MarkFailed(v1.PipelineRunReasonInvalidMatrixParameterTypes.String(), err.Error())
 				return controller.NewPermanentError(err)
 			}
 		}
@@ -895,12 +896,12 @@ func (c *Reconciler) createTaskRun(ctx context.Context, taskRunName string, para
 // handleRunCreationError marks the PipelineRun as failed and returns a permanent error if the run creation error is not retryable
 func (c *Reconciler) handleRunCreationError(ctx context.Context, pr *v1.PipelineRun, err error) error {
 	if controller.IsPermanentError(err) {
-		pr.Status.MarkFailed(ReasonCreateRunFailed, err.Error())
+		pr.Status.MarkFailed(v1.PipelineRunReasonCreateRunFailed.String(), err.Error())
 		return err
 	}
 	// This is not a complete list of permanent errors. Any permanent error with TaskRun/CustomRun creation can be added here.
 	if apierrors.IsInvalid(err) || apierrors.IsBadRequest(err) {
-		pr.Status.MarkFailed(ReasonCreateRunFailed, err.Error())
+		pr.Status.MarkFailed(v1.PipelineRunReasonCreateRunFailed.String(), err.Error())
 		return controller.NewPermanentError(err)
 	}
 	return err

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -800,7 +800,7 @@ spec:
   pipelineRef:
     name: pipeline-not-exist
 `),
-		reason:             ReasonCouldntGetPipeline,
+		reason:             v1.PipelineRunReasonCouldntGetPipeline.String(),
 		hasNoDefaultLabels: true,
 		permanentError:     true,
 		wantEvents: []string{
@@ -817,7 +817,7 @@ spec:
   pipelineRef:
     name: pipeline-missing-tasks
 `),
-		reason:         ReasonCouldntGetTask,
+		reason:         v1.PipelineRunReasonCouldntGetTask.String(),
 		permanentError: true,
 		wantEvents: []string{
 			"Normal Started",
@@ -833,7 +833,7 @@ spec:
   pipelineRef:
     name: a-pipeline-without-params
 `),
-		reason:         ReasonFailedValidation,
+		reason:         v1.PipelineRunReasonFailedValidation.String(),
 		permanentError: true,
 		wantEvents: []string{
 			"Normal Started",
@@ -852,7 +852,7 @@ spec:
     - name: some-param
       value: stringval
 `),
-		reason:         ReasonParameterTypeMismatch,
+		reason:         v1.PipelineRunReasonParameterTypeMismatch.String(),
 		permanentError: true,
 		wantEvents: []string{
 			"Normal Started",
@@ -872,7 +872,7 @@ spec:
       value:
         key1: "a"
 `),
-		reason:         ReasonObjectParameterMissKeys,
+		reason:         v1.PipelineRunReasonObjectParameterMissKeys.String(),
 		permanentError: true,
 		wantEvents: []string{
 			"Normal Started",
@@ -893,7 +893,7 @@ spec:
         - "a"
         - "b"
     `),
-		reason:         ReasonParamArrayIndexingInvalid,
+		reason:         v1.PipelineRunReasonParamArrayIndexingInvalid.String(),
 		permanentError: true,
 		wantEvents: []string{
 			"Normal Started",
@@ -912,7 +912,7 @@ spec:
         taskRef:
           name: b@d-t@$k
 `),
-		reason:         ReasonFailedValidation,
+		reason:         v1.PipelineRunReasonFailedValidation.String(),
 		permanentError: true,
 		wantEvents: []string{
 			"Normal Started",
@@ -937,7 +937,7 @@ spec:
     - name: some-param
       value: stringval
 `, v1.ParamTypeArray)),
-		reason:         ReasonParameterTypeMismatch,
+		reason:         v1.PipelineRunReasonParameterTypeMismatch.String(),
 		permanentError: true,
 		wantEvents: []string{
 			"Normal Started",
@@ -959,7 +959,7 @@ spec:
         taskRef:
           name: a-task-that-needs-params
 `, v1.ParamTypeString)),
-		reason:         ReasonParameterMissing,
+		reason:         v1.PipelineRunReasonParameterMissing.String(),
 		permanentError: true,
 		wantEvents: []string{
 			"Normal Started",
@@ -979,7 +979,7 @@ spec:
           name: dag-task-1
         runAfter: [ dag-task-1 ]
 `),
-		reason:         ReasonInvalidGraph,
+		reason:         v1.PipelineRunReasonInvalidGraph.String(),
 		permanentError: true,
 		wantEvents: []string{
 			"Normal Started",
@@ -1005,7 +1005,7 @@ spec:
         taskRef:
           name: taskName
 `),
-		reason:         ReasonInvalidGraph,
+		reason:         v1.PipelineRunReasonInvalidGraph.String(),
 		permanentError: true,
 		wantEvents: []string{
 			"Normal Started",
@@ -1410,7 +1410,7 @@ func TestReconcileOnCancelledPipelineRun(t *testing.T) {
 		{
 			name:       "cancelled",
 			specStatus: v1.PipelineRunSpecStatusCancelled,
-			reason:     ReasonCancelled,
+			reason:     v1.PipelineRunReasonCancelled.String(),
 		},
 	}
 
@@ -2988,7 +2988,7 @@ spec:
 			}
 
 			// The PipelineRun should not be cancelled b/c we couldn't cancel the TaskRun
-			checkPipelineRunConditionStatusAndReason(t, reconciledRun, corev1.ConditionUnknown, ReasonCouldntCancel)
+			checkPipelineRunConditionStatusAndReason(t, reconciledRun, corev1.ConditionUnknown, v1.PipelineRunReasonCouldntCancel.String())
 			// The event here is "Normal" because in case we fail to cancel we leave the condition to unknown
 			// Further reconcile might converge then the status of the pipeline.
 			// See https://github.com/tektoncd/pipeline/issues/2647 for further details.
@@ -3106,7 +3106,7 @@ spec:
 	}
 
 	// The PipelineRun should not be timed out b/c we couldn't timeout the TaskRun
-	checkPipelineRunConditionStatusAndReason(t, reconciledRun, corev1.ConditionUnknown, ReasonCouldntTimeOut)
+	checkPipelineRunConditionStatusAndReason(t, reconciledRun, corev1.ConditionUnknown, v1.PipelineRunReasonCouldntTimeOut.String())
 	// The event here is "Normal" because in case we fail to timeout we leave the condition to unknown
 	// Further reconcile might converge then the status of the pipeline.
 	// See https://github.com/tektoncd/pipeline/issues/2647 for further details.
@@ -6833,7 +6833,7 @@ spec:
 			t.Fatalf("Somehow had error getting reconciled run out of fake client: %s", err)
 		}
 
-		if tc.wantFailed && reconciledRun.Status.GetCondition(apis.ConditionSucceeded).Reason != ReasonFailedValidation {
+		if tc.wantFailed && reconciledRun.Status.GetCondition(apis.ConditionSucceeded).Reason != v1.PipelineRunReasonFailedValidation.String() {
 			t.Errorf("Expected PipelineRun to have reason FailedValidation, but condition reason is %s", reconciledRun.Status.GetCondition(apis.ConditionSucceeded))
 		}
 		if !tc.wantFailed && reconciledRun.Status.GetCondition(apis.ConditionSucceeded).IsFalse() {
@@ -7057,19 +7057,19 @@ spec:
 	}{
 		{
 			name:   "pipelinerun-param-invalid-result-variable",
-			reason: ReasonInvalidTaskResultReference,
+			reason: v1.PipelineRunReasonInvalidTaskResultReference.String(),
 		}, {
 			name:   "pipelinerun-pipeline-result-invalid-result-variable",
-			reason: ReasonInvalidTaskResultReference,
+			reason: v1.PipelineRunReasonInvalidTaskResultReference.String(),
 		}, {
 			name:   "pipelinerun-with-optional-workspace-validation",
-			reason: ReasonRequiredWorkspaceMarkedOptional,
+			reason: v1.PipelineRunReasonRequiredWorkspaceMarkedOptional.String(),
 		}, {
 			name:   "pipelinerun-matrix-param-invalid-type",
-			reason: ReasonInvalidMatrixParameterTypes,
+			reason: v1.PipelineRunReasonInvalidMatrixParameterTypes.String(),
 		}, {
 			name:   "pipelinerun-with-invalid-taskrunspecs",
-			reason: ReasonInvalidTaskRunSpec,
+			reason: v1.PipelineRunReasonInvalidTaskRunSpec.String(),
 		},
 	}
 	for _, tc := range testCases {
@@ -7116,7 +7116,7 @@ spec:
 
 	wantEvents := []string(nil)
 	pipelinerun, _ := prt.reconcileRun(pr.Namespace, pr.Name, wantEvents, false)
-	checkPipelineRunConditionStatusAndReason(t, pipelinerun, corev1.ConditionUnknown, ReasonResolvingPipelineRef)
+	checkPipelineRunConditionStatusAndReason(t, pipelinerun, corev1.ConditionUnknown, v1.PipelineRunReasonResolvingPipelineRef.String())
 
 	client := prt.TestAssets.Clients.ResolutionRequests.ResolutionV1beta1().ResolutionRequests("default")
 	resolutionrequests, err := client.List(prt.TestAssets.Ctx, metav1.ListOptions{})
@@ -7191,7 +7191,7 @@ spec:
 
 	wantEvents := []string(nil)
 	pipelinerun, _ := prt.reconcileRun(pr.Namespace, pr.Name, wantEvents, false)
-	checkPipelineRunConditionStatusAndReason(t, pipelinerun, corev1.ConditionUnknown, ReasonResolvingPipelineRef)
+	checkPipelineRunConditionStatusAndReason(t, pipelinerun, corev1.ConditionUnknown, v1.PipelineRunReasonResolvingPipelineRef.String())
 
 	client := prt.TestAssets.Clients.ResolutionRequests.ResolutionV1beta1().ResolutionRequests("default")
 	resolutionrequests, err := client.List(prt.TestAssets.Ctx, metav1.ListOptions{})
@@ -7217,7 +7217,7 @@ spec:
 
 	// Check that the pipeline fails with the appropriate reason.
 	updatedPipelineRun, _ := prt.reconcileRun("default", "pr", nil, true)
-	checkPipelineRunConditionStatusAndReason(t, updatedPipelineRun, corev1.ConditionFalse, ReasonCouldntGetPipeline)
+	checkPipelineRunConditionStatusAndReason(t, updatedPipelineRun, corev1.ConditionFalse, v1.PipelineRunReasonCouldntGetPipeline.String())
 }
 
 // TestReconcileWithFailingTaskResolver checks that a PipelineRun with a failing Resolver
@@ -7278,7 +7278,7 @@ spec:
 
 	// Check that the pipeline fails.
 	updatedPipelineRun, _ := prt.reconcileRun("default", "pr", nil, true)
-	checkPipelineRunConditionStatusAndReason(t, updatedPipelineRun, corev1.ConditionFalse, ReasonCouldntGetTask)
+	checkPipelineRunConditionStatusAndReason(t, updatedPipelineRun, corev1.ConditionFalse, v1.PipelineRunReasonCouldntGetTask.String())
 }
 
 // TestReconcileWithTaskResolver checks that a PipelineRun with a populated Resolver
@@ -13055,7 +13055,7 @@ spec:
 			defer prt.Cancel()
 
 			reconciledRun, _ := prt.reconcileRun("foo", "test-pipelinerun", []string{}, true)
-			checkPipelineRunConditionStatusAndReason(t, reconciledRun, corev1.ConditionFalse, ReasonResourceVerificationFailed)
+			checkPipelineRunConditionStatusAndReason(t, reconciledRun, corev1.ConditionFalse, v1.PipelineRunReasonResourceVerificationFailed.String())
 			gotVerificationCondition := reconciledRun.Status.GetCondition(trustedresources.ConditionTrustedResourcesVerified)
 			if gotVerificationCondition == nil || gotVerificationCondition.Status != corev1.ConditionFalse {
 				t.Errorf("Expected to have false condition, but had %v", gotVerificationCondition)
@@ -13390,7 +13390,7 @@ spec:
 			defer prt.Cancel()
 
 			reconciledRun, _ := prt.reconcileRun("foo", "test-pipelinerun", []string{}, true)
-			checkPipelineRunConditionStatusAndReason(t, reconciledRun, corev1.ConditionFalse, ReasonResourceVerificationFailed)
+			checkPipelineRunConditionStatusAndReason(t, reconciledRun, corev1.ConditionFalse, v1.PipelineRunReasonResourceVerificationFailed.String())
 			gotVerificationCondition := reconciledRun.Status.GetCondition(trustedresources.ConditionTrustedResourcesVerified)
 			if gotVerificationCondition == nil || gotVerificationCondition.Status != corev1.ConditionFalse {
 				t.Errorf("Expected to have false condition, but had %v", gotVerificationCondition)

--- a/pkg/reconciler/pipelinerun/timeout.go
+++ b/pkg/reconciler/pipelinerun/timeout.go
@@ -82,7 +82,7 @@ func timeoutPipelineRun(ctx context.Context, logger *zap.SugaredLogger, pr *v1.P
 		pr.Status.SetCondition(&apis.Condition{
 			Type:    apis.ConditionSucceeded,
 			Status:  corev1.ConditionUnknown,
-			Reason:  ReasonCouldntTimeOut,
+			Reason:  v1.PipelineRunReasonCouldntTimeOut.String(),
 			Message: fmt.Sprintf("PipelineRun %q was timed out but had errors trying to time out TaskRuns and/or Runs: %s", pr.Name, e),
 		})
 		return fmt.Errorf("error(s) from timing out TaskRun(s) from PipelineRun %s: %s", pr.Name, e)


### PR DESCRIPTION
Prior to this commit, strings that were set as "Reasons" in the PipelineRun status were split between pkg/apis and pkg/reconciler/pipelinerun. This commit moves all PipelineRun reasons to pkg/apis and adds aliases for backwards compatibility. This adds consistency, correctly signals to clients that all Reasons are part of the API, and helps avoid circular imports (as in https://github.com/tektoncd/pipeline/pull/7094).

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- n/a Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- n/a Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- n/a Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
