### PR TITLE
Remove results annotations filtering

### DIFF
--- a/pkg/apis/pipeline/constant.go
+++ b/pkg/apis/pipeline/constant.go
@@ -18,5 +18,5 @@ package pipeline
 
 const (
 	// TektonReservedAnnotationExpr is the expression we use to filter out reserved key in annotation
-	TektonReservedAnnotationExpr = "(results.tekton.dev|chains.tekton.dev)/.*"
+	TektonReservedAnnotationExpr = "(chains.tekton.dev)/.*"
 )

--- a/pkg/apis/pipeline/v1/pipelinerun_defaults_test.go
+++ b/pkg/apis/pipeline/v1/pipelinerun_defaults_test.go
@@ -465,7 +465,7 @@ func TestPipelineRunDefaultingOnCreate(t *testing.T) {
 		},
 		want: &v1.PipelineRun{
 			ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{"tekton.dev/foo": "bar", "foo": "bar"},
+				Annotations: map[string]string{"results.tekton.dev/hello": "world", "tekton.dev/foo": "bar", "foo": "bar"},
 			},
 			Spec: v1.PipelineRunSpec{
 				TaskRunTemplate: v1.PipelineTaskRunTemplate{

--- a/pkg/apis/pipeline/v1/taskrun_defaults_test.go
+++ b/pkg/apis/pipeline/v1/taskrun_defaults_test.go
@@ -451,7 +451,7 @@ func TestTaskRunDefaultingOnCreate(t *testing.T) {
 		want: &v1.TaskRun{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels:      map[string]string{"app.kubernetes.io/managed-by": "tekton-pipelines"},
-				Annotations: map[string]string{"tekton.dev/foo": "bar", "foo": "bar"},
+				Annotations: map[string]string{"results.tekton.dev/hello": "world", "tekton.dev/foo": "bar", "foo": "bar"},
 			},
 			Spec: v1.TaskRunSpec{
 				TaskRef: &v1.TaskRef{

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_defaults_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_defaults_test.go
@@ -420,7 +420,7 @@ func TestPipelineRunDefaultingOnCreate(t *testing.T) {
 		},
 		want: &v1beta1.PipelineRun{
 			ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{"tekton.dev/foo": "bar", "foo": "bar"},
+				Annotations: map[string]string{"results.tekton.dev/hello": "world", "tekton.dev/foo": "bar", "foo": "bar"},
 			},
 			Spec: v1beta1.PipelineRunSpec{
 				ServiceAccountName: config.DefaultServiceAccountValue,

--- a/pkg/apis/pipeline/v1beta1/taskrun_defaults_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_defaults_test.go
@@ -435,7 +435,7 @@ func TestTaskRunDefaultingOnCreate(t *testing.T) {
 		want: &v1beta1.TaskRun{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels:      map[string]string{"app.kubernetes.io/managed-by": "tekton-pipelines"},
-				Annotations: map[string]string{"tekton.dev/foo": "bar", "foo": "bar"},
+				Annotations: map[string]string{"results.tekton.dev/hello": "world", "tekton.dev/foo": "bar", "foo": "bar"},
 			},
 			Spec: v1beta1.TaskRunSpec{
 				TaskRef: &v1beta1.TaskRef{

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -12125,7 +12125,6 @@ func TestReconcile_FilterLabels(t *testing.T) {
   namespace: foo
   annotations:
     chains.tekton.dev/signed: "true"
-    results.tekton.dev/foo: "bar"
     tekton.dev/foo: "bar"
     foo: bar
 spec:


### PR DESCRIPTION
We require some of the results annotations at creation time. 
Fixes #6857

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
/kind bug