### PR TITLE
Recover Conversion Functions from Pipeline Resources for backwards compatibility

### DIFF
--- a/pkg/apis/pipeline/v1beta1/pipeline_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_conversion.go
@@ -23,6 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"github.com/tektoncd/pipeline/pkg/apis/version"
 	"knative.dev/pkg/apis"
 )
 
@@ -36,6 +37,9 @@ func (p *Pipeline) ConvertTo(ctx context.Context, to apis.Convertible) error {
 	switch sink := to.(type) {
 	case *v1.Pipeline:
 		sink.ObjectMeta = p.ObjectMeta
+		if err := serializePipelineResources(&sink.ObjectMeta, &p.Spec); err != nil {
+			return err
+		}
 		return p.Spec.ConvertTo(ctx, &sink.Spec, &sink.ObjectMeta)
 	default:
 		return fmt.Errorf("unknown version, got: %T", sink)
@@ -90,6 +94,9 @@ func (p *Pipeline) ConvertFrom(ctx context.Context, from apis.Convertible) error
 	switch source := from.(type) {
 	case *v1.Pipeline:
 		p.ObjectMeta = source.ObjectMeta
+		if err := deserializePipelineResources(&p.ObjectMeta, &p.Spec); err != nil {
+			return err
+		}
 		return p.Spec.ConvertFrom(ctx, &source.Spec, &p.ObjectMeta)
 	default:
 		return fmt.Errorf("unknown version, got: %T", p)
@@ -320,4 +327,23 @@ func (ptm PipelineTaskMetadata) convertTo(ctx context.Context, sink *v1.Pipeline
 func (ptm *PipelineTaskMetadata) convertFrom(ctx context.Context, source v1.PipelineTaskMetadata) {
 	ptm.Labels = source.Labels
 	ptm.Annotations = source.Labels
+}
+
+func serializePipelineResources(meta *metav1.ObjectMeta, spec *PipelineSpec) error {
+	if spec.Resources == nil {
+		return nil
+	}
+	return version.SerializeToMetadata(meta, spec.Resources, resourcesAnnotationKey)
+}
+
+func deserializePipelineResources(meta *metav1.ObjectMeta, spec *PipelineSpec) error {
+	resources := &[]PipelineDeclaredResource{}
+	err := version.DeserializeFromMetadata(meta, resources, resourcesAnnotationKey)
+	if err != nil {
+		return err
+	}
+	if len(*resources) != 0 {
+		spec.Resources = *resources
+	}
+	return nil
 }

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_conversion.go
@@ -23,6 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"github.com/tektoncd/pipeline/pkg/apis/version"
 	"knative.dev/pkg/apis"
 )
 
@@ -36,6 +37,9 @@ func (pr *PipelineRun) ConvertTo(ctx context.Context, to apis.Convertible) error
 	switch sink := to.(type) {
 	case *v1.PipelineRun:
 		sink.ObjectMeta = pr.ObjectMeta
+		if err := serializePipelineRunResources(&sink.ObjectMeta, &pr.Spec); err != nil {
+			return err
+		}
 		if err := pr.Status.convertTo(ctx, &sink.Status, &sink.ObjectMeta); err != nil {
 			return err
 		}
@@ -96,6 +100,9 @@ func (pr *PipelineRun) ConvertFrom(ctx context.Context, from apis.Convertible) e
 	switch source := from.(type) {
 	case *v1.PipelineRun:
 		pr.ObjectMeta = source.ObjectMeta
+		if err := deserializePipelineRunResources(&pr.ObjectMeta, &pr.Spec); err != nil {
+			return err
+		}
 		if err := pr.Status.convertFrom(ctx, &source.Status, &pr.ObjectMeta); err != nil {
 			return err
 		}
@@ -344,4 +351,23 @@ func (csr *ChildStatusReference) convertFrom(ctx context.Context, source v1.Chil
 		new.convertFrom(ctx, we)
 		csr.WhenExpressions = append(csr.WhenExpressions, new)
 	}
+}
+
+func serializePipelineRunResources(meta *metav1.ObjectMeta, spec *PipelineRunSpec) error {
+	if spec.Resources == nil {
+		return nil
+	}
+	return version.SerializeToMetadata(meta, spec.Resources, resourcesAnnotationKey)
+}
+
+func deserializePipelineRunResources(meta *metav1.ObjectMeta, spec *PipelineRunSpec) error {
+	resources := []PipelineResourceBinding{}
+	err := version.DeserializeFromMetadata(meta, &resources, resourcesAnnotationKey)
+	if err != nil {
+		return err
+	}
+	if len(resources) != 0 {
+		spec.Resources = resources
+	}
+	return nil
 }

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_conversion_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_conversion_test.go
@@ -401,6 +401,42 @@ func TestPipelineRunConversionFromDeprecated(t *testing.T) {
 		in   *v1beta1.PipelineRun
 		want *v1beta1.PipelineRun
 	}{{
+		name: "resources",
+		in: &v1beta1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "bar",
+			},
+			Spec: v1beta1.PipelineRunSpec{
+				Resources: []v1beta1.PipelineResourceBinding{
+					{
+						Name:        "git-resource",
+						ResourceRef: &v1beta1.PipelineResourceRef{Name: "sweet-resource"},
+					}, {
+						Name:        "image-resource",
+						ResourceRef: &v1beta1.PipelineResourceRef{Name: "sweet-resource2"},
+					},
+				},
+			},
+		},
+		want: &v1beta1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "bar",
+			},
+			Spec: v1beta1.PipelineRunSpec{
+				Resources: []v1beta1.PipelineResourceBinding{
+					{
+						Name:        "git-resource",
+						ResourceRef: &v1beta1.PipelineResourceRef{Name: "sweet-resource"},
+					}, {
+						Name:        "image-resource",
+						ResourceRef: &v1beta1.PipelineResourceRef{Name: "sweet-resource2"},
+					},
+				},
+			},
+		},
+	}, {
 		name: "timeout to timeouts",
 		in: &v1beta1.PipelineRun{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/apis/pipeline/v1beta1/resource_types.go
+++ b/pkg/apis/pipeline/v1beta1/resource_types.go
@@ -47,6 +47,16 @@ type ResourceParam = resource.ResourceParam
 // Deprecated: Unused, preserved only for backwards compatibility
 type PipelineResourceType = resource.PipelineResourceType
 
+const (
+	// PipelineResourceTypeGit indicates that this source is a GitHub repo.
+	// Deprecated: Unused, preserved only for backwards compatibility
+	PipelineResourceTypeGit PipelineResourceType = resource.PipelineResourceTypeGit
+
+	// PipelineResourceTypeStorage indicates that this source is a storage blob resource.
+	// Deprecated: Unused, preserved only for backwards compatibility
+	PipelineResourceTypeStorage PipelineResourceType = resource.PipelineResourceTypeStorage
+)
+
 // PipelineDeclaredResource is used by a Pipeline to declare the types of the
 // PipelineResources that it will required to run and names which can be used to
 // refer to these PipelineResources in PipelineTaskResourceBindings.

--- a/pkg/apis/pipeline/v1beta1/task_conversion_test.go
+++ b/pkg/apis/pipeline/v1beta1/task_conversion_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/tektoncd/pipeline/test/diff"
 	"github.com/tektoncd/pipeline/test/parse"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
 )
 
 func TestTaskConversionBadType(t *testing.T) {
@@ -324,5 +325,83 @@ spec:
 				t.Errorf("roundtrip %s", diff.PrintWantGot(d))
 			}
 		})
+	}
+}
+
+func TestTaskConversionFromDeprecated(t *testing.T) {
+	tests := []struct {
+		name string
+		in   *v1beta1.Task
+		want *v1beta1.Task
+	}{{
+		name: "input resources",
+		in: &v1beta1.Task{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "foo",
+				Namespace:  "bar",
+				Generation: 1,
+			},
+			Spec: v1beta1.TaskSpec{
+				Resources: &v1beta1.TaskResources{
+					Inputs: []v1beta1.TaskResource{{v1beta1.ResourceDeclaration{Name: "input-resource"}}},
+				},
+			},
+		},
+		want: &v1beta1.Task{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "foo",
+				Namespace:  "bar",
+				Generation: 1,
+			},
+			Spec: v1beta1.TaskSpec{
+				Resources: &v1beta1.TaskResources{
+					Inputs: []v1beta1.TaskResource{{v1beta1.ResourceDeclaration{Name: "input-resource"}}},
+				},
+			},
+		},
+	}, {
+		name: "output resources",
+		in: &v1beta1.Task{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "foo",
+				Namespace:  "bar",
+				Generation: 1,
+			},
+			Spec: v1beta1.TaskSpec{
+				Resources: &v1beta1.TaskResources{
+					Outputs: []v1beta1.TaskResource{{v1beta1.ResourceDeclaration{Name: "output-resource"}}},
+				},
+			},
+		},
+		want: &v1beta1.Task{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "foo",
+				Namespace:  "bar",
+				Generation: 1,
+			},
+			Spec: v1beta1.TaskSpec{Resources: &v1beta1.TaskResources{
+				Outputs: []v1beta1.TaskResource{{v1beta1.ResourceDeclaration{Name: "output-resource"}}},
+			}},
+		},
+	}}
+	for _, test := range tests {
+		versions := []apis.Convertible{&v1.Task{}}
+		for _, version := range versions {
+			t.Run(test.name, func(t *testing.T) {
+				ver := version
+				if err := test.in.ConvertTo(context.Background(), ver); err != nil {
+					t.Errorf("ConvertTo() = %v", err)
+				}
+				t.Logf("ConvertTo() = %#v", ver)
+				got := &v1beta1.Task{}
+				if err := got.ConvertFrom(context.Background(), ver); err != nil {
+					t.Errorf("ConvertFrom() = %v", err)
+				}
+				t.Logf("ConvertFrom() = %#v", got)
+				if d := cmp.Diff(test.want, got); d != "" {
+					t.Errorf("roundtrip %s", diff.PrintWantGot(d))
+				}
+			})
+		}
 	}
 }

--- a/pkg/apis/pipeline/v1beta1/taskrun_conversion_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_conversion_test.go
@@ -410,6 +410,56 @@ func TestTaskRunConversionFromDeprecated(t *testing.T) {
 				},
 			},
 		},
+	}, {
+		name: "resourcesResult",
+		in: &v1beta1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "bar",
+			},
+			Spec: v1beta1.TaskRunSpec{
+				TaskRef: &v1beta1.TaskRef{
+					Name: "test-resources-result",
+				},
+			},
+			Status: v1beta1.TaskRunStatus{
+				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+					ResourcesResult: []v1beta1.RunResult{{
+						Key:          "digest",
+						Value:        "sha256:1234",
+						ResourceName: "source-image",
+					}, {
+						Key:          "digest-11",
+						Value:        "sha256:1234",
+						ResourceName: "source-image",
+					}},
+				},
+			},
+		},
+		want: &v1beta1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "bar",
+			},
+			Spec: v1beta1.TaskRunSpec{
+				TaskRef: &v1beta1.TaskRef{
+					Name: "test-resources-result",
+				},
+			},
+			Status: v1beta1.TaskRunStatus{
+				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+					ResourcesResult: []v1beta1.RunResult{{
+						Key:          "digest",
+						Value:        "sha256:1234",
+						ResourceName: "source-image",
+					}, {
+						Key:          "digest-11",
+						Value:        "sha256:1234",
+						ResourceName: "source-image",
+					}},
+				},
+			},
+		},
 	}}
 	for _, test := range tests {
 		versions := []apis.Convertible{&v1.TaskRun{}}

--- a/pkg/apis/resource/v1alpha1/pipeline_resource_types.go
+++ b/pkg/apis/resource/v1alpha1/pipeline_resource_types.go
@@ -26,6 +26,20 @@ import (
 // Deprecated: Unused, preserved only for backwards compatibility
 type PipelineResourceType = string
 
+const (
+	// PipelineResourceTypeGit indicates that this source is a GitHub repo.
+	// Deprecated: Unused, preserved only for backwards compatibility
+	PipelineResourceTypeGit PipelineResourceType = "git"
+
+	// PipelineResourceTypeStorage indicates that this source is a storage blob resource.
+	// Deprecated: Unused, preserved only for backwards compatibility
+	PipelineResourceTypeStorage PipelineResourceType = "storage"
+
+	// PipelineResourceTypeGCS is the subtype for the GCSResources, which is backed by a GCS blob/directory.
+	// Deprecated: Unused, preserved only for backwards compatibility
+	PipelineResourceTypeGCS PipelineResourceType = "gcs"
+)
+
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +genclient:noStatus


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

When we reverted removal of `PipelineResources` [related fields](https://github.com/tektoncd/pipeline/pull/6436),
we did not recover the conversion functions. As a result, when migrating
Tekton Chains to watch `v1` objects, we run into Issue https://github.com/tektoncd/pipeline/issues/7105.

This PR recovers the conversion functions so that we can continue to convert PipelineResources related fields. It addresses issue  https://github.com/tektoncd/pipeline/issues/7105.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Recover Conversion Functions from Pipeline Resources for backwards compatibility
```

/kind bug
