### PR TITLE
Fix latest folder in releases

### DIFF
--- a/tekton/release-pipeline.yaml
+++ b/tekton/release-pipeline.yaml
@@ -221,6 +221,8 @@ spec:
           value: $(params.versionTag)
         - name: serviceAccountPath
           value: $(params.serviceAccountPath)
+        - name: deleteExtraFiles
+          value: "true" # Uses rsync to copy content into latest
     - name: report-bucket
       runAfter: [publish-to-bucket]
       params:


### PR DESCRIPTION
# Changes

The gcs-upload task by default uses "gsutil cp -r" to copy the local folder with release files to the latest folder.

That works well if "latest" does not exists, otherwise it creates a "<version>" folder into "latest", which is not the desired behaviour.

The "deleteExtraFiles" flag in the task means that "gsutil rsync -r" is used instead, which achieves the correct behaviour in all cases ("latest" exists or not.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```

/kind misc