### PR TITLE
[TEP-0050] Add OnError field

### DIFF
--- a/docs/pipeline-api.md
+++ b/docs/pipeline-api.md
@@ -2851,6 +2851,23 @@ PipelineSpec
 Note: PipelineSpec is in preview mode and not yet supported</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>onError</code><br/>
+<em>
+<a href="#tekton.dev/v1.PipelineTaskOnErrorType">
+PipelineTaskOnErrorType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>OnError defines the exiting behavior of a PipelineRun on error
+can be set to [ continue | stopAndFail ]
+Note: OnError is in preview mode and not yet supported
+TODO(#7165)</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="tekton.dev/v1.PipelineTaskMetadata">PipelineTaskMetadata
@@ -2892,6 +2909,29 @@ map[string]string
 </td>
 </tr>
 </tbody>
+</table>
+<h3 id="tekton.dev/v1.PipelineTaskOnErrorType">PipelineTaskOnErrorType
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineTask">PipelineTask</a>)
+</p>
+<div>
+<p>PipelineTaskOnErrorType defines a list of supported failure handling behaviors of a PipelineTask on error</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;continue&#34;</p></td>
+<td><p>PipelineTaskContinue indicates to continue executing the rest of the DAG when the PipelineTask fails</p>
+</td>
+</tr><tr><td><p>&#34;stopAndFail&#34;</p></td>
+<td><p>PipelineTaskStopAndFail indicates to stop and fail the PipelineRun if the PipelineTask fails</p>
+</td>
+</tr></tbody>
 </table>
 <h3 id="tekton.dev/v1.PipelineTaskParam">PipelineTaskParam
 </h3>
@@ -10933,6 +10973,23 @@ PipelineSpec
 Note: PipelineSpec is in preview mode and not yet supported</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>onError</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.PipelineTaskOnErrorType">
+PipelineTaskOnErrorType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>OnError defines the exiting behavior of a PipelineRun on error
+can be set to [ continue | stopAndFail ]
+Note: OnError is in preview mode and not yet supported
+TODO(#7165)</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="tekton.dev/v1beta1.PipelineTaskInputResource">PipelineTaskInputResource
@@ -11031,6 +11088,14 @@ map[string]string
 </tr>
 </tbody>
 </table>
+<h3 id="tekton.dev/v1beta1.PipelineTaskOnErrorType">PipelineTaskOnErrorType
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineTask">PipelineTask</a>)
+</p>
+<div>
+<p>PipelineTaskOnErrorType defines a list of supported failure handling behaviors of a PipelineTask on error</p>
+</div>
 <h3 id="tekton.dev/v1beta1.PipelineTaskOutputResource">PipelineTaskOutputResource
 </h3>
 <p>

--- a/pkg/apis/pipeline/v1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1/openapi_generated.go
@@ -1892,6 +1892,13 @@ func schema_pkg_apis_pipeline_v1_PipelineTask(ref common.ReferenceCallback) comm
 							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineSpec"),
 						},
 					},
+					"onError": {
+						SchemaProps: spec.SchemaProps{
+							Description: "OnError defines the exiting behavior of a PipelineRun on error can be set to [ continue | stopAndFail ] Note: OnError is in preview mode and not yet supported",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/apis/pipeline/v1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1/pipeline_types.go
@@ -27,6 +27,9 @@ import (
 	"knative.dev/pkg/kmeta"
 )
 
+// PipelineTaskOnErrorType defines a list of supported failure handling behaviors of a PipelineTask on error
+type PipelineTaskOnErrorType string
+
 const (
 	// PipelineTasksAggregateStatus is a param representing aggregate status of all dag pipelineTasks
 	PipelineTasksAggregateStatus = "tasks.status"
@@ -34,6 +37,10 @@ const (
 	PipelineTasks = "tasks"
 	// PipelineFinallyTasks is a value representing a task is a member of "finally" section of the pipeline
 	PipelineFinallyTasks = "finally"
+	// PipelineTaskStopAndFail indicates to stop and fail the PipelineRun if the PipelineTask fails
+	PipelineTaskStopAndFail PipelineTaskOnErrorType = "stopAndFail"
+	// PipelineTaskContinue indicates to continue executing the rest of the DAG when the PipelineTask fails
+	PipelineTaskContinue PipelineTaskOnErrorType = "continue"
 )
 
 // +genclient
@@ -238,6 +245,13 @@ type PipelineTask struct {
 	// Note: PipelineSpec is in preview mode and not yet supported
 	// +optional
 	PipelineSpec *PipelineSpec `json:"pipelineSpec,omitempty"`
+
+	// OnError defines the exiting behavior of a PipelineRun on error
+	// can be set to [ continue | stopAndFail ]
+	// Note: OnError is in preview mode and not yet supported
+	// TODO(#7165)
+	// +optional
+	OnError PipelineTaskOnErrorType `json:"onError,omitempty"`
 }
 
 // IsCustomTask checks whether an embedded TaskSpec is a Custom Task

--- a/pkg/apis/pipeline/v1/swagger.json
+++ b/pkg/apis/pipeline/v1/swagger.json
@@ -885,6 +885,10 @@
           "description": "Name is the name of this task within the context of a Pipeline. Name is used as a coordinate with the `from` and `runAfter` fields to establish the execution order of tasks relative to one another.",
           "type": "string"
         },
+        "onError": {
+          "description": "OnError defines the exiting behavior of a PipelineRun on error can be set to [ continue | stopAndFail ] Note: OnError is in preview mode and not yet supported",
+          "type": "string"
+        },
         "params": {
           "description": "Parameters declares parameters passed to this task.",
           "type": "array",

--- a/pkg/apis/pipeline/v1beta1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1beta1/openapi_generated.go
@@ -2649,6 +2649,13 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineTask(ref common.ReferenceCallback)
 							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineSpec"),
 						},
 					},
+					"onError": {
+						SchemaProps: spec.SchemaProps{
+							Description: "OnError defines the exiting behavior of a PipelineRun on error can be set to [ continue | stopAndFail ] Note: OnError is in preview mode and not yet supported",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/apis/pipeline/v1beta1/pipeline_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_conversion.go
@@ -167,6 +167,7 @@ func (pt PipelineTask) convertTo(ctx context.Context, sink *v1.PipelineTask, met
 		we.convertTo(ctx, &new)
 		sink.When = append(sink.When, new)
 	}
+	sink.OnError = (v1.PipelineTaskOnErrorType)(pt.OnError)
 	sink.Retries = pt.Retries
 	sink.RunAfter = pt.RunAfter
 	sink.Params = nil
@@ -215,6 +216,7 @@ func (pt *PipelineTask) convertFrom(ctx context.Context, source v1.PipelineTask,
 		new.convertFrom(ctx, we)
 		pt.WhenExpressions = append(pt.WhenExpressions, new)
 	}
+	pt.OnError = (PipelineTaskOnErrorType)(source.OnError)
 	pt.Retries = source.Retries
 	pt.RunAfter = source.RunAfter
 	pt.Params = nil

--- a/pkg/apis/pipeline/v1beta1/pipeline_conversion_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_conversion_test.go
@@ -60,6 +60,7 @@ func TestPipelineConversion(t *testing.T) {
 				Description: "test",
 				Tasks: []v1beta1.PipelineTask{{
 					Name:    "foo",
+					OnError: v1beta1.PipelineTaskContinue,
 					TaskRef: &v1beta1.TaskRef{Name: "example.com/my-foo-task"},
 				}},
 				Params: []v1beta1.ParamSpec{{
@@ -138,11 +139,13 @@ func TestPipelineConversion(t *testing.T) {
 				DisplayName: "pipeline-display-name",
 				Description: "test",
 				Tasks: []v1beta1.PipelineTask{{
-					Name: "task-1",
+					Name:    "task-1",
+					OnError: v1beta1.PipelineTaskContinue,
 				}, {
 					Name:        "foo",
 					DisplayName: "task-display-name",
 					Description: "task-description",
+					OnError:     v1beta1.PipelineTaskContinue,
 					TaskRef:     &v1beta1.TaskRef{Name: "example.com/my-foo-task"},
 					TaskSpec: &v1beta1.EmbeddedTask{
 						TaskSpec: v1beta1.TaskSpec{

--- a/pkg/apis/pipeline/v1beta1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types.go
@@ -27,6 +27,9 @@ import (
 	"knative.dev/pkg/kmeta"
 )
 
+// PipelineTaskOnErrorType defines a list of supported failure handling behaviors of a PipelineTask on error
+type PipelineTaskOnErrorType string
+
 const (
 	// PipelineTasksAggregateStatus is a param representing aggregate status of all dag pipelineTasks
 	PipelineTasksAggregateStatus = "tasks.status"
@@ -34,6 +37,10 @@ const (
 	PipelineTasks = "tasks"
 	// PipelineFinallyTasks is a value representing a task is a member of "finally" section of the pipeline
 	PipelineFinallyTasks = "finally"
+	// PipelineTaskStopAndFail indicates to stop and fail the PipelineRun if the PipelineTask fails
+	PipelineTaskStopAndFail PipelineTaskOnErrorType = "stopAndFail"
+	// PipelineTaskContinue indicates to continue executing the rest of the DAG when the PipelineTask fails
+	PipelineTaskContinue PipelineTaskOnErrorType = "continue"
 )
 
 // +genclient
@@ -252,6 +259,13 @@ type PipelineTask struct {
 	// Note: PipelineSpec is in preview mode and not yet supported
 	// +optional
 	PipelineSpec *PipelineSpec `json:"pipelineSpec,omitempty"`
+
+	// OnError defines the exiting behavior of a PipelineRun on error
+	// can be set to [ continue | stopAndFail ]
+	// Note: OnError is in preview mode and not yet supported
+	// TODO(#7165)
+	// +optional
+	OnError PipelineTaskOnErrorType `json:"onError,omitempty"`
 }
 
 // IsCustomTask checks whether an embedded TaskSpec is a Custom Task

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation.go
@@ -159,6 +159,17 @@ func (pt PipelineTask) Validate(ctx context.Context) (errs *apis.FieldError) {
 		NamespacedTaskKind: true,
 		ClusterTaskKind:    true,
 	}
+
+	if pt.OnError != "" {
+		errs = errs.Also(config.ValidateEnabledAPIFields(ctx, "OnError", config.AlphaAPIFields))
+		if pt.OnError != PipelineTaskContinue && pt.OnError != PipelineTaskStopAndFail {
+			errs = errs.Also(apis.ErrInvalidValue(pt.OnError, "OnError", "PipelineTask OnError must be either \"continue\" or \"stopAndFail\""))
+		}
+		if pt.OnError == PipelineTaskContinue && pt.Retries > 0 {
+			errs = errs.Also(apis.ErrGeneric("PipelineTask OnError cannot be set to \"continue\" when Retries is greater than 0"))
+		}
+	}
+
 	cfg := config.FromContextOrDefaults(ctx)
 	// Pipeline task having taskRef/taskSpec with APIVersion is classified as custom task
 	switch {

--- a/pkg/apis/pipeline/v1beta1/swagger.json
+++ b/pkg/apis/pipeline/v1beta1/swagger.json
@@ -1278,6 +1278,10 @@
           "description": "Name is the name of this task within the context of a Pipeline. Name is used as a coordinate with the `from` and `runAfter` fields to establish the execution order of tasks relative to one another.",
           "type": "string"
         },
+        "onError": {
+          "description": "OnError defines the exiting behavior of a PipelineRun on error can be set to [ continue | stopAndFail ] Note: OnError is in preview mode and not yet supported",
+          "type": "string"
+        },
         "params": {
           "description": "Parameters declares parameters passed to this task.",
           "type": "array",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Part of https://github.com/tektoncd/pipeline/issues/7165. In [TEP-0050][tep-0050], we proposed to add an `OnError` API field under `PipelineTask` to configure error handling strategy.

This commits add the new `OnError` API field and the related documentations. The validation and business logic will be added in the follow-up PRs.

Note: OnError is in preview mode and not yet supported.

/kind feature

[tep-0050]: https://github.com/tektoncd/community/blob/main/teps/0050-ignore-task-failures.md

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
None
```
