### PR TITLE
TEP-140: Produce Results in Matrix

### DIFF
--- a/docs/variables.md
+++ b/docs/variables.md
@@ -28,10 +28,12 @@ For instructions on using variable substitutions see the relevant section of [th
 | `params["<param name>"][i]` | (see above) |
 | `params.<object-param-name>[*]` | Get the value of the whole object param. This is alpha feature, set `enable-api-fields` to `alpha`  to use it.|
 | `params.<object-param-name>.<individual-key-name>` | Get the value of an individual child of an object param. This is alpha feature, set `enable-api-fields` to `alpha`  to use it. |
+| `tasks.<taskName>.matrix.length` | The length of the `Matrix` combination count. |
 | `tasks.<taskName>.results.<resultName>` | The value of the `Task's` result. Can alter `Task` execution order within a `Pipeline`.) |
 | `tasks.<taskName>.results.<resultName>[i]` | The ith value of the `Task's` array result. Can alter `Task` execution order within a `Pipeline`.) |
 | `tasks.<taskName>.results.<resultName>[*]` | The array value of the `Task's` result. Can alter `Task` execution order within a `Pipeline`. Cannot be used in `script`.) |
 | `tasks.<taskName>.results.<resultName>.key` | The `key` value of the `Task's` object result. Can alter `Task` execution order within a `Pipeline`.) |
+| `tasks.<taskName>.matrix.<resultName>.length` | The length of the matrixed `Task's` results. (Can alter `Task` execution order within a `Pipeline`.) |
 | `workspaces.<workspaceName>.bound` | Whether a `Workspace` has been bound or not. "false" if the `Workspace` declaration has `optional: true` and the Workspace binding was omitted by the PipelineRun. |
 | `context.pipelineRun.name` | The name of the `PipelineRun` that this `Pipeline` is running in. |
 | `context.pipelineRun.namespace` | The namespace of the `PipelineRun` that this `Pipeline` is running in. |

--- a/examples/v1/pipelineruns/alpha/pipelinerun-with-matrix-context-variables.yaml
+++ b/examples/v1/pipelineruns/alpha/pipelinerun-with-matrix-context-variables.yaml
@@ -1,0 +1,123 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: validate-matrix-result-length
+spec:
+  params:
+    - name: matrixlength
+      type: string
+  steps:
+    - name: validate
+      image: alpine
+      args: ["$(params.matrixlength)"]
+      script: |
+        #!/usr/bin/env sh
+        echo "Validating the length of the matrix context variable"
+        echo "The length of the matrix is 3"
+        if [ "$(params.matrixlength)" != 3 ]; then
+          echo "Error: expected matrix to have the length 3 but has length $(params.matrixlength)"
+          exit 1
+        fi
+        echo "Done validating the length of the matrix context variable"
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: validate-matrix-results-length
+spec:
+  params:
+    - name: matrixresultslength-1
+      type: string
+    - name: matrixresultslength-2
+      type: string
+  steps:
+    - name: validate
+      image: alpine
+      script: |
+        #!/usr/bin/env sh
+        echo "Validating the length of the matrix results context variable"
+        echo "The length of the matrix results are $(params.matrixresultslength-1) and $(params.matrixresultslength-2)"
+        if [ "$(params.matrixresultslength-1)" != 3 ]; then
+          echo "Error: expected matrix results to have the length 3 but has length $(params.matrixresultslength-1)"
+          exit 1
+        fi
+        if [ "$(params.matrixresultslength-2)" != 1 ]; then
+          echo "Error: expected matrix results to have the length 1 but has length $(params.matrixresultslength-2)"
+          exit 1
+        fi
+        echo "Done validating the length of the matrix context variable"
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: taskwithresults
+spec:
+  params:
+    - name: IMAGE
+    - name: DIGEST
+      default: ""
+  results:
+    - name: IMAGE-DIGEST
+    - name: IMAGE-URL
+  steps:
+    - name: produce-results
+      image: bash:latest
+      script: |
+        #!/usr/bin/env bash
+        echo "Building image for $(params.IMAGE)"
+        echo -n "$(params.DIGEST)" | sha256sum | tee $(results.IMAGE-DIGEST.path)
+        if [ -z $(params.DIGEST) ]; then
+          echo -n "$(params.DIGEST)" | sha256sum | tee $(results.IMAGE-URL.path)
+        fi
+---
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  generateName: matrix-context-variables-
+spec:
+  taskRunTemplate:
+    serviceAccountName: "default"
+  pipelineSpec:
+    tasks:
+      - name: matrix-emitting-results
+        matrix:
+          include:
+            - name: build-1
+              params:
+                - name: IMAGE
+                  value: image-1
+                - name: DIGEST
+                  value: path/to/Dockerfile1
+            - name: build-2
+              params:
+                - name: IMAGE
+                  value: image-2
+                - name: DIGEST
+                  value: path/to/Dockerfile2
+            - name: build-3
+              params:
+                - name: IMAGE
+                  value: image-3
+        taskRef:
+          name: taskwithresults
+          kind: Task
+      - name: matrixed-echo-length
+        runAfter:
+          - matrix-emitting-results
+        params:
+          - name: matrixlength
+            value: $(tasks.matrix-emitting-results.matrix.length)
+        taskRef:
+          name: validate-matrix-result-length
+          kind: Task
+      - name: matrixed-echo-results-length
+        runAfter:
+          - matrix-emitting-results
+        params:
+          - name: matrixresultslength-1
+            value: $(tasks.matrix-emitting-results.matrix.IMAGE-DIGEST.length)
+          - name: matrixresultslength-2
+            value: $(tasks.matrix-emitting-results.matrix.IMAGE-URL.length)
+        taskRef:
+          name: validate-matrix-results-length
+          kind: Task

--- a/examples/v1/pipelineruns/alpha/pipelinerun-with-matrix-emitting-results.yaml
+++ b/examples/v1/pipelineruns/alpha/pipelinerun-with-matrix-emitting-results.yaml
@@ -1,0 +1,110 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: echostringurl
+spec:
+  params:
+    - name: url
+      type: string
+  steps:
+    - name: echo
+      image: alpine
+      script: |
+        echo "$(params.url)"
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: validate-array-url
+spec:
+  params:
+    - name: url
+      type: array
+  steps:
+    - name: validate
+      image: ubuntu
+      args: ["$(params.url[*])"]
+      script: |
+        #!/usr/bin/env bash
+        args=("$@")
+        URLS=( )
+        URLS[0]="https://api.example/get-report/linux-chrome"
+        URLS[1]="https://api.example/get-report/mac-chrome"
+        URLS[2]="https://api.example/get-report/windows-chrome"
+        URLS[3]="https://api.example/get-report/linux-safari"
+        URLS[4]="https://api.example/get-report/mac-safari"
+        URLS[5]="https://api.example/get-report/windows-safari"
+        URLS[6]="https://api.example/get-report/linux-firefox"
+        URLS[7]="https://api.example/get-report/mac-firefox"
+        URLS[8]="https://api.example/get-report/windows-firefox"
+        for i in "${!URLS[@]}"; do
+            if [ "${URLS[$i]}" != ${args[$i]} ]; then
+              echo "Error: expected url to be ${URLS[$i]}, but got ${args[$i]}"
+              exit 1
+            fi
+            echo "Done validating the url: ${args[$i]}"
+        done
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: task-producing-results
+spec:
+  params:
+    - name: platform
+      default: ""
+    - name: browser
+      default: ""
+  results:
+    - name: report-url
+      type: string
+  steps:
+    - name: produce-report-url
+      image: alpine
+      script: |
+        echo "Running tests on $(params.platform)-$(params.browser)"
+        echo -n "https://api.example/get-report/$(params.platform)-$(params.browser)" | tee $(results.report-url.path)
+---
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  generateName: platforms-with-results
+spec:
+  taskRunTemplate:
+    serviceAccountName: "default"
+  pipelineSpec:
+    results:
+      - name: pr-result-1
+        value: $(tasks.matrix-emitting-results.results.report-url[*])
+    tasks:
+      - name: matrix-emitting-results
+        matrix:
+          params:
+            - name: platform
+              value:
+                - linux
+                - mac
+                - windows
+            - name: browser
+              value:
+                - chrome
+                - safari
+                - firefox
+        taskRef:
+          name: task-producing-results
+          kind: Task
+      - name: task-consuming-results
+        taskRef:
+          name: validate-array-url
+          kind: Task
+        params:
+          - name: url
+            value: $(tasks.matrix-emitting-results.results.report-url[*])
+      - name: matrix-consuming-results
+        taskRef:
+          name: echostringurl
+          kind: Task
+        matrix:
+          params:
+            - name: url
+              value: $(tasks.matrix-emitting-results.results.report-url[*])

--- a/pkg/apis/pipeline/v1/param_types.go
+++ b/pkg/apis/pipeline/v1/param_types.go
@@ -208,6 +208,29 @@ func (ps Params) extractParamMapArrVals() map[string][]string {
 	return paramsMap
 }
 
+// ParseTaskandResultName parses "task name", "result name" from a Matrix Context Variable
+// Valid Example 1:
+// - Input: tasks.myTask.matrix.length
+// - Output: "myTask", ""
+// Valid Example 2:
+// - Input: tasks.myTask.matrix.ResultName.length
+// - Output: "myTask", "ResultName"
+func (p Param) ParseTaskandResultName() (string, string) {
+	if expressions, ok := p.GetVarSubstitutionExpressions(); ok {
+		for _, expression := range expressions {
+			subExpressions := strings.Split(expression, ".")
+			pipelineTaskName := subExpressions[1]
+			if len(subExpressions) == 4 {
+				return pipelineTaskName, ""
+			} else if len(subExpressions) == 5 {
+				resultName := subExpressions[3]
+				return pipelineTaskName, resultName
+			}
+		}
+	}
+	return "", ""
+}
+
 // Params is a list of Param
 type Params []Param
 

--- a/pkg/apis/pipeline/v1/param_types_test.go
+++ b/pkg/apis/pipeline/v1/param_types_test.go
@@ -653,3 +653,38 @@ func TestExtractDefaultParamArrayLengths(t *testing.T) {
 		})
 	}
 }
+
+func TestParseTaskandResultName(t *testing.T) {
+	tcs := []struct {
+		name             string
+		param            v1.Param
+		pipelineTaskName string
+		resultName       string
+	}{{
+		name:             "matrix length context var",
+		param:            v1.Param{Name: "foo", Value: v1.ParamValue{StringVal: "$(tasks.matrix-emitting-results.matrix.length)", Type: v1.ParamTypeString}},
+		pipelineTaskName: "matrix-emitting-results",
+	}, {
+		name:             "matrix results length context var",
+		param:            v1.Param{Name: "foo", Value: v1.ParamValue{StringVal: "$(tasks.myTask.matrix.ResultName.length)", Type: v1.ParamTypeString}},
+		pipelineTaskName: "myTask",
+		resultName:       "ResultName",
+	}, {
+		name:             "empty context var",
+		param:            v1.Param{Name: "foo", Value: v1.ParamValue{StringVal: "", Type: v1.ParamTypeString}},
+		pipelineTaskName: "",
+		resultName:       "",
+	}}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			pipelineTaskName, resultName := tc.param.ParseTaskandResultName()
+
+			if d := cmp.Diff(tc.pipelineTaskName, pipelineTaskName); d != "" {
+				t.Errorf(diff.PrintWantGot(d))
+			}
+			if d := cmp.Diff(tc.resultName, resultName); d != "" {
+				t.Errorf(diff.PrintWantGot(d))
+			}
+		})
+	}
+}

--- a/pkg/apis/pipeline/v1/pipeline_types_test.go
+++ b/pkg/apis/pipeline/v1/pipeline_types_test.go
@@ -847,6 +847,7 @@ func TestPipelineTask_ValidateMatrix(t *testing.T) {
 		name     string
 		pt       *PipelineTask
 		wantErrs *apis.FieldError
+		tasks    []PipelineTask
 	}{{
 		name: "parameter duplicated in matrix.params and pipelinetask.params",
 		pt: &PipelineTask{

--- a/pkg/apis/pipeline/v1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1/pipeline_validation_test.go
@@ -3575,6 +3575,7 @@ func Test_validateMatrix(t *testing.T) {
 	tests := []struct {
 		name     string
 		tasks    []PipelineTask
+		finally  []PipelineTask
 		wantErrs *apis.FieldError
 	}{{
 		name: "parameter in both matrix and params",
@@ -3630,6 +3631,420 @@ func Test_validateMatrix(t *testing.T) {
 					Name: "a-param", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"$(tasks.foo-task.results.a-task-results[*])"}},
 				}}},
 		}},
+	}, {
+		name: "results from matrixed task consumed in tasks through parameters",
+		tasks: PipelineTaskList{{
+			Name:    "a-task",
+			TaskRef: &TaskRef{Name: "a-task"},
+			Matrix: &Matrix{
+				Params: Params{{
+					Name: "a-param", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"foo", "bar"}},
+				}}},
+		}, {
+			Name:    "b-task",
+			TaskRef: &TaskRef{Name: "b-task"},
+			Params: Params{{
+				Name: "b-param", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"$(tasks.a-task.results.a-result[*])"}},
+			}},
+		}},
+	}, {
+		name: "results from matrixed task consumed in finally through parameters",
+		tasks: PipelineTaskList{{
+			Name:    "a-task",
+			TaskRef: &TaskRef{Name: "a-task"},
+			Matrix: &Matrix{
+				Params: Params{{
+					Name: "a-param", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"foo", "bar"}},
+				}}},
+		}},
+		finally: PipelineTaskList{{
+			Name:    "b-task",
+			TaskRef: &TaskRef{Name: "b-task"},
+			Params: Params{{
+				Name: "b-param", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"$(tasks.a-task.results.a-result[*])"}},
+			}},
+		}},
+	}, {
+		name: "results from matrixed task consumed in tasks and finally through parameters",
+		tasks: PipelineTaskList{{
+			Name:    "a-task",
+			TaskRef: &TaskRef{Name: "a-task"},
+			Matrix: &Matrix{
+				Params: Params{{
+					Name: "a-param", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"foo", "bar"}},
+				}}},
+		}, {
+			Name:    "b-task",
+			TaskRef: &TaskRef{Name: "b-task"},
+			Params: Params{{
+				Name: "b-param", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"$(tasks.a-task.results.a-result[*])"}},
+			}},
+		}},
+		finally: PipelineTaskList{{
+			Name:    "c-task",
+			TaskRef: &TaskRef{Name: "c-task"},
+			Params: Params{{
+				Name: "b-param", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"$(tasks.a-task.results.a-result[*])"}},
+			}},
+		}},
+	}, {
+		name: "results from matrixed task consumed in tasks through when expressions",
+		tasks: PipelineTaskList{{
+			Name:    "a-task",
+			TaskRef: &TaskRef{Name: "a-task"},
+			Matrix: &Matrix{
+				Params: Params{{
+					Name: "a-param", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"foo", "bar"}},
+				}}},
+		}, {
+			Name:    "b-task",
+			TaskRef: &TaskRef{Name: "b-task"},
+			When: WhenExpressions{{
+				Input:    "foo",
+				Operator: selection.In,
+				Values:   []string{"$(tasks.a-task.results.a-result[*])"},
+			}},
+		}},
+	}, {
+		name: "results from matrixed task consumed in finally through when expressions",
+		tasks: PipelineTaskList{{
+			Name:    "a-task",
+			TaskRef: &TaskRef{Name: "a-task"},
+			Matrix: &Matrix{
+				Params: Params{{
+					Name: "a-param", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"foo", "bar"}},
+				}}},
+		}},
+		finally: PipelineTaskList{{
+			Name:    "b-task",
+			TaskRef: &TaskRef{Name: "b-task"},
+			When: WhenExpressions{{
+				Input:    "$(tasks.a-task.results.a-result[*])",
+				Operator: selection.In,
+				Values:   []string{"foo", "bar"},
+			}},
+		}},
+	}, {
+		name: "results from matrixed task consumed in tasks and finally through when expressions",
+		tasks: PipelineTaskList{{
+			Name:    "a-task",
+			TaskRef: &TaskRef{Name: "a-task"},
+			Matrix: &Matrix{
+				Params: Params{{
+					Name: "a-param", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"foo", "bar"}},
+				}}},
+		}, {
+			Name:    "b-task",
+			TaskRef: &TaskRef{Name: "b-task"},
+			When: WhenExpressions{{
+				Input:    "$(tasks.a-task.results.a-result[*])",
+				Operator: selection.In,
+				Values:   []string{"foo", "bar"},
+			}},
+		}},
+		finally: PipelineTaskList{{
+			Name:    "c-task",
+			TaskRef: &TaskRef{Name: "c-task"},
+			When: WhenExpressions{{
+				Input:    "foo",
+				Operator: selection.In,
+				Values:   []string{"$(tasks.a-task.results.a-result)[*]"},
+			}},
+		}},
+	}, {
+		name: "valid matrix emitting string results consumed in aggregate by another pipelineTask",
+		finally: PipelineTaskList{{
+			Name:    "matrix-emitting-results",
+			TaskRef: &TaskRef{Name: "taskwithresult"},
+			Matrix: &Matrix{
+				Params: Params{{
+					Name: "platform", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"linux", "mac"}},
+				}, {
+					Name: "browser", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"chrome", "safari"}},
+				}}},
+		}, {
+			Name: "echoarrayurl",
+			TaskSpec: &EmbeddedTask{TaskSpec: TaskSpec{
+				Params: ParamSpecs{{
+					Name: "url", Type: "array",
+				}},
+				Steps: []Step{{
+					Name:  "use-environments",
+					Image: "bash:latest",
+					Args:  []string{"$(params.url[*])"},
+					Script: `for arg in "$@"; do
+						echo "URL: $arg"
+							done`,
+				}},
+			}},
+		}, {
+			Name: "taskwithresult",
+			TaskSpec: &EmbeddedTask{TaskSpec: TaskSpec{
+				Params: ParamSpecs{{
+					Name: "platform",
+				}, {
+					Name: "browser"}},
+				Results: []TaskResult{{
+					Name: "report-url",
+					Type: ResultsTypeString,
+				}},
+				Steps: []Step{{
+					Name:  "produce-report-url",
+					Image: "alpine",
+					Script: ` |
+							echo -n "https://api.example/get-report/$(params.platform)-$(params.browser)" | tee $(results.report-url.path)`}},
+			}},
+		}, {
+			Name:    "task-consuming-results",
+			TaskRef: &TaskRef{Name: "echoarrayurl"},
+			Params: Params{{
+				Name: "b-param", Value: ParamValue{Type: ParamTypeString, StringVal: "$(tasks.matrix-emitting-results.results.report-url[*])"},
+			}},
+		}, {
+			Name: "echoarrayurl",
+			TaskSpec: &EmbeddedTask{TaskSpec: TaskSpec{
+				Params: ParamSpecs{{
+					Name: "url", Type: "array",
+				}},
+				Steps: []Step{{
+					Name:  "use-environments",
+					Image: "bash:latest",
+					Args:  []string{"$(params.url[*])"},
+					Script: `for arg in "$@"; do
+					echo "URL: $arg"
+				done`,
+				}},
+			}},
+		}},
+	}, {
+		name: "valid matrix emitting string results consumed in aggregate by another pipelineTask (embedded taskSpec)",
+		tasks: PipelineTaskList{{
+			Name:    "matrix-emitting-results",
+			TaskRef: &TaskRef{Name: "taskwithresult"},
+			Matrix: &Matrix{
+				Params: Params{{
+					Name: "platform", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"linux", "mac"}},
+				}, {
+					Name: "browser", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"chrome", "safari"}},
+				}}},
+		}, {
+			Name: "task-consuming-results",
+			TaskSpec: &EmbeddedTask{TaskSpec: TaskSpec{
+				Params: ParamSpecs{{
+					Name: "url", Type: "array",
+				}},
+				Steps: []Step{{
+					Name:  "use-environments",
+					Image: "bash:latest",
+					Args:  []string{"$(params.url[*])"},
+					Script: `for arg in "$@"; do
+						echo "URL: $arg"
+							done`,
+				}},
+			}},
+			Params: Params{{
+				Name: "b-param", Value: ParamValue{Type: ParamTypeString, StringVal: "$(tasks.matrix-emitting-results.results.report-url[*])"},
+			}},
+		}},
+	}, {
+		name: "invalid matrix emitting stings results consumed using array indexing by another pipelineTask",
+		tasks: PipelineTaskList{{
+			Name:    "matrix-emitting-results",
+			TaskRef: &TaskRef{Name: "taskwithresult"},
+			Matrix: &Matrix{
+				Params: Params{{
+					Name: "platform", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"linux", "mac"}},
+				}, {
+					Name: "browser", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"chrome", "safari"}},
+				}}},
+		}, {
+			Name: "taskwithresult",
+			TaskSpec: &EmbeddedTask{TaskSpec: TaskSpec{
+				Params: ParamSpecs{{
+					Name: "platform",
+				}, {
+					Name: "browser"}},
+				Results: []TaskResult{{
+					Name: "report-url",
+					Type: ResultsTypeString,
+				}},
+				Steps: []Step{{
+					Name:  "produce-report-url",
+					Image: "alpine",
+					Script: ` |
+						echo -n "https://api.example/get-report/$(params.platform)-$(params.browser)" | tee $(results.report-url.path)`}},
+			}},
+		}, {
+			Name:    "task-consuming-results",
+			TaskRef: &TaskRef{Name: "echoarrayurl"},
+			Params: Params{{
+				Name: "b-param", Value: ParamValue{Type: ParamTypeString, StringVal: "$(tasks.matrix-emitting-results.results.report-url[0])"},
+			}},
+		}, {
+			Name: "echoarrayurl",
+			TaskSpec: &EmbeddedTask{TaskSpec: TaskSpec{
+				Params: ParamSpecs{{
+					Name: "url", Type: "array",
+				}},
+				Steps: []Step{{
+					Name:  "use-environments",
+					Image: "bash:latest",
+					Args:  []string{"$(params.url[*])"},
+					Script: `for arg in "$@"; do
+					echo "URL: $arg"
+				done`,
+				}},
+			}},
+		}},
+		wantErrs: apis.ErrGeneric("A matrixed pipelineTask can only be consumed in aggregate using [*] notation, but is currently set to tasks.matrix-emitting-results.results.report-url[0]"),
+	}, {
+		name: "invalid matrix emitting array results consumed in aggregate by another pipelineTask (embedded TaskSpec)",
+		tasks: PipelineTaskList{{
+			Name: "matrix-emitting-results-embedded",
+			TaskSpec: &EmbeddedTask{TaskSpec: TaskSpec{
+				Params: ParamSpecs{{
+					Name: "platform",
+				}, {
+					Name: "browser"}},
+				Results: []TaskResult{{
+					Name: "array-result",
+					Type: ResultsTypeArray,
+				}},
+				Steps: []Step{{
+					Name:  "produce-array-result",
+					Image: "alpine",
+					Script: ` |
+						echo -n "[\"${params.platform}\",\"${params.browser}\"]" | tee $(results.array-result.path)`}},
+			}},
+			Matrix: &Matrix{
+				Params: Params{{
+					Name: "platform", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"linux", "mac"}},
+				}, {
+					Name: "browser", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"chrome", "safari"}},
+				}}},
+		}, {
+			Name: "taskwithresult",
+			TaskSpec: &EmbeddedTask{TaskSpec: TaskSpec{
+				Params: ParamSpecs{{
+					Name: "platform",
+				}, {
+					Name: "browser"}},
+				Results: []TaskResult{{
+					Name: "array-result",
+					Type: ResultsTypeArray,
+				}},
+				Steps: []Step{{
+					Name:  "produce-array-result",
+					Image: "alpine",
+					Script: ` |
+						echo -n "https://api.example/get-report/$(params.platform)-$(params.browser)" | tee $(results.array-result.path)`}},
+			}},
+		}, {
+			Name:    "task-consuming-results",
+			TaskRef: &TaskRef{Name: "echoarrayurl"},
+			Params: Params{{
+				Name: "b-param", Value: ParamValue{Type: ParamTypeString, StringVal: "$(tasks.matrix-emitting-results-embedded.results.array-result[*])"},
+			}},
+		}, {
+			Name: "echoarrayurl",
+			TaskSpec: &EmbeddedTask{TaskSpec: TaskSpec{
+				Params: ParamSpecs{{
+					Name: "url", Type: "array",
+				}},
+				Steps: []Step{{
+					Name:  "use-environments",
+					Image: "bash:latest",
+					Args:  []string{"$(params.url[*])"},
+					Script: `for arg in "$@"; do
+					echo "URL: $arg"
+				done`,
+				}},
+			}},
+		}},
+		wantErrs: apis.ErrInvalidValue("Matrixed PipelineTasks emitting results must have an underlying type string, but result array-result has type array in pipelineTask", ""),
+	}, {
+		name: "invalid matrix emitting stings results consumed using array indexing by another pipelineTask (embedded TaskSpec)",
+		tasks: PipelineTaskList{{
+			Name: "matrix-emitting-results-embedded",
+			TaskSpec: &EmbeddedTask{TaskSpec: TaskSpec{
+				Params: ParamSpecs{{
+					Name: "platform",
+				}, {
+					Name: "browser"}},
+				Results: []TaskResult{{
+					Name: "array-result",
+					Type: ResultsTypeArray,
+				}},
+				Steps: []Step{{
+					Name:  "produce-array-result",
+					Image: "alpine",
+					Script: ` |
+						echo -n "[\"${params.platform}\",\"${params.browser}\"]" | tee $(results.array-result.path)`}},
+			}},
+			Matrix: &Matrix{
+				Params: Params{{
+					Name: "platform", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"linux", "mac"}},
+				}, {
+					Name: "browser", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"chrome", "safari"}},
+				}}},
+		}, {
+			Name: "task-consuming-results",
+			TaskSpec: &EmbeddedTask{TaskSpec: TaskSpec{
+				Params: ParamSpecs{{
+					Name: "platform",
+				}, {
+					Name: "browser"}},
+				Results: []TaskResult{{
+					Name: "report-url",
+					Type: ResultsTypeString,
+				}},
+				Steps: []Step{{
+					Name:  "produce-report-url",
+					Image: "alpine",
+					Script: ` |
+							echo -n "https://api.example/get-report/$(params.platform)-$(params.browser)" | tee $(results.report-url.path)`}},
+			}},
+			Params: Params{{
+				Name: "b-param", Value: ParamValue{Type: ParamTypeString, StringVal: "$(tasks.matrix-emitting-results-embedded.results.report-url[0])"},
+			}},
+		}},
+		wantErrs: apis.ErrGeneric("A matrixed pipelineTask can only be consumed in aggregate using [*] notation, but is currently set to tasks.matrix-emitting-results-embedded.results.report-url[0]"),
+	}, {
+		name: "invalid matrix emitting array results consumed in aggregate by another pipelineTask",
+		tasks: PipelineTaskList{{
+			Name:    "matrix-emitting-results",
+			TaskRef: &TaskRef{Name: "taskwithresult"},
+			Matrix: &Matrix{
+				Params: Params{{
+					Name: "platform", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"linux", "mac"}},
+				}, {
+					Name: "browser", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"chrome", "safari"}},
+				}}},
+		}, {
+			Name: "taskwithresult",
+			TaskSpec: &EmbeddedTask{TaskSpec: TaskSpec{
+				Params: ParamSpecs{{
+					Name: "platform",
+				}, {
+					Name: "browser"}},
+				Results: []TaskResult{{
+					Name: "array-result",
+					Type: ResultsTypeArray,
+				}},
+				Steps: []Step{{
+					Name:  "produce-array-result",
+					Image: "alpine",
+					Script: ` |
+						echo -n "[\"${params.platform}\",\"${params.browser}\"]" | tee $(results.array-result.path)`}},
+			}},
+		}, {
+			Name:    "task-consuming-results",
+			TaskRef: &TaskRef{Name: "echoarrayurl"},
+			Params: Params{{
+				Name: "b-param", Value: ParamValue{Type: ParamTypeString, StringVal: "$(tasks.matrix-emitting-results.results.array-result[*])"},
+			}},
+		}},
+		wantErrs: apis.ErrInvalidValue("Matrixed PipelineTasks emitting results must have an underlying type string, but result array-result has type array in pipelineTask", ""),
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -3647,166 +4062,6 @@ func Test_validateMatrix(t *testing.T) {
 			ctx := config.ToContext(context.Background(), cfg)
 			if d := cmp.Diff(tt.wantErrs.Error(), validateMatrix(ctx, tt.tasks).Error()); d != "" {
 				t.Errorf("validateMatrix() errors diff %s", diff.PrintWantGot(d))
-			}
-		})
-	}
-}
-
-func Test_validateResultsFromMatrixedPipelineTasksNotConsumed(t *testing.T) {
-	tests := []struct {
-		name     string
-		tasks    []PipelineTask
-		finally  []PipelineTask
-		wantErrs *apis.FieldError
-	}{{
-		name: "results from matrixed task consumed in tasks through parameters",
-		tasks: PipelineTaskList{{
-			Name:    "a-task",
-			TaskRef: &TaskRef{Name: "a-task"},
-			Matrix: &Matrix{
-				Params: Params{{
-					Name: "a-param", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"foo", "bar"}},
-				}}},
-		}, {
-			Name:    "b-task",
-			TaskRef: &TaskRef{Name: "b-task"},
-			Params: Params{{
-				Name: "b-param", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"$(tasks.a-task.results.a-result)"}},
-			}},
-		}},
-		wantErrs: &apis.FieldError{
-			Message: "invalid value: consuming results from matrixed task a-task is not allowed",
-			Paths:   []string{"tasks[1]"},
-		},
-	}, {
-		name: "results from matrixed task consumed in finally through parameters",
-		tasks: PipelineTaskList{{
-			Name:    "a-task",
-			TaskRef: &TaskRef{Name: "a-task"},
-			Matrix: &Matrix{
-				Params: Params{{
-					Name: "a-param", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"foo", "bar"}},
-				}}},
-		}},
-		finally: PipelineTaskList{{
-			Name:    "b-task",
-			TaskRef: &TaskRef{Name: "b-task"},
-			Params: Params{{
-				Name: "b-param", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"$(tasks.a-task.results.a-result)"}},
-			}},
-		}},
-		wantErrs: &apis.FieldError{
-			Message: "invalid value: consuming results from matrixed task a-task is not allowed",
-			Paths:   []string{"finally[0]"},
-		},
-	}, {
-		name: "results from matrixed task consumed in tasks and finally through parameters",
-		tasks: PipelineTaskList{{
-			Name:    "a-task",
-			TaskRef: &TaskRef{Name: "a-task"},
-			Matrix: &Matrix{
-				Params: Params{{
-					Name: "a-param", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"foo", "bar"}},
-				}}},
-		}, {
-			Name:    "b-task",
-			TaskRef: &TaskRef{Name: "b-task"},
-			Params: Params{{
-				Name: "b-param", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"$(tasks.a-task.results.a-result)"}},
-			}},
-		}},
-		finally: PipelineTaskList{{
-			Name:    "c-task",
-			TaskRef: &TaskRef{Name: "c-task"},
-			Params: Params{{
-				Name: "b-param", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"$(tasks.a-task.results.a-result)"}},
-			}},
-		}},
-		wantErrs: &apis.FieldError{
-			Message: "invalid value: consuming results from matrixed task a-task is not allowed",
-			Paths:   []string{"tasks[1]", "finally[0]"},
-		},
-	}, {
-		name: "results from matrixed task consumed in tasks through when expressions",
-		tasks: PipelineTaskList{{
-			Name:    "a-task",
-			TaskRef: &TaskRef{Name: "a-task"},
-			Matrix: &Matrix{
-				Params: Params{{
-					Name: "a-param", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"foo", "bar"}},
-				}}},
-		}, {
-			Name:    "b-task",
-			TaskRef: &TaskRef{Name: "b-task"},
-			When: WhenExpressions{{
-				Input:    "foo",
-				Operator: selection.In,
-				Values:   []string{"$(tasks.a-task.results.a-result)"},
-			}},
-		}},
-		wantErrs: &apis.FieldError{
-			Message: "invalid value: consuming results from matrixed task a-task is not allowed",
-			Paths:   []string{"tasks[1]"},
-		},
-	}, {
-		name: "results from matrixed task consumed in finally through when expressions",
-		tasks: PipelineTaskList{{
-			Name:    "a-task",
-			TaskRef: &TaskRef{Name: "a-task"},
-			Matrix: &Matrix{
-				Params: Params{{
-					Name: "a-param", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"foo", "bar"}},
-				}}},
-		}},
-		finally: PipelineTaskList{{
-			Name:    "b-task",
-			TaskRef: &TaskRef{Name: "b-task"},
-			When: WhenExpressions{{
-				Input:    "$(tasks.a-task.results.a-result)",
-				Operator: selection.In,
-				Values:   []string{"foo", "bar"},
-			}},
-		}},
-		wantErrs: &apis.FieldError{
-			Message: "invalid value: consuming results from matrixed task a-task is not allowed",
-			Paths:   []string{"finally[0]"},
-		},
-	}, {
-		name: "results from matrixed task consumed in tasks and finally through when expressions",
-		tasks: PipelineTaskList{{
-			Name:    "a-task",
-			TaskRef: &TaskRef{Name: "a-task"},
-			Matrix: &Matrix{
-				Params: Params{{
-					Name: "a-param", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"foo", "bar"}},
-				}}},
-		}, {
-			Name:    "b-task",
-			TaskRef: &TaskRef{Name: "b-task"},
-			When: WhenExpressions{{
-				Input:    "$(tasks.a-task.results.a-result)",
-				Operator: selection.In,
-				Values:   []string{"foo", "bar"},
-			}},
-		}},
-		finally: PipelineTaskList{{
-			Name:    "c-task",
-			TaskRef: &TaskRef{Name: "c-task"},
-			When: WhenExpressions{{
-				Input:    "foo",
-				Operator: selection.In,
-				Values:   []string{"$(tasks.a-task.results.a-result)"},
-			}},
-		}},
-		wantErrs: &apis.FieldError{
-			Message: "invalid value: consuming results from matrixed task a-task is not allowed",
-			Paths:   []string{"tasks[1]", "finally[0]"},
-		},
-	}}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if d := cmp.Diff(tt.wantErrs.Error(), validateResultsFromMatrixedPipelineTasksNotConsumed(tt.tasks, tt.finally).Error()); d != "" {
-				t.Errorf("validateResultsFromMatrixedPipelineTasksNotConsumed() errors diff %s", diff.PrintWantGot(d))
 			}
 		})
 	}

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation.go
@@ -90,7 +90,6 @@ func (ps *PipelineSpec) Validate(ctx context.Context) (errs *apis.FieldError) {
 	errs = errs.Also(validateWhenExpressions(ps.Tasks, ps.Finally))
 	errs = errs.Also(validateMatrix(ctx, ps.Tasks).ViaField("tasks"))
 	errs = errs.Also(validateMatrix(ctx, ps.Finally).ViaField("finally"))
-	errs = errs.Also(validateResultsFromMatrixedPipelineTasksNotConsumed(ps.Tasks, ps.Finally))
 	return errs
 }
 
@@ -210,15 +209,6 @@ func (pt PipelineTask) validateEmbeddedOrType() (errs *apis.FieldError) {
 		}
 	}
 	return
-}
-
-func (pt *PipelineTask) validateResultsFromMatrixedPipelineTasksNotConsumed(matrixedPipelineTasks sets.String) (errs *apis.FieldError) {
-	for _, ref := range PipelineTaskResultRefs(pt) {
-		if matrixedPipelineTasks.Has(ref.PipelineTask) {
-			errs = errs.Also(apis.ErrInvalidValue(fmt.Sprintf("consuming results from matrixed task %s is not allowed", ref.PipelineTask), ""))
-		}
-	}
-	return errs
 }
 
 func (pt *PipelineTask) validateWorkspaces(workspaceNames sets.String) (errs *apis.FieldError) {
@@ -731,21 +721,103 @@ func validateMatrix(ctx context.Context, tasks []PipelineTask) (errs *apis.Field
 	for idx, task := range tasks {
 		errs = errs.Also(task.validateMatrix(ctx).ViaIndex(idx))
 	}
+	errs = errs.Also(validateTaskResultsFromMatrixedPipelineTasksConsumed(tasks))
 	return errs
 }
 
-func validateResultsFromMatrixedPipelineTasksNotConsumed(tasks []PipelineTask, finally []PipelineTask) (errs *apis.FieldError) {
-	matrixedPipelineTasks := sets.String{}
-	for _, pt := range tasks {
-		if pt.IsMatrixed() {
-			matrixedPipelineTasks.Insert(pt.Name)
+// findAndValidateResultRefsForMatrix checks that any result references to Matrixed PipelineTasks if consumed
+// by another PipelineTask that the entire array of results produced by a matrix is consumed in aggregate
+// since consuming a singular result produced by a matrix is currently not supported
+func findAndValidateResultRefsForMatrix(tasks []PipelineTask, taskMapping map[string]PipelineTask) (resultRefs []*ResultRef, errs *apis.FieldError) {
+	for _, t := range tasks {
+		for _, p := range t.Params {
+			if expressions, ok := GetVarSubstitutionExpressionsForParam(p); ok {
+				if LooksLikeContainsResultRefs(expressions) {
+					resultRefs, errs = validateMatrixedPipelineTaskConsumed(expressions, taskMapping)
+					if errs != nil {
+						return nil, errs
+					}
+				}
+			}
 		}
 	}
-	for idx, pt := range tasks {
-		errs = errs.Also(pt.validateResultsFromMatrixedPipelineTasksNotConsumed(matrixedPipelineTasks).ViaFieldIndex("tasks", idx))
+	return resultRefs, errs
+}
+
+// validateMatrixedPipelineTaskConsumed checks that any Matrixed Pipeline Task that the is being consumed is consumed in
+// aggregate [*] since consuming a singular result produced by a matrix is currently not supported
+func validateMatrixedPipelineTaskConsumed(expressions []string, taskMapping map[string]PipelineTask) (resultRefs []*ResultRef, errs *apis.FieldError) {
+	var filteredExpressions []string
+	for _, expression := range expressions {
+		// ie. "tasks.<pipelineTaskName>.results.<resultName>[*]"
+		subExpressions := strings.Split(expression, ".")
+		pipelineTask := subExpressions[1] // pipelineTaskName
+		taskConsumed := taskMapping[pipelineTask]
+		if taskConsumed.IsMatrixed() {
+			if !strings.HasSuffix(expression, "[*]") {
+				errs = errs.Also(apis.ErrGeneric(fmt.Sprintf("A matrixed pipelineTask can only be consumed in aggregate using [*] notation, but is currently set to %s", expression)))
+			}
+			filteredExpressions = append(filteredExpressions, expression)
+		}
 	}
-	for idx, pt := range finally {
-		errs = errs.Also(pt.validateResultsFromMatrixedPipelineTasksNotConsumed(matrixedPipelineTasks).ViaFieldIndex("finally", idx))
+	return NewResultRefs(filteredExpressions), errs
+}
+
+// validateTaskResultsFromMatrixedPipelineTasksConsumed checks that any Matrixed Pipeline Task that the is being consumed
+// is consumed in aggregate [*] since consuming a singular result produced by a matrix is currently not supported.
+// It also validates that a matrix emitting results can only emit results with the underlying type string
+// if those results are being consumed by another PipelineTask.
+func validateTaskResultsFromMatrixedPipelineTasksConsumed(tasks []PipelineTask) (errs *apis.FieldError) {
+	taskMapping := createTaskMapping(tasks)
+	resultRefs, errs := findAndValidateResultRefsForMatrix(tasks, taskMapping)
+	if errs != nil {
+		return errs
+	}
+
+	errs = errs.Also(validateMatrixEmittingStringResults(resultRefs, taskMapping))
+	return errs
+}
+
+// createTaskMapping maps the PipelineTaskName to the PipelineTask to easily access
+// the pipelineTask by Name
+func createTaskMapping(tasks []PipelineTask) (taskMap map[string]PipelineTask) {
+	taskMapping := make(map[string]PipelineTask)
+	for _, task := range tasks {
+		taskMapping[task.Name] = task
+	}
+	return taskMapping
+}
+
+// validateMatrixEmittingStringResults checks a matrix emitting results can only emit results with the underlying type string
+// if those results are being consumed by another PipelineTask.
+func validateMatrixEmittingStringResults(resultRefs []*ResultRef, taskMapping map[string]PipelineTask) (errs *apis.FieldError) {
+	for _, resultRef := range resultRefs {
+		task := taskMapping[resultRef.PipelineTask]
+		resultName := resultRef.Result
+		if task.TaskRef != nil {
+			referencedTaskName := task.TaskRef.Name
+			referencedTask := taskMapping[referencedTaskName]
+			if referencedTask.TaskSpec != nil {
+				errs = errs.Also(validateStringResults(referencedTask.TaskSpec.Results, resultName))
+			}
+		} else if task.TaskSpec != nil {
+			errs = errs.Also(validateStringResults(task.TaskSpec.Results, resultName))
+		}
+	}
+	return errs
+}
+
+// validateStringResults ensure that the result type is string
+func validateStringResults(results []TaskResult, resultName string) (errs *apis.FieldError) {
+	for _, result := range results {
+		if result.Name == resultName {
+			if result.Type != ResultsTypeString {
+				errs = errs.Also(apis.ErrInvalidValue(
+					fmt.Sprintf("Matrixed PipelineTasks emitting results must have an underlying type string, but result %s has type %s in pipelineTask", resultName, string(result.Type)),
+					"",
+				))
+			}
+		}
 	}
 	return errs
 }

--- a/pkg/reconciler/pipelinerun/resources/apply_test.go
+++ b/pkg/reconciler/pipelinerun/resources/apply_test.go
@@ -3241,6 +3241,8 @@ func TestApplyPipelineTaskContexts(t *testing.T) {
 	for _, tc := range []struct {
 		description string
 		pt          v1.PipelineTask
+		prstatus    v1.PipelineRunStatus
+		facts       *resources.PipelineRunFacts
 		want        v1.PipelineTask
 	}{{
 		description: "context retries replacement",
@@ -3324,9 +3326,155 @@ func TestApplyPipelineTaskContexts(t *testing.T) {
 				}},
 			},
 		},
+	}, {
+		description: "matrix length context variable",
+		pt: v1.PipelineTask{
+			Params: v1.Params{{
+				Name:  "matrixlength",
+				Value: *v1.NewStructuredValues("$(tasks.matrixed-task-run.matrix.length)"),
+			}},
+		},
+		prstatus: v1.PipelineRunStatus{
+			PipelineRunStatusFields: v1.PipelineRunStatusFields{
+				PipelineSpec: &v1.PipelineSpec{
+					Tasks: []v1.PipelineTask{{
+						Name: "matrixed-task-run",
+						Matrix: &v1.Matrix{
+							Params: v1.Params{
+								{Name: "platform", Value: *v1.NewStructuredValues("linux", "mac", "windows")},
+								{Name: "browser", Value: *v1.NewStructuredValues("chrome", "firefox", "safari")},
+							}},
+					}},
+				},
+			}},
+		want: v1.PipelineTask{
+			Params: v1.Params{{
+				Name:  "matrixlength",
+				Value: *v1.NewStructuredValues("9"),
+			}},
+		},
+	}, {
+		description: "matrix length and matrix results length context variables in matrix include params ",
+		pt: v1.PipelineTask{
+			Params: v1.Params{{
+				Name:  "matrixlength",
+				Value: *v1.NewStructuredValues("$(tasks.matrix-emitting-results.matrix.length)"),
+			}, {
+				Name:  "matrixresultslength",
+				Value: *v1.NewStructuredValues("$(tasks.matrix-emitting-results.matrix.IMAGE-DIGEST.length)"),
+			}},
+		},
+		prstatus: v1.PipelineRunStatus{
+			PipelineRunStatusFields: v1.PipelineRunStatusFields{
+				PipelineSpec: &v1.PipelineSpec{
+					Tasks: []v1.PipelineTask{{
+						Name: "matrix-emitting-results",
+						TaskSpec: &v1.EmbeddedTask{
+							TaskSpec: v1.TaskSpec{
+								Params: []v1.ParamSpec{{
+									Name: "IMAGE",
+									Type: v1.ParamTypeString,
+								}, {
+									Name: "DIGEST",
+									Type: v1.ParamTypeString,
+								}},
+								Results: []v1.TaskResult{{
+									Name: "IMAGE-DIGEST",
+								}},
+								Steps: []v1.Step{{
+									Name:   "produce-results",
+									Image:  "bash:latest",
+									Script: `#!/usr/bin/env bash\necho -n "$(params.DIGEST)" | sha256sum | tee $(results.IMAGE-DIGEST.path)"`,
+								}},
+							},
+						},
+						Matrix: &v1.Matrix{
+							Include: []v1.IncludeParams{{
+								Name: "build-1",
+								Params: v1.Params{{
+									Name: "DOCKERFILE", Value: *v1.NewStructuredValues("path/to/Dockerfile1"),
+								}, {
+									Name: "IMAGE", Value: *v1.NewStructuredValues("image-1"),
+								}},
+							}, {
+								Name: "build-2",
+								Params: v1.Params{{
+									Name: "DOCKERFILE", Value: *v1.NewStructuredValues("path/to/Dockerfile2"),
+								}, {
+									Name: "IMAGE", Value: *v1.NewStructuredValues("image-2"),
+								}},
+							}, {
+								Name: "build-3",
+								Params: v1.Params{{
+									Name: "DOCKERFILE", Value: *v1.NewStructuredValues("path/to/Dockerfile3"),
+								}, {
+									Name: "IMAGE", Value: *v1.NewStructuredValues("image-3"),
+								}},
+							}},
+						}},
+					},
+				},
+			},
+		},
+		facts: &resources.PipelineRunFacts{
+			State: resources.PipelineRunState{{
+				PipelineTask: &v1.PipelineTask{
+					Name: "matrix-emitting-results",
+				},
+				TaskRunNames: []string{"matrix-emitting-results-0"},
+				TaskRuns: []*v1.TaskRun{{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "matrix-emitting-results-0",
+					},
+					Status: v1.TaskRunStatus{
+						TaskRunStatusFields: v1.TaskRunStatusFields{
+							Results: []v1.TaskRunResult{{
+								Name:  "IMAGE-DIGEST",
+								Value: *v1.NewStructuredValues("123"),
+							}},
+						},
+					},
+				}, {
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "matrix-emitting-results-1",
+					},
+					Status: v1.TaskRunStatus{
+						TaskRunStatusFields: v1.TaskRunStatusFields{
+							Results: []v1.TaskRunResult{{
+								Name:  "IMAGE-DIGEST",
+								Value: *v1.NewStructuredValues("456"),
+							}},
+						},
+					},
+				}, {
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "matrix-emitting-results-2",
+					},
+					Status: v1.TaskRunStatus{
+						TaskRunStatusFields: v1.TaskRunStatusFields{
+							Results: []v1.TaskRunResult{{
+								Name:  "IMAGE-DIGEST",
+								Value: *v1.NewStructuredValues("789"),
+							}},
+						},
+					},
+				},
+				},
+				ResultsCache: map[string][]string{},
+			}},
+		},
+		want: v1.PipelineTask{
+			Params: v1.Params{{
+				Name:  "matrixlength",
+				Value: *v1.NewStructuredValues("3"),
+			}, {
+				Name:  "matrixresultslength",
+				Value: *v1.NewStructuredValues("3"),
+			}},
+		},
 	}} {
 		t.Run(tc.description, func(t *testing.T) {
-			got := resources.ApplyPipelineTaskContexts(&tc.pt)
+			got := resources.ApplyPipelineTaskContexts(&tc.pt, tc.prstatus, tc.facts)
 			if d := cmp.Diff(&tc.want, got); d != "" {
 				t.Errorf(diff.PrintWantGot(d))
 			}

--- a/pkg/reconciler/pipelinerun/resources/validate_params.go
+++ b/pkg/reconciler/pipelinerun/resources/validate_params.go
@@ -105,6 +105,13 @@ func ValidateParameterTypesInMatrix(state PipelineRunState) error {
 		if m.HasParams() {
 			for _, param := range m.Params {
 				if param.Value.Type != v1.ParamTypeArray {
+					// If it's an array type that contains result references because it's consuming results
+					// from a Matrixed PipelineTask continue
+					if ps, ok := param.GetVarSubstitutionExpressions(); ok {
+						if v1.LooksLikeContainsResultRefs(ps) {
+							continue
+						}
+					}
 					return fmt.Errorf("parameters of type array only are allowed, but param \"%s\" has type \"%s\" in pipelineTask \"%s\"",
 						param.Name, string(param.Value.Type), rpt.PipelineTask.Name)
 				}

--- a/pkg/reconciler/pipelinerun/resources/validate_params_test.go
+++ b/pkg/reconciler/pipelinerun/resources/validate_params_test.go
@@ -410,6 +410,17 @@ func TestValidatePipelineParameterTypes(t *testing.T) {
 			},
 		}},
 		wantErrs: "parameters of type string only are allowed, but param \"barfoo\" has type \"object\" in pipelineTask \"task\"",
+	}, {
+		desc: "parameters in matrix are result references",
+		state: resources.PipelineRunState{{
+			PipelineTask: &v1.PipelineTask{
+				Name: "task",
+				Matrix: &v1.Matrix{
+					Params: v1.Params{{
+						Name: "url", Value: v1.ParamValue{Type: v1.ParamTypeString, StringVal: `$(tasks.matrix-emitting-results.results.report-url[*])`},
+					}}},
+			},
+		}},
 	}} {
 		t.Run(tc.desc, func(t *testing.T) {
 			err := resources.ValidateParameterTypesInMatrix(tc.state)


### PR DESCRIPTION
This PR enables producing Results from Matrixed PipelineTasks so that they can be used in subsequent PipelineTasks [See [TEP-140: Produce Results in Matrix](https://github.com/tektoncd/community/blob/main/teps/0140-producing-results-in-matrix.md)]. A Pipeline author can now declare a matrixed taskRun that emits results of type string that are fanned out over multiple taskRuns and aggregated into an array of results that can then be consumed by another pipelineTask using the syntax `$(tasks.<pipelineTaskName>.results.<resultName>[*])`.

This commit also introduces 2 context variables to 1) Access Matrix Combinations Length using `tasks.<pipelineTaskName>.matrix.length` and 2) Access Aggregated Results Length using `tasks.<pipelineTaskName>.matrix.<resultName>.length`

Note: Currently, we don't support consuming a single instance/combinations of results. Authors must consume the entire aggregated results array. t message for your changes. 
/kind feature

Closes #5265
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Pipeline authors can now produce results from a Matrixed PipelineTask as an aggregated array and consume them in an array params. Two context variables are introduced as part of this feature, $(tasks.<pipelineTaskName>.matrix.length) to get the length of a matrix combinations and $(tasks.<pipelineTaskName>.matrix.<resultName>.length) to get a length of aggregated result.
```
