### PR TITLE
update perl docker image with multi-arch tag

### DIFF
--- a/examples/v1/taskruns/step-script.yaml
+++ b/examples/v1/taskruns/step-script.yaml
@@ -71,7 +71,7 @@ spec:
         print("Hello from Python!")
 
     - name: perl
-      image: perl
+      image: perl:devel-bullseye
       script: |
         #!/usr/bin/perl
         print "Hello from Perl!"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Upstream examples tests are failing s390x and ppc64le due to multi-arch image issue. perl:latest image is not multi-arch so. updating multi-arch tag of perl image.

CI link:
 https://dashboard.dogfooding.tekton.dev/#/namespaces/bastion-z/pipelineruns/tekton-pipeline-s390x-nightly-run-629qd?pipelineTask=examples-test-pipeline&step=run-e2e-tests
 -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
