### PR TITLE
Rename test cases for beta feature validations

### DIFF
--- a/pkg/apis/pipeline/v1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1/pipeline_validation_test.go
@@ -3857,7 +3857,7 @@ func TestPipelineWithBetaFields(t *testing.T) {
 			}},
 		},
 	}, {
-		name: "pipeline tasks - use of resolver without the feature flag set",
+		name: "pipeline tasks - use of resolver",
 		spec: PipelineSpec{
 			Tasks: []PipelineTask{{
 				Name:    "uses-resolver",
@@ -3865,7 +3865,7 @@ func TestPipelineWithBetaFields(t *testing.T) {
 			}},
 		},
 	}, {
-		name: "pipeline tasks - use of resolver params without the feature flag set",
+		name: "pipeline tasks - use of resolver params",
 		spec: PipelineSpec{
 			Tasks: []PipelineTask{{
 				Name:    "uses-resolver-params",
@@ -3873,7 +3873,7 @@ func TestPipelineWithBetaFields(t *testing.T) {
 			}},
 		},
 	}, {
-		name: "finally tasks - use of resolver without the feature flag set",
+		name: "finally tasks - use of resolver",
 		spec: PipelineSpec{
 			Tasks: []PipelineTask{{
 				Name:    "valid-pipeline-task",
@@ -3885,7 +3885,7 @@ func TestPipelineWithBetaFields(t *testing.T) {
 			}},
 		},
 	}, {
-		name: "finally tasks - use of resolver params without the feature flag set",
+		name: "finally tasks - use of resolver params",
 		spec: PipelineSpec{
 			Tasks: []PipelineTask{{
 				Name:    "valid-pipeline-task",

--- a/pkg/apis/pipeline/v1/pipelinerun_validation_test.go
+++ b/pkg/apis/pipeline/v1/pipelinerun_validation_test.go
@@ -1447,7 +1447,7 @@ func TestPipelineRunSpecBetaFeatures(t *testing.T) {
 			}},
 		},
 	}, {
-		name: "pipeline tasks - use of resolver without the feature flag set",
+		name: "pipeline tasks - use of resolver",
 		spec: v1.PipelineSpec{
 			Tasks: []v1.PipelineTask{{
 				Name:    "uses-resolver",
@@ -1455,7 +1455,7 @@ func TestPipelineRunSpecBetaFeatures(t *testing.T) {
 			}},
 		},
 	}, {
-		name: "pipeline tasks - use of resolver params without the feature flag set",
+		name: "pipeline tasks - use of resolver params",
 		spec: v1.PipelineSpec{
 			Tasks: []v1.PipelineTask{{
 				Name:    "uses-resolver-params",
@@ -1463,7 +1463,7 @@ func TestPipelineRunSpecBetaFeatures(t *testing.T) {
 			}},
 		},
 	}, {
-		name: "finally tasks - use of resolver without the feature flag set",
+		name: "finally tasks - use of resolver",
 		spec: v1.PipelineSpec{
 			Tasks: []v1.PipelineTask{{
 				Name:    "valid-pipeline-task",
@@ -1475,7 +1475,7 @@ func TestPipelineRunSpecBetaFeatures(t *testing.T) {
 			}},
 		},
 	}, {
-		name: "finally tasks - use of resolver params without the feature flag set",
+		name: "finally tasks - use of resolver params",
 		spec: v1.PipelineSpec{
 			Tasks: []v1.PipelineTask{{
 				Name:    "valid-pipeline-task",


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This commit renames the test cases for beta feature validations which previously had the tests constructed to return an error without the feature flags being set. This was no longer the case after the refactor and this commit aims to avoid the confusions.

/kind misc
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [n/a] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [n/a] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [n/a ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [n/a] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [n/a] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [n/a ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
