### PR TITLE
#6614 Add inclusive source scanning

### DIFF
--- a/.github/workflows/woke.yml
+++ b/.github/workflows/woke.yml
@@ -1,0 +1,22 @@
+name: 'woke'
+on:
+  - pull_request
+jobs:
+  woke:
+    name: 'woke'
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+
+      - uses: jitterbit/get-changed-files@v1
+        id: files
+
+      - name: 'woke'
+        uses: get-woke/woke-action@v0
+        with:
+          # Cause the check to fail on any broke rules
+          fail-on-error: true
+          # See https://github.com/marketplace/actions/get-all-changed-files
+          # for more options
+          woke-args: ${{ steps.files.outputs.added_modified }}

--- a/.wokeignore
+++ b/.wokeignore
@@ -1,0 +1,3 @@
+go.mod
+go.sum
+vendor

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -95,6 +95,11 @@ You must install these tools:
    > **Note** Linter findings are dependent on your installed Go version. Match
    the version in [`go.mod`](go.mod) to match the findings in your PR.
 
+1. (Optional)
+   [`woke`](https://docs.getwoke.tech/installation/) is executed for every pull 
+   request. To ensure your work does not contain offensive language, you may 
+   want to install and run this tool locally.
+
 ### Configure environment
 
 To [build, deploy and run your Tekton Objects with `ko`](#install-pipeline), you'll need to set these environment variables:

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,10 @@ TESTPKGS = $(shell env GO111MODULE=on $(GO) list -f \
 			'{{ if or .TestGoFiles .XTestGoFiles }}{{ .ImportPath }}{{ end }}' \
 			$(PKGS))
 BIN      = $(CURDIR)/.bin
+WOKE 	?= go run -modfile go.mod github.com/get-woke/woke
 
 GOLANGCI_VERSION = v1.52.2
+WOKE_VERSION     = v0.19.0
 
 GO           = go
 TIMEOUT_UNIT = 5m
@@ -184,6 +186,14 @@ goimports: | $(GOIMPORTS) ; $(info $(M) running goimports…) ## Run goimports
 .PHONY: fmt
 fmt: ; $(info $(M) running gofmt…) @ ## Run gofmt on all source files
 	$Q $(GO) fmt $(PKGS)
+
+WOKE = $(BIN)/woke
+$(BIN)/woke: ; $(info $(M) getting woke $(WOKE_VERSION))
+	cd tools; GOBIN=$(BIN) go install github.com/get-woke/woke@$(WOKE_VERSION)
+
+.PHONY: woke 
+woke: | $(WOKE) ; $(info $(M) running woke...) @ ## Run woke
+	$Q $(WOKE) -c https://github.com/canonical/Inclusive-naming/raw/main/config.yml
 
 # Misc
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

Resolves #6614 

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Add inclusive terminology scan tool [woke](https://github.com/get-woke/woke) to the repository, including the [woke-action](https://github.com/get-woke/woke-action) workflow

Suggest using the configuration file here: https://github.com/canonical/Inclusive-naming/raw/main/config.yml. A configuration can be defined locally, if needed.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
