### PR TITLE
#7027 Cleanup `cmp.Diff(want, got)` for all `diff.PrintWantGot()`

### DIFF
--- a/pkg/apis/config/metrics_test.go
+++ b/pkg/apis/config/metrics_test.go
@@ -85,7 +85,7 @@ func verifyConfigFileWithExpectedMetricsConfig(t *testing.T, fileName string, ex
 	t.Helper()
 	cm := test.ConfigMapFromTestFile(t, fileName)
 	if ab, err := config.NewMetricsFromConfigMap(cm); err == nil {
-		if d := cmp.Diff(ab, expectedConfig); d != "" {
+		if d := cmp.Diff(expectedConfig, ab); d != "" {
 			t.Errorf("Diff:\n%s", diff.PrintWantGot(d))
 		}
 	} else {

--- a/pkg/apis/config/resolver/store_test.go
+++ b/pkg/apis/config/resolver/store_test.go
@@ -41,7 +41,7 @@ func TestStoreLoadWithContext(t *testing.T) {
 
 	cfg := resolver.FromContext(store.ToContext(context.Background()))
 
-	if d := cmp.Diff(cfg, expected); d != "" {
+	if d := cmp.Diff(expected, cfg); d != "" {
 		t.Errorf("Unexpected config %s", diff.PrintWantGot(d))
 	}
 }

--- a/pkg/apis/config/store_test.go
+++ b/pkg/apis/config/store_test.go
@@ -61,7 +61,7 @@ func TestStoreLoadWithContext(t *testing.T) {
 
 	cfg := config.FromContext(store.ToContext(context.Background()))
 
-	if d := cmp.Diff(cfg, expected); d != "" {
+	if d := cmp.Diff(expected, cfg); d != "" {
 		t.Errorf("Unexpected config %s", diff.PrintWantGot(d))
 	}
 }

--- a/pkg/apis/pipeline/internal/checksum/checksum_test.go
+++ b/pkg/apis/pipeline/internal/checksum/checksum_test.go
@@ -85,7 +85,7 @@ func TestPrepareObjectMeta(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			task := PrepareObjectMeta(tc.objectmeta)
-			if d := cmp.Diff(task, tc.expected); d != "" {
+			if d := cmp.Diff(tc.expected, task); d != "" {
 				t.Error(diff.PrintWantGot(d))
 			}
 		})
@@ -97,7 +97,7 @@ func TestComputeSha256Checksum(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Could not marshal hello %v", err)
 	}
-	if d := cmp.Diff(hex.EncodeToString(sha), "5aa762ae383fbb727af3c7a36d4940a5b8c40a989452d2304fc958ff3f354e7a"); d != "" {
+	if d := cmp.Diff("5aa762ae383fbb727af3c7a36d4940a5b8c40a989452d2304fc958ff3f354e7a", hex.EncodeToString(sha)); d != "" {
 		t.Error(diff.PrintWantGot(d))
 	}
 }

--- a/pkg/apis/pipeline/v1/param_types_test.go
+++ b/pkg/apis/pipeline/v1/param_types_test.go
@@ -152,7 +152,7 @@ func TestParamSpec_SetDefaults(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
 			tc.before.SetDefaults(ctx)
-			if d := cmp.Diff(tc.before, tc.defaultsApplied); d != "" {
+			if d := cmp.Diff(tc.defaultsApplied, tc.before); d != "" {
 				t.Error(diff.PrintWantGot(d))
 			}
 		})

--- a/pkg/apis/pipeline/v1/pipeline_types_test.go
+++ b/pkg/apis/pipeline/v1/pipeline_types_test.go
@@ -1246,7 +1246,7 @@ func TestPipelineChecksum(t *testing.T) {
 				t.Fatalf("Error computing checksum: %v", err)
 			}
 
-			if d := cmp.Diff(hex.EncodeToString(sha), "98bc732636b8fbc08f3d353932147e4eff4e667f0c1af675656a48efdc8178e3"); d != "" {
+			if d := cmp.Diff("98bc732636b8fbc08f3d353932147e4eff4e667f0c1af675656a48efdc8178e3", hex.EncodeToString(sha)); d != "" {
 				t.Error(diff.PrintWantGot(d))
 			}
 		})

--- a/pkg/apis/pipeline/v1/pipelinerun_defaults_test.go
+++ b/pkg/apis/pipeline/v1/pipelinerun_defaults_test.go
@@ -438,7 +438,7 @@ func TestPipelineRunDefaulting(t *testing.T) {
 			got := tc.in
 			got.SetDefaults(ctx)
 			if !cmp.Equal(got, tc.want, ignoreUnexportedResources) {
-				d := cmp.Diff(got, tc.want, ignoreUnexportedResources)
+				d := cmp.Diff(tc.want, got, ignoreUnexportedResources)
 				t.Errorf("SetDefaults %s", diff.PrintWantGot(d))
 			}
 		})
@@ -486,7 +486,7 @@ func TestPipelineRunDefaultingOnCreate(t *testing.T) {
 			got := tc.in
 			got.SetDefaults(ctx)
 			if !cmp.Equal(got, tc.want, ignoreUnexportedResources) {
-				d := cmp.Diff(got, tc.want, ignoreUnexportedResources)
+				d := cmp.Diff(tc.want, got, ignoreUnexportedResources)
 				t.Errorf("SetDefaults %s", diff.PrintWantGot(d))
 			}
 		})

--- a/pkg/apis/pipeline/v1/pipelinerun_types_test.go
+++ b/pkg/apis/pipeline/v1/pipelinerun_types_test.go
@@ -52,7 +52,7 @@ func TestPipelineRunStatusConditions(t *testing.T) {
 	p.Status.SetCondition(foo)
 
 	fooStatus := p.Status.GetCondition(foo.Type)
-	if d := cmp.Diff(fooStatus, foo, ignoreVolatileTime); d != "" {
+	if d := cmp.Diff(foo, fooStatus, ignoreVolatileTime); d != "" {
 		t.Errorf("Unexpected pipeline run condition type; diff %v", diff.PrintWantGot(d))
 	}
 
@@ -61,7 +61,7 @@ func TestPipelineRunStatusConditions(t *testing.T) {
 
 	barStatus := p.Status.GetCondition(bar.Type)
 
-	if d := cmp.Diff(barStatus, bar, ignoreVolatileTime); d != "" {
+	if d := cmp.Diff(bar, barStatus, ignoreVolatileTime); d != "" {
 		t.Fatalf("Unexpected pipeline run condition type; diff %s", diff.PrintWantGot(d))
 	}
 }

--- a/pkg/apis/pipeline/v1/pipelinerun_validation_test.go
+++ b/pkg/apis/pipeline/v1/pipelinerun_validation_test.go
@@ -1317,7 +1317,7 @@ func TestPipelineRun_InvalidTimeouts(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
 			err := tc.pr.Validate(ctx)
-			if d := cmp.Diff(err.Error(), tc.want.Error()); d != "" {
+			if d := cmp.Diff(tc.want.Error(), err.Error()); d != "" {
 				t.Error(diff.PrintWantGot(d))
 			}
 		})

--- a/pkg/apis/pipeline/v1/result_defaults_test.go
+++ b/pkg/apis/pipeline/v1/result_defaults_test.go
@@ -87,7 +87,7 @@ func TestTaskResult_SetDefaults(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
 			tc.before.SetDefaults(ctx)
-			if d := cmp.Diff(tc.before, tc.after); d != "" {
+			if d := cmp.Diff(tc.after, tc.before); d != "" {
 				t.Error(diff.PrintWantGot(d))
 			}
 		})

--- a/pkg/apis/pipeline/v1/task_types_test.go
+++ b/pkg/apis/pipeline/v1/task_types_test.go
@@ -82,7 +82,7 @@ func TestTask_Checksum(t *testing.T) {
 				t.Fatalf("Error computing checksum: %v", err)
 			}
 
-			if d := cmp.Diff(hex.EncodeToString(sha), "0cf41a775529eaaa55ff115eebe5db01a3b6bf2f4b924606888736274ceb267a"); d != "" {
+			if d := cmp.Diff("0cf41a775529eaaa55ff115eebe5db01a3b6bf2f4b924606888736274ceb267a", hex.EncodeToString(sha)); d != "" {
 				t.Error(diff.PrintWantGot(d))
 			}
 		})

--- a/pkg/apis/pipeline/v1/taskrun_defaults_test.go
+++ b/pkg/apis/pipeline/v1/taskrun_defaults_test.go
@@ -423,7 +423,7 @@ func TestTaskRunDefaulting(t *testing.T) {
 			got := tc.in
 			got.SetDefaults(ctx)
 			if !cmp.Equal(got, tc.want, ignoreUnexportedResources) {
-				d := cmp.Diff(got, tc.want, ignoreUnexportedResources)
+				d := cmp.Diff(tc.want, got, ignoreUnexportedResources)
 				t.Errorf("SetDefaults %s", diff.PrintWantGot(d))
 			}
 		})
@@ -469,7 +469,7 @@ func TestTaskRunDefaultingOnCreate(t *testing.T) {
 			got := tc.in
 			got.SetDefaults(ctx)
 			if !cmp.Equal(got, tc.want, ignoreUnexportedResources) {
-				d := cmp.Diff(got, tc.want, ignoreUnexportedResources)
+				d := cmp.Diff(tc.want, got, ignoreUnexportedResources)
 				t.Errorf("SetDefaults %s", diff.PrintWantGot(d))
 			}
 		})

--- a/pkg/apis/pipeline/v1/taskrun_types_test.go
+++ b/pkg/apis/pipeline/v1/taskrun_types_test.go
@@ -366,7 +366,7 @@ func TestHasTimedOut(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			result := tc.taskRun.HasTimedOut(context.Background(), testClock)
-			if d := cmp.Diff(result, tc.expectedStatus); d != "" {
+			if d := cmp.Diff(tc.expectedStatus, result); d != "" {
 				t.Fatalf(diff.PrintWantGot(d))
 			}
 		})
@@ -440,7 +440,7 @@ func TestIsStepNeedDebug(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			result := tc.args.trd.StepNeedsDebug(tc.args.stepName)
-			if d := cmp.Diff(result, tc.want); d != "" {
+			if d := cmp.Diff(tc.want, result); d != "" {
 				t.Fatalf(diff.PrintWantGot(d))
 			}
 		})
@@ -477,7 +477,7 @@ func TestIsNeedDebug(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			result := tc.args.trd.NeedsDebug()
-			if d := cmp.Diff(result, tc.want); d != "" {
+			if d := cmp.Diff(tc.want, result); d != "" {
 				t.Fatalf(diff.PrintWantGot(d))
 			}
 		})

--- a/pkg/apis/pipeline/v1alpha1/run_types_test.go
+++ b/pkg/apis/pipeline/v1alpha1/run_types_test.go
@@ -342,7 +342,7 @@ func TestRunGetTimeOut(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			result := tc.run.GetTimeout()
-			if d := cmp.Diff(result, tc.expectedValue); d != "" {
+			if d := cmp.Diff(tc.expectedValue, result); d != "" {
 				t.Fatalf(diff.PrintWantGot(d))
 			}
 		})
@@ -408,7 +408,7 @@ func TestRunHasTimedOut(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			result := tc.run.HasTimedOut(testClock)
-			if d := cmp.Diff(result, tc.expectedValue); d != "" {
+			if d := cmp.Diff(tc.expectedValue, result); d != "" {
 				t.Fatalf(diff.PrintWantGot(d))
 			}
 		})

--- a/pkg/apis/pipeline/v1alpha1/run_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/run_validation_test.go
@@ -184,7 +184,7 @@ func TestRun_Invalid(t *testing.T) {
 	}} {
 		t.Run(c.name, func(t *testing.T) {
 			err := c.run.Validate(context.Background())
-			if d := cmp.Diff(err.Error(), c.want.Error()); d != "" {
+			if d := cmp.Diff(c.want.Error(), err.Error()); d != "" {
 				t.Error(diff.PrintWantGot(d))
 			}
 		})

--- a/pkg/apis/pipeline/v1beta1/customrun_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/customrun_types_test.go
@@ -375,7 +375,7 @@ func TestRunGetTimeOut(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			result := tc.customRun.GetTimeout()
-			if d := cmp.Diff(result, tc.expectedValue); d != "" {
+			if d := cmp.Diff(tc.expectedValue, result); d != "" {
 				t.Fatalf(diff.PrintWantGot(d))
 			}
 		})
@@ -441,7 +441,7 @@ func TestRunHasTimedOut(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			result := tc.customRun.HasTimedOut(testClock)
-			if d := cmp.Diff(result, tc.expectedValue); d != "" {
+			if d := cmp.Diff(tc.expectedValue, result); d != "" {
 				t.Fatalf(diff.PrintWantGot(d))
 			}
 		})

--- a/pkg/apis/pipeline/v1beta1/customrun_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/customrun_validation_test.go
@@ -183,7 +183,7 @@ func TestCustomRun_Invalid(t *testing.T) {
 	}} {
 		t.Run(c.name, func(t *testing.T) {
 			err := c.customRun.Validate(context.Background())
-			if d := cmp.Diff(err.Error(), c.want.Error()); d != "" {
+			if d := cmp.Diff(c.want.Error(), err.Error()); d != "" {
 				t.Error(diff.PrintWantGot(d))
 			}
 		})

--- a/pkg/apis/pipeline/v1beta1/param_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/param_types_test.go
@@ -152,7 +152,7 @@ func TestParamSpec_SetDefaults(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
 			tc.before.SetDefaults(ctx)
-			if d := cmp.Diff(tc.before, tc.defaultsApplied); d != "" {
+			if d := cmp.Diff(tc.defaultsApplied, tc.before); d != "" {
 				t.Error(diff.PrintWantGot(d))
 			}
 		})
@@ -481,7 +481,7 @@ func TestArrayOrString(t *testing.T) {
 			expected = v1beta1.NewArrayOrString(tt.inputA, tt.inputB)
 		}
 
-		if d := cmp.Diff(expected, tt.expected); d != "" {
+		if d := cmp.Diff(tt.expected, expected); d != "" {
 			t.Errorf(diff.PrintWantGot(d))
 		}
 	}

--- a/pkg/apis/pipeline/v1beta1/pipeline_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types_test.go
@@ -1230,7 +1230,7 @@ func TestPipelineChecksum(t *testing.T) {
 				t.Fatalf("Error computing checksum: %v", err)
 			}
 
-			if d := cmp.Diff(hex.EncodeToString(sha), "ef400089e645c69a588e71fe629ce2a989743e303c058073b0829c6c6338ab8a"); d != "" {
+			if d := cmp.Diff("ef400089e645c69a588e71fe629ce2a989743e303c058073b0829c6c6338ab8a", hex.EncodeToString(sha)); d != "" {
 				t.Error(diff.PrintWantGot(d))
 			}
 		})

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_defaults_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_defaults_test.go
@@ -393,7 +393,7 @@ func TestPipelineRunDefaulting(t *testing.T) {
 			got := tc.in
 			got.SetDefaults(ctx)
 			if !cmp.Equal(got, tc.want, ignoreUnexportedResources) {
-				d := cmp.Diff(got, tc.want, ignoreUnexportedResources)
+				d := cmp.Diff(tc.want, got, ignoreUnexportedResources)
 				t.Errorf("SetDefaults %s", diff.PrintWantGot(d))
 			}
 		})
@@ -437,7 +437,7 @@ func TestPipelineRunDefaultingOnCreate(t *testing.T) {
 			got := tc.in
 			got.SetDefaults(ctx)
 			if !cmp.Equal(got, tc.want, ignoreUnexportedResources) {
-				d := cmp.Diff(got, tc.want, ignoreUnexportedResources)
+				d := cmp.Diff(tc.want, got, ignoreUnexportedResources)
 				t.Errorf("SetDefaults %s", diff.PrintWantGot(d))
 			}
 		})

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_types_test.go
@@ -56,7 +56,7 @@ func TestPipelineRunStatusConditions(t *testing.T) {
 	p.Status.SetCondition(foo)
 
 	fooStatus := p.Status.GetCondition(foo.Type)
-	if d := cmp.Diff(fooStatus, foo, ignoreVolatileTime); d != "" {
+	if d := cmp.Diff(foo, fooStatus, ignoreVolatileTime); d != "" {
 		t.Errorf("Unexpected pipeline run condition type; diff %v", diff.PrintWantGot(d))
 	}
 
@@ -65,7 +65,7 @@ func TestPipelineRunStatusConditions(t *testing.T) {
 
 	barStatus := p.Status.GetCondition(bar.Type)
 
-	if d := cmp.Diff(barStatus, bar, ignoreVolatileTime); d != "" {
+	if d := cmp.Diff(bar, barStatus, ignoreVolatileTime); d != "" {
 		t.Fatalf("Unexpected pipeline run condition type; diff %s", diff.PrintWantGot(d))
 	}
 }

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_validation_test.go
@@ -1453,7 +1453,7 @@ func TestPipelineRun_InvalidTimeouts(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
 			err := tc.pr.Validate(ctx)
-			if d := cmp.Diff(err.Error(), tc.want.Error()); d != "" {
+			if d := cmp.Diff(tc.want.Error(), err.Error()); d != "" {
 				t.Error(diff.PrintWantGot(d))
 			}
 		})

--- a/pkg/apis/pipeline/v1beta1/result_defaults_test.go
+++ b/pkg/apis/pipeline/v1beta1/result_defaults_test.go
@@ -87,7 +87,7 @@ func TestTaskResult_SetDefaults(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
 			tc.before.SetDefaults(ctx)
-			if d := cmp.Diff(tc.before, tc.after); d != "" {
+			if d := cmp.Diff(tc.after, tc.before); d != "" {
 				t.Error(diff.PrintWantGot(d))
 			}
 		})

--- a/pkg/apis/pipeline/v1beta1/task_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/task_types_test.go
@@ -82,7 +82,7 @@ func TestTask_Checksum(t *testing.T) {
 				t.Fatalf("Error computing checksum: %v", err)
 			}
 
-			if d := cmp.Diff(hex.EncodeToString(sha), "c913fb33ce186f8a98e77eb2885495da71103de323a1dc420d1df1809a10dfd4"); d != "" {
+			if d := cmp.Diff("c913fb33ce186f8a98e77eb2885495da71103de323a1dc420d1df1809a10dfd4", hex.EncodeToString(sha)); d != "" {
 				t.Error(diff.PrintWantGot(d))
 			}
 		})

--- a/pkg/apis/pipeline/v1beta1/taskrun_defaults_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_defaults_test.go
@@ -407,7 +407,7 @@ func TestTaskRunDefaulting(t *testing.T) {
 			got := tc.in
 			got.SetDefaults(ctx)
 			if !cmp.Equal(got, tc.want, ignoreUnexportedResources) {
-				d := cmp.Diff(got, tc.want, ignoreUnexportedResources)
+				d := cmp.Diff(tc.want, got, ignoreUnexportedResources)
 				t.Errorf("SetDefaults %s", diff.PrintWantGot(d))
 			}
 		})
@@ -453,7 +453,7 @@ func TestTaskRunDefaultingOnCreate(t *testing.T) {
 			got := tc.in
 			got.SetDefaults(ctx)
 			if !cmp.Equal(got, tc.want, ignoreUnexportedResources) {
-				d := cmp.Diff(got, tc.want, ignoreUnexportedResources)
+				d := cmp.Diff(tc.want, got, ignoreUnexportedResources)
 				t.Errorf("SetDefaults %s", diff.PrintWantGot(d))
 			}
 		})

--- a/pkg/apis/pipeline/v1beta1/taskrun_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_types_test.go
@@ -426,7 +426,7 @@ func TestHasTimedOut(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			result := tc.taskRun.HasTimedOut(context.Background(), testClock)
-			if d := cmp.Diff(result, tc.expectedStatus); d != "" {
+			if d := cmp.Diff(tc.expectedStatus, result); d != "" {
 				t.Fatalf(diff.PrintWantGot(d))
 			}
 		})
@@ -500,7 +500,7 @@ func TestIsStepNeedDebug(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			result := tc.args.trd.StepNeedsDebug(tc.args.stepName)
-			if d := cmp.Diff(result, tc.want); d != "" {
+			if d := cmp.Diff(tc.want, result); d != "" {
 				t.Fatalf(diff.PrintWantGot(d))
 			}
 		})
@@ -537,7 +537,7 @@ func TestIsNeedDebug(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			result := tc.args.trd.NeedsDebug()
-			if d := cmp.Diff(result, tc.want); d != "" {
+			if d := cmp.Diff(tc.want, result); d != "" {
 				t.Fatalf(diff.PrintWantGot(d))
 			}
 		})

--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -2717,7 +2717,7 @@ func TestPodBuildwithSpireEnabled(t *testing.T) {
 			}
 
 			want := kmeta.ChildName(tr.Name, "-pod")
-			if d := cmp.Diff(got.Name, want); d != "" {
+			if d := cmp.Diff(want, got.Name); d != "" {
 				t.Errorf("Unexpected pod name, diff=%s", diff.PrintWantGot(d))
 			}
 
@@ -2766,7 +2766,7 @@ func TestMakeLabels(t *testing.T) {
 			},
 		},
 	})
-	if d := cmp.Diff(got, want); d != "" {
+	if d := cmp.Diff(want, got); d != "" {
 		t.Errorf("Diff labels %s", diff.PrintWantGot(d))
 	}
 }

--- a/pkg/reconciler/pipeline/dag/dag_test.go
+++ b/pkg/reconciler/pipeline/dag/dag_test.go
@@ -80,7 +80,7 @@ func TestGetSchedulable(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Didn't expect error when getting next tasks for %v but got %v", tc.finished, err)
 			}
-			if d := cmp.Diff(tasks, tc.expectedTasks, cmpopts.IgnoreFields(v1.PipelineTask{}, "RunAfter")); d != "" {
+			if d := cmp.Diff(tc.expectedTasks, tasks, cmpopts.IgnoreFields(v1.PipelineTask{}, "RunAfter")); d != "" {
 				t.Errorf("expected that with %v done, %v would be ready to schedule but was different: %s", tc.finished, tc.expectedTasks, diff.PrintWantGot(d))
 			}
 		})

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -1210,7 +1210,7 @@ status:
 	}
 
 	// The PipelineRun should be marked as failed due to InvalidTaskResultReference.
-	if d := cmp.Diff(reconciledRun, expectedPipelineRun, ignoreResourceVersion, ignoreLastTransitionTime, ignoreTypeMeta,
+	if d := cmp.Diff(expectedPipelineRun, reconciledRun, ignoreResourceVersion, ignoreLastTransitionTime, ignoreTypeMeta,
 		ignoreStartTime, ignoreCompletionTime, ignoreProvenance); d != "" {
 		t.Errorf("Expected to see PipelineRun run marked as failed with the reason: InvalidTaskResultReference. Diff %s", diff.PrintWantGot(d))
 	}
@@ -1359,7 +1359,7 @@ status:
 		t.Errorf("Expected PipelineRun status to be complete, but was %v", reconciledRun.Status.GetCondition(apis.ConditionSucceeded))
 	}
 
-	if d := cmp.Diff(reconciledRun.Status.ChildReferences, expectedChildReferences); d != "" {
+	if d := cmp.Diff(expectedChildReferences, reconciledRun.Status.ChildReferences); d != "" {
 		t.Fatalf("Expected PipelineRun status to match ChildReference(s) status, but got a mismatch %s", diff.PrintWantGot(d))
 	}
 
@@ -3324,7 +3324,7 @@ spec:
 		if err != nil {
 			t.Fatalf("Expected a TaskRun to be created, but it wasn't: %s", err)
 		}
-		if d := cmp.Diff(actual, expectedTaskRuns[i], ignoreResourceVersion, ignoreTypeMeta); d != "" {
+		if d := cmp.Diff(expectedTaskRuns[i], actual, ignoreResourceVersion, ignoreTypeMeta); d != "" {
 			t.Errorf("expected to see TaskRun %v created. Diff %s", expectedTaskRuns[i], diff.PrintWantGot(d))
 		}
 	}
@@ -3672,7 +3672,7 @@ spec:
 			Values:   []string{"yes"},
 		}},
 	}}
-	if d := cmp.Diff(actualSkippedTasks, expectedSkippedTasks); d != "" {
+	if d := cmp.Diff(expectedSkippedTasks, actualSkippedTasks); d != "" {
 		t.Errorf("expected to find Skipped Tasks %v. Diff %s", expectedSkippedTasks, diff.PrintWantGot(d))
 	}
 
@@ -5086,10 +5086,10 @@ status:
 
 	reconciledRun, _ := prt.reconcileRun("foo", "test-failed-pr-with-task-results", []string{}, false)
 
-	if d := cmp.Diff(reconciledRun.Status.Conditions, wantPrs[0].Status.Conditions, ignoreResourceVersion, ignoreLastTransitionTime); d != "" {
+	if d := cmp.Diff(wantPrs[0].Status.Conditions, reconciledRun.Status.Conditions, ignoreResourceVersion, ignoreLastTransitionTime); d != "" {
 		t.Errorf("expected to see pipeline run marked as failed. Diff %s", diff.PrintWantGot(d))
 	}
-	if d := cmp.Diff(reconciledRun.Status.Results, wantPrs[0].Status.Results, ignoreResourceVersion, ignoreLastTransitionTime); d != "" {
+	if d := cmp.Diff(wantPrs[0].Status.Results, reconciledRun.Status.Results, ignoreResourceVersion, ignoreLastTransitionTime); d != "" {
 		t.Errorf("expected to see pipeline run results created. Diff %s", diff.PrintWantGot(d))
 	}
 }
@@ -5175,7 +5175,7 @@ metadata:
 			if err := storePipelineSpecAndMergeMeta(context.Background(), pr, tc.reconcile1Args.pipelineSpec, tc.reconcile1Args.resolvedObjectMeta); err != nil {
 				t.Errorf("storePipelineSpec() error = %v", err)
 			}
-			if d := cmp.Diff(pr, tc.wantPipelineRun); d != "" {
+			if d := cmp.Diff(tc.wantPipelineRun, pr); d != "" {
 				t.Fatalf(diff.PrintWantGot(d))
 			}
 
@@ -5183,7 +5183,7 @@ metadata:
 			if err := storePipelineSpecAndMergeMeta(context.Background(), pr, tc.reconcile2Args.pipelineSpec, tc.reconcile2Args.resolvedObjectMeta); err != nil {
 				t.Errorf("storePipelineSpec() error = %v", err)
 			}
-			if d := cmp.Diff(pr, tc.wantPipelineRun); d != "" {
+			if d := cmp.Diff(tc.wantPipelineRun, pr); d != "" {
 				t.Fatalf(diff.PrintWantGot(d))
 			}
 		})
@@ -5207,10 +5207,10 @@ func Test_storePipelineSpec_metadata(t *testing.T) {
 	}); err != nil {
 		t.Errorf("storePipelineSpecAndMergeMeta error = %v", err)
 	}
-	if d := cmp.Diff(pr.ObjectMeta.Labels, wantedlabels); d != "" {
+	if d := cmp.Diff(wantedlabels, pr.ObjectMeta.Labels); d != "" {
 		t.Fatalf(diff.PrintWantGot(d))
 	}
-	if d := cmp.Diff(pr.ObjectMeta.Annotations, wantedannotations); d != "" {
+	if d := cmp.Diff(wantedannotations, pr.ObjectMeta.Annotations); d != "" {
 		t.Fatalf(diff.PrintWantGot(d))
 	}
 }

--- a/pkg/reconciler/pipelinerun/resources/pipelineref_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelineref_test.go
@@ -167,7 +167,7 @@ func TestLocalPipelineRef(t *testing.T) {
 				t.Fatalf("Received unexpected error ( %#v )", err)
 			}
 
-			if d := cmp.Diff(resolvedPipeline, tc.expected); tc.expected != nil && d != "" {
+			if d := cmp.Diff(tc.expected, resolvedPipeline); tc.expected != nil && d != "" {
 				t.Error(diff.PrintWantGot(d))
 			}
 
@@ -749,7 +749,7 @@ func TestGetPipelineFunc_V1beta1Pipeline_VerifyNoError(t *testing.T) {
 				}
 				return
 			}
-			if d := cmp.Diff(gotVerificationResult, tc.expectedVerificationResult, verificationResultCmp); d != "" {
+			if d := cmp.Diff(tc.expectedVerificationResult, gotVerificationResult, verificationResultCmp); d != "" {
 				t.Errorf("VerificationResult did not match:%s", diff.PrintWantGot(d))
 			}
 		})
@@ -868,7 +868,7 @@ func TestGetPipelineFunc_V1beta1Pipeline_VerifyError(t *testing.T) {
 			if err != nil {
 				t.Errorf("want err nil but got %v", err)
 			}
-			if d := cmp.Diff(gotVerificationResult, tc.expectedVerificationResult, verificationResultCmp); d != "" {
+			if d := cmp.Diff(tc.expectedVerificationResult, gotVerificationResult, verificationResultCmp); d != "" {
 				t.Errorf("VerificationResult did not match:%s", diff.PrintWantGot(d))
 			}
 		})
@@ -1079,7 +1079,7 @@ func TestGetPipelineFunc_V1Pipeline_VerifyNoError(t *testing.T) {
 				}
 				return
 			}
-			if d := cmp.Diff(gotVerificationResult, tc.expectedVerificationResult, verificationResultCmp); d != "" {
+			if d := cmp.Diff(tc.expectedVerificationResult, gotVerificationResult, verificationResultCmp); d != "" {
 				t.Errorf("VerificationResult did not match:%s", diff.PrintWantGot(d))
 			}
 		})
@@ -1195,7 +1195,7 @@ func TestGetPipelineFunc_V1Pipeline_VerifyError(t *testing.T) {
 			if err != nil {
 				t.Errorf("want err nil but got %v", err)
 			}
-			if d := cmp.Diff(gotVerificationResult, tc.expectedVerificationResult, verificationResultCmp); d != "" {
+			if d := cmp.Diff(tc.expectedVerificationResult, gotVerificationResult, verificationResultCmp); d != "" {
 				t.Errorf("VerificationResult did not match:%s", diff.PrintWantGot(d))
 			}
 		})

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
@@ -2411,10 +2411,10 @@ func TestResolvePipelineRun_PipelineTaskHasNoResources(t *testing.T) {
 		TaskName: task.Name,
 		TaskSpec: &task.Spec,
 	}
-	if d := cmp.Diff(pipelineState[0].ResolvedTask, expectedTask, cmpopts.IgnoreUnexported(v1.TaskRunSpec{})); d != "" {
+	if d := cmp.Diff(expectedTask, pipelineState[0].ResolvedTask, cmpopts.IgnoreUnexported(v1.TaskRunSpec{})); d != "" {
 		t.Fatalf("Expected resources where only Tasks were resolved but actual differed %s", diff.PrintWantGot(d))
 	}
-	if d := cmp.Diff(pipelineState[1].ResolvedTask, expectedTask, cmpopts.IgnoreUnexported(v1.TaskRunSpec{})); d != "" {
+	if d := cmp.Diff(expectedTask, pipelineState[1].ResolvedTask, cmpopts.IgnoreUnexported(v1.TaskRunSpec{})); d != "" {
 		t.Fatalf("Expected resources where only Tasks were resolved but actual differed %s", diff.PrintWantGot(d))
 	}
 }

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
@@ -868,7 +868,7 @@ func TestGetNextTaskWithRetries(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			next := tc.state.getNextTasks(tc.candidates)
-			if d := cmp.Diff(next, tc.expectedNext); d != "" {
+			if d := cmp.Diff(tc.expectedNext, next); d != "" {
 				t.Errorf("Didn't get expected next Tasks %s", diff.PrintWantGot(d))
 			}
 		})
@@ -1297,7 +1297,7 @@ func TestPipelineRunState_CompletedOrSkippedDAGTasks(t *testing.T) {
 				},
 			}
 			names := facts.completedOrSkippedDAGTasks()
-			if d := cmp.Diff(names, tc.expectedNames); d != "" {
+			if d := cmp.Diff(tc.expectedNames, names); d != "" {
 				t.Errorf("Expected to get completed names %v but got something different %s", tc.expectedNames, diff.PrintWantGot(d))
 			}
 		})

--- a/pkg/reconciler/taskrun/resources/taskref_test.go
+++ b/pkg/reconciler/taskrun/resources/taskref_test.go
@@ -284,7 +284,7 @@ func TestLocalTaskRef(t *testing.T) {
 				t.Fatalf("Received unexpected error ( %#v )", err)
 			}
 
-			if d := cmp.Diff(task, tc.expected); tc.expected != nil && d != "" {
+			if d := cmp.Diff(tc.expected, task); tc.expected != nil && d != "" {
 				t.Error(diff.PrintWantGot(d))
 			}
 
@@ -1123,7 +1123,7 @@ func TestGetTaskFunc_V1Task_VerifyNoError(t *testing.T) {
 			if d := cmp.Diff(tc.expectedRefSource, gotRefSource); d != "" {
 				t.Errorf("refSources did not match: %s", diff.PrintWantGot(d))
 			}
-			if d := cmp.Diff(gotVerificationResult, tc.expectedVerificationResult, verificationResultCmp); d != "" {
+			if d := cmp.Diff(tc.expectedVerificationResult, gotVerificationResult, verificationResultCmp); d != "" {
 				t.Errorf("VerificationResult did not match:%s", diff.PrintWantGot(d))
 			}
 		})
@@ -1237,7 +1237,7 @@ func TestGetTaskFunc_V1Task_VerifyError(t *testing.T) {
 			fn := resources.GetTaskFunc(ctx, k8sclient, tektonclient, tc.requester, tr, tr.Spec.TaskRef, "", "default", "default", vps)
 
 			_, _, gotVerificationResult, _ := fn(ctx, taskRef.Name)
-			if d := cmp.Diff(gotVerificationResult, tc.expectedVerificationResult, verificationResultCmp); d != "" {
+			if d := cmp.Diff(tc.expectedVerificationResult, gotVerificationResult, verificationResultCmp); d != "" {
 				t.Errorf("VerificationResult did not match:%s", diff.PrintWantGot(d))
 			}
 		})

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -1906,7 +1906,7 @@ status:
 				ignoreStatusTaskSpec,
 				ignoreTaskRunStatusFields,
 			}
-			if d := cmp.Diff(reconciledTaskRun, tc.wantTr, ignoreFields...); d != "" {
+			if d := cmp.Diff(tc.wantTr, reconciledTaskRun, ignoreFields...); d != "" {
 				t.Errorf("Didn't get expected TaskRun: %v", diff.PrintWantGot(d))
 			}
 
@@ -3930,7 +3930,7 @@ status:
 			if err != nil {
 				t.Fatal(err)
 			}
-			if d := cmp.Diff(tc.taskRun.Status.GetCondition(apis.ConditionSucceeded), &tc.expectedStatus, ignoreLastTransitionTime); d != "" {
+			if d := cmp.Diff(&tc.expectedStatus, tc.taskRun.Status.GetCondition(apis.ConditionSucceeded), ignoreLastTransitionTime); d != "" {
 				t.Fatalf(diff.PrintWantGot(d))
 			}
 
@@ -4034,7 +4034,7 @@ spec:
 			if err := storeTaskSpecAndMergeMeta(context.Background(), tr, tc.reconcile1Args.taskSpec, tc.reconcile1Args.resolvedObjectMeta); err != nil {
 				t.Errorf("storePipelineSpec() error = %v", err)
 			}
-			if d := cmp.Diff(tr, tc.wantTaskRun); d != "" {
+			if d := cmp.Diff(tc.wantTaskRun, tr); d != "" {
 				t.Fatalf(diff.PrintWantGot(d))
 			}
 
@@ -4042,7 +4042,7 @@ spec:
 			if err := storeTaskSpecAndMergeMeta(context.Background(), tr, tc.reconcile2Args.taskSpec, tc.reconcile2Args.resolvedObjectMeta); err != nil {
 				t.Errorf("storePipelineSpec() error = %v", err)
 			}
-			if d := cmp.Diff(tr, tc.wantTaskRun); d != "" {
+			if d := cmp.Diff(tc.wantTaskRun, tr); d != "" {
 				t.Fatalf(diff.PrintWantGot(d))
 			}
 		})
@@ -4067,10 +4067,10 @@ func Test_storeTaskSpec_metadata(t *testing.T) {
 	if err := storeTaskSpecAndMergeMeta(context.Background(), tr, &v1.TaskSpec{}, &resolvedMeta); err != nil {
 		t.Errorf("storeTaskSpecAndMergeMeta error = %v", err)
 	}
-	if d := cmp.Diff(tr.ObjectMeta.Labels, wantedlabels); d != "" {
+	if d := cmp.Diff(wantedlabels, tr.ObjectMeta.Labels); d != "" {
 		t.Fatalf(diff.PrintWantGot(d))
 	}
-	if d := cmp.Diff(tr.ObjectMeta.Annotations, wantedannotations); d != "" {
+	if d := cmp.Diff(wantedannotations, tr.ObjectMeta.Annotations); d != "" {
 		t.Fatalf(diff.PrintWantGot(d))
 	}
 }
@@ -4348,7 +4348,7 @@ status:
 	}
 
 	// check that injected sidecar is replaced with nop image
-	if d := cmp.Diff(retrievedPod.Spec.Containers[1].Image, images.NopImage); d != "" {
+	if d := cmp.Diff(images.NopImage, retrievedPod.Spec.Containers[1].Image); d != "" {
 		t.Errorf("expected injected sidecar image to be replaced with nop image %s", diff.PrintWantGot(d))
 	}
 }
@@ -4994,7 +4994,7 @@ status:
 			if err != nil {
 				t.Fatalf("getting updated taskrun: %v", err)
 			}
-			if d := cmp.Diff(tr.Status.Results, tc.expectedResults); d != "" {
+			if d := cmp.Diff(tc.expectedResults, tr.Status.Results); d != "" {
 				t.Errorf("got unexpected results %s", diff.PrintWantGot(d))
 			}
 			condition := tr.Status.GetCondition(apis.ConditionSucceeded)

--- a/pkg/remote/oci/resolver_test.go
+++ b/pkg/remote/oci/resolver_test.go
@@ -197,7 +197,7 @@ func TestOCIResolver(t *testing.T) {
 
 			// The contents of the image are in a specific order so we can expect this iteration to be consistent.
 			for idx, actual := range listActual {
-				if d := cmp.Diff(actual, tc.listExpected[idx]); d != "" {
+				if d := cmp.Diff(tc.listExpected[idx], actual); d != "" {
 					t.Error(diff.PrintWantGot(d))
 				}
 			}
@@ -208,7 +208,7 @@ func TestOCIResolver(t *testing.T) {
 					t.Fatalf("could not retrieve object from image: %#v", err)
 				}
 
-				if d := cmp.Diff(actual, obj); d != "" {
+				if d := cmp.Diff(obj, actual); d != "" {
 					t.Error(diff.PrintWantGot(d))
 				}
 

--- a/pkg/resolution/resource/request_test.go
+++ b/pkg/resolution/resource/request_test.go
@@ -68,7 +68,7 @@ func TestNewRequest(t *testing.T) {
 			if request.Namespace() != tt.want.namespace {
 				t.Errorf("NewRequest().Namespace() = %v, want %v", request.Namespace(), tt.want.namespace)
 			}
-			if d := cmp.Diff(request.Params(), tt.want.params); d != "" {
+			if d := cmp.Diff(tt.want.params, request.Params()); d != "" {
 				t.Errorf("expected params to match %s", diff.PrintWantGot(d))
 			}
 		})

--- a/pkg/substitution/substitution_test.go
+++ b/pkg/substitution/substitution_test.go
@@ -182,7 +182,7 @@ func TestValidateNoReferencesToUnknownVariables(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got := substitution.ValidateNoReferencesToUnknownVariables(tc.args.input, tc.args.prefix, tc.args.vars)
 
-			if d := cmp.Diff(got, tc.expectedError, cmp.AllowUnexported(apis.FieldError{})); d != "" {
+			if d := cmp.Diff(tc.expectedError, got, cmp.AllowUnexported(apis.FieldError{})); d != "" {
 				t.Errorf("ValidateVariableP() error did not match expected error %s", diff.PrintWantGot(d))
 			}
 		})
@@ -312,7 +312,7 @@ func TestValidateValidateNoReferencesToEntireProhibitedVariables(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got := substitution.ValidateNoReferencesToEntireProhibitedVariables(tc.args.input, tc.args.prefix, tc.args.vars)
 
-			if d := cmp.Diff(got, tc.expectedError, cmp.AllowUnexported(apis.FieldError{})); d != "" {
+			if d := cmp.Diff(tc.expectedError, got, cmp.AllowUnexported(apis.FieldError{})); d != "" {
 				t.Errorf("ValidateEntireVariableProhibitedP() error did not match expected error %s", diff.PrintWantGot(d))
 			}
 		})
@@ -457,7 +457,7 @@ func TestApplyReplacements(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			actualOutput := substitution.ApplyReplacements(tt.args.input, tt.args.replacements)
-			if d := cmp.Diff(actualOutput, tt.expectedOutput); d != "" {
+			if d := cmp.Diff(tt.expectedOutput, actualOutput); d != "" {
 				t.Errorf("ApplyReplacements() output did not match expected value %s", diff.PrintWantGot(d))
 			}
 		})
@@ -535,7 +535,7 @@ func TestApplyArrayReplacements(t *testing.T) {
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			actualOutput := substitution.ApplyArrayReplacements(tc.args.input, tc.args.stringReplacements, tc.args.arrayReplacements)
-			if d := cmp.Diff(actualOutput, tc.expectedOutput); d != "" {
+			if d := cmp.Diff(tc.expectedOutput, actualOutput); d != "" {
 				t.Errorf("ApplyArrayReplacements() output did not match expected value %s", diff.PrintWantGot(d))
 			}
 		})

--- a/test/pipelinefinally_test.go
+++ b/test/pipelinefinally_test.go
@@ -384,7 +384,7 @@ spec:
 
 	actualSkippedTasks := pr.Status.SkippedTasks
 	// Sort tasks based on their names to get similar order as in expected list
-	if d := cmp.Diff(actualSkippedTasks, expectedSkippedTasks, cmpopts.SortSlices(func(i, j v1.SkippedTask) bool {
+	if d := cmp.Diff(expectedSkippedTasks, actualSkippedTasks, cmpopts.SortSlices(func(i, j v1.SkippedTask) bool {
 		return i.Name < j.Name
 	})); d != "" {
 		t.Fatalf("Expected four skipped tasks, dag task with condition failure dagtask3, dag task with when expression,"+

--- a/test/trustedresources_test.go
+++ b/test/trustedresources_test.go
@@ -81,7 +81,7 @@ func TestSignInterface(t *testing.T) {
 
 			if tc.expected != "" {
 				signature := base64.StdEncoding.EncodeToString(sig)
-				if d := cmp.Diff(signature, tc.expected); d != "" {
+				if d := cmp.Diff(tc.expected, signature); d != "" {
 					t.Fatalf("Diff:\n%s", diff.PrintWantGot(d))
 				}
 				return


### PR DESCRIPTION
# Changes

Fix #7027 
/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- n/a Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- n/a Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- n/a Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- n/a Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
