### PR TITLE
Extend release timeouts in release cheatsheet

### DIFF
--- a/tekton/release-cheat-sheet.md
+++ b/tekton/release-cheat-sheet.md
@@ -58,7 +58,9 @@ the pipelines repo, a terminal window and a text editor.
       --param=versionTag="${TEKTON_VERSION}" \
       --param=releaseBucket=gs://tekton-releases/pipeline \
       --workspace name=release-secret,secret=release-secret \
-      --workspace name=workarea,volumeClaimTemplateFile=workspace-template.yaml
+      --workspace name=workarea,volumeClaimTemplateFile=workspace-template.yaml \
+      --tasks-timeout 2h \
+      --pipeline-timeout 3h
     ```
 
     Accept the default values of the parameters (except for "releaseAsLatest" if backporting).


### PR DESCRIPTION
# Changes

The release pipeline tends to timeout.
Extend the timeout params passed via tkn to avoid that.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```

/kind documentation