### PR TITLE
Fix navigation to add new crd types in development.md

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -164,8 +164,11 @@ The Tekton project requires that you develop (commit) code changes to branches t
 
         ```shell
         git remote add upstream git@github.com:tektoncd/pipeline.git
+        ```
 
-        # Optional: Prevent accidental pushing of commits by changing the upstream URL to `no_push`
+    1. Optional: Prevent accidental pushing of commits by changing the upstream URL to `no_push`
+
+        ```shell
         git remote set-url --push upstream no_push
         ```
 
@@ -271,9 +274,9 @@ The recommended minimum development configuration is:
   - 8 GB of (actual or virtualized) platform memory
 - Node autoscaling, up to 3 nodes
 
-#### Using [KinD](https://kind.sigs.k8s.io/)
+#### Using [Kind](https://kind.sigs.k8s.io/)
 
-[KinD](https://kind.sigs.k8s.io/) is a great tool for working with Kubernetes clusters locally. It is particularly useful to quickly test code against different cluster [configurations](https://kind.sigs.k8s.io/docs/user/quick-start/#advanced).
+[Kind](https://kind.sigs.k8s.io/) is a great tool for working with Kubernetes clusters locally. It is particularly useful to quickly test code against different cluster [configurations](https://kind.sigs.k8s.io/docs/user/quick-start/#advanced).
 
 1. Install [required tools](./DEVELOPMENT.md#install-tools) (note: may require a newer version of Go).
 2. Install [Docker](https://www.docker.com/get-started).
@@ -353,7 +356,7 @@ While iterating on code changes to the project, you may need to:
     - Update your (external) dependencies with: `./hack/update-deps.sh`
     - Update your type definitions with: `./hack/update-codegen.sh`
     -  Update your OpenAPI specs with: `./hack/update-openapigen.sh`
-1. Update or [add new CRD types](#adding-new-types) as needed
+1. Update or [add new CRD types](#adding-new-crd-types) as needed
 1. Update, [add and run tests](./test/README.md#tests)
 
 To make changes to these CRDs, you will probably interact with:


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
1. In DEVELOPMENT.md file , to configure upstream optional , while set up a fork , the instructions throws an error when used in zsh shell , because of # symbol not found. 
2. In setup cluster of type kind , the word kind is in Camel case Kind , changed it to lower case kind
3. The update or add new crd types in Iterating on code changes section, doesn't navigate  and has been corrected.

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
