### PR TITLE
Let the user pass a secret via a parameter for SCM API operations when using the git API resolver

### DIFF
--- a/examples/v1/pipelineruns/no-ci/git-resolver-custom-secret.yaml
+++ b/examples/v1/pipelineruns/no-ci/git-resolver-custom-secret.yaml
@@ -1,0 +1,42 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  generateName: git-resolver-
+spec:
+  workspaces:
+    - name: output  # this workspace name must be declared in the Pipeline
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce  # access mode may affect how you can use this volume in parallel tasks
+          resources:
+            requests:
+              storage: 1Gi
+  pipelineSpec:
+    workspaces:
+      - name: output
+    tasks:
+      - name: task1
+        workspaces:
+          - name: output
+        taskRef:
+          resolver: git
+          params:
+            - name: url
+              value: https://github.com/tektoncd/catalog.git
+            - name: pathInRepo
+              value: /task/git-clone/0.7/git-clone.yaml
+            - name: revision
+              value: main
+            # my-secret-token should be created in the namespace where the
+            # pipelinerun is created and contain a GitHub personal access
+            # token in the token key of the secret.
+            - name: token
+              value: my-secret-token
+            - name: tokenKey
+              value: token
+        params:
+          - name: url
+            value: https://github.com/tektoncd/catalog
+          - name: deleteExisting
+            value: "true"

--- a/pkg/resolution/resolver/git/params.go
+++ b/pkg/resolution/resolver/git/params.go
@@ -27,4 +27,10 @@ const (
 	pathParam string = "pathInRepo"
 	// revisionParam is the git revision that a file should be fetched from. This is used with both approaches.
 	revisionParam string = "revision"
+	// tokenParam is an optional reference to a secret name for SCM API authentication
+	tokenParam string = "token"
+	// tokenKeyParam is an optional reference to a key in the tokenParam secret for SCM API authentication
+	tokenKeyParam string = "tokenKey"
+	// defaultTokenKeyParam is the default key in the tokenParam secret for SCM API authentication
+	defaultTokenKeyParam string = "token"
 )


### PR DESCRIPTION
We were previously only allowing using a secret from the global configmap, which mean every users on the cluster would have to use the same git value (which could be a security issue).

We now let the user use their own token on their own namespace with the optional "token" and (even more optional) "tokenKey" params.

The fallback will still be the global configmap.

Added a bit logic to make sure we are caching secrets only when user use the token from global configmap. Since we can't ensure for local secrets on namespace may be rotated often.
 
/kind feature

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
User are now able to pass a secret referencing token (or a tokenKey) for a SCM operation on the git resolver instead of using the global one from the configmap.
```
