### PR TITLE
[TEP-0145] Add CEL field to WhenExpression, and feature flag to guard the field

### DIFF
--- a/config/config-feature-flags.yaml
+++ b/config/config-feature-flags.yaml
@@ -121,3 +121,6 @@ data:
   # Setting this flag to "true" will keep pod on cancellation
   # allowing examination of the logs on the pods from cancelled taskruns
   keep-pod-on-cancel: "false"
+  # Setting this flag to "true" will enable the CEL evaluation in WhenExpression
+  # This feature is in preview mode and not implemented yet. Please check #7244 for the updates.
+  enable-cel-in-whenexpression: "false"

--- a/docs/additional-configs.md
+++ b/docs/additional-configs.md
@@ -317,6 +317,7 @@ Features currently in "alpha" are:
 | [Configure Default Resolver](./resolution.md#configuring-built-in-resolvers)                        | [TEP-0133](https://github.com/tektoncd/community/blob/main/teps/0133-configure-default-resolver.md)                        | N/A                                 |                                |
 | [Coschedule](./affinityassistants.md)                                                               | [TEP-0135](https://github.com/tektoncd/community/blob/main/teps/0135-coscheduling-pipelinerun-pods.md)                        | N/A                                 |`coschedule`                                |
 | [keep pod on cancel](./taskruns.md#cancelling-a-taskrun)                                            | N/A |  v0.52 | keep-pod-on-cancel |
+| [CEL in WhenExpression](./taskruns.md#cancelling-a-taskrun)                                            | [TEP-0145](https://github.com/tektoncd/community/blob/main/teps/0145-cel-in-whenexpression.md) |  N/A | enable-cel-in-whenexpression |
 
 ### Beta Features
 

--- a/docs/pipeline-api.md
+++ b/docs/pipeline-api.md
@@ -5782,6 +5782,20 @@ k8s.io/apimachinery/pkg/selection.Operator
 It must be non-empty</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>cel</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CEL is a string of Common Language Expression, which can be used to conditionally execute
+the task based on the result of the expression evaluation
+More info about CEL syntax: <a href="https://github.com/google/cel-spec/blob/master/doc/langdef.md">https://github.com/google/cel-spec/blob/master/doc/langdef.md</a></p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="tekton.dev/v1.WhenExpressions">WhenExpressions
@@ -14547,6 +14561,20 @@ k8s.io/apimachinery/pkg/selection.Operator
 <td>
 <p>Values is an array of strings, which is compared against the input, for guard checking
 It must be non-empty</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>cel</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CEL is a string of Common Language Expression, which can be used to conditionally execute
+the task based on the result of the expression evaluation
+More info about CEL syntax: <a href="https://github.com/google/cel-spec/blob/master/doc/langdef.md">https://github.com/google/cel-spec/blob/master/doc/langdef.md</a></p>
 </td>
 </tr>
 </tbody>

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -705,7 +705,7 @@ If the result is **NOT** initialized before failing, and there is a `PipelineTas
 ```
 
 - If the consuming `PipelineTask` has `OnError:stopAndFail`, the `PipelineRun` will fail with `InvalidTaskResultReference`.
-- If the consuming `PipelineTask` has `OnError:continue`, the consuming `PipelineTask` will be skipped with reason `Results were missing`, 
+- If the consuming `PipelineTask` has `OnError:continue`, the consuming `PipelineTask` will be skipped with reason `Results were missing`,
 and the `PipelineRun` will continue to execute.
 
 ### Guard `Task` execution using `when` expressions
@@ -774,6 +774,14 @@ There are a lot of scenarios where `when` expressions can be really useful. Some
 - Checking if an image exists in the registry
 - Checking if the name of a CI job matches
 - Checking if an optional Workspace has been provided
+
+#### Use CEL expression in WhenExpression
+
+> :seedling: **`CEL in WhenExpression` is an [alpha](install.md#alpha-features) feature.**
+> The `enable-cel-in-whenexpression` feature flag must be set to `"true"` to enable the use of `CEL` in `WhenExpression`.
+>
+> :warning: This feature is in a preview mode.
+> It is still in a very early stage of development and is not yet fully functional
 
 #### Guarding a `Task` and its dependent `Tasks`
 

--- a/pkg/apis/config/feature_flags.go
+++ b/pkg/apis/config/feature_flags.go
@@ -92,6 +92,10 @@ const (
 	KeepPodOnCancel = "keep-pod-on-cancel"
 	// DefaultEnableKeepPodOnCancel is the default value for "keep-pod-on-cancel"
 	DefaultEnableKeepPodOnCancel = false
+	// EnableCELInWhenExpression is the flag to enabled CEL in WhenExpression
+	EnableCELInWhenExpression = "enable-cel-in-whenexpression"
+	// DefaultEnableCELInWhenExpression is the default value for EnableCELInWhenExpression
+	DefaultEnableCELInWhenExpression = false
 
 	disableAffinityAssistantKey         = "disable-affinity-assistant"
 	disableCredsInitKey                 = "disable-creds-init"
@@ -140,6 +144,7 @@ type FeatureFlags struct {
 	MaxResultSize             int
 	SetSecurityContext        bool
 	Coschedule                string
+	EnableCELInWhenExpression bool
 }
 
 // GetFeatureFlagsConfigName returns the name of the configmap containing all
@@ -209,8 +214,10 @@ func NewFeatureFlagsFromMap(cfgMap map[string]string) (*FeatureFlags, error) {
 	if err := setFeature(setSecurityContextKey, DefaultSetSecurityContext, &tc.SetSecurityContext); err != nil {
 		return nil, err
 	}
-
 	if err := setCoschedule(cfgMap, DefaultCoschedule, tc.DisableAffinityAssistant, &tc.Coschedule); err != nil {
+		return nil, err
+	}
+	if err := setFeature(EnableCELInWhenExpression, DefaultEnableCELInWhenExpression, &tc.EnableCELInWhenExpression); err != nil {
 		return nil, err
 	}
 	// Given that they are alpha features, Tekton Bundles and Custom Tasks should be switched on if

--- a/pkg/apis/config/feature_flags_test.go
+++ b/pkg/apis/config/feature_flags_test.go
@@ -73,6 +73,7 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 				MaxResultSize:                    4096,
 				SetSecurityContext:               true,
 				Coschedule:                       config.CoscheduleDisabled,
+				EnableCELInWhenExpression:        true,
 			},
 			fileName: "feature-flags-all-flags-set",
 		},
@@ -269,6 +270,9 @@ func TestNewFeatureFlagsConfigMapErrors(t *testing.T) {
 	}, {
 		fileName: "feature-flags-invalid-disable-affinity-assistant",
 		want:     `failed parsing feature flags config "truee": strconv.ParseBool: parsing "truee": invalid syntax`,
+	}, {
+		fileName: "feature-flags-invalid-enable-cel-in-whenexpression",
+		want:     `failed parsing feature flags config "invalid": strconv.ParseBool: parsing "invalid": invalid syntax`,
 	}} {
 		t.Run(tc.fileName, func(t *testing.T) {
 			cm := test.ConfigMapFromTestFile(t, tc.fileName)

--- a/pkg/apis/config/testdata/feature-flags-invalid-enable-cel-in-whenexpression.yaml
+++ b/pkg/apis/config/testdata/feature-flags-invalid-enable-cel-in-whenexpression.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 The Tekton Authors
+# Copyright 2023 The Tekton Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,18 +18,4 @@ metadata:
   name: feature-flags
   namespace: tekton-pipelines
 data:
-  disable-affinity-assistant: "true"
-  coschedule: "disabled"
-  running-in-environment-with-injected-sidecars: "false"
-  await-sidecar-readiness: "false"
-  require-git-ssh-secret-known-hosts: "true"
-  enable-tekton-oci-bundles: "true"
-  enable-custom-tasks: "true"
-  enable-api-fields: "alpha"
-  send-cloudevents-for-runs: "true"
-  enforce-nonfalsifiability: "spire"
-  trusted-resources-verification-no-match-policy: "fail"
-  enable-provenance-in-status: "false"
-  set-security-context: "true"
-  keep-pod-on-cancel: "true"
-  enable-cel-in-whenexpression: "true"
+  enable-cel-in-whenexpression: "invalid"

--- a/pkg/apis/pipeline/v1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1/openapi_generated.go
@@ -4289,7 +4289,6 @@ func schema_pkg_apis_pipeline_v1_WhenExpression(ref common.ReferenceCallback) co
 					"input": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Input is the string for guard checking which can be a static input or an output from a parent Task",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -4297,7 +4296,6 @@ func schema_pkg_apis_pipeline_v1_WhenExpression(ref common.ReferenceCallback) co
 					"operator": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Operator that represents an Input's relationship to the values",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -4322,8 +4320,14 @@ func schema_pkg_apis_pipeline_v1_WhenExpression(ref common.ReferenceCallback) co
 							},
 						},
 					},
+					"cel": {
+						SchemaProps: spec.SchemaProps{
+							Description: "CEL is a string of Common Language Expression, which can be used to conditionally execute the task based on the result of the expression evaluation More info about CEL syntax: https://github.com/google/cel-spec/blob/master/doc/langdef.md",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
-				Required: []string{"input", "operator", "values"},
 			},
 		},
 	}

--- a/pkg/apis/pipeline/v1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1/pipeline_validation.go
@@ -88,7 +88,7 @@ func (ps *PipelineSpec) Validate(ctx context.Context) (errs *apis.FieldError) {
 	errs = errs.Also(validatePipelineResults(ps.Results, ps.Tasks, ps.Finally))
 	errs = errs.Also(validateTasksAndFinallySection(ps))
 	errs = errs.Also(validateFinalTasks(ps.Tasks, ps.Finally))
-	errs = errs.Also(validateWhenExpressions(ps.Tasks, ps.Finally))
+	errs = errs.Also(validateWhenExpressions(ctx, ps.Tasks, ps.Finally))
 	errs = errs.Also(validateMatrix(ctx, ps.Tasks).ViaField("tasks"))
 	errs = errs.Also(validateMatrix(ctx, ps.Finally).ViaField("finally"))
 	return errs
@@ -745,12 +745,12 @@ func validateResultsVariablesExpressionsInFinally(expressions []string, pipeline
 	return errs
 }
 
-func validateWhenExpressions(tasks []PipelineTask, finalTasks []PipelineTask) (errs *apis.FieldError) {
+func validateWhenExpressions(ctx context.Context, tasks []PipelineTask, finalTasks []PipelineTask) (errs *apis.FieldError) {
 	for i, t := range tasks {
-		errs = errs.Also(t.When.validate().ViaFieldIndex("tasks", i))
+		errs = errs.Also(t.When.validate(ctx).ViaFieldIndex("tasks", i))
 	}
 	for i, t := range finalTasks {
-		errs = errs.Also(t.When.validate().ViaFieldIndex("finally", i))
+		errs = errs.Also(t.When.validate(ctx).ViaFieldIndex("finally", i))
 	}
 	return errs
 }

--- a/pkg/apis/pipeline/v1/swagger.json
+++ b/pkg/apis/pipeline/v1/swagger.json
@@ -2220,21 +2220,18 @@
     "v1.WhenExpression": {
       "description": "WhenExpression allows a PipelineTask to declare expressions to be evaluated before the Task is run to determine whether the Task should be executed or skipped",
       "type": "object",
-      "required": [
-        "input",
-        "operator",
-        "values"
-      ],
       "properties": {
+        "cel": {
+          "description": "CEL is a string of Common Language Expression, which can be used to conditionally execute the task based on the result of the expression evaluation More info about CEL syntax: https://github.com/google/cel-spec/blob/master/doc/langdef.md",
+          "type": "string"
+        },
         "input": {
           "description": "Input is the string for guard checking which can be a static input or an output from a parent Task",
-          "type": "string",
-          "default": ""
+          "type": "string"
         },
         "operator": {
           "description": "Operator that represents an Input's relationship to the values",
-          "type": "string",
-          "default": ""
+          "type": "string"
         },
         "values": {
           "description": "Values is an array of strings, which is compared against the input, for guard checking It must be non-empty",

--- a/pkg/apis/pipeline/v1/when_types.go
+++ b/pkg/apis/pipeline/v1/when_types.go
@@ -27,15 +27,21 @@ import (
 // to determine whether the Task should be executed or skipped
 type WhenExpression struct {
 	// Input is the string for guard checking which can be a static input or an output from a parent Task
-	Input string `json:"input"`
+	Input string `json:"input,omitempty"`
 
 	// Operator that represents an Input's relationship to the values
-	Operator selection.Operator `json:"operator"`
+	Operator selection.Operator `json:"operator,omitempty"`
 
 	// Values is an array of strings, which is compared against the input, for guard checking
 	// It must be non-empty
 	// +listType=atomic
-	Values []string `json:"values"`
+	Values []string `json:"values,omitempty"`
+
+	// CEL is a string of Common Language Expression, which can be used to conditionally execute
+	// the task based on the result of the expression evaluation
+	// More info about CEL syntax: https://github.com/google/cel-spec/blob/master/doc/langdef.md
+	// +optional
+	CEL string `json:"cel,omitempty"`
 }
 
 func (we *WhenExpression) isInputInValues() bool {

--- a/pkg/apis/pipeline/v1/when_validation_test.go
+++ b/pkg/apis/pipeline/v1/when_validation_test.go
@@ -17,8 +17,10 @@ limitations under the License.
 package v1
 
 import (
+	"context"
 	"testing"
 
+	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"k8s.io/apimachinery/pkg/selection"
 )
 
@@ -54,7 +56,7 @@ func TestWhenExpressions_Valid(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := tt.wes.validate(); err != nil {
+			if err := tt.wes.validate(context.Background()); err != nil {
 				t.Errorf("WhenExpressions.validate() returned an error for valid when expressions: %s", tt.wes)
 			}
 		})
@@ -97,8 +99,67 @@ func TestWhenExpressions_Invalid(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := tt.wes.validate(); err == nil {
+			if err := tt.wes.validate(context.Background()); err == nil {
 				t.Errorf("WhenExpressions.validate() did not return error for invalid when expressions: %s, %s", tt.wes, err)
+			}
+		})
+	}
+}
+
+func TestCELinWhenExpressions_Valid(t *testing.T) {
+	ctx := config.ToContext(context.Background(), &config.Config{
+		FeatureFlags: &config.FeatureFlags{
+			EnableCELInWhenExpression: true,
+		},
+	})
+	tests := []struct {
+		name string
+		wes  WhenExpressions
+	}{{
+		name: "valid cel",
+		wes: []WhenExpression{{
+			CEL: " 'foo' == 'foo' ",
+		}},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.wes.validate(ctx); err != nil {
+				t.Errorf("WhenExpressions.validate() returned an error: %s for valid when expressions: %s", err, tt.wes)
+			}
+		})
+	}
+}
+
+func TestCELWhenExpressions_Invalid(t *testing.T) {
+	tests := []struct {
+		name                      string
+		wes                       WhenExpressions
+		enableCELInWhenExpression bool
+	}{{
+		name: "feature flag not set",
+		wes: []WhenExpression{{
+			CEL: " 'foo' == 'foo' ",
+		}},
+		enableCELInWhenExpression: false,
+	}, {
+		name: "CEL should not coexist with input+operator+values",
+		wes: []WhenExpression{{
+			CEL:      "'foo' != 'foo'",
+			Input:    "foo",
+			Operator: selection.In,
+			Values:   []string{"foo"},
+		}},
+		enableCELInWhenExpression: true,
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := config.ToContext(context.Background(), &config.Config{
+				FeatureFlags: &config.FeatureFlags{
+					EnableCELInWhenExpression: tt.enableCELInWhenExpression,
+				},
+			})
+			if err := tt.wes.validate(ctx); err == nil {
+				t.Errorf("WhenExpressions.validate() did not return error for invalid when expressions: %s", tt.wes)
 			}
 		})
 	}

--- a/pkg/apis/pipeline/v1beta1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1beta1/openapi_generated.go
@@ -5693,7 +5693,6 @@ func schema_pkg_apis_pipeline_v1beta1_WhenExpression(ref common.ReferenceCallbac
 					"input": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Input is the string for guard checking which can be a static input or an output from a parent Task",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -5701,7 +5700,6 @@ func schema_pkg_apis_pipeline_v1beta1_WhenExpression(ref common.ReferenceCallbac
 					"operator": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Operator that represents an Input's relationship to the values",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -5726,8 +5724,14 @@ func schema_pkg_apis_pipeline_v1beta1_WhenExpression(ref common.ReferenceCallbac
 							},
 						},
 					},
+					"cel": {
+						SchemaProps: spec.SchemaProps{
+							Description: "CEL is a string of Common Language Expression, which can be used to conditionally execute the task based on the result of the expression evaluation More info about CEL syntax: https://github.com/google/cel-spec/blob/master/doc/langdef.md",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
-				Required: []string{"input", "operator", "values"},
 			},
 		},
 	}

--- a/pkg/apis/pipeline/v1beta1/pipeline_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_conversion.go
@@ -262,12 +262,14 @@ func (we WhenExpression) convertTo(ctx context.Context, sink *v1.WhenExpression)
 	sink.Input = we.Input
 	sink.Operator = we.Operator
 	sink.Values = we.Values
+	sink.CEL = we.CEL
 }
 
 func (we *WhenExpression) convertFrom(ctx context.Context, source v1.WhenExpression) {
 	we.Input = source.Input
 	we.Operator = source.Operator
 	we.Values = source.Values
+	we.CEL = source.CEL
 }
 
 func (m *Matrix) convertTo(ctx context.Context, sink *v1.Matrix) {

--- a/pkg/apis/pipeline/v1beta1/pipeline_conversion_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_conversion_test.go
@@ -62,6 +62,9 @@ func TestPipelineConversion(t *testing.T) {
 					Name:    "foo",
 					OnError: v1beta1.PipelineTaskContinue,
 					TaskRef: &v1beta1.TaskRef{Name: "example.com/my-foo-task"},
+					WhenExpressions: v1beta1.WhenExpressions{{
+						CEL: "'$(params.param-1)'=='foo'",
+					}},
 				}},
 				Params: []v1beta1.ParamSpec{{
 					Name:        "param-1",

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation.go
@@ -86,7 +86,7 @@ func (ps *PipelineSpec) Validate(ctx context.Context) (errs *apis.FieldError) {
 	errs = errs.Also(validatePipelineResults(ps.Results, ps.Tasks, ps.Finally))
 	errs = errs.Also(validateTasksAndFinallySection(ps))
 	errs = errs.Also(validateFinalTasks(ps.Tasks, ps.Finally))
-	errs = errs.Also(validateWhenExpressions(ps.Tasks, ps.Finally))
+	errs = errs.Also(validateWhenExpressions(ctx, ps.Tasks, ps.Finally))
 	errs = errs.Also(validateMatrix(ctx, ps.Tasks).ViaField("tasks"))
 	errs = errs.Also(validateMatrix(ctx, ps.Finally).ViaField("finally"))
 	return errs
@@ -707,12 +707,12 @@ func validateResultsVariablesExpressionsInFinally(expressions []string, pipeline
 	return errs
 }
 
-func validateWhenExpressions(tasks []PipelineTask, finalTasks []PipelineTask) (errs *apis.FieldError) {
+func validateWhenExpressions(ctx context.Context, tasks []PipelineTask, finalTasks []PipelineTask) (errs *apis.FieldError) {
 	for i, t := range tasks {
-		errs = errs.Also(t.WhenExpressions.validate().ViaFieldIndex("tasks", i))
+		errs = errs.Also(t.WhenExpressions.validate(ctx).ViaFieldIndex("tasks", i))
 	}
 	for i, t := range finalTasks {
-		errs = errs.Also(t.WhenExpressions.validate().ViaFieldIndex("finally", i))
+		errs = errs.Also(t.WhenExpressions.validate(ctx).ViaFieldIndex("finally", i))
 	}
 	return errs
 }

--- a/pkg/apis/pipeline/v1beta1/swagger.json
+++ b/pkg/apis/pipeline/v1beta1/swagger.json
@@ -3111,21 +3111,18 @@
     "v1beta1.WhenExpression": {
       "description": "WhenExpression allows a PipelineTask to declare expressions to be evaluated before the Task is run to determine whether the Task should be executed or skipped",
       "type": "object",
-      "required": [
-        "input",
-        "operator",
-        "values"
-      ],
       "properties": {
+        "cel": {
+          "description": "CEL is a string of Common Language Expression, which can be used to conditionally execute the task based on the result of the expression evaluation More info about CEL syntax: https://github.com/google/cel-spec/blob/master/doc/langdef.md",
+          "type": "string"
+        },
         "input": {
           "description": "Input is the string for guard checking which can be a static input or an output from a parent Task",
-          "type": "string",
-          "default": ""
+          "type": "string"
         },
         "operator": {
           "description": "Operator that represents an Input's relationship to the values",
-          "type": "string",
-          "default": ""
+          "type": "string"
         },
         "values": {
           "description": "Values is an array of strings, which is compared against the input, for guard checking It must be non-empty",

--- a/pkg/apis/pipeline/v1beta1/when_types.go
+++ b/pkg/apis/pipeline/v1beta1/when_types.go
@@ -27,15 +27,21 @@ import (
 // to determine whether the Task should be executed or skipped
 type WhenExpression struct {
 	// Input is the string for guard checking which can be a static input or an output from a parent Task
-	Input string `json:"input"`
+	Input string `json:"input,omitempty"`
 
 	// Operator that represents an Input's relationship to the values
-	Operator selection.Operator `json:"operator"`
+	Operator selection.Operator `json:"operator,omitempty"`
 
 	// Values is an array of strings, which is compared against the input, for guard checking
 	// It must be non-empty
 	// +listType=atomic
-	Values []string `json:"values"`
+	Values []string `json:"values,omitempty"`
+
+	// CEL is a string of Common Language Expression, which can be used to conditionally execute
+	// the task based on the result of the expression evaluation
+	// More info about CEL syntax: https://github.com/google/cel-spec/blob/master/doc/langdef.md
+	// +optional
+	CEL string `json:"cel,omitempty"`
 }
 
 func (we *WhenExpression) isInputInValues() bool {

--- a/pkg/apis/pipeline/v1beta1/when_validation.go
+++ b/pkg/apis/pipeline/v1beta1/when_validation.go
@@ -17,9 +17,11 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
+	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -31,18 +33,28 @@ var validWhenOperators = []string{
 	string(selection.NotIn),
 }
 
-func (wes WhenExpressions) validate() *apis.FieldError {
-	return wes.validateWhenExpressionsFields().ViaField("when")
+func (wes WhenExpressions) validate(ctx context.Context) *apis.FieldError {
+	return wes.validateWhenExpressionsFields(ctx).ViaField("when")
 }
 
-func (wes WhenExpressions) validateWhenExpressionsFields() (errs *apis.FieldError) {
+func (wes WhenExpressions) validateWhenExpressionsFields(ctx context.Context) (errs *apis.FieldError) {
 	for idx, we := range wes {
-		errs = errs.Also(we.validateWhenExpressionFields().ViaIndex(idx))
+		errs = errs.Also(we.validateWhenExpressionFields(ctx).ViaIndex(idx))
 	}
 	return errs
 }
 
-func (we *WhenExpression) validateWhenExpressionFields() *apis.FieldError {
+func (we *WhenExpression) validateWhenExpressionFields(ctx context.Context) *apis.FieldError {
+	if we.CEL != "" {
+		if !config.FromContextOrDefaults(ctx).FeatureFlags.EnableCELInWhenExpression {
+			return apis.ErrGeneric("feature flag %s should be set to true to use CEL: %s in WhenExpression", config.EnableCELInWhenExpression, we.CEL)
+		}
+		if we.Input != "" || we.Operator != "" || len(we.Values) != 0 {
+			return apis.ErrGeneric(fmt.Sprintf("cel and input+operator+values cannot be set in one WhenExpression: %v", we))
+		}
+		return nil
+	}
+
 	if equality.Semantic.DeepEqual(we, &WhenExpression{}) || we == nil {
 		return apis.ErrMissingField(apis.CurrentField)
 	}

--- a/pkg/apis/pipeline/v1beta1/when_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/when_validation_test.go
@@ -17,8 +17,10 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"testing"
 
+	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"k8s.io/apimachinery/pkg/selection"
 )
 
@@ -54,7 +56,7 @@ func TestWhenExpressions_Valid(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := tt.wes.validate(); err != nil {
+			if err := tt.wes.validate(context.Background()); err != nil {
 				t.Errorf("WhenExpressions.validate() returned an error for valid when expressions: %s", tt.wes)
 			}
 		})
@@ -97,8 +99,67 @@ func TestWhenExpressions_Invalid(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := tt.wes.validate(); err == nil {
+			if err := tt.wes.validate(context.Background()); err == nil {
 				t.Errorf("WhenExpressions.validate() did not return error for invalid when expressions: %s, %s", tt.wes, err)
+			}
+		})
+	}
+}
+
+func TestCELinWhenExpressions_Valid(t *testing.T) {
+	ctx := config.ToContext(context.Background(), &config.Config{
+		FeatureFlags: &config.FeatureFlags{
+			EnableCELInWhenExpression: true,
+		},
+	})
+	tests := []struct {
+		name string
+		wes  WhenExpressions
+	}{{
+		name: "valid cel",
+		wes: []WhenExpression{{
+			CEL: " 'foo' == 'foo' ",
+		}},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.wes.validate(ctx); err != nil {
+				t.Errorf("WhenExpressions.validate() returned an error: %s for valid when expressions: %s", err, tt.wes)
+			}
+		})
+	}
+}
+
+func TestCELWhenExpressions_Invalid(t *testing.T) {
+	tests := []struct {
+		name                      string
+		wes                       WhenExpressions
+		enableCELInWhenExpression bool
+	}{{
+		name: "feature flag not set",
+		wes: []WhenExpression{{
+			CEL: " 'foo' == 'foo' ",
+		}},
+		enableCELInWhenExpression: false,
+	}, {
+		name: "CEL should not coexist with input+operator+values",
+		wes: []WhenExpression{{
+			CEL:      "'foo' != 'foo'",
+			Input:    "foo",
+			Operator: selection.In,
+			Values:   []string{"foo"},
+		}},
+		enableCELInWhenExpression: true,
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := config.ToContext(context.Background(), &config.Config{
+				FeatureFlags: &config.FeatureFlags{
+					EnableCELInWhenExpression: tt.enableCELInWhenExpression,
+				},
+			})
+			if err := tt.wes.validate(ctx); err == nil {
+				t.Errorf("WhenExpressions.validate() did not return error for invalid when expressions: %s", tt.wes)
 			}
 		})
 	}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This commit is the 2nd PR of [TEP-0145](https://github.com/tektoncd/community/blob/main/teps/0145-cel-in-whenexpression.md) tracking issue is https://github.com/tektoncd/pipeline/issues/7244.

This commit adds `CEL` field to the `WhenExpression`, a feature flag `enable-cel-in-whenexpression` to guard the new api field.

Signed-off-by: Yongxuan Zhang yongxuanzhang@google.com

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
