### PR TITLE
Set public Tekton Hub API as default catalog

### DIFF
--- a/config/resolvers/resolvers-deployment.yaml
+++ b/config/resolvers/resolvers-deployment.yaml
@@ -102,6 +102,8 @@ spec:
       # Override this env var to set a private hub api endpoint
         - name: ARTIFACT_HUB_API
           value: "https://artifacthub.io/"
+        - name: TEKTON_HUB_API
+          value: "https://api.hub.tekton.dev/"
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true

--- a/docs/hub-resolver.md
+++ b/docs/hub-resolver.md
@@ -64,7 +64,10 @@ env
   value: "https://artifacthub.io/"
 ```
 
-When setting the `type` field to `tekton`, you **must** configure your own instance of the Tekton Hub by setting the `TEKTON_HUB_API` environment variable in
+When setting the `type` field to `tekton`, the resolver will hit the public
+tekton catalog api at https://api.hub.tekton.dev by default but you can configure
+your own instance of the Tekton Hub by setting the `TEKTON_HUB_API` environment
+variable in
 [`../config/resolvers/resolvers-deployment.yaml`](../config/resolvers/resolvers-deployment.yaml). Example:
 
 ```yaml

--- a/go.mod
+++ b/go.mod
@@ -190,7 +190,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
-	github.com/hashicorp/go-version v1.6.0 // indirect
+	github.com/hashicorp/go-version v1.6.0
 	github.com/imdario/mergo v0.3.13 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect


### PR DESCRIPTION
Public tekton hub API was not set by default in the hub resolver, i understand that ArtifactHUB is the future but until then makes it more easier to use the tekton hub

/kind feature

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [X] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [X] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [X] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [X] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [X] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
tekton resolver now uses hub.tekton.dev  by default.
```
