### PR TITLE
Hub resolver: add version constraints

### DIFF
--- a/cmd/resolvers/main.go
+++ b/cmd/resolvers/main.go
@@ -33,8 +33,8 @@ import (
 
 func main() {
 	ctx := filteredinformerfactory.WithSelectors(signals.NewContext(), v1alpha1.ManagedByLabelKey)
-	tektonHubURL := buildHubURL(os.Getenv("TEKTON_HUB_API"), "", hub.TektonHubYamlEndpoint)
-	artifactHubURL := buildHubURL(os.Getenv("ARTIFACT_HUB_API"), hub.DefaultArtifactHubURL, hub.ArtifactHubYamlEndpoint)
+	tektonHubURL := buildHubURL(os.Getenv("TEKTON_HUB_API"), "")
+	artifactHubURL := buildHubURL(os.Getenv("ARTIFACT_HUB_API"), hub.DefaultArtifactHubURL)
 
 	sharedmain.MainWithContext(ctx, "controller",
 		framework.NewController(ctx, &git.Resolver{}),
@@ -43,16 +43,12 @@ func main() {
 		framework.NewController(ctx, &cluster.Resolver{}))
 }
 
-func buildHubURL(configAPI, defaultURL, yamlEndpoint string) string {
+func buildHubURL(configAPI, defaultURL string) string {
 	var hubURL string
 	if configAPI == "" {
 		hubURL = defaultURL
 	} else {
-		if !strings.HasSuffix(configAPI, "/") {
-			configAPI += "/"
-		}
-		hubURL = configAPI + yamlEndpoint
+		hubURL = configAPI
 	}
-
-	return hubURL
+	return strings.TrimSuffix(hubURL, "/")
 }

--- a/cmd/resolvers/main_test.go
+++ b/cmd/resolvers/main_test.go
@@ -1,0 +1,40 @@
+package main
+
+import "testing"
+
+func TestBuildHubURL(t *testing.T) {
+	testCases := []struct {
+		name       string
+		configAPI  string
+		defaultURL string
+		expected   string
+	}{
+		{
+			name:       "configAPI empty",
+			configAPI:  "",
+			defaultURL: "https://tekton.dev",
+			expected:   "https://tekton.dev",
+		},
+		{
+			name:       "configAPI not empty",
+			configAPI:  "https://myhub.com",
+			defaultURL: "https://foo.com",
+			expected:   "https://myhub.com",
+		},
+		{
+			name:       "defaultURL ends with slash",
+			configAPI:  "",
+			defaultURL: "https://bar.com/",
+			expected:   "https://bar.com",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := buildHubURL(tc.configAPI, tc.defaultURL)
+			if actual != tc.expected {
+				t.Errorf("expected %s, but got %s", tc.expected, actual)
+			}
+		})
+	}
+}

--- a/docs/hub-resolver.md
+++ b/docs/hub-resolver.md
@@ -17,7 +17,7 @@ Use resolver type `hub`.
 | `type`           | The type of Hub from where to pull the resource (Optional). Either `artifact` or `tekton` | Default:  `artifact`                                         |
 | `kind`           | Either `task` or `pipeline` (Optional)                                        | Default: `task`                                                     |
 | `name`           | The name of the task or pipeline to fetch from the hub                        | `golang-build`                                             |
-| `version`        | Version of task or pipeline to pull in from hub. Wrap the number in quotes!   | `"0.5.0"`                                                    |
+| `version`        | Version or a Constraint (see [below](#version-constraint) of a task or a pipeline to pull in from. Wrap the number in quotes!   | `"0.5.0"`, `">= 0.5.0"`                                                    |
 
 The Catalogs in the Artifact Hub follows the semVer (i.e.` <major-version>.<minor-version>.0`) and the Catalogs in the Tekton Hub follows the simplified semVer (i.e. `<major-version>.<minor-version>`). Both full and simplified semantic versioning will be accepted by the `version` parameter. The Hub Resolver will map the version to the format expected by the target Hub `type`.
 
@@ -125,6 +125,38 @@ spec:
   # Resolution of the pipeline will succeed but the PipelineRun
   # overall will not succeed without those parameters.
 ```
+
+### Version constraint
+
+Instead of a version you can specify a constraint to choose from. The constraint is a string as documented in the [go-version](https://github.com/hashicorp/go-version) library.
+
+Some examples:
+
+```yaml
+params:
+  - name: name
+    value: git-clone
+  - name: version
+    value: ">=0.7.0"
+```
+
+Will only choose the git-clone task that is greater than version `0.7.0`
+
+```yaml
+params:
+  - name: name
+    value: git-clone
+  - name: version
+    value: ">=0.7.0, < 2.0.0"
+```
+
+Will select the **latest** git-clone task that is greater than version `0.7.0` and
+less than version `2.0.0`, so if the latest task is the version `0.9.0` it will
+be selected.
+
+Other operators for selection are available for comparisons, see the
+[go-version](https://github.com/hashicorp/go-version/blob/644291d14038339745c2d883a1a114488e30b702/constraint.go#L40C2-L48)
+source code.
 
 ---
 

--- a/go.mod
+++ b/go.mod
@@ -190,7 +190,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
-	github.com/hashicorp/go-version v1.6.0 // indirect
+	github.com/hashicorp/go-version v1.6.0
 	github.com/imdario/mergo v0.3.13 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect

--- a/pkg/resolution/resolver/hub/params.go
+++ b/pkg/resolution/resolver/hub/params.go
@@ -14,13 +14,19 @@ limitations under the License.
 package hub
 
 // DefaultArtifactHubURL is the default url for the Artifact hub api
-const DefaultArtifactHubURL = "https://artifacthub.io/api/v1/packages/tekton-%s/%s/%s/%s"
+const DefaultArtifactHubURL = "https://artifacthub.io"
 
 // TektonHubYamlEndpoint is the suffix for a private custom Tekton hub instance
 const TektonHubYamlEndpoint = "v1/resource/%s/%s/%s/%s/yaml"
 
+// DefaultTektonHubListTasksEndpoint
+const TektonHubListTasksEndpoint = "v1/resource/%s/%s/%s"
+
 // ArtifactHubYamlEndpoint is the suffix for a private custom Artifact hub instance
 const ArtifactHubYamlEndpoint = "api/v1/packages/tekton-%s/%s/%s/%s"
+
+// ArtifactHubListTasksEndpoint
+const ArtifactHubListTasksEndpoint = "api/v1/packages/tekton-%s/%s/%s"
 
 // ParamName is the parameter defining what the layer name in the bundle
 // image is.

--- a/test/resolvers_test.go
+++ b/test/resolvers_test.go
@@ -194,7 +194,7 @@ spec:
 	if err := WaitForPipelineRunState(ctx, c, prName, timeout,
 		Chain(
 			FailedWithReason(pod.ReasonCouldntGetTask, prName),
-			FailedWithMessage("requested resource 'https://artifacthub.io/api/v1/packages/tekton-task/tekton-catalog-tasks/git-clone-this-does-not-exist/0.7.0' not found on hub", prName),
+			FailedWithMessage("fail to fetch Artifact Hub resource: requested resource 'https://artifacthub.io/api/v1/packages/tekton-task/tekton-catalog-tasks/git-clone-this-does-not-exist' not found on hub", prName),
 		), "PipelineRunFailed", v1Version); err != nil {
 		t.Fatalf("Error waiting for PipelineRun to finish with expected error: %s", err)
 	}


### PR DESCRIPTION
This let the user specify a version constraint to choose from.

Version constraint looks like this:

```yaml
version: ">= 0.5.0"
```

This will only choose the tasks that are greater than 0.5.0

Additional constraint operators are available, for example:

```yaml
version: ">= 0.5.0, < 2.0.0"
```

/kind feature

This will only choose the tasks that are greater than 0.5.0 and less than 2.0.0

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [X] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [X] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [X] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [X] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [X] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [X] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
hub resolver can now specify a version constraint to choose a version (example: version: ">=0.2.0,< 1.0.0")
```
