### PR TITLE
TEP-0142: Referencing StepActions in Steps

### DIFF
--- a/docs/stepactions.md
+++ b/docs/stepactions.md
@@ -72,6 +72,40 @@ spec:
           name: step-action
 ```
 
+Upon resolution and execution of the `TaskRun`, the `Status` will look something like:
+
+```yaml
+status:
+  completionTime: "2023-10-24T20:28:42Z"
+  conditions:
+  - lastTransitionTime: "2023-10-24T20:28:42Z"
+    message: All Steps have completed executing
+    reason: Succeeded
+    status: "True"
+    type: Succeeded
+  podName: step-action-run-pod
+  provenance:
+    featureFlags:
+      EnableStepActions: true
+      ...
+  startTime: "2023-10-24T20:28:32Z"
+  steps:
+  - container: step-action-runner
+    imageID: docker.io/library/alpine@sha256:eece025e432126ce23f223450a0326fbebde39cdf496a85d8c016293fc851978
+    name: action-runner
+    terminated:
+      containerID: containerd://46a836588967202c05b594696077b147a0eb0621976534765478925bb7ce57f6
+      exitCode: 0
+      finishedAt: "2023-10-24T20:28:42Z"
+      reason: Completed
+      startedAt: "2023-10-24T20:28:42Z"
+  taskSpec:
+    steps:
+    - computeResources: {}
+      image: alpine
+      name: action-runner
+```
+
 If a `Step` is referencing a `StepAction`, it cannot contain the fields supported by `StepActions`. This includes:
 - `image`
 - `command`

--- a/examples/v1/taskruns/alpha/stepaction.yaml
+++ b/examples/v1/taskruns/alpha/stepaction.yaml
@@ -1,0 +1,19 @@
+apiVersion: tekton.dev/v1alpha1
+kind: StepAction
+metadata:
+  name: step-action
+spec:
+  image: alpine
+  script: |
+    echo "I am a Step Action!!!"
+---
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  name: step-action-run
+spec:
+  TaskSpec:
+    steps:
+      - name: action-runner
+        ref:
+          name: step-action

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -332,8 +332,9 @@ func (c *Reconciler) prepare(ctx context.Context, tr *v1.TaskRun) (*v1.TaskSpec,
 		return nil, nil, fmt.Errorf("failed to list VerificationPolicies from namespace %s with error %w", tr.Namespace, err)
 	}
 	getTaskfunc := resources.GetTaskFuncFromTaskRun(ctx, c.KubeClientSet, c.PipelineClientSet, c.resolutionRequester, tr, vp)
+	getStepActionfunc := resources.GetStepActionFunc(c.PipelineClientSet, tr.Namespace)
 
-	taskMeta, taskSpec, err := resources.GetTaskData(ctx, tr, getTaskfunc)
+	taskMeta, taskSpec, err := resources.GetTaskData(ctx, tr, getTaskfunc, getStepActionfunc)
 	switch {
 	case errors.Is(err, remote.ErrRequestInProgress):
 		message := fmt.Sprintf("TaskRun %s/%s awaiting remote resource", tr.Namespace, tr.Name)

--- a/test/parse/yaml.go
+++ b/test/parse/yaml.go
@@ -23,6 +23,17 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+// MustParseV1alpha1StepAction takes YAML and parses it into a *v1alpha1.StepAction
+func MustParseV1alpha1StepAction(t *testing.T, yaml string) *v1alpha1.StepAction {
+	t.Helper()
+	var sa v1alpha1.StepAction
+	yaml = `apiVersion: tekton.dev/v1alpha1
+kind: StepAction
+` + yaml
+	mustParseYAML(t, yaml, &sa)
+	return &sa
+}
+
 // MustParseV1beta1TaskRun takes YAML and parses it into a *v1beta1.TaskRun
 func MustParseV1beta1TaskRun(t *testing.T, yaml string) *v1beta1.TaskRun {
 	t.Helper()


### PR DESCRIPTION
This PR allows the `Step` to reference a `StepAction` CRD deployed on the cluster. This capability is gated behind a feature flag `enable-step-actions`.  Remote resolution of `StepActions` will be implemented in a follow-up PR.

This is the fourth item on the implementation Issue https://github.com/tektoncd/pipeline/issues/7259

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
[WIP] Enables referencing of StepActions in Steps if the feature flag "enable-step-actions: true" is set.
```
/kind feature