### PR TITLE
fix wait entrypoint cancellation error log output.

### DIFF
--- a/cmd/entrypoint/main.go
+++ b/cmd/entrypoint/main.go
@@ -183,7 +183,7 @@ func main() {
 			log.Print(err.Error())
 			os.Exit(1)
 		case entrypoint.ContextError:
-			if errors.Is(err, entrypoint.ErrContextCanceled) {
+			if entrypoint.IsContextCanceledError(err) {
 				log.Print("Step was cancelled")
 				// use the SIGKILL signal to distinguish normal exit programs, just like kill -9 PID
 				os.Exit(int(syscall.SIGKILL))

--- a/pkg/entrypoint/entrypointer.go
+++ b/pkg/entrypoint/entrypointer.go
@@ -60,6 +60,16 @@ var (
 	ErrContextCanceled = ContextError(context.Canceled.Error())
 )
 
+// IsContextDeadlineError determine whether the error is context deadline
+func IsContextDeadlineError(err error) bool {
+	return errors.Is(err, ErrContextDeadlineExceeded)
+}
+
+// IsContextCanceledError determine whether the error is context canceled
+func IsContextCanceledError(err error) bool {
+	return errors.Is(err, ErrContextCanceled)
+}
+
 // Entrypointer holds fields for running commands with redirected
 // entrypoints.
 type Entrypointer struct {
@@ -174,7 +184,7 @@ func (e Entrypointer) Go() error {
 		defer cancel()
 		// start a goroutine to listen for cancellation file
 		go func() {
-			if err := e.waitingCancellation(ctx, cancel); err != nil {
+			if err := e.waitingCancellation(ctx, cancel); err != nil && (!IsContextCanceledError(err) && !IsContextDeadlineError(err)) {
 				logger.Error("Error while waiting for cancellation", zap.Error(err))
 			}
 		}()

--- a/pkg/entrypoint/entrypointer_test.go
+++ b/pkg/entrypoint/entrypointer_test.go
@@ -686,6 +686,28 @@ func TestEntrypointerStopOnCancel(t *testing.T) {
 	}
 }
 
+func TestIsContextDeadlineError(t *testing.T) {
+	ctxErr := ContextError(context.DeadlineExceeded.Error())
+	if !IsContextDeadlineError(ctxErr) {
+		t.Errorf("expected context deadline error, got %v", ctxErr)
+	}
+	normalErr := ContextError("normal error")
+	if IsContextDeadlineError(normalErr) {
+		t.Errorf("expected normal error, got %v", normalErr)
+	}
+}
+
+func TestIsContextCanceledError(t *testing.T) {
+	ctxErr := ContextError(context.Canceled.Error())
+	if !IsContextCanceledError(ctxErr) {
+		t.Errorf("expected context canceled error, got %v", ctxErr)
+	}
+	normalErr := ContextError("normal error")
+	if IsContextCanceledError(normalErr) {
+		t.Errorf("expected normal error, got %v", normalErr)
+	}
+}
+
 type fakeWaiter struct {
 	sync.Mutex
 	waited             []string


### PR DESCRIPTION
# Changes
fix #7268 
context canceled should be treated as normal completion for `waitingCancellation`

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
