### PR TITLE
[TEP-0144] Add feature flag and doc placeholder

### DIFF
--- a/config/config-feature-flags.yaml
+++ b/config/config-feature-flags.yaml
@@ -127,3 +127,6 @@ data:
   # Setting this flag to "true" will enable the use of StepActions in Steps
   # This feature is in preview mode and not implemented yet. Please check #7259 for updates.
   enable-step-actions: "false"
+  # Setting this flag to "true" will enable the built-in param input validation via param enum.
+  # NOTE (#7270): this feature is still under development and not yet functional.
+  enable-param-enum: "false"

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -269,6 +269,13 @@ spec:
         - "bar"
 ```
 
+#### Param enum
+> :seedling: **Specifying `enum` is an [alpha](additional-configs.md#alpha-features) feature.** The `enable-param-enum` feature flag must be set to `"true"` to enable this feature.
+
+> :seedling: This feature is WIP and not yet supported/implemented. Documentation to be completed.
+
+Parameter declarations can include `enum` which is a predefine set of valid values that can be accepted by the `Pipeline`.
+
 ## Adding `Tasks` to the `Pipeline`
 
  Your `Pipeline` definition must reference at least one [`Task`](tasks.md).

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -712,6 +712,13 @@ spec:
         - "--someotherflag"
 ```
 
+#### Param enum
+> :seedling: **Specifying `enum` is an [alpha](additional-configs.md#alpha-features) feature.** The `enable-param-enum` feature flag must be set to `"true"` to enable this feature.
+
+> :seedling: This feature is WIP and not yet supported/implemented. Documentation to be completed.
+
+Parameter declarations can include `enum` which is a predefine set of valid values that can be accepted by the `Task`.
+
 ### Specifying `Workspaces`
 
 [`Workspaces`](workspaces.md#using-workspaces-in-tasks) allow you to specify

--- a/pkg/apis/config/feature_flags.go
+++ b/pkg/apis/config/feature_flags.go
@@ -100,6 +100,10 @@ const (
 	EnableStepActions = "enable-step-actions"
 	// DefaultEnableStepActions is the default value for EnableStepActions
 	DefaultEnableStepActions = false
+	// EnableParamEnum is the flag to enabled enum in params
+	EnableParamEnum = "enable-param-enum"
+	// DefaultEnableParamEnum is the default value for EnableParamEnum
+	DefaultEnableParamEnum = false
 
 	disableAffinityAssistantKey         = "disable-affinity-assistant"
 	disableCredsInitKey                 = "disable-creds-init"
@@ -150,6 +154,7 @@ type FeatureFlags struct {
 	Coschedule                string
 	EnableCELInWhenExpression bool
 	EnableStepActions         bool
+	EnableParamEnum           bool
 }
 
 // GetFeatureFlagsConfigName returns the name of the configmap containing all
@@ -226,6 +231,9 @@ func NewFeatureFlagsFromMap(cfgMap map[string]string) (*FeatureFlags, error) {
 		return nil, err
 	}
 	if err := setFeature(EnableStepActions, DefaultEnableStepActions, &tc.EnableStepActions); err != nil {
+		return nil, err
+	}
+	if err := setFeature(EnableParamEnum, DefaultEnableParamEnum, &tc.EnableParamEnum); err != nil {
 		return nil, err
 	}
 	// Given that they are alpha features, Tekton Bundles and Custom Tasks should be switched on if

--- a/pkg/apis/config/feature_flags_test.go
+++ b/pkg/apis/config/feature_flags_test.go
@@ -75,6 +75,7 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 				Coschedule:                       config.CoscheduleDisabled,
 				EnableCELInWhenExpression:        true,
 				EnableStepActions:                true,
+				EnableParamEnum:                  true,
 			},
 			fileName: "feature-flags-all-flags-set",
 		},
@@ -276,6 +277,9 @@ func TestNewFeatureFlagsConfigMapErrors(t *testing.T) {
 		want:     `failed parsing feature flags config "invalid": strconv.ParseBool: parsing "invalid": invalid syntax`,
 	}, {
 		fileName: "feature-flags-invalid-enable-step-actions",
+		want:     `failed parsing feature flags config "invalid": strconv.ParseBool: parsing "invalid": invalid syntax`,
+	}, {
+		fileName: "feature-flags-invalid-enable-param-enum",
 		want:     `failed parsing feature flags config "invalid": strconv.ParseBool: parsing "invalid": invalid syntax`,
 	}} {
 		t.Run(tc.fileName, func(t *testing.T) {

--- a/pkg/apis/config/testdata/feature-flags-all-flags-set.yaml
+++ b/pkg/apis/config/testdata/feature-flags-all-flags-set.yaml
@@ -34,3 +34,4 @@ data:
   keep-pod-on-cancel: "true"
   enable-cel-in-whenexpression: "true"
   enable-step-actions: "true"
+  enable-param-enum: "true"

--- a/pkg/apis/config/testdata/feature-flags-invalid-enable-param-enum.yaml
+++ b/pkg/apis/config/testdata/feature-flags-invalid-enable-param-enum.yaml
@@ -1,0 +1,21 @@
+# Copyright 2023 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: feature-flags
+  namespace: tekton-pipelines
+data:
+  enable-param-enum: "invalid"


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Part of [#7270][#7270]. In [TEP-0144][tep-0144] we proposed a new `enum` field to support built-in param input validation.

This commit adds the feature flag `enable-param-enum` and documentation placeholder for the feature.

/kind feature

[#7270]: https://github.com/tektoncd/pipeline/issues/7270
[tep-0144]: https://github.com/tektoncd/community/blob/main/teps/0144-param-enum.md

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
[WIP] Add `enable-param-enum` feature flag to gate the use of `Param.Enum` API field
```
