### PR TITLE
[TEP-0144] Add enum API field

### DIFF
--- a/docs/pipeline-api.md
+++ b/docs/pipeline-api.md
@@ -1691,6 +1691,19 @@ default is set, a Task may be executed without a supplied value for the
 parameter.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>enum</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Enum declares a set of allowed param input values for tasks/pipelines that can be validated.
+If Enum is not set, no input validation is performed for the param.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="tekton.dev/v1.ParamSpecs">ParamSpecs
@@ -9961,6 +9974,19 @@ ParamValue
 <p>Default is the value a parameter takes if no input value is supplied. If
 default is set, a Task may be executed without a supplied value for the
 parameter.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>enum</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Enum declares a set of allowed param input values for tasks/pipelines that can be validated.
+If Enum is not set, no input validation is performed for the param.</p>
 </td>
 </tr>
 </tbody>

--- a/hack/ignored-openapi-violations.list
+++ b/hack/ignored-openapi-violations.list
@@ -41,3 +41,5 @@ API rule violation: names_match,github.com/tektoncd/pipeline/pkg/apis/resolution
 API rule violation: list_type_missing,github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1,RunSpec,Workspaces
 API rule violation: list_type_missing,github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1,VerificationPolicySpec,Authorities
 API rule violation: list_type_missing,github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1,VerificationPolicySpec,Resources
+API rule violation: list_type_missing,github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1,ParamSpec,Enum
+API rule violation: list_type_missing,github.com/tektoncd/pipeline/pkg/apis/pipeline/v1,ParamSpec,Enum

--- a/pkg/apis/pipeline/v1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1/openapi_generated.go
@@ -789,6 +789,21 @@ func schema_pkg_apis_pipeline_v1_ParamSpec(ref common.ReferenceCallback) common.
 							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.ParamValue"),
 						},
 					},
+					"enum": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Enum declares a set of allowed param input values for tasks/pipelines that can be validated. If Enum is not set, no input validation is performed for the param.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
+									},
+								},
+							},
+						},
+					},
 				},
 				Required: []string{"name"},
 			},

--- a/pkg/apis/pipeline/v1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1/pipeline_validation.go
@@ -433,11 +433,12 @@ func validatePipelineTasksWorkspacesUsage(wss []PipelineWorkspaceDeclaration, pt
 
 // ValidatePipelineParameterVariables validates parameters with those specified by each pipeline task,
 // (1) it validates the type of parameter is either string or array (2) parameter default value matches
-// with the type of that param
+// with the type of that param (3) no duplication, feature flag and allowed param type when using param enum
 func ValidatePipelineParameterVariables(ctx context.Context, tasks []PipelineTask, params ParamSpecs) (errs *apis.FieldError) {
 	// validates all the types within a slice of ParamSpecs
 	errs = errs.Also(ValidateParameterTypes(ctx, params).ViaField("params"))
 	errs = errs.Also(params.validateNoDuplicateNames())
+	errs = errs.Also(params.validateParamEnums(ctx).ViaField("params"))
 	for i, task := range tasks {
 		errs = errs.Also(task.Params.validateDuplicateParameters().ViaField("params").ViaIndex(i))
 	}

--- a/pkg/apis/pipeline/v1/swagger.json
+++ b/pkg/apis/pipeline/v1/swagger.json
@@ -343,6 +343,14 @@
           "description": "Description is a user-facing description of the parameter that may be used to populate a UI.",
           "type": "string"
         },
+        "enum": {
+          "description": "Enum declares a set of allowed param input values for tasks/pipelines that can be validated. If Enum is not set, no input validation is performed for the param.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "default": ""
+          }
+        },
         "name": {
           "description": "Name declares the name by which a parameter is referenced.",
           "type": "string",

--- a/pkg/apis/pipeline/v1/task_validation.go
+++ b/pkg/apis/pipeline/v1/task_validation.go
@@ -435,6 +435,7 @@ func (p ParamSpec) ValidateObjectType(ctx context.Context) *apis.FieldError {
 func ValidateParameterVariables(ctx context.Context, steps []Step, params ParamSpecs) *apis.FieldError {
 	var errs *apis.FieldError
 	errs = errs.Also(params.validateNoDuplicateNames())
+	errs = errs.Also(params.validateParamEnums(ctx).ViaField("params"))
 	stringParams, arrayParams, objectParams := params.sortByType()
 	stringParameterNames := sets.NewString(stringParams.getNames()...)
 	arrayParameterNames := sets.NewString(arrayParams.getNames()...)

--- a/pkg/apis/pipeline/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/pipeline/v1/zz_generated.deepcopy.go
@@ -231,6 +231,11 @@ func (in *ParamSpec) DeepCopyInto(out *ParamSpec) {
 		*out = new(ParamValue)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Enum != nil {
+		in, out := &in.Enum, &out.Enum
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/apis/pipeline/v1beta1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1beta1/openapi_generated.go
@@ -1330,6 +1330,21 @@ func schema_pkg_apis_pipeline_v1beta1_ParamSpec(ref common.ReferenceCallback) co
 							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.ParamValue"),
 						},
 					},
+					"enum": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Enum declares a set of allowed param input values for tasks/pipelines that can be validated. If Enum is not set, no input validation is performed for the param.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
+									},
+								},
+							},
+						},
+					},
 				},
 				Required: []string{"name"},
 			},

--- a/pkg/apis/pipeline/v1beta1/param_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/param_conversion.go
@@ -30,6 +30,7 @@ func (p ParamSpec) convertTo(ctx context.Context, sink *v1.ParamSpec) {
 		sink.Type = v1.ParamType(ParamTypeString)
 	}
 	sink.Description = p.Description
+	sink.Enum = p.Enum
 	var properties map[string]v1.PropertySpec
 	if p.Properties != nil {
 		properties = make(map[string]v1.PropertySpec)
@@ -54,6 +55,7 @@ func (p *ParamSpec) convertFrom(ctx context.Context, source v1.ParamSpec) {
 		p.Type = ParamTypeString
 	}
 	p.Description = source.Description
+	p.Enum = source.Enum
 	var properties map[string]PropertySpec
 	if source.Properties != nil {
 		properties = make(map[string]PropertySpec)

--- a/pkg/apis/pipeline/v1beta1/param_types.go
+++ b/pkg/apis/pipeline/v1beta1/param_types.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/substitution"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -53,6 +54,10 @@ type ParamSpec struct {
 	// parameter.
 	// +optional
 	Default *ParamValue `json:"default,omitempty"`
+	// Enum declares a set of allowed param input values for tasks/pipelines that can be validated.
+	// If Enum is not set, no input validation is performed for the param.
+	// +optional
+	Enum []string `json:"enum,omitempty"`
 }
 
 // ParamSpecs is a list of ParamSpec
@@ -123,20 +128,45 @@ func (ps ParamSpecs) sortByType() (ParamSpecs, ParamSpecs, ParamSpecs) {
 
 // validateNoDuplicateNames returns an error if any of the params have the same name
 func (ps ParamSpecs) validateNoDuplicateNames() *apis.FieldError {
-	names := ps.getNames()
-	seen := sets.String{}
-	dups := sets.String{}
 	var errs *apis.FieldError
-	for _, n := range names {
-		if seen.Has(n) {
-			dups.Insert(n)
-		}
-		seen.Insert(n)
-	}
-	for n := range dups {
-		errs = errs.Also(apis.ErrGeneric("parameter appears more than once", "").ViaFieldKey("params", n))
+	names := ps.getNames()
+	for dup := range findDups(names) {
+		errs = errs.Also(apis.ErrGeneric("parameter appears more than once", "").ViaFieldKey("params", dup))
 	}
 	return errs
+}
+
+// validateParamEnum validates feature flag, duplication and allowed types for Param Enum
+func (ps ParamSpecs) validateParamEnums(ctx context.Context) *apis.FieldError {
+	var errs *apis.FieldError
+	for _, p := range ps {
+		if len(p.Enum) == 0 {
+			continue
+		}
+		if !config.FromContextOrDefaults(ctx).FeatureFlags.EnableParamEnum {
+			errs = errs.Also(errs, apis.ErrGeneric(fmt.Sprintf("feature flag `%s` should be set to true to use Enum", config.EnableParamEnum), "").ViaKey(p.Name))
+		}
+		if p.Type != ParamTypeString {
+			errs = errs.Also(apis.ErrGeneric("enum can only be set with string type param", "").ViaKey(p.Name))
+		}
+		for dup := range findDups(p.Enum) {
+			errs = errs.Also(apis.ErrGeneric(fmt.Sprintf("parameter enum value %v appears more than once", dup), "").ViaKey(p.Name))
+		}
+	}
+	return errs
+}
+
+// findDups returns the duplicate element in the given slice
+func findDups(vals []string) sets.String {
+	seen := sets.String{}
+	dups := sets.String{}
+	for _, val := range vals {
+		if seen.Has(val) {
+			dups.Insert(val)
+		}
+		seen.Insert(val)
+	}
+	return dups
 }
 
 // setDefaultsForProperties sets default type for PropertySpec (string) if it's not specified

--- a/pkg/apis/pipeline/v1beta1/pipeline_conversion_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_conversion_test.go
@@ -69,6 +69,7 @@ func TestPipelineConversion(t *testing.T) {
 				Params: []v1beta1.ParamSpec{{
 					Name:        "param-1",
 					Type:        v1beta1.ParamTypeString,
+					Enum:        []string{"v1", "v2"},
 					Description: "My first param",
 				}},
 			},

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation.go
@@ -452,11 +452,12 @@ func validatePipelineTasksWorkspacesUsage(wss []PipelineWorkspaceDeclaration, pt
 
 // ValidatePipelineParameterVariables validates parameters with those specified by each pipeline task,
 // (1) it validates the type of parameter is either string or array (2) parameter default value matches
-// with the type of that param
+// with the type of that param (3) no duplication, feature flag and allowed param type when using param enum
 func ValidatePipelineParameterVariables(ctx context.Context, tasks []PipelineTask, params ParamSpecs) (errs *apis.FieldError) {
 	// validates all the types within a slice of ParamSpecs
 	errs = errs.Also(ValidateParameterTypes(ctx, params).ViaField("params"))
 	errs = errs.Also(params.validateNoDuplicateNames())
+	errs = errs.Also(params.validateParamEnums(ctx).ViaField("params"))
 	for i, task := range tasks {
 		errs = errs.Also(task.Params.validateDuplicateParameters().ViaField("params").ViaIndex(i))
 	}

--- a/pkg/apis/pipeline/v1beta1/swagger.json
+++ b/pkg/apis/pipeline/v1beta1/swagger.json
@@ -624,6 +624,14 @@
           "description": "Description is a user-facing description of the parameter that may be used to populate a UI.",
           "type": "string"
         },
+        "enum": {
+          "description": "Enum declares a set of allowed param input values for tasks/pipelines that can be validated. If Enum is not set, no input validation is performed for the param.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "default": ""
+          }
+        },
         "name": {
           "description": "Name declares the name by which a parameter is referenced.",
           "type": "string",

--- a/pkg/apis/pipeline/v1beta1/task_conversion_test.go
+++ b/pkg/apis/pipeline/v1beta1/task_conversion_test.go
@@ -56,6 +56,7 @@ spec:
   params:
   - name: param-1
     type: string
+    enum: ["v1", "v2"]
     description: my first param
   results:
   - name: result-1

--- a/pkg/apis/pipeline/v1beta1/task_validation.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation.go
@@ -441,6 +441,7 @@ func (p ParamSpec) ValidateObjectType(ctx context.Context) *apis.FieldError {
 func ValidateParameterVariables(ctx context.Context, steps []Step, params ParamSpecs) *apis.FieldError {
 	var errs *apis.FieldError
 	errs = errs.Also(params.validateNoDuplicateNames())
+	errs = errs.Also(params.validateParamEnums(ctx).ViaField("params"))
 	stringParams, arrayParams, objectParams := params.sortByType()
 	stringParameterNames := sets.NewString(stringParams.getNames()...)
 	arrayParameterNames := sets.NewString(arrayParams.getNames()...)

--- a/pkg/apis/pipeline/v1beta1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	cfgtesting "github.com/tektoncd/pipeline/pkg/apis/config/testing"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/test/diff"
 	corev1 "k8s.io/api/core/v1"
@@ -2088,5 +2089,108 @@ func TestGetArrayIndexParamRefs(t *testing.T) {
 				t.Errorf("GetIndexingReferencesToArrayParams diff %s", diff.PrintWantGot(d))
 			}
 		})
+	}
+}
+
+func TestParamEnum_Success(t *testing.T) {
+	tcs := []struct {
+		name      string
+		params    v1.ParamSpecs
+		configMap map[string]string
+	}{{
+		name: "valid param enum - success",
+		params: []v1.ParamSpec{{
+			Name: "param1",
+			Type: v1.ParamTypeString,
+			Enum: []string{"v1", "v2"},
+		}, {
+			Name: "param2",
+			Type: v1.ParamTypeString,
+			Enum: []string{"v1", "v2"},
+		}},
+	}, {
+		name: "valid empty param enum - success",
+		params: []v1.ParamSpec{{
+			Name: "param1",
+			Type: v1.ParamTypeString,
+		}, {
+			Name: "param2",
+			Type: v1.ParamTypeString,
+		}},
+	}}
+
+	for _, tc := range tcs {
+		cfg := map[string]string{"enable-param-enum": "true"}
+		ctx := cfgtesting.SetFeatureFlags(context.Background(), t, cfg)
+
+		err := v1.ValidateParameterVariables(ctx, []v1.Step{{Image: "foo"}}, tc.params)
+		if err != nil {
+			t.Errorf("No error expected from ValidateParameterVariables() but got = %v", err)
+		}
+	}
+}
+
+func TestParamEnum_Failure(t *testing.T) {
+	tcs := []struct {
+		name        string
+		params      v1beta1.ParamSpecs
+		configMap   map[string]string
+		expectedErr error
+	}{{
+		name: "param enum with array type - failure",
+		params: []v1beta1.ParamSpec{{
+			Name: "param1",
+			Type: v1beta1.ParamTypeArray,
+			Enum: []string{"v1", "v2"},
+		}},
+		configMap: map[string]string{
+			"enable-param-enum": "true",
+		},
+		expectedErr: fmt.Errorf("enum can only be set with string type param: params[param1]"),
+	}, {
+		name: "param enum with object type - failure",
+		params: []v1beta1.ParamSpec{{
+			Name: "param1",
+			Type: v1beta1.ParamTypeObject,
+			Enum: []string{"v1", "v2"},
+		}},
+		configMap: map[string]string{
+			"enable-param-enum": "true",
+		},
+		expectedErr: fmt.Errorf("enum can only be set with string type param: params[param1]"),
+	}, {
+		name: "param enum with duplicate values - failure",
+		params: []v1beta1.ParamSpec{{
+			Name: "param1",
+			Type: v1beta1.ParamTypeString,
+			Enum: []string{"v1", "v1", "v2"},
+		}},
+		configMap: map[string]string{
+			"enable-param-enum": "true",
+		},
+		expectedErr: fmt.Errorf("parameter enum value v1 appears more than once: params[param1]"),
+	}, {
+		name: "param enum with feature flag disabled - failure",
+		params: []v1beta1.ParamSpec{{
+			Name: "param1",
+			Type: v1beta1.ParamTypeString,
+			Enum: []string{"v1", "v2"},
+		}},
+		configMap: map[string]string{
+			"enable-param-enum": "false",
+		},
+		expectedErr: fmt.Errorf("feature flag `enable-param-enum` should be set to true to use Enum: params[param1]"),
+	}}
+
+	for _, tc := range tcs {
+		ctx := cfgtesting.SetFeatureFlags(context.Background(), t, tc.configMap)
+
+		err := v1beta1.ValidateParameterVariables(ctx, []v1beta1.Step{{Image: "foo"}}, tc.params)
+
+		if err == nil {
+			t.Errorf("No error expected from ValidateParameterVariables() but got = %v", err)
+		} else if d := cmp.Diff(tc.expectedErr.Error(), err.Error()); d != "" {
+			t.Errorf("Rerturned error from ValidateParameterVariables() does not match with the expected error: %s", diff.PrintWantGot(d))
+		}
 	}
 }

--- a/pkg/apis/pipeline/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/pipeline/v1beta1/zz_generated.deepcopy.go
@@ -515,6 +515,11 @@ func (in *ParamSpec) DeepCopyInto(out *ParamSpec) {
 		*out = new(ParamValue)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Enum != nil {
+		in, out := &in.Enum, &out.Enum
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Part of [#7270][#7270]. In [TEP-0144][tep-0144] we proposed a new `enum` field to support built-in param input validation.

This commit adds the `Enum` api field, validation and conversion logic.

/kind feature

[#7270]: https://github.com/tektoncd/pipeline/issues/7270
[tep-0144]: https://github.com/tektoncd/community/blob/main/teps/0144-param-enum.md
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
[WIP] Add `Enum` API field
```
