### PR TITLE
Add credentials to HTTP resolver

### DIFF
--- a/docs/git-resolver.md
+++ b/docs/git-resolver.md
@@ -112,6 +112,10 @@ Note that not all `go-scm` implementations have been tested with the `git` resol
   * BitBucket Server
   * BitBucket Cloud
 
+Fetching from multiple Git providers with different configuration is not
+supported. You can use the [http resolver](./http-resolver.md) to fetch URL
+from another provider with different credentials.
+
 #### Task Resolution
 
 ```yaml

--- a/docs/http-resolver.md
+++ b/docs/http-resolver.md
@@ -1,5 +1,6 @@
 <!--
 ---
+
 linkTitle: "HTTP Resolver"
 weight: 311
 ---
@@ -11,9 +12,12 @@ This resolver responds to type `http`.
 
 ## Parameters
 
-| Param Name       | Description                                                                   | Example Value                                              |
-|------------------|-------------------------------------------------------------------------------|------------------------------------------------------------|
-| `url`            | The URL to fetch from                                                         | https://raw.githubusercontent.com/tektoncd-catalog/git-clone/main/task/git-clone/git-clone.yaml                                                   |
+| Param Name                 | Description                                                                                                                                                                | Example Value                                                                                   |   |
+|----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------|---|
+| `url`                      | The URL to fetch from                                                                                                                                                      | <https://raw.githubusercontent.com/tektoncd-catalog/git-clone/main/task/git-clone/git-clone.yaml> |   |
+| `http-username`            | An optional username when fetching a task with credentials (need to be used in conjunction with `http-password-secret`)                                                    | `git`                                                                                           |   |
+| `http-password-secret`     | An optional secret in the PipelineRun namespace with a reference to a password when fetching a task with credentials (need to be used in conjunction with `http-username`) | `http-password`                                                                                 |   |
+| `http-password-secret-key` | An optional key in the `http-password-secret` to be used when fetching a task with credentials                                                                             | Default: `password`                                                                             |   |
 
 A valid URL must be provided. Only HTTP or HTTPS URLs are supported.
 
@@ -52,6 +56,27 @@ spec:
     params:
     - name: url
       value: https://raw.githubusercontent.com/tektoncd-catalog/git-clone/main/task/git-clone/git-clone.yaml
+```
+
+### Task Resolution with Basic Auth
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: remote-task-reference
+spec:
+  taskRef:
+    resolver: http
+    params:
+    - name: url
+      value: https://raw.githubusercontent.com/owner/private-repo/main/task/task.yaml
+    - name: http-username
+      value: git
+    - name: http-password-secret
+      value: git-secret
+    - name: http-password-secret-key
+      value: git-token
 ```
 
 ### Pipeline Resolution

--- a/examples/v1/pipelineruns/beta/http-resolver-credentials.yaml
+++ b/examples/v1/pipelineruns/beta/http-resolver-credentials.yaml
@@ -1,0 +1,35 @@
+# This http resolver example will uses a username and password to access the
+# URL.
+#
+# http-password-secret is a Kubernetes secret containing the
+# password in the same namespace where this PipelineRun runs.
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: my-secret
+stringData:
+  token: "token"
+---
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  generateName: http-resolver-
+spec:
+  pipelineSpec:
+    tasks:
+      - name: http-resolver
+        taskRef:
+          resolver: http
+          params:
+            - name: url
+              value: https://api.hub.tekton.dev/v1/resource/tekton/task/tkn/0.4/raw
+            - name: http-username
+              value: git
+            - name: http-password-secret
+              value: my-secret
+            - name: http-password-secret-key
+              value: token
+        params:
+          - name: ARGS
+            value: ["version"]

--- a/pkg/resolution/resolver/framework/testing/fakecontroller.go
+++ b/pkg/resolution/resolver/framework/testing/fakecontroller.go
@@ -71,14 +71,14 @@ func RunResolverReconcileTest(ctx context.Context, t *testing.T, d test.Data, re
 	err := testAssets.Controller.Reconciler.Reconcile(testAssets.Ctx, getRequestName(request))
 	if expectedErr != nil {
 		if err == nil {
-			t.Fatalf("expected to get error %v, but got nothing", expectedErr)
+			t.Fatalf("expected to get error: `%v`, but got nothing", expectedErr)
 		}
 		if expectedErr.Error() != err.Error() {
-			t.Fatalf("expected to get error %v, but got %v", expectedErr, err)
+			t.Fatalf("expected to get error `%v`, but got `%v`", expectedErr, err)
 		}
 	} else if err != nil {
 		if ok, _ := controller.IsRequeueKey(err); !ok {
-			t.Fatalf("did not expect an error, but got %v", err)
+			t.Fatalf("did not expect an error, but got `%v`", err)
 		}
 	}
 

--- a/pkg/resolution/resolver/http/params.go
+++ b/pkg/resolution/resolver/http/params.go
@@ -14,6 +14,15 @@ limitations under the License.
 package http
 
 const (
-	// urlParam is the url to fetch the task from
+	// urlParam is the URL to fetch the task from
 	urlParam string = "url"
+
+	// httpBasicAuthUsername is the user name to use for basic auth
+	httpBasicAuthUsername string = "http-username"
+
+	// httpBasicAuthSecret is the reference to a secret in the PipelineRun or TaskRun namespace to use for basic auth
+	httpBasicAuthSecret string = "http-password-secret"
+
+	// httpBasicAuthSecretKey is the key in the httpBasicAuthSecret secret to use for basic auth
+	httpBasicAuthSecretKey string = "http-password-secret-key"
 )


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This adds the ability to pass credentials to the HTTP resolver when fetching the URL.

This let the user for example fetch a task from another SCM private repositories on another SCM providers than the one configured with the git resolver.

Fixes #7296 

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [X] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [X] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [X] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [X] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [X] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
The http resolver supports passing username and password for fetching URLs with basic credentials
```

/kind feature