### PR TITLE
Fix capitalization inconsistency in reconciler

### DIFF
--- a/pkg/reconciler/events/cache/cache.go
+++ b/pkg/reconciler/events/cache/cache.go
@@ -58,7 +58,7 @@ func EventKey(event *cloudevents.Event) (string, error) {
 		return "", err
 	}
 	if data.CustomRun == nil {
-		return "", fmt.Errorf("Invalid CustomRun data in %v", event)
+		return "", fmt.Errorf("invalid CustomRun data in %v", event)
 	}
 	resourceName = data.CustomRun.Name
 	resourceNamespace = data.CustomRun.Namespace

--- a/pkg/reconciler/events/cloudevent/cloud_event_controller.go
+++ b/pkg/reconciler/events/cloudevent/cloud_event_controller.go
@@ -114,7 +114,7 @@ func SendCloudEventWithRetries(ctx context.Context, object runtime.Object) error
 		if isCustomRun {
 			cloudEventSent, err := cache.ContainsOrAddCloudEvent(cacheClient, event)
 			if err != nil {
-				logger.Errorf("error while checking cache: %s", err)
+				logger.Errorf("Error while checking cache: %s", err)
 			}
 			if cloudEventSent {
 				logger.Infof("cloudevent %v already sent", event)

--- a/pkg/reconciler/events/k8sevent/events.go
+++ b/pkg/reconciler/events/k8sevent/events.go
@@ -75,7 +75,7 @@ func eventsFromChannel(c chan string, wantEvents []string) error {
 	for {
 		select {
 		case event := <-c:
-			return fmt.Errorf("Unexpected event: %q", event)
+			return fmt.Errorf("unexpected event: %q", event)
 		default:
 			return nil
 		}

--- a/pkg/reconciler/pipelinerun/cancel.go
+++ b/pkg/reconciler/pipelinerun/cancel.go
@@ -139,7 +139,7 @@ func cancelPipelineTaskRunsForTaskNames(ctx context.Context, logger *zap.Sugared
 		logger.Infof("cancelling TaskRun %s", taskRunName)
 
 		if err := cancelTaskRun(ctx, taskRunName, pr.Namespace, clientSet); err != nil {
-			errs = append(errs, fmt.Errorf("Failed to patch TaskRun `%s` with cancellation: %w", taskRunName, err).Error())
+			errs = append(errs, fmt.Errorf("failed to patch TaskRun `%s` with cancellation: %w", taskRunName, err).Error())
 			continue
 		}
 	}
@@ -148,7 +148,7 @@ func cancelPipelineTaskRunsForTaskNames(ctx context.Context, logger *zap.Sugared
 		logger.Infof("cancelling CustomRun %s", runName)
 
 		if err := cancelCustomRun(ctx, runName, pr.Namespace, clientSet); err != nil {
-			errs = append(errs, fmt.Errorf("Failed to patch CustomRun `%s` with cancellation: %w", runName, err).Error())
+			errs = append(errs, fmt.Errorf("failed to patch CustomRun `%s` with cancellation: %w", runName, err).Error())
 			continue
 		}
 	}

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -1371,13 +1371,13 @@ func (c *Reconciler) updatePipelineRunStatusFromInformer(ctx context.Context, pr
 	pipelineRunLabels := getTaskrunLabels(pr, "", false)
 	taskRuns, err := c.taskRunLister.TaskRuns(pr.Namespace).List(k8slabels.SelectorFromSet(pipelineRunLabels))
 	if err != nil {
-		logger.Errorf("could not list TaskRuns %#v", err)
+		logger.Errorf("Could not list TaskRuns %#v", err)
 		return err
 	}
 
 	customRuns, err := c.customRunLister.CustomRuns(pr.Namespace).List(k8slabels.SelectorFromSet(pipelineRunLabels))
 	if err != nil {
-		logger.Errorf("could not list CustomRuns %#v", err)
+		logger.Errorf("Could not list CustomRuns %#v", err)
 		return err
 	}
 	return updatePipelineRunStatusFromChildObjects(ctx, logger, pr, taskRuns, customRuns)
@@ -1525,7 +1525,7 @@ func conditionFromVerificationResult(verificationResult *trustedresources.Verifi
 	var err error
 	switch verificationResult.VerificationResultType {
 	case trustedresources.VerificationError:
-		err = fmt.Errorf("PipelineRun %s/%s referred resource %s failed signature verification: %w", pr.Namespace, pr.Name, resourceName, verificationResult.Err)
+		err = fmt.Errorf("pipelineRun %s/%s referred resource %s failed signature verification: %w", pr.Namespace, pr.Name, resourceName, verificationResult.Err)
 		condition = &apis.Condition{
 			Type:    trustedresources.ConditionTrustedResourcesVerified,
 			Status:  corev1.ConditionFalse,

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -879,7 +879,7 @@ spec:
 		permanentError: true,
 		wantEvents: []string{
 			"Normal Started",
-			"Warning Failed PipelineRun foo/pipeline-missing-object-param-keys parameters is missing object keys required by Pipeline foo/a-pipeline-with-object-params's parameters: PipelineRun missing object keys for parameters",
+			"Warning Failed PipelineRun foo/pipeline-missing-object-param-keys parameters is missing object keys required by Pipeline foo/a-pipeline-with-object-params's parameters: pipelineRun missing object keys for parameters",
 		},
 	}, {
 		name: "invalid-pipeline-array-index-out-of-bound",
@@ -12264,7 +12264,7 @@ spec:
 			wantEvents :=
 				[]string{
 					"Normal Started",
-					"Warning Failed PipelineRun foo/pr can't be Run; couldn't resolve all references: Array Result Index 3 for Task pt-with-result Result platforms is out of bound of size 3",
+					"Warning Failed PipelineRun foo/pr can't be Run; couldn't resolve all references: array Result Index 3 for Task pt-with-result Result platforms is out of bound of size 3",
 					"Warning InternalError 1 error occurred:",
 				}
 			prt := newPipelineRunTest(t, d)

--- a/pkg/reconciler/pipelinerun/resources/pipelineref.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelineref.go
@@ -97,7 +97,7 @@ type LocalPipelineRefResolver struct {
 func (l *LocalPipelineRefResolver) GetPipeline(ctx context.Context, name string) (*v1.Pipeline, *v1.RefSource, *trustedresources.VerificationResult, error) {
 	// If we are going to resolve this reference locally, we need a namespace scope.
 	if l.Namespace == "" {
-		return nil, nil, nil, fmt.Errorf("Must specify namespace to resolve reference to pipeline %s", name)
+		return nil, nil, nil, fmt.Errorf("must specify namespace to resolve reference to pipeline %s", name)
 	}
 
 	pipeline, err := l.Tektonclient.TektonV1().Pipelines(l.Namespace).Get(ctx, name, metav1.GetOptions{})

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -525,7 +525,7 @@ func ValidateTaskRunSpecs(p *v1.PipelineSpec, pr *v1.PipelineRun) error {
 
 	for _, taskrunSpec := range pr.Spec.TaskRunSpecs {
 		if _, ok := pipelineTasks[taskrunSpec.PipelineTaskName]; !ok {
-			return fmt.Errorf("PipelineRun's taskrunSpecs defined wrong taskName: %q, does not exist in Pipeline", taskrunSpec.PipelineTaskName)
+			return fmt.Errorf("pipelineRun's taskrunSpecs defined wrong taskName: %q, does not exist in Pipeline", taskrunSpec.PipelineTaskName)
 		}
 	}
 	return nil

--- a/pkg/reconciler/pipelinerun/resources/resultrefresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/resultrefresolution.go
@@ -71,7 +71,7 @@ func validateArrayResultsIndex(allResolvedResultRefs ResolvedResultRefs) error {
 	for _, r := range allResolvedResultRefs {
 		if r.Value.Type == v1.ParamTypeArray {
 			if r.ResultReference.ResultsIndex >= len(r.Value.ArrayVal) {
-				return fmt.Errorf("Array Result Index %d for Task %s Result %s is out of bound of size %d", r.ResultReference.ResultsIndex, r.ResultReference.PipelineTask, r.ResultReference.Result, len(r.Value.ArrayVal))
+				return fmt.Errorf("array Result Index %d for Task %s Result %s is out of bound of size %d", r.ResultReference.ResultsIndex, r.ResultReference.PipelineTask, r.ResultReference.Result, len(r.Value.ArrayVal))
 			}
 		}
 	}

--- a/pkg/reconciler/pipelinerun/resources/resultrefresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/resultrefresolution_test.go
@@ -757,7 +757,7 @@ func TestValidateArrayResultsIndex(t *testing.T) {
 			},
 			FromTaskRun: "aTaskRun",
 		}},
-		wantErr: "Array Result Index 1 for Task aTask Result aResult is out of bound of size 0",
+		wantErr: "array Result Index 1 for Task aTask Result aResult is out of bound of size 0",
 	}, {
 		name: "In Bounds Array",
 		refs: ResolvedResultRefs{{
@@ -787,7 +787,7 @@ func TestValidateArrayResultsIndex(t *testing.T) {
 			},
 			FromTaskRun: "aTaskRun",
 		}},
-		wantErr: "Array Result Index 3 for Task aTask Result aResult is out of bound of size 3",
+		wantErr: "array Result Index 3 for Task aTask Result aResult is out of bound of size 3",
 	}, {
 		name: "In Bounds and Out of Bounds Array",
 		refs: ResolvedResultRefs{{
@@ -813,7 +813,7 @@ func TestValidateArrayResultsIndex(t *testing.T) {
 			},
 			FromTaskRun: "aTaskRun",
 		}},
-		wantErr: "Array Result Index 3 for Task aTask Result aResult is out of bound of size 3",
+		wantErr: "array Result Index 3 for Task aTask Result aResult is out of bound of size 3",
 	}} {
 		t.Run(tt.name, func(t *testing.T) {
 			err := validateArrayResultsIndex(tt.refs)

--- a/pkg/reconciler/pipelinerun/resources/validate_params.go
+++ b/pkg/reconciler/pipelinerun/resources/validate_params.go
@@ -71,7 +71,7 @@ func ValidateRequiredParametersProvided(pipelineParameters *v1.ParamSpecs, pipel
 
 	// Return an error with the missing parameters' names, or return nil if there are none.
 	if len(missingParams) != 0 {
-		return fmt.Errorf("PipelineRun missing parameters: %s", missingParams)
+		return fmt.Errorf("pipelineRun missing parameters: %s", missingParams)
 	}
 	return nil
 }
@@ -80,7 +80,7 @@ func ValidateRequiredParametersProvided(pipelineParameters *v1.ParamSpecs, pipel
 func ValidateObjectParamRequiredKeys(pipelineParameters []v1.ParamSpec, pipelineRunParameters []v1.Param) error {
 	missings := taskrun.MissingKeysObjectParamNames(pipelineParameters, pipelineRunParameters)
 	if len(missings) != 0 {
-		return fmt.Errorf("PipelineRun missing object keys for parameters: %v", missings)
+		return fmt.Errorf("pipelineRun missing object keys for parameters: %v", missings)
 	}
 
 	return nil

--- a/pkg/reconciler/pipelinerun/timeout.go
+++ b/pkg/reconciler/pipelinerun/timeout.go
@@ -113,7 +113,7 @@ func timeoutPipelineTasksForTaskNames(ctx context.Context, logger *zap.SugaredLo
 		logger.Infof("cancelling TaskRun %s for timeout", taskRunName)
 
 		if _, err := clientSet.TektonV1().TaskRuns(pr.Namespace).Patch(ctx, taskRunName, types.JSONPatchType, timeoutTaskRunPatchBytes, metav1.PatchOptions{}, ""); err != nil {
-			errs = append(errs, fmt.Errorf("Failed to patch TaskRun `%s` with cancellation: %w", taskRunName, err).Error())
+			errs = append(errs, fmt.Errorf("failed to patch TaskRun `%s` with cancellation: %w", taskRunName, err).Error())
 			continue
 		}
 	}
@@ -122,7 +122,7 @@ func timeoutPipelineTasksForTaskNames(ctx context.Context, logger *zap.SugaredLo
 		logger.Infof("cancelling CustomRun %s for timeout", custonRunName)
 
 		if err := timeoutCustomRun(ctx, custonRunName, pr.Namespace, clientSet); err != nil {
-			errs = append(errs, fmt.Errorf("Failed to patch CustomRun `%s` with cancellation: %w", custonRunName, err).Error())
+			errs = append(errs, fmt.Errorf("failed to patch CustomRun `%s` with cancellation: %w", custonRunName, err).Error())
 			continue
 		}
 	}

--- a/pkg/reconciler/taskrun/validate_taskrun.go
+++ b/pkg/reconciler/taskrun/validate_taskrun.go
@@ -181,13 +181,13 @@ func validateTaskSpecRequestResources(taskSpec *v1.TaskSpec) error {
 				// First validate the limit in step
 				if limit, ok := step.ComputeResources.Limits[k]; ok {
 					if (&limit).Cmp(request) == -1 {
-						return fmt.Errorf("Invalid request resource value: %v must be less or equal to limit %v", request.String(), limit.String())
+						return fmt.Errorf("invalid request resource value: %v must be less or equal to limit %v", request.String(), limit.String())
 					}
 				} else if taskSpec.StepTemplate != nil {
 					// If step doesn't configure the limit, validate the limit in stepTemplate
 					if limit, ok := taskSpec.StepTemplate.ComputeResources.Limits[k]; ok {
 						if (&limit).Cmp(request) == -1 {
-							return fmt.Errorf("Invalid request resource value: %v must be less or equal to limit %v", request.String(), limit.String())
+							return fmt.Errorf("invalid request resource value: %v must be less or equal to limit %v", request.String(), limit.String())
 						}
 					}
 				}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Go [style](https://google.github.io/styleguide/go/decisions.html#error-strings) states that error messages typically shouldn't be capitalized unless in logs, tests, API response, or UI.
Updates error messages returned in pkg/reconciler to begin with lowercase. Updates error logs in pkg/reconciler to begin with uppercase.

Fixes the first task in tektoncd#7266

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [X] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [X] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [X] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [X] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```

/kind cleanup