### PR TITLE
[TEP-0142] Remote Resolution for StepAction

### DIFF
--- a/docs/stepactions.md
+++ b/docs/stepactions.md
@@ -17,7 +17,7 @@ A `StepAction` is the reusable and scriptable unit of work that is performed by 
 
 A `Step` is not reusable, the work it performs is reusable and referenceable. `Steps` are in-lined in the `Task` definition and either perform work directly or perform a `StepAction`. A `StepAction` cannot be run stand-alone (unlike a `TaskRun` or a `PipelineRun`). It has to be referenced by a `Step`. Another way to ehink about this is that a `Step` is not composed of `StepActions` (unlike a `Task` being composed of `Steps` and `Sidecars`). Instead, a `Step` is an actionable component, meaning that it has the ability to refer to a `StepAction`. The author of the `StepAction` must be able to compose a `Step` using a `StepAction` and provide all the necessary context (or orchestration) to it.
 
- 
+
 ## Configuring a `StepAction`
 
 A `StepAction` definition supports the following fields:
@@ -29,7 +29,7 @@ A `StepAction` definition supports the following fields:
   - [`metadata`][kubernetes-overview] - Specifies metadata that uniquely identifies the
     `StepAction` resource object. For example, a `name`.
   - [`spec`][kubernetes-overview] - Specifies the configuration information for this `StepAction` resource object.
-  - `image` - Specifies the image to use for the `Step`. 
+  - `image` - Specifies the image to use for the `Step`.
     - The container image must abide by the [container contract](./container-contract.md).
 - Optional
   - `command`
@@ -52,15 +52,15 @@ spec:
   env:
     - name: HOME
       value: /home
-  image: ubuntu 
+  image: ubuntu
   command: ["ls"]
   args: ["-lh"]
 ```
 
 ### Declaring Parameters
 
-Like with `Tasks`, a `StepAction` must declare all the parameters that it used. The same rules for `Parameter` [name](./tasks.md/#parameter-name), [type](./tasks.md/#parameter-type) (including [object](./tasks.md/#object-type), [array](./tasks.md/#array-type) and [string](./tasks.md/#string-type)) apply as when declaring them in `Tasks`. A `StepAction` can also provide [default value](./tasks.md/#default-value) to a `Parameter`. 
- 
+Like with `Tasks`, a `StepAction` must declare all the parameters that it used. The same rules for `Parameter` [name](./tasks.md/#parameter-name), [type](./tasks.md/#parameter-type) (including [object](./tasks.md/#object-type), [array](./tasks.md/#array-type) and [string](./tasks.md/#string-type)) apply as when declaring them in `Tasks`. A `StepAction` can also provide [default value](./tasks.md/#default-value) to a `Parameter`.
+
  `Parameters` are passed to the `StepAction` from its corresponding `Step` referencing it.
 
 ```yaml
@@ -93,7 +93,7 @@ spec:
 
 ### Declaring Results
 
-A `StepAction` also declares the results that it will emit. 
+A `StepAction` also declares the results that it will emit.
 
 ```yaml
 apiVersion: tekton.dev/v1alpha1
@@ -233,7 +233,7 @@ spec:
         onError: continue
 ```
 
-### Passing Params to StepAction 
+### Passing Params to StepAction
 
 A `StepAction` may require [params](#(declaring-parameters)). In this case, a `Task` needs to ensure that the `StepAction` has access to all the required `params`.
 When referencing a `StepAction`, a `Step` can also provide it with `params`, just like how a `TaskRun` provides params to the underlying `Task`.
@@ -258,3 +258,29 @@ spec:
 ```
 
 **Note:** If a `Step` declares `params` for an `inlined Step`, it will also lead to a validation error. This is because an `inlined Step` gets it's `params` from the `TaskRun`.
+
+### Specifying Remote StepActions
+
+A `ref` field may specify a `StepAction` in a remote location such as git.
+Support for specific types of remote will depend on the `Resolvers` your
+cluster's operator has installed. For more information including a tutorial, please check [resolution docs](resolution.md). The below example demonstrates referencing a `StepAction` in git:
+
+```yaml
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  generateName: step-action-run-
+spec:
+  TaskSpec:
+    steps:
+      - name: action-runner
+        ref:
+          resolver: git
+          params:
+            - name: url
+              value: https://github.com/repo/repo.git
+            - name: revision
+              value: main
+            - name: pathInRepo
+              value: remote_step.yaml
+```

--- a/examples/v1/taskruns/alpha/stepaction-git-resolver.yaml
+++ b/examples/v1/taskruns/alpha/stepaction-git-resolver.yaml
@@ -1,0 +1,18 @@
+# TODO(#7325): use StepAction from Catalog
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  generateName: step-action-run-
+spec:
+  TaskSpec:
+    steps:
+      - name: action-runner
+        ref:
+          resolver: git
+          params:
+            - name: url
+              value: https://github.com/chitrangpatel/repo1M.git
+            - name: revision
+              value: main
+            - name: pathInRepo
+              value: basic_step.yaml

--- a/pkg/apis/pipeline/v1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1/taskrun_types.go
@@ -179,6 +179,9 @@ const (
 	// TaskRunReasonResolvingTaskRef indicates that the TaskRun is waiting for
 	// its taskRef to be asynchronously resolved.
 	TaskRunReasonResolvingTaskRef = "ResolvingTaskRef"
+	// TaskRunReasonResolvingStepActionRef indicates that the TaskRun is waiting for
+	// its StepAction's Ref to be asynchronously resolved.
+	TaskRunReasonResolvingStepActionRef = "ResolvingStepActionRef"
 	// TaskRunReasonImagePullFailed is the reason set when the step of a task fails due to image not being pulled
 	TaskRunReasonImagePullFailed TaskRunReason = "TaskRunImagePullFailed"
 	// TaskRunReasonResultLargerThanAllowedLimit is the reason set when one of the results exceeds its maximum allowed limit of 1 KB

--- a/pkg/reconciler/apiserver/apiserver.go
+++ b/pkg/reconciler/apiserver/apiserver.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/uuid"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	clientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -54,6 +55,13 @@ func DryRunValidate(ctx context.Context, namespace string, obj runtime.Object, t
 		dryRunObj.Name = dryRunObjName
 		dryRunObj.Namespace = namespace // Make sure the namespace is the same as the TaskRun
 		if _, err := tekton.TektonV1beta1().Tasks(namespace).Create(ctx, dryRunObj, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}}); err != nil {
+			return handleDryRunCreateErr(err, obj.Name)
+		}
+	case *v1alpha1.StepAction:
+		dryRunObj := obj.DeepCopy()
+		dryRunObj.Name = dryRunObjName
+		dryRunObj.Namespace = namespace // Make sure the namespace is the same as the StepAction
+		if _, err := tekton.TektonV1alpha1().StepActions(namespace).Create(ctx, dryRunObj, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}}); err != nil {
 			return handleDryRunCreateErr(err, obj.Name)
 		}
 	default:

--- a/pkg/reconciler/apiserver/apiserver_test.go
+++ b/pkg/reconciler/apiserver/apiserver_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned/fake"
 	"github.com/tektoncd/pipeline/pkg/reconciler/apiserver"
@@ -34,6 +35,9 @@ func TestDryRunCreate_Valid_DifferentGVKs(t *testing.T) {
 	}, {
 		name: "v1beta1 pipeline",
 		obj:  &v1beta1.Pipeline{},
+	}, {
+		name: "v1alpha1 stepaction",
+		obj:  &v1alpha1.StepAction{},
 	}, {
 		name:    "unsupported gvk",
 		obj:     &v1beta1.ClusterTask{},
@@ -72,6 +76,10 @@ func TestDryRunCreate_Invalid_DifferentGVKs(t *testing.T) {
 		obj:     &v1beta1.Pipeline{},
 		wantErr: apiserver.ErrReferencedObjectValidationFailed,
 	}, {
+		name:    "v1alpha1 stepaction",
+		obj:     &v1alpha1.StepAction{},
+		wantErr: apiserver.ErrReferencedObjectValidationFailed,
+	}, {
 		name:    "unsupported gvk",
 		obj:     &v1beta1.ClusterTask{},
 		wantErr: cmpopts.AnyError,
@@ -83,6 +91,9 @@ func TestDryRunCreate_Invalid_DifferentGVKs(t *testing.T) {
 				return true, nil, apierrors.NewBadRequest("bad request")
 			})
 			tektonclient.PrependReactor("create", "pipelines", func(action ktesting.Action) (bool, runtime.Object, error) {
+				return true, nil, apierrors.NewBadRequest("bad request")
+			})
+			tektonclient.PrependReactor("create", "stepactions", func(action ktesting.Action) (bool, runtime.Object, error) {
 				return true, nil, apierrors.NewBadRequest("bad request")
 			})
 			err := apiserver.DryRunValidate(context.Background(), "default", tc.obj, tektonclient)

--- a/pkg/reconciler/taskrun/resources/taskspec_test.go
+++ b/pkg/reconciler/taskrun/resources/taskspec_test.go
@@ -459,7 +459,7 @@ func TestGetStepActionsData(t *testing.T) {
 		ctx := context.Background()
 		tektonclient := fake.NewSimpleClientset(tt.stepAction)
 
-		got, err := resources.GetStepActionsData(ctx, *tt.tr.Spec.TaskSpec, tt.tr, tektonclient)
+		got, err := resources.GetStepActionsData(ctx, *tt.tr.Spec.TaskSpec, tt.tr, tektonclient, nil, nil)
 		if err != nil {
 			t.Errorf("Did not expect an error but got : %s", err)
 		}
@@ -494,7 +494,7 @@ func TestGetStepActionsData_Error(t *testing.T) {
 		expectedError: fmt.Errorf("must specify namespace to resolve reference to step action stepActionError"),
 	}}
 	for _, tt := range tests {
-		_, err := resources.GetStepActionsData(context.Background(), *tt.tr.Spec.TaskSpec, tt.tr, nil)
+		_, err := resources.GetStepActionsData(context.Background(), *tt.tr.Spec.TaskSpec, tt.tr, nil, nil, nil)
 		if err == nil {
 			t.Fatalf("Expected to get an error but did not find any.")
 		}


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This commit is part of #7259. It adds the remote resolution for StepAction.

/kind feature

Signed-off-by: Yongxuan Zhang yongxuanzhang@google.com

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Support Remote Resolution for StepAction
```
