### PR TITLE
change bundle resolver to use secret instead of service account

### DIFF
--- a/config/resolvers/bundleresolver-config.yaml
+++ b/config/resolvers/bundleresolver-config.yaml
@@ -22,7 +22,5 @@ metadata:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
 data:
-  # the default service account name to use for bundle requests.
-  default-service-account: "default"
   # The default layer kind in the bundle image.
   default-kind: "task"

--- a/docs/bundle-resolver.md
+++ b/docs/bundle-resolver.md
@@ -15,7 +15,7 @@ This Resolver responds to type `bundles`.
 
 | Param Name       | Description                                                                   | Example Value                                              |
 |------------------|-------------------------------------------------------------------------------|------------------------------------------------------------|
-| `serviceAccount` | The name of the service account to use when constructing registry credentials | `default`                                                  |
+| `secret` | The name of the secret to use when constructing registry credentials | `default`                                                  |
 | `bundle`         | The bundle url pointing at the image to fetch                                 | `gcr.io/tekton-releases/catalog/upstream/golang-build:0.1` |
 | `name`           | The name of the resource to pull out of the bundle                            | `golang-build`                                             |
 | `kind`           | The resource kind to pull out of the bundle                                   | `task`                                                     |
@@ -24,7 +24,7 @@ This Resolver responds to type `bundles`.
 
 - A cluster running Tekton Pipeline v0.41.0 or later.
 - The [built-in remote resolvers installed](./install.md#installing-and-configuring-remote-task-and-pipeline-resolution).
-- The `enable-bundles-resolver` feature flag in the `resolvers-feature-flags` ConfigMap 
+- The `enable-bundles-resolver` feature flag in the `resolvers-feature-flags` ConfigMap
   in the `tekton-pipelines-resolvers` namespace set to `true`.
 - [Beta features](./additional-configs.md#beta-features) enabled.
 
@@ -38,7 +38,6 @@ for the name, namespace and defaults that the resolver ships with.
 
 | Option Name               | Description                                                  | Example Values        |
 |---------------------------|--------------------------------------------------------------|-----------------------|
-| `default-service-account` | The default service account name to use for bundle requests. | `default`, `someuser` |
 | `default-kind`            | The default layer kind in the bundle image.                  | `task`, `pipeline`    |
 
 ## Usage

--- a/pkg/resolution/resolver/bundle/bundle.go
+++ b/pkg/resolution/resolver/bundle/bundle.go
@@ -37,10 +37,10 @@ const (
 // RequestOptions are the options used to request a resource from
 // a remote bundle.
 type RequestOptions struct {
-	ServiceAccount string
-	Bundle         string
-	EntryName      string
-	Kind           string
+	ImagePullSecret string
+	Bundle          string
+	EntryName       string
+	Kind            string
 }
 
 // ResolvedResource wraps the content of a matched entry in a bundle.

--- a/pkg/resolution/resolver/bundle/config.go
+++ b/pkg/resolution/resolver/bundle/config.go
@@ -16,9 +16,6 @@ package bundle
 const (
 	// ConfigMapName is the bundle resolver's config map
 	ConfigMapName = "bundleresolver-config"
-	// ConfigServiceAccount is the configuration field name for controlling
-	// the Service Account name to use for bundle requests.
-	ConfigServiceAccount = "default-service-account"
 	// ConfigKind is the configuration field name for controlling
 	// what the layer name in the bundle image is.
 	ConfigKind = "default-kind"

--- a/pkg/resolution/resolver/bundle/params.go
+++ b/pkg/resolution/resolver/bundle/params.go
@@ -22,9 +22,9 @@ import (
 	"github.com/tektoncd/pipeline/pkg/resolution/resolver/framework"
 )
 
-// ParamServiceAccount is the parameter defining what service
-// account name to use for bundle requests.
-const ParamServiceAccount = "serviceAccount"
+// ParamImagePullSecret is the parameter defining what secret
+// name to use for bundle requests.
+const ParamImagePullSecret = "secret"
 
 // ParamBundle is the parameter defining what the bundle image url is.
 const ParamBundle = "bundle"
@@ -46,18 +46,6 @@ func OptionsFromParams(ctx context.Context, params []pipelinev1.Param) (RequestO
 	paramsMap := make(map[string]pipelinev1.ParamValue)
 	for _, p := range params {
 		paramsMap[p.Name] = p.Value
-	}
-
-	saVal, ok := paramsMap[ParamServiceAccount]
-	sa := ""
-	if !ok || saVal.StringVal == "" {
-		if saString, ok := conf[ConfigServiceAccount]; ok {
-			sa = saString
-		} else {
-			return opts, fmt.Errorf("default Service Account was not set during installation of the bundle resolver")
-		}
-	} else {
-		sa = saVal.StringVal
 	}
 
 	bundleVal, ok := paramsMap[ParamBundle]
@@ -85,7 +73,7 @@ func OptionsFromParams(ctx context.Context, params []pipelinev1.Param) (RequestO
 		kind = kindVal.StringVal
 	}
 
-	opts.ServiceAccount = sa
+	opts.ImagePullSecret = paramsMap[ParamImagePullSecret].StringVal
 	opts.Bundle = bundleVal.StringVal
 	opts.EntryName = nameVal.StringVal
 	opts.Kind = kind


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This commit fixes #7159. The bundle resolver's service account doesn't have the permission to fetch the service account which contains the credientials to pull bundle, and the error is also omitted. This commit changes to use secret directly, without granting SA read permissions to resolver.

/kind bug

Signed-off-by: Yongxuan Zhang yongxuanzhang@google.com

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
action required: Bundle resolve uses secret to pull bundle Tasks/Pipelines from private registry instead of Service Account. Please update your bundle resolver ref to use secret.
```
