### PR TITLE
TEP-0142: Add support for params between Step and StepActions

### DIFF
--- a/examples/v1/pipelineruns/alpha/stepaction-params.yaml
+++ b/examples/v1/pipelineruns/alpha/stepaction-params.yaml
@@ -1,0 +1,67 @@
+apiVersion: tekton.dev/v1alpha1
+kind: StepAction
+metadata:
+  name: step-action
+spec:
+  params:
+    - name: string-param
+      default: "a string param"
+    - name: array-param
+      type: array
+      default:
+        - an
+        - array
+        - param
+    - name: object-param
+      type: object
+      properties:
+        key1:
+          type: string
+        key2:
+          type: string
+        key3:
+          type: string
+      default:
+        key1: "step-action default key1"
+        key2: "step-action default key2"
+        key3: "step-action default key3"
+  image: bash:3.2
+  args: [
+    "echo",
+    "$(params.array-param[*])",
+    "$(params.string-param)",
+    "$(params.object-param.key1)",
+    "$(params.object-param.key2)"
+  ]
+---
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: step-action-pipeline-run-propagated
+spec:
+  params:
+    - name: stringparam
+      value: "pipelinerun stringparam"
+    - name: arrayparam
+      value:
+        - "pipelinerun"
+        - "array"
+        - "param"
+    - name: objectparam
+      value:
+        key2: "pipelinerun key2"
+  PipelineSpec:
+    tasks:
+      - name: run-action
+        taskSpec:
+          steps:
+          - name: action-runner
+            ref:
+              name: step-action
+            params:
+              - name: string-param
+                value: $(params.stringparam)
+              - name: array-param
+                value: $(params.arrayparam[*])
+              - name: object-param
+                value: $(params.objectparam[*])

--- a/examples/v1/taskruns/alpha/stepaction-params.yaml
+++ b/examples/v1/taskruns/alpha/stepaction-params.yaml
@@ -1,0 +1,82 @@
+apiVersion: tekton.dev/v1alpha1
+kind: StepAction
+metadata:
+  name: step-action
+spec:
+  params:
+    - name: string-param
+      default: "a string param"
+    - name: array-param
+      type: array
+      default:
+        - an
+        - array
+        - param
+    - name: object-param
+      type: object
+      properties:
+        key1:
+          type: string
+        key2:
+          type: string
+        key3:
+          type: string
+      default:
+        key1: "step-action default key1"
+        key2: "step-action default key2"
+        key3: "step-action default key3"
+  image: ubuntu
+  script: |
+    #!/bin/bash
+    ARRAYVALUE=("$(params.array-param[0])" "$(params.array-param[1])" "$(params.array-param[2])" "$(params.string-param)" "$(params.object-param.key1)" "$(params.object-param.key2)" "$(params.object-param.key3)")
+    ARRAYEXPECTED=("taskrun" "array" "param" "taskrun stringparam" "taskspec default key1" "taskrun key2" "step-action default key3")
+    for i in "${!ARRAYVALUE[@]}"; do
+        VALUE="${ARRAYVALUE[i]}"
+        EXPECTED="${ARRAYEXPECTED[i]}"
+        diff=$(diff <(printf "%s\n" "${VALUE[@]}") <(printf "%s\n" "${EXPECTED[@]}"))
+        if [[ -z "$diff" ]]; then
+            echo "Got expected: ${VALUE}"
+        else
+            echo "Want: ${EXPECTED} Got: ${VALUE}"
+            exit 1
+        fi
+    done
+---
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  name: step-action-run
+spec:
+  params:
+    - name: stringparam
+      value: "taskrun stringparam"
+    - name: arrayparam
+      value:
+        - "taskrun"
+        - "array"
+        - "param"
+    - name: objectparam
+      value:
+        key2: "taskrun key2"
+  TaskSpec:
+    params:
+      - name: objectparam
+        properties:
+          key1:
+            type: string
+          key2:
+            type: string
+        default:
+          key1: "taskspec default key1"
+          key2: "taskspec default key2"
+    steps:
+      - name: action-runner
+        ref:
+          name: step-action
+        params:
+          - name: string-param
+            value: $(params.stringparam)
+          - name: array-param
+            value: $(params.arrayparam[*])
+          - name: object-param
+            value: $(params.objectparam[*])

--- a/pkg/reconciler/pipelinerun/resources/apply.go
+++ b/pkg/reconciler/pipelinerun/resources/apply.go
@@ -367,9 +367,9 @@ func propagateParams(t v1.PipelineTask, stringReplacements map[string]string, ar
 				}
 			}
 		}
-		t.TaskSpec.TaskSpec = *resources.ApplyReplacements(&t.TaskSpec.TaskSpec, stringReplacementsDup, arrayReplacementsDup)
+		t.TaskSpec.TaskSpec = *resources.ApplyReplacements(&t.TaskSpec.TaskSpec, stringReplacementsDup, arrayReplacementsDup, objectReplacementsDup)
 	} else {
-		t.TaskSpec.TaskSpec = *resources.ApplyReplacements(&t.TaskSpec.TaskSpec, stringReplacements, arrayReplacements)
+		t.TaskSpec.TaskSpec = *resources.ApplyReplacements(&t.TaskSpec.TaskSpec, stringReplacements, arrayReplacements, objectReplacements)
 	}
 	return t
 }
@@ -395,7 +395,7 @@ func PropagateResults(rpt *ResolvedPipelineTask, runStates PipelineRunState) {
 			}
 		}
 	}
-	rpt.ResolvedTask.TaskSpec = resources.ApplyReplacements(rpt.ResolvedTask.TaskSpec, stringReplacements, arrayReplacements)
+	rpt.ResolvedTask.TaskSpec = resources.ApplyReplacements(rpt.ResolvedTask.TaskSpec, stringReplacements, arrayReplacements, map[string]map[string]string{})
 }
 
 // ApplyTaskResultsToPipelineResults applies the results of completed TasksRuns and Runs to a Pipeline's

--- a/pkg/reconciler/taskrun/resources/taskref.go
+++ b/pkg/reconciler/taskrun/resources/taskref.go
@@ -97,7 +97,7 @@ func GetTaskFunc(ctx context.Context, k8s kubernetes.Interface, tekton clientset
 		return func(ctx context.Context, name string) (*v1.Task, *v1.RefSource, *trustedresources.VerificationResult, error) {
 			var replacedParams v1.Params
 			if ownerAsTR, ok := owner.(*v1.TaskRun); ok {
-				stringReplacements, arrayReplacements := paramsFromTaskRun(ctx, ownerAsTR)
+				stringReplacements, arrayReplacements, _ := replacementsFromParams(ownerAsTR.Spec.Params)
 				for k, v := range getContextReplacements("", ownerAsTR) {
 					stringReplacements[k] = v
 				}

--- a/pkg/reconciler/taskrun/resources/taskspec.go
+++ b/pkg/reconciler/taskrun/resources/taskspec.go
@@ -112,6 +112,8 @@ func GetStepActionsData(ctx context.Context, taskSpec v1.TaskSpec, taskRun *v1.T
 				return nil, err
 			}
 			stepActionSpec := stepAction.StepActionSpec()
+			stepActionSpec.SetDefaults(ctx)
+
 			s.Image = stepActionSpec.Image
 			s.SecurityContext = stepActionSpec.SecurityContext
 			if len(stepActionSpec.Command) > 0 {
@@ -126,6 +128,11 @@ func GetStepActionsData(ctx context.Context, taskSpec v1.TaskSpec, taskRun *v1.T
 			if stepActionSpec.Env != nil {
 				s.Env = stepActionSpec.Env
 			}
+			if err := validateStepHasStepActionParameters(s.Params, stepActionSpec.Params); err != nil {
+				return nil, err
+			}
+			s = applyStepActionParameters(s, &taskSpec, taskRun, s.Params, stepActionSpec.Params)
+			s.Params = nil
 			s.Ref = nil
 			steps = append(steps, *s)
 		} else {

--- a/pkg/reconciler/taskrun/resources/validate_params.go
+++ b/pkg/reconciler/taskrun/resources/validate_params.go
@@ -45,3 +45,40 @@ func ValidateOutOfBoundArrayParams(declarations v1.ParamSpecs, params v1.Params,
 	}
 	return nil
 }
+
+func validateStepHasStepActionParameters(stepParams v1.Params, stepActionDefaults []v1.ParamSpec) error {
+	stepActionParams := sets.String{}
+	requiredStepActionParams := []string{}
+	for _, sa := range stepActionDefaults {
+		stepActionParams.Insert(sa.Name)
+		if sa.Default == nil {
+			requiredStepActionParams = append(requiredStepActionParams, sa.Name)
+		}
+	}
+
+	stepProvidedParams := sets.String{}
+	extra := []string{}
+	for _, sp := range stepParams {
+		stepProvidedParams.Insert(sp.Name)
+		if !stepActionParams.Has(sp.Name) {
+			// Extra parameter that is not needed
+			extra = append(extra, sp.Name)
+		}
+	}
+	if len(extra) > 0 {
+		return fmt.Errorf("extra params passed by Step to StepAction: %v", extra)
+	}
+
+	missing := []string{}
+
+	for _, requiredParam := range requiredStepActionParams {
+		if !stepProvidedParams.Has(requiredParam) {
+			// Missing required param
+			missing = append(missing, requiredParam)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("non-existent params in Step: %v", missing)
+	}
+	return nil
+}

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -841,7 +841,7 @@ func applyParamsContextsResultsAndWorkspaces(ctx context.Context, tr *v1.TaskRun
 		defaults = append(defaults, ts.Params...)
 	}
 	// Apply parameter substitution from the taskrun.
-	ts = resources.ApplyParameters(ctx, ts, tr, defaults...)
+	ts = resources.ApplyParameters(ts, tr, defaults...)
 
 	// Apply context substitution from the taskrun
 	ts = resources.ApplyContexts(ts, rtr.TaskName, tr)


### PR DESCRIPTION
Following the previous [PR](https://github.com/tektoncd/pipeline/pull/7334), which introduced the syntax in `Steps` to provide params to `StepAction`, this PR reconciles `param` usage between `Steps` and `StepActions`. This completes support for params in `StepActions`. This work is part of issue https://github.com/tektoncd/pipeline/issues/7259.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

We how pass objectParam replacements inside a `Task` since the `Steps` can provide params to `StepActions`. The params passed to `StepActions` could be object params and could require objectParam replacements.

For example, this is now allowed:
```
steps:
  - ref:
      name: step-action
  params:
    - name: object-param
       value: $(params.objectparam[*])
```
Therefore, we now need to allow passing of objectParams into a `Task`. 

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
[WIP] Completes support for params in StepActions.
```

/kind feature