### PR TITLE
[TEP-0142] Add SecurityContext

### DIFF
--- a/docs/pipeline-api.md
+++ b/docs/pipeline-api.md
@@ -6598,6 +6598,23 @@ Params must be supplied as inputs in Steps unless they declare a defaultvalue.</
 <p>Results are values that this StepAction can output</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>securityContext</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#securitycontext-v1-core">
+Kubernetes core/v1.SecurityContext
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>SecurityContext defines the security options the Step should be run with.
+If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+More info: <a href="https://kubernetes.io/docs/tasks/configure-pod-container/security-context/">https://kubernetes.io/docs/tasks/configure-pod-container/security-context/</a>
+The value set in StepAction will take precedence over the value from Task.</p>
+</td>
+</tr>
 </table>
 </td>
 </tr>
@@ -7455,6 +7472,23 @@ Params must be supplied as inputs in Steps unless they declare a defaultvalue.</
 <td>
 <em>(Optional)</em>
 <p>Results are values that this StepAction can output</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>securityContext</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#securitycontext-v1-core">
+Kubernetes core/v1.SecurityContext
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>SecurityContext defines the security options the Step should be run with.
+If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+More info: <a href="https://kubernetes.io/docs/tasks/configure-pod-container/security-context/">https://kubernetes.io/docs/tasks/configure-pod-container/security-context/</a>
+The value set in StepAction will take precedence over the value from Task.</p>
 </td>
 </tr>
 </tbody>

--- a/docs/stepactions.md
+++ b/docs/stepactions.md
@@ -17,7 +17,7 @@ A `StepAction` is the reusable and scriptable unit of work that is performed by 
 
 A `Step` is not reusable, the work it performs is reusable and referenceable. `Steps` are in-lined in the `Task` definition and either perform work directly or perform a `StepAction`. A `StepAction` cannot be run stand-alone (unlike a `TaskRun` or a `PipelineRun`). It has to be referenced by a `Step`. Another way to ehink about this is that a `Step` is not composed of `StepActions` (unlike a `Task` being composed of `Steps` and `Sidecars`). Instead, a `Step` is an actionable component, meaning that it has the ability to refer to a `StepAction`. The author of the `StepAction` must be able to compose a `Step` using a `StepAction` and provide all the necessary context (or orchestration) to it.
 
- 
+
 ## Configuring a `StepAction`
 
 A `StepAction` definition supports the following fields:
@@ -29,7 +29,7 @@ A `StepAction` definition supports the following fields:
   - [`metadata`][kubernetes-overview] - Specifies metadata that uniquely identifies the
     `StepAction` resource object. For example, a `name`.
   - [`spec`][kubernetes-overview] - Specifies the configuration information for this `StepAction` resource object.
-  - `image` - Specifies the image to use for the `Step`. 
+  - `image` - Specifies the image to use for the `Step`.
     - The container image must abide by the [container contract](./container-contract.md).
 - Optional
   - `command`
@@ -40,6 +40,7 @@ A `StepAction` definition supports the following fields:
   - `env`
   - [`params`](#declaring-params)
   - [`results`](#declaring-results)
+  - [`securityContext`](#declaring-securitycontext)
 
 The non-functional example below demonstrates the use of most of the above-mentioned fields:
 
@@ -52,15 +53,15 @@ spec:
   env:
     - name: HOME
       value: /home
-  image: ubuntu 
+  image: ubuntu
   command: ["ls"]
   args: ["-lh"]
 ```
 
 ### Declaring Parameters
 
-Like with `Tasks`, a `StepAction` must declare all the parameters that it used. The same rules for `Parameter` [name](./tasks.md/#parameter-name), [type](./tasks.md/#parameter-type) (including [object](./tasks.md/#object-type), [array](./tasks.md/#array-type) and [string](./tasks.md/#string-type)) apply as when declaring them in `Tasks`. A `StepAction` can also provide [default value](./tasks.md/#default-value) to a `Parameter`. 
- 
+Like with `Tasks`, a `StepAction` must declare all the parameters that it used. The same rules for `Parameter` [name](./tasks.md/#parameter-name), [type](./tasks.md/#parameter-type) (including [object](./tasks.md/#object-type), [array](./tasks.md/#array-type) and [string](./tasks.md/#string-type)) apply as when declaring them in `Tasks`. A `StepAction` can also provide [default value](./tasks.md/#default-value) to a `Parameter`.
+
  `Parameters` are passed to the `StepAction` from its corresponding `Step` referencing it.
 
 ```yaml
@@ -93,7 +94,7 @@ spec:
 
 ### Declaring Results
 
-A `StepAction` also declares the results that it will emit. 
+A `StepAction` also declares the results that it will emit.
 
 ```yaml
 apiVersion: tekton.dev/v1alpha1
@@ -112,6 +113,26 @@ spec:
     date +%s | tee $(results.current-date-unix-timestamp.path)
     date | tee $(results.current-date-human-readable.path)
 ```
+
+### Declaring SecurityContext
+
+You can declare `securityContext` in a `StepAction`:
+
+```yaml
+apiVersion: tekton.dev/v1alpha1
+kind: StepAction
+metadata:
+  name: example-stepaction-name
+spec:
+  image:  gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:latest
+  securityContext:
+      runAsUser: 0
+  script: |
+    # clone the repo
+    ...
+```
+
+Note that the `securityContext` from `StepAction` will overwrite the `securityContext` from [`TaskRun`](./taskruns.md/#example-of-running-step-containers-as-a-non-root-user).
 
 ## Referencing a StepAction
 

--- a/pkg/apis/pipeline/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1alpha1/openapi_generated.go
@@ -921,11 +921,17 @@ func schema_pkg_apis_pipeline_v1alpha1_StepActionSpec(ref common.ReferenceCallba
 							},
 						},
 					},
+					"securityContext": {
+						SchemaProps: spec.SchemaProps{
+							Description: "SecurityContext defines the security options the Step should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ The value set in StepAction will take precedence over the value from Task.",
+							Ref:         ref("k8s.io/api/core/v1.SecurityContext"),
+						},
+					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.ParamSpec", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1.StepActionResult", "k8s.io/api/core/v1.EnvVar"},
+			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.ParamSpec", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1.StepActionResult", "k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.SecurityContext"},
 	}
 }
 

--- a/pkg/apis/pipeline/v1alpha1/stepaction_types.go
+++ b/pkg/apis/pipeline/v1alpha1/stepaction_types.go
@@ -121,6 +121,12 @@ type StepActionSpec struct {
 	// +optional
 	// +listType=atomic
 	Results []StepActionResult `json:"results,omitempty"`
+	// SecurityContext defines the security options the Step should be run with.
+	// If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+	// More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+	// The value set in StepAction will take precedence over the value from Task.
+	// +optional
+	SecurityContext *corev1.SecurityContext `json:"securityContext,omitempty" protobuf:"bytes,15,opt,name=securityContext"`
 }
 
 // StepActionObject is implemented by StepAction

--- a/pkg/apis/pipeline/v1alpha1/swagger.json
+++ b/pkg/apis/pipeline/v1alpha1/swagger.json
@@ -472,6 +472,10 @@
         "script": {
           "description": "Script is the contents of an executable file to execute.\n\nIf Script is not empty, the Step cannot have an Command and the Args will be passed to the Script.",
           "type": "string"
+        },
+        "securityContext": {
+          "description": "SecurityContext defines the security options the Step should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ The value set in StepAction will take precedence over the value from Task.",
+          "$ref": "#/definitions/v1.SecurityContext"
         }
       }
     },

--- a/pkg/apis/pipeline/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/pipeline/v1alpha1/zz_generated.deepcopy.go
@@ -335,6 +335,11 @@ func (in *StepActionSpec) DeepCopyInto(out *StepActionSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.SecurityContext != nil {
+		in, out := &in.SecurityContext, &out.SecurityContext
+		*out = new(v1.SecurityContext)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/pkg/reconciler/taskrun/resources/taskspec.go
+++ b/pkg/reconciler/taskrun/resources/taskspec.go
@@ -112,6 +112,7 @@ func GetStepActionsData(ctx context.Context, taskSpec v1.TaskSpec, tr *v1.TaskRu
 			}
 			stepActionSpec := stepAction.StepActionSpec()
 			s.Image = stepActionSpec.Image
+			s.SecurityContext = stepActionSpec.SecurityContext
 			if len(stepActionSpec.Command) > 0 {
 				s.Command = stepActionSpec.Command
 			}

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -2760,6 +2760,8 @@ metadata:
 spec:
   image: myImage
   command: ["ls"]
+  securityContext:
+    privileged: true
 `)
 	stepAction2 := parse.MustParseV1alpha1StepAction(t, `
 metadata:
@@ -2790,11 +2792,13 @@ spec:
 	}
 	getTaskRun, _ := testAssets.Clients.Pipeline.TektonV1().TaskRuns(taskRun.Namespace).Get(testAssets.Ctx, taskRun.Name, metav1.GetOptions{})
 	got := getTaskRun.Status.TaskSpec.Steps
+	securityContextPrivileged := true
 	want := []v1.Step{{
-		Image:      "myImage",
-		Command:    []string{"ls"},
-		Name:       "step1",
-		WorkingDir: "/foo",
+		Image:           "myImage",
+		Command:         []string{"ls"},
+		Name:            "step1",
+		WorkingDir:      "/foo",
+		SecurityContext: &corev1.SecurityContext{Privileged: &securityContextPrivileged},
 	}, {
 		Image:  "myImage",
 		Script: "echo hi",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This commit adds SecurityContext to StepAction. Part of #7259 

Signed-off-by: Yongxuan Zhang yongxuanzhang@google.com

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Users can declare SecurityContext in StepAction.
```
