### PR TITLE
[TEP-0144] Validate PipelineRun for Param Enum

### DIFF
--- a/config/config-feature-flags.yaml
+++ b/config/config-feature-flags.yaml
@@ -127,5 +127,4 @@ data:
   # This feature is in preview mode and not implemented yet. Please check #7259 for updates.
   enable-step-actions: "false"
   # Setting this flag to "true" will enable the built-in param input validation via param enum.
-  # NOTE (#7270): this feature is still under development and not yet functional.
   enable-param-enum: "false"

--- a/docs/additional-configs.md
+++ b/docs/additional-configs.md
@@ -317,6 +317,7 @@ Features currently in "alpha" are:
 | [Coschedule](./affinityassistants.md)                                                               | [TEP-0135](https://github.com/tektoncd/community/blob/main/teps/0135-coscheduling-pipelinerun-pods.md)                        | N/A                                 |`coschedule`                                |
 | [keep pod on cancel](./taskruns.md#cancelling-a-taskrun)                                            | N/A |  v0.52 | keep-pod-on-cancel |
 | [CEL in WhenExpression](./taskruns.md#cancelling-a-taskrun)                                            | [TEP-0145](https://github.com/tektoncd/community/blob/main/teps/0145-cel-in-whenexpression.md) |  N/A | enable-cel-in-whenexpression |
+| [Param Enum](./taskruns.md#parameter-enums)                                            | [TEP-0144](https://github.com/tektoncd/community/blob/main/teps/0144-param-enum.md) |  N/A | `enable-param-enum` |
 
 ### Beta Features
 

--- a/docs/pipeline-api.md
+++ b/docs/pipeline-api.md
@@ -1997,6 +1997,9 @@ associated Pipeline is an invalid graph (a.k.a wrong order, cycle, …)</p>
 </tr><tr><td><p>&#34;InvalidMatrixParameterTypes&#34;</p></td>
 <td><p>ReasonInvalidMatrixParameterTypes indicates a matrix contains invalid parameter types</p>
 </td>
+</tr><tr><td><p>&#34;InvalidParamValue&#34;</p></td>
+<td><p>PipelineRunReasonInvalidParamValue indicates that the PipelineRun Param input value is not allowed.</p>
+</td>
 </tr><tr><td><p>&#34;InvalidTaskResultReference&#34;</p></td>
 <td><p>ReasonInvalidTaskResultReference indicates a task result was declared
 but was not initialized by that task</p>

--- a/docs/pipelineruns.md
+++ b/docs/pipelineruns.md
@@ -271,6 +271,18 @@ case is when your CI system autogenerates `PipelineRuns` and it has `Parameters`
 provide to all `PipelineRuns`. Because you can pass in extra `Parameters`, you don't have to
 go through the complexity of checking each `Pipeline` and providing only the required params.
 
+#### Parameter Enums
+
+> :seedling: **`enum` is an [alpha](additional-configs.md#alpha-features) feature.** The `enable-param-enum` feature flag must be set to `"true"` to enable this feature.
+
+If a `Parameter` is guarded by `Enum` in the `Pipeline`, you can only provide `Parameter` values in the `PipelineRun` that are predefined in the `Param.Enum` in the `Pipeline`. The `PipelineRun` will fail with reason `InvalidParamValue` otherwise. 
+
+Tekton will also the validate the `param` values passed to any referenced `Tasks` (via `taskRef`) if `Enum` is specified for the `Task`. The `PipelineRun` will fail with reason `InvalidParamValue` if `Enum` validation is failed for any of the `PipelineTask`. 
+
+You can also specify `Enum` in an embedded `Pipeline` in a `PipelineRun`. The same `Param` validation will be executed in this scenario.
+
+See more details in [Param.Enum](./pipelines.md#param-enum).
+
 #### Propagated Parameters
 
 When using an inlined spec, parameters from the parent `PipelineRun` will be

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -272,11 +272,77 @@ spec:
 ```
 
 #### Param enum
-> :seedling: **Specifying `enum` is an [alpha](additional-configs.md#alpha-features) feature.** The `enable-param-enum` feature flag must be set to `"true"` to enable this feature.
+> :seedling: **`enum` is an [alpha](additional-configs.md#alpha-features) feature.** The `enable-param-enum` feature flag must be set to `"true"` to enable this feature.
 
-> :seedling: This feature is WIP and not yet supported/implemented. Documentation to be completed.
+Parameter declarations can include `enum` which is a predefine set of valid values that can be accepted by the `Pipeline` `Param`. If a `Param` has both `enum` and default value, the default value must be in the `enum` set. For example, the valid/allowed values for `Param` "message" is bounded to `v1` and `v2`:
 
-Parameter declarations can include `enum` which is a predefine set of valid values that can be accepted by the `Pipeline`.
+``` yaml
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: pipeline-param-enum
+spec:
+  params:
+  - name: message
+    enum: ["v1", "v2"]
+    default: "v1"
+  tasks:
+  - name: task1
+    params:
+      - name: message
+        value: $(params.message)
+    steps:
+    - name: build
+      image: bash:3.2
+      script: |
+        echo "$(params.message)"
+```
+
+If the `Param` value passed in by `PipelineRun` is **NOT** in the predefined `enum` list, the `PipelineRun` will fail with reason `InvalidParamValue`.
+
+If a `PipelineTask` references a `Task` with `enum`, the `enums` specified in the Pipeline `spec.params` (pipeline-level `enum`) must be
+a **subset** of the `enums` specified in the referenced `Task` (task-level `enum`). Note that an empty pipeline-level `enum` is invalid 
+in this scenario since an empty `enum` set indicates a "universal set" which allows all possible values. In the below example, the referenced `Task` accepts `v1` and `v2` as valid values, the `Pipeline` further restricts the valid values to `v1`.
+
+``` yaml
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: param-enum-demo
+spec:
+  params:
+  - name: message
+    type: string
+    enum: ["v1", "v2"]
+  steps:
+  - name: build
+    image: bash:latest
+    script: |
+      echo "$(params.message)"
+```
+
+``` yaml
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: pipeline-param-enum
+spec:
+  params:
+  - name: message
+    enum: ["v1"]  # note that an empty enum set is invalid
+  tasks:
+  - name: task1
+    params:
+      - name: message
+        value: $(params.message)
+    taskRef:
+      name: param-enum-demo
+```
+
+Tekton validates user-provided values in a `PipelineRun` against the `enum` specified in the `PipelineSpec.params`. Tekton also validates
+any resolved `param` value against the `enum` specified in each `PipelineTask` before creating the `TaskRun`.
+
+See usage in this [example](../examples/v1/pipelineruns/alpha/param-enum.yaml)
 
 ## Adding `Tasks` to the `Pipeline`
 

--- a/docs/taskruns.md
+++ b/docs/taskruns.md
@@ -404,9 +404,7 @@ go through the complexity of checking each `Task` and providing only the require
 
 #### Parameter Enums
 
-> :seedling: **Specifying `enum` is an [alpha](additional-configs.md#alpha-features) feature.** The `enable-param-enum` feature flag must be set to `"true"` to enable this feature.
-
-> :seedling: This feature is WIP and not yet supported/implemented. Documentation to be completed.
+> :seedling: **`enum` is an [alpha](additional-configs.md#alpha-features) feature.** The `enable-param-enum` feature flag must be set to `"true"` to enable this feature.
 
 If a `Parameter` is guarded by `Enum` in the `Task`, you can only provide `Parameter` values in the `TaskRun` that are predefined in the `Param.Enum` in the `Task`. The `TaskRun` will fail with reason `InvalidParamValue` otherwise.
 

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -713,11 +713,9 @@ spec:
 ```
 
 #### Param enum
-> :seedling: **Specifying `enum` is an [alpha](additional-configs.md#alpha-features) feature.** The `enable-param-enum` feature flag must be set to `"true"` to enable this feature.
+> :seedling: **`enum` is an [alpha](additional-configs.md#alpha-features) feature.** The `enable-param-enum` feature flag must be set to `"true"` to enable this feature.
 
-> :seedling: This feature is WIP and not yet supported/implemented. Documentation to be completed.
-
-Parameter declarations can include `enum` which is a predefine set of valid values that can be accepted by the `Param`. For example, the valid/allowed values for `Param` "message" is bounded to `v1`, `v2` and `v3`:
+Parameter declarations can include `enum` which is a predefine set of valid values that can be accepted by the `Param`. If a `Param` has both `enum` and default value, the default value must be in the `enum` set. For example, the valid/allowed values for `Param` "message" is bounded to `v1`, `v2` and `v3`:
 
 ``` yaml
 apiVersion: tekton.dev/v1
@@ -729,6 +727,7 @@ spec:
   - name: message
     type: string
     enum: ["v1", "v2", "v3"]
+    default: "v1"
   steps:
   - name: build
     image: bash:latest

--- a/examples/v1/pipelineruns/alpha/param-enum.yaml
+++ b/examples/v1/pipelineruns/alpha/param-enum.yaml
@@ -1,0 +1,42 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: task-param-enum
+spec:
+  params:
+  - name: message
+    type: string
+    enum: ["v1", "v2", "v3"]
+  steps:
+  - name: build
+    image: bash:latest
+    script: |
+      echo "$(params.message)"
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: pipeline-param-enum
+spec:
+  params:
+  - name: message
+    enum: ["v1", "v2"]
+    default: "v1"
+  tasks:
+  - name: task1
+    params:
+      - name: message
+        value: $(params.message)
+    taskRef:
+      name: task-param-enum
+---
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: pipelinerun-param-enum
+spec:
+  pipelineRef:
+    name: pipeline-param-enum
+  params:
+    - name: message
+      value: "v1"

--- a/pkg/apis/pipeline/v1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1/pipelinerun_types.go
@@ -408,6 +408,8 @@ const (
 	PipelineRunReasonCreateRunFailed PipelineRunReason = "CreateRunFailed"
 	// ReasonCELEvaluationFailed indicates the pipeline fails the CEL evaluation
 	PipelineRunReasonCELEvaluationFailed PipelineRunReason = "CELEvaluationFailed"
+	// PipelineRunReasonInvalidParamValue indicates that the PipelineRun Param input value is not allowed.
+	PipelineRunReasonInvalidParamValue PipelineRunReason = "InvalidParamValue"
 )
 
 func (t PipelineRunReason) String() string {

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -29,6 +29,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/reconciler/taskrun/resources"
 	"github.com/tektoncd/pipeline/pkg/remote"
+	"github.com/tektoncd/pipeline/pkg/substitution"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/kmeta"
@@ -807,4 +808,74 @@ func createResultsCacheMatrixedTaskRuns(rpt *ResolvedPipelineTask) (resultsCache
 		}
 	}
 	return resultsCache
+}
+
+// ValidateParamEnumSubset finds the referenced pipeline-level params in the resolved pipelineTask.
+// It then validates if the referenced pipeline-level param enums are subsets of the resolved pipelineTask-level param enums
+func ValidateParamEnumSubset(pipelineTaskParams []v1.Param, pipelineParamSpecs []v1.ParamSpec, rt *resources.ResolvedTask) error {
+	for _, p := range pipelineTaskParams {
+		// calculate referenced param enums
+		res, present, errString := substitution.ExtractVariablesFromString(p.Value.StringVal, "params")
+		if !present {
+			continue
+		}
+		if errString != "" {
+			return fmt.Errorf("unexpected error in ExtractVariablesFromString: %s", errString)
+		}
+		if len(res) != 1 {
+			return fmt.Errorf("unexpected resolved param in ExtractVariablesFromString, expect 1 but got %v", len(res))
+		}
+
+		// resolve pipeline-level and pipelineTask-level enums
+		paramName := substitution.TrimArrayIndex(res[0])
+		pipelineParam := getParamFromName(paramName, pipelineParamSpecs)
+		resolvedTaskParam := getParamFromName(p.Name, rt.TaskSpec.Params)
+
+		// param enum is only supported for string param type,
+		// we only validate the enum subset requirement for string typed param.
+		// If there is no task-level enum (allowing any value), any pipeline-level enum is allowed
+		if pipelineParam.Type != v1.ParamTypeString || len(resolvedTaskParam.Enum) == 0 {
+			return nil
+		}
+
+		// if pipelin-level enum is empty (allowing any value) but task-level enum is not, it is not a "subset"
+		if len(pipelineParam.Enum) == 0 && len(resolvedTaskParam.Enum) > 0 {
+			return fmt.Errorf("pipeline param \"%s\" has no enum, but referenced in \"%s\" task has enums: %v", pipelineParam.Name, rt.TaskName, resolvedTaskParam.Enum)
+		}
+
+		// validate if pipeline-level enum is a subset of pipelineTask-level enum
+		if isValid := isSubset(pipelineParam.Enum, resolvedTaskParam.Enum); !isValid {
+			return fmt.Errorf("pipeline param \"%s\" enum: %v is not a subset of the referenced in \"%s\" task param enum: %v", pipelineParam.Name, pipelineParam.Enum, rt.TaskName, resolvedTaskParam.Enum)
+		}
+	}
+
+	return nil
+}
+
+func isSubset(pipelineEnum, taskEnum []string) bool {
+	pipelineEnumMap := make(map[string]bool)
+	TaskEnumMap := make(map[string]bool)
+	for _, e := range pipelineEnum {
+		pipelineEnumMap[e] = true
+	}
+	for _, e := range taskEnum {
+		TaskEnumMap[e] = true
+	}
+
+	for e := range pipelineEnumMap {
+		if !TaskEnumMap[e] {
+			return false
+		}
+	}
+
+	return true
+}
+
+func getParamFromName(name string, pss v1.ParamSpecs) v1.ParamSpec {
+	for _, ps := range pss {
+		if ps.Name == name {
+			return ps
+		}
+	}
+	return v1.ParamSpec{}
 }


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Part of [#7270][#7270]. In [TEP-0144][tep-0144] we proposed a new `enum` field to support built-in param input validation.

This commit adds validation logic for PipelineRun against Param Enum

/kind feature

[#7270]: https://github.com/tektoncd/pipeline/issues/7270
[tep-0144]: https://github.com/tektoncd/community/blob/main/teps/0144-param-enum.md

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Implement Param Enum validation for PipelineRuns. Param Enum is supported per TEP-0144
```
