### PR TITLE
[TEP-0142] Support default resolver for Ref to remote StepAction

### DIFF
--- a/docs/stepactions.md
+++ b/docs/stepactions.md
@@ -305,3 +305,5 @@ spec:
             - name: pathInRepo
               value: remote_step.yaml
 ```
+
+The default resolver type can be configured by the `default-resolver-type` field in the `config-defaults` ConfigMap (`alpha` feature). See [additional-configs.md](./additional-configs.md) for details.

--- a/pkg/apis/pipeline/v1/task_defaults.go
+++ b/pkg/apis/pipeline/v1/task_defaults.go
@@ -19,6 +19,7 @@ package v1
 import (
 	"context"
 
+	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"knative.dev/pkg/apis"
 )
 
@@ -31,6 +32,12 @@ func (t *Task) SetDefaults(ctx context.Context) {
 
 // SetDefaults set any defaults for the task spec
 func (ts *TaskSpec) SetDefaults(ctx context.Context) {
+	cfg := config.FromContextOrDefaults(ctx)
+	for _, s := range ts.Steps {
+		if s.Ref != nil && s.Ref.Name == "" && s.Ref.Resolver == "" {
+			s.Ref.Resolver = ResolverName(cfg.Defaults.DefaultResolverType)
+		}
+	}
 	for i := range ts.Params {
 		ts.Params[i].SetDefaults(ctx)
 	}

--- a/pkg/apis/pipeline/v1/task_defaults_test.go
+++ b/pkg/apis/pipeline/v1/task_defaults_test.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2023 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package v1_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	cfgtesting "github.com/tektoncd/pipeline/pkg/apis/config/testing"
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"github.com/tektoncd/pipeline/test/diff"
+)
+
+func TestTask_SetDefaults(t *testing.T) {
+	tests := []struct {
+		name string
+		in   *v1.Task
+		want *v1.Task
+	}{{
+		name: "remote Ref uses default resolver",
+		in: &v1.Task{
+			Spec: v1.TaskSpec{
+				Steps: []v1.Step{{
+					Name: "foo",
+					Ref:  &v1.Ref{},
+				}},
+			},
+		},
+		want: &v1.Task{
+			Spec: v1.TaskSpec{
+				Steps: []v1.Step{{
+					Name: "foo",
+					Ref:  &v1.Ref{ResolverRef: v1.ResolverRef{Resolver: "git"}},
+				}},
+			},
+		},
+	}, {
+		name: "remote Ref has resolver not overwritten by default resolver",
+		in: &v1.Task{
+			Spec: v1.TaskSpec{
+				Steps: []v1.Step{{
+					Name: "foo",
+					Ref:  &v1.Ref{ResolverRef: v1.ResolverRef{Resolver: "bundle"}},
+				}},
+			},
+		},
+		want: &v1.Task{
+			Spec: v1.TaskSpec{
+				Steps: []v1.Step{{
+					Name: "foo",
+					Ref:  &v1.Ref{ResolverRef: v1.ResolverRef{Resolver: "bundle"}},
+				}},
+			},
+		},
+	}, {
+		name: "local Ref not adding default resolver",
+		in: &v1.Task{
+			Spec: v1.TaskSpec{
+				Steps: []v1.Step{{
+					Name: "foo",
+					Ref:  &v1.Ref{Name: "local"},
+				}},
+			},
+		},
+		want: &v1.Task{
+			Spec: v1.TaskSpec{
+				Steps: []v1.Step{{
+					Name: "foo",
+					Ref:  &v1.Ref{Name: "local"},
+				}},
+			},
+		},
+	}}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := cfgtesting.SetDefaults(context.Background(), t, map[string]string{
+				"default-resolver-type": "git",
+			})
+			got := tc.in
+			got.SetDefaults(ctx)
+			if d := cmp.Diff(tc.want, got); d != "" {
+				t.Errorf("SetDefaults %s", diff.PrintWantGot(d))
+			}
+		})
+	}
+}


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This commit fixes #7329. It adds the default resolver for the Ref to remote StepAction.

/kind feature

Signed-off-by: Yongxuan Zhang yongxuanzhang@google.com

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
