### PR TITLE
TEP-0142: Introduce Value in TaskResults

### DIFF
--- a/docs/pipeline-api.md
+++ b/docs/pipeline-api.md
@@ -1741,7 +1741,7 @@ Used to distinguish between a single string and an array of strings.</p>
 <h3 id="tekton.dev/v1.ParamValue">ParamValue
 </h3>
 <p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.Param">Param</a>, <a href="#tekton.dev/v1.ParamSpec">ParamSpec</a>, <a href="#tekton.dev/v1.PipelineResult">PipelineResult</a>, <a href="#tekton.dev/v1.PipelineRunResult">PipelineRunResult</a>, <a href="#tekton.dev/v1.TaskRunResult">TaskRunResult</a>)
+(<em>Appears on:</em><a href="#tekton.dev/v1.Param">Param</a>, <a href="#tekton.dev/v1.ParamSpec">ParamSpec</a>, <a href="#tekton.dev/v1.PipelineResult">PipelineResult</a>, <a href="#tekton.dev/v1.PipelineRunResult">PipelineRunResult</a>, <a href="#tekton.dev/v1.TaskResult">TaskResult</a>, <a href="#tekton.dev/v1.TaskRunResult">TaskRunResult</a>)
 </p>
 <div>
 <p>ResultValue is a type alias of ParamValue</p>
@@ -4929,6 +4929,20 @@ string
 <td>
 <em>(Optional)</em>
 <p>Description is a human-readable description of the result</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>value</code><br/>
+<em>
+<a href="#tekton.dev/v1.ParamValue">
+ParamValue
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Value the expression used to retrieve the value of the result from an underlying Step.</p>
 </td>
 </tr>
 </tbody>
@@ -10232,7 +10246,7 @@ Used to distinguish between a single string and an array of strings.</p>
 <h3 id="tekton.dev/v1beta1.ParamValue">ParamValue
 </h3>
 <p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.Param">Param</a>, <a href="#tekton.dev/v1beta1.ParamSpec">ParamSpec</a>, <a href="#tekton.dev/v1beta1.PipelineResult">PipelineResult</a>, <a href="#tekton.dev/v1beta1.PipelineRunResult">PipelineRunResult</a>, <a href="#tekton.dev/v1beta1.TaskRunResult">TaskRunResult</a>)
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.Param">Param</a>, <a href="#tekton.dev/v1beta1.ParamSpec">ParamSpec</a>, <a href="#tekton.dev/v1beta1.PipelineResult">PipelineResult</a>, <a href="#tekton.dev/v1beta1.PipelineRunResult">PipelineRunResult</a>, <a href="#tekton.dev/v1beta1.TaskResult">TaskResult</a>, <a href="#tekton.dev/v1beta1.TaskRunResult">TaskRunResult</a>)
 </p>
 <div>
 <p>ResultValue is a type alias of ParamValue</p>
@@ -14133,6 +14147,20 @@ string
 <td>
 <em>(Optional)</em>
 <p>Description is a human-readable description of the result</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>value</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.ParamValue">
+ParamValue
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Value the expression used to retrieve the value of the result from an underlying Step.</p>
 </td>
 </tr>
 </tbody>

--- a/pkg/apis/pipeline/v1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1/openapi_generated.go
@@ -3425,12 +3425,18 @@ func schema_pkg_apis_pipeline_v1_TaskResult(ref common.ReferenceCallback) common
 							Format:      "",
 						},
 					},
+					"value": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Value the expression used to retrieve the value of the result from an underlying Step.",
+							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.ParamValue"),
+						},
+					},
 				},
 				Required: []string{"name"},
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PropertySpec"},
+			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.ParamValue", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PropertySpec"},
 	}
 }
 

--- a/pkg/apis/pipeline/v1/result_types.go
+++ b/pkg/apis/pipeline/v1/result_types.go
@@ -32,6 +32,10 @@ type TaskResult struct {
 	// Description is a human-readable description of the result
 	// +optional
 	Description string `json:"description,omitempty"`
+
+	// Value the expression used to retrieve the value of the result from an underlying Step.
+	// +optional
+	Value *ResultValue `json:"value,omitempty"`
 }
 
 // TaskRunResult used to describe the results of a task

--- a/pkg/apis/pipeline/v1/result_validation.go
+++ b/pkg/apis/pipeline/v1/result_validation.go
@@ -16,7 +16,10 @@ package v1
 import (
 	"context"
 	"fmt"
+	"regexp"
 
+	"github.com/tektoncd/pipeline/pkg/apis/config"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"knative.dev/pkg/apis"
 )
 
@@ -28,20 +31,16 @@ func (tr TaskResult) Validate(ctx context.Context) (errs *apis.FieldError) {
 
 	switch {
 	case tr.Type == ResultsTypeObject:
-		errs := validateObjectResult(tr)
-		return errs
+		errs = errs.Also(validateObjectResult(tr))
 	case tr.Type == ResultsTypeArray:
-		return nil
 	// Resources created before the result. Type was introduced may not have Type set
 	// and should be considered valid
 	case tr.Type == "":
-		return nil
 	// By default, the result type is string
 	case tr.Type != ResultsTypeString:
-		return apis.ErrInvalidValue(tr.Type, "type", "type must be string")
+		errs = errs.Also(apis.ErrInvalidValue(tr.Type, "type", "type must be string"))
 	}
-
-	return nil
+	return errs.Also(tr.validateValue(ctx))
 }
 
 // validateObjectResult validates the object result and check if the Properties is missing
@@ -65,4 +64,61 @@ func validateObjectResult(tr TaskResult) (errs *apis.FieldError) {
 		}
 	}
 	return nil
+}
+
+// validateValue validates the value of the TaskResult.
+// It requires that enable-step-actions is true, the value is of type string
+// and format $(steps.<stepName>.results.<resultName>)
+func (tr TaskResult) validateValue(ctx context.Context) (errs *apis.FieldError) {
+	if tr.Value == nil {
+		return nil
+	}
+	if !config.FromContextOrDefaults(ctx).FeatureFlags.EnableStepActions {
+		return apis.ErrGeneric("feature flag %s should be set to true to fetch Results from Steps using StepActions.", config.EnableStepActions)
+	}
+	if tr.Value.Type != ParamTypeString {
+		return &apis.FieldError{
+			Message: fmt.Sprintf(
+				"Invalid Type. Wanted string but got: \"%v\"", tr.Value.Type),
+			Paths: []string{
+				fmt.Sprintf("%s.type", tr.Name),
+			},
+		}
+	}
+	if tr.Value.StringVal != "" {
+		stepName, resultName, err := ExtractStepResultName(tr.Value.StringVal)
+		if err != nil {
+			return &apis.FieldError{
+				Message: fmt.Sprintf("%v", err),
+				Paths:   []string{fmt.Sprintf("%s.value", tr.Name)},
+			}
+		}
+		if e := validation.IsDNS1123Label(stepName); len(e) > 0 {
+			errs = errs.Also(&apis.FieldError{
+				Message: fmt.Sprintf("invalid extracted step name %q", stepName),
+				Paths:   []string{fmt.Sprintf("%s.value", tr.Name)},
+				Details: "stepName in $(steps.<stepName>.results.<resultName>) must be a valid DNS Label, For more info refer to https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+			})
+		}
+		if !resultNameFormatRegex.MatchString(resultName) {
+			errs = errs.Also(&apis.FieldError{
+				Message: fmt.Sprintf("invalid extracted result name %q", resultName),
+				Paths:   []string{fmt.Sprintf("%s.value", tr.Name)},
+				Details: fmt.Sprintf("resultName in $(steps.<stepName>.results.<resultName>) must consist of alphanumeric characters, '-', '_', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my-name',  or 'my_name', regex used for validation is '%s')", ResultNameFormat),
+			})
+		}
+	}
+	return errs
+}
+
+// ExtractStepResultName extracts the step name and result name from a string matching
+// formtat $(steps.<stepName>.results.<resultName>).
+// If a match is not found, an error is retured.
+func ExtractStepResultName(value string) (string, string, error) {
+	re := regexp.MustCompile(`\$\(steps\.(.*?)\.results\.(.*?)\)`)
+	rs := re.FindStringSubmatch(value)
+	if len(rs) != 3 {
+		return "", "", fmt.Errorf("Could not extract step name and result name. Expected value to look like $(steps.<stepName>.results.<resultName>) but got \"%v\"", value)
+	}
+	return rs[1], rs[2], nil
 }

--- a/pkg/apis/pipeline/v1/swagger.json
+++ b/pkg/apis/pipeline/v1/swagger.json
@@ -1763,6 +1763,10 @@
         "type": {
           "description": "Type is the user-specified type of the result. The possible type is currently \"string\" and will support \"array\" in following work.",
           "type": "string"
+        },
+        "value": {
+          "description": "Value the expression used to retrieve the value of the result from an underlying Step.",
+          "$ref": "#/definitions/v1.ParamValue"
         }
       }
     },

--- a/pkg/apis/pipeline/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/pipeline/v1/zz_generated.deepcopy.go
@@ -1504,6 +1504,11 @@ func (in *TaskResult) DeepCopyInto(out *TaskResult) {
 			(*out)[key] = val
 		}
 	}
+	if in.Value != nil {
+		in, out := &in.Value, &out.Value
+		*out = new(ParamValue)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/pkg/apis/pipeline/v1beta1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1beta1/openapi_generated.go
@@ -4637,12 +4637,18 @@ func schema_pkg_apis_pipeline_v1beta1_TaskResult(ref common.ReferenceCallback) c
 							Format:      "",
 						},
 					},
+					"value": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Value the expression used to retrieve the value of the result from an underlying Step.",
+							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.ParamValue"),
+						},
+					},
 				},
 				Required: []string{"name"},
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PropertySpec"},
+			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.ParamValue", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PropertySpec"},
 	}
 }
 

--- a/pkg/apis/pipeline/v1beta1/result_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/result_conversion.go
@@ -33,6 +33,10 @@ func (r TaskResult) convertTo(ctx context.Context, sink *v1.TaskResult) {
 		}
 		sink.Properties = properties
 	}
+	if r.Value != nil {
+		sink.Value = &v1.ParamValue{}
+		r.Value.convertTo(ctx, sink.Value)
+	}
 }
 
 func (r *TaskResult) convertFrom(ctx context.Context, source v1.TaskResult) {
@@ -45,5 +49,9 @@ func (r *TaskResult) convertFrom(ctx context.Context, source v1.TaskResult) {
 			properties[k] = PropertySpec{Type: ParamType(v.Type)}
 		}
 		r.Properties = properties
+	}
+	if source.Value != nil {
+		r.Value = &ParamValue{}
+		r.Value.convertFrom(ctx, *source.Value)
 	}
 }

--- a/pkg/apis/pipeline/v1beta1/result_types.go
+++ b/pkg/apis/pipeline/v1beta1/result_types.go
@@ -32,6 +32,10 @@ type TaskResult struct {
 	// Description is a human-readable description of the result
 	// +optional
 	Description string `json:"description,omitempty"`
+
+	// Value the expression used to retrieve the value of the result from an underlying Step.
+	// +optional
+	Value *ResultValue `json:"value,omitempty"`
 }
 
 // TaskRunResult used to describe the results of a task

--- a/pkg/apis/pipeline/v1beta1/result_validation.go
+++ b/pkg/apis/pipeline/v1beta1/result_validation.go
@@ -17,6 +17,9 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/tektoncd/pipeline/pkg/apis/config"
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"knative.dev/pkg/apis"
 )
 
@@ -28,20 +31,16 @@ func (tr TaskResult) Validate(ctx context.Context) (errs *apis.FieldError) {
 
 	switch {
 	case tr.Type == ResultsTypeObject:
-		errs := validateObjectResult(tr)
-		return errs
+		errs = errs.Also(validateObjectResult(tr))
 	case tr.Type == ResultsTypeArray:
-		return errs
 	// Resources created before the result. Type was introduced may not have Type set
 	// and should be considered valid
 	case tr.Type == "":
-		return nil
 	// By default, the result type is string
 	case tr.Type != ResultsTypeString:
-		return apis.ErrInvalidValue(tr.Type, "type", "type must be string")
+		errs = errs.Also(apis.ErrInvalidValue(tr.Type, "type", "type must be string"))
 	}
-
-	return nil
+	return errs.Also(tr.validateValue(ctx))
 }
 
 // validateObjectResult validates the object result and check if the Properties is missing
@@ -65,4 +64,49 @@ func validateObjectResult(tr TaskResult) (errs *apis.FieldError) {
 		}
 	}
 	return nil
+}
+
+// validateValue validates the value of the TaskResult.
+// It requires that enable-step-actions is true, the value is of type string
+// and format $(steps.<stepName>.results.<resultName>)
+func (tr TaskResult) validateValue(ctx context.Context) (errs *apis.FieldError) {
+	if tr.Value == nil {
+		return nil
+	}
+	if !config.FromContextOrDefaults(ctx).FeatureFlags.EnableStepActions {
+		return apis.ErrGeneric("feature flag %s should be set to true to fetch Results from Steps using StepActions.", config.EnableStepActions)
+	}
+	if tr.Value.Type != ParamTypeString {
+		return &apis.FieldError{
+			Message: fmt.Sprintf(
+				"Invalid Type. Wanted string but got: \"%v\"", tr.Value.Type),
+			Paths: []string{
+				fmt.Sprintf("%s.type", tr.Name),
+			},
+		}
+	}
+	if tr.Value.StringVal != "" {
+		stepName, resultName, err := v1.ExtractStepResultName(tr.Value.StringVal)
+		if err != nil {
+			return &apis.FieldError{
+				Message: fmt.Sprintf("%v", err),
+				Paths:   []string{fmt.Sprintf("%s.value", tr.Name)},
+			}
+		}
+		if e := validation.IsDNS1123Label(stepName); len(e) > 0 {
+			errs = errs.Also(&apis.FieldError{
+				Message: fmt.Sprintf("invalid extracted step name %q", stepName),
+				Paths:   []string{fmt.Sprintf("%s.value", tr.Name)},
+				Details: "stepName in $(steps.<stepName>.results.<resultName>) must be a valid DNS Label, For more info refer to https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+			})
+		}
+		if !resultNameFormatRegex.MatchString(resultName) {
+			errs = errs.Also(&apis.FieldError{
+				Message: fmt.Sprintf("invalid extracted result name %q", resultName),
+				Paths:   []string{fmt.Sprintf("%s.value", tr.Name)},
+				Details: fmt.Sprintf("resultName in $(steps.<stepName>.results.<resultName>) must consist of alphanumeric characters, '-', '_', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my-name',  or 'my_name', regex used for validation is '%s')", ResultNameFormat),
+			})
+		}
+	}
+	return errs
 }

--- a/pkg/apis/pipeline/v1beta1/swagger.json
+++ b/pkg/apis/pipeline/v1beta1/swagger.json
@@ -2564,6 +2564,10 @@
         "type": {
           "description": "Type is the user-specified type of the result. The possible type is currently \"string\" and will support \"array\" in following work.",
           "type": "string"
+        },
+        "value": {
+          "description": "Value the expression used to retrieve the value of the result from an underlying Step.",
+          "$ref": "#/definitions/v1beta1.ParamValue"
         }
       }
     },

--- a/pkg/apis/pipeline/v1beta1/task_conversion_test.go
+++ b/pkg/apis/pipeline/v1beta1/task_conversion_test.go
@@ -88,6 +88,20 @@ spec:
           value: hello
 `
 
+	stepActionTaskResultYAML := `
+metadata:
+  name: foo
+  namespace: bar
+spec:
+  results:
+    - name: stepActionResult
+      type: string
+      value: "$(steps.stepName.results.resultName)"
+  steps:
+    - name: stepName
+      ref:
+        name: "step-action"
+`
 	remoteStepActionTaskYAML := `
 metadata:
   name: foo
@@ -295,6 +309,9 @@ spec:
 	stepActionTaskV1beta1 := parse.MustParseV1beta1Task(t, stepActionTaskYAML)
 	stepActionTaskV1 := parse.MustParseV1Task(t, stepActionTaskYAML)
 
+	stepActionTaskResultV1beta1 := parse.MustParseV1beta1Task(t, stepActionTaskResultYAML)
+	stepActionTaskResultV1 := parse.MustParseV1Task(t, stepActionTaskResultYAML)
+
 	remoteStepActionTaskV1beta1 := parse.MustParseV1beta1Task(t, remoteStepActionTaskYAML)
 	remoteStepActionTaskV1 := parse.MustParseV1Task(t, remoteStepActionTaskYAML)
 
@@ -334,6 +351,10 @@ spec:
 		name:        "step action in task",
 		v1beta1Task: stepActionTaskV1beta1,
 		v1Task:      stepActionTaskV1,
+	}, {
+		name:        "value in task result",
+		v1beta1Task: stepActionTaskResultV1beta1,
+		v1Task:      stepActionTaskResultV1,
 	}, {
 		name:        "remote step action in task",
 		v1beta1Task: remoteStepActionTaskV1beta1,

--- a/pkg/apis/pipeline/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/pipeline/v1beta1/zz_generated.deepcopy.go
@@ -2066,6 +2066,11 @@ func (in *TaskResult) DeepCopyInto(out *TaskResult) {
 			(*out)[key] = val
 		}
 	}
+	if in.Value != nil {
+		in, out := &in.Value, &out.Value
+		*out = new(ParamValue)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 


### PR DESCRIPTION
This PR introduces the field `Value` in `TaskResults`. This field is necessary to capture the results produced by `StepActions` if the Task needs to resolve name conflicts.

This is part of issue https://github.com/tektoncd/pipeline/issues/7259. Following this PR, we will add support for extracting StepAction results via termination message and sidecar logs.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
[WIP] StepActions: Introduce Value in TaskResults
```
/kind feature