### PR TITLE
TEP-0142: Surface step results via termination message

### DIFF
--- a/cmd/entrypoint/main.go
+++ b/cmd/entrypoint/main.go
@@ -49,6 +49,7 @@ var (
 	postFile            = flag.String("post_file", "", "If specified, file to write upon completion")
 	terminationPath     = flag.String("termination_path", "/tekton/termination", "If specified, file to write upon termination")
 	results             = flag.String("results", "", "If specified, list of file names that might contain task results")
+	stepResults         = flag.String("step_results", "", "step results if specified")
 	timeout             = flag.Duration("timeout", time.Duration(0), "If specified, sets timeout for step")
 	stdoutPath          = flag.String("stdout_path", "", "If specified, file to copy stdout to")
 	stderrPath          = flag.String("stderr_path", "", "If specified, file to copy stderr to")
@@ -159,6 +160,7 @@ func main() {
 		},
 		PostWriter:             &realPostWriter{},
 		Results:                strings.Split(*results, ","),
+		StepResults:            strings.Split(*stepResults, ","),
 		Timeout:                timeout,
 		BreakpointOnFailure:    *breakpointOnFailure,
 		OnError:                *onError,

--- a/docs/pipeline-api.md
+++ b/docs/pipeline-api.md
@@ -4622,6 +4622,18 @@ string
 <td>
 </td>
 </tr>
+<tr>
+<td>
+<code>results</code><br/>
+<em>
+<a href="#tekton.dev/v1.TaskRunResult">
+[]TaskRunResult
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="tekton.dev/v1.StepTemplate">StepTemplate
@@ -5140,10 +5152,10 @@ reasons that emerge from underlying resources are not included here</p>
 <h3 id="tekton.dev/v1.TaskRunResult">TaskRunResult
 </h3>
 <p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.TaskRunStatusFields">TaskRunStatusFields</a>)
+(<em>Appears on:</em><a href="#tekton.dev/v1.StepState">StepState</a>, <a href="#tekton.dev/v1.TaskRunStatusFields">TaskRunStatusFields</a>)
 </p>
 <div>
-<p>TaskRunResult used to describe the results of a task</p>
+<p>TaskRunStepResult is a type alias of TaskRunResult</p>
 </div>
 <table>
 <thead>
@@ -13462,6 +13474,18 @@ string
 <td>
 </td>
 </tr>
+<tr>
+<td>
+<code>results</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.TaskRunResult">
+[]TaskRunResult
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="tekton.dev/v1beta1.StepTemplate">StepTemplate
@@ -14364,10 +14388,10 @@ reasons that emerge from underlying resources are not included here</p>
 <h3 id="tekton.dev/v1beta1.TaskRunResult">TaskRunResult
 </h3>
 <p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskRunStatusFields">TaskRunStatusFields</a>)
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.StepState">StepState</a>, <a href="#tekton.dev/v1beta1.TaskRunStatusFields">TaskRunStatusFields</a>)
 </p>
 <div>
-<p>TaskRunResult used to describe the results of a task</p>
+<p>TaskRunStepResult is a type alias of TaskRunResult</p>
 </div>
 <table>
 <thead>

--- a/examples/v1/taskruns/no-ci/stepaction-results.yaml
+++ b/examples/v1/taskruns/no-ci/stepaction-results.yaml
@@ -1,0 +1,24 @@
+apiVersion: tekton.dev/v1alpha1
+kind: StepAction
+metadata:
+  name: step-action
+spec:
+  image: alpine
+  results:
+    - name: result1
+  script: |
+    echo "I am a Step Action!!!" >> $(step.results.result1.path)
+---
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  name: step-action-run
+spec:
+  TaskSpec:
+    results:
+      - name: step-result
+        value: $(steps.action-runner.results.result1)
+    steps:
+      - name: action-runner
+        ref:
+          name: step-action

--- a/hack/ignored-openapi-violations.list
+++ b/hack/ignored-openapi-violations.list
@@ -49,3 +49,5 @@ API rule violation: list_type_missing,github.com/tektoncd/pipeline/pkg/apis/pipe
 API rule violation: list_type_missing,github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1,VerificationPolicySpec,Resources
 API rule violation: list_type_missing,github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1,ParamSpec,Enum
 API rule violation: list_type_missing,github.com/tektoncd/pipeline/pkg/apis/pipeline/v1,ParamSpec,Enum
+API rule violation: list_type_missing,github.com/tektoncd/pipeline/pkg/apis/pipeline/v1,StepState,Results
+API rule violation: list_type_missing,github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1,StepState,Results

--- a/pkg/apis/pipeline/v1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1/openapi_generated.go
@@ -3130,11 +3130,24 @@ func schema_pkg_apis_pipeline_v1_StepState(ref common.ReferenceCallback) common.
 							Format: "",
 						},
 					},
+					"results": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: map[string]interface{}{},
+										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskRunResult"),
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/api/core/v1.ContainerStateRunning", "k8s.io/api/core/v1.ContainerStateTerminated", "k8s.io/api/core/v1.ContainerStateWaiting"},
+			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskRunResult", "k8s.io/api/core/v1.ContainerStateRunning", "k8s.io/api/core/v1.ContainerStateTerminated", "k8s.io/api/core/v1.ContainerStateWaiting"},
 	}
 }
 
@@ -3666,7 +3679,7 @@ func schema_pkg_apis_pipeline_v1_TaskRunResult(ref common.ReferenceCallback) com
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "TaskRunResult used to describe the results of a task",
+				Description: "TaskRunStepResult is a type alias of TaskRunResult",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"name": {

--- a/pkg/apis/pipeline/v1/result_types.go
+++ b/pkg/apis/pipeline/v1/result_types.go
@@ -72,6 +72,9 @@ type TaskRunResult struct {
 	Value ResultValue `json:"value"`
 }
 
+// TaskRunStepResult is a type alias of TaskRunResult
+type TaskRunStepResult = TaskRunResult
+
 // ResultValue is a type alias of ParamValue
 type ResultValue = ParamValue
 

--- a/pkg/apis/pipeline/v1/swagger.json
+++ b/pkg/apis/pipeline/v1/swagger.json
@@ -1595,6 +1595,13 @@
         "name": {
           "type": "string"
         },
+        "results": {
+          "type": "array",
+          "items": {
+            "default": {},
+            "$ref": "#/definitions/v1.TaskRunResult"
+          }
+        },
         "running": {
           "description": "Details about a running container",
           "$ref": "#/definitions/v1.ContainerStateRunning"
@@ -1887,7 +1894,7 @@
       }
     },
     "v1.TaskRunResult": {
-      "description": "TaskRunResult used to describe the results of a task",
+      "description": "TaskRunStepResult is a type alias of TaskRunResult",
       "type": "object",
       "required": [
         "name",

--- a/pkg/apis/pipeline/v1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1/taskrun_types.go
@@ -338,9 +338,10 @@ func (trs *TaskRunStatus) SetCondition(newCond *apis.Condition) {
 // StepState reports the results of running a step in a Task.
 type StepState struct {
 	corev1.ContainerState `json:",inline"`
-	Name                  string `json:"name,omitempty"`
-	Container             string `json:"container,omitempty"`
-	ImageID               string `json:"imageID,omitempty"`
+	Name                  string              `json:"name,omitempty"`
+	Container             string              `json:"container,omitempty"`
+	ImageID               string              `json:"imageID,omitempty"`
+	Results               []TaskRunStepResult `json:"results,omitempty"`
 }
 
 // SidecarState reports the results of running a sidecar in a Task.

--- a/pkg/apis/pipeline/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/pipeline/v1/zz_generated.deepcopy.go
@@ -1360,6 +1360,13 @@ func (in *StepResult) DeepCopy() *StepResult {
 func (in *StepState) DeepCopyInto(out *StepState) {
 	*out = *in
 	in.ContainerState.DeepCopyInto(&out.ContainerState)
+	if in.Results != nil {
+		in, out := &in.Results, &out.Results
+		*out = make([]TaskRunResult, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 

--- a/pkg/apis/pipeline/v1beta1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1beta1/openapi_generated.go
@@ -4030,11 +4030,24 @@ func schema_pkg_apis_pipeline_v1beta1_StepState(ref common.ReferenceCallback) co
 							Format: "",
 						},
 					},
+					"results": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: map[string]interface{}{},
+										Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskRunResult"),
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/api/core/v1.ContainerStateRunning", "k8s.io/api/core/v1.ContainerStateTerminated", "k8s.io/api/core/v1.ContainerStateWaiting"},
+			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskRunResult", "k8s.io/api/core/v1.ContainerStateRunning", "k8s.io/api/core/v1.ContainerStateTerminated", "k8s.io/api/core/v1.ContainerStateWaiting"},
 	}
 }
 
@@ -4928,7 +4941,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunResult(ref common.ReferenceCallback
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "TaskRunResult used to describe the results of a task",
+				Description: "TaskRunStepResult is a type alias of TaskRunResult",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"name": {

--- a/pkg/apis/pipeline/v1beta1/result_types.go
+++ b/pkg/apis/pipeline/v1beta1/result_types.go
@@ -52,6 +52,9 @@ type TaskRunResult struct {
 	Value ResultValue `json:"value"`
 }
 
+// TaskRunStepResult is a type alias of TaskRunResult
+type TaskRunStepResult = TaskRunResult
+
 // ResultValue is a type alias of ParamValue
 type ResultValue = ParamValue
 

--- a/pkg/apis/pipeline/v1beta1/swagger.json
+++ b/pkg/apis/pipeline/v1beta1/swagger.json
@@ -2220,6 +2220,13 @@
         "name": {
           "type": "string"
         },
+        "results": {
+          "type": "array",
+          "items": {
+            "default": {},
+            "$ref": "#/definitions/v1beta1.TaskRunResult"
+          }
+        },
         "running": {
           "description": "Details about a running container",
           "$ref": "#/definitions/v1.ContainerStateRunning"
@@ -2704,7 +2711,7 @@
       }
     },
     "v1beta1.TaskRunResult": {
-      "description": "TaskRunResult used to describe the results of a task",
+      "description": "TaskRunStepResult is a type alias of TaskRunResult",
       "type": "object",
       "required": [
         "name",

--- a/pkg/apis/pipeline/v1beta1/taskrun_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_conversion.go
@@ -330,6 +330,12 @@ func (ss StepState) convertTo(ctx context.Context, sink *v1.StepState) {
 	sink.Name = ss.Name
 	sink.Container = ss.ContainerName
 	sink.ImageID = ss.ImageID
+	sink.Results = nil
+	for _, r := range ss.Results {
+		new := v1.TaskRunStepResult{}
+		r.convertTo(ctx, &new)
+		sink.Results = append(sink.Results, new)
+	}
 }
 
 func (ss *StepState) convertFrom(ctx context.Context, source v1.StepState) {
@@ -337,6 +343,12 @@ func (ss *StepState) convertFrom(ctx context.Context, source v1.StepState) {
 	ss.Name = source.Name
 	ss.ContainerName = source.Container
 	ss.ImageID = source.ImageID
+	ss.Results = nil
+	for _, r := range source.Results {
+		new := TaskRunStepResult{}
+		new.convertFrom(ctx, r)
+		ss.Results = append(ss.Results, new)
+	}
 }
 
 func (trr TaskRunResult) convertTo(ctx context.Context, sink *v1.TaskRunResult) {

--- a/pkg/apis/pipeline/v1beta1/taskrun_conversion_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_conversion_test.go
@@ -103,6 +103,29 @@ func TestTaskRunConversion(t *testing.T) {
 			},
 		},
 	}, {
+		name: "taskrun with step Results in step state",
+		in: &v1beta1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "bar",
+			},
+			Spec: v1beta1.TaskRunSpec{},
+			Status: v1beta1.TaskRunStatus{
+				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+					Steps: []v1beta1.StepState{{
+						Results: []v1beta1.TaskRunStepResult{{
+							Name: "foo",
+							Type: v1beta1.ResultsTypeString,
+							Value: v1beta1.ResultValue{
+								Type:      v1beta1.ParamTypeString,
+								StringVal: "bar",
+							},
+						}},
+					}},
+				},
+			},
+		},
+	}, {
 		name: "taskrun conversion all non deprecated fields",
 		in: &v1beta1.TaskRun{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/apis/pipeline/v1beta1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_types.go
@@ -367,9 +367,10 @@ func (trs *TaskRunStatus) SetCondition(newCond *apis.Condition) {
 // StepState reports the results of running a step in a Task.
 type StepState struct {
 	corev1.ContainerState `json:",inline"`
-	Name                  string `json:"name,omitempty"`
-	ContainerName         string `json:"container,omitempty"`
-	ImageID               string `json:"imageID,omitempty"`
+	Name                  string              `json:"name,omitempty"`
+	ContainerName         string              `json:"container,omitempty"`
+	ImageID               string              `json:"imageID,omitempty"`
+	Results               []TaskRunStepResult `json:"results,omitempty"`
 }
 
 // SidecarState reports the results of running a sidecar in a Task.

--- a/pkg/apis/pipeline/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/pipeline/v1beta1/zz_generated.deepcopy.go
@@ -1810,6 +1810,13 @@ func (in *StepOutputConfig) DeepCopy() *StepOutputConfig {
 func (in *StepState) DeepCopyInto(out *StepState) {
 	*out = *in
 	in.ContainerState.DeepCopyInto(&out.ContainerState)
+	if in.Results != nil {
+		in, out := &in.Results, &out.Results
+		*out = make([]TaskRunResult, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 

--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -239,9 +239,9 @@ func (b *Builder) Build(ctx context.Context, taskRun *v1.TaskRun, taskSpec v1.Ta
 	readyImmediately := isPodReadyImmediately(*featureFlags, taskSpec.Sidecars)
 
 	if alphaAPIEnabled {
-		stepContainers, err = orderContainers(commonExtraEntrypointArgs, stepContainers, &taskSpec, taskRun.Spec.Debug, !readyImmediately, enableKeepPodOnCancel)
+		stepContainers, err = orderContainers(ctx, commonExtraEntrypointArgs, stepContainers, &taskSpec, taskRun.Spec.Debug, !readyImmediately, enableKeepPodOnCancel)
 	} else {
-		stepContainers, err = orderContainers(commonExtraEntrypointArgs, stepContainers, &taskSpec, nil, !readyImmediately, enableKeepPodOnCancel)
+		stepContainers, err = orderContainers(ctx, commonExtraEntrypointArgs, stepContainers, &taskSpec, nil, !readyImmediately, enableKeepPodOnCancel)
 	}
 	if err != nil {
 		return nil, err

--- a/pkg/reconciler/taskrun/resources/taskspec.go
+++ b/pkg/reconciler/taskrun/resources/taskspec.go
@@ -131,6 +131,9 @@ func GetStepActionsData(ctx context.Context, taskSpec v1.TaskSpec, taskRun *v1.T
 			if len(stepActionSpec.VolumeMounts) > 0 {
 				s.VolumeMounts = stepActionSpec.VolumeMounts
 			}
+			if len(stepActionSpec.Results) > 0 {
+				s.Results = stepActionSpec.Results
+			}
 			if err := validateStepHasStepActionParameters(s.Params, stepActionSpec.Params); err != nil {
 				return nil, err
 			}

--- a/pkg/reconciler/taskrun/resources/taskspec_test.go
+++ b/pkg/reconciler/taskrun/resources/taskspec_test.go
@@ -422,6 +422,41 @@ func TestGetStepActionsData(t *testing.T) {
 			}},
 		}},
 	}, {
+		name: "step-action-with-step-result",
+		tr: &v1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "mytaskrun",
+				Namespace: "default",
+			},
+			Spec: v1.TaskRunSpec{
+				TaskSpec: &v1.TaskSpec{
+					Steps: []v1.Step{{
+						Ref: &v1.Ref{
+							Name: "stepActionWithScript",
+						},
+					}},
+				},
+			},
+		},
+		stepAction: &v1alpha1.StepAction{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "stepActionWithScript",
+				Namespace: "default",
+			},
+			Spec: v1alpha1.StepActionSpec{
+				Image:  "myimage",
+				Script: "ls",
+				Results: []v1.StepResult{{
+					Name: "foo",
+				}},
+			},
+		},
+		want: []v1.Step{{
+			Image:   "myimage",
+			Script:  "ls",
+			Results: []v1.StepResult{{Name: "foo", Type: "string"}},
+		}},
+	}, {
 		name: "inline and ref StepAction",
 		tr: &v1.TaskRun{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -847,7 +847,7 @@ func applyParamsContextsResultsAndWorkspaces(ctx context.Context, tr *v1.TaskRun
 	ts = resources.ApplyContexts(ts, rtr.TaskName, tr)
 
 	// Apply task result substitution
-	ts = resources.ApplyTaskResults(ts)
+	ts = resources.ApplyResults(ts)
 
 	// Apply step exitCode path substitution
 	ts = resources.ApplyStepExitCodePath(ts)

--- a/pkg/result/result.go
+++ b/pkg/result/result.go
@@ -33,6 +33,8 @@ const (
 	InternalTektonResultType = 3
 	// UnknownResultType default unknown result type value
 	UnknownResultType = 10
+	// StepResultType default step result value
+	StepResultType ResultType = 4
 )
 
 // RunResult is used to write key/value pairs to TaskRun pod termination messages.
@@ -80,6 +82,8 @@ func (r *ResultType) UnmarshalJSON(data []byte) error {
 	}
 
 	switch asString {
+	case "StepResult":
+		*r = StepResultType
 	case "TaskRunResult":
 		*r = TaskRunResultType
 	case "InternalTektonResult":

--- a/pkg/result/result_test.go
+++ b/pkg/result/result_test.go
@@ -33,6 +33,10 @@ func TestRunResult_UnmarshalJSON(t *testing.T) {
 		name: "type defined as string - TaskRunResult",
 		data: "{\"key\":\"resultName\",\"value\":\"resultValue\", \"type\": \"TaskRunResult\"}",
 		pr:   RunResult{Key: "resultName", Value: "resultValue", ResultType: TaskRunResultType},
+	}, {
+		name: "type defined as string - StepResult",
+		data: "{\"key\":\"resultName\",\"value\":\"resultValue\", \"type\": \"StepResult\"}",
+		pr:   RunResult{Key: "resultName", Value: "resultValue", ResultType: StepResultType},
 	},
 		{
 			name: "type defined as string - InternalTektonResult",

--- a/test/clients.go
+++ b/test/clients.go
@@ -68,6 +68,7 @@ type clients struct {
 	V1TaskClient                     v1.TaskInterface
 	V1TaskRunClient                  v1.TaskRunInterface
 	V1PipelineRunClient              v1.PipelineRunInterface
+	V1alpha1StepActionClient         v1alpha1.StepActionInterface
 }
 
 // newClients instantiates and returns several clientsets required for making requests to the
@@ -109,5 +110,6 @@ func newClients(t *testing.T, configPath, clusterName, namespace string) *client
 	c.V1TaskClient = cs.TektonV1().Tasks(namespace)
 	c.V1TaskRunClient = cs.TektonV1().TaskRuns(namespace)
 	c.V1PipelineRunClient = cs.TektonV1().PipelineRuns(namespace)
+	c.V1alpha1StepActionClient = cs.TektonV1alpha1().StepActions(namespace)
 	return c
 }

--- a/test/stepaction_results_test.go
+++ b/test/stepaction_results_test.go
@@ -1,0 +1,258 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2022 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/tektoncd/pipeline/pkg/apis/config"
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	v1alpha1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/test/parse"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/system"
+	knativetest "knative.dev/pkg/test"
+)
+
+var (
+	ignoreProvenance             = cmpopts.IgnoreFields(v1.TaskRunStatusFields{}, "Provenance")
+	requireEnableStepActionsGate = map[string]string{
+		"enable-step-actions": "true",
+	}
+)
+
+func TestStepResultsStepActions(t *testing.T) {
+	featureFlags := getFeatureFlagsBaseOnAPIFlag(t)
+	previousResultExtractionMethod := featureFlags.ResultExtractionMethod
+
+	type tests struct {
+		name           string
+		taskRunFunc    func(*testing.T, string) (*v1.TaskRun, *v1.TaskRun)
+		stepActionFunc func(*testing.T, string) *v1alpha1.StepAction
+	}
+
+	tds := []tests{{
+		name:           "step results",
+		taskRunFunc:    getStepActionsTaskRun,
+		stepActionFunc: getStepAction,
+	}}
+
+	for _, td := range tds {
+		td := td
+		t.Run(td.name, func(t *testing.T) {
+			ctx := context.Background()
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			c, namespace := setUpStepActionsResults(ctx, t)
+
+			// reset configmap
+			knativetest.CleanupOnInterrupt(func() { resetStepActionsResults(ctx, t, c, previousResultExtractionMethod) }, t.Logf)
+			defer resetSidecarLogs(ctx, t, c, previousResultExtractionMethod)
+
+			knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
+			defer tearDown(ctx, t, c, namespace)
+
+			t.Logf("Setting up test resources for %q test in namespace %s", td.name, namespace)
+			taskRun, expectedResolvedTaskRun := td.taskRunFunc(t, namespace)
+			stepAction := td.stepActionFunc(t, namespace)
+
+			trName := taskRun.Name
+
+			_, err := c.V1alpha1StepActionClient.Create(ctx, stepAction, metav1.CreateOptions{})
+			if err != nil {
+				t.Fatalf("Failed to create StepAction : %s", err)
+			}
+
+			_, err = c.V1TaskRunClient.Create(ctx, taskRun, metav1.CreateOptions{})
+			if err != nil {
+				t.Fatalf("Failed to create TaskRun `%s`: %s", trName, err)
+			}
+
+			t.Logf("Waiting for TaskRun %s in namespace %s to complete", trName, namespace)
+			if err := WaitForTaskRunState(ctx, c, trName, TaskRunSucceed(trName), "TaskRunSuccess", v1Version); err != nil {
+				t.Fatalf("Error waiting for TaskRun %s to finish: %s", trName, err)
+			}
+			taskrun, _ := c.V1TaskRunClient.Get(ctx, trName, metav1.GetOptions{})
+			d := cmp.Diff(expectedResolvedTaskRun, taskrun,
+				ignoreTypeMeta,
+				ignoreObjectMeta,
+				ignoreCondition,
+				ignoreTaskRunStatus,
+				ignoreContainerStates,
+				ignoreProvenance,
+				ignoreSidecarState,
+				ignoreStepState,
+			)
+			if d != "" {
+				t.Fatalf(`The expected taskrun does not match created taskrun. Here is the diff: %v`, d)
+			}
+
+			t.Logf("Successfully finished test %q", td.name)
+		})
+	}
+}
+
+func getStepAction(t *testing.T, namespace string) *v1alpha1.StepAction {
+	t.Helper()
+	return parse.MustParseV1alpha1StepAction(t, fmt.Sprintf(`
+metadata:
+  name: step-action
+  namespace: %s
+spec:
+  results:
+    - name: result1
+      type: string
+  image: alpine
+  script: |
+    echo -n step-action >> $(step.results.result1.path)
+`, namespace))
+}
+
+func getStepActionsTaskRun(t *testing.T, namespace string) (*v1.TaskRun, *v1.TaskRun) {
+	t.Helper()
+	taskRun := parse.MustParseV1TaskRun(t, fmt.Sprintf(`
+metadata:
+  name: step-results-task-run
+  namespace: %s
+spec:
+  taskSpec:
+    steps:
+     - name: step1
+       image: alpine
+       script: |
+         echo -n inlined-step >> $(step.results.result1.path)
+       results:
+         - name: result1
+           type: string
+     - name: step2
+       ref:
+         name: step-action
+    results:
+      - name: inlined-step-result
+        type: string
+        value: $(steps.step1.results.result1)
+      - name: step-action-result
+        type: string
+        value: $(steps.step2.results.result1)
+`, namespace))
+
+	expectedTaskRun := parse.MustParseV1TaskRun(t, fmt.Sprintf(`
+metadata:
+  name: step-results-task-run
+  namespace: %s
+spec:
+  serviceAccountName: default
+  timeout: 1h
+  taskSpec:
+    steps:
+      - name: step1
+        image: alpine
+        script: |
+          echo -n inlined-step >> $(step.results.result1.path)
+        results:
+          - name: result1
+            type: string
+      - name: step2
+        ref:
+          name: step-action
+    results:
+      - name: inlined-step-result
+        type: string
+        value: $(steps.step1.results.result1)
+      - name: step-action-result
+        type: string
+        value: $(steps.step2.results.result1)
+status:
+  conditions:
+    - type: "Succeeded"
+      status: "True"
+      reason: "Succeeded"
+  podName: step-results-task-run-pod
+  taskSpec:
+    steps:
+      - name: step1
+        image: alpine
+        results:
+          - name: result1
+            type: string
+        script: |
+          echo -n inlined-step >> /tekton/steps/step-step1/results/result1
+      - name: step2
+        image: alpine
+        results:
+          - name: result1
+            type: string
+        script: |
+          echo -n step-action >> /tekton/steps/step-step2/results/result1
+    results:
+      - name: inlined-step-result
+        type: string
+        value: $(steps.step1.results.result1)
+      - name: step-action-result
+        type: string
+        value: $(steps.step2.results.result1)
+  results:
+    - name: inlined-step-result
+      type: string
+      value: inlined-step
+    - name: step-action-result
+      type: string
+      value: step-action
+  steps:
+    - name: step1
+      container: step-step1
+      results:
+        - name: result1
+          type: string
+          value: inlined-step
+    - name: step2
+      container: step-step2
+      results:
+        - name: result1
+          type: string
+          value: step-action
+`, namespace))
+	return taskRun, expectedTaskRun
+}
+
+func setUpStepActionsResults(ctx context.Context, t *testing.T) (*clients, string) {
+	t.Helper()
+	c, ns := setup(ctx, t, requireAllGates(requireEnableStepActionsGate))
+	configMapData := map[string]string{
+		"results-from": "termination-message",
+	}
+
+	if err := updateConfigMap(ctx, c.KubeClient, system.Namespace(), config.GetFeatureFlagsConfigName(), configMapData); err != nil {
+		t.Fatal(err)
+	}
+	return c, ns
+}
+
+func resetStepActionsResults(ctx context.Context, t *testing.T, c *clients, previousResultExtractionMethod string) {
+	t.Helper()
+	if err := updateConfigMap(ctx, c.KubeClient, system.Namespace(), config.GetFeatureFlagsConfigName(), map[string]string{"results-from": previousResultExtractionMethod}); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
This PR surfaces step results (i.e results written to `$(step.results.<resultName>.path)`) via termination messages. A followup PR will handle surfacing the results via sidecar logs.
The use of `$(step.results.<resultName>.path)` is currently only available in `StepActions` not inlined steps. 

This PR is part of issue https://github.com/tektoncd/pipeline/issues/7259.
# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
[WIP] Surface step results via termination message
```
/kind feature