### PR TITLE
[RFC] Label user errors for failed PipelineRun status in user-facing messages

### DIFF
--- a/docs/pipelineruns.md
+++ b/docs/pipelineruns.md
@@ -32,6 +32,7 @@ weight: 204
   - [<code>PipelineRun</code> status](#pipelinerun-status)
     - [The <code>status</code> field](#the-status-field)
     - [Monitoring execution status](#monitoring-execution-status)
+    - [Marking off user errors](#marking-off-user-errors)
   - [Cancelling a <code>PipelineRun</code>](#cancelling-a-pipelinerun)
   - [Gracefully cancelling a <code>PipelineRun</code>](#gracefully-cancelling-a-pipelinerun)
   - [Gracefully stopping a <code>PipelineRun</code>](#gracefully-stopping-a-pipelinerun)
@@ -1525,6 +1526,27 @@ Some examples:
 | pipeline-run-0123456789-0123456789-0123456789-0123456789 | task3                                                        | pipeline-run-0123456789-0123456789-0123456789-0123456789-task3                         |
 | pipeline-run-0123456789-0123456789-0123456789-0123456789 | task2-0123456789-0123456789-0123456789-0123456789-0123456789 | pipeline-run-0123456789-012345607ad8c7aac5873cdfabe472a68996b5c                        |
 | pipeline-run                                             | task4 (with 2x2 `Matrix`)                                    | pipeline-run-task1-0, pipeline-run-task1-2, pipeline-run-task1-3, pipeline-run-task1-4 |
+
+### Marking off user errors
+
+A user error in Tekton is any mistake made by user, such as a syntax error when specifying pipelines, tasks. User errors can occur in various stages of the Tekton pipeline, from authoring the pipeline configuration to executing the pipelines. They are currently explicitly labeled in the Run's conditions message, for example:
+```yaml
+# Failed PipelineRun with User Error labeled
+apiVersion: tekton.dev/v1 # or tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  ...
+spec:
+  ...
+status:
+  ...
+  conditions:
+  - lastTransitionTime: "2022-06-02T19:02:58Z"
+    message: "User Error: PipelineRun default/foo's Pipeline DAG is invalid"
+    reason: Failed
+    status: "False"
+    type: Succeeded
+```
 
 ## Cancelling a `PipelineRun`
 

--- a/pkg/apis/pipeline/v1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1/pipelinerun_types.go
@@ -455,7 +455,10 @@ func (pr *PipelineRunStatus) MarkSucceeded(reason, messageFormat string, message
 }
 
 // MarkFailed changes the Succeeded condition to False with the provided reason and message.
-func (pr *PipelineRunStatus) MarkFailed(reason, messageFormat string, messageA ...interface{}) {
+func (pr *PipelineRunStatus) MarkFailed(isUserError bool, reason, messageFormat string, messageA ...interface{}) {
+	if isUserError {
+		messageFormat = "User Error: " + messageFormat
+	}
 	pipelineRunCondSet.Manage(pr).MarkFalse(apis.ConditionSucceeded, reason, messageFormat, messageA...)
 	succeeded := pr.GetCondition(apis.ConditionSucceeded)
 	pr.CompletionTime = &succeeded.LastTransitionTime.Inner

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -840,7 +840,7 @@ spec:
 		permanentError: true,
 		wantEvents: []string{
 			"Normal Started",
-			"Warning Failed invalid input params for task a-task-that-needs-params: missing values",
+			"Warning Failed User Error: invalid input params for task a-task-that-needs-params: missing values",
 		},
 	}, {
 		name: "invalid-pipeline-mismatching-parameter-types",
@@ -859,7 +859,7 @@ spec:
 		permanentError: true,
 		wantEvents: []string{
 			"Normal Started",
-			"Warning Failed PipelineRun foo/pipeline-mismatching-param-type parameters have mismatching types",
+			"Warning Failed User Error: PipelineRun foo/pipeline-mismatching-param-type parameters have mismatching types",
 		},
 	}, {
 		name: "invalid-pipeline-missing-object-keys",
@@ -879,7 +879,7 @@ spec:
 		permanentError: true,
 		wantEvents: []string{
 			"Normal Started",
-			"Warning Failed PipelineRun foo/pipeline-missing-object-param-keys parameters is missing object keys required by Pipeline foo/a-pipeline-with-object-params's parameters: pipelineRun missing object keys for parameters",
+			"Warning Failed User Error: PipelineRun foo/pipeline-missing-object-param-keys parameters is missing object keys required by Pipeline foo/a-pipeline-with-object-params's parameters: pipelineRun missing object keys for parameters: map[some-param:[key2]]",
 		},
 	}, {
 		name: "invalid-pipeline-array-index-out-of-bound",
@@ -900,7 +900,7 @@ spec:
 		permanentError: true,
 		wantEvents: []string{
 			"Normal Started",
-			"Warning Failed PipelineRun foo/pipeline-param-array-out-of-bound failed validation: failed to validate Pipeline foo/a-pipeline-with-array-indexing-params's parameter which has an invalid index while referring to an array: non-existent param references:[$(params.some-param[2]",
+			"Warning Failed User Error: PipelineRun foo/pipeline-param-array-out-of-bound failed validation: failed to validate Pipeline foo/a-pipeline-with-array-indexing-params's parameter which has an invalid index while referring to an array: non-existent param references:[$(params.some-param[2]",
 		},
 	}, {
 		name: "invalid-embedded-pipeline-bad-name-shd-stop-reconciling",
@@ -919,7 +919,7 @@ spec:
 		permanentError: true,
 		wantEvents: []string{
 			"Normal Started",
-			"Warning Failed Pipeline foo/embedded-pipeline-invalid can't be Run; it has an invalid spec",
+			"Warning Failed User Error: Pipeline foo/embedded-pipeline-invalid can't be Run; it has an invalid spec",
 		},
 	}, {
 		name: "invalid-embedded-pipeline-mismatching-parameter-types",
@@ -944,7 +944,7 @@ spec:
 		permanentError: true,
 		wantEvents: []string{
 			"Normal Started",
-			"Warning Failed PipelineRun foo/embedded-pipeline-mismatching-param-type parameters have mismatching types",
+			"Warning Failed User Error: PipelineRun foo/embedded-pipeline-mismatching-param-type parameters have mismatching types",
 		},
 	}, {
 		name: "invalid-pipeline-run-missing-params-shd-stop-reconciling",
@@ -966,7 +966,7 @@ spec:
 		permanentError: true,
 		wantEvents: []string{
 			"Normal Started",
-			"Warning Failed PipelineRun foo parameters is missing some parameters required by Pipeline pipelinerun-missing-params",
+			"Warning Failed User Error: PipelineRun foo parameters is missing some parameters required by Pipeline pipelinerun-missing-params",
 		},
 	}, {
 		name: "invalid-pipeline-with-invalid-dag-graph",
@@ -986,7 +986,7 @@ spec:
 		permanentError: true,
 		wantEvents: []string{
 			"Normal Started",
-			"Warning Failed PipelineRun foo/pipeline-invalid-dag-graph's Pipeline DAG is invalid",
+			"Warning Failed User Error: PipelineRun foo/pipeline-invalid-dag-graph's Pipeline DAG is invalid",
 		},
 	}, {
 		name: "invalid-pipeline-with-invalid-final-tasks-graph",
@@ -1012,7 +1012,7 @@ spec:
 		permanentError: true,
 		wantEvents: []string{
 			"Normal Started",
-			"Warning Failed PipelineRun foo's Pipeline DAG is invalid for finally clause",
+			"Warning Failed User Error: PipelineRun foo's Pipeline DAG is invalid for finally clause",
 		},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1190,7 +1190,7 @@ status:
           image: busybox
           script: 'exit 0'
   conditions:
-  - message: "Invalid task result reference: Could not find result with name result2 for task task1"
+  - message: "User Error: Invalid task result reference: Could not find result with name result2 for task task1"
     reason: InvalidTaskResultReference
     status: "False"
     type: Succeeded
@@ -12264,7 +12264,7 @@ spec:
 			wantEvents :=
 				[]string{
 					"Normal Started",
-					"Warning Failed PipelineRun foo/pr can't be Run; couldn't resolve all references: array Result Index 3 for Task pt-with-result Result platforms is out of bound of size 3",
+					"Warning Failed User Error: PipelineRun foo/pr can't be Run; couldn't resolve all references: array Result Index 3 for Task pt-with-result Result platforms is out of bound of size 3",
 					"Warning InternalError 1 error occurred:",
 				}
 			prt := newPipelineRunTest(t, d)


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This commit labels the user errors for failed PipelineRun status. This aims to communicate explicitly with users of whether the run failed due to a user error or not.

This is a step 1 for #6859

part of  #7276

/kind misc
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
