### PR TITLE
Replace ubi9/ubi-minimal with busybox image

### DIFF
--- a/examples/v1/taskruns/5080-entrypoint-init-regression.yaml
+++ b/examples/v1/taskruns/5080-entrypoint-init-regression.yaml
@@ -20,7 +20,7 @@ spec:
       - "--help"
     steps:
       - name: echo-cli
-        image: registry.access.redhat.com/ubi9/ubi-minimal:9.0.0-1580
+        image: cgr.dev/chainguard/busybox
         workingDir: /tekton/home
         args:
         - "$(params.ARGS)"


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Seems like the ubi9/ubi-minimal image may cause e2e failures (at least from time to time).

ubi-minimal or busybox shouldn't really matter for that regression example test, so this switch to an image we already use (as the "shell" image on the controller).

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
