### PR TITLE
Fix the controller and webhook images to use stable alpine

### DIFF
--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -104,7 +104,7 @@ spec:
       # NOTE: Make sure this list of images to use the combined base image is in sync with what's in test/presubmit-tests.sh's 'ko_resolve' function.
       cat <<EOF > /workspace/.ko.yaml
       # This matches the value configured in .ko.yaml
-      defaultBaseImage: cgr.dev/chainguard/static
+      defaultBaseImage: cgr.dev/chainguard/static@sha256:67a1b00e0134e2b3a614c7198a26f7deed9d11b7acad4d52c79c0cfd47a2eae7
       baseImageOverrides:
         # Use the combined base image for images that should include Windows support.
         $(params.package)/cmd/entrypoint: ${COMBINED_BASE_IMAGE}


### PR DESCRIPTION
# Changes

https://github.com/tektoncd/pipeline/pull/7356 fixed the images used by Tekton workloads, but not the controller ones.
Controllers do not support windows, and do not use the combined image, so the default base image has to be updated too.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
The Tekton controller images are now based on a distroless base image which is built on top of Alpine 3.18
```

/kind misc