### PR TITLE
Error sweep: refactor steps termination when failing TaskRun

### DIFF
--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -4189,6 +4189,7 @@ status:
 					Terminated: &corev1.ContainerStateTerminated{
 						ExitCode: 1,
 						Reason:   v1.TaskRunReasonCancelled.String(),
+						Message:  "Step  terminated as pod foo-is-bar is terminated",
 					},
 				},
 			},
@@ -4234,6 +4235,7 @@ status:
 					Terminated: &corev1.ContainerStateTerminated{
 						ExitCode: 1,
 						Reason:   v1.TaskRunReasonCancelled.String(),
+						Message:  "Step  terminated as pod foo-is-bar is terminated",
 					},
 				},
 			},
@@ -4275,6 +4277,7 @@ status:
 					Terminated: &corev1.ContainerStateTerminated{
 						ExitCode: 1,
 						Reason:   v1.TaskRunReasonTimedOut.String(),
+						Message:  "Step  terminated as pod foo-is-bar is terminated",
 					},
 				},
 			},
@@ -4331,6 +4334,7 @@ status:
 					Terminated: &corev1.ContainerStateTerminated{
 						ExitCode: 1,
 						Reason:   v1.TaskRunReasonTimedOut.String(),
+						Message:  "Step  terminated as pod foo-is-bar is terminated",
 					},
 				},
 			},
@@ -4339,6 +4343,7 @@ status:
 					Terminated: &corev1.ContainerStateTerminated{
 						ExitCode: 1,
 						Reason:   v1.TaskRunReasonTimedOut.String(),
+						Message:  "Step  terminated as pod foo-is-bar is terminated",
 					},
 				},
 			},
@@ -4384,6 +4389,7 @@ status:
 					Terminated: &corev1.ContainerStateTerminated{
 						ExitCode: 1,
 						Reason:   v1.TaskRunReasonTimedOut.String(),
+						Message:  "Step  terminated as pod foo-is-bar is terminated",
 					},
 				},
 			},
@@ -4392,6 +4398,7 @@ status:
 					Terminated: &corev1.ContainerStateTerminated{
 						ExitCode: 1,
 						Reason:   v1.TaskRunReasonTimedOut.String(),
+						Message:  "Step  terminated as pod foo-is-bar is terminated",
 					},
 				},
 			},
@@ -4400,6 +4407,7 @@ status:
 					Terminated: &corev1.ContainerStateTerminated{
 						ExitCode: 1,
 						Reason:   v1.TaskRunReasonTimedOut.String(),
+						Message:  "Step  terminated as pod foo-is-bar is terminated",
 					},
 				},
 			},
@@ -4453,6 +4461,7 @@ status:
 					Terminated: &corev1.ContainerStateTerminated{
 						ExitCode: 1,
 						Reason:   v1.TaskRunReasonTimedOut.String(),
+						Message:  "Step  terminated as pod foo-is-bar is terminated",
 					},
 				},
 			},


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This commit refactors the step termination logics once the pod for the TaskRun is marked failed. It adds to the container termination message and complete the prerequisites for differentiating pod termination reason with TaskRunReasons which are currently used to cover container termination reasons.

part of #7385
/kind cleanup
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
