### PR TITLE
Add granular termination reason in container termination message

### DIFF
--- a/cmd/entrypoint/main.go
+++ b/cmd/entrypoint/main.go
@@ -178,7 +178,7 @@ func main() {
 	if err := e.Go(); err != nil {
 		breakpointExitPostFile := e.PostFile + breakpointExitSuffix
 		switch t := err.(type) { //nolint:errorlint // checking for multiple types with errors.As is ugly.
-		case skipError:
+		case entrypoint.SkipError:
 			log.Print("Skipping step because a previous step failed")
 			os.Exit(1)
 		case termination.MessageLengthError:

--- a/cmd/entrypoint/waiter.go
+++ b/cmd/entrypoint/waiter.go
@@ -71,7 +71,7 @@ func (rw *realWaiter) Wait(ctx context.Context, file string, expectContent bool,
 			if breakpointOnFailure {
 				return nil
 			}
-			return skipError("error file present, bail and skip the step")
+			return entrypoint.ErrSkipPreviousStepFailed
 		}
 		select {
 		case <-ctx.Done():
@@ -85,10 +85,4 @@ func (rw *realWaiter) Wait(ctx context.Context, file string, expectContent bool,
 		case <-time.After(rw.waitPollingInterval):
 		}
 	}
-}
-
-type skipError string
-
-func (e skipError) Error() string {
-	return string(e)
 }

--- a/cmd/entrypoint/waiter_test.go
+++ b/cmd/entrypoint/waiter_test.go
@@ -153,7 +153,7 @@ func TestRealWaiterWaitWithErrorWaitfile(t *testing.T) {
 		if err == nil {
 			t.Errorf("expected skipError upon encounter error waitfile")
 		}
-		var skipErr skipError
+		var skipErr entrypoint.SkipError
 		if errors.As(err, &skipErr) {
 			close(doneCh)
 		} else {
@@ -292,7 +292,7 @@ func TestRealWaiterWaitContextWithErrorWaitfile(t *testing.T) {
 		if err == nil {
 			t.Errorf("expected skipError upon encounter error waitfile")
 		}
-		var skipErr skipError
+		var skipErr entrypoint.SkipError
 		if errors.As(err, &skipErr) {
 			close(doneCh)
 		} else {

--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -61,6 +61,18 @@ const (
 
 	// osSelectorLabel is the label Kubernetes uses for OS-specific workloads (https://kubernetes.io/docs/reference/labels-annotations-taints/#kubernetes-io-os)
 	osSelectorLabel = "kubernetes.io/os"
+
+	// TerminationReasonTimeoutExceeded indicates a step execution timed out.
+	TerminationReasonTimeoutExceeded = "TimeoutExceeded"
+
+	// TerminationReasonSkipped indicates a step execution was skipped due to previous step failed.
+	TerminationReasonSkipped = "Skipped"
+
+	// TerminationReasonContinued indicates a step errored but was ignored since onError was set to continue.
+	TerminationReasonContinued = "Continued"
+
+	// TerminationReasonCancelled indicates a step was cancelled.
+	TerminationReasonCancelled = "Cancelled"
 )
 
 // These are effectively const, but Go doesn't have such an annotation.

--- a/pkg/pod/status_test.go
+++ b/pkg/pod/status_test.go
@@ -1330,6 +1330,7 @@ func TestMakeTaskRunStatus(t *testing.T) {
 					ContainerState: corev1.ContainerState{
 						Terminated: &corev1.ContainerStateTerminated{
 							ExitCode: 11,
+							Reason:   "Continued",
 						},
 					},
 					Name:      "first",
@@ -2338,6 +2339,209 @@ func TestGetStepResultsFromSidecarLogs_Error(t *testing.T) {
 	wantErr := fmt.Errorf("invalid string %s-%s : expected somtthing that looks like <stepName>.<resultName>", stepName, resultName)
 	if d := cmp.Diff(wantErr.Error(), err.Error()); d != "" {
 		t.Errorf(diff.PrintWantGot(d))
+	}
+}
+
+func TestGetStepTerminationReasonFromContainerStatus(t *testing.T) {
+	tests := []struct {
+		desc                      string
+		pod                       corev1.Pod
+		expectedTerminationReason map[string]string
+	}{
+		{
+			desc: "Step skipped",
+			expectedTerminationReason: map[string]string{
+				"step-1": "Skipped",
+			},
+			pod: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pod",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "step-1"},
+					},
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodFailed,
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name:    "step-1",
+							ImageID: "image-id-1",
+							State: corev1.ContainerState{
+								Terminated: &corev1.ContainerStateTerminated{
+									Message:  `[{"key":"StartedAt","value":"2023-11-26T19:53:29.452Z","type":3},{"key":"Reason","value":"Skipped","type":3}]`,
+									ExitCode: 1,
+									Reason:   "Error",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			desc: "Step continued",
+			expectedTerminationReason: map[string]string{
+				"step-1": "Continued",
+			},
+			pod: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pod",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "step-1"},
+					},
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodFailed,
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name:    "step-1",
+							ImageID: "image-id-1",
+							State: corev1.ContainerState{
+								Terminated: &corev1.ContainerStateTerminated{
+									Message:  `[{"key":"StartedAt","value":"2023-11-26T19:53:29.452Z","type":3},{"key":"ExitCode","value":"1","type":3}]`,
+									ExitCode: 0,
+									Reason:   "Completed",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			desc: "Step timedout",
+			expectedTerminationReason: map[string]string{
+				"step-1": "TimeoutExceeded",
+			},
+			pod: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pod",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "step-1"},
+					},
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodFailed,
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name:    "step-1",
+							ImageID: "image-id-1",
+							State: corev1.ContainerState{
+								Terminated: &corev1.ContainerStateTerminated{
+									Message:  `[{"key":"StartedAt","value":"2023-11-26T19:53:29.452Z","type":3},{"key":"Reason","value":"TimeoutExceeded","type":3}]`,
+									ExitCode: 1,
+									Reason:   "Error",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			desc: "Step completed",
+			expectedTerminationReason: map[string]string{
+				"step-1": "Completed",
+			},
+			pod: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pod",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "step-1"},
+					},
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodFailed,
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name:    "step-1",
+							ImageID: "image-id-1",
+							State: corev1.ContainerState{
+								Terminated: &corev1.ContainerStateTerminated{
+									Message:  `[{"key":"StartedAt","value":"2023-11-26T19:53:29.452Z","type":3}]`,
+									ExitCode: 0,
+									Reason:   "Completed",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			desc: "Step error",
+			expectedTerminationReason: map[string]string{
+				"step-1": "Error",
+			},
+			pod: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pod",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "step-1"},
+					},
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodFailed,
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name:    "step-1",
+							ImageID: "image-id-1",
+							State: corev1.ContainerState{
+								Terminated: &corev1.ContainerStateTerminated{
+									Message:  `[{"key":"StartedAt","value":"2023-11-26T19:53:29.452Z","type":3}]`,
+									ExitCode: 1,
+									Reason:   "Error",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			startTime := time.Date(2010, 1, 1, 1, 1, 1, 1, time.UTC)
+			tr := v1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "task-run",
+				},
+				Status: v1.TaskRunStatus{
+					TaskRunStatusFields: v1.TaskRunStatusFields{
+						StartTime: &metav1.Time{Time: startTime},
+					},
+				},
+			}
+			logger, _ := logging.NewLogger("", "status")
+			kubeclient := fakek8s.NewSimpleClientset()
+
+			trs, err := MakeTaskRunStatus(context.Background(), logger, tr, &test.pod, kubeclient, &v1.TaskSpec{})
+			if err != nil {
+				t.Errorf("MakeTaskRunResult: %s", err)
+			}
+
+			for _, step := range trs.Steps {
+				if step.Terminated == nil {
+					t.Errorf("Terminated status not found for %s", step.Name)
+				}
+				want := test.expectedTerminationReason[step.Container]
+				got := step.Terminated.Reason
+				if d := cmp.Diff(want, got, ignoreVolatileTime); d != "" {
+					t.Errorf("Diff %s", diff.PrintWantGot(d))
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Fixes #7223.

To report specific Steps termination reasons we need to know why its continer finished; we use the termination message to store a new "state" with this information. We evaluated changing the container `reason` directly, but looks like k8s doesn't allow this.

/kind feature

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Steps in a TaskRun will have more granular termination reasons indicating what exactly happened: Completed, Continued, Error, TimeoutExceeded, Skipped, TaskRunCancelled
```
