### PR TITLE
fix: move getFeatureFlagsBaseOnAPIFlag from custom_task_test to another file

### DIFF
--- a/test/custom_task_test.go
+++ b/test/custom_task_test.go
@@ -20,10 +20,8 @@ limitations under the License.
 package test
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"os"
 	"os/exec"
 	"strings"
 	"sync"
@@ -32,7 +30,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -724,64 +721,4 @@ func resetConfigMap(ctx context.Context, t *testing.T, c *clients, namespace, co
 	if err := updateConfigMap(ctx, c.KubeClient, namespace, configName, values); err != nil {
 		t.Log(err)
 	}
-}
-
-func getFeatureFlagsBaseOnAPIFlag(t *testing.T) *config.FeatureFlags {
-	t.Helper()
-	alphaFeatureFlags, err := config.NewFeatureFlagsFromMap(map[string]string{
-		"enable-api-fields":            "alpha",
-		"results-from":                 "sidecar-logs",
-		"enable-tekton-oci-bundles":    "true",
-		"enable-step-actions":          "true",
-		"enable-cel-in-whenexpression": "true",
-		"enable-param-enum":            "true",
-	})
-	if err != nil {
-		t.Fatalf("error creating alpha feature flags configmap: %v", err)
-	}
-	betaFeatureFlags, err := config.NewFeatureFlagsFromMap(map[string]string{
-		"enable-api-fields": "beta",
-	})
-	if err != nil {
-		t.Fatalf("error creating beta feature flags configmap: %v", err)
-	}
-	stableFeatureFlags, err := config.NewFeatureFlagsFromMap(map[string]string{
-		"enable-api-fields": "stable",
-	})
-	if err != nil {
-		t.Fatalf("error creating stable feature flags configmap: %v", err)
-	}
-	enabledFeatureGate, err := getAPIFeatureGate()
-	if err != nil {
-		t.Fatalf("error reading enabled feature gate: %v", err)
-	}
-	switch enabledFeatureGate {
-	case "alpha":
-		return alphaFeatureFlags
-	case "beta":
-		return betaFeatureFlags
-	default:
-		return stableFeatureFlags
-	}
-}
-
-// getAPIFeatureGate queries the tekton pipelines namespace for the
-// current value of the "enable-api-fields" feature gate.
-func getAPIFeatureGate() (string, error) {
-	ns := os.Getenv("SYSTEM_NAMESPACE")
-	if ns == "" {
-		ns = "tekton-pipelines"
-	}
-
-	cmd := exec.Command("kubectl", "get", "configmap", "feature-flags", "-n", ns, "-o", `jsonpath="{.data['enable-api-fields']}"`)
-	output, err := cmd.Output()
-	if err != nil {
-		return "", fmt.Errorf("error getting feature-flags configmap: %w", err)
-	}
-	output = bytes.TrimSpace(output)
-	output = bytes.Trim(output, "\"")
-	if len(output) == 0 {
-		output = []byte("stable")
-	}
-	return string(output), nil
 }

--- a/test/featureflags.go
+++ b/test/featureflags.go
@@ -17,8 +17,11 @@ limitations under the License.
 package test
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"os"
+	"os/exec"
 	"strings"
 	"testing"
 
@@ -103,4 +106,64 @@ func requireAllGates(gates map[string]string) func(context.Context, *testing.T, 
 			t.Skipf("One or more feature flags not matching required: %s", strings.Join(pairs, "; "))
 		}
 	}
+}
+
+func getFeatureFlagsBaseOnAPIFlag(t *testing.T) *config.FeatureFlags {
+	t.Helper()
+	alphaFeatureFlags, err := config.NewFeatureFlagsFromMap(map[string]string{
+		"enable-api-fields":            "alpha",
+		"results-from":                 "sidecar-logs",
+		"enable-tekton-oci-bundles":    "true",
+		"enable-step-actions":          "true",
+		"enable-cel-in-whenexpression": "true",
+		"enable-param-enum":            "true",
+	})
+	if err != nil {
+		t.Fatalf("error creating alpha feature flags configmap: %v", err)
+	}
+	betaFeatureFlags, err := config.NewFeatureFlagsFromMap(map[string]string{
+		"enable-api-fields": "beta",
+	})
+	if err != nil {
+		t.Fatalf("error creating beta feature flags configmap: %v", err)
+	}
+	stableFeatureFlags, err := config.NewFeatureFlagsFromMap(map[string]string{
+		"enable-api-fields": "stable",
+	})
+	if err != nil {
+		t.Fatalf("error creating stable feature flags configmap: %v", err)
+	}
+	enabledFeatureGate, err := getAPIFeatureGate()
+	if err != nil {
+		t.Fatalf("error reading enabled feature gate: %v", err)
+	}
+	switch enabledFeatureGate {
+	case "alpha":
+		return alphaFeatureFlags
+	case "beta":
+		return betaFeatureFlags
+	default:
+		return stableFeatureFlags
+	}
+}
+
+// getAPIFeatureGate queries the tekton pipelines namespace for the
+// current value of the "enable-api-fields" feature gate.
+func getAPIFeatureGate() (string, error) {
+	ns := os.Getenv("SYSTEM_NAMESPACE")
+	if ns == "" {
+		ns = "tekton-pipelines"
+	}
+
+	cmd := exec.Command("kubectl", "get", "configmap", "feature-flags", "-n", ns, "-o", `jsonpath="{.data['enable-api-fields']}"`)
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("error getting feature-flags configmap: %w", err)
+	}
+	output = bytes.TrimSpace(output)
+	output = bytes.Trim(output, "\"")
+	if len(output) == 0 {
+		output = []byte("stable")
+	}
+	return string(output), nil
 }


### PR DESCRIPTION
/kind cleanup
fixes #7269 
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Moved the functions
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
