### PR TITLE
Error sweep: Move TaskRun Reasons in pkg/pod to pkg/apis

### DIFF
--- a/docs/pipeline-api.md
+++ b/docs/pipeline-api.md
@@ -5026,8 +5026,23 @@ reasons that emerge from underlying resources are not included here</p>
 </tr><tr><td><p>&#34;Failed&#34;</p></td>
 <td><p>TaskRunReasonFailed is the reason set when the TaskRun completed with a failure</p>
 </td>
+</tr><tr><td><p>&#34;TaskRunResolutionFailed&#34;</p></td>
+<td><p>TaskRunReasonFailedResolution indicated that the reason for failure status is
+that references within the TaskRun could not be resolved</p>
+</td>
+</tr><tr><td><p>&#34;TaskRunValidationFailed&#34;</p></td>
+<td><p>TaskRunReasonFailedValidation indicated that the reason for failure status is
+that taskrun failed runtime validation</p>
+</td>
 </tr><tr><td><p>&#34;TaskRunImagePullFailed&#34;</p></td>
 <td><p>TaskRunReasonImagePullFailed is the reason set when the step of a task fails due to image not being pulled</p>
+</td>
+</tr><tr><td><p>&#34;InvalidParamValue&#34;</p></td>
+<td><p>TaskRunReasonInvalidParamValue indicates that the TaskRun Param input value is not allowed.</p>
+</td>
+</tr><tr><td><p>&#34;ResourceVerificationFailed&#34;</p></td>
+<td><p>TaskRunReasonResourceVerificationFailed indicates that the task fails the trusted resource verification,
+it could be the content has changed, signature is invalid or public key is invalid</p>
 </td>
 </tr><tr><td><p>&#34;TaskRunResultLargerThanAllowedLimit&#34;</p></td>
 <td><p>TaskRunReasonResultLargerThanAllowedLimit is the reason set when one of the results exceeds its maximum allowed limit of 1 KB</p>
@@ -5038,8 +5053,15 @@ reasons that emerge from underlying resources are not included here</p>
 </tr><tr><td><p>&#34;Started&#34;</p></td>
 <td><p>TaskRunReasonStarted is the reason set when the TaskRun has just started</p>
 </td>
+</tr><tr><td><p>&#34;TaskRunStopSidecarFailed&#34;</p></td>
+<td><p>TaskRunReasonStopSidecarFailed indicates that the sidecar is not properly stopped.</p>
+</td>
 </tr><tr><td><p>&#34;Succeeded&#34;</p></td>
 <td><p>TaskRunReasonSuccessful is the reason set when the TaskRun completed successfully</p>
+</td>
+</tr><tr><td><p>&#34;TaskValidationFailed&#34;</p></td>
+<td><p>TaskRunReasonTaskFailedValidation indicated that the reason for failure status is
+that task failed runtime validation</p>
 </td>
 </tr><tr><td><p>&#34;TaskRunTimeout&#34;</p></td>
 <td><p>TaskRunReasonTimedOut is the reason set when one TaskRun execution has timed out</p>

--- a/pkg/apis/pipeline/v1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1/taskrun_types.go
@@ -187,9 +187,21 @@ const (
 	// TaskRunReasonResultLargerThanAllowedLimit is the reason set when one of the results exceeds its maximum allowed limit of 1 KB
 	TaskRunReasonResultLargerThanAllowedLimit TaskRunReason = "TaskRunResultLargerThanAllowedLimit"
 	// TaskRunReasonStopSidecarFailed indicates that the sidecar is not properly stopped.
-	TaskRunReasonStopSidecarFailed = "TaskRunStopSidecarFailed"
+	TaskRunReasonStopSidecarFailed TaskRunReason = "TaskRunStopSidecarFailed"
 	// TaskRunReasonInvalidParamValue indicates that the TaskRun Param input value is not allowed.
-	TaskRunReasonInvalidParamValue = "InvalidParamValue"
+	TaskRunReasonInvalidParamValue TaskRunReason = "InvalidParamValue"
+	// TaskRunReasonFailedResolution indicated that the reason for failure status is
+	// that references within the TaskRun could not be resolved
+	TaskRunReasonFailedResolution TaskRunReason = "TaskRunResolutionFailed"
+	// TaskRunReasonFailedValidation indicated that the reason for failure status is
+	// that taskrun failed runtime validation
+	TaskRunReasonFailedValidation TaskRunReason = "TaskRunValidationFailed"
+	// TaskRunReasonTaskFailedValidation indicated that the reason for failure status is
+	// that task failed runtime validation
+	TaskRunReasonTaskFailedValidation TaskRunReason = "TaskValidationFailed"
+	// TaskRunReasonResourceVerificationFailed indicates that the task fails the trusted resource verification,
+	// it could be the content has changed, signature is invalid or public key is invalid
+	TaskRunReasonResourceVerificationFailed TaskRunReason = "ResourceVerificationFailed"
 )
 
 func (t TaskRunReason) String() string {

--- a/pkg/pod/status.go
+++ b/pkg/pod/status.go
@@ -38,19 +38,23 @@ import (
 	"knative.dev/pkg/apis"
 )
 
-const (
+// Aliased for backwards compatibility; do not add additional TaskRun reasons here
+var (
 	// ReasonFailedResolution indicated that the reason for failure status is
 	// that references within the TaskRun could not be resolved
-	ReasonFailedResolution = "TaskRunResolutionFailed"
-
+	ReasonFailedResolution = v1.TaskRunReasonFailedResolution.String()
 	// ReasonFailedValidation indicated that the reason for failure status is
 	// that taskrun failed runtime validation
-	ReasonFailedValidation = "TaskRunValidationFailed"
-
+	ReasonFailedValidation = v1.TaskRunReasonFailedValidation.String()
 	// ReasonTaskFailedValidation indicated that the reason for failure status is
 	// that task failed runtime validation
-	ReasonTaskFailedValidation = "TaskValidationFailed"
+	ReasonTaskFailedValidation = v1.TaskRunReasonTaskFailedValidation.String()
+	// ReasonResourceVerificationFailed indicates that the task fails the trusted resource verification,
+	// it could be the content has changed, signature is invalid or public key is invalid
+	ReasonResourceVerificationFailed = v1.TaskRunReasonResourceVerificationFailed.String()
+)
 
+const (
 	// ReasonExceededResourceQuota indicates that the TaskRun failed to create a pod due to
 	// a ResourceQuota in the namespace
 	ReasonExceededResourceQuota = "ExceededResourceQuota"
@@ -75,11 +79,7 @@ const (
 
 	// ReasonPending indicates that the pod is in corev1.Pending, and the reason is not
 	// ReasonExceededNodeResources or isPodHitConfigError
-	ReasonPending = "Pending"
-
-	// ReasonResourceVerificationFailed indicates that the task fails the trusted resource verification,
-	// it could be the content has changed, signature is invalid or public key is invalid
-	ReasonResourceVerificationFailed = "ResourceVerificationFailed"
+	ReasonPodPending = "Pending"
 
 	// timeFormat is RFC3339 with millisecond
 	timeFormat = "2006-01-02T15:04:05.000Z07:00"
@@ -380,7 +380,7 @@ func updateIncompleteTaskRunStatus(trs *v1.TaskRunStatus, pod *corev1.Pod) {
 		case isPullImageError(pod):
 			markStatusRunning(trs, ReasonPullImageFailed, getWaitingMessage(pod))
 		default:
-			markStatusRunning(trs, ReasonPending, getWaitingMessage(pod))
+			markStatusRunning(trs, ReasonPodPending, getWaitingMessage(pod))
 		}
 	case corev1.PodSucceeded, corev1.PodFailed, corev1.PodUnknown:
 		// Do nothing; pod has completed or is in an unknown state.

--- a/pkg/pod/status.go
+++ b/pkg/pod/status.go
@@ -39,10 +39,6 @@ import (
 )
 
 const (
-	// ReasonCouldntGetTask indicates that the reason for the failure status is that the
-	// Task couldn't be found
-	ReasonCouldntGetTask = "CouldntGetTask"
-
 	// ReasonFailedResolution indicated that the reason for failure status is
 	// that references within the TaskRun could not be resolved
 	ReasonFailedResolution = "TaskRunResolutionFailed"

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -2072,7 +2072,7 @@ spec:
 			t.Fatalf("Somehow had error getting reconciled run out of fake client: %s", err)
 		}
 
-		if tc.wantFailed && reconciledRun.Status.GetCondition(apis.ConditionSucceeded).Reason != podconvert.ReasonTaskFailedValidation {
+		if tc.wantFailed && reconciledRun.Status.GetCondition(apis.ConditionSucceeded).Reason != v1.TaskRunReasonTaskFailedValidation.String() {
 			t.Errorf("Expected TaskRun to have reason FailedValidation, but condition reason is %s", reconciledRun.Status.GetCondition(apis.ConditionSucceeded))
 		}
 		if !tc.wantFailed && reconciledRun.Status.GetCondition(apis.ConditionSucceeded).IsFalse() {
@@ -3493,7 +3493,7 @@ status:
 		err:            k8sapierrors.NewConflict(k8sruntimeschema.GroupResource{Group: "v1", Resource: "resourcequotas"}, "sample", errors.New("operation cannot be fulfilled on resourcequotas sample the object has been modified please apply your changes to the latest version and try again")),
 		expectedType:   apis.ConditionSucceeded,
 		expectedStatus: corev1.ConditionUnknown,
-		expectedReason: podconvert.ReasonPending,
+		expectedReason: podconvert.ReasonPodPending,
 	}, {
 		description:    "exceeded quota errors are surfaced in taskrun condition but do not fail taskrun",
 		err:            k8sapierrors.NewForbidden(k8sruntimeschema.GroupResource{Group: "foo", Resource: "bar"}, "baz", errors.New("exceeded quota")),
@@ -3505,7 +3505,7 @@ status:
 		err:            errors.New("TaskRun validation failed"),
 		expectedType:   apis.ConditionSucceeded,
 		expectedStatus: corev1.ConditionFalse,
-		expectedReason: podconvert.ReasonFailedValidation,
+		expectedReason: v1.TaskRunReasonFailedValidation.String(),
 	}, {
 		description:    "errors other than exceeded quota fail the taskrun",
 		err:            errors.New("this is a fatal error"),
@@ -3714,7 +3714,7 @@ spec:
 
 	failedCorrectly := false
 	for _, c := range tr.Status.Conditions {
-		if c.Type == apis.ConditionSucceeded && c.Status == corev1.ConditionFalse && c.Reason == podconvert.ReasonFailedValidation {
+		if c.Type == apis.ConditionSucceeded && c.Status == corev1.ConditionFalse && c.Reason == v1.TaskRunReasonFailedValidation.String() {
 			failedCorrectly = true
 		}
 	}
@@ -3780,7 +3780,7 @@ spec:
 	}
 
 	for _, c := range tr.Status.Conditions {
-		if c.Type == apis.ConditionSucceeded && c.Status == corev1.ConditionFalse && c.Reason == podconvert.ReasonFailedValidation {
+		if c.Type == apis.ConditionSucceeded && c.Status == corev1.ConditionFalse && c.Reason == v1.TaskRunReasonFailedValidation.String() {
 			t.Errorf("Expected TaskRun to pass Validation by using the default workspace but it did not. Final conditions were:\n%#v", tr.Status.Conditions)
 		}
 	}
@@ -3972,7 +3972,7 @@ spec:
 			"disable-affinity-assistant": "false",
 			"coschedule":                 "workspaces",
 		},
-		expectFailureReason: podconvert.ReasonFailedValidation,
+		expectFailureReason: v1.TaskRunReasonFailedValidation.String(),
 	}, {
 		name: "multiple PVC based Workspaces in per pipelinerun coschedule mode - success",
 		cfgMap: map[string]string{
@@ -5620,13 +5620,13 @@ status:
 	}{{
 		name:             "taskrun results type mismatched",
 		taskRun:          taskRunResultsTypeMismatched,
-		wantFailedReason: podconvert.ReasonFailedValidation,
+		wantFailedReason: v1.TaskRunReasonFailedValidation.String(),
 		expectedError:    fmt.Errorf("1 error occurred:\n\t* Provided results don't match declared results; may be invalid JSON or missing result declaration:  \"aResult\": task result is expected to be \"array\" type but was initialized to a different type \"string\", \"objectResult\": task result is expected to be \"object\" type but was initialized to a different type \"string\""),
 		expectedResults:  nil,
 	}, {
 		name:             "taskrun results object miss key",
 		taskRun:          taskRunResultsObjectMissKey,
-		wantFailedReason: podconvert.ReasonFailedValidation,
+		wantFailedReason: v1.TaskRunReasonFailedValidation.String(),
 		expectedError:    fmt.Errorf("1 error occurred:\n\t* missing keys for these results which are required in TaskResult's properties map[objectResult:[commit]]"),
 		expectedResults: []v1.TaskRunResult{
 			{
@@ -5978,7 +5978,7 @@ status:
 				t.Fatalf("getting updated taskrun: %v", err)
 			}
 			condition := reconciledRun.Status.GetCondition(apis.ConditionSucceeded)
-			if condition.Type != apis.ConditionSucceeded || condition.Status != corev1.ConditionFalse || condition.Reason != podconvert.ReasonResourceVerificationFailed {
+			if condition.Type != apis.ConditionSucceeded || condition.Status != corev1.ConditionFalse || condition.Reason != v1.TaskRunReasonResourceVerificationFailed.String() {
 				t.Errorf("Expected TaskRun to fail with reason \"%s\" but it did not. Final conditions were:\n%#v", podconvert.ReasonResourceVerificationFailed, tr.Status.Conditions)
 			}
 			gotVerificationCondition := reconciledRun.Status.GetCondition(trustedresources.ConditionTrustedResourcesVerified)
@@ -6233,7 +6233,7 @@ status:
 				t.Fatalf("getting updated taskrun: %v", err)
 			}
 			condition := reconciledRun.Status.GetCondition(apis.ConditionSucceeded)
-			if condition.Type != apis.ConditionSucceeded || condition.Status != corev1.ConditionFalse || condition.Reason != podconvert.ReasonResourceVerificationFailed {
+			if condition.Type != apis.ConditionSucceeded || condition.Status != corev1.ConditionFalse || condition.Reason != v1.TaskRunReasonResourceVerificationFailed.String() {
 				t.Errorf("Expected TaskRun to fail with reason \"%s\" but it did not. Final conditions were:\n%#v", podconvert.ReasonResourceVerificationFailed, tr.Status.Conditions)
 			}
 			gotVerificationCondition := reconciledRun.Status.GetCondition(trustedresources.ConditionTrustedResourcesVerified)

--- a/test/resolvers_test.go
+++ b/test/resolvers_test.go
@@ -35,7 +35,7 @@ import (
 	"github.com/goccy/kpoward"
 	"github.com/jenkins-x/go-scm/scm/factory"
 	resolverconfig "github.com/tektoncd/pipeline/pkg/apis/config/resolver"
-	"github.com/tektoncd/pipeline/pkg/pod"
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/reconciler/pipelinerun"
 	"github.com/tektoncd/pipeline/pkg/resolution/resolver/git"
 	"github.com/tektoncd/pipeline/test/parse"
@@ -193,7 +193,7 @@ spec:
 	t.Logf("Waiting for PipelineRun %s in namespace %s to complete", prName, namespace)
 	if err := WaitForPipelineRunState(ctx, c, prName, timeout,
 		Chain(
-			FailedWithReason(pod.ReasonCouldntGetTask, prName),
+			FailedWithReason(v1.PipelineRunReasonCouldntGetTask.String(), prName),
 			FailedWithMessage("fail to fetch Artifact Hub resource: requested resource 'https://artifacthub.io/api/v1/packages/tekton-task/tekton-catalog-tasks/git-clone-this-does-not-exist' not found on hub", prName),
 		), "PipelineRunFailed", v1Version); err != nil {
 		t.Fatalf("Error waiting for PipelineRun to finish with expected error: %s", err)
@@ -357,7 +357,7 @@ spec:
 			t.Logf("Waiting for PipelineRun %s in namespace %s to complete", prName, namespace)
 			if err := WaitForPipelineRunState(ctx, c, prName, timeout,
 				Chain(
-					FailedWithReason(pod.ReasonCouldntGetTask, prName),
+					FailedWithReason(v1.PipelineRunReasonCouldntGetTask.String(), prName),
 					FailedWithMessage(expectedErr, prName),
 				), "PipelineRunFailed", v1Version); err != nil {
 				t.Fatalf("Error waiting for PipelineRun to finish with expected error: %s", err)

--- a/test/tektonbundles_test.go
+++ b/test/tektonbundles_test.go
@@ -36,8 +36,8 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/layout"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
+	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
-	"github.com/tektoncd/pipeline/pkg/pod"
 	"github.com/tektoncd/pipeline/pkg/reconciler/pipelinerun"
 	"github.com/tektoncd/pipeline/test/parse"
 	corev1 "k8s.io/api/core/v1"
@@ -300,7 +300,7 @@ spec:
 	t.Logf("Waiting for PipelineRun in namespace %s to finish", namespace)
 	if err := WaitForPipelineRunState(ctx, c, pipelineRunName, timeout,
 		Chain(
-			FailedWithReason(pod.ReasonCouldntGetTask, pipelineRunName),
+			FailedWithReason(pipelinev1.PipelineRunReasonCouldntGetTask.String(), pipelineRunName),
 			FailedWithMessage("does not contain a dev.tekton.image.apiVersion annotation", pipelineRunName),
 		), "PipelineRunFailed", v1beta1Version); err != nil {
 		t.Fatalf("Error waiting for PipelineRun to finish with expected error: %s", err)

--- a/test/trusted_resources_test.go
+++ b/test/trusted_resources_test.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/sigstore/sigstore/pkg/signature"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
-	"github.com/tektoncd/pipeline/pkg/pod"
+	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/test/parse"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -283,8 +283,8 @@ spec:
 	if pr.Status.GetCondition(apis.ConditionSucceeded).IsTrue() {
 		t.Errorf("Expected PipelineRun to fail but found condition: %s", pr.Status.GetCondition(apis.ConditionSucceeded))
 	}
-	if pr.Status.Conditions[0].Reason != pod.ReasonResourceVerificationFailed {
-		t.Errorf("Expected PipelineRun fail condition is: %s but got: %s", pod.ReasonResourceVerificationFailed, pr.Status.Conditions[0].Reason)
+	if pr.Status.Conditions[0].Reason != pipelinev1.TaskRunReasonResourceVerificationFailed.String() {
+		t.Errorf("Expected PipelineRun fail condition is: %s but got: %s", pipelinev1.TaskRunReasonResourceVerificationFailed, pr.Status.Conditions[0].Reason)
 	}
 }
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Prior to this commit, strings that were set as Reasons for the TaskRun status
were split between pkg/apis and pkg/reconciler/taskrun. This commit moves all TaskRun related
reasons to pkg/apis and adds aliases for backwards compatibility. This adds consistency,
correctly signals to clients that all Reasons are part of the API, and helps avoid circular imports.

It also renames ReasonPending to ReasonPodPending.

/kind cleanup
fixes: https://github.com/tektoncd/pipeline/issues/7397

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
