### PR TITLE
TEP-0142: Surface step results via sidecar logs

### DIFF
--- a/cmd/sidecarlogresults/main.go
+++ b/cmd/sidecarlogresults/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"encoding/json"
 	"flag"
 	"log"
 	"os"
@@ -30,14 +31,20 @@ import (
 func main() {
 	var resultsDir string
 	var resultNames string
+	var stepResultsStr string
 	flag.StringVar(&resultsDir, "results-dir", pipeline.DefaultResultPath, "Path to the results directory. Default is /tekton/results")
 	flag.StringVar(&resultNames, "result-names", "", "comma separated result names to expect from the steps running in the pod. eg. foo,bar,baz")
+	flag.StringVar(&stepResultsStr, "step-results", "", "json containing a map of step Name as key and list of result Names. eg. {\"stepName\":[\"foo\",\"bar\",\"baz\"]}")
 	flag.Parse()
 	if resultNames == "" {
 		log.Fatal("result-names were not provided")
 	}
 	expectedResults := strings.Split(resultNames, ",")
-	err := sidecarlogresults.LookForResults(os.Stdout, pod.RunDir, resultsDir, expectedResults)
+	expectedStepResults := map[string][]string{}
+	if err := json.Unmarshal([]byte(stepResultsStr), &expectedStepResults); err != nil {
+		log.Fatal(err)
+	}
+	err := sidecarlogresults.LookForResults(os.Stdout, pod.RunDir, resultsDir, expectedResults, pipeline.StepsDir, expectedStepResults)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/docs/stepactions.md
+++ b/docs/stepactions.md
@@ -19,7 +19,6 @@ weight: 201
     - [Specifying Remote StepActions](#specifying-remote-stepactions)
 - [Known Limitations](#known-limitations)
   - [Cannot pass Step Results between Steps](#cannot-pass-step-results-between-steps)
-  - [Cannot extract Step Results via Sidecar logs](#cannot-extract-step-results-via-sidecar-logs)
 
 ## Overview
 :warning: This feature is in a preview mode.
@@ -430,7 +429,3 @@ The default resolver type can be configured by the `default-resolver-type` field
 ### Cannot pass Step Results between Steps
 
 It's not currently possible to pass results produced by a `Step` into following `Steps`. We are working on this feature and will be made available soon.
-
-### Cannot extract Step Results via Sidecar logs
-
-Currently, we only support Step Results via `Termination Message` (the default method of result extraction). The ability to extract `Step` results from `sidecar-logs` is not yet available. We are working on enabling this soon.

--- a/examples/v1/taskruns/alpha/stepaction-results.yaml
+++ b/examples/v1/taskruns/alpha/stepaction-results.yaml
@@ -6,8 +6,10 @@ spec:
   image: alpine
   results:
     - name: result1
+    - name: result2
   script: |
     echo "I am a Step Action!!!" >> $(step.results.result1.path)
+    echo "I am a hidden step action!!!" >> $(step.results.result2.path)
 ---
 apiVersion: tekton.dev/v1
 kind: TaskRun


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
Prior to this, we enabled surfacing `Step Results` via `termination-message`. This PR does the same thing for `sidecar-logs`. It would ensure that we can use `StepResults` when `results-from: sidecar-logs` feature flag is enabled.

This PR is part of issue https://github.com/tektoncd/pipeline/issues/7259.
# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Surface step results via sidecar logs
```
/kind feature