### PR TITLE
fix: resolve issue where resolutionrequest defaulted to v1alpha1 vs v1beta1

### DIFF
--- a/pkg/apis/resolution/v1beta1/resolution_request_defaults.go
+++ b/pkg/apis/resolution/v1beta1/resolution_request_defaults.go
@@ -28,6 +28,6 @@ func (rr *ResolutionRequest) SetDefaults(ctx context.Context) {
 		rr.TypeMeta.Kind = "ResolutionRequest"
 	}
 	if rr.TypeMeta.APIVersion == "" {
-		rr.TypeMeta.APIVersion = "resolution.tekton.dev/v1alpha1"
+		rr.TypeMeta.APIVersion = "resolution.tekton.dev/v1beta1"
 	}
 }


### PR DESCRIPTION
/kind cleanup

# Changes

It was identified that the default APIVersion was `v1alpha1` in pkg/apis/resolution/v1beta1/resolution_request_defaults.go when it should be `v1beta1`. This PR fixes this incorrect default API version
# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [N/A] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] [N/A] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Resolved issue where resolutionrequest defaulted to v1alpha1 when it should be v1beta1
```