### PR TITLE
Support overriding the SCM type and server URL

### DIFF
--- a/docs/git-resolver.md
+++ b/docs/git-resolver.md
@@ -13,15 +13,17 @@ This Resolver responds to type `git`.
 
 ## Parameters
 
-| Param Name   | Description                                                                                                            | Example Value                                               |
-|--------------|------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------|
-| `url`        | URL of the repo to fetch and clone anonymously. Either `url`, or `repo` (with `org`) must be specified, but not both.  | `https://github.com/tektoncd/catalog.git`                   |
-| `repo`       | The repository to find the resource in. Either `url`, or `repo` (with `org`) must be specified, but not both.          | `pipeline`, `test-infra`                                    |
-| `org`        | The organization to find the repository in. Default can be set in [configuration](#configuration).                     | `tektoncd`, `kubernetes`                                    |
-| `token`      | An optional secret name in the `PipelineRun` namespace to fetch the token from. Defaults to empty, meaning it will try to use the configuration from the global configmap.      | `secret-name`, (empty)  |
-| `tokenKey`   | An optional key in the token secret name in the `PipelineRun` namespace to fetch the token from. Defaults to `token`.  | `token`                                                     |
-| `revision`   | Git revision to checkout a file from. This can be commit SHA, branch or tag.                                           | `aeb957601cf41c012be462827053a21a420befca` `main` `v0.38.2` |
-| `pathInRepo` | Where to find the file in the repo.                                                                                    | `task/golang-build/0.3/golang-build.yaml`                   |
+| Param Name   | Description                                                                                                                                                                | Example Value                                               |
+|--------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------|
+| `url`        | URL of the repo to fetch and clone anonymously. Either `url`, or `repo` (with `org`) must be specified, but not both.                                                      | `https://github.com/tektoncd/catalog.git`                   |
+| `repo`       | The repository to find the resource in. Either `url`, or `repo` (with `org`) must be specified, but not both.                                                              | `pipeline`, `test-infra`                                    |
+| `org`        | The organization to find the repository in. Default can be set in [configuration](#configuration).                                                                         | `tektoncd`, `kubernetes`                                    |
+| `token`      | An optional secret name in the `PipelineRun` namespace to fetch the token from. Defaults to empty, meaning it will try to use the configuration from the global configmap. | `secret-name`, (empty)                                      |
+| `tokenKey`   | An optional key in the token secret name in the `PipelineRun` namespace to fetch the token from. Defaults to `token`.                                                      | `token`                                                     |
+| `revision`   | Git revision to checkout a file from. This can be commit SHA, branch or tag.                                                                                               | `aeb957601cf41c012be462827053a21a420befca` `main` `v0.38.2` |
+| `pathInRepo` | Where to find the file in the repo.                                                                                                                                        | `task/golang-build/0.3/golang-build.yaml`                   |
+| `serverURL`  | An optional server URL (that includes the https:// prefix) to connect for API operations                                                                                   | `https:/github.mycompany.com`                               |
+| `scmType`    | An optional SCM type to use for API operations                                                                                                                             | `github`, `gitlab`, `gitea`                                 |
 
 ## Requirements
 
@@ -137,7 +139,7 @@ spec:
       value: task/git-clone/0.6/git-clone.yaml
 ```
 
-#### Task Resolution with a custom token to the SCM provider
+#### Task Resolution with a custom token to a custom SCM provider
 
 ```yaml
 apiVersion: tekton.dev/v1beta1
@@ -163,6 +165,10 @@ spec:
       value: my-secret-token
     - name: tokenKey
       value: token
+    - name: scmType
+      value: github
+    - name: serverURL
+      value: https://ghe.mycompany.com
 ```
 
 #### Pipeline resolution

--- a/examples/v1/pipelineruns/no-ci/git-resolver-custom-apiurl.yaml
+++ b/examples/v1/pipelineruns/no-ci/git-resolver-custom-apiurl.yaml
@@ -1,0 +1,47 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  generateName: git-resolver-
+spec:
+  workspaces:
+    - name: output  # this workspace name must be declared in the Pipeline
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce  # access mode may affect how you can use this volume in parallel tasks
+          resources:
+            requests:
+              storage: 1Gi
+  pipelineSpec:
+    workspaces:
+      - name: output
+    tasks:
+      - name: task1
+        workspaces:
+          - name: output
+        taskRef:
+          resolver: git
+          params:
+            - name: url
+              value: https://github.com/tektoncd/catalog.git
+            - name: pathInRepo
+              value: /task/git-clone/0.7/git-clone.yaml
+            - name: revision
+              value: main
+            # my-secret-token should be created in the namespace where the
+            # pipelinerun is created and contain a GitHub personal access
+            # token in the token key of the secret for the GitHub endpoint
+            # where the serverURL is configured to
+            - name: token
+              value: my-secret-token
+            - name: tokenKey
+              value: token
+            - name: serverURL
+              value: https://github.my-company.com
+            - name: scmType
+              value: github
+        params:
+          - name: url
+            value: https://github.com/tektoncd/catalog
+          - name: deleteExisting
+            value: "true"

--- a/pkg/resolution/resolver/git/params.go
+++ b/pkg/resolution/resolver/git/params.go
@@ -33,4 +33,8 @@ const (
 	tokenKeyParam string = "tokenKey"
 	// defaultTokenKeyParam is the default key in the tokenParam secret for SCM API authentication
 	defaultTokenKeyParam string = "token"
+	// scmTypeParams is an optional string overriding the scm-type configuration (ie: github, gitea, gitlab etc..)
+	scmTypeParam string = "scmType"
+	// serverURLParams is an optional string to the server URL for the SCM API to connect to
+	serverURLParam string = "serverURL"
 )


### PR DESCRIPTION
# Changes

When using the git resolver it was only possible to use one single provider across cluster.

If the user wanted to mix different providers to fetch the task from they would not have been able to do so.

With this change we now support overriding the SCM type and server URL as a parameters in the PipelineRun for the user to pass.

Fixed bug #7448

/kind feature

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [X] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [X] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [X] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [X] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
User are now able to override the global server URL when using the git resolver to allow fetching from multiple git providers.
```
