### PR TITLE
[release-v0.53.x] Do not require `enable-api-fields: alpha` for entrypoint cancellation

### DIFF
--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -151,7 +151,7 @@ func (b *Builder) Build(ctx context.Context, taskRun *v1.TaskRun, taskSpec v1.Ta
 	defaultForbiddenEnv := config.FromContextOrDefaults(ctx).Defaults.DefaultForbiddenEnv
 	alphaAPIEnabled := featureFlags.EnableAPIFields == config.AlphaAPIFields
 	sidecarLogsResultsEnabled := config.FromContextOrDefaults(ctx).FeatureFlags.ResultExtractionMethod == config.ResultExtractionMethodSidecarLogs
-	enableKeepPodOnCancel := alphaAPIEnabled && featureFlags.EnableKeepPodOnCancel
+	enableKeepPodOnCancel := featureFlags.EnableKeepPodOnCancel
 	setSecurityContext := config.FromContextOrDefaults(ctx).FeatureFlags.SetSecurityContext
 
 	// Add our implicit volumes first, so they can be overridden by the user if they prefer.

--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -2184,7 +2184,7 @@ _EOF_
 								FieldRef: &corev1.ObjectFieldSelector{
 									FieldPath: fmt.Sprintf("metadata.annotations['%s']", readyAnnotation),
 								},
-							}},
+							}, downwardCancelVolumeItem},
 						},
 					},
 				}, corev1.Volume{

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -488,7 +488,6 @@ func (c *Reconciler) reconcile(ctx context.Context, tr *v1.TaskRun, rtr *resourc
 		// current labels may not be set on a previously created Pod.
 		labelSelector := labels.Set{pipeline.TaskRunLabelKey: tr.Name}
 		pos, err := c.podLister.Pods(tr.Namespace).List(labelSelector.AsSelector())
-
 		if err != nil {
 			logger.Errorf("Error listing pods: %v", err)
 			return err
@@ -688,8 +687,7 @@ func (c *Reconciler) failTaskRun(ctx context.Context, tr *v1.TaskRun, reason v1.
 	}
 
 	var err error
-	if reason == v1.TaskRunReasonCancelled &&
-		(config.FromContextOrDefaults(ctx).FeatureFlags.EnableKeepPodOnCancel && config.FromContextOrDefaults(ctx).FeatureFlags.EnableAPIFields == config.AlphaAPIFields) {
+	if reason == v1.TaskRunReasonCancelled && (config.FromContextOrDefaults(ctx).FeatureFlags.EnableKeepPodOnCancel) {
 		logger.Infof("canceling task run %q by entrypoint", tr.Name)
 		err = podconvert.CancelPod(ctx, c.KubeClientSet, tr.Namespace, tr.Status.PodName)
 	} else {


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This commit removes the need for `enable-api-fields: alpha` to enable the entrypoint cancellation. This feature should only behind the `keep-pod-on-cancel: true` feature-flag.

(cherry picked from commit 1b075fb1f56f22abba058f59aaa9efbdfe37ac75)

This cherry-picks #7430 manually (as it conflicted).

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Entrypoint cancellation only requires `keep-pod-on-cancel: true` feature-flag.
```
