### PR TITLE
TEP-0142: Introduce WorkingDir in StepActions

### DIFF
--- a/docs/pipeline-api.md
+++ b/docs/pipeline-api.md
@@ -6720,6 +6720,21 @@ string
 </tr>
 <tr>
 <td>
+<code>workingDir</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Step&rsquo;s working directory.
+If not specified, the container runtime&rsquo;s default will be used, which
+might be configured in the container image.
+Cannot be updated.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>params</code><br/>
 <em>
 <a href="#tekton.dev/v1.ParamSpecs">
@@ -7537,6 +7552,21 @@ string
 <em>(Optional)</em>
 <p>Script is the contents of an executable file to execute.</p>
 <p>If Script is not empty, the Step cannot have an Command and the Args will be passed to the Script.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>workingDir</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Step&rsquo;s working directory.
+If not specified, the container runtime&rsquo;s default will be used, which
+might be configured in the container image.
+Cannot be updated.</p>
 </td>
 </tr>
 <tr>

--- a/docs/stepactions.md
+++ b/docs/stepactions.md
@@ -13,6 +13,7 @@ weight: 201
     - [Passing Params to StepAction](#passing-params-to-stepaction)
   - [Emitting Results](#emitting-results)
     - [Fetching Emitted Results from StepActions](#fetching-emitted-results-from-stepactions)
+  - [Declaring WorkingDir](#declaring-workingdir)
   - [Declaring SecurityContext](#declaring-securitycontext)
   - [Declaring VolumeMounts](#declaring-volumemounts)
   - [Referencing a StepAction](#referencing-a-stepaction)
@@ -51,6 +52,7 @@ A `StepAction` definition supports the following fields:
   - `env`
   - [`params`](#declaring-parameters)
   - [`results`](#emitting-results)
+  - [`workingDir`](#declaring-workingdir)
   - [`securityContext`](#declaring-securitycontext)
   - [`volumeMounts`](#declaring-volumemounts)
 
@@ -233,6 +235,40 @@ spec:
       ref:
         name: kaniko-step-action
 ```
+
+### Declaring WorkingDir
+
+You can declare `workingDir` in a `StepAction`:
+
+```yaml
+apiVersion: tekton.dev/v1alpha1
+kind: StepAction
+metadata:
+  name: example-stepaction-name
+spec:
+  image:  gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:latest
+  workingDir: /workspace
+  script: |
+    # clone the repo
+    ...
+```
+
+The `Task` using the `StepAction` has more context about how the `Steps` have been orchestrated. As such, the `Task` should be able to update the `workingDir` of the `StepAction` so that the `StepAction` is executed from the correct location.
+The `StepAction` can parametrize the `workingDir` and work relative to it. This way, the `Task` does not really need control over the workingDir, it just needs to pass the path as a parameter. 
+
+```yaml
+apiVersion: tekton.dev/v1alpha1
+kind: StepAction
+metadata:
+  name: example-stepaction-name
+spec:
+  image: ubuntu
+  params:
+    - name: source
+      description: "The path to the source code."
+  workingDir: $(params.source)
+```
+
 
 ### Declaring SecurityContext
 

--- a/pkg/apis/pipeline/v1/task_validation.go
+++ b/pkg/apis/pipeline/v1/task_validation.go
@@ -352,6 +352,12 @@ func validateStep(ctx context.Context, s Step, names sets.String) (errs *apis.Fi
 				Paths:   []string{"script"},
 			})
 		}
+		if s.WorkingDir != "" {
+			errs = errs.Also(&apis.FieldError{
+				Message: "working dir cannot be used with Ref",
+				Paths:   []string{"workingDir"},
+			})
+		}
 		if s.Env != nil {
 			errs = errs.Also(&apis.FieldError{
 				Message: "env cannot be used with Ref",

--- a/pkg/apis/pipeline/v1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1/task_validation_test.go
@@ -528,8 +528,7 @@ func TestTaskSpecStepActionReferenceValidate(t *testing.T) {
 	}{{
 		name: "valid stepaction ref",
 		Steps: []v1.Step{{
-			Name:       "mystep",
-			WorkingDir: "/foo",
+			Name: "mystep",
 			Ref: &v1.Ref{
 				Name: "stepAction",
 			},
@@ -1535,6 +1534,18 @@ func TestTaskSpecValidateErrorWithStepActionRef(t *testing.T) {
 		expectedError: apis.FieldError{
 			Message: "script cannot be used with Ref",
 			Paths:   []string{"steps[0].script"},
+		},
+	}, {
+		name: "Cannot use workingDir with Ref",
+		Steps: []v1.Step{{
+			Ref: &v1.Ref{
+				Name: "stepAction",
+			},
+			WorkingDir: "/workspace",
+		}},
+		expectedError: apis.FieldError{
+			Message: "working dir cannot be used with Ref",
+			Paths:   []string{"steps[0].workingDir"},
 		},
 	}, {
 		name: "Cannot use env with Ref",

--- a/pkg/apis/pipeline/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1alpha1/openapi_generated.go
@@ -829,6 +829,13 @@ func schema_pkg_apis_pipeline_v1alpha1_StepActionSpec(ref common.ReferenceCallba
 							Format:      "",
 						},
 					},
+					"workingDir": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Step's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"params": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{

--- a/pkg/apis/pipeline/v1alpha1/stepaction_types.go
+++ b/pkg/apis/pipeline/v1alpha1/stepaction_types.go
@@ -112,6 +112,12 @@ type StepActionSpec struct {
 	// If Script is not empty, the Step cannot have an Command and the Args will be passed to the Script.
 	// +optional
 	Script string `json:"script,omitempty"`
+	// Step's working directory.
+	// If not specified, the container runtime's default will be used, which
+	// might be configured in the container image.
+	// Cannot be updated.
+	// +optional
+	WorkingDir string `json:"workingDir,omitempty" protobuf:"bytes,5,opt,name=workingDir"`
 	// Params is a list of input parameters required to run the stepAction.
 	// Params must be supplied as inputs in Steps unless they declare a defaultvalue.
 	// +optional

--- a/pkg/apis/pipeline/v1alpha1/swagger.json
+++ b/pkg/apis/pipeline/v1alpha1/swagger.json
@@ -457,6 +457,10 @@
           "x-kubernetes-list-type": "atomic",
           "x-kubernetes-patch-merge-key": "mountPath",
           "x-kubernetes-patch-strategy": "merge"
+        },
+        "workingDir": {
+          "description": "Step's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.",
+          "type": "string"
         }
       }
     },

--- a/pkg/apis/pipeline/v1beta1/task_validation.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation.go
@@ -341,6 +341,12 @@ func validateStep(ctx context.Context, s Step, names sets.String) (errs *apis.Fi
 				Paths:   []string{"script"},
 			})
 		}
+		if s.WorkingDir != "" {
+			errs = errs.Also(&apis.FieldError{
+				Message: "working dir cannot be used with Ref",
+				Paths:   []string{"workingDir"},
+			})
+		}
 		if s.Env != nil {
 			errs = errs.Also(&apis.FieldError{
 				Message: "env cannot be used with Ref",

--- a/pkg/apis/pipeline/v1beta1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation_test.go
@@ -532,8 +532,7 @@ func TestTaskSpecStepActionReferenceValidate(t *testing.T) {
 	}{{
 		name: "valid stepaction ref",
 		Steps: []v1beta1.Step{{
-			Name:       "mystep",
-			WorkingDir: "/foo",
+			Name: "mystep",
 			Ref: &v1beta1.Ref{
 				Name: "stepAction",
 			},
@@ -1548,6 +1547,18 @@ func TestTaskSpecValidateErrorWithStepActionRef(t *testing.T) {
 		expectedError: apis.FieldError{
 			Message: "script cannot be used with Ref",
 			Paths:   []string{"steps[0].script"},
+		},
+	}, {
+		name: "Cannot use workingDir with Ref",
+		Steps: []v1beta1.Step{{
+			Ref: &v1beta1.Ref{
+				Name: "stepAction",
+			},
+			WorkingDir: "/workspace",
+		}},
+		expectedError: apis.FieldError{
+			Message: "working dir cannot be used with Ref",
+			Paths:   []string{"steps[0].workingDir"},
 		},
 	}, {
 		name: "Cannot use env with Ref",

--- a/pkg/reconciler/taskrun/resources/taskspec.go
+++ b/pkg/reconciler/taskrun/resources/taskspec.go
@@ -125,6 +125,7 @@ func GetStepActionsData(ctx context.Context, taskSpec v1.TaskSpec, taskRun *v1.T
 			if stepActionSpec.Script != "" {
 				s.Script = stepActionSpec.Script
 			}
+			s.WorkingDir = stepActionSpec.WorkingDir
 			if stepActionSpec.Env != nil {
 				s.Env = stepActionSpec.Env
 			}

--- a/pkg/reconciler/taskrun/resources/taskspec_test.go
+++ b/pkg/reconciler/taskrun/resources/taskspec_test.go
@@ -321,8 +321,7 @@ func TestGetStepActionsData(t *testing.T) {
 						Ref: &v1.Ref{
 							Name: "stepAction",
 						},
-						WorkingDir: "/bar",
-						Timeout:    &metav1.Duration{Duration: time.Hour},
+						Timeout: &metav1.Duration{Duration: time.Hour},
 					}},
 				},
 			},
@@ -343,11 +342,10 @@ func TestGetStepActionsData(t *testing.T) {
 			},
 		},
 		want: []v1.Step{{
-			Image:      "myimage",
-			Command:    []string{"ls"},
-			Args:       []string{"-lh"},
-			WorkingDir: "/bar",
-			Timeout:    &metav1.Duration{Duration: time.Hour},
+			Image:   "myimage",
+			Command: []string{"ls"},
+			Args:    []string{"-lh"},
+			Timeout: &metav1.Duration{Duration: time.Hour},
 			VolumeMounts: []corev1.VolumeMount{{
 				Name:      "$(params.foo)",
 				MountPath: "/path",
@@ -469,8 +467,7 @@ func TestGetStepActionsData(t *testing.T) {
 						Ref: &v1.Ref{
 							Name: "stepAction",
 						},
-						WorkingDir: "/bar",
-						Timeout:    &metav1.Duration{Duration: time.Hour},
+						Timeout: &metav1.Duration{Duration: time.Hour},
 					}, {
 						Image:   "foo",
 						Command: []string{"ls"},
@@ -490,11 +487,10 @@ func TestGetStepActionsData(t *testing.T) {
 			},
 		},
 		want: []v1.Step{{
-			Image:      "myimage",
-			Command:    []string{"ls"},
-			Args:       []string{"-lh"},
-			WorkingDir: "/bar",
-			Timeout:    &metav1.Duration{Duration: time.Hour},
+			Image:   "myimage",
+			Command: []string{"ls"},
+			Args:    []string{"-lh"},
+			Timeout: &metav1.Duration{Duration: time.Hour},
 		}, {
 			Image:   "foo",
 			Command: []string{"ls"},

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -2942,7 +2942,6 @@ spec:
       - ref:
           name: stepAction
         name: step1
-        workingDir: /foo
       - ref:
           name: stepAction2
         name: step2
@@ -2993,7 +2992,6 @@ spec:
 		Image:           "myImage",
 		Command:         []string{"ls"},
 		Name:            "step1",
-		WorkingDir:      "/foo",
 		SecurityContext: &corev1.SecurityContext{Privileged: &securityContextPrivileged},
 	}, {
 		Image:  "myImage",


### PR DESCRIPTION
This PR introduces `workingDir` into `StepActions`. This allows the `StepAction` to set the `workingDir` and work relative to it.

https://github.com/tektoncd/community/blob/main/teps/0142-enable-step-reusability.md#workingdir

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Introduce WorkingDir in StepActions
```
/kind feature