### PR TITLE
Label `user error` for failure PipelineRun Status

### DIFF
--- a/docs/pipelineruns.md
+++ b/docs/pipelineruns.md
@@ -32,6 +32,7 @@ weight: 204
   - [<code>PipelineRun</code> status](#pipelinerun-status)
     - [The <code>status</code> field](#the-status-field)
     - [Monitoring execution status](#monitoring-execution-status)
+    - [Marking off user errors](#marking-off-user-errors)
   - [Cancelling a <code>PipelineRun</code>](#cancelling-a-pipelinerun)
   - [Gracefully cancelling a <code>PipelineRun</code>](#gracefully-cancelling-a-pipelinerun)
   - [Gracefully stopping a <code>PipelineRun</code>](#gracefully-stopping-a-pipelinerun)
@@ -1537,6 +1538,36 @@ Some examples:
 | pipeline-run-0123456789-0123456789-0123456789-0123456789 | task3                                                        | pipeline-run-0123456789-0123456789-0123456789-0123456789-task3                         |
 | pipeline-run-0123456789-0123456789-0123456789-0123456789 | task2-0123456789-0123456789-0123456789-0123456789-0123456789 | pipeline-run-0123456789-012345607ad8c7aac5873cdfabe472a68996b5c                        |
 | pipeline-run                                             | task4 (with 2x2 `Matrix`)                                    | pipeline-run-task1-0, pipeline-run-task1-2, pipeline-run-task1-3, pipeline-run-task1-4 |
+
+### Marking off user errors
+
+A user error in Tekton is any mistake made by user, such as a syntax error when specifying pipelines, tasks. User errors can occur in various stages of the Tekton pipeline, from authoring the pipeline configuration to executing the pipelines. They are currently explicitly labeled in the Run's conditions reason, for example:
+
+```yaml
+# Failed PipelineRun with reason labeled "User error"
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  ...
+spec:
+  ...
+status:
+  ...
+  conditions:
+  - lastTransitionTime: "2022-06-02T19:02:58Z"
+    message: 'PipelineRun default parameters is missing some parameters required by
+      Pipeline pipelinerun-with-params''s parameters: pipelineRun missing parameters:
+      [pl-param-x]'
+    reason: '[User error] ParameterMissing'
+    status: "False"
+    type: Succeeded
+```
+
+```console
+~/pipeline$ tkn pr list
+NAME                      STARTED         DURATION   STATUS
+pipelinerun-with-params   5 seconds ago   0s         Failed([User error] ParameterMissing)
+```
 
 ## Cancelling a `PipelineRun`
 

--- a/pkg/apis/pipeline/errors/errors.go
+++ b/pkg/apis/pipeline/errors/errors.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2023 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package errors
+
+const userErrorLabel = "[User error] "
+
+type UserError struct {
+	Reason   string
+	Original error
+}
+
+var _ error = &UserError{}
+
+// Error returns the original error message. This implements the error.Error interface.
+func (e *UserError) Error() string {
+	return e.Original.Error()
+}
+
+// Unwrap returns the original error without the Reason annotation. This is
+// intended to support usage of errors.Is and errors.As with Errors.
+func (e *UserError) Unwrap() error {
+	return e.Original
+}
+
+// newUserError returns a UserError with the given reason and underlying
+// original error.
+func newUserError(reason string, err error) *UserError {
+	return &UserError{
+		Reason:   reason,
+		Original: err,
+	}
+}
+
+// WrapUserError wraps the original error with the user error label
+func WrapUserError(err error) error {
+	return newUserError(userErrorLabel, err)
+}
+
+// LabelsUserErrorReason labels the failure RunStatus Reason if any of its error messages has been
+// wrapped as an UserError. It indicates that the user is responsible for an error.
+// See github.com/tektoncd/pipeline/blob/main/docs/pipelineruns.md#marking-off-user-errors
+// for more details.
+func LabelsUserErrorReason(reason string, messageA []interface{}) string {
+	for _, message := range messageA {
+		if ue, ok := message.(*UserError); ok {
+			return ue.Reason + reason
+		}
+	}
+	return reason
+}

--- a/pkg/apis/pipeline/errors/errors_test.go
+++ b/pkg/apis/pipeline/errors/errors_test.go
@@ -85,10 +85,9 @@ func makeMessages(hasUserError bool) []interface{} {
 	msgs := []string{"foo error message", "bar error format"}
 	original := errors.New("orignal error")
 
-	var messages []interface{}
-	messages = make([]interface{}, len(msgs)+1)
-	for i, v := range msgs {
-		messages[i] = v
+	messages := make([]interface{}, 0)
+	for _, msg := range msgs {
+		messages = append(messages, msg)
 	}
 
 	if hasUserError {

--- a/pkg/apis/pipeline/errors/errors_test.go
+++ b/pkg/apis/pipeline/errors/errors_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2023 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package errors_test
+
+import (
+	"errors"
+	"testing"
+
+	pipelineErrors "github.com/tektoncd/pipeline/pkg/apis/pipeline/errors"
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+)
+
+type TestError struct{}
+
+var _ error = &TestError{}
+
+func (*TestError) Error() string {
+	return "test error"
+}
+
+func TestUserErrorUnwrap(t *testing.T) {
+	originalError := &TestError{}
+	userError := pipelineErrors.WrapUserError(originalError)
+
+	if !errors.Is(userError, &TestError{}) {
+		t.Errorf("user error  expected to unwrap successfully")
+	}
+}
+
+func TestResolutionErrorMessage(t *testing.T) {
+	originalError := &TestError{}
+	expectedErrorMessage := originalError.Error()
+
+	userError := pipelineErrors.WrapUserError(originalError)
+
+	if userError.Error() != expectedErrorMessage {
+		t.Errorf("user error message expected to equal to %s, got: %s", expectedErrorMessage, userError.Error())
+	}
+}
+
+func TestLabelsUserError(t *testing.T) {
+	const hasUserError = true
+	tcs := []struct {
+		description string
+		reason      string
+		messages    []interface{}
+		expected    string
+	}{{
+		description: "error messags with user error",
+		reason:      v1.PipelineRunReasonInvalidGraph.String(),
+		messages:    makeMessages(hasUserError),
+		expected:    "[User error] " + v1.PipelineRunReasonInvalidGraph.String(),
+	}, {
+		description: "error messags without user error",
+		messages:    makeMessages(!hasUserError),
+		reason:      v1.PipelineRunReasonInvalidGraph.String(),
+		expected:    v1.PipelineRunReasonInvalidGraph.String(),
+	}}
+	for _, tc := range tcs {
+		{
+			reason := pipelineErrors.LabelsUserErrorReason(tc.reason, tc.messages)
+
+			if reason != tc.expected {
+				t.Errorf("failure reason expected: %s; but got %s", tc.expected, reason)
+			}
+		}
+	}
+}
+
+func makeMessages(hasUserError bool) []interface{} {
+	msgs := []string{"foo error message", "bar error format"}
+	original := errors.New("orignal error")
+
+	var messages []interface{}
+	messages = make([]interface{}, len(msgs)+1)
+	for i, v := range msgs {
+		messages[i] = v
+	}
+
+	if hasUserError {
+		messages = append(messages, pipelineErrors.WrapUserError(original))
+	}
+	return messages
+}

--- a/pkg/apis/pipeline/v1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1/pipelinerun_types.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
+	pipelineErrors "github.com/tektoncd/pipeline/pkg/apis/pipeline/errors"
 	pod "github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
 	runv1beta1 "github.com/tektoncd/pipeline/pkg/apis/run/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -458,6 +459,7 @@ func (pr *PipelineRunStatus) MarkSucceeded(reason, messageFormat string, message
 
 // MarkFailed changes the Succeeded condition to False with the provided reason and message.
 func (pr *PipelineRunStatus) MarkFailed(reason, messageFormat string, messageA ...interface{}) {
+	reason = pipelineErrors.LabelsUserErrorReason(reason, messageA)
 	pipelineRunCondSet.Manage(pr).MarkFalse(apis.ConditionSucceeded, reason, messageFormat, messageA...)
 	succeeded := pr.GetCondition(apis.ConditionSucceeded)
 	pr.CompletionTime = &succeeded.LastTransitionTime.Inner

--- a/pkg/reconciler/apiserver/apiserver.go
+++ b/pkg/reconciler/apiserver/apiserver.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
+	pipelineErrors "github.com/tektoncd/pipeline/pkg/apis/pipeline/errors"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -76,7 +77,7 @@ func handleDryRunCreateErr(err error, objectName string) error {
 	case apierrors.IsBadRequest(err): // Object rejected by validating webhook
 		errType = ErrReferencedObjectValidationFailed
 	case apierrors.IsInvalid(err), apierrors.IsMethodNotSupported(err):
-		errType = ErrCouldntValidateObjectPermanent
+		errType = pipelineErrors.WrapUserError(ErrCouldntValidateObjectPermanent)
 	case apierrors.IsTimeout(err), apierrors.IsServerTimeout(err), apierrors.IsTooManyRequests(err):
 		errType = ErrCouldntValidateObjectRetryable
 	default:

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -641,7 +641,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1.PipelineRun, getPipel
 			if err != nil {
 				logger.Errorf("Failed to validate pipelinerun %s with error %w", pr.Name, err)
 				pr.Status.MarkFailed(v1.PipelineRunReasonFailedValidation.String(),
-					"Failed to validate pipelinerun %s with error %s",
+					"Validation failed for pipelinerun %s with error %s",
 					pr.Name, pipelineErrors.WrapUserError(err))
 				return controller.NewPermanentError(err)
 			}
@@ -650,7 +650,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1.PipelineRun, getPipel
 				if err := resources.ValidateParamEnumSubset(originalTasks[i].Params, pipelineSpec.Params, rpt.ResolvedTask); err != nil {
 					logger.Errorf("Failed to validate pipelinerun %q with error %w", pr.Name, err)
 					pr.Status.MarkFailed(v1.PipelineRunReasonFailedValidation.String(),
-						"Failed to validate pipelinerun with error %s",
+						"Validation failed for pipelinerun with error %s",
 						pipelineErrors.WrapUserError(err))
 					return controller.NewPermanentError(err)
 				}

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -840,7 +840,7 @@ spec:
 		permanentError: true,
 		wantEvents: []string{
 			"Normal Started",
-			"Warning Failed Failed to validate pipelinerun pipeline-params-dont-exist with error invalid input params for task a-task-that-needs-params: missing values",
+			"Warning Failed Validation failed for pipelinerun pipeline-params-dont-exist with error invalid input params for task a-task-that-needs-params: missing values",
 		},
 	}, {
 		name: "invalid-pipeline-mismatching-parameter-types",

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/cel-go/cel"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
+	pipelineErrors "github.com/tektoncd/pipeline/pkg/apis/pipeline/errors"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/reconciler/taskrun/resources"
@@ -507,7 +508,7 @@ func ValidateWorkspaceBindings(p *v1.PipelineSpec, pr *v1.PipelineRun) error {
 			continue
 		}
 		if _, ok := pipelineRunWorkspaces[ws.Name]; !ok {
-			return fmt.Errorf("pipeline requires workspace with name %q be provided by pipelinerun", ws.Name)
+			return pipelineErrors.WrapUserError(fmt.Errorf("pipeline requires workspace with name %q be provided by pipelinerun", ws.Name))
 		}
 	}
 	return nil
@@ -526,7 +527,7 @@ func ValidateTaskRunSpecs(p *v1.PipelineSpec, pr *v1.PipelineRun) error {
 
 	for _, taskrunSpec := range pr.Spec.TaskRunSpecs {
 		if _, ok := pipelineTasks[taskrunSpec.PipelineTaskName]; !ok {
-			return fmt.Errorf("pipelineRun's taskrunSpecs defined wrong taskName: %q, does not exist in Pipeline", taskrunSpec.PipelineTaskName)
+			return pipelineErrors.WrapUserError(fmt.Errorf("pipelineRun's taskrunSpecs defined wrong taskName: %q, does not exist in Pipeline", taskrunSpec.PipelineTaskName))
 		}
 	}
 	return nil

--- a/pkg/reconciler/pipelinerun/resources/resultrefresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/resultrefresolution.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"sort"
 
+	pipelineErrors "github.com/tektoncd/pipeline/pkg/apis/pipeline/errors"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 )
@@ -28,7 +29,7 @@ import (
 var (
 	// ErrInvalidTaskResultReference indicates that the reason for the failure status is that there
 	// is an invalid task result reference
-	ErrInvalidTaskResultReference = errors.New("Invalid task result reference")
+	ErrInvalidTaskResultReference = pipelineErrors.WrapUserError(errors.New("Invalid task result reference"))
 )
 
 // ResolvedResultRefs represents all of the ResolvedResultRef for a pipeline task

--- a/pkg/reconciler/pipelinerun/resources/validate_dependencies.go
+++ b/pkg/reconciler/pipelinerun/resources/validate_dependencies.go
@@ -19,6 +19,7 @@ package resources
 import (
 	"fmt"
 
+	pipelineErrors "github.com/tektoncd/pipeline/pkg/apis/pipeline/errors"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -32,7 +33,7 @@ func ValidatePipelineTaskResults(state PipelineRunState) error {
 	for _, rpt := range state {
 		for _, ref := range v1.PipelineTaskResultRefs(rpt.PipelineTask) {
 			if err := validateResultRef(ref, ptMap); err != nil {
-				return fmt.Errorf("invalid result reference in pipeline task %q: %w", rpt.PipelineTask.Name, err)
+				return pipelineErrors.WrapUserError(fmt.Errorf("invalid result reference in pipeline task %q: %w", rpt.PipelineTask.Name, err))
 			}
 		}
 	}

--- a/pkg/reconciler/pipelinerun/resources/validate_params.go
+++ b/pkg/reconciler/pipelinerun/resources/validate_params.go
@@ -19,6 +19,7 @@ package resources
 import (
 	"fmt"
 
+	pipelineErrors "github.com/tektoncd/pipeline/pkg/apis/pipeline/errors"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/list"
 	"github.com/tektoncd/pipeline/pkg/reconciler/taskrun"
@@ -45,7 +46,7 @@ func ValidateParamTypesMatching(p *v1.PipelineSpec, pr *v1.PipelineRun) error {
 
 	// Return an error with the misconfigured parameters' names, or return nil if there are none.
 	if len(wrongTypeParamNames) != 0 {
-		return fmt.Errorf("parameters have inconsistent types : %s", wrongTypeParamNames)
+		return pipelineErrors.WrapUserError(fmt.Errorf("parameters have inconsistent types : %s", wrongTypeParamNames))
 	}
 	return nil
 }
@@ -71,7 +72,7 @@ func ValidateRequiredParametersProvided(pipelineParameters *v1.ParamSpecs, pipel
 
 	// Return an error with the missing parameters' names, or return nil if there are none.
 	if len(missingParams) != 0 {
-		return fmt.Errorf("pipelineRun missing parameters: %s", missingParams)
+		return pipelineErrors.WrapUserError(fmt.Errorf("pipelineRun missing parameters: %s", missingParams))
 	}
 	return nil
 }
@@ -80,7 +81,7 @@ func ValidateRequiredParametersProvided(pipelineParameters *v1.ParamSpecs, pipel
 func ValidateObjectParamRequiredKeys(pipelineParameters []v1.ParamSpec, pipelineRunParameters []v1.Param) error {
 	missings := taskrun.MissingKeysObjectParamNames(pipelineParameters, pipelineRunParameters)
 	if len(missings) != 0 {
-		return fmt.Errorf("pipelineRun missing object keys for parameters: %v", missings)
+		return pipelineErrors.WrapUserError(fmt.Errorf("pipelineRun missing object keys for parameters: %v", missings))
 	}
 
 	return nil

--- a/pkg/reconciler/taskrun/resources/validate_params.go
+++ b/pkg/reconciler/taskrun/resources/validate_params.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"fmt"
 
+	pipelineErrors "github.com/tektoncd/pipeline/pkg/apis/pipeline/errors"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/substitution"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -41,7 +42,7 @@ func ValidateOutOfBoundArrayParams(declarations v1.ParamSpecs, params v1.Params,
 		}
 	}
 	if outofBoundParams.Len() > 0 {
-		return fmt.Errorf("non-existent param references:%v", outofBoundParams.List())
+		return pipelineErrors.WrapUserError(fmt.Errorf("non-existent param references:%v", outofBoundParams.List()))
 	}
 	return nil
 }


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This commit labels the user errors for failed PipelineRun status. This aims to communicate explicitly with users of whether the run failed could be attributed to users' responsibility.

/kind misc
part of #7276
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
