### PR TITLE
[release-v0.53.x] Use a maintained action for "changed files"

### DIFF
--- a/.github/workflows/woke.yml
+++ b/.github/workflows/woke.yml
@@ -7,16 +7,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout'
-        uses: actions/checkout@v2
-
-      - uses: jitterbit/get-changed-files@v1
-        id: files
+        uses: actions/checkout@v4
+        
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v40
+        with:
+          write_output_files: true
+          files: |
+            **
 
       - name: 'woke'
+        if: steps.changed-files.outputs.any_changed == 'true'
         uses: get-woke/woke-action@v0
         with:
           # Cause the check to fail on any broke rules
           fail-on-error: true
-          # See https://github.com/marketplace/actions/get-all-changed-files
-          # for more options
-          woke-args: ${{ steps.files.outputs.added_modified }}
+          woke-args: ${{ steps.changed_files.outputs.all_changed_files }}

--- a/.wokeignore
+++ b/.wokeignore
@@ -1,3 +1,5 @@
 go.mod
 go.sum
 vendor
+config/dummy.go
+.wokeignore

--- a/pkg/apis/pipeline/v1beta1/resource_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/resource_types_test.go
@@ -21,13 +21,13 @@ import (
 var (
 	prependStep = v1beta1.Step{
 		Name:    "prepend-step",
-		Image:   "dummy",
+		Image:   "sample",
 		Command: []string{"doit"},
 		Args:    []string{"stuff", "things"},
 	}
 	appendStep = v1beta1.Step{
 		Name:    "append-step",
-		Image:   "dummy",
+		Image:   "sample",
 		Command: []string{"doit"},
 		Args:    []string{"other stuff", "other things"},
 	}

--- a/pkg/reconciler/pipelinerun/resources/pipelineref_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelineref_test.go
@@ -53,9 +53,9 @@ import (
 )
 
 var (
-	dummyPipeline = &v1.Pipeline{
+	samplePipeline = &v1.Pipeline{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "dummy",
+			Name:      "sample",
 			Namespace: "default",
 		},
 		TypeMeta: metav1.TypeMeta{
@@ -130,7 +130,7 @@ func TestLocalPipelineRef(t *testing.T) {
 	}{
 		{
 			name:      "local-pipeline",
-			pipelines: []runtime.Object{simplePipeline(), dummyPipeline},
+			pipelines: []runtime.Object{simplePipeline(), samplePipeline},
 			ref: &v1.PipelineRef{
 				Name: "simple",
 			},
@@ -191,9 +191,9 @@ func TestGetPipelineFunc_Local(t *testing.T) {
 		name: "local-pipeline",
 		localPipelines: []runtime.Object{
 			simplePipelineWithBaseSpec(),
-			dummyPipeline,
+			samplePipeline,
 		},
-		remotePipelines: []runtime.Object{simplePipeline(), dummyPipeline},
+		remotePipelines: []runtime.Object{simplePipeline(), samplePipeline},
 		ref: &v1.PipelineRef{
 			Name: "simple",
 		},
@@ -240,7 +240,7 @@ func TestGetPipelineFuncSpecAlreadyFetched(t *testing.T) {
 	ctx := context.Background()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	tektonclient := fake.NewSimpleClientset(simplePipeline(), dummyPipeline)
+	tektonclient := fake.NewSimpleClientset(simplePipeline(), samplePipeline)
 	kubeclient := fakek8s.NewSimpleClientset(&corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",

--- a/pkg/reconciler/taskrun/resources/taskref_test.go
+++ b/pkg/reconciler/taskrun/resources/taskref_test.go
@@ -90,7 +90,8 @@ var (
 	unsignedV1Task = v1.Task{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "tekton.dev/v1",
-			Kind:       "Task"},
+			Kind:       "Task",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "task",
 			Annotations: map[string]string{"foo": "bar"},
@@ -174,7 +175,7 @@ func TestLocalTaskRef(t *testing.T) {
 				},
 				&v1.Task{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "dummy",
+						Name:      "sample",
 						Namespace: "default",
 					},
 				},
@@ -201,7 +202,7 @@ func TestLocalTaskRef(t *testing.T) {
 				},
 				&v1beta1.ClusterTask{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "dummy-task",
+						Name: "sample-task",
 					},
 				},
 			},
@@ -322,7 +323,7 @@ func TestGetTaskFunc_Local(t *testing.T) {
 				},
 				&v1.Task{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "dummy",
+						Name: "sample",
 					},
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "tekton.dev/v1",
@@ -345,7 +346,7 @@ func TestGetTaskFunc_Local(t *testing.T) {
 				},
 				&v1beta1.ClusterTask{
 					TypeMeta:   metav1.TypeMeta{APIVersion: "tekton.dev/v1alpha1", Kind: "ClusterTask"},
-					ObjectMeta: metav1.ObjectMeta{Name: "dummy"},
+					ObjectMeta: metav1.ObjectMeta{Name: "sample"},
 				},
 			},
 			ref: &v1.TaskRef{
@@ -785,55 +786,56 @@ func TestGetTaskFunc_V1beta1Task_VerifyNoError(t *testing.T) {
 		expected                   runtime.Object
 		expectedRefSource          *v1.RefSource
 		expectedVerificationResult *trustedresources.VerificationResult
-	}{{
-		name:                       "signed task with matching policy pass verification with enforce no match policy",
-		requester:                  requesterMatched,
-		verificationNoMatchPolicy:  config.FailNoMatchPolicy,
-		policies:                   vps,
-		expected:                   signedV1Task,
-		expectedRefSource:          matchPolicyRefSource,
-		expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationPass},
-	}, {
-		name:                       "signed task with matching policy pass verification with warn no match policy",
-		requester:                  requesterMatched,
-		verificationNoMatchPolicy:  config.WarnNoMatchPolicy,
-		policies:                   vps,
-		expected:                   signedV1Task,
-		expectedRefSource:          matchPolicyRefSource,
-		expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationPass},
-	}, {
-		name:                       "signed task with matching policy pass verification with ignore no match policy",
-		requester:                  requesterMatched,
-		verificationNoMatchPolicy:  config.IgnoreNoMatchPolicy,
-		policies:                   vps,
-		expected:                   signedV1Task,
-		expectedRefSource:          matchPolicyRefSource,
-		expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationPass},
-	}, {
-		name:                       "warn unsigned task without matching policies",
-		requester:                  requesterUnmatched,
-		verificationNoMatchPolicy:  config.WarnNoMatchPolicy,
-		policies:                   vps,
-		expected:                   unsignedV1Task,
-		expectedRefSource:          noMatchPolicyRefSource,
-		expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationWarn, Err: trustedresources.ErrNoMatchedPolicies},
-	}, {
-		name:                       "task fails warn mode policy return warn VerificationResult",
-		requester:                  requesterUnsignedMatched,
-		verificationNoMatchPolicy:  config.FailNoMatchPolicy,
-		policies:                   vps,
-		expected:                   unsignedV1Task,
-		expectedRefSource:          warnPolicyRefSource,
-		expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationWarn, Err: trustedresources.ErrResourceVerificationFailed},
-	}, {
-		name:                       "ignore unsigned task without matching policies",
-		requester:                  requesterUnmatched,
-		verificationNoMatchPolicy:  config.IgnoreNoMatchPolicy,
-		policies:                   vps,
-		expected:                   unsignedV1Task,
-		expectedRefSource:          noMatchPolicyRefSource,
-		expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationSkip},
-	},
+	}{
+		{
+			name:                       "signed task with matching policy pass verification with enforce no match policy",
+			requester:                  requesterMatched,
+			verificationNoMatchPolicy:  config.FailNoMatchPolicy,
+			policies:                   vps,
+			expected:                   signedV1Task,
+			expectedRefSource:          matchPolicyRefSource,
+			expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationPass},
+		}, {
+			name:                       "signed task with matching policy pass verification with warn no match policy",
+			requester:                  requesterMatched,
+			verificationNoMatchPolicy:  config.WarnNoMatchPolicy,
+			policies:                   vps,
+			expected:                   signedV1Task,
+			expectedRefSource:          matchPolicyRefSource,
+			expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationPass},
+		}, {
+			name:                       "signed task with matching policy pass verification with ignore no match policy",
+			requester:                  requesterMatched,
+			verificationNoMatchPolicy:  config.IgnoreNoMatchPolicy,
+			policies:                   vps,
+			expected:                   signedV1Task,
+			expectedRefSource:          matchPolicyRefSource,
+			expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationPass},
+		}, {
+			name:                       "warn unsigned task without matching policies",
+			requester:                  requesterUnmatched,
+			verificationNoMatchPolicy:  config.WarnNoMatchPolicy,
+			policies:                   vps,
+			expected:                   unsignedV1Task,
+			expectedRefSource:          noMatchPolicyRefSource,
+			expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationWarn, Err: trustedresources.ErrNoMatchedPolicies},
+		}, {
+			name:                       "task fails warn mode policy return warn VerificationResult",
+			requester:                  requesterUnsignedMatched,
+			verificationNoMatchPolicy:  config.FailNoMatchPolicy,
+			policies:                   vps,
+			expected:                   unsignedV1Task,
+			expectedRefSource:          warnPolicyRefSource,
+			expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationWarn, Err: trustedresources.ErrResourceVerificationFailed},
+		}, {
+			name:                       "ignore unsigned task without matching policies",
+			requester:                  requesterUnmatched,
+			verificationNoMatchPolicy:  config.IgnoreNoMatchPolicy,
+			policies:                   vps,
+			expected:                   unsignedV1Task,
+			expectedRefSource:          noMatchPolicyRefSource,
+			expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationSkip},
+		},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -848,7 +850,6 @@ func TestGetTaskFunc_V1beta1Task_VerifyNoError(t *testing.T) {
 			fn := resources.GetTaskFunc(ctx, k8sclient, tektonclient, tc.requester, tr, tr.Spec.TaskRef, "", "trusted-resources", "default", tc.policies)
 
 			resolvedTask, refSource, vr, err := fn(ctx, taskRef.Name)
-
 			if err != nil {
 				t.Fatalf("Received unexpected error ( %#v )", err)
 			}
@@ -912,56 +913,57 @@ func TestGetTaskFunc_V1beta1Task_VerifyError(t *testing.T) {
 		expected                       *v1.Task
 		expectedErr                    error
 		expectedVerificationResultType trustedresources.VerificationResultType
-	}{{
-		name:                           "unsigned task fails verification with fail no match policy",
-		requester:                      requesterUnsigned,
-		verificationNoMatchPolicy:      config.FailNoMatchPolicy,
-		expected:                       nil,
-		expectedErr:                    trustedresources.ErrResourceVerificationFailed,
-		expectedVerificationResultType: trustedresources.VerificationError,
-	}, {
-		name:                           "unsigned task fails verification with warn no match policy",
-		requester:                      requesterUnsigned,
-		verificationNoMatchPolicy:      config.WarnNoMatchPolicy,
-		expected:                       nil,
-		expectedErr:                    trustedresources.ErrResourceVerificationFailed,
-		expectedVerificationResultType: trustedresources.VerificationError,
-	}, {
-		name:                           "unsigned task fails verification with ignore no match policy",
-		requester:                      requesterUnsigned,
-		verificationNoMatchPolicy:      config.IgnoreNoMatchPolicy,
-		expected:                       nil,
-		expectedErr:                    trustedresources.ErrResourceVerificationFailed,
-		expectedVerificationResultType: trustedresources.VerificationError,
-	}, {
-		name:                           "modified task fails verification with fail no match policy",
-		requester:                      requesterModified,
-		verificationNoMatchPolicy:      config.FailNoMatchPolicy,
-		expected:                       nil,
-		expectedErr:                    trustedresources.ErrResourceVerificationFailed,
-		expectedVerificationResultType: trustedresources.VerificationError,
-	}, {
-		name:                           "modified task fails verification with warn no match policy",
-		requester:                      requesterModified,
-		verificationNoMatchPolicy:      config.WarnNoMatchPolicy,
-		expected:                       nil,
-		expectedErr:                    trustedresources.ErrResourceVerificationFailed,
-		expectedVerificationResultType: trustedresources.VerificationError,
-	}, {
-		name:                           "modified task fails verification with ignore no match policy",
-		requester:                      requesterModified,
-		verificationNoMatchPolicy:      config.IgnoreNoMatchPolicy,
-		expected:                       nil,
-		expectedErr:                    trustedresources.ErrResourceVerificationFailed,
-		expectedVerificationResultType: trustedresources.VerificationError,
-	}, {
-		name:                           "unmatched task fails with verification fail no match policy",
-		requester:                      requesterUnmatched,
-		verificationNoMatchPolicy:      config.FailNoMatchPolicy,
-		expected:                       nil,
-		expectedErr:                    trustedresources.ErrNoMatchedPolicies,
-		expectedVerificationResultType: trustedresources.VerificationError,
-	},
+	}{
+		{
+			name:                           "unsigned task fails verification with fail no match policy",
+			requester:                      requesterUnsigned,
+			verificationNoMatchPolicy:      config.FailNoMatchPolicy,
+			expected:                       nil,
+			expectedErr:                    trustedresources.ErrResourceVerificationFailed,
+			expectedVerificationResultType: trustedresources.VerificationError,
+		}, {
+			name:                           "unsigned task fails verification with warn no match policy",
+			requester:                      requesterUnsigned,
+			verificationNoMatchPolicy:      config.WarnNoMatchPolicy,
+			expected:                       nil,
+			expectedErr:                    trustedresources.ErrResourceVerificationFailed,
+			expectedVerificationResultType: trustedresources.VerificationError,
+		}, {
+			name:                           "unsigned task fails verification with ignore no match policy",
+			requester:                      requesterUnsigned,
+			verificationNoMatchPolicy:      config.IgnoreNoMatchPolicy,
+			expected:                       nil,
+			expectedErr:                    trustedresources.ErrResourceVerificationFailed,
+			expectedVerificationResultType: trustedresources.VerificationError,
+		}, {
+			name:                           "modified task fails verification with fail no match policy",
+			requester:                      requesterModified,
+			verificationNoMatchPolicy:      config.FailNoMatchPolicy,
+			expected:                       nil,
+			expectedErr:                    trustedresources.ErrResourceVerificationFailed,
+			expectedVerificationResultType: trustedresources.VerificationError,
+		}, {
+			name:                           "modified task fails verification with warn no match policy",
+			requester:                      requesterModified,
+			verificationNoMatchPolicy:      config.WarnNoMatchPolicy,
+			expected:                       nil,
+			expectedErr:                    trustedresources.ErrResourceVerificationFailed,
+			expectedVerificationResultType: trustedresources.VerificationError,
+		}, {
+			name:                           "modified task fails verification with ignore no match policy",
+			requester:                      requesterModified,
+			verificationNoMatchPolicy:      config.IgnoreNoMatchPolicy,
+			expected:                       nil,
+			expectedErr:                    trustedresources.ErrResourceVerificationFailed,
+			expectedVerificationResultType: trustedresources.VerificationError,
+		}, {
+			name:                           "unmatched task fails with verification fail no match policy",
+			requester:                      requesterUnmatched,
+			verificationNoMatchPolicy:      config.FailNoMatchPolicy,
+			expected:                       nil,
+			expectedErr:                    trustedresources.ErrNoMatchedPolicies,
+			expectedVerificationResultType: trustedresources.VerificationError,
+		},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1048,55 +1050,56 @@ func TestGetTaskFunc_V1Task_VerifyNoError(t *testing.T) {
 		expected                   runtime.Object
 		expectedRefSource          *v1.RefSource
 		expectedVerificationResult *trustedresources.VerificationResult
-	}{{
-		name:                       "signed task with matching policy pass verification with enforce no match policy",
-		requester:                  requesterMatched,
-		verificationNoMatchPolicy:  config.FailNoMatchPolicy,
-		policies:                   vps,
-		expected:                   signedV1Task,
-		expectedRefSource:          matchPolicyRefSource,
-		expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationPass},
-	}, {
-		name:                       "signed task with matching policy pass verification with warn no match policy",
-		requester:                  requesterMatched,
-		verificationNoMatchPolicy:  config.WarnNoMatchPolicy,
-		policies:                   vps,
-		expected:                   signedV1Task,
-		expectedRefSource:          matchPolicyRefSource,
-		expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationPass},
-	}, {
-		name:                       "signed task with matching policy pass verification with ignore no match policy",
-		requester:                  requesterMatched,
-		verificationNoMatchPolicy:  config.IgnoreNoMatchPolicy,
-		policies:                   vps,
-		expected:                   signedV1Task,
-		expectedRefSource:          matchPolicyRefSource,
-		expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationPass},
-	}, {
-		name:                       "warn unsigned task without matching policies",
-		requester:                  requesterUnmatched,
-		verificationNoMatchPolicy:  config.WarnNoMatchPolicy,
-		policies:                   vps,
-		expected:                   &unsignedV1Task,
-		expectedRefSource:          noMatchPolicyRefSource,
-		expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationWarn, Err: trustedresources.ErrNoMatchedPolicies},
-	}, {
-		name:                       "task fails warn mode policy return warn VerificationResult",
-		requester:                  requesterUnsignedMatched,
-		verificationNoMatchPolicy:  config.FailNoMatchPolicy,
-		policies:                   vps,
-		expected:                   &unsignedV1Task,
-		expectedRefSource:          warnPolicyRefSource,
-		expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationWarn, Err: trustedresources.ErrResourceVerificationFailed},
-	}, {
-		name:                       "ignore unsigned task without matching policies",
-		requester:                  requesterUnmatched,
-		verificationNoMatchPolicy:  config.IgnoreNoMatchPolicy,
-		policies:                   vps,
-		expected:                   &unsignedV1Task,
-		expectedRefSource:          noMatchPolicyRefSource,
-		expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationSkip},
-	},
+	}{
+		{
+			name:                       "signed task with matching policy pass verification with enforce no match policy",
+			requester:                  requesterMatched,
+			verificationNoMatchPolicy:  config.FailNoMatchPolicy,
+			policies:                   vps,
+			expected:                   signedV1Task,
+			expectedRefSource:          matchPolicyRefSource,
+			expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationPass},
+		}, {
+			name:                       "signed task with matching policy pass verification with warn no match policy",
+			requester:                  requesterMatched,
+			verificationNoMatchPolicy:  config.WarnNoMatchPolicy,
+			policies:                   vps,
+			expected:                   signedV1Task,
+			expectedRefSource:          matchPolicyRefSource,
+			expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationPass},
+		}, {
+			name:                       "signed task with matching policy pass verification with ignore no match policy",
+			requester:                  requesterMatched,
+			verificationNoMatchPolicy:  config.IgnoreNoMatchPolicy,
+			policies:                   vps,
+			expected:                   signedV1Task,
+			expectedRefSource:          matchPolicyRefSource,
+			expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationPass},
+		}, {
+			name:                       "warn unsigned task without matching policies",
+			requester:                  requesterUnmatched,
+			verificationNoMatchPolicy:  config.WarnNoMatchPolicy,
+			policies:                   vps,
+			expected:                   &unsignedV1Task,
+			expectedRefSource:          noMatchPolicyRefSource,
+			expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationWarn, Err: trustedresources.ErrNoMatchedPolicies},
+		}, {
+			name:                       "task fails warn mode policy return warn VerificationResult",
+			requester:                  requesterUnsignedMatched,
+			verificationNoMatchPolicy:  config.FailNoMatchPolicy,
+			policies:                   vps,
+			expected:                   &unsignedV1Task,
+			expectedRefSource:          warnPolicyRefSource,
+			expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationWarn, Err: trustedresources.ErrResourceVerificationFailed},
+		}, {
+			name:                       "ignore unsigned task without matching policies",
+			requester:                  requesterUnmatched,
+			verificationNoMatchPolicy:  config.IgnoreNoMatchPolicy,
+			policies:                   vps,
+			expected:                   &unsignedV1Task,
+			expectedRefSource:          noMatchPolicyRefSource,
+			expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationSkip},
+		},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1111,7 +1114,6 @@ func TestGetTaskFunc_V1Task_VerifyNoError(t *testing.T) {
 			fn := resources.GetTaskFunc(ctx, k8sclient, tektonclient, tc.requester, tr, tr.Spec.TaskRef, "", "default", "default", tc.policies)
 
 			gotResolvedTask, gotRefSource, gotVerificationResult, err := fn(ctx, taskRef.Name)
-
 			if err != nil {
 				t.Fatalf("Received unexpected error ( %#v )", err)
 			}
@@ -1175,54 +1177,55 @@ func TestGetTaskFunc_V1Task_VerifyError(t *testing.T) {
 		expected                   *v1.Task
 		expectedErr                error
 		expectedVerificationResult *trustedresources.VerificationResult
-	}{{
-		name:                       "unsigned task fails verification with fail no match policy",
-		requester:                  requesterUnsigned,
-		verificationNoMatchPolicy:  config.FailNoMatchPolicy,
-		expected:                   nil,
-		expectedErr:                trustedresources.ErrResourceVerificationFailed,
-		expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationError, Err: trustedresources.ErrResourceVerificationFailed},
-	}, {
-		name:                       "unsigned task fails verification with warn no match policy",
-		requester:                  requesterUnsigned,
-		verificationNoMatchPolicy:  config.WarnNoMatchPolicy,
-		expected:                   nil,
-		expectedErr:                trustedresources.ErrResourceVerificationFailed,
-		expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationError, Err: trustedresources.ErrResourceVerificationFailed},
-	}, {
-		name:                       "unsigned task fails verification with ignore no match policy",
-		requester:                  requesterUnsigned,
-		verificationNoMatchPolicy:  config.IgnoreNoMatchPolicy,
-		expected:                   nil,
-		expectedErr:                trustedresources.ErrResourceVerificationFailed,
-		expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationError, Err: trustedresources.ErrResourceVerificationFailed},
-	}, {
-		name:                       "modified task fails verification with fail no match policy",
-		requester:                  requesterModified,
-		verificationNoMatchPolicy:  config.FailNoMatchPolicy,
-		expected:                   nil,
-		expectedErr:                trustedresources.ErrResourceVerificationFailed,
-		expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationError, Err: trustedresources.ErrResourceVerificationFailed},
-	}, {
-		name:                       "modified task fails verification with warn no match policy",
-		requester:                  requesterModified,
-		verificationNoMatchPolicy:  config.WarnNoMatchPolicy,
-		expected:                   nil,
-		expectedErr:                trustedresources.ErrResourceVerificationFailed,
-		expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationError, Err: trustedresources.ErrResourceVerificationFailed},
-	}, {
-		name:                       "modified task fails verification with ignore no match policy",
-		requester:                  requesterModified,
-		verificationNoMatchPolicy:  config.IgnoreNoMatchPolicy,
-		expected:                   nil,
-		expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationError, Err: trustedresources.ErrResourceVerificationFailed},
-	}, {
-		name:                       "unmatched task fails with verification fail no match policy",
-		requester:                  requesterUnmatched,
-		verificationNoMatchPolicy:  config.FailNoMatchPolicy,
-		expected:                   nil,
-		expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationError, Err: trustedresources.ErrNoMatchedPolicies},
-	},
+	}{
+		{
+			name:                       "unsigned task fails verification with fail no match policy",
+			requester:                  requesterUnsigned,
+			verificationNoMatchPolicy:  config.FailNoMatchPolicy,
+			expected:                   nil,
+			expectedErr:                trustedresources.ErrResourceVerificationFailed,
+			expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationError, Err: trustedresources.ErrResourceVerificationFailed},
+		}, {
+			name:                       "unsigned task fails verification with warn no match policy",
+			requester:                  requesterUnsigned,
+			verificationNoMatchPolicy:  config.WarnNoMatchPolicy,
+			expected:                   nil,
+			expectedErr:                trustedresources.ErrResourceVerificationFailed,
+			expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationError, Err: trustedresources.ErrResourceVerificationFailed},
+		}, {
+			name:                       "unsigned task fails verification with ignore no match policy",
+			requester:                  requesterUnsigned,
+			verificationNoMatchPolicy:  config.IgnoreNoMatchPolicy,
+			expected:                   nil,
+			expectedErr:                trustedresources.ErrResourceVerificationFailed,
+			expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationError, Err: trustedresources.ErrResourceVerificationFailed},
+		}, {
+			name:                       "modified task fails verification with fail no match policy",
+			requester:                  requesterModified,
+			verificationNoMatchPolicy:  config.FailNoMatchPolicy,
+			expected:                   nil,
+			expectedErr:                trustedresources.ErrResourceVerificationFailed,
+			expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationError, Err: trustedresources.ErrResourceVerificationFailed},
+		}, {
+			name:                       "modified task fails verification with warn no match policy",
+			requester:                  requesterModified,
+			verificationNoMatchPolicy:  config.WarnNoMatchPolicy,
+			expected:                   nil,
+			expectedErr:                trustedresources.ErrResourceVerificationFailed,
+			expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationError, Err: trustedresources.ErrResourceVerificationFailed},
+		}, {
+			name:                       "modified task fails verification with ignore no match policy",
+			requester:                  requesterModified,
+			verificationNoMatchPolicy:  config.IgnoreNoMatchPolicy,
+			expected:                   nil,
+			expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationError, Err: trustedresources.ErrResourceVerificationFailed},
+		}, {
+			name:                       "unmatched task fails with verification fail no match policy",
+			requester:                  requesterUnmatched,
+			verificationNoMatchPolicy:  config.FailNoMatchPolicy,
+			expected:                   nil,
+			expectedVerificationResult: &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationError, Err: trustedresources.ErrNoMatchedPolicies},
+		},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -2977,7 +2977,7 @@ status:
 		expectedReason string
 	}{{
 		description:    "ResourceQuotaConflictError does not fail taskrun",
-		err:            k8sapierrors.NewConflict(k8sruntimeschema.GroupResource{Group: "v1", Resource: "resourcequotas"}, "dummy", errors.New("operation cannot be fulfilled on resourcequotas dummy the object has been modified please apply your changes to the latest version and try again")),
+		err:            k8sapierrors.NewConflict(k8sruntimeschema.GroupResource{Group: "v1", Resource: "resourcequotas"}, "sample", errors.New("operation cannot be fulfilled on resourcequotas sample the object has been modified please apply your changes to the latest version and try again")),
 		expectedType:   apis.ConditionSucceeded,
 		expectedStatus: corev1.ConditionUnknown,
 		expectedReason: podconvert.ReasonPending,
@@ -3432,7 +3432,7 @@ spec:
 	taskRun := parse.MustParseV1TaskRun(t, `
 metadata:
   annotations:
-    pipeline.tekton.dev/affinity-assistant: dummy-affinity-assistant
+    pipeline.tekton.dev/affinity-assistant: sample-affinity-assistant
   name: taskrun-with-two-workspaces
   namespace: foo
 spec:


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Cherry-pick for 0.53.x of [7407](https://github.com/tektoncd/pipeline/pull/7364)
And replace "dummy" with "sample" in go tests to make `woke` happy :)
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
