### PR TITLE
Freeze image sha for dind-sidecar example test.

### DIFF
--- a/examples/v1/taskruns/dind-sidecar.yaml
+++ b/examples/v1/taskruns/dind-sidecar.yaml
@@ -40,7 +40,7 @@ spec:
         name: dind-certs
 
     sidecars:
-    - image: docker:dind
+    - image: docker@sha256:74e78208fc18da48ddf8b569abe21563730845c312130bd0f0b059746a7e10f5
       name: server
       args:
         - --storage-driver=vfs


### PR DESCRIPTION
The example test examples/v1/taskruns/dind-sidecar.yaml has been failing in multiple PRs:
- https://github.com/tektoncd/pipeline/pull/7492#issuecomment-1858094356
- https://github.com/tektoncd/pipeline/pull/7494#issuecomment-1858208742
- https://github.com/tektoncd/pipeline/pull/7458#issuecomment-1858132922

That example has not been updated in a year. My guess is that the [new image](https://hub.docker.com/layers/library/docker/dind/images/sha256-e8c7a73504adaeff4bab939e8d1f18a6114c99c868b9203a66a42f25aa51e613?context=explore) which was released 16 hours ago (at this point) is causing this.

When the image is tagged to the previous version (`docker:24.0.6-dind`) in the taskrun yaml, it executes fine. This PR updates the example test to use the sha256 of the previously working image.This PR fixes https://github.com/tektoncd/pipeline/issues/7496.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
/kind bug