### PR TITLE
Add back conversion for TaskRunStatus Resources

### DIFF
--- a/pkg/apis/pipeline/v1beta1/taskrun_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_conversion.go
@@ -29,6 +29,7 @@ import (
 const (
 	cloudEventsAnnotationKey     = "tekton.dev/v1beta1CloudEvents"
 	resourcesResultAnnotationKey = "tekton.dev/v1beta1ResourcesResult"
+	resourcesStatusAnnotationKey = "tekton.dev/v1beta1ResourcesStatus"
 )
 
 var _ apis.Convertible = (*TaskRun)(nil)
@@ -41,10 +42,16 @@ func (tr *TaskRun) ConvertTo(ctx context.Context, to apis.Convertible) error {
 	switch sink := to.(type) {
 	case *v1.TaskRun:
 		sink.ObjectMeta = tr.ObjectMeta
+		if err := serializeTaskRunResources(&sink.ObjectMeta, &tr.Spec); err != nil {
+			return err
+		}
 		if err := serializeTaskRunCloudEvents(&sink.ObjectMeta, &tr.Status); err != nil {
 			return err
 		}
 		if err := serializeTaskRunResourcesResult(&sink.ObjectMeta, &tr.Status); err != nil {
+			return err
+		}
+		if err := serializeTaskRunResourcesStatus(&sink.ObjectMeta, &tr.Status); err != nil {
 			return err
 		}
 		if err := tr.Status.ConvertTo(ctx, &sink.Status, &sink.ObjectMeta); err != nil {
@@ -115,6 +122,9 @@ func (tr *TaskRun) ConvertFrom(ctx context.Context, from apis.Convertible) error
 	switch source := from.(type) {
 	case *v1.TaskRun:
 		tr.ObjectMeta = source.ObjectMeta
+		if err := deserializeTaskRunResources(&tr.ObjectMeta, &tr.Spec); err != nil {
+			return err
+		}
 		if err := deserializeTaskRunCloudEvents(&tr.ObjectMeta, &tr.Status); err != nil {
 			return err
 		}
@@ -122,6 +132,9 @@ func (tr *TaskRun) ConvertFrom(ctx context.Context, from apis.Convertible) error
 			return err
 		}
 		if err := tr.Status.ConvertFrom(ctx, source.Status, &tr.ObjectMeta); err != nil {
+			return err
+		}
+		if err := deserializeTaskRunResourcesStatus(&tr.ObjectMeta, &tr.Status); err != nil {
 			return err
 		}
 		return tr.Spec.ConvertFrom(ctx, &source.Spec, &tr.ObjectMeta)
@@ -381,6 +394,25 @@ func (ss *SidecarState) convertFrom(ctx context.Context, source v1.SidecarState)
 	ss.ImageID = source.ImageID
 }
 
+func serializeTaskRunResources(meta *metav1.ObjectMeta, spec *TaskRunSpec) error {
+	if spec.Resources == nil {
+		return nil
+	}
+	return version.SerializeToMetadata(meta, spec.Resources, resourcesAnnotationKey)
+}
+
+func deserializeTaskRunResources(meta *metav1.ObjectMeta, spec *TaskRunSpec) error {
+	resources := &TaskRunResources{}
+	err := version.DeserializeFromMetadata(meta, resources, resourcesAnnotationKey)
+	if err != nil {
+		return err
+	}
+	if resources.Inputs != nil || resources.Outputs != nil {
+		spec.Resources = resources
+	}
+	return nil
+}
+
 func serializeTaskRunCloudEvents(meta *metav1.ObjectMeta, status *TaskRunStatus) error {
 	if status.CloudEvents == nil {
 		return nil
@@ -415,6 +447,31 @@ func deserializeTaskRunResourcesResult(meta *metav1.ObjectMeta, status *TaskRunS
 	}
 	if len(resourcesResult) != 0 {
 		status.ResourcesResult = resourcesResult
+	}
+	return nil
+}
+
+func serializeTaskRunResourcesStatus(meta *metav1.ObjectMeta, status *TaskRunStatus) error {
+	if status.TaskSpec == nil {
+		return nil
+	}
+	if status.TaskSpec.Resources == nil {
+		return nil
+	}
+	return version.SerializeToMetadata(meta, status.TaskSpec.Resources, resourcesStatusAnnotationKey)
+}
+
+func deserializeTaskRunResourcesStatus(meta *metav1.ObjectMeta, status *TaskRunStatus) error {
+	resourcesStatus := &TaskResources{}
+	err := version.DeserializeFromMetadata(meta, resourcesStatus, resourcesStatusAnnotationKey)
+	if err != nil {
+		return err
+	}
+	if resourcesStatus.Inputs != nil || resourcesStatus.Outputs != nil {
+		if status.TaskRunStatusFields.TaskSpec == nil {
+			status.TaskSpec = &TaskSpec{}
+		}
+		status.TaskSpec.Resources = resourcesStatus
 	}
 	return nil
 }

--- a/pkg/apis/pipeline/v1beta1/taskrun_conversion_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_conversion_test.go
@@ -334,6 +334,147 @@ func TestTaskRunConversionFromDeprecated(t *testing.T) {
 		in   *v1beta1.TaskRun
 		want *v1beta1.TaskRun
 	}{{
+		name: "input resources",
+		in: &v1beta1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "bar",
+			},
+			Spec: v1beta1.TaskRunSpec{
+				Resources: &v1beta1.TaskRunResources{
+					Inputs: []v1beta1.TaskResourceBinding{{
+						PipelineResourceBinding: v1beta1.PipelineResourceBinding{
+							ResourceRef: &v1beta1.PipelineResourceRef{
+								Name: "the-git-with-branch",
+							},
+							Name: "gitspace",
+						},
+						Paths: []string{"test-path"},
+					}},
+				},
+			},
+		},
+		want: &v1beta1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "bar",
+			},
+			Spec: v1beta1.TaskRunSpec{
+				Resources: &v1beta1.TaskRunResources{
+					Inputs: []v1beta1.TaskResourceBinding{{
+						PipelineResourceBinding: v1beta1.PipelineResourceBinding{
+							ResourceRef: &v1beta1.PipelineResourceRef{
+								Name: "the-git-with-branch",
+							},
+							Name: "gitspace",
+						},
+						Paths: []string{"test-path"},
+					}},
+				},
+			},
+		},
+	}, {
+		name: "output resources",
+		in: &v1beta1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "bar",
+			},
+			Spec: v1beta1.TaskRunSpec{
+				Resources: &v1beta1.TaskRunResources{
+					Outputs: []v1beta1.TaskResourceBinding{{
+						PipelineResourceBinding: v1beta1.PipelineResourceBinding{
+							ResourceRef: &v1beta1.PipelineResourceRef{
+								Name: "the-git-with-branch",
+							},
+							Name: "gitspace",
+						},
+						Paths: []string{"test-path"},
+					}},
+				},
+			},
+		},
+		want: &v1beta1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "bar",
+			},
+			Spec: v1beta1.TaskRunSpec{
+				Resources: &v1beta1.TaskRunResources{
+					Outputs: []v1beta1.TaskResourceBinding{{
+						PipelineResourceBinding: v1beta1.PipelineResourceBinding{
+							ResourceRef: &v1beta1.PipelineResourceRef{
+								Name: "the-git-with-branch",
+							},
+							Name: "gitspace",
+						},
+						Paths: []string{"test-path"},
+					}},
+				},
+			},
+		},
+	}, {
+		name: "taskrun status task resources",
+		in: &v1beta1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "bar",
+			},
+			Spec: v1beta1.TaskRunSpec{
+				TaskRef: &v1beta1.TaskRef{
+					Name: "test-resources-status",
+				},
+			},
+			Status: v1beta1.TaskRunStatus{
+				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+					TaskSpec: &v1beta1.TaskSpec{
+						Resources: &v1beta1.TaskResources{
+							Inputs: []v1beta1.TaskResource{{
+								v1beta1.ResourceDeclaration{
+									Name: "input-resource",
+								},
+							}},
+							Outputs: []v1beta1.TaskResource{{
+								v1beta1.ResourceDeclaration{
+									Name: "input-resource",
+									Type: "image",
+								},
+							}},
+						},
+					},
+				},
+			},
+		},
+		want: &v1beta1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "bar",
+			},
+			Spec: v1beta1.TaskRunSpec{
+				TaskRef: &v1beta1.TaskRef{
+					Name: "test-resources-status",
+				},
+			},
+			Status: v1beta1.TaskRunStatus{
+				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+					TaskSpec: &v1beta1.TaskSpec{
+						Resources: &v1beta1.TaskResources{
+							Inputs: []v1beta1.TaskResource{{
+								v1beta1.ResourceDeclaration{
+									Name: "input-resource",
+								},
+							}},
+							Outputs: []v1beta1.TaskResource{{
+								v1beta1.ResourceDeclaration{
+									Name: "input-resource",
+									Type: "image",
+								},
+							}},
+						},
+					},
+				},
+			}},
+	}, {
 		name: "bundle",
 		in: &v1beta1.TaskRun{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This commit adds back the conversion for TaskrunStatus resources which are used by chains to sign outputs of image resources type. It also adds back the conversion for TaskRun Resources.

/kind misc
fixes: #7504
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
restore conversion functions from taskRun and taskRunStatus resources for backwards compatibility
```
