### PR TITLE
Fix showing error message when validation fail

### DIFF
--- a/pkg/apis/pipeline/v1/result_validation.go
+++ b/pkg/apis/pipeline/v1/result_validation.go
@@ -74,7 +74,7 @@ func (tr TaskResult) validateValue(ctx context.Context) (errs *apis.FieldError) 
 		return nil
 	}
 	if !config.FromContextOrDefaults(ctx).FeatureFlags.EnableStepActions {
-		return apis.ErrGeneric("feature flag %s should be set to true to fetch Results from Steps using StepActions.", config.EnableStepActions)
+		return apis.ErrGeneric(fmt.Sprintf("feature flag %s should be set to true to fetch Results from Steps using StepActions.", config.EnableStepActions))
 	}
 	if tr.Value.Type != ParamTypeString {
 		return &apis.FieldError{

--- a/pkg/apis/pipeline/v1/result_validation_test.go
+++ b/pkg/apis/pipeline/v1/result_validation_test.go
@@ -175,8 +175,7 @@ func TestResultsValidateValueError(t *testing.T) {
 		},
 		enableStepActions: false,
 		expectedError: apis.FieldError{
-			Message: "feature flag %s should be set to true to fetch Results from Steps using StepActions.",
-			Paths:   []string{"enable-step-actions"},
+			Message: "feature flag enable-step-actions should be set to true to fetch Results from Steps using StepActions.",
 		},
 	}, {
 		name: "invalid result value type array",

--- a/pkg/apis/pipeline/v1/task_validation.go
+++ b/pkg/apis/pipeline/v1/task_validation.go
@@ -325,7 +325,7 @@ func isCreateOrUpdateAndDiverged(ctx context.Context, s Step) bool {
 func validateStep(ctx context.Context, s Step, names sets.String) (errs *apis.FieldError) {
 	if s.Ref != nil {
 		if !config.FromContextOrDefaults(ctx).FeatureFlags.EnableStepActions && isCreateOrUpdateAndDiverged(ctx, s) {
-			return apis.ErrGeneric("feature flag %s should be set to true to reference StepActions in Steps.", config.EnableStepActions)
+			return apis.ErrGeneric(fmt.Sprintf("feature flag %s should be set to true to reference StepActions in Steps.", config.EnableStepActions), "")
 		}
 		errs = errs.Also(s.Ref.Validate(ctx))
 		if s.Image != "" {
@@ -385,7 +385,7 @@ func validateStep(ctx context.Context, s Step, names sets.String) (errs *apis.Fi
 		}
 		if len(s.Results) > 0 {
 			if !config.FromContextOrDefaults(ctx).FeatureFlags.EnableStepActions && isCreateOrUpdateAndDiverged(ctx, s) {
-				return apis.ErrGeneric("feature flag %s should be set to true in order to use Results in Steps.", config.EnableStepActions)
+				return apis.ErrGeneric(fmt.Sprintf("feature flag %s should be set to true in order to use Results in Steps.", config.EnableStepActions), "")
 			}
 		}
 		if s.Image == "" {

--- a/pkg/apis/pipeline/v1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1/task_validation_test.go
@@ -1429,8 +1429,8 @@ func TestTaskSpecValidateErrorWithStepActionRef_CreateUpdateEvent(t *testing.T) 
 		isCreate: true,
 		isUpdate: false,
 		expectedError: apis.FieldError{
-			Message: "feature flag %s should be set to true to reference StepActions in Steps.",
-			Paths:   []string{"steps[0].enable-step-actions"},
+			Message: "feature flag enable-step-actions should be set to true to reference StepActions in Steps.",
+			Paths:   []string{"steps[0]"},
 		},
 	}, {
 		name: "is update ctx",
@@ -1442,8 +1442,8 @@ func TestTaskSpecValidateErrorWithStepActionRef_CreateUpdateEvent(t *testing.T) 
 		isCreate: false,
 		isUpdate: true,
 		expectedError: apis.FieldError{
-			Message: "feature flag %s should be set to true to reference StepActions in Steps.",
-			Paths:   []string{"steps[0].enable-step-actions"},
+			Message: "feature flag enable-step-actions should be set to true to reference StepActions in Steps.",
+			Paths:   []string{"steps[0]"},
 		},
 	}, {
 		name: "ctx is not create or update",
@@ -2642,8 +2642,8 @@ func TestTaskSpecValidate_StepResults_Error(t *testing.T) {
 		enableStepActions: false,
 		isCreate:          true,
 		expectedError: apis.FieldError{
-			Message: "feature flag %s should be set to true in order to use Results in Steps.",
-			Paths:   []string{"steps[0].enable-step-actions"},
+			Message: "feature flag enable-step-actions should be set to true in order to use Results in Steps.",
+			Paths:   []string{"steps[0]"},
 		},
 	}, {
 		name: "step result not allowed without enable step actions - update and diverged event",
@@ -2664,8 +2664,8 @@ func TestTaskSpecValidate_StepResults_Error(t *testing.T) {
 			},
 		},
 		expectedError: apis.FieldError{
-			Message: "feature flag %s should be set to true in order to use Results in Steps.",
-			Paths:   []string{"steps[0].enable-step-actions"},
+			Message: "feature flag enable-step-actions should be set to true in order to use Results in Steps.",
+			Paths:   []string{"steps[0]"},
 		},
 	}, {
 		name: "step result allowed without enable step actions - update but not diverged",

--- a/pkg/apis/pipeline/v1beta1/result_validation.go
+++ b/pkg/apis/pipeline/v1beta1/result_validation.go
@@ -74,7 +74,7 @@ func (tr TaskResult) validateValue(ctx context.Context) (errs *apis.FieldError) 
 		return nil
 	}
 	if !config.FromContextOrDefaults(ctx).FeatureFlags.EnableStepActions {
-		return apis.ErrGeneric("feature flag %s should be set to true to fetch Results from Steps using StepActions.", config.EnableStepActions)
+		return apis.ErrGeneric(fmt.Sprintf("feature flag %s should be set to true to fetch Results from Steps using StepActions.", config.EnableStepActions))
 	}
 	if tr.Value.Type != ParamTypeString {
 		return &apis.FieldError{
@@ -89,7 +89,7 @@ func (tr TaskResult) validateValue(ctx context.Context) (errs *apis.FieldError) 
 		stepName, resultName, err := v1.ExtractStepResultName(tr.Value.StringVal)
 		if err != nil {
 			return &apis.FieldError{
-				Message: fmt.Sprintf("%v", err),
+				Message: err.Error(),
 				Paths:   []string{fmt.Sprintf("%s.value", tr.Name)},
 			}
 		}

--- a/pkg/apis/pipeline/v1beta1/result_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/result_validation_test.go
@@ -176,8 +176,7 @@ func TestResultsValidateValueError(t *testing.T) {
 		},
 		enableStepActions: false,
 		expectedError: apis.FieldError{
-			Message: "feature flag %s should be set to true to fetch Results from Steps using StepActions.",
-			Paths:   []string{"enable-step-actions"},
+			Message: "feature flag enable-step-actions should be set to true to fetch Results from Steps using StepActions.",
 		},
 	}, {
 		name: "invalid result value type array",

--- a/pkg/apis/pipeline/v1beta1/task_validation.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation.go
@@ -314,7 +314,7 @@ func isCreateOrUpdateAndDiverged(ctx context.Context, s Step) bool {
 func validateStep(ctx context.Context, s Step, names sets.String) (errs *apis.FieldError) {
 	if s.Ref != nil {
 		if !config.FromContextOrDefaults(ctx).FeatureFlags.EnableStepActions && isCreateOrUpdateAndDiverged(ctx, s) {
-			return apis.ErrGeneric("feature flag %s should be set to true to reference StepActions in Steps.", config.EnableStepActions)
+			return apis.ErrGeneric(fmt.Sprintf("feature flag %s should be set to true to reference StepActions in Steps.", config.EnableStepActions), "")
 		}
 		errs = errs.Also(s.Ref.Validate(ctx))
 		if s.Image != "" {
@@ -374,7 +374,7 @@ func validateStep(ctx context.Context, s Step, names sets.String) (errs *apis.Fi
 		}
 		if len(s.Results) > 0 {
 			if !config.FromContextOrDefaults(ctx).FeatureFlags.EnableStepActions && isCreateOrUpdateAndDiverged(ctx, s) {
-				return apis.ErrGeneric("feature flag %s should be set to true in order to use Results in Steps.", config.EnableStepActions)
+				return apis.ErrGeneric(fmt.Sprintf("feature flag %s should be set to true in order to use Results in Steps.", config.EnableStepActions), "")
 			}
 		}
 		if s.Image == "" {

--- a/pkg/apis/pipeline/v1beta1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation_test.go
@@ -1442,8 +1442,8 @@ func TestTaskSpecValidateErrorWithStepActionRef_CreateUpdateEvent(t *testing.T) 
 		isCreate: true,
 		isUpdate: false,
 		expectedError: apis.FieldError{
-			Message: "feature flag %s should be set to true to reference StepActions in Steps.",
-			Paths:   []string{"steps[0].enable-step-actions"},
+			Message: "feature flag enable-step-actions should be set to true to reference StepActions in Steps.",
+			Paths:   []string{"steps[0]"},
 		},
 	}, {
 		name: "is update ctx",
@@ -1455,8 +1455,8 @@ func TestTaskSpecValidateErrorWithStepActionRef_CreateUpdateEvent(t *testing.T) 
 		isCreate: false,
 		isUpdate: true,
 		expectedError: apis.FieldError{
-			Message: "feature flag %s should be set to true to reference StepActions in Steps.",
-			Paths:   []string{"steps[0].enable-step-actions"},
+			Message: "feature flag enable-step-actions should be set to true to reference StepActions in Steps.",
+			Paths:   []string{"steps[0]"},
 		},
 	}, {
 		name: "ctx is not create or update",
@@ -2428,8 +2428,8 @@ func TestTaskSpecValidate_StepResults_Error(t *testing.T) {
 		enableStepActions: false,
 		isCreate:          true,
 		expectedError: apis.FieldError{
-			Message: "feature flag %s should be set to true in order to use Results in Steps.",
-			Paths:   []string{"steps[0].enable-step-actions"},
+			Message: "feature flag enable-step-actions should be set to true in order to use Results in Steps.",
+			Paths:   []string{"steps[0]"},
 		},
 	}, {
 		name: "step result not allowed without enable step actions - update and diverged event",
@@ -2450,8 +2450,8 @@ func TestTaskSpecValidate_StepResults_Error(t *testing.T) {
 			},
 		},
 		expectedError: apis.FieldError{
-			Message: "feature flag %s should be set to true in order to use Results in Steps.",
-			Paths:   []string{"steps[0].enable-step-actions"},
+			Message: "feature flag enable-step-actions should be set to true in order to use Results in Steps.",
+			Paths:   []string{"steps[0]"},
 		},
 	}, {
 		name: "step result allowed without enable step actions - update but not diverged",


### PR DESCRIPTION
# Changes

When step action is used in step, and feature flag is not enabled, the
error message is not shown correctly and would show a %s.

We are now using fmt.Sprintf to format the error message and show the
feature flag that need to be enabled properly. apis.ErrGeneric need a
empty string as second argument to be able to show the path steps so
adding this.

errror message should now show:


```
Error from server (BadRequest): error when creating "task.yaml": admission webhook "validation.webhook.pipeline.tekton.dev" denied the request: validation failed: feature flag enable-step-actions should be set to true to reference StepActions in Steps.: spec.steps[0]
```

instead of:

```
Error from server (BadRequest): error when creating "task.yaml": admission webhook "validation.webhook.pipeline.tekton.dev" denied the request: validation failed: feature flag %s should be set to true to reference StepActions in Steps.: spec.steps[0].enable-step-actions
```

Fixes bug #7493

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [X] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [X] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [X] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [X] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [X] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [X] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [X] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```

/kind misc
