### PR TITLE
Export deprecated fields annotation keys

### DIFF
--- a/pkg/apis/pipeline/v1beta1/pipeline_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_conversion.go
@@ -337,12 +337,12 @@ func serializePipelineResources(meta *metav1.ObjectMeta, spec *PipelineSpec) err
 	if spec.Resources == nil {
 		return nil
 	}
-	return version.SerializeToMetadata(meta, spec.Resources, resourcesAnnotationKey)
+	return version.SerializeToMetadata(meta, spec.Resources, ResourcesAnnotationKey)
 }
 
 func deserializePipelineResources(meta *metav1.ObjectMeta, spec *PipelineSpec) error {
 	resources := &[]PipelineDeclaredResource{}
-	err := version.DeserializeFromMetadata(meta, resources, resourcesAnnotationKey)
+	err := version.DeserializeFromMetadata(meta, resources, ResourcesAnnotationKey)
 	if err != nil {
 		return err
 	}

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_conversion.go
@@ -357,12 +357,12 @@ func serializePipelineRunResources(meta *metav1.ObjectMeta, spec *PipelineRunSpe
 	if spec.Resources == nil {
 		return nil
 	}
-	return version.SerializeToMetadata(meta, spec.Resources, resourcesAnnotationKey)
+	return version.SerializeToMetadata(meta, spec.Resources, ResourcesAnnotationKey)
 }
 
 func deserializePipelineRunResources(meta *metav1.ObjectMeta, spec *PipelineRunSpec) error {
 	resources := []PipelineResourceBinding{}
-	err := version.DeserializeFromMetadata(meta, &resources, resourcesAnnotationKey)
+	err := version.DeserializeFromMetadata(meta, &resources, ResourcesAnnotationKey)
 	if err != nil {
 		return err
 	}

--- a/pkg/apis/pipeline/v1beta1/task_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/task_conversion.go
@@ -55,7 +55,7 @@ import (
 //	}`
 const (
 	TaskDeprecationsAnnotationKey = "tekton.dev/v1beta1.task-deprecations"
-	resourcesAnnotationKey        = "tekton.dev/v1beta1Resources"
+	ResourcesAnnotationKey        = "tekton.dev/v1beta1Resources"
 )
 
 var _ apis.Convertible = (*Task)(nil)
@@ -327,12 +327,12 @@ func serializeResources(meta *metav1.ObjectMeta, spec *TaskSpec) error {
 	if spec.Resources == nil {
 		return nil
 	}
-	return version.SerializeToMetadata(meta, spec.Resources, resourcesAnnotationKey)
+	return version.SerializeToMetadata(meta, spec.Resources, ResourcesAnnotationKey)
 }
 
 func deserializeResources(meta *metav1.ObjectMeta, spec *TaskSpec) error {
 	resources := &TaskResources{}
-	err := version.DeserializeFromMetadata(meta, resources, resourcesAnnotationKey)
+	err := version.DeserializeFromMetadata(meta, resources, ResourcesAnnotationKey)
 	if err != nil {
 		return err
 	}

--- a/pkg/apis/pipeline/v1beta1/taskrun_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_conversion.go
@@ -27,8 +27,8 @@ import (
 )
 
 const (
-	cloudEventsAnnotationKey     = "tekton.dev/v1beta1CloudEvents"
-	resourcesResultAnnotationKey = "tekton.dev/v1beta1ResourcesResult"
+	CloudEventsAnnotationKey     = "tekton.dev/v1beta1CloudEvents"
+	ResourcesResultAnnotationKey = "tekton.dev/v1beta1ResourcesResult"
 )
 
 var _ apis.Convertible = (*TaskRun)(nil)
@@ -385,12 +385,12 @@ func serializeTaskRunCloudEvents(meta *metav1.ObjectMeta, status *TaskRunStatus)
 	if status.CloudEvents == nil {
 		return nil
 	}
-	return version.SerializeToMetadata(meta, status.CloudEvents, cloudEventsAnnotationKey)
+	return version.SerializeToMetadata(meta, status.CloudEvents, CloudEventsAnnotationKey)
 }
 
 func deserializeTaskRunCloudEvents(meta *metav1.ObjectMeta, status *TaskRunStatus) error {
 	cloudEvents := []CloudEventDelivery{}
-	err := version.DeserializeFromMetadata(meta, &cloudEvents, cloudEventsAnnotationKey)
+	err := version.DeserializeFromMetadata(meta, &cloudEvents, CloudEventsAnnotationKey)
 	if err != nil {
 		return err
 	}
@@ -404,12 +404,12 @@ func serializeTaskRunResourcesResult(meta *metav1.ObjectMeta, status *TaskRunSta
 	if status.ResourcesResult == nil {
 		return nil
 	}
-	return version.SerializeToMetadata(meta, status.ResourcesResult, resourcesResultAnnotationKey)
+	return version.SerializeToMetadata(meta, status.ResourcesResult, ResourcesResultAnnotationKey)
 }
 
 func deserializeTaskRunResourcesResult(meta *metav1.ObjectMeta, status *TaskRunStatus) error {
 	resourcesResult := []RunResult{}
-	err := version.DeserializeFromMetadata(meta, &resourcesResult, resourcesResultAnnotationKey)
+	err := version.DeserializeFromMetadata(meta, &resourcesResult, ResourcesResultAnnotationKey)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This commit exports all the deprecated fields conversion annotation keys in v1beta1 to let pipeline pkg users be able to reference to them.

/kind misc
part of #7504
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
