### PR TITLE
Bump golang.org/x/crypto from 0.16.0 to 0.17.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/containerd/containerd v1.7.8
 	github.com/go-git/go-git/v5 v5.10.0
 	github.com/google/go-cmp v0.6.0
-	github.com/google/go-containerregistry v0.16.1
+	github.com/google/go-containerregistry v0.17.0
 	github.com/google/uuid v1.4.0
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -601,8 +601,8 @@ github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-containerregistry v0.6.0/go.mod h1:euCCtNbZ6tKqi1E72vwDj2xZcN5ttKpZLfa/wSo5iLw=
-github.com/google/go-containerregistry v0.16.1 h1:rUEt426sR6nyrL3gt+18ibRcvYpKYdpsa5ZW7MA08dQ=
-github.com/google/go-containerregistry v0.16.1/go.mod h1:u0qB2l7mvtWVR5kNcbFIhFY1hLbf8eeGapA+vbFDCtQ=
+github.com/google/go-containerregistry v0.17.0 h1:5p+zYs/R4VGHkhyvgWurWrpJ2hW4Vv9fQI+GzdcwXLk=
+github.com/google/go-containerregistry v0.17.0/go.mod h1:u0qB2l7mvtWVR5kNcbFIhFY1hLbf8eeGapA+vbFDCtQ=
 github.com/google/go-containerregistry/pkg/authn/k8schain v0.0.0-20230625233257-b8504803389b h1:ptt4Cmxx6HsJQUSRp0LRB8nAxMdn9mxnqhc4dxwYlSM=
 github.com/google/go-containerregistry/pkg/authn/k8schain v0.0.0-20230625233257-b8504803389b/go.mod h1:Ek+8PQrShkA7aHEj3/zSW33wU0V/Bx3zW/gFh7l21xY=
 github.com/google/go-containerregistry/pkg/authn/kubernetes v0.0.0-20230516205744-dbecb1de8cfa h1:+MG+Q2Q7mtW6kCIbUPZ9ZMrj7xOWDKI1hhy1qp0ygI0=

--- a/vendor/github.com/google/go-containerregistry/pkg/authn/keychain.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/authn/keychain.go
@@ -53,7 +53,7 @@ type defaultKeychain struct {
 
 var (
 	// DefaultKeychain implements Keychain by interpreting the docker config file.
-	DefaultKeychain = RefreshingKeychain(&defaultKeychain{}, 5*time.Minute)
+	DefaultKeychain = &defaultKeychain{}
 )
 
 const (

--- a/vendor/github.com/google/go-containerregistry/pkg/v1/layout/gc.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/layout/gc.go
@@ -1,0 +1,137 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This is an EXPERIMENTAL package, and may change in arbitrary ways without notice.
+package layout
+
+import (
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"strings"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+)
+
+// GarbageCollect removes unreferenced blobs from the oci-layout
+//
+//	This is an experimental api, and not subject to any stability guarantees
+//	We may abandon it at any time, without prior notice.
+//	Deprecated: Use it at your own risk!
+func (l Path) GarbageCollect() ([]v1.Hash, error) {
+	idx, err := l.ImageIndex()
+	if err != nil {
+		return nil, err
+	}
+	blobsToKeep := map[string]bool{}
+	if err := l.garbageCollectImageIndex(idx, blobsToKeep); err != nil {
+		return nil, err
+	}
+	blobsDir := l.path("blobs")
+	removedBlobs := []v1.Hash{}
+
+	err = filepath.WalkDir(blobsDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			return nil
+		}
+
+		rel, err := filepath.Rel(blobsDir, path)
+		if err != nil {
+			return err
+		}
+		hashString := strings.Replace(rel, "/", ":", 1)
+		if present := blobsToKeep[hashString]; !present {
+			h, err := v1.NewHash(hashString)
+			if err != nil {
+				return err
+			}
+			removedBlobs = append(removedBlobs, h)
+		}
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return removedBlobs, nil
+}
+
+func (l Path) garbageCollectImageIndex(index v1.ImageIndex, blobsToKeep map[string]bool) error {
+	idxm, err := index.IndexManifest()
+	if err != nil {
+		return err
+	}
+
+	h, err := index.Digest()
+	if err != nil {
+		return err
+	}
+
+	blobsToKeep[h.String()] = true
+
+	for _, descriptor := range idxm.Manifests {
+		if descriptor.MediaType.IsImage() {
+			img, err := index.Image(descriptor.Digest)
+			if err != nil {
+				return err
+			}
+			if err := l.garbageCollectImage(img, blobsToKeep); err != nil {
+				return err
+			}
+		} else if descriptor.MediaType.IsIndex() {
+			idx, err := index.ImageIndex(descriptor.Digest)
+			if err != nil {
+				return err
+			}
+			if err := l.garbageCollectImageIndex(idx, blobsToKeep); err != nil {
+				return err
+			}
+		} else {
+			return fmt.Errorf("gc: unknown media type: %s", descriptor.MediaType)
+		}
+	}
+	return nil
+}
+
+func (l Path) garbageCollectImage(image v1.Image, blobsToKeep map[string]bool) error {
+	h, err := image.Digest()
+	if err != nil {
+		return err
+	}
+	blobsToKeep[h.String()] = true
+
+	h, err = image.ConfigName()
+	if err != nil {
+		return err
+	}
+	blobsToKeep[h.String()] = true
+
+	ls, err := image.Layers()
+	if err != nil {
+		return err
+	}
+	for _, l := range ls {
+		h, err := l.Digest()
+		if err != nil {
+			return err
+		}
+		blobsToKeep[h.String()] = true
+	}
+	return nil
+}

--- a/vendor/github.com/google/go-containerregistry/pkg/v1/remote/write.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/remote/write.go
@@ -280,6 +280,11 @@ func (w *writer) streamBlob(ctx context.Context, layer v1.Layer, streamLocation 
 	if _, ok := layer.(*stream.Layer); !ok {
 		// We can't retry streaming layers.
 		req.GetBody = getBody
+
+		// If we know the size, set it.
+		if size, err := layer.Size(); err == nil {
+			req.ContentLength = size
+		}
 	}
 	req.Header.Set("Content-Type", "application/octet-stream")
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -547,7 +547,7 @@ github.com/google/go-cmp/cmp/internal/diff
 github.com/google/go-cmp/cmp/internal/flags
 github.com/google/go-cmp/cmp/internal/function
 github.com/google/go-cmp/cmp/internal/value
-# github.com/google/go-containerregistry v0.16.1
+# github.com/google/go-containerregistry v0.17.0
 ## explicit; go 1.18
 github.com/google/go-containerregistry/internal/and
 github.com/google/go-containerregistry/internal/compression


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The dependabot PR https://github.com/tektoncd/pipeline/pull/7523
updates other dependencies as well, this isolate the update.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
