### PR TITLE
fix:Refactored Steps and Sidecars to container_validation #7454

### DIFF
--- a/pkg/apis/pipeline/v1/container_validation.go
+++ b/pkg/apis/pipeline/v1/container_validation.go
@@ -18,9 +18,12 @@ package v1
 
 import (
 	"context"
+	"fmt"
 	"strings"
+	"time"
 
 	"github.com/tektoncd/pipeline/pkg/apis/config"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"knative.dev/pkg/apis"
 )
@@ -57,6 +60,166 @@ func (ref *Ref) Validate(ctx context.Context) (errs *apis.FieldError) {
 		}
 	default:
 		errs = errs.Also(apis.ErrMissingField("name"))
+	}
+	return errs
+}
+
+func validateSidecars(sidecars []Sidecar) (errs *apis.FieldError) {
+	for _, sc := range sidecars {
+		errs = errs.Also(validateSidecarName(sc))
+
+		if sc.Image == "" {
+			errs = errs.Also(apis.ErrMissingField("image"))
+		}
+
+		if sc.Script != "" {
+			if len(sc.Command) > 0 {
+				errs = errs.Also(&apis.FieldError{
+					Message: "script cannot be used with command",
+					Paths:   []string{"script"},
+				})
+			}
+		}
+	}
+	return errs
+}
+
+func validateStep(ctx context.Context, s Step, names sets.String) (errs *apis.FieldError) {
+	if s.Ref != nil {
+		if !config.FromContextOrDefaults(ctx).FeatureFlags.EnableStepActions && isCreateOrUpdateAndDiverged(ctx, s) {
+			return apis.ErrGeneric(fmt.Sprintf("feature flag %s should be set to true to reference StepActions in Steps.", config.EnableStepActions), "")
+		}
+		errs = errs.Also(s.Ref.Validate(ctx))
+		if s.Image != "" {
+			errs = errs.Also(&apis.FieldError{
+				Message: "image cannot be used with Ref",
+				Paths:   []string{"image"},
+			})
+		}
+		if len(s.Command) > 0 {
+			errs = errs.Also(&apis.FieldError{
+				Message: "command cannot be used with Ref",
+				Paths:   []string{"command"},
+			})
+		}
+		if len(s.Args) > 0 {
+			errs = errs.Also(&apis.FieldError{
+				Message: "args cannot be used with Ref",
+				Paths:   []string{"args"},
+			})
+		}
+		if s.Script != "" {
+			errs = errs.Also(&apis.FieldError{
+				Message: "script cannot be used with Ref",
+				Paths:   []string{"script"},
+			})
+		}
+		if s.WorkingDir != "" {
+			errs = errs.Also(&apis.FieldError{
+				Message: "working dir cannot be used with Ref",
+				Paths:   []string{"workingDir"},
+			})
+		}
+		if s.Env != nil {
+			errs = errs.Also(&apis.FieldError{
+				Message: "env cannot be used with Ref",
+				Paths:   []string{"env"},
+			})
+		}
+		if len(s.VolumeMounts) > 0 {
+			errs = errs.Also(&apis.FieldError{
+				Message: "volumeMounts cannot be used with Ref",
+				Paths:   []string{"volumeMounts"},
+			})
+		}
+		if len(s.Results) > 0 {
+			errs = errs.Also(&apis.FieldError{
+				Message: "results cannot be used with Ref",
+				Paths:   []string{"results"},
+			})
+		}
+	} else {
+		if len(s.Params) > 0 {
+			errs = errs.Also(&apis.FieldError{
+				Message: "params cannot be used without Ref",
+				Paths:   []string{"params"},
+			})
+		}
+		if len(s.Results) > 0 {
+			if !config.FromContextOrDefaults(ctx).FeatureFlags.EnableStepActions && isCreateOrUpdateAndDiverged(ctx, s) {
+				return apis.ErrGeneric(fmt.Sprintf("feature flag %s should be set to true in order to use Results in Steps.", config.EnableStepActions), "")
+			}
+		}
+		if s.Image == "" {
+			errs = errs.Also(apis.ErrMissingField("Image"))
+		}
+
+		if s.Script != "" {
+			if len(s.Command) > 0 {
+				errs = errs.Also(&apis.FieldError{
+					Message: "script cannot be used with command",
+					Paths:   []string{"script"},
+				})
+			}
+		}
+	}
+
+	if s.Name != "" {
+		if names.Has(s.Name) {
+			errs = errs.Also(apis.ErrInvalidValue(s.Name, "name"))
+		}
+		if e := validation.IsDNS1123Label(s.Name); len(e) > 0 {
+			errs = errs.Also(&apis.FieldError{
+				Message: fmt.Sprintf("invalid value %q", s.Name),
+				Paths:   []string{"name"},
+				Details: "Task step name must be a valid DNS Label, For more info refer to https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+			})
+		}
+		names.Insert(s.Name)
+	}
+
+	if s.Timeout != nil {
+		if s.Timeout.Duration < time.Duration(0) {
+			return apis.ErrInvalidValue(s.Timeout.Duration, "negative timeout")
+		}
+	}
+
+	for j, vm := range s.VolumeMounts {
+		if strings.HasPrefix(vm.MountPath, "/tekton/") &&
+			!strings.HasPrefix(vm.MountPath, "/tekton/home") {
+			errs = errs.Also(apis.ErrGeneric(fmt.Sprintf("volumeMount cannot be mounted under /tekton/ (volumeMount %q mounted at %q)", vm.Name, vm.MountPath), "mountPath").ViaFieldIndex("volumeMounts", j))
+		}
+		if strings.HasPrefix(vm.Name, "tekton-internal-") {
+			errs = errs.Also(apis.ErrGeneric(fmt.Sprintf(`volumeMount name %q cannot start with "tekton-internal-"`, vm.Name), "name").ViaFieldIndex("volumeMounts", j))
+		}
+	}
+
+	if s.OnError != "" {
+		if !isParamRefs(string(s.OnError)) && s.OnError != Continue && s.OnError != StopAndFail {
+			errs = errs.Also(&apis.FieldError{
+				Message: fmt.Sprintf("invalid value: \"%v\"", s.OnError),
+				Paths:   []string{"onError"},
+				Details: "Task step onError must be either \"continue\" or \"stopAndFail\"",
+			})
+		}
+	}
+
+	if s.Script != "" {
+		cleaned := strings.TrimSpace(s.Script)
+		if strings.HasPrefix(cleaned, "#!win") {
+			errs = errs.Also(config.ValidateEnabledAPIFields(ctx, "windows script support", config.AlphaAPIFields).ViaField("script"))
+		}
+	}
+
+	// StdoutConfig is an alpha feature and will fail validation if it's used in a task spec
+	// when the enable-api-fields feature gate is not "alpha".
+	if s.StdoutConfig != nil {
+		errs = errs.Also(config.ValidateEnabledAPIFields(ctx, "step stdout stream support", config.AlphaAPIFields).ViaField("stdoutconfig"))
+	}
+	// StderrConfig is an alpha feature and will fail validation if it's used in a task spec
+	// when the enable-api-fields feature gate is not "alpha".
+	if s.StderrConfig != nil {
+		errs = errs.Also(config.ValidateEnabledAPIFields(ctx, "step stderr stream support", config.AlphaAPIFields).ViaField("stderrconfig"))
 	}
 	return errs
 }

--- a/pkg/apis/pipeline/v1/task_validation.go
+++ b/pkg/apis/pipeline/v1/task_validation.go
@@ -23,7 +23,6 @@ import (
 	"reflect"
 	"regexp"
 	"strings"
-	"time"
 
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
@@ -32,7 +31,6 @@ import (
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apimachinery/pkg/util/validation"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/webhook/resourcesemantics"
 )
@@ -144,26 +142,6 @@ func ValidateObjectParamsHaveProperties(ctx context.Context, params ParamSpecs) 
 	for _, p := range params {
 		if p.Type == ParamTypeObject && p.Properties == nil {
 			errs = errs.Also(apis.ErrMissingField(fmt.Sprintf("%s.properties", p.Name)))
-		}
-	}
-	return errs
-}
-
-func validateSidecars(sidecars []Sidecar) (errs *apis.FieldError) {
-	for _, sc := range sidecars {
-		errs = errs.Also(validateSidecarName(sc))
-
-		if sc.Image == "" {
-			errs = errs.Also(apis.ErrMissingField("image"))
-		}
-
-		if sc.Script != "" {
-			if len(sc.Command) > 0 {
-				errs = errs.Also(&apis.FieldError{
-					Message: "script cannot be used with command",
-					Paths:   []string{"script"},
-				})
-			}
 		}
 	}
 	return errs
@@ -320,146 +298,6 @@ func isCreateOrUpdateAndDiverged(ctx context.Context, s Step) bool {
 		return diverged
 	}
 	return false
-}
-
-func validateStep(ctx context.Context, s Step, names sets.String) (errs *apis.FieldError) {
-	if s.Ref != nil {
-		if !config.FromContextOrDefaults(ctx).FeatureFlags.EnableStepActions && isCreateOrUpdateAndDiverged(ctx, s) {
-			return apis.ErrGeneric(fmt.Sprintf("feature flag %s should be set to true to reference StepActions in Steps.", config.EnableStepActions), "")
-		}
-		errs = errs.Also(s.Ref.Validate(ctx))
-		if s.Image != "" {
-			errs = errs.Also(&apis.FieldError{
-				Message: "image cannot be used with Ref",
-				Paths:   []string{"image"},
-			})
-		}
-		if len(s.Command) > 0 {
-			errs = errs.Also(&apis.FieldError{
-				Message: "command cannot be used with Ref",
-				Paths:   []string{"command"},
-			})
-		}
-		if len(s.Args) > 0 {
-			errs = errs.Also(&apis.FieldError{
-				Message: "args cannot be used with Ref",
-				Paths:   []string{"args"},
-			})
-		}
-		if s.Script != "" {
-			errs = errs.Also(&apis.FieldError{
-				Message: "script cannot be used with Ref",
-				Paths:   []string{"script"},
-			})
-		}
-		if s.WorkingDir != "" {
-			errs = errs.Also(&apis.FieldError{
-				Message: "working dir cannot be used with Ref",
-				Paths:   []string{"workingDir"},
-			})
-		}
-		if s.Env != nil {
-			errs = errs.Also(&apis.FieldError{
-				Message: "env cannot be used with Ref",
-				Paths:   []string{"env"},
-			})
-		}
-		if len(s.VolumeMounts) > 0 {
-			errs = errs.Also(&apis.FieldError{
-				Message: "volumeMounts cannot be used with Ref",
-				Paths:   []string{"volumeMounts"},
-			})
-		}
-		if len(s.Results) > 0 {
-			errs = errs.Also(&apis.FieldError{
-				Message: "results cannot be used with Ref",
-				Paths:   []string{"results"},
-			})
-		}
-	} else {
-		if len(s.Params) > 0 {
-			errs = errs.Also(&apis.FieldError{
-				Message: "params cannot be used without Ref",
-				Paths:   []string{"params"},
-			})
-		}
-		if len(s.Results) > 0 {
-			if !config.FromContextOrDefaults(ctx).FeatureFlags.EnableStepActions && isCreateOrUpdateAndDiverged(ctx, s) {
-				return apis.ErrGeneric(fmt.Sprintf("feature flag %s should be set to true in order to use Results in Steps.", config.EnableStepActions), "")
-			}
-		}
-		if s.Image == "" {
-			errs = errs.Also(apis.ErrMissingField("Image"))
-		}
-
-		if s.Script != "" {
-			if len(s.Command) > 0 {
-				errs = errs.Also(&apis.FieldError{
-					Message: "script cannot be used with command",
-					Paths:   []string{"script"},
-				})
-			}
-		}
-	}
-
-	if s.Name != "" {
-		if names.Has(s.Name) {
-			errs = errs.Also(apis.ErrInvalidValue(s.Name, "name"))
-		}
-		if e := validation.IsDNS1123Label(s.Name); len(e) > 0 {
-			errs = errs.Also(&apis.FieldError{
-				Message: fmt.Sprintf("invalid value %q", s.Name),
-				Paths:   []string{"name"},
-				Details: "Task step name must be a valid DNS Label, For more info refer to https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-			})
-		}
-		names.Insert(s.Name)
-	}
-
-	if s.Timeout != nil {
-		if s.Timeout.Duration < time.Duration(0) {
-			return apis.ErrInvalidValue(s.Timeout.Duration, "negative timeout")
-		}
-	}
-
-	for j, vm := range s.VolumeMounts {
-		if strings.HasPrefix(vm.MountPath, "/tekton/") &&
-			!strings.HasPrefix(vm.MountPath, "/tekton/home") {
-			errs = errs.Also(apis.ErrGeneric(fmt.Sprintf("volumeMount cannot be mounted under /tekton/ (volumeMount %q mounted at %q)", vm.Name, vm.MountPath), "mountPath").ViaFieldIndex("volumeMounts", j))
-		}
-		if strings.HasPrefix(vm.Name, "tekton-internal-") {
-			errs = errs.Also(apis.ErrGeneric(fmt.Sprintf(`volumeMount name %q cannot start with "tekton-internal-"`, vm.Name), "name").ViaFieldIndex("volumeMounts", j))
-		}
-	}
-
-	if s.OnError != "" {
-		if !isParamRefs(string(s.OnError)) && s.OnError != Continue && s.OnError != StopAndFail {
-			errs = errs.Also(&apis.FieldError{
-				Message: fmt.Sprintf("invalid value: \"%v\"", s.OnError),
-				Paths:   []string{"onError"},
-				Details: "Task step onError must be either \"continue\" or \"stopAndFail\"",
-			})
-		}
-	}
-
-	if s.Script != "" {
-		cleaned := strings.TrimSpace(s.Script)
-		if strings.HasPrefix(cleaned, "#!win") {
-			errs = errs.Also(config.ValidateEnabledAPIFields(ctx, "windows script support", config.AlphaAPIFields).ViaField("script"))
-		}
-	}
-
-	// StdoutConfig is an alpha feature and will fail validation if it's used in a task spec
-	// when the enable-api-fields feature gate is not "alpha".
-	if s.StdoutConfig != nil {
-		errs = errs.Also(config.ValidateEnabledAPIFields(ctx, "step stdout stream support", config.AlphaAPIFields).ViaField("stdoutconfig"))
-	}
-	// StderrConfig is an alpha feature and will fail validation if it's used in a task spec
-	// when the enable-api-fields feature gate is not "alpha".
-	if s.StderrConfig != nil {
-		errs = errs.Also(config.ValidateEnabledAPIFields(ctx, "step stderr stream support", config.AlphaAPIFields).ViaField("stderrconfig"))
-	}
-	return errs
 }
 
 // ValidateParameterTypes validates all the types within a slice of ParamSpecs


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

/kind cleanup
fixes #7442 

# Changes

Moved validateSidecars and validateStep functions to container_validation

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
