### PR TITLE
Label user error for failed TaskRunStatus message

### DIFF
--- a/pkg/apis/pipeline/errors/errors.go
+++ b/pkg/apis/pipeline/errors/errors.go
@@ -13,7 +13,9 @@ limitations under the License.
 
 package errors
 
-const userErrorLabel = "[User error] "
+import "errors"
+
+const UserErrorLabel = "[User error] "
 
 type UserError struct {
 	Reason   string
@@ -44,7 +46,7 @@ func newUserError(reason string, err error) *UserError {
 
 // WrapUserError wraps the original error with the user error label
 func WrapUserError(err error) error {
-	return newUserError(userErrorLabel, err)
+	return newUserError(UserErrorLabel, err)
 }
 
 // LabelUserError labels the failure RunStatus message if any of its error messages has been
@@ -58,4 +60,14 @@ func LabelUserError(messageFormat string, messageA []interface{}) string {
 		}
 	}
 	return messageFormat
+}
+
+// GetErrorMessage returns the error message with the user error label if it is of type user
+// error
+func GetErrorMessage(err error) string {
+	var ue *UserError
+	if errors.As(err, &ue) {
+		return ue.Reason + err.Error()
+	}
+	return err.Error()
 }

--- a/pkg/apis/pipeline/errors/errors_test.go
+++ b/pkg/apis/pipeline/errors/errors_test.go
@@ -96,3 +96,29 @@ func TestLabelsUserError(t *testing.T) {
 		}
 	}
 }
+
+func TestGetErrorMess(t *testing.T) {
+	original := errors.New("orignal error")
+	tcs := []struct {
+		description string
+		err         error
+		expected    string
+	}{{
+		description: "error messages with user error",
+		err:         pipelineErrors.WrapUserError(original),
+		expected:    "[User error] " + original.Error(),
+	}, {
+		description: "error messages without user error",
+		err:         original,
+		expected:    original.Error(),
+	}}
+	for _, tc := range tcs {
+		{
+			msg := pipelineErrors.GetErrorMessage(tc.err)
+
+			if msg != tc.expected {
+				t.Errorf("failure messageFormat expected: %s; but got %s", tc.expected, msg)
+			}
+		}
+	}
+}

--- a/pkg/apis/pipeline/v1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1/taskrun_types.go
@@ -21,6 +21,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	apisconfig "github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
+	pipelineErrors "github.com/tektoncd/pipeline/pkg/apis/pipeline/errors"
 	pod "github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -242,7 +243,7 @@ func (trs *TaskRunStatus) MarkResourceFailed(reason TaskRunReason, err error) {
 		Type:    apis.ConditionSucceeded,
 		Status:  corev1.ConditionFalse,
 		Reason:  reason.String(),
-		Message: err.Error(),
+		Message: pipelineErrors.GetErrorMessage(err),
 	})
 	succeeded := trs.GetCondition(apis.ConditionSucceeded)
 	trs.CompletionTime = &succeeded.LastTransitionTime.Inner

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -28,6 +28,7 @@ import (
 	"github.com/tektoncd/pipeline/internal/sidecarlogresults"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
+	pipelineErrors "github.com/tektoncd/pipeline/pkg/apis/pipeline/errors"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	clientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
@@ -196,7 +197,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, tr *v1.TaskRun) pkgrecon
 		logger.Errorf("Reconcile: %v", err.Error())
 		if errors.Is(err, sidecarlogresults.ErrSizeExceeded) {
 			cfg := config.FromContextOrDefaults(ctx)
-			message := fmt.Sprintf("TaskRun \"%q\" failed: results exceeded size limit %d bytes", tr.Name, cfg.FeatureFlags.MaxResultSize)
+			message := fmt.Sprintf("%s TaskRun \"%q\" failed: results exceeded size limit %d bytes", pipelineErrors.UserErrorLabel, tr.Name, cfg.FeatureFlags.MaxResultSize)
 			err := c.failTaskRun(ctx, tr, v1.TaskRunReasonResultLargerThanAllowedLimit, message)
 			return c.finishReconcileUpdateEmitEvents(ctx, tr, before, err)
 		}

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	cfgtesting "github.com/tektoncd/pipeline/pkg/apis/config/testing"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
+	pipelineErrors "github.com/tektoncd/pipeline/pkg/apis/pipeline/errors"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
@@ -1666,7 +1667,7 @@ status:
       type: string
       value: aResultValue
 `)
-		failedOnReconcileFailureTaskRun = parse.MustParseV1TaskRun(t, `
+		failedOnReconcileFailureTaskRun = parse.MustParseV1TaskRun(t, fmt.Sprintf(`
 metadata:
   name: test-taskrun-results-type-mismatched
   namespace: foo
@@ -1679,14 +1680,14 @@ status:
   - reason: ToBeRetried
     status: Unknown
     type: Succeeded
-    message: "Provided results don't match declared results; may be invalid JSON or missing result declaration:  \"aResult\": task result is expected to be \"array\" type but was initialized to a different type \"string\""
+    message: "%sProvided results don't match declared results; may be invalid JSON or missing result declaration:  \"aResult\": task result is expected to be \"array\" type but was initialized to a different type \"string\""
   sideCars:
   retriesStatus:
   - conditions:
     - reason: TaskRunValidationFailed
       status: "False"
       type: "Succeeded"
-      message: "Provided results don't match declared results; may be invalid JSON or missing result declaration:  \"aResult\": task result is expected to be \"array\" type but was initialized to a different type \"string\""
+      message: "%sProvided results don't match declared results; may be invalid JSON or missing result declaration:  \"aResult\": task result is expected to be \"array\" type but was initialized to a different type \"string\""
     startTime: "2021-12-31T23:59:59Z"
     completionTime: "2022-01-01T00:00:00Z"
     podName: "test-taskrun-results-type-mismatched-pod"
@@ -1714,7 +1715,7 @@ status:
       ResultExtractionMethod: "termination-message"
       MaxResultSize: 4096
       Coschedule: "workspaces"
-`)
+`, pipelineErrors.UserErrorLabel, pipelineErrors.UserErrorLabel))
 		reconciliatonError = fmt.Errorf("1 error occurred:\n\t* Provided results don't match declared results; may be invalid JSON or missing result declaration:  \"aResult\": task result is expected to be \"array\" type but was initialized to a different type \"string\"")
 		toBeRetriedTaskRun = parse.MustParseV1TaskRun(t, `
 metadata:

--- a/pkg/workspace/validate.go
+++ b/pkg/workspace/validate.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	pipelineErrors "github.com/tektoncd/pipeline/pkg/apis/pipeline/errors"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -31,7 +32,7 @@ func ValidateBindings(ctx context.Context, decls []v1.WorkspaceDeclaration, bind
 	// reason we'll invoke the same validation here.
 	for _, b := range binds {
 		if err := b.Validate(ctx); err != nil {
-			return fmt.Errorf("binding %q is invalid: %w", b.Name, err)
+			return pipelineErrors.WrapUserError(fmt.Errorf("binding %q is invalid: %w", b.Name, err))
 		}
 	}
 
@@ -49,12 +50,12 @@ func ValidateBindings(ctx context.Context, decls []v1.WorkspaceDeclaration, bind
 			continue
 		}
 		if !bindNames.Has(decl.Name) {
-			return fmt.Errorf("declared workspace %q is required but has not been bound", decl.Name)
+			return pipelineErrors.WrapUserError(fmt.Errorf("declared workspace %q is required but has not been bound", decl.Name))
 		}
 	}
 	for _, bind := range binds {
 		if !declNames.Has(bind.Name) {
-			return fmt.Errorf("workspace binding %q does not match any declared workspace", bind.Name)
+			return pipelineErrors.WrapUserError(fmt.Errorf("workspace binding %q does not match any declared workspace", bind.Name))
 		}
 	}
 
@@ -78,7 +79,7 @@ func ValidateOnlyOnePVCIsUsed(wb []v1.WorkspaceBinding) error {
 	}
 
 	if len(workspaceVolumes) > 1 {
-		return fmt.Errorf("more than one PersistentVolumeClaim is bound")
+		return pipelineErrors.WrapUserError(fmt.Errorf("more than one PersistentVolumeClaim is bound"))
 	}
 	return nil
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This commit follows up https://github.com/tektoncd/pipeline/pull/7475 and labels user error for failed TaskRun
status messages. It marks off user errors in the taskrun reconciler and
communicate to users via TaskRunStatus condition messages.

/kind misc
part of https://github.com/tektoncd/pipeline/issues/7276

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
