### PR TITLE
RFC: Add FailureReason field for PipelineRun and TaskRun Status

### DIFF
--- a/docs/pipeline-api.md
+++ b/docs/pipeline-api.md
@@ -2493,6 +2493,19 @@ map[string]string
 <p>SpanContext contains tracing span context fields</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>failureReason</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>FailureReason stands for the granular PipelineRun failure reason.
+It is the provisional status field for making breaking changes to the existing PipelineRunReasons. It will replace
+the existing apis.Condition.Reason with the next major version bump.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="tekton.dev/v1.PipelineRunTaskRunStatus">PipelineRunTaskRunStatus
@@ -5716,6 +5729,19 @@ map[string]string
 </td>
 <td>
 <p>SpanContext contains tracing span context fields</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>failureReason</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>FailureReason stands for the granular TaskRun failure reason.
+It is the provisional status field for making breaking changes to the existing PipelineRunReasons. It will replace
+the existing apis.Condition.Reason with the next major version bump.</p>
 </td>
 </tr>
 </tbody>

--- a/pkg/apis/pipeline/v1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1/openapi_generated.go
@@ -1469,6 +1469,13 @@ func schema_pkg_apis_pipeline_v1_PipelineRunStatus(ref common.ReferenceCallback)
 							},
 						},
 					},
+					"failureReason": {
+						SchemaProps: spec.SchemaProps{
+							Description: "FailureReason stands for the granular PipelineRun failure reason. It is the provisional status field for making breaking changes to the existing PipelineRunReasons. It will replace the existing apis.Condition.Reason with the next major version bump.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},
@@ -1585,6 +1592,13 @@ func schema_pkg_apis_pipeline_v1_PipelineRunStatusFields(ref common.ReferenceCal
 									},
 								},
 							},
+						},
+					},
+					"failureReason": {
+						SchemaProps: spec.SchemaProps{
+							Description: "FailureReason stands for the granular PipelineRun failure reason. It is the provisional status field for making breaking changes to the existing PipelineRunReasons. It will replace the existing apis.Condition.Reason with the next major version bump.",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},
@@ -4069,6 +4083,13 @@ func schema_pkg_apis_pipeline_v1_TaskRunStatus(ref common.ReferenceCallback) com
 							},
 						},
 					},
+					"failureReason": {
+						SchemaProps: spec.SchemaProps{
+							Description: "FailureReason stands for the granular TaskRun failure reason. It is the provisional status field for making breaking changes to the existing PipelineRunReasons. It will replace the existing apis.Condition.Reason with the next major version bump.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"podName"},
 			},
@@ -4207,6 +4228,13 @@ func schema_pkg_apis_pipeline_v1_TaskRunStatusFields(ref common.ReferenceCallbac
 									},
 								},
 							},
+						},
+					},
+					"failureReason": {
+						SchemaProps: spec.SchemaProps{
+							Description: "FailureReason stands for the granular TaskRun failure reason. It is the provisional status field for making breaking changes to the existing PipelineRunReasons. It will replace the existing apis.Condition.Reason with the next major version bump.",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},

--- a/pkg/apis/pipeline/v1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1/pipelinerun_types.go
@@ -470,6 +470,11 @@ func (pr *PipelineRunStatus) MarkFailed(reason, messageFormat string, messageA .
 	pr.CompletionTime = &succeeded.LastTransitionTime.Inner
 }
 
+// SetFailureReason sets PipelineRun failure reason that is more granular and precise
+func (prs *PipelineRunStatus) SetFailureReason(reason TaskRunReason) {
+	prs.FailureReason = reason.String()
+}
+
 // MarkRunning changes the Succeeded condition to Unknown with the provided reason and message.
 func (pr *PipelineRunStatus) MarkRunning(reason, messageFormat string, messageA ...interface{}) {
 	pipelineRunCondSet.Manage(pr).MarkUnknown(apis.ConditionSucceeded, reason, messageFormat, messageA...)
@@ -527,6 +532,11 @@ type PipelineRunStatusFields struct {
 
 	// SpanContext contains tracing span context fields
 	SpanContext map[string]string `json:"spanContext,omitempty"`
+
+	// FailureReason stands for the granular PipelineRun failure reason.
+	// It is the provisional status field for making breaking changes to the existing PipelineRunReasons. It will replace
+	// the existing apis.Condition.Reason with the next major version bump.
+	FailureReason string `json:"failureReason,omitempty"`
 }
 
 // SkippedTask is used to describe the Tasks that were skipped due to their When Expressions

--- a/pkg/apis/pipeline/v1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1/pipelinerun_types.go
@@ -399,6 +399,9 @@ const (
 	// ReasonInvalidTaskResultReference indicates a task result was declared
 	// but was not initialized by that task
 	PipelineRunReasonInvalidTaskResultReference PipelineRunReason = "InvalidTaskResultReference"
+	// PipelineRunReasonInvalidPipelineResultReference indicates a pipeline result was declared
+	// by the pipeline but not initialized in the pipelineTask
+	PipelineRunReasonInvalidPipelineResultReference PipelineRunReason = "InvalidPipelineResultReference"
 	// ReasonRequiredWorkspaceMarkedOptional indicates an optional workspace
 	// has been passed to a Task that is expecting a non-optional workspace
 	PipelineRunReasonRequiredWorkspaceMarkedOptional PipelineRunReason = "RequiredWorkspaceMarkedOptional"

--- a/pkg/apis/pipeline/v1/swagger.json
+++ b/pkg/apis/pipeline/v1/swagger.json
@@ -681,6 +681,10 @@
           "x-kubernetes-patch-merge-key": "type",
           "x-kubernetes-patch-strategy": "merge"
         },
+        "failureReason": {
+          "description": "FailureReason stands for the granular PipelineRun failure reason. It is the provisional status field for making breaking changes to the existing PipelineRunReasons. It will replace the existing apis.Condition.Reason with the next major version bump.",
+          "type": "string"
+        },
         "finallyStartTime": {
           "description": "FinallyStartTime is when all non-finally tasks have been completed and only finally tasks are being executed.",
           "$ref": "#/definitions/v1.Time"
@@ -746,6 +750,10 @@
         "completionTime": {
           "description": "CompletionTime is the time the PipelineRun completed.",
           "$ref": "#/definitions/v1.Time"
+        },
+        "failureReason": {
+          "description": "FailureReason stands for the granular PipelineRun failure reason. It is the provisional status field for making breaking changes to the existing PipelineRunReasons. It will replace the existing apis.Condition.Reason with the next major version bump.",
+          "type": "string"
         },
         "finallyStartTime": {
           "description": "FinallyStartTime is when all non-finally tasks have been completed and only finally tasks are being executed.",
@@ -2045,6 +2053,10 @@
           "x-kubernetes-patch-merge-key": "type",
           "x-kubernetes-patch-strategy": "merge"
         },
+        "failureReason": {
+          "description": "FailureReason stands for the granular TaskRun failure reason. It is the provisional status field for making breaking changes to the existing PipelineRunReasons. It will replace the existing apis.Condition.Reason with the next major version bump.",
+          "type": "string"
+        },
         "observedGeneration": {
           "description": "ObservedGeneration is the 'Generation' of the Service that was last processed by the controller.",
           "type": "integer",
@@ -2123,6 +2135,10 @@
         "completionTime": {
           "description": "CompletionTime is the time the build completed.",
           "$ref": "#/definitions/v1.Time"
+        },
+        "failureReason": {
+          "description": "FailureReason stands for the granular TaskRun failure reason. It is the provisional status field for making breaking changes to the existing PipelineRunReasons. It will replace the existing apis.Condition.Reason with the next major version bump.",
+          "type": "string"
         },
         "podName": {
           "description": "PodName is the name of the pod responsible for executing this task's steps.",

--- a/pkg/apis/pipeline/v1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1/taskrun_types.go
@@ -248,6 +248,12 @@ func (trs *TaskRunStatus) MarkResourceFailed(reason TaskRunReason, err error) {
 	trs.CompletionTime = &succeeded.LastTransitionTime.Inner
 }
 
+// SetFailureReason sets TaskRun failure reason that is more granular and precise
+// to the existing TaskRunReason
+func (trs *TaskRunStatus) SetFailureReason(reason TaskRunReason) {
+	trs.FailureReason = reason.String()
+}
+
 // TaskRunStatusFields holds the fields of TaskRun's status.  This is defined
 // separately and inlined so that other types can readily consume these fields
 // via duck typing.
@@ -291,6 +297,11 @@ type TaskRunStatusFields struct {
 
 	// SpanContext contains tracing span context fields
 	SpanContext map[string]string `json:"spanContext,omitempty"`
+
+	// FailureReason stands for the granular TaskRun failure reason.
+	// It is the provisional status field for making breaking changes to the existing PipelineRunReasons. It will replace
+	// the existing apis.Condition.Reason with the next major version bump.
+	FailureReason string `json:"failureReason,omitempty"`
 }
 
 // TaskRunStepSpec is used to override the values of a Step in the corresponding Task.

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -688,6 +688,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1.PipelineRun, getPipel
 		if err := resources.ValidatePipelineResults(pipelineSpec, pipelineRunFacts.State); err != nil {
 			logger.Errorf("Failed to resolve task result reference for %q with error %v", pr.Name, err)
 			pr.Status.MarkFailed(v1.PipelineRunReasonInvalidTaskResultReference.String(), err.Error())
+			pr.Status.SetFailureReason(v1.InvalidPipelineResultReference)
 			return controller.NewPermanentError(err)
 		}
 
@@ -794,7 +795,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1.PipelineRun, getPipel
 		pr.Status.Results, err = resources.ApplyTaskResultsToPipelineResults(ctx, pipelineSpec.Results,
 			pipelineRunFacts.State.GetTaskRunsResults(), pipelineRunFacts.State.GetRunsResults(), taskStatus)
 		if err != nil {
-			pr.Status.MarkFailed(v1.PipelineRunReasonCouldntGetPipelineResult.String(),
+			pr.Status.MarkFailed(v1.PipelineRunReasonInvalidPipelineResultReference.String(),
 				"Failed to get PipelineResult from TaskRun Results for PipelineRun %s: %s",
 				pr.Name, err)
 			return err


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
This PR adds the new field FailureReason for PipelineRunStatus
and TaskRun status. It aims to provide more granular reasons with
backwards compatibility kept while making changes to the existing error
reasons.

part of https://github.com/tektoncd/pipeline/issues/7396
# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
