### PR TITLE
TEP-0142: `param` substitutions not allowed in `StepAction's` `script` 

### DIFF
--- a/docs/stepactions.md
+++ b/docs/stepactions.md
@@ -109,6 +109,9 @@ spec:
   ]
 ```
 
+> :seedling: **`params` cannot be directly used in a `script` in `StepActions`.**
+> Directly substituting `params` in `scripts` makes the workload prone to shell attacks. Therefore, we do not allow direct usage of `params` in `scripts` in `StepActions`. Instead, rely on passing `params` to `env` variables and reference them in `scripts`. We cannot do the same for `inlined-steps` because it breaks `v1 API` compatibility for existing users. 
+
 #### Passing Params to StepAction
 
 A `StepAction` may require [params](#declaring-parameters). In this case, a `Task` needs to ensure that the `StepAction` has access to all the required `params`.

--- a/examples/v1/taskruns/alpha/stepaction-params.yaml
+++ b/examples/v1/taskruns/alpha/stepaction-params.yaml
@@ -25,10 +25,25 @@ spec:
         key1: "step-action default key1"
         key2: "step-action default key2"
         key3: "step-action default key3"
+  env:
+    - name: arrayparam0
+      value: $(params.array-param[0])
+    - name: arrayparam1
+      value: $(params.array-param[1])
+    - name: arrayparam2
+      value: $(params.array-param[2])
+    - name: stringparam
+      value: $(params.string-param)
+    - name: objectparamkey1
+      value: $(params.object-param.key1)
+    - name: objectparamkey2
+      value: $(params.object-param.key2)
+    - name: objectparamkey3
+      value: $(params.object-param.key3)
   image: ubuntu
   script: |
     #!/bin/bash
-    ARRAYVALUE=("$(params.array-param[0])" "$(params.array-param[1])" "$(params.array-param[2])" "$(params.string-param)" "$(params.object-param.key1)" "$(params.object-param.key2)" "$(params.object-param.key3)")
+    ARRAYVALUE=("${arrayparam0}" "${arrayparam1}" "${arrayparam2}" "${stringparam}" "${objectparamkey1}" "${objectparamkey2}" "${objectparamkey3}")
     ARRAYEXPECTED=("taskrun" "array" "param" "taskrun stringparam" "taskspec default key1" "taskrun key2" "step-action default key3")
     for i in "${!ARRAYVALUE[@]}"; do
         VALUE="${ARRAYVALUE[i]}"


### PR DESCRIPTION
Based on discussions in https://github.com/tektoncd/pipeline/issues/7497 and consensus in the API WG, we disallow direct parameter substitution in scripts. While we cannot do this for inlined-steps since it is a major breaking change in `v1`, we can do this in `Step Actions`.

In this PR we add validation that params cannot be directly replaced in `scripts` of `StepActions`. Based on Issue https://github.com/tektoncd/pipeline/issues/7497. The docs have been updated to inform this to the users and encourage the use of `env` vars in `scripts` instead.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Param substitutions not allowed directly in StepAction's script
```
/kind feature