### PR TITLE
fix: ensure global podTemplate configuration is merged correctly

### DIFF
--- a/docs/matrix.md
+++ b/docs/matrix.md
@@ -176,7 +176,7 @@ data:
   ...
 ```
 
-For more information, see [installation customizations](install.md#customizing-basic-execution-parameters).
+For more information, see [installation customizations](./additional-configs.md#customizing-basic-execution-parameters).
 
 ## Parameters
 

--- a/docs/podtemplates.md
+++ b/docs/podtemplates.md
@@ -13,11 +13,11 @@ configuration that Tekton can use as "boilerplate" for a Pod that runs your `Tas
 You can specify a Pod template for `TaskRuns` and `PipelineRuns`. In the template, you can specify custom values for fields governing
 the execution of individual `Tasks` or for all `Tasks` executed by a given `PipelineRun`.
 
-You also have the option to define a global Pod template [in your Tekton config](./install.md#customizing-basic-execution-parameters) using the key `default-pod-template`.
-However, this global template is going to be merged with any templates
-you specify in your `TaskRuns` and `PipelineRuns`. Any field that is
-present in both the global template and the `TaskRun`'s or
+You also have the option to define a global Pod template [in your Tekton config](./additional-configs.md#customizing-basic-execution-parameters) using the key `default-pod-template`.
+However, this global template is going to be merged with any templates you specify in your `TaskRuns` and `PipelineRuns`.<br>
+Except for the `env` and `volumes` fields, other fields that exist in both the global template and the `TaskRun`'s or
 `PipelineRun`'s template will be taken from the `TaskRun` or `PipelineRun`.
+The `env` and `volumes` fields are merged by the `name` value in the array elements. If the item's `name` is the same, the item from `TaskRun` or `PipelineRun` will be used.
 
 See the following for examples of specifying a Pod template:
 - [Specifying a Pod template for a `TaskRun`](./taskruns.md#specifying-a-pod-template)
@@ -33,7 +33,7 @@ The supported fields are: `tolerations`, `nodeSelector`, and
 `imagePullSecrets` (see the table below for more details).
 
 Similarily to Pod templates, you have the option to define a global affinity
-assistant Pod template [in your Tekton config](./install.md#customizing-basic-execution-parameters)
+assistant Pod template [in your Tekton config](./additional-configs.md#customizing-basic-execution-parameters)
 using the key `default-affinity-assistant-pod-template`. The merge strategy is
 the same as the one described above.
 

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -255,7 +255,7 @@ a `Task` requires but which are not provided by the `TaskRun` will be bound with
 
 The configuration for the default `Workspace Binding` is added to the `config-defaults` `ConfigMap`, under
 the `default-task-run-workspace-binding` key. For an example, see the [Customizing basic execution
-parameters](./install.md#customizing-basic-execution-parameters) section of the install doc.
+parameters](./additional-configs.md#customizing-basic-execution-parameters) section of the install doc.
 
 **Note:** the default configuration is used for any _required_ `Workspace` declared by a `Task`. Optional
 `Workspaces` are not populated with the default binding. This is because a `Task's` behaviour will typically

--- a/pkg/apis/pipeline/pod/template_test.go
+++ b/pkg/apis/pipeline/pod/template_test.go
@@ -1,0 +1,170 @@
+/*
+Copyright 2024 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pod
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestMergeByName(t *testing.T) {
+	type testCase struct {
+		name      string
+		base      []interface{}
+		overrides []interface{}
+		expected  []interface{}
+	}
+
+	testCases := []testCase{
+		{
+			name:      "empty overrides",
+			base:      []interface{}{corev1.EnvVar{Name: "foo", Value: "bar"}},
+			overrides: []interface{}{},
+			expected:  []interface{}{corev1.EnvVar{Name: "foo", Value: "bar"}},
+		},
+		{
+			name:      "empty base",
+			base:      []interface{}{},
+			overrides: []interface{}{corev1.EnvVar{Name: "foo", Value: "bar"}},
+			expected:  []interface{}{corev1.EnvVar{Name: "foo", Value: "bar"}},
+		},
+		{
+			name:      "same name",
+			base:      []interface{}{corev1.EnvVar{Name: "foo", Value: "bar"}},
+			overrides: []interface{}{corev1.EnvVar{Name: "foo", Value: "baz"}},
+			expected:  []interface{}{corev1.EnvVar{Name: "foo", Value: "baz"}},
+		},
+		{
+			name:      "different name",
+			base:      []interface{}{corev1.EnvVar{Name: "foo", Value: "bar"}},
+			overrides: []interface{}{corev1.EnvVar{Name: "bar", Value: "baz"}},
+			expected:  []interface{}{corev1.EnvVar{Name: "bar", Value: "baz"}, corev1.EnvVar{Name: "foo", Value: "bar"}},
+		},
+		{
+			name:      "different volume name",
+			base:      []interface{}{corev1.Volume{Name: "foo", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}}},
+			overrides: []interface{}{corev1.Volume{Name: "bar", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}}},
+			expected: []interface{}{
+				corev1.Volume{Name: "bar", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+				corev1.Volume{Name: "foo", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+			},
+		},
+		{
+			name:      "unsupported type",
+			base:      []interface{}{corev1.EnvVar{Name: "foo", Value: "bar"}},
+			overrides: []interface{}{42},
+			expected:  []interface{}{corev1.EnvVar{Name: "foo", Value: "bar"}},
+		},
+		{
+			name:      "empty name",
+			base:      []interface{}{corev1.EnvVar{Name: "", Value: "bar"}},
+			overrides: []interface{}{corev1.EnvVar{Name: "", Value: "bar"}},
+			expected:  []interface{}{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := mergeByName(tc.base, tc.overrides)
+			if !reflect.DeepEqual(result, tc.expected) {
+				t.Errorf("mergeByName(%v, %v) = %v, want %v", tc.base, tc.overrides, result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestMergePodTemplateWithDefault(t *testing.T) {
+	type testCase struct {
+		name       string
+		tpl        *PodTemplate
+		defaultTpl *PodTemplate
+		expected   *PodTemplate
+	}
+
+	testCases := []testCase{
+		{
+			name: "defaultTpl is nil",
+			tpl: &PodTemplate{
+				NodeSelector: map[string]string{"foo": "bar"},
+			},
+			defaultTpl: nil,
+			expected: &PodTemplate{
+				NodeSelector: map[string]string{"foo": "bar"},
+			},
+		},
+		{
+			name: "tpl is nil",
+			tpl:  nil,
+			defaultTpl: &PodTemplate{
+				NodeSelector: map[string]string{"foo": "bar"},
+			},
+			expected: &PodTemplate{
+				NodeSelector: map[string]string{"foo": "bar"},
+			},
+		},
+		{
+			name: "override default env",
+			tpl: &PodTemplate{
+				Env: []corev1.EnvVar{{Name: "foo", Value: "bar"}},
+			},
+			defaultTpl: &PodTemplate{
+				Env: []corev1.EnvVar{{Name: "foo", Value: "baz"}},
+			},
+			expected: &PodTemplate{
+				Env: []corev1.EnvVar{{Name: "foo", Value: "bar"}},
+			},
+		},
+		{
+			name: "merge envs",
+			tpl: &PodTemplate{
+				Env: []corev1.EnvVar{{Name: "foo", Value: "bar"}},
+			},
+			defaultTpl: &PodTemplate{
+				Env: []corev1.EnvVar{{Name: "bar", Value: "bar"}},
+			},
+			expected: &PodTemplate{
+				Env: []corev1.EnvVar{
+					{Name: "foo", Value: "bar"},
+					{Name: "bar", Value: "bar"},
+				},
+			},
+		},
+		{
+			name: "update host network",
+			tpl: &PodTemplate{
+				HostNetwork: false,
+			},
+			defaultTpl: &PodTemplate{
+				HostNetwork: true,
+			},
+			expected: &PodTemplate{
+				HostNetwork: true,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := MergePodTemplateWithDefault(tc.tpl, tc.defaultTpl)
+			if !reflect.DeepEqual(result, tc.expected) {
+				t.Errorf("mergeByName(%v, %v) = %v, want %v", tc.tpl, tc.defaultTpl, result, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
fix #7551

Adjust the behavior of how global Pod templates are merged with TaskRun or PipelineRun.
The `env` and `volumes` fields are merged by the `name` value in the array elements.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Merge the `env` and `volumes` from the podTemplate in the pipelineRun or TaskRun with the global defaults, instead of only considering the specified in the Run's.
```

/kind bug