### PR TITLE
docs: optimize examples for propagating results

### DIFF
--- a/docs/pipelineruns.md
+++ b/docs/pipelineruns.md
@@ -792,9 +792,8 @@ spec:
             image: busybox
             command: ["/bin/sh", "-c"]
             args:
-              - echo
-              # - $(params.uid)
-              - $(tasks.add-uid.results.uid)
+              - echo $(tasks.add-uid.results.uid)
+              # - echo $(params.uid)
 ```
 
 On executing the `PipelineRun`, the `Results` will be interpolated during resolution.
@@ -809,8 +808,7 @@ spec:
   taskSpec:
     steps:
       args:
-        echo
-        1001
+        echo 1001
       command:
         - /bin/sh
         - -c
@@ -831,8 +829,7 @@ status:
   taskSpec:
     steps:
       args:
-        echo
-        1001
+        echo 1001
       command:
         /bin/sh
         -c

--- a/examples/v1/pipelineruns/propagating_results_implicit_resultref.yaml
+++ b/examples/v1/pipelineruns/propagating_results_implicit_resultref.yaml
@@ -30,5 +30,4 @@ spec:
               image: busybox
               command: ["/bin/sh", "-c"]
               args:
-                - echo
-                - $(tasks.add-uid.results.uid)
+                - echo $(tasks.add-uid.results.uid)


### PR DESCRIPTION
The previous example did not actually output results, leading to the misconception that it was not effective.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```

/kind documentation