### PR TITLE
allow pipeline runs whose task/custom runs have been deleted still timeout

### DIFF
--- a/pkg/reconciler/pipelinerun/timeout_test.go
+++ b/pkg/reconciler/pipelinerun/timeout_test.go
@@ -60,6 +60,23 @@ func TestTimeoutPipelineRun(t *testing.T) {
 			{ObjectMeta: metav1.ObjectMeta{Name: "t1"}},
 		},
 	}, {
+		name: "multiple-runs-missing",
+		pipelineRun: &v1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pipeline-run-timedout"},
+			Spec:       v1.PipelineRunSpec{},
+			Status: v1.PipelineRunStatus{PipelineRunStatusFields: v1.PipelineRunStatusFields{
+				ChildReferences: []v1.ChildStatusReference{{
+					TypeMeta:         runtime.TypeMeta{Kind: taskRun},
+					Name:             "t1",
+					PipelineTaskName: "task-1",
+				}, {
+					TypeMeta:         runtime.TypeMeta{Kind: customRun},
+					Name:             "t2",
+					PipelineTaskName: "task-2",
+				}},
+			}},
+		},
+	}, {
 		name: "multiple-taskruns",
 		pipelineRun: &v1.PipelineRun{
 			ObjectMeta: metav1.ObjectMeta{Name: "test-pipeline-run-timedout"},


### PR DESCRIPTION
Fixes #7556 

# Changes

Back with PR 5134 Tekton started using the cancel function for cleaning up underlying TaskRuns of PipelineRuns that are timing out, though separate timeout functions were used (presumably in case the timeout behavior needed to be tweaked from the cancel behavior later on).  Then, in PR 5288, improvements to the baseline cancel function were made to still complete cancel processing of a PipelineRun if the underlying TaskRuns were deleted.  However, that same accomodation was not made for the timeout path.  This change addresses that, but still keeps the timeout codepaths separate from the 'base' cancel codepaths.


# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [/ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ /] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ /] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [/ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [n/a ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
PipelineRuns that timeout will no longer be blocked on reaching a terminal, cancelled state if their underlying TaskRuns or CustomRuns were deleted beforehand.
```

@vdemeester @afrittoli @abayer PTAL - thanks