### PR TITLE
matrix `taskRun` name updated to end with the instance count

### DIFF
--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/google/cel-go/cel"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
@@ -701,6 +702,15 @@ func getNewRunNames(ptName, prName string, numberOfRuns int) []string {
 	// For a matrix we append i to then end of the fanned out TaskRuns "matrixed-pr-taskrun-0"
 	for i := 0; i < numberOfRuns; i++ {
 		taskRunName := kmeta.ChildName(prName, fmt.Sprintf("-%s-%d", ptName, i))
+		// check if the taskRun name ends with a matrix instance count
+		if !strings.HasSuffix(taskRunName, fmt.Sprintf("-%d", i)) {
+			taskRunName = kmeta.ChildName(prName, fmt.Sprintf("-%s", ptName))
+			// kmeta.ChildName limits the size of a name to max of 63 characters based on k8s guidelines
+			// truncate the name such that "-<matrix-id>" can be appended to the taskRun name
+			longest := 63 - len(fmt.Sprintf("-%d", numberOfRuns))
+			taskRunName = taskRunName[0:longest]
+			taskRunName = fmt.Sprintf("%s-%d", taskRunName, i)
+		}
 		taskRunNames = append(taskRunNames, taskRunName)
 	}
 	return taskRunNames

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
@@ -3372,8 +3372,8 @@ func TestGetNamesOfTaskRuns(t *testing.T) {
 		name:   "new pipelinetask with long names",
 		ptName: "longtask-0123456789-0123456789-0123456789-0123456789-0123456789",
 		wantTrNames: []string{
-			"mypipelinerun09c563f6b29a3a2c16b98e6dc95979c5-longtask-01234567",
-			"mypipelinerunab643c1924b632f050e5a07fe482fc25-longtask-01234567",
+			"mypipelineruna56c4ee0aab148ee219d40b21dfe935a-longtask-012345-0",
+			"mypipelineruna56c4ee0aab148ee219d40b21dfe935a-longtask-012345-1",
 		},
 	}, {
 		name:   "new taskruns, pipelinerun with long name",
@@ -3388,8 +3388,8 @@ func TestGetNamesOfTaskRuns(t *testing.T) {
 		ptName: "task2-0123456789-0123456789-0123456789-0123456789-0123456789",
 		prName: "pipeline-run-0123456789-0123456789-0123456789-0123456789",
 		wantTrNames: []string{
-			"pipeline-run-0123456789-01234563c0313c59d28c85a2c2b3fd3b17a9514",
-			"pipeline-run-0123456789-01234569d54677e88e96776942290e00b578ca5",
+			"pipeline-run-0123456789-012345607ad8c7aac5873cdfabe472a68996b-0",
+			"pipeline-run-0123456789-012345607ad8c7aac5873cdfabe472a68996b-1",
 		},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -3435,8 +3435,8 @@ func TestGetNamesOfRuns(t *testing.T) {
 		name:   "new pipelinetask with long names",
 		ptName: "longtask-0123456789-0123456789-0123456789-0123456789-0123456789",
 		wantRunNames: []string{
-			"mypipelinerun09c563f6b29a3a2c16b98e6dc95979c5-longtask-01234567",
-			"mypipelinerunab643c1924b632f050e5a07fe482fc25-longtask-01234567",
+			"mypipelineruna56c4ee0aab148ee219d40b21dfe935a-longtask-012345-0",
+			"mypipelineruna56c4ee0aab148ee219d40b21dfe935a-longtask-012345-1",
 		},
 	}, {
 		name:   "new runs, pipelinerun with long name",
@@ -3451,8 +3451,8 @@ func TestGetNamesOfRuns(t *testing.T) {
 		ptName: "task2-0123456789-0123456789-0123456789-0123456789-0123456789",
 		prName: "pipeline-run-0123456789-0123456789-0123456789-0123456789",
 		wantRunNames: []string{
-			"pipeline-run-0123456789-01234563c0313c59d28c85a2c2b3fd3b17a9514",
-			"pipeline-run-0123456789-01234569d54677e88e96776942290e00b578ca5",
+			"pipeline-run-0123456789-012345607ad8c7aac5873cdfabe472a68996b-0",
+			"pipeline-run-0123456789-012345607ad8c7aac5873cdfabe472a68996b-1",
 		},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

matrix creates multiple taskRuns using the specified combination of inputs. The taskRun name in general is predictable unless it exceeds the max. number of characters (63). When the combination of a pipelineTask name and the pipelineRun name exceeds 63 characters, the taskRun names looses all their instance indices.

Updating the taskRun name generation such that in case of a matrix task, when the generated taskRun name exceeds k8s restriction of 63 characters, the taskRun name is truncated and instance id of matrix is appended.

https://github.com/tektoncd/pipeline/issues/7562

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
taskRun names updated to end with the instance count for all fan out instances of matrix.
```
