### PR TITLE
Add granular termination reason in container termination message

### DIFF
--- a/cmd/entrypoint/main.go
+++ b/cmd/entrypoint/main.go
@@ -178,7 +178,7 @@ func main() {
 	if err := e.Go(); err != nil {
 		breakpointExitPostFile := e.PostFile + breakpointExitSuffix
 		switch t := err.(type) { //nolint:errorlint // checking for multiple types with errors.As is ugly.
-		case skipError:
+		case entrypoint.SkipError:
 			log.Print("Skipping step because a previous step failed")
 			os.Exit(1)
 		case termination.MessageLengthError:

--- a/cmd/entrypoint/waiter.go
+++ b/cmd/entrypoint/waiter.go
@@ -71,7 +71,7 @@ func (rw *realWaiter) Wait(ctx context.Context, file string, expectContent bool,
 			if breakpointOnFailure {
 				return nil
 			}
-			return skipError("error file present, bail and skip the step")
+			return entrypoint.ErrSkipPreviousStepFailed
 		}
 		select {
 		case <-ctx.Done():
@@ -85,10 +85,4 @@ func (rw *realWaiter) Wait(ctx context.Context, file string, expectContent bool,
 		case <-time.After(rw.waitPollingInterval):
 		}
 	}
-}
-
-type skipError string
-
-func (e skipError) Error() string {
-	return string(e)
 }

--- a/cmd/entrypoint/waiter_test.go
+++ b/cmd/entrypoint/waiter_test.go
@@ -153,7 +153,7 @@ func TestRealWaiterWaitWithErrorWaitfile(t *testing.T) {
 		if err == nil {
 			t.Errorf("expected skipError upon encounter error waitfile")
 		}
-		var skipErr skipError
+		var skipErr entrypoint.SkipError
 		if errors.As(err, &skipErr) {
 			close(doneCh)
 		} else {
@@ -292,7 +292,7 @@ func TestRealWaiterWaitContextWithErrorWaitfile(t *testing.T) {
 		if err == nil {
 			t.Errorf("expected skipError upon encounter error waitfile")
 		}
-		var skipErr skipError
+		var skipErr entrypoint.SkipError
 		if errors.As(err, &skipErr) {
 			close(doneCh)
 		} else {

--- a/docs/pipeline-api.md
+++ b/docs/pipeline-api.md
@@ -4641,6 +4641,16 @@ string
 <td>
 </td>
 </tr>
+<tr>
+<td>
+<code>terminationReason</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="tekton.dev/v1.StepTemplate">StepTemplate

--- a/docs/stepactions.md
+++ b/docs/stepactions.md
@@ -410,6 +410,7 @@ status:
   - container: step-action-runner
     imageID: docker.io/library/alpine@sha256:eece025e432126ce23f223450a0326fbebde39cdf496a85d8c016293fc851978
     name: action-runner
+    terminationReason: Completed
     terminated:
       containerID: containerd://46a836588967202c05b594696077b147a0eb0621976534765478925bb7ce57f6
       exitCode: 0

--- a/docs/taskruns.md
+++ b/docs/taskruns.md
@@ -799,6 +799,7 @@ The `status` field defines the observed state of `TaskRun`
     - `refSource`: the source from where a remote `Task` definition was fetched.
     - `featureFlags`: Identifies the feature flags used during the `TaskRun`.
   - `steps` - Contains the `state` of each `step` container.
+    - `steps[].terminationReason` - When the step is terminated, it stores the step's final state.
   - `retriesStatus` - Contains the history of `TaskRun`'s `status` in case of a retry in order to keep record of failures. No `status` stored within `retriesStatus` will have any `date` within as it is redundant.
 
   - [`sidecars`](tasks.md#using-a-sidecar-in-a-task) - This field is a list. The list has one entry per `sidecar` in the manifest. Each entry represents the imageid of the corresponding sidecar.
@@ -831,6 +832,7 @@ steps:
   - container: step-hello
     imageID: docker-pullable://busybox@sha256:895ab622e92e18d6b461d671081757af7dbaa3b00e3e28e12505af7817f73649
     name: hello
+    terminationReason: Completed
     terminated:
       containerID: docker://d5a54f5bbb8e7a6fd3bc7761b78410403244cf4c9c5822087fb0209bf59e3621
       exitCode: 0

--- a/pkg/apis/pipeline/v1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1/openapi_generated.go
@@ -3142,6 +3142,12 @@ func schema_pkg_apis_pipeline_v1_StepState(ref common.ReferenceCallback) common.
 							},
 						},
 					},
+					"terminationReason": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/apis/pipeline/v1/swagger.json
+++ b/pkg/apis/pipeline/v1/swagger.json
@@ -1609,6 +1609,9 @@
           "description": "Details about a terminated container",
           "$ref": "#/definitions/v1.ContainerStateTerminated"
         },
+        "terminationReason": {
+          "type": "string"
+        },
         "waiting": {
           "description": "Details about a waiting container",
           "$ref": "#/definitions/v1.ContainerStateWaiting"

--- a/pkg/apis/pipeline/v1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1/taskrun_types.go
@@ -358,6 +358,7 @@ type StepState struct {
 	Container             string              `json:"container,omitempty"`
 	ImageID               string              `json:"imageID,omitempty"`
 	Results               []TaskRunStepResult `json:"results,omitempty"`
+	TerminationReason     string              `json:"terminationReason,omitempty"`
 }
 
 // SidecarState reports the results of running a sidecar in a Task.

--- a/pkg/apis/pipeline/v1beta1/taskrun_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_conversion.go
@@ -344,6 +344,11 @@ func (ss StepState) convertTo(ctx context.Context, sink *v1.StepState) {
 	sink.Container = ss.ContainerName
 	sink.ImageID = ss.ImageID
 	sink.Results = nil
+
+	if ss.ContainerState.Terminated != nil {
+		sink.TerminationReason = ss.ContainerState.Terminated.Reason
+	}
+
 	for _, r := range ss.Results {
 		new := v1.TaskRunStepResult{}
 		r.convertTo(ctx, &new)

--- a/pkg/entrypoint/entrypointer.go
+++ b/pkg/entrypoint/entrypointer.go
@@ -55,11 +55,19 @@ func (e ContextError) Error() string {
 	return string(e)
 }
 
+type SkipError string
+
+func (e SkipError) Error() string {
+	return string(e)
+}
+
 var (
 	// ErrContextDeadlineExceeded is the error returned when the context deadline is exceeded
 	ErrContextDeadlineExceeded = ContextError(context.DeadlineExceeded.Error())
 	// ErrContextCanceled is the error returned when the context is canceled
 	ErrContextCanceled = ContextError(context.Canceled.Error())
+	// ErrSkipPreviousStepFailed is the error returned when the step is skipped due to previous step error
+	ErrSkipPreviousStepFailed = SkipError("error file present, bail and skip the step")
 )
 
 // IsContextDeadlineError determine whether the error is context deadline
@@ -167,6 +175,11 @@ func (e Entrypointer) Go() error {
 				Value:      time.Now().Format(timeFormat),
 				ResultType: result.InternalTektonResultType,
 			})
+
+			if errors.Is(err, ErrSkipPreviousStepFailed) {
+				output = append(output, e.outputRunResult(pod.TerminationReasonSkipped))
+			}
+
 			return err
 		}
 	}
@@ -199,26 +212,18 @@ func (e Entrypointer) Go() error {
 			}
 		}()
 		err = e.Runner.Run(ctx, e.Command...)
-		if errors.Is(err, ErrContextDeadlineExceeded) {
-			output = append(output, result.RunResult{
-				Key:        "Reason",
-				Value:      "TimeoutExceeded",
-				ResultType: result.InternalTektonResultType,
-			})
-		}
 	}
 
 	var ee *exec.ExitError
 	switch {
 	case err != nil && errors.Is(err, ErrContextCanceled):
 		logger.Info("Step was canceling")
-		output = append(output, result.RunResult{
-			Key:        "Reason",
-			Value:      "Cancelled",
-			ResultType: result.InternalTektonResultType,
-		})
+		output = append(output, e.outputRunResult(pod.TerminationReasonCancelled))
 		e.WritePostFile(e.PostFile, ErrContextCanceled)
 		e.WriteExitCodeFile(e.StepMetadataDir, syscall.SIGKILL.String())
+	case errors.Is(err, ErrContextDeadlineExceeded):
+		e.WritePostFile(e.PostFile, err)
+		output = append(output, e.outputRunResult(pod.TerminationReasonTimeoutExceeded))
 	case err != nil && e.BreakpointOnFailure:
 		logger.Info("Skipping writing to PostFile")
 	case e.OnError == ContinueOnError && errors.As(err, &ee):
@@ -452,4 +457,13 @@ func (e *Entrypointer) applyStepResultSubstitutions(stepDir string) error {
 	}
 	e.Command = newCommand
 	return nil
+}
+
+// outputRunResult returns the run reason for a termination
+func (e Entrypointer) outputRunResult(terminationReason string) result.RunResult {
+	return result.RunResult{
+		Key:        "Reason",
+		Value:      terminationReason,
+		ResultType: result.InternalTektonResultType,
+	}
 }

--- a/pkg/entrypoint/entrypointer_test.go
+++ b/pkg/entrypoint/entrypointer_test.go
@@ -901,29 +901,203 @@ func TestIsContextCanceledError(t *testing.T) {
 	}
 }
 
+func TestTerminationReason(t *testing.T) {
+	tests := []struct {
+		desc              string
+		waitFiles         []string
+		onError           string
+		runError          error
+		expectedRunErr    error
+		expectedExitCode  *string
+		expectedWrotefile *string
+		expectedStatus    []result.RunResult
+	}{
+		{
+			desc:              "reason completed",
+			expectedExitCode:  ptr("0"),
+			expectedWrotefile: ptr("postfile"),
+			expectedStatus: []result.RunResult{
+				{
+					Key:        "StartedAt",
+					ResultType: result.InternalTektonResultType,
+				},
+			},
+		},
+		{
+			desc:              "reason continued",
+			onError:           ContinueOnError,
+			runError:          ptr(exec.ExitError{}),
+			expectedRunErr:    ptr(exec.ExitError{}),
+			expectedExitCode:  ptr("-1"),
+			expectedWrotefile: ptr("postfile"),
+			expectedStatus: []result.RunResult{
+				{
+					Key:        "ExitCode",
+					Value:      "-1",
+					ResultType: result.InternalTektonResultType,
+				},
+				{
+					Key:        "StartedAt",
+					ResultType: result.InternalTektonResultType,
+				},
+			},
+		},
+		{
+			desc:              "reason errored",
+			runError:          ptr(exec.Error{}),
+			expectedRunErr:    ptr(exec.Error{}),
+			expectedWrotefile: ptr("postfile.err"),
+			expectedStatus: []result.RunResult{
+				{
+					Key:        "StartedAt",
+					ResultType: result.InternalTektonResultType,
+				},
+			},
+		},
+		{
+			desc:              "reason timedout",
+			runError:          ErrContextDeadlineExceeded,
+			expectedRunErr:    ErrContextDeadlineExceeded,
+			expectedWrotefile: ptr("postfile.err"),
+			expectedStatus: []result.RunResult{
+				{
+					Key:        "Reason",
+					Value:      pod.TerminationReasonTimeoutExceeded,
+					ResultType: result.InternalTektonResultType,
+				},
+				{
+					Key:        "StartedAt",
+					ResultType: result.InternalTektonResultType,
+				},
+			},
+		},
+		{
+			desc:              "reason skipped",
+			waitFiles:         []string{"file"},
+			expectedRunErr:    ErrSkipPreviousStepFailed,
+			expectedWrotefile: ptr("postfile.err"),
+			expectedStatus: []result.RunResult{
+				{
+					Key:        "Reason",
+					Value:      pod.TerminationReasonSkipped,
+					ResultType: result.InternalTektonResultType,
+				},
+				{
+					Key:        "StartedAt",
+					ResultType: result.InternalTektonResultType,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			fw, fr, fpw := &fakeWaiter{skipStep: true}, &fakeRunner{runError: test.runError}, &fakePostWriter{}
+
+			tmpFolder, err := os.MkdirTemp("", "")
+			if err != nil {
+				t.Fatalf("unexpected error creating temporary folder: %v", err)
+			} else {
+				defer os.RemoveAll(tmpFolder)
+			}
+
+			terminationFile, err := os.CreateTemp(tmpFolder, "termination")
+			if err != nil {
+				t.Fatalf("unexpected error creating termination file: %v", err)
+			}
+
+			e := Entrypointer{
+				Command:             append([]string{}, []string{}...),
+				WaitFiles:           test.waitFiles,
+				PostFile:            "postfile",
+				Waiter:              fw,
+				Runner:              fr,
+				PostWriter:          fpw,
+				TerminationPath:     terminationFile.Name(),
+				BreakpointOnFailure: false,
+				StepMetadataDir:     tmpFolder,
+				OnError:             test.onError,
+			}
+
+			err = e.Go()
+
+			if d := cmp.Diff(test.expectedRunErr, err); d != "" {
+				t.Fatalf("entrypoint error doesn't match %s", diff.PrintWantGot(d))
+			}
+
+			if d := cmp.Diff(test.expectedExitCode, fpw.exitCode); d != "" {
+				t.Fatalf("exitCode doesn't match %s", diff.PrintWantGot(d))
+			}
+
+			if d := cmp.Diff(test.expectedWrotefile, fpw.wrote); d != "" {
+				t.Fatalf("wrote file doesn't match %s", diff.PrintWantGot(d))
+			}
+
+			termination, err := getTermination(t, terminationFile.Name())
+			if err != nil {
+				t.Fatalf("error getting termination output: %v", err)
+			}
+
+			if d := cmp.Diff(test.expectedStatus, termination); d != "" {
+				t.Fatalf("termination status doesn't match %s", diff.PrintWantGot(d))
+			}
+		})
+	}
+}
+
+func getTermination(t *testing.T, terminationFile string) ([]result.RunResult, error) {
+	t.Helper()
+	fileContents, err := os.ReadFile(terminationFile)
+	if err != nil {
+		return nil, err
+	}
+
+	logger, _ := logging.NewLogger("", "status")
+	terminationStatus, err := termination.ParseMessage(logger, string(fileContents))
+	if err != nil {
+		return nil, err
+	}
+
+	for i, termination := range terminationStatus {
+		if termination.Key == "StartedAt" {
+			terminationStatus[i].Value = ""
+		}
+	}
+
+	return terminationStatus, nil
+}
+
 type fakeWaiter struct {
 	sync.Mutex
 	waited             []string
 	waitCancelDuration time.Duration
+	skipStep           bool
 }
 
 func (f *fakeWaiter) Wait(ctx context.Context, file string, _ bool, _ bool) error {
-	if file == pod.DownwardMountCancelFile && f.waitCancelDuration > 0 {
+	switch {
+	case file == pod.DownwardMountCancelFile && f.waitCancelDuration > 0:
 		time.Sleep(f.waitCancelDuration)
-	} else if file == pod.DownwardMountCancelFile {
+	case file == pod.DownwardMountCancelFile:
 		return nil
+	case f.skipStep:
+		return ErrSkipPreviousStepFailed
 	}
+
 	f.Lock()
 	f.waited = append(f.waited, file)
 	f.Unlock()
 	return nil
 }
 
-type fakeRunner struct{ args *[]string }
+type fakeRunner struct {
+	args     *[]string
+	runError error
+}
 
 func (f *fakeRunner) Run(ctx context.Context, args ...string) error {
 	f.args = &args
-	return nil
+	return f.runError
 }
 
 type fakePostWriter struct {
@@ -1056,4 +1230,8 @@ func getMockSpireClient(ctx context.Context) (spire.EntrypointerAPIClient, spire
 	}
 
 	return sc, sc, tr
+}
+
+func ptr[T any](value T) *T {
+	return &value
 }

--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -61,6 +61,18 @@ const (
 
 	// osSelectorLabel is the label Kubernetes uses for OS-specific workloads (https://kubernetes.io/docs/reference/labels-annotations-taints/#kubernetes-io-os)
 	osSelectorLabel = "kubernetes.io/os"
+
+	// TerminationReasonTimeoutExceeded indicates a step execution timed out.
+	TerminationReasonTimeoutExceeded = "TimeoutExceeded"
+
+	// TerminationReasonSkipped indicates a step execution was skipped due to previous step failed.
+	TerminationReasonSkipped = "Skipped"
+
+	// TerminationReasonContinued indicates a step errored but was ignored since onError was set to continue.
+	TerminationReasonContinued = "Continued"
+
+	// TerminationReasonCancelled indicates a step was cancelled.
+	TerminationReasonCancelled = "Cancelled"
 )
 
 // These are effectively const, but Go doesn't have such an annotation.

--- a/pkg/pod/status.go
+++ b/pkg/pod/status.go
@@ -272,6 +272,7 @@ func setTaskRunStatusBasedOnStepStatus(ctx context.Context, logger *zap.SugaredL
 		}
 
 		// Parse termination messages
+		terminationReason := ""
 		if state.Terminated != nil && len(state.Terminated.Message) != 0 {
 			msg := state.Terminated.Message
 
@@ -311,14 +312,18 @@ func setTaskRunStatusBasedOnStepStatus(ctx context.Context, logger *zap.SugaredL
 				if exitCode != nil {
 					state.Terminated.ExitCode = *exitCode
 				}
+
+				terminationFromResults := extractTerminationReasonFromResults(results)
+				terminationReason = getTerminationReason(state.Terminated.Reason, terminationFromResults, exitCode)
 			}
 		}
 		trs.Steps = append(trs.Steps, v1.StepState{
-			ContainerState: *state,
-			Name:           trimStepPrefix(s.Name),
-			Container:      s.Name,
-			ImageID:        s.ImageID,
-			Results:        taskRunStepResults,
+			ContainerState:    *state,
+			Name:              trimStepPrefix(s.Name),
+			Container:         s.Name,
+			ImageID:           s.ImageID,
+			Results:           taskRunStepResults,
+			TerminationReason: terminationReason,
 		})
 	}
 
@@ -488,6 +493,27 @@ func extractExitCodeFromResults(results []result.RunResult) (*int32, error) {
 	return nil, nil //nolint:nilnil // would be more ergonomic to return a sentinel error
 }
 
+func extractTerminationReasonFromResults(results []result.RunResult) string {
+	for _, r := range results {
+		if r.ResultType == result.InternalTektonResultType && r.Key == "Reason" {
+			return r.Value
+		}
+	}
+	return ""
+}
+
+func getTerminationReason(terminatedStateReason string, terminationFromResults string, exitCodeFromResults *int32) string {
+	if terminationFromResults != "" {
+		return terminationFromResults
+	}
+
+	if exitCodeFromResults != nil {
+		return TerminationReasonContinued
+	}
+
+	return terminatedStateReason
+}
+
 func updateCompletedTaskRunStatus(logger *zap.SugaredLogger, trs *v1.TaskRunStatus, pod *corev1.Pod, onError v1.PipelineTaskOnErrorType) {
 	if DidTaskRunFail(pod) {
 		msg := getFailureMessage(logger, pod)
@@ -612,7 +638,7 @@ func extractContainerFailureMessage(logger *zap.SugaredLogger, status corev1.Con
 		msg := status.State.Terminated.Message
 		r, _ := termination.ParseMessage(logger, msg)
 		for _, runResult := range r {
-			if runResult.ResultType == result.InternalTektonResultType && runResult.Key == "Reason" && runResult.Value == "TimeoutExceeded" {
+			if runResult.ResultType == result.InternalTektonResultType && runResult.Key == "Reason" && runResult.Value == TerminationReasonTimeoutExceeded {
 				return fmt.Sprintf("%q exited because the step exceeded the specified timeout limit", status.Name)
 			}
 		}

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -757,6 +757,7 @@ func terminateStepsInPod(tr *v1.TaskRun, taskRunReason v1.TaskRunReason) {
 				Reason:  taskRunReason.String(),
 				Message: fmt.Sprintf("Step %s terminated as pod %s is terminated", step.Name, tr.Status.PodName),
 			}
+			step.TerminationReason = taskRunReason.String()
 			step.Running = nil
 			tr.Status.Steps[i] = step
 		}
@@ -769,6 +770,7 @@ func terminateStepsInPod(tr *v1.TaskRun, taskRunReason v1.TaskRunReason) {
 				Reason:  taskRunReason.String(),
 				Message: fmt.Sprintf("Step %s terminated as pod %s is terminated", step.Name, tr.Status.PodName),
 			}
+			step.TerminationReason = taskRunReason.String()
 			step.Waiting = nil
 			tr.Status.Steps[i] = step
 		}

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -4619,6 +4619,7 @@ status:
 		},
 		expectedStepStates: []v1.StepState{
 			{
+				TerminationReason: v1.TaskRunReasonCancelled.String(),
 				ContainerState: corev1.ContainerState{
 					Terminated: &corev1.ContainerStateTerminated{
 						ExitCode: 1,
@@ -4665,6 +4666,7 @@ status:
 		},
 		expectedStepStates: []v1.StepState{
 			{
+				TerminationReason: v1.TaskRunReasonCancelled.String(),
 				ContainerState: corev1.ContainerState{
 					Terminated: &corev1.ContainerStateTerminated{
 						ExitCode: 1,
@@ -4707,6 +4709,7 @@ status:
 		},
 		expectedStepStates: []v1.StepState{
 			{
+				TerminationReason: v1.TaskRunReasonTimedOut.String(),
 				ContainerState: corev1.ContainerState{
 					Terminated: &corev1.ContainerStateTerminated{
 						ExitCode: 1,
@@ -4764,6 +4767,7 @@ status:
 				},
 			},
 			{
+				TerminationReason: v1.TaskRunReasonTimedOut.String(),
 				ContainerState: corev1.ContainerState{
 					Terminated: &corev1.ContainerStateTerminated{
 						ExitCode: 1,
@@ -4773,6 +4777,7 @@ status:
 				},
 			},
 			{
+				TerminationReason: v1.TaskRunReasonTimedOut.String(),
 				ContainerState: corev1.ContainerState{
 					Terminated: &corev1.ContainerStateTerminated{
 						ExitCode: 1,
@@ -4819,6 +4824,7 @@ status:
 		},
 		expectedStepStates: []v1.StepState{
 			{
+				TerminationReason: v1.TaskRunReasonTimedOut.String(),
 				ContainerState: corev1.ContainerState{
 					Terminated: &corev1.ContainerStateTerminated{
 						ExitCode: 1,
@@ -4828,6 +4834,7 @@ status:
 				},
 			},
 			{
+				TerminationReason: v1.TaskRunReasonTimedOut.String(),
 				ContainerState: corev1.ContainerState{
 					Terminated: &corev1.ContainerStateTerminated{
 						ExitCode: 1,
@@ -4837,6 +4844,7 @@ status:
 				},
 			},
 			{
+				TerminationReason: v1.TaskRunReasonTimedOut.String(),
 				ContainerState: corev1.ContainerState{
 					Terminated: &corev1.ContainerStateTerminated{
 						ExitCode: 1,
@@ -4866,6 +4874,7 @@ status:
       finishedAt: "2022-01-01T00:00:00Z"
       reason: Completed
       startedAt: "2022-01-01T00:00:00Z"
+    terminationReason: Completed
   - running:
       startedAt: "2022-01-01T00:00:00Z"
 `),
@@ -4883,6 +4892,7 @@ status:
 		},
 		expectedStepStates: []v1.StepState{
 			{
+				TerminationReason: "Completed",
 				ContainerState: corev1.ContainerState{
 					Terminated: &corev1.ContainerStateTerminated{
 						ExitCode: 12,
@@ -4891,6 +4901,7 @@ status:
 				},
 			},
 			{
+				TerminationReason: v1.TaskRunReasonTimedOut.String(),
 				ContainerState: corev1.ContainerState{
 					Terminated: &corev1.ContainerStateTerminated{
 						ExitCode: 1,

--- a/test/conversion_test.go
+++ b/test/conversion_test.go
@@ -468,6 +468,7 @@ status:
   steps:
   - container: step-echo
     name: step-echo
+    terminationReason: Completed
     terminated:
       reason: Completed
 `
@@ -734,6 +735,7 @@ status:
   - image: alpine
     name: hello
     script: 'echo Hello'
+    terminationReason: Completed
     terminated:
       reason: Completed
 `

--- a/test/propagated_params_test.go
+++ b/test/propagated_params_test.go
@@ -43,7 +43,7 @@ var (
 	ignoreTaskRunStatus     = cmpopts.IgnoreFields(v1.TaskRunStatusFields{}, "StartTime", "CompletionTime")
 	ignoreConditions        = cmpopts.IgnoreFields(duckv1.Status{}, "Conditions")
 	ignoreContainerStates   = cmpopts.IgnoreFields(corev1.ContainerState{}, "Terminated")
-	ignoreStepState         = cmpopts.IgnoreFields(v1.StepState{}, "ImageID")
+	ignoreStepState         = cmpopts.IgnoreFields(v1.StepState{}, "ImageID", "TerminationReason")
 	// ignoreSATaskRunSpec ignores the service account in the TaskRunSpec as it may differ across platforms
 	ignoreSATaskRunSpec = cmpopts.IgnoreFields(v1.TaskRunSpec{}, "ServiceAccountName")
 	// ignoreSAPipelineRunSpec ignores the service account in the PipelineRunSpec as it may differ across platforms

--- a/test/taskrun_test.go
+++ b/test/taskrun_test.go
@@ -21,6 +21,7 @@ package test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"strings"
@@ -31,8 +32,10 @@ import (
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/pod"
 	"github.com/tektoncd/pipeline/test/parse"
+	jsonpatch "gomodules.xyz/jsonpatch/v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	knativetest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/helpers"
 )
@@ -99,8 +102,9 @@ spec:
 				Reason:   "Completed",
 			},
 		},
-		Name:      "unnamed-0",
-		Container: "step-unnamed-0",
+		TerminationReason: "Completed",
+		Name:              "unnamed-0",
+		Container:         "step-unnamed-0",
 	}, {
 		ContainerState: corev1.ContainerState{
 			Terminated: &corev1.ContainerStateTerminated{
@@ -108,8 +112,9 @@ spec:
 				Reason:   "Error",
 			},
 		},
-		Name:      "unnamed-1",
-		Container: "step-unnamed-1",
+		TerminationReason: "Error",
+		Name:              "unnamed-1",
+		Container:         "step-unnamed-1",
 	}, {
 		ContainerState: corev1.ContainerState{
 			Terminated: &corev1.ContainerStateTerminated{
@@ -117,8 +122,9 @@ spec:
 				Reason:   "Error",
 			},
 		},
-		Name:      "unnamed-2",
-		Container: "step-unnamed-2",
+		TerminationReason: "Skipped",
+		Name:              "unnamed-2",
+		Container:         "step-unnamed-2",
 	}}
 	ignoreTerminatedFields := cmpopts.IgnoreFields(corev1.ContainerStateTerminated{}, "StartedAt", "FinishedAt", "ContainerID")
 	ignoreStepFields := cmpopts.IgnoreFields(v1.StepState{}, "ImageID")
@@ -185,6 +191,7 @@ spec:
 	}
 
 	expectedStepState := []v1.StepState{{
+		TerminationReason: "Completed",
 		ContainerState: corev1.ContainerState{
 			Terminated: &corev1.ContainerStateTerminated{
 				ExitCode: 0,
@@ -208,4 +215,278 @@ spec:
 	if d := cmp.Diff(taskrun.Status.TaskSpec, &task.Spec); d != "" {
 		t.Fatalf("-got, +want: %v", d)
 	}
+}
+
+func TestTaskRunStepsTerminationReasons(t *testing.T) {
+	ctx := context.Background()
+	c, namespace := setup(ctx, t)
+	defer tearDown(ctx, t, c, namespace)
+	fqImageName := getTestImage(busyboxImage)
+
+	tests := []struct {
+		description        string
+		shouldSucceed      bool
+		taskRun            string
+		shouldCancel       bool
+		expectedStepStatus []v1.StepState
+	}{
+		{
+			description:   "termination completed",
+			shouldSucceed: true,
+			taskRun: `
+metadata:
+  name: %v
+  namespace: %v
+spec:
+  taskSpec:
+    steps:
+    - image: %v
+      name: first
+      command: ['/bin/sh']
+      args: ['-c', 'echo hello']`,
+			expectedStepStatus: []v1.StepState{
+				{
+					Container:         "step-first",
+					Name:              "first",
+					TerminationReason: "Completed",
+					ContainerState: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							ExitCode: 0,
+							Reason:   "Completed",
+						},
+					},
+				},
+			},
+		},
+		{
+			description:   "termination continued",
+			shouldSucceed: true,
+			taskRun: `
+metadata:
+  name: %v
+  namespace: %v
+spec:
+  taskSpec:
+    steps:
+    - image: %v
+      onError: continue
+      name: first
+      command: ['/bin/sh']
+      args: ['-c', 'echo hello; exit 1']`,
+			expectedStepStatus: []v1.StepState{
+				{
+					Container:         "step-first",
+					Name:              "first",
+					TerminationReason: "Continued",
+					ContainerState: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							ExitCode: 1,
+							Reason:   "Completed",
+						},
+					},
+				},
+			},
+		},
+		{
+			description:   "termination errored",
+			shouldSucceed: false,
+			taskRun: `
+metadata:
+  name: %v
+  namespace: %v
+spec:
+  taskSpec:
+    steps:
+    - image: %v
+      name: first
+      command: ['/bin/sh']
+      args: ['-c', 'echo hello; exit 1']`,
+			expectedStepStatus: []v1.StepState{
+				{
+					Container:         "step-first",
+					Name:              "first",
+					TerminationReason: "Error",
+					ContainerState: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							ExitCode: 1,
+							Reason:   "Error",
+						},
+					},
+				},
+			},
+		},
+		{
+			description:   "termination timedout",
+			shouldSucceed: false,
+			taskRun: `
+metadata:
+  name: %v
+  namespace: %v
+spec:
+  taskSpec:
+    steps:
+    - image: %v
+      name: first
+      timeout: 1s
+      command: ['/bin/sh']
+      args: ['-c', 'echo hello; sleep 5s']`,
+			expectedStepStatus: []v1.StepState{
+				{
+					Container:         "step-first",
+					Name:              "first",
+					TerminationReason: "TimeoutExceeded",
+					ContainerState: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							ExitCode: 1,
+							Reason:   "Error",
+						},
+					},
+				},
+			},
+		},
+		{
+			description:   "termination skipped",
+			shouldSucceed: false,
+			taskRun: `
+metadata:
+  name: %v
+  namespace: %v
+spec:
+  taskSpec:
+    steps:
+    - image: %v
+      name: first
+      command: ['/bin/sh']
+      args: ['-c', 'echo hello; exit 1']
+    - image: %v
+      name: second
+      command: ['/bin/sh']
+      args: ['-c', 'echo hello']`,
+			expectedStepStatus: []v1.StepState{
+				{
+					Container:         "step-first",
+					Name:              "first",
+					TerminationReason: "Error",
+					ContainerState: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							ExitCode: 1,
+							Reason:   "Error",
+						},
+					},
+				},
+				{
+					Container:         "step-second",
+					Name:              "second",
+					TerminationReason: "Skipped",
+					ContainerState: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							ExitCode: 1,
+							Reason:   "Error",
+						},
+					},
+				},
+			},
+		},
+		{
+			description:   "termination cancelled",
+			shouldSucceed: false,
+			shouldCancel:  true,
+			taskRun: `
+metadata:
+  name: %v
+  namespace: %v
+spec:
+  taskSpec:
+    steps:
+    - image: %v
+      name: first
+      command: ['/bin/sh']
+      args: ['-c', 'sleep infinity; echo hello']`,
+			expectedStepStatus: []v1.StepState{
+				{
+					Container:         "step-first",
+					Name:              "first",
+					TerminationReason: "TaskRunCancelled",
+					ContainerState: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							ExitCode: 1,
+							Reason:   "TaskRunCancelled",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			taskRunName := helpers.ObjectNameForTest(t)
+			values := []interface{}{taskRunName, namespace}
+			for range test.expectedStepStatus {
+				values = append(values, fqImageName)
+			}
+			taskRunYaml := fmt.Sprintf(test.taskRun, values...)
+			taskRun := parse.MustParseV1TaskRun(t, taskRunYaml)
+
+			if _, err := c.V1TaskRunClient.Create(ctx, taskRun, metav1.CreateOptions{}); err != nil {
+				t.Fatalf("Failed to create TaskRun: %s", err)
+			}
+
+			expectedTaskRunState := TaskRunFailed(taskRunName)
+			finalStatus := "Failed"
+			if test.shouldSucceed {
+				expectedTaskRunState = TaskRunSucceed(taskRunName)
+				finalStatus = "Succeeded"
+			}
+
+			if test.shouldCancel {
+				expectedTaskRunState = FailedWithReason("TaskRunCancelled", taskRunName)
+				if err := cancelTaskRun(t, ctx, taskRunName, c); err != nil {
+					t.Fatalf("Error cancelling taskrun: %s", err)
+				}
+			}
+
+			err := WaitForTaskRunState(ctx, c, taskRunName, expectedTaskRunState, finalStatus, v1Version)
+			if err != nil {
+				t.Fatalf("Error waiting for TaskRun to finish: %s", err)
+			}
+
+			taskRunState, err := c.V1TaskRunClient.Get(ctx, taskRunName, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("Couldn't get expected TaskRun %s: %s", taskRunName, err)
+			}
+
+			ignoreTerminatedFields := cmpopts.IgnoreFields(corev1.ContainerStateTerminated{}, "StartedAt", "FinishedAt", "ContainerID", "Message")
+			ignoreStepFields := cmpopts.IgnoreFields(v1.StepState{}, "ImageID")
+			if d := cmp.Diff(taskRunState.Status.Steps, test.expectedStepStatus, ignoreTerminatedFields, ignoreStepFields); d != "" {
+				t.Fatalf("-got, +want: %v", d)
+			}
+		})
+	}
+}
+
+func cancelTaskRun(t *testing.T, ctx context.Context, taskRunName string, c *clients) error {
+	t.Helper()
+
+	err := WaitForTaskRunState(ctx, c, taskRunName, Running(taskRunName), "Running", v1Version)
+	if err != nil {
+		t.Fatalf("Error waiting for TaskRun to start running before cancelling: %s", err)
+	}
+
+	patches := []jsonpatch.JsonPatchOperation{{
+		Operation: "add",
+		Path:      "/spec/status",
+		Value:     "TaskRunCancelled",
+	}}
+
+	patchBytes, err := json.Marshal(patches)
+	if err != nil {
+		return err
+	}
+
+	if _, err := c.V1TaskRunClient.Patch(ctx, taskRunName, types.JSONPatchType, patchBytes, metav1.PatchOptions{}, ""); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/test/upgrade_test.go
+++ b/test/upgrade_test.go
@@ -147,10 +147,12 @@ status:
   steps:
   - container: step-echo
     name: step-echo
+    terminationReason: Completed
     terminated:
       reason: Completed
   - container: check-workspace
     name: check-workspace
+    terminationReason: Completed
     terminated:
       reason: Completed
 `


### PR DESCRIPTION
Fixes https://github.com/tektoncd/pipeline/issues/7223 and https://github.com/tektoncd/pipeline/issues/7539

To report specific Steps termination reasons we need to know why its container finished; we use the termination message to store a new "state" with this information. To avoid breaking changes we are introducing a new `status.steps[].terminationReason` in TaskRun, to store the information from the container state for each step.

The schema conversion logic for v1beta1 to v1 is modified to take into account the new field introduced in v1 TaskRun.

/kind feature

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Steps in a TaskRun will have more granular termination reasons indicating what exactly happened in new terminationReason field: Completed, Continued, Error, TimeoutExceeded, Skipped, TaskRunCancelled
```
