### PR TITLE
kind/bug allowExecution evaluation for when expression returns early when CEL is defined 

### DIFF
--- a/pkg/apis/pipeline/v1/when_types.go
+++ b/pkg/apis/pipeline/v1/when_types.go
@@ -105,10 +105,7 @@ type WhenExpressions []WhenExpression
 // if the Task should be skipped.
 func (wes WhenExpressions) AllowsExecution(evaluatedCEL map[string]bool) bool {
 	for _, we := range wes {
-		if we.CEL != "" {
-			return evaluatedCEL[we.CEL]
-		}
-		if !we.isTrue() {
+		if !we.isTrue() || (we.CEL != "" && !evaluatedCEL[we.CEL]) {
 			return false
 		}
 	}

--- a/pkg/apis/pipeline/v1/when_types_test.go
+++ b/pkg/apis/pipeline/v1/when_types_test.go
@@ -96,7 +96,36 @@ func TestAllowsExecution(t *testing.T) {
 		},
 		evaluatedCEL: map[string]bool{"'foo'!='foo'": false},
 		expected:     false,
-	}}
+	},
+		{
+			name: "multiple expressions - 1. CEL is true 2. In Op is false, expect false",
+			whenExpressions: WhenExpressions{
+				{
+					CEL: "'foo'=='foo'",
+				},
+				{
+					Input:    "foo",
+					Operator: selection.In,
+					Values:   []string{"bar"},
+				},
+			},
+			evaluatedCEL: map[string]bool{"'foo'=='foo'": true},
+			expected:     false,
+		},
+		{
+			name: "multiple expressions - 1. CEL is true 2. CEL is false, expect false",
+			whenExpressions: WhenExpressions{
+				{
+					CEL: "'foo'!='foo'",
+				},
+				{
+					CEL: "'xxx'!='xxx'",
+				},
+			},
+			evaluatedCEL: map[string]bool{"'foo'=='foo'": true, "'xxx'!='xxx'": false},
+			expected:     false,
+		},
+	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			got := tc.whenExpressions.AllowsExecution(tc.evaluatedCEL)

--- a/pkg/apis/pipeline/v1beta1/when_types.go
+++ b/pkg/apis/pipeline/v1beta1/when_types.go
@@ -105,10 +105,7 @@ type WhenExpressions []WhenExpression
 // if the Task should be skipped.
 func (wes WhenExpressions) AllowsExecution(evaluatedCEL map[string]bool) bool {
 	for _, we := range wes {
-		if we.CEL != "" {
-			return evaluatedCEL[we.CEL]
-		}
-		if !we.isTrue() {
+		if !we.isTrue() || (we.CEL != "" && !evaluatedCEL[we.CEL]) {
 			return false
 		}
 	}

--- a/pkg/apis/pipeline/v1beta1/when_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/when_types_test.go
@@ -96,7 +96,36 @@ func TestAllowsExecution(t *testing.T) {
 		},
 		evaluatedCEL: map[string]bool{"'foo'!='foo'": false},
 		expected:     false,
-	}}
+	},
+		{
+			name: "multiple expressions - 1. CEL is true 2. In Op is false, expect false",
+			whenExpressions: WhenExpressions{
+				{
+					CEL: "'foo'=='foo'",
+				},
+				{
+					Input:    "foo",
+					Operator: selection.In,
+					Values:   []string{"bar"},
+				},
+			},
+			evaluatedCEL: map[string]bool{"'foo'=='foo'": true},
+			expected:     false,
+		},
+		{
+			name: "multiple expressions - 1. CEL is true 2. CEL is false, expect false",
+			whenExpressions: WhenExpressions{
+				{
+					CEL: "'foo'!='foo'",
+				},
+				{
+					CEL: "'xxx'!='xxx'",
+				},
+			},
+			evaluatedCEL: map[string]bool{"'foo'=='foo'": true, "'xxx'!='xxx'": false},
+			expected:     false,
+		},
+	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			got := tc.whenExpressions.AllowsExecution(tc.evaluatedCEL)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
 - fixes: #7559
 - AllowExecution method should only return true if all when expression is true, the previous logic returns early when CEL is defined, it ignores the rest other false results.
 - The pr fix the issue ^ 



