### PR TITLE
update docker-in-docker testimage for s390x

### DIFF
--- a/test/examples_test.go
+++ b/test/examples_test.go
@@ -271,7 +271,7 @@ func imageNamesMapping() map[string]string {
 			"registry":                              getTestImage(registryImage),
 			"node":                                  "node:alpine3.11",
 			"gcr.io/cloud-builders/git":             "alpine/git:latest",
-			"docker:dind":                           "ibmcom/docker-s390x:20.10",
+			"docker@sha256:74e78208fc18da48ddf8b569abe21563730845c312130bd0f0b059746a7e10f5":                           "ibmcom/docker-s390x:20.10",
 			"docker":                                "docker:18.06.3",
 			"mikefarah/yq:3":                        "danielxlee/yq:2.4.0",
 			"stedolan/jq":                           "ibmcom/jq-s390x:latest",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
https://github.com/tektoncd/pipeline/issues/7496 This PR is updated the docker:dind image in the test examples. this is not multi arch image, its failing in s390x CI platforms, so use different image for s390x platform. 

CI Failure:
https://dashboard.dogfooding.tekton.dev/#/namespaces/bastion-z/pipelineruns/tekton-pipeline-s390x-nightly-run-mnhzc?pipelineTask=examples-test-pipeline 

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
