### PR TITLE
fix: ensure clustertask annotations are synced to taskrun

### DIFF
--- a/pkg/reconciler/taskrun/resources/taskref.go
+++ b/pkg/reconciler/taskrun/resources/taskref.go
@@ -295,10 +295,12 @@ func convertClusterTaskToTask(ctx context.Context, ct v1beta1.ClusterTask) (*v1.
 			Kind:       "Task",
 			APIVersion: "tekton.dev/v1beta1",
 		},
+		// We need to keep ObjectMeta to keep consistent with the existing Task logic.
+		// TaskRun will inherit the original Annotations and Labels information.
+		ObjectMeta: ct.ObjectMeta,
 	}
 
 	t.Spec = ct.Spec
-	t.ObjectMeta.Name = ct.ObjectMeta.Name
 
 	v1Task := &v1.Task{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/reconciler/taskrun/resources/taskref_test.go
+++ b/pkg/reconciler/taskrun/resources/taskref_test.go
@@ -228,6 +228,12 @@ func TestLocalTaskRef(t *testing.T) {
 				&v1beta1.ClusterTask{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "cluster-task",
+						Annotations: map[string]string{
+							"foo": "bar",
+						},
+						Labels: map[string]string{
+							"foo": "bar",
+						},
 					},
 				},
 				&v1beta1.ClusterTask{
@@ -247,6 +253,12 @@ func TestLocalTaskRef(t *testing.T) {
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-task",
+					Annotations: map[string]string{
+						"foo": "bar",
+					},
+					Labels: map[string]string{
+						"foo": "bar",
+					},
 				},
 			},
 			wantErr: nil,


### PR DESCRIPTION
fix #7601

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
fix: ensure `ClusterTask` annotations and labels are synced to `TaskRun`
```
/kind bug