### PR TITLE
TEP-0138 New features to use Per-feature flag struct

### DIFF
--- a/pkg/apis/config/feature_flags_test.go
+++ b/pkg/apis/config/feature_flags_test.go
@@ -53,6 +53,10 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 				SetSecurityContext:               config.DefaultSetSecurityContext,
 				Coschedule:                       config.DefaultCoschedule,
 				EnforceNonfalsifiability:         config.DefaultEnforceNonfalsifiability,
+				EnableKeepPodOnCancel:            config.DefaultEnableKeepPodOnCancel.Enabled,
+				EnableCELInWhenExpression:        config.DefaultEnableCELInWhenExpression.Enabled,
+				EnableStepActions:                config.DefaultEnableStepActions.Enabled,
+				EnableParamEnum:                  config.DefaultEnableParamEnum.Enabled,
 			},
 			fileName: config.GetFeatureFlagsConfigName(),
 		},
@@ -98,6 +102,10 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 				MaxResultSize:                    config.DefaultMaxResultSize,
 				SetSecurityContext:               config.DefaultSetSecurityContext,
 				Coschedule:                       config.DefaultCoschedule,
+				EnableKeepPodOnCancel:            config.DefaultEnableKeepPodOnCancel.Enabled,
+				EnableCELInWhenExpression:        config.DefaultEnableCELInWhenExpression.Enabled,
+				EnableStepActions:                config.DefaultEnableStepActions.Enabled,
+				EnableParamEnum:                  config.DefaultEnableParamEnum.Enabled,
 			},
 			fileName: "feature-flags-enable-api-fields-overrides-bundles-and-custom-tasks",
 		},
@@ -118,6 +126,7 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 				MaxResultSize:                    config.DefaultMaxResultSize,
 				SetSecurityContext:               config.DefaultSetSecurityContext,
 				Coschedule:                       config.DefaultCoschedule,
+				EnableParamEnum:                  config.DefaultEnableParamEnum.Enabled,
 			},
 			fileName: "feature-flags-bundles-and-custom-tasks",
 		},
@@ -138,6 +147,7 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 				MaxResultSize:                    config.DefaultMaxResultSize,
 				SetSecurityContext:               config.DefaultSetSecurityContext,
 				Coschedule:                       config.DefaultCoschedule,
+				EnableParamEnum:                  config.DefaultEnableParamEnum.Enabled,
 			},
 			fileName: "feature-flags-beta-api-fields",
 		},
@@ -154,6 +164,10 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 				MaxResultSize:                    config.DefaultMaxResultSize,
 				SetSecurityContext:               config.DefaultSetSecurityContext,
 				Coschedule:                       config.DefaultCoschedule,
+				EnableKeepPodOnCancel:            config.DefaultEnableKeepPodOnCancel.Enabled,
+				EnableCELInWhenExpression:        config.DefaultEnableCELInWhenExpression.Enabled,
+				EnableStepActions:                config.DefaultEnableStepActions.Enabled,
+				EnableParamEnum:                  config.DefaultEnableParamEnum.Enabled,
 			},
 			fileName: "feature-flags-enforce-nonfalsifiability-spire",
 		},
@@ -169,6 +183,10 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 				MaxResultSize:                    8192,
 				SetSecurityContext:               config.DefaultSetSecurityContext,
 				Coschedule:                       config.DefaultCoschedule,
+				EnableKeepPodOnCancel:            config.DefaultEnableKeepPodOnCancel.Enabled,
+				EnableCELInWhenExpression:        config.DefaultEnableCELInWhenExpression.Enabled,
+				EnableStepActions:                config.DefaultEnableStepActions.Enabled,
+				EnableParamEnum:                  config.DefaultEnableParamEnum.Enabled,
 			},
 			fileName: "feature-flags-results-via-sidecar-logs",
 		},
@@ -201,6 +219,10 @@ func TestNewFeatureFlagsFromEmptyConfigMap(t *testing.T) {
 		MaxResultSize:                    config.DefaultMaxResultSize,
 		SetSecurityContext:               config.DefaultSetSecurityContext,
 		Coschedule:                       config.DefaultCoschedule,
+		EnableKeepPodOnCancel:            config.DefaultEnableKeepPodOnCancel.Enabled,
+		EnableCELInWhenExpression:        config.DefaultEnableCELInWhenExpression.Enabled,
+		EnableStepActions:                config.DefaultEnableStepActions.Enabled,
+		EnableParamEnum:                  config.DefaultEnableParamEnum.Enabled,
 	}
 	verifyConfigFileWithExpectedFeatureFlagsConfig(t, FeatureFlagsConfigEmptyName, expectedConfig)
 }
@@ -265,7 +287,7 @@ func TestNewFeatureFlagsConfigMapErrors(t *testing.T) {
 		want:     `invalid value for feature flag "coschedule": "invalid"`,
 	}, {
 		fileName: "feature-flags-invalid-keep-pod-on-cancel",
-		want:     `failed parsing feature flags config "invalid": strconv.ParseBool: parsing "invalid": invalid syntax`,
+		want:     `failed parsing feature flags config "invalid": strconv.ParseBool: parsing "invalid": invalid syntax for feature keep-pod-on-cancel`,
 	}, {
 		fileName: "feature-flags-invalid-running-in-environment-with-injected-sidecars",
 		want:     `failed parsing feature flags config "invalid-boolean": strconv.ParseBool: parsing "invalid-boolean": invalid syntax`,
@@ -274,13 +296,13 @@ func TestNewFeatureFlagsConfigMapErrors(t *testing.T) {
 		want:     `failed parsing feature flags config "truee": strconv.ParseBool: parsing "truee": invalid syntax`,
 	}, {
 		fileName: "feature-flags-invalid-enable-cel-in-whenexpression",
-		want:     `failed parsing feature flags config "invalid": strconv.ParseBool: parsing "invalid": invalid syntax`,
+		want:     `failed parsing feature flags config "invalid": strconv.ParseBool: parsing "invalid": invalid syntax for feature enable-cel-in-whenexpression`,
 	}, {
 		fileName: "feature-flags-invalid-enable-step-actions",
-		want:     `failed parsing feature flags config "invalid": strconv.ParseBool: parsing "invalid": invalid syntax`,
+		want:     `failed parsing feature flags config "invalid": strconv.ParseBool: parsing "invalid": invalid syntax for feature enable-step-actions`,
 	}, {
 		fileName: "feature-flags-invalid-enable-param-enum",
-		want:     `failed parsing feature flags config "invalid": strconv.ParseBool: parsing "invalid": invalid syntax`,
+		want:     `failed parsing feature flags config "invalid": strconv.ParseBool: parsing "invalid": invalid syntax for feature enable-param-enum`,
 	}} {
 		t.Run(tc.fileName, func(t *testing.T) {
 			cm := test.ConfigMapFromTestFile(t, tc.fileName)


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This commit uses the Per-feature flag struct for features added in between the window that the changes per TEP0138 was made. All new features should conform to the new Per-feature flag struct.

/kind misc
fixes: #7285

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
