### PR TITLE
implementing TEP-0150 - `displayName` in `childReferences`

### DIFF
--- a/docs/pipeline-api.md
+++ b/docs/pipeline-api.md
@@ -1419,6 +1419,18 @@ string
 </tr>
 <tr>
 <td>
+<code>displayName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>DisplayName is a user-facing name of the pipelineTask that may be
+used to populate a UI.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>pipelineTaskName</code><br/>
 <em>
 string
@@ -9705,6 +9717,18 @@ string
 </td>
 <td>
 <p>Name is the name of the TaskRun or Run this is referencing.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>displayName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>DisplayName is a user-facing name of the pipelineTask that may be
+used to populate a UI.</p>
 </td>
 </tr>
 <tr>

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -434,6 +434,10 @@ Specifying task results in the `displayName` does not introduce an inherent reso
 pipeline author is responsible for specifying dependency explicitly either using [runAfter](#using-the-runafter-field)
 or rely on [whenExpressions](#guard-task-execution-using-when-expressions) or [task results in params](#using-results).
 
+Fully resolved `displayName` is also available in the status as part of the `pipelineRun.status.childReferences`. The
+clients such as the dashboard, CLI, etc. can retrieve the `displayName` from the `childReferences`. The `displayName` mainly
+drives a better user experience and at the same time it is not validated for the content or length by the controller.
+
 ### Specifying Remote Tasks
 
 **([beta feature](https://github.com/tektoncd/pipeline/blob/main/docs/install.md#beta-features))**
@@ -1541,6 +1545,10 @@ spec:
 The `displayName` also allows you to parameterize the human-readable name of your choice based on the
 [params](#specifying-parameters), [the task results](#consuming-task-execution-results-in-finally),
 and [the context variables](#context-variables).
+
+Fully resolved `displayName` is also available in the status as part of the `pipelineRun.status.childReferences`. The
+clients such as the dashboard, CLI, etc. can retrieve the `displayName` from the `childReferences`. The `displayName` mainly
+drives a better user experience and at the same time it is not validated for the content or length by the controller.
 
 ### Specifying `Workspaces` in `finally` tasks
 

--- a/examples/v1/pipelineruns/beta/pipelinerun-with-matrix.yaml
+++ b/examples/v1/pipelineruns/beta/pipelinerun-with-matrix.yaml
@@ -25,6 +25,7 @@ spec:
   pipelineSpec:
     tasks:
       - name: platforms-and-browsers
+        displayName: "Platform: $(params.platform) with Browser: $(params.browser)"
         matrix:
           params:
             - name: platform
@@ -47,6 +48,18 @@ spec:
                 - linux
                 - mac
                 - windows
+        params:
+          - name: browser
+            value: chrome
+        taskRef:
+          name: platform-browsers
+      - name: matrix-and-params-include
+        matrix:
+          include:
+            - name: "Platform: $(params.platform) with Browser: $(params.browser)"
+              params:
+                - name: platform
+                  value: linux
         params:
           - name: browser
             value: chrome

--- a/pkg/apis/pipeline/v1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1/openapi_generated.go
@@ -481,6 +481,13 @@ func schema_pkg_apis_pipeline_v1_ChildStatusReference(ref common.ReferenceCallba
 							Format:      "",
 						},
 					},
+					"displayName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "DisplayName is a user-facing name of the pipelineTask that may be used to populate a UI.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"pipelineTaskName": {
 						SchemaProps: spec.SchemaProps{
 							Description: "PipelineTaskName is the name of the PipelineTask this is referencing.",

--- a/pkg/apis/pipeline/v1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1/pipelinerun_types.go
@@ -484,6 +484,9 @@ type ChildStatusReference struct {
 	runtime.TypeMeta `json:",inline"`
 	// Name is the name of the TaskRun or Run this is referencing.
 	Name string `json:"name,omitempty"`
+	// DisplayName is a user-facing name of the pipelineTask that may be
+	// used to populate a UI.
+	DisplayName string `json:"displayName,omitempty"`
 	// PipelineTaskName is the name of the PipelineTask this is referencing.
 	PipelineTaskName string `json:"pipelineTaskName,omitempty"`
 

--- a/pkg/apis/pipeline/v1/swagger.json
+++ b/pkg/apis/pipeline/v1/swagger.json
@@ -192,6 +192,10 @@
         "apiVersion": {
           "type": "string"
         },
+        "displayName": {
+          "description": "DisplayName is a user-facing name of the pipelineTask that may be used to populate a UI.",
+          "type": "string"
+        },
         "kind": {
           "type": "string"
         },

--- a/pkg/apis/pipeline/v1beta1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1beta1/openapi_generated.go
@@ -505,6 +505,13 @@ func schema_pkg_apis_pipeline_v1beta1_ChildStatusReference(ref common.ReferenceC
 							Format:      "",
 						},
 					},
+					"displayName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "DisplayName is a user-facing name of the pipelineTask that may be used to populate a UI.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"pipelineTaskName": {
 						SchemaProps: spec.SchemaProps{
 							Description: "PipelineTaskName is the name of the PipelineTask this is referencing.",

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_conversion.go
@@ -332,6 +332,7 @@ func (st *SkippedTask) convertFrom(ctx context.Context, source v1.SkippedTask) {
 func (csr ChildStatusReference) convertTo(ctx context.Context, sink *v1.ChildStatusReference) {
 	sink.TypeMeta = csr.TypeMeta
 	sink.Name = csr.Name
+	sink.DisplayName = csr.DisplayName
 	sink.PipelineTaskName = csr.PipelineTaskName
 	sink.WhenExpressions = nil
 	for _, we := range csr.WhenExpressions {
@@ -344,6 +345,7 @@ func (csr ChildStatusReference) convertTo(ctx context.Context, sink *v1.ChildSta
 func (csr *ChildStatusReference) convertFrom(ctx context.Context, source v1.ChildStatusReference) {
 	csr.TypeMeta = source.TypeMeta
 	csr.Name = source.Name
+	csr.DisplayName = source.DisplayName
 	csr.PipelineTaskName = source.PipelineTaskName
 	csr.WhenExpressions = nil
 	for _, we := range source.WhenExpressions {

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_conversion_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_conversion_test.go
@@ -43,12 +43,14 @@ var (
 	childRefTaskRuns = []v1beta1.ChildStatusReference{{
 		TypeMeta:         runtime.TypeMeta{Kind: "TaskRun", APIVersion: "tekton.dev/v1beta1"},
 		Name:             "tr-0",
+		DisplayName:      "TR 0",
 		PipelineTaskName: "ptn",
 		WhenExpressions:  []v1beta1.WhenExpression{{Input: "default-value", Operator: "in", Values: []string{"val"}}},
 	}}
 	childRefRuns = []v1beta1.ChildStatusReference{{
 		TypeMeta:         runtime.TypeMeta{Kind: "Run", APIVersion: "tekton.dev/v1alpha1"},
 		Name:             "r-0",
+		DisplayName:      "R 0",
 		PipelineTaskName: "ptn-0",
 		WhenExpressions:  []v1beta1.WhenExpression{{Input: "default-value-0", Operator: "in", Values: []string{"val-0", "val-1"}}},
 	}}

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
@@ -432,6 +432,9 @@ type ChildStatusReference struct {
 	runtime.TypeMeta `json:",inline"`
 	// Name is the name of the TaskRun or Run this is referencing.
 	Name string `json:"name,omitempty"`
+	// DisplayName is a user-facing name of the pipelineTask that may be
+	// used to populate a UI.
+	DisplayName string `json:"displayName,omitempty"`
 	// PipelineTaskName is the name of the PipelineTask this is referencing.
 	PipelineTaskName string `json:"pipelineTaskName,omitempty"`
 

--- a/pkg/apis/pipeline/v1beta1/swagger.json
+++ b/pkg/apis/pipeline/v1beta1/swagger.json
@@ -192,6 +192,10 @@
         "apiVersion": {
           "type": "string"
         },
+        "displayName": {
+          "description": "DisplayName is a user-facing name of the pipelineTask that may be used to populate a UI.",
+          "type": "string"
+        },
         "kind": {
           "type": "string"
         },

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -10735,30 +10735,37 @@ status:
   - apiVersion: tekton.dev/v1
     kind: TaskRun
     name: pr-matrix-include-0
+    displayName: common-package go117-context
     pipelineTaskName: matrix-include
   - apiVersion: tekton.dev/v1
     kind: TaskRun
     name: pr-matrix-include-1
+    displayName: common-package go117-context
     pipelineTaskName: matrix-include
   - apiVersion: tekton.dev/v1
     kind: TaskRun
     name: pr-matrix-include-2
+    displayName: common-package s390x-no-race go117-context
     pipelineTaskName: matrix-include
   - apiVersion: tekton.dev/v1
     kind: TaskRun
     name: pr-matrix-include-3
+    displayName: common-package
     pipelineTaskName: matrix-include
   - apiVersion: tekton.dev/v1
     kind: TaskRun
     name: pr-matrix-include-4
+    displayName: common-package
     pipelineTaskName: matrix-include
   - apiVersion: tekton.dev/v1
     kind: TaskRun
     name: pr-matrix-include-5
+    displayName: common-package s390x-no-race
     pipelineTaskName: matrix-include
   - apiVersion: tekton.dev/v1
     kind: TaskRun
     name: pr-matrix-include-6
+    displayName: non-existent-arch
     pipelineTaskName: matrix-include
 `),
 	}, {
@@ -10928,30 +10935,37 @@ status:
   - apiVersion: tekton.dev/v1
     kind: TaskRun
     name: pr-matrix-include-0
+    displayName: common-package go117-context
     pipelineTaskName: matrix-include
   - apiVersion: tekton.dev/v1
     kind: TaskRun
     name: pr-matrix-include-1
+    displayName: common-package go117-context
     pipelineTaskName: matrix-include
   - apiVersion: tekton.dev/v1
     kind: TaskRun
     name: pr-matrix-include-2
+    displayName: common-package s390x-no-race go117-context
     pipelineTaskName: matrix-include
   - apiVersion: tekton.dev/v1
     kind: TaskRun
     name: pr-matrix-include-3
+    displayName: common-package
     pipelineTaskName: matrix-include
   - apiVersion: tekton.dev/v1
     kind: TaskRun
     name: pr-matrix-include-4
+    displayName: common-package
     pipelineTaskName: matrix-include
   - apiVersion: tekton.dev/v1
     kind: TaskRun
     name: pr-matrix-include-5
+    displayName: common-package s390x-no-race
     pipelineTaskName: matrix-include
   - apiVersion: tekton.dev/v1
     kind: TaskRun
     name: pr-matrix-include-6
+    displayName: non-existent-arch
     pipelineTaskName: matrix-include
 `),
 	}}
@@ -11169,14 +11183,17 @@ status:
   - apiVersion: tekton.dev/v1
     kind: TaskRun
     name: pr-matrix-include-0
+    displayName: build-1
     pipelineTaskName: matrix-include
   - apiVersion: tekton.dev/v1
     kind: TaskRun
     name: pr-matrix-include-1
+    displayName: build-2
     pipelineTaskName: matrix-include
   - apiVersion: tekton.dev/v1
     kind: TaskRun
     name: pr-matrix-include-2
+    displayName: build-3
     pipelineTaskName: matrix-include
 `),
 	},
@@ -14332,14 +14349,17 @@ status:
   - apiVersion: tekton.dev/v1
     kind: TaskRun
     name: pr-matrix-emitting-results-0
+    displayName: build-1
     pipelineTaskName: matrix-emitting-results
   - apiVersion: tekton.dev/v1
     kind: TaskRun
     name: pr-matrix-emitting-results-1
+    displayName: build-2
     pipelineTaskName: matrix-emitting-results
   - apiVersion: tekton.dev/v1
     kind: TaskRun
     name: pr-matrix-emitting-results-2
+    displayName: build-3
     pipelineTaskName: matrix-emitting-results
   - apiVersion: tekton.dev/v1
     kind: TaskRun
@@ -14496,14 +14516,17 @@ status:
   - apiVersion: tekton.dev/v1
     kind: TaskRun
     name: pr-matrix-emitting-results-0
+    displayName: build-1
     pipelineTaskName: matrix-emitting-results
   - apiVersion: tekton.dev/v1
     kind: TaskRun
     name: pr-matrix-emitting-results-1
+    displayName: build-2
     pipelineTaskName: matrix-emitting-results
   - apiVersion: tekton.dev/v1
     kind: TaskRun
     name: pr-matrix-emitting-results-2
+    displayName: build-3
     pipelineTaskName: matrix-emitting-results
   - apiVersion: tekton.dev/v1
     kind: TaskRun
@@ -14655,14 +14678,17 @@ status:
   - apiVersion: tekton.dev/v1
     kind: TaskRun
     name: pr-matrix-emitting-results-0
+    displayName: build-1
     pipelineTaskName: matrix-emitting-results
   - apiVersion: tekton.dev/v1
     kind: TaskRun
     name: pr-matrix-emitting-results-1
+    displayName: build-2
     pipelineTaskName: matrix-emitting-results
   - apiVersion: tekton.dev/v1
     kind: TaskRun
     name: pr-matrix-emitting-results-2
+    displayName: build-3
     pipelineTaskName: matrix-emitting-results
   - apiVersion: tekton.dev/v1
     kind: TaskRun

--- a/pkg/reconciler/pipelinerun/resources/apply_test.go
+++ b/pkg/reconciler/pipelinerun/resources/apply_test.go
@@ -1739,12 +1739,12 @@ func TestApplyParameters(t *testing.T) {
 		},
 	} {
 		tt := tt // capture range variable
-		ctx := context.Background()
-		if tt.wc != nil {
-			ctx = tt.wc(ctx)
-		}
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			ctx := context.Background()
+			if tt.wc != nil {
+				ctx = tt.wc(ctx)
+			}
 			run := &v1.PipelineRun{
 				Spec: v1.PipelineRunSpec{
 					Params: tt.params,
@@ -3321,17 +3321,28 @@ func TestContext(t *testing.T) {
 						Params:      v1.Params{tc.original},
 						Matrix: &v1.Matrix{
 							Params: v1.Params{tc.original},
-						}}},
+						}},
+					},
+					Finally: []v1.PipelineTask{{
+						DisplayName: tc.displayName,
+						Params:      v1.Params{tc.original},
+					}},
 				},
 			}
 			got := resources.ApplyContexts(&orig.Spec, orig.Name, tc.pr)
 			if d := cmp.Diff(tc.expected, got.Tasks[0].Params[0]); d != "" {
 				t.Errorf(diff.PrintWantGot(d))
 			}
+			if d := cmp.Diff(tc.expected, got.Finally[0].Params[0]); d != "" {
+				t.Errorf(diff.PrintWantGot(d))
+			}
 			if d := cmp.Diff(tc.expected, got.Tasks[0].Matrix.Params[0]); d != "" {
 				t.Errorf(diff.PrintWantGot(d))
 			}
 			if d := cmp.Diff(tc.expectedDisplayName, got.Tasks[0].DisplayName); d != "" {
+				t.Errorf(diff.PrintWantGot(d))
+			}
+			if d := cmp.Diff(tc.expectedDisplayName, got.Finally[0].DisplayName); d != "" {
 				t.Errorf(diff.PrintWantGot(d))
 			}
 		})

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
@@ -3193,7 +3193,8 @@ func TestPipelineRunState_GetChildReferences(t *testing.T) {
 			state: PipelineRunState{{
 				TaskRunNames: []string{"single-task-run"},
 				PipelineTask: &v1.PipelineTask{
-					Name: "single-task-1",
+					Name:        "single-task-1",
+					DisplayName: "Human readable name for single-task-1",
 					TaskRef: &v1.TaskRef{
 						Name:       "single-task",
 						Kind:       "Task",
@@ -3217,6 +3218,8 @@ func TestPipelineRunState_GetChildReferences(t *testing.T) {
 				},
 				Name:             "single-task-run",
 				PipelineTaskName: "single-task-1",
+				DisplayName:      "Human readable name for single-task-1",
+
 				WhenExpressions: []v1.WhenExpression{{
 					Input:    "foo",
 					Operator: selection.In,
@@ -3230,7 +3233,8 @@ func TestPipelineRunState_GetChildReferences(t *testing.T) {
 				CustomRunNames: []string{"single-custom-task-run"},
 				CustomTask:     true,
 				PipelineTask: &v1.PipelineTask{
-					Name: "single-custom-task-1",
+					Name:        "single-custom-task-1",
+					DisplayName: "Single Custom Task 1",
 					TaskRef: &v1.TaskRef{
 						APIVersion: "example.dev/v0",
 						Kind:       "Example",
@@ -3255,6 +3259,7 @@ func TestPipelineRunState_GetChildReferences(t *testing.T) {
 				},
 				Name:             "single-custom-task-run",
 				PipelineTaskName: "single-custom-task-1",
+				DisplayName:      "Single Custom Task 1",
 				WhenExpressions: []v1.WhenExpression{{
 					Input:    "foo",
 					Operator: selection.In,
@@ -3267,7 +3272,8 @@ func TestPipelineRunState_GetChildReferences(t *testing.T) {
 			state: PipelineRunState{{
 				TaskRunNames: []string{"single-task-run"},
 				PipelineTask: &v1.PipelineTask{
-					Name: "single-task-1",
+					Name:        "single-task-1",
+					DisplayName: "Single Task 1",
 					TaskRef: &v1.TaskRef{
 						Name:       "single-task",
 						Kind:       "Task",
@@ -3282,7 +3288,8 @@ func TestPipelineRunState_GetChildReferences(t *testing.T) {
 				CustomRunNames: []string{"single-custom-task-run"},
 				CustomTask:     true,
 				PipelineTask: &v1.PipelineTask{
-					Name: "single-custom-task-1",
+					Name:        "single-custom-task-1",
+					DisplayName: "Single Custom Task 1",
 					TaskRef: &v1.TaskRef{
 						APIVersion: "example.dev/v0",
 						Kind:       "Example",
@@ -3302,6 +3309,7 @@ func TestPipelineRunState_GetChildReferences(t *testing.T) {
 				},
 				Name:             "single-task-run",
 				PipelineTaskName: "single-task-1",
+				DisplayName:      "Single Task 1",
 			}, {
 				TypeMeta: runtime.TypeMeta{
 					APIVersion: "tekton.dev/v1beta1",
@@ -3309,6 +3317,7 @@ func TestPipelineRunState_GetChildReferences(t *testing.T) {
 				},
 				Name:             "single-custom-task-run",
 				PipelineTaskName: "single-custom-task-1",
+				DisplayName:      "Single Custom Task 1",
 			}},
 		},
 		{
@@ -3316,7 +3325,8 @@ func TestPipelineRunState_GetChildReferences(t *testing.T) {
 			state: PipelineRunState{{
 				TaskRunNames: []string{"task-run-0", "task-run-1", "task-run-2", "task-run-3"},
 				PipelineTask: &v1.PipelineTask{
-					Name: "matrixed-task",
+					Name:        "matrixed-task",
+					DisplayName: "Matrixed Task",
 					TaskRef: &v1.TaskRef{
 						Name:       "task",
 						Kind:       "Task",
@@ -3345,7 +3355,8 @@ func TestPipelineRunState_GetChildReferences(t *testing.T) {
 			state: PipelineRunState{{
 				TaskRunNames: []string{"matrixed-task-run-0"},
 				PipelineTask: &v1.PipelineTask{
-					Name: "matrixed-task",
+					Name:        "matrixed-task",
+					DisplayName: "Matrixed Task $(params.foobar) and $(params.quxbaz)",
 					TaskRef: &v1.TaskRef{
 						Name:       "task",
 						Kind:       "Task",
@@ -3368,15 +3379,51 @@ func TestPipelineRunState_GetChildReferences(t *testing.T) {
 				TaskRuns: []*v1.TaskRun{{
 					TypeMeta:   metav1.TypeMeta{APIVersion: "tekton.dev/v1"},
 					ObjectMeta: metav1.ObjectMeta{Name: "matrixed-task-run-0"},
+					Spec: v1.TaskRunSpec{
+						Params: v1.Params{{
+							Name:  "foobar",
+							Value: v1.ParamValue{Type: "string", StringVal: "foo"},
+						}, {
+							Name:  "quxbaz",
+							Value: v1.ParamValue{Type: "string", StringVal: "qux"},
+						}},
+					},
 				}, {
 					TypeMeta:   metav1.TypeMeta{APIVersion: "tekton.dev/v1"},
 					ObjectMeta: metav1.ObjectMeta{Name: "matrixed-task-run-1"},
+					Spec: v1.TaskRunSpec{
+						Params: v1.Params{{
+							Name:  "foobar",
+							Value: v1.ParamValue{Type: "string", StringVal: "foo"},
+						}, {
+							Name:  "quxbaz",
+							Value: v1.ParamValue{Type: "string", StringVal: "baz"},
+						}},
+					},
 				}, {
 					TypeMeta:   metav1.TypeMeta{APIVersion: "tekton.dev/v1"},
 					ObjectMeta: metav1.ObjectMeta{Name: "matrixed-task-run-2"},
+					Spec: v1.TaskRunSpec{
+						Params: v1.Params{{
+							Name:  "foobar",
+							Value: v1.ParamValue{Type: "string", StringVal: "bar"},
+						}, {
+							Name:  "quxbaz",
+							Value: v1.ParamValue{Type: "string", StringVal: "qux"},
+						}},
+					},
 				}, {
 					TypeMeta:   metav1.TypeMeta{APIVersion: "tekton.dev/v1"},
 					ObjectMeta: metav1.ObjectMeta{Name: "matrixed-task-run-3"},
+					Spec: v1.TaskRunSpec{
+						Params: v1.Params{{
+							Name:  "foobar",
+							Value: v1.ParamValue{Type: "string", StringVal: "bar"},
+						}, {
+							Name:  "quxbaz",
+							Value: v1.ParamValue{Type: "string", StringVal: "baz"},
+						}},
+					},
 				}},
 			}},
 			childRefs: []v1.ChildStatusReference{{
@@ -3385,6 +3432,7 @@ func TestPipelineRunState_GetChildReferences(t *testing.T) {
 					Kind:       "TaskRun",
 				},
 				Name:             "matrixed-task-run-0",
+				DisplayName:      "Matrixed Task foo and qux",
 				PipelineTaskName: "matrixed-task",
 				WhenExpressions: []v1.WhenExpression{{
 					Input:    "foo",
@@ -3397,6 +3445,7 @@ func TestPipelineRunState_GetChildReferences(t *testing.T) {
 					Kind:       "TaskRun",
 				},
 				Name:             "matrixed-task-run-1",
+				DisplayName:      "Matrixed Task foo and baz",
 				PipelineTaskName: "matrixed-task",
 				WhenExpressions: []v1.WhenExpression{{
 					Input:    "foo",
@@ -3409,6 +3458,7 @@ func TestPipelineRunState_GetChildReferences(t *testing.T) {
 					Kind:       "TaskRun",
 				},
 				Name:             "matrixed-task-run-2",
+				DisplayName:      "Matrixed Task bar and qux",
 				PipelineTaskName: "matrixed-task",
 				WhenExpressions: []v1.WhenExpression{{
 					Input:    "foo",
@@ -3421,6 +3471,7 @@ func TestPipelineRunState_GetChildReferences(t *testing.T) {
 					Kind:       "TaskRun",
 				},
 				Name:             "matrixed-task-run-3",
+				DisplayName:      "Matrixed Task bar and baz",
 				PipelineTaskName: "matrixed-task",
 				WhenExpressions: []v1.WhenExpression{{
 					Input:    "foo",
@@ -3460,7 +3511,8 @@ func TestPipelineRunState_GetChildReferences(t *testing.T) {
 			name: "matrixed-custom-task",
 			state: PipelineRunState{{
 				PipelineTask: &v1.PipelineTask{
-					Name: "matrixed-task",
+					Name:        "matrixed-task",
+					DisplayName: "Matrixed Task with Custom Run $(params.foobar) and $(params.quxbaz)",
 					TaskRef: &v1.TaskRef{
 						APIVersion: "example.dev/v0",
 						Kind:       "Example",
@@ -3481,10 +3533,10 @@ func TestPipelineRunState_GetChildReferences(t *testing.T) {
 				},
 				CustomTask: true,
 				CustomRuns: []*v1beta1.CustomRun{
-					customRunWithName("matrixed-run-0"),
-					customRunWithName("matrixed-run-1"),
-					customRunWithName("matrixed-run-2"),
-					customRunWithName("matrixed-run-3"),
+					customRunWithName("matrixed-run-0", "foo", "qux"),
+					customRunWithName("matrixed-run-1", "foo", "baz"),
+					customRunWithName("matrixed-run-2", "bar", "qux"),
+					customRunWithName("matrixed-run-3", "bar", "baz"),
 				},
 			}},
 			childRefs: []v1.ChildStatusReference{{
@@ -3493,6 +3545,7 @@ func TestPipelineRunState_GetChildReferences(t *testing.T) {
 					Kind:       "CustomRun",
 				},
 				Name:             "matrixed-run-0",
+				DisplayName:      "Matrixed Task with Custom Run foo and qux",
 				PipelineTaskName: "matrixed-task",
 				WhenExpressions: []v1.WhenExpression{{
 					Input:    "foo",
@@ -3505,6 +3558,7 @@ func TestPipelineRunState_GetChildReferences(t *testing.T) {
 					Kind:       "CustomRun",
 				},
 				Name:             "matrixed-run-1",
+				DisplayName:      "Matrixed Task with Custom Run foo and baz",
 				PipelineTaskName: "matrixed-task",
 				WhenExpressions: []v1.WhenExpression{{
 					Input:    "foo",
@@ -3517,6 +3571,7 @@ func TestPipelineRunState_GetChildReferences(t *testing.T) {
 					Kind:       "CustomRun",
 				},
 				Name:             "matrixed-run-2",
+				DisplayName:      "Matrixed Task with Custom Run bar and qux",
 				PipelineTaskName: "matrixed-task",
 				WhenExpressions: []v1.WhenExpression{{
 					Input:    "foo",
@@ -3529,6 +3584,7 @@ func TestPipelineRunState_GetChildReferences(t *testing.T) {
 					Kind:       "CustomRun",
 				},
 				Name:             "matrixed-run-3",
+				DisplayName:      "Matrixed Task with Custom Run bar and baz",
 				PipelineTaskName: "matrixed-task",
 				WhenExpressions: []v1.WhenExpression{{
 					Input:    "foo",
@@ -3543,7 +3599,8 @@ func TestPipelineRunState_GetChildReferences(t *testing.T) {
 				{
 					TaskRunNames: []string{"task-generate-results"},
 					PipelineTask: &v1.PipelineTask{
-						Name: "task1",
+						Name:        "task1",
+						DisplayName: "Task 1",
 					},
 					TaskRuns: []*v1.TaskRun{
 						{
@@ -3583,7 +3640,8 @@ func TestPipelineRunState_GetChildReferences(t *testing.T) {
 				{
 					TaskRunNames: []string{"task-reference-previous-result"},
 					PipelineTask: &v1.PipelineTask{
-						Name: "task2",
+						Name:        "task2",
+						DisplayName: "Task 2 with $(tasks.task1.results.string-result) and $(tasks.task1.results.array-result[1])",
 						When: []v1.WhenExpression{
 							{
 								Input:    "$(tasks.task1.results.string-result)",
@@ -3620,6 +3678,7 @@ func TestPipelineRunState_GetChildReferences(t *testing.T) {
 					},
 					Name:             "task-generate-results",
 					PipelineTaskName: "task1",
+					DisplayName:      "Task 1",
 				},
 				{
 					TypeMeta: runtime.TypeMeta{
@@ -3627,6 +3686,7 @@ func TestPipelineRunState_GetChildReferences(t *testing.T) {
 						Kind:       "TaskRun",
 					},
 					Name:             "task-reference-previous-result",
+					DisplayName:      "Task 2 with value1 and array-value2",
 					PipelineTaskName: "task2",
 					WhenExpressions: []v1.WhenExpression{
 						{
@@ -3642,6 +3702,418 @@ func TestPipelineRunState_GetChildReferences(t *testing.T) {
 					},
 				},
 			},
+		}, {
+			name: "matrixed-task-with-displayName-and-include",
+			state: PipelineRunState{{
+				TaskRunNames: []string{"matrixed-task-run-0"},
+				PipelineTask: &v1.PipelineTask{
+					Name:        "matrixed-task",
+					DisplayName: "Matrixed Task $(params.foobar) and $(params.quxbaz)",
+					TaskRef: &v1.TaskRef{
+						Name:       "task",
+						Kind:       "Task",
+						APIVersion: "v1",
+					},
+					Matrix: &v1.Matrix{
+						Params: v1.Params{{
+							Name:  "foobar",
+							Value: v1.ParamValue{Type: v1.ParamTypeArray, ArrayVal: []string{"foo", "bar"}},
+						}, {
+							Name:  "quxbaz",
+							Value: v1.ParamValue{Type: v1.ParamTypeArray, ArrayVal: []string{"qux", "baz"}},
+						}},
+						Include: v1.IncludeParamsList{{
+							Name: "Execute a random case for foo",
+							Params: v1.Params{{
+								Name:  "foobar",
+								Value: v1.ParamValue{Type: v1.ParamTypeString, StringVal: "foo"},
+							}, {
+								Name:  "random",
+								Value: v1.ParamValue{Type: v1.ParamTypeString, StringVal: "random"},
+							}},
+						}, {
+							Name: "Does not exist",
+							Params: v1.Params{{
+								Name:  "foobar",
+								Value: v1.ParamValue{Type: v1.ParamTypeString, StringVal: "foo-does-not-exist"},
+							}},
+						}},
+					},
+				},
+				TaskRuns: []*v1.TaskRun{{
+					TypeMeta:   metav1.TypeMeta{APIVersion: "tekton.dev/v1"},
+					ObjectMeta: metav1.ObjectMeta{Name: "matrixed-task-run-0"},
+					Spec: v1.TaskRunSpec{
+						Params: v1.Params{{
+							Name:  "foobar",
+							Value: v1.ParamValue{Type: "string", StringVal: "foo"},
+						}, {
+							Name:  "quxbaz",
+							Value: v1.ParamValue{Type: "string", StringVal: "qux"},
+						}, {
+							Name:  "random",
+							Value: v1.ParamValue{Type: v1.ParamTypeString, StringVal: "random"},
+						}},
+					},
+				}, {
+					TypeMeta:   metav1.TypeMeta{APIVersion: "tekton.dev/v1"},
+					ObjectMeta: metav1.ObjectMeta{Name: "matrixed-task-run-1"},
+					Spec: v1.TaskRunSpec{
+						Params: v1.Params{{
+							Name:  "foobar",
+							Value: v1.ParamValue{Type: "string", StringVal: "foo"},
+						}, {
+							Name:  "quxbaz",
+							Value: v1.ParamValue{Type: "string", StringVal: "baz"},
+						}, {
+							Name:  "random",
+							Value: v1.ParamValue{Type: v1.ParamTypeString, StringVal: "random"},
+						}},
+					},
+				}, {
+					TypeMeta:   metav1.TypeMeta{APIVersion: "tekton.dev/v1"},
+					ObjectMeta: metav1.ObjectMeta{Name: "matrixed-task-run-2"},
+					Spec: v1.TaskRunSpec{
+						Params: v1.Params{{
+							Name:  "foobar",
+							Value: v1.ParamValue{Type: "string", StringVal: "bar"},
+						}, {
+							Name:  "quxbaz",
+							Value: v1.ParamValue{Type: "string", StringVal: "qux"},
+						}},
+					},
+				}, {
+					TypeMeta:   metav1.TypeMeta{APIVersion: "tekton.dev/v1"},
+					ObjectMeta: metav1.ObjectMeta{Name: "matrixed-task-run-3"},
+					Spec: v1.TaskRunSpec{
+						Params: v1.Params{{
+							Name:  "foobar",
+							Value: v1.ParamValue{Type: "string", StringVal: "bar"},
+						}, {
+							Name:  "quxbaz",
+							Value: v1.ParamValue{Type: "string", StringVal: "baz"},
+						}},
+					},
+				}, {
+					TypeMeta:   metav1.TypeMeta{APIVersion: "tekton.dev/v1"},
+					ObjectMeta: metav1.ObjectMeta{Name: "matrixed-task-run-4"},
+					Spec: v1.TaskRunSpec{
+						Params: v1.Params{{
+							Name:  "foobar",
+							Value: v1.ParamValue{Type: "string", StringVal: "foo-does-not-exist"},
+						}},
+					},
+				}},
+			}},
+			childRefs: []v1.ChildStatusReference{{
+				TypeMeta: runtime.TypeMeta{
+					APIVersion: "tekton.dev/v1",
+					Kind:       "TaskRun",
+				},
+				Name:             "matrixed-task-run-0",
+				DisplayName:      "Execute a random case for foo",
+				PipelineTaskName: "matrixed-task",
+			}, {
+				TypeMeta: runtime.TypeMeta{
+					APIVersion: "tekton.dev/v1",
+					Kind:       "TaskRun",
+				},
+				Name:             "matrixed-task-run-1",
+				DisplayName:      "Execute a random case for foo",
+				PipelineTaskName: "matrixed-task",
+			}, {
+				TypeMeta: runtime.TypeMeta{
+					APIVersion: "tekton.dev/v1",
+					Kind:       "TaskRun",
+				},
+				Name:             "matrixed-task-run-2",
+				DisplayName:      "Matrixed Task bar and qux",
+				PipelineTaskName: "matrixed-task",
+			}, {
+				TypeMeta: runtime.TypeMeta{
+					APIVersion: "tekton.dev/v1",
+					Kind:       "TaskRun",
+				},
+				Name:             "matrixed-task-run-3",
+				DisplayName:      "Matrixed Task bar and baz",
+				PipelineTaskName: "matrixed-task",
+			}, {
+				TypeMeta: runtime.TypeMeta{
+					APIVersion: "tekton.dev/v1",
+					Kind:       "TaskRun",
+				},
+				Name:             "matrixed-task-run-4",
+				DisplayName:      "Does not exist",
+				PipelineTaskName: "matrixed-task",
+			}},
+		}, {
+			name: "matrixed-task-with-displayname-and-some-include-name",
+			state: PipelineRunState{{
+				TaskRunNames: []string{"matrixed-task-run-0"},
+				PipelineTask: &v1.PipelineTask{
+					Name:        "matrixed-task",
+					DisplayName: "Matrixed Task $(params.foobar) and $(params.quxbaz)",
+					TaskRef: &v1.TaskRef{
+						Name:       "task",
+						Kind:       "Task",
+						APIVersion: "v1",
+					},
+					Matrix: &v1.Matrix{
+						Params: v1.Params{{
+							Name:  "foobar",
+							Value: v1.ParamValue{Type: v1.ParamTypeArray, ArrayVal: []string{"foo", "bar"}},
+						}, {
+							Name:  "quxbaz",
+							Value: v1.ParamValue{Type: v1.ParamTypeArray, ArrayVal: []string{"qux", "baz"}},
+						}},
+						Include: v1.IncludeParamsList{{
+							Name: "additional name for foo",
+							Params: v1.Params{{
+								Name:  "foobar",
+								Value: v1.ParamValue{Type: v1.ParamTypeString, StringVal: "foo"},
+							}, {
+								Name:  "random1",
+								Value: v1.ParamValue{Type: v1.ParamTypeString, StringVal: "random"},
+							}},
+						}, {
+							Name: "one more additional name for foo",
+							Params: v1.Params{{
+								Name:  "foobar",
+								Value: v1.ParamValue{Type: v1.ParamTypeString, StringVal: "foo"},
+							}, {
+								Name:  "random2",
+								Value: v1.ParamValue{Type: v1.ParamTypeString, StringVal: "random"},
+							}},
+						}},
+					},
+				},
+				TaskRuns: []*v1.TaskRun{{
+					TypeMeta:   metav1.TypeMeta{APIVersion: "tekton.dev/v1"},
+					ObjectMeta: metav1.ObjectMeta{Name: "matrixed-task-run-0"},
+					Spec: v1.TaskRunSpec{
+						Params: v1.Params{{
+							Name:  "foobar",
+							Value: v1.ParamValue{Type: "string", StringVal: "foo"},
+						}, {
+							Name:  "quxbaz",
+							Value: v1.ParamValue{Type: "string", StringVal: "qux"},
+						}, {
+							Name:  "random1",
+							Value: v1.ParamValue{Type: v1.ParamTypeString, StringVal: "random"},
+						}, {
+							Name:  "random2",
+							Value: v1.ParamValue{Type: v1.ParamTypeString, StringVal: "random"},
+						}},
+					},
+				}, {
+					TypeMeta:   metav1.TypeMeta{APIVersion: "tekton.dev/v1"},
+					ObjectMeta: metav1.ObjectMeta{Name: "matrixed-task-run-1"},
+					Spec: v1.TaskRunSpec{
+						Params: v1.Params{{
+							Name:  "foobar",
+							Value: v1.ParamValue{Type: "string", StringVal: "foo"},
+						}, {
+							Name:  "quxbaz",
+							Value: v1.ParamValue{Type: "string", StringVal: "baz"},
+						}, {
+							Name:  "random1",
+							Value: v1.ParamValue{Type: v1.ParamTypeString, StringVal: "random"},
+						}, {
+							Name:  "random2",
+							Value: v1.ParamValue{Type: v1.ParamTypeString, StringVal: "random"},
+						}},
+					},
+				}, {
+					TypeMeta:   metav1.TypeMeta{APIVersion: "tekton.dev/v1"},
+					ObjectMeta: metav1.ObjectMeta{Name: "matrixed-task-run-2"},
+					Spec: v1.TaskRunSpec{
+						Params: v1.Params{{
+							Name:  "foobar",
+							Value: v1.ParamValue{Type: "string", StringVal: "bar"},
+						}, {
+							Name:  "quxbaz",
+							Value: v1.ParamValue{Type: "string", StringVal: "qux"},
+						}},
+					},
+				}, {
+					TypeMeta:   metav1.TypeMeta{APIVersion: "tekton.dev/v1"},
+					ObjectMeta: metav1.ObjectMeta{Name: "matrixed-task-run-3"},
+					Spec: v1.TaskRunSpec{
+						Params: v1.Params{{
+							Name:  "foobar",
+							Value: v1.ParamValue{Type: "string", StringVal: "bar"},
+						}, {
+							Name:  "quxbaz",
+							Value: v1.ParamValue{Type: "string", StringVal: "baz"},
+						}},
+					},
+				}},
+			}},
+			childRefs: []v1.ChildStatusReference{{
+				TypeMeta: runtime.TypeMeta{
+					APIVersion: "tekton.dev/v1",
+					Kind:       "TaskRun",
+				},
+				Name:             "matrixed-task-run-0",
+				DisplayName:      "additional name for foo one more additional name for foo",
+				PipelineTaskName: "matrixed-task",
+			}, {
+				TypeMeta: runtime.TypeMeta{
+					APIVersion: "tekton.dev/v1",
+					Kind:       "TaskRun",
+				},
+				Name:             "matrixed-task-run-1",
+				DisplayName:      "additional name for foo one more additional name for foo",
+				PipelineTaskName: "matrixed-task",
+			}, {
+				TypeMeta: runtime.TypeMeta{
+					APIVersion: "tekton.dev/v1",
+					Kind:       "TaskRun",
+				},
+				Name:             "matrixed-task-run-2",
+				DisplayName:      "Matrixed Task bar and qux",
+				PipelineTaskName: "matrixed-task",
+			}, {
+				TypeMeta: runtime.TypeMeta{
+					APIVersion: "tekton.dev/v1",
+					Kind:       "TaskRun",
+				},
+				Name:             "matrixed-task-run-3",
+				DisplayName:      "Matrixed Task bar and baz",
+				PipelineTaskName: "matrixed-task",
+			}},
+		}, {
+			name: "matrixed-task-without-displayname-and-some-include-name",
+			state: PipelineRunState{{
+				TaskRunNames: []string{"matrixed-task-run-0"},
+				PipelineTask: &v1.PipelineTask{
+					Name: "matrixed-task",
+					TaskRef: &v1.TaskRef{
+						Name:       "task",
+						Kind:       "Task",
+						APIVersion: "v1",
+					},
+					Matrix: &v1.Matrix{
+						Params: v1.Params{{
+							Name:  "foobar",
+							Value: v1.ParamValue{Type: v1.ParamTypeArray, ArrayVal: []string{"foo", "bar"}},
+						}, {
+							Name:  "quxbaz",
+							Value: v1.ParamValue{Type: v1.ParamTypeArray, ArrayVal: []string{"qux", "baz"}},
+						}},
+						Include: v1.IncludeParamsList{{
+							Name: "task running foo and random",
+							Params: v1.Params{{
+								Name:  "foobar",
+								Value: v1.ParamValue{Type: v1.ParamTypeString, StringVal: "foo"},
+							}, {
+								Name:  "random1",
+								Value: v1.ParamValue{Type: v1.ParamTypeString, StringVal: "random"},
+							}},
+						}, {
+							Params: v1.Params{{
+								Name:  "foobar",
+								Value: v1.ParamValue{Type: v1.ParamTypeString, StringVal: "bar"},
+							}, {
+								Name:  "random2",
+								Value: v1.ParamValue{Type: v1.ParamTypeString, StringVal: "random"},
+							}},
+						}},
+					},
+				},
+				TaskRuns: []*v1.TaskRun{{
+					TypeMeta:   metav1.TypeMeta{APIVersion: "tekton.dev/v1"},
+					ObjectMeta: metav1.ObjectMeta{Name: "matrixed-task-run-0"},
+					Spec: v1.TaskRunSpec{
+						Params: v1.Params{{
+							Name:  "foobar",
+							Value: v1.ParamValue{Type: "string", StringVal: "foo"},
+						}, {
+							Name:  "quxbaz",
+							Value: v1.ParamValue{Type: "string", StringVal: "qux"},
+						}, {
+							Name:  "random1",
+							Value: v1.ParamValue{Type: v1.ParamTypeString, StringVal: "random"},
+						}},
+					},
+				}, {
+					TypeMeta:   metav1.TypeMeta{APIVersion: "tekton.dev/v1"},
+					ObjectMeta: metav1.ObjectMeta{Name: "matrixed-task-run-1"},
+					Spec: v1.TaskRunSpec{
+						Params: v1.Params{{
+							Name:  "foobar",
+							Value: v1.ParamValue{Type: "string", StringVal: "foo"},
+						}, {
+							Name:  "quxbaz",
+							Value: v1.ParamValue{Type: "string", StringVal: "baz"},
+						}, {
+							Name:  "random1",
+							Value: v1.ParamValue{Type: v1.ParamTypeString, StringVal: "random"},
+						}},
+					},
+				}, {
+					TypeMeta:   metav1.TypeMeta{APIVersion: "tekton.dev/v1"},
+					ObjectMeta: metav1.ObjectMeta{Name: "matrixed-task-run-2"},
+					Spec: v1.TaskRunSpec{
+						Params: v1.Params{{
+							Name:  "foobar",
+							Value: v1.ParamValue{Type: "string", StringVal: "bar"},
+						}, {
+							Name:  "quxbaz",
+							Value: v1.ParamValue{Type: "string", StringVal: "qux"},
+						}, {
+							Name:  "random2",
+							Value: v1.ParamValue{Type: v1.ParamTypeString, StringVal: "random"},
+						}},
+					},
+				}, {
+					TypeMeta:   metav1.TypeMeta{APIVersion: "tekton.dev/v1"},
+					ObjectMeta: metav1.ObjectMeta{Name: "matrixed-task-run-3"},
+					Spec: v1.TaskRunSpec{
+						Params: v1.Params{{
+							Name:  "foobar",
+							Value: v1.ParamValue{Type: "string", StringVal: "bar"},
+						}, {
+							Name:  "quxbaz",
+							Value: v1.ParamValue{Type: "string", StringVal: "baz"},
+						}, {
+							Name:  "random2",
+							Value: v1.ParamValue{Type: v1.ParamTypeString, StringVal: "random"},
+						}},
+					},
+				}},
+			}},
+			childRefs: []v1.ChildStatusReference{{
+				TypeMeta: runtime.TypeMeta{
+					APIVersion: "tekton.dev/v1",
+					Kind:       "TaskRun",
+				},
+				Name:             "matrixed-task-run-0",
+				DisplayName:      "task running foo and random",
+				PipelineTaskName: "matrixed-task",
+			}, {
+				TypeMeta: runtime.TypeMeta{
+					APIVersion: "tekton.dev/v1",
+					Kind:       "TaskRun",
+				},
+				Name:             "matrixed-task-run-1",
+				DisplayName:      "task running foo and random",
+				PipelineTaskName: "matrixed-task",
+			}, {
+				TypeMeta: runtime.TypeMeta{
+					APIVersion: "tekton.dev/v1",
+					Kind:       "TaskRun",
+				},
+				Name:             "matrixed-task-run-2",
+				PipelineTaskName: "matrixed-task",
+			}, {
+				TypeMeta: runtime.TypeMeta{
+					APIVersion: "tekton.dev/v1",
+					Kind:       "TaskRun",
+				},
+				Name:             "matrixed-task-run-3",
+				PipelineTaskName: "matrixed-task",
+			}},
 		},
 	}
 	for _, tc := range testCases {
@@ -3702,10 +4174,19 @@ func TestConvertResultsMapToTaskRunResults(t *testing.T) {
 	}
 }
 
-func customRunWithName(name string) *v1beta1.CustomRun {
+func customRunWithName(name, p1, p2 string) *v1beta1.CustomRun {
 	return &v1beta1.CustomRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
+		},
+		Spec: v1beta1.CustomRunSpec{
+			Params: v1beta1.Params{{
+				Name:  "foobar",
+				Value: v1beta1.ParamValue{Type: "string", StringVal: p1},
+			}, {
+				Name:  "quxbaz",
+				Value: v1beta1.ParamValue{Type: "string", StringVal: p2},
+			}},
 		},
 	}
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Implementing proposal TEP-0150.

Adding a functionality where the existing displayName can be used to configure unique names for each instance using the params from each combination such that the matrix instances in the Tekton Dashboard are rendered to distinguishable names.

Also, repurposing an existing name field as part of the matrix.include[].name. If specified, a fully resolved name field is available in the childReferences.

Fixes https://github.com/tektoncd/pipeline/issues/7082

/kind feature

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
A fully resolved displayName is now available in childReferences along with the pipelineTaskName. This is mainly beneficial to parameterize and easily distinguish matrix instances of the task. 
```
