### PR TITLE
fix:add missing documentation link

### DIFF
--- a/docs/additional-configs.md
+++ b/docs/additional-configs.md
@@ -706,5 +706,8 @@ Except as otherwise noted, the content of this page is licensed under the
 under the [Apache 2.0 License][apache2l].
 {{% /comment %}}
 
+[quickstarts]: https://tekton.dev/docs/getting-started/
+[howtos]: https://tekton.dev/docs/how-to-guides/
+[examples]: https://github.com/tektoncd/pipeline/tree/main/examples/
 [cca4]: https://creativecommons.org/licenses/by/4.0/
 [apache2l]: https://www.apache.org/licenses/LICENSE-2.0


### PR DESCRIPTION

![image](https://github.com/tektoncd/pipeline/assets/19320253/a66f3269-4ab9-4bf8-bc8d-68b508fe5e42)

As shown above: add missing document link.

/kind doc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
