### PR TITLE
fix: avoid panic when used pipelineRef or pipelineSpec in pipeline task

### DIFF
--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -631,7 +631,8 @@ func resolveTask(
 	pipelineTask v1.PipelineTask,
 ) (*resources.ResolvedTask, error) {
 	rt := &resources.ResolvedTask{}
-	if pipelineTask.TaskRef != nil {
+	switch {
+	case pipelineTask.TaskRef != nil:
 		// If the TaskRun has already a stored TaskSpec in its status, use it as source of truth
 		if taskRun != nil && taskRun.Status.TaskSpec != nil {
 			rt.TaskSpec = taskRun.Status.TaskSpec
@@ -656,8 +657,13 @@ func resolveTask(
 			}
 		}
 		rt.Kind = pipelineTask.TaskRef.Kind
-	} else {
+	case pipelineTask.TaskSpec != nil:
 		rt.TaskSpec = &pipelineTask.TaskSpec.TaskSpec
+	default:
+		// If the alpha feature is enabled, and the user has configured pipelineSpec or pipelineRef, it will enter here.
+		// Currently, the controller is not yet adapted, and to avoid a panic, an error message is provided here.
+		// TODO: Adjust the logic here once the feature is supported in the future.
+		return nil, fmt.Errorf("Currently, Task %q does not support PipelineRef or PipelineSpec, please use TaskRef or TaskSpec instead", pipelineTask.Name)
 	}
 	rt.TaskSpec.SetDefaults(ctx)
 	return rt, nil


### PR DESCRIPTION
fix #7720

This issue has been present since v0.52
https://github.com/tektoncd/pipeline/commit/61501916eae6f682cadf422134724304b0019ba8

Currently, the `pipelineRef` and `pipelineSpec` are only in preview mode and not yet supported. If a user has configured this field and enabled alpha features, it might bypass validation and enter into controller logic. It is now necessary to implement relevant checks within the controller logic to clearly prompt the user, instead of causing the program to panic.

### Field definition
https://github.com/tektoncd/pipeline/blob/9be03e219feccb336a509b13e139085c22291048/pkg/apis/pipeline/v1/pipeline_types.go#L239-L247

### validation logic
https://github.com/tektoncd/pipeline/blob/9be03e219feccb336a509b13e139085c22291048/pkg/apis/pipeline/v1/pipeline_validation.go#L291-L305

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
fix: avoid panic when used pipelineRef or pipelineSpec in pipeline task
```

/kind bug