### PR TITLE
fix: prevent repeated setting of pipeline name label

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -1308,6 +1308,11 @@ func propagatePipelineNameLabelToPipelineRun(pr *v1.PipelineRun) error {
 	if pr.ObjectMeta.Labels == nil {
 		pr.ObjectMeta.Labels = make(map[string]string)
 	}
+
+	if _, ok := pr.ObjectMeta.Labels[pipeline.PipelineLabelKey]; ok {
+		return nil
+	}
+
 	switch {
 	case pr.Spec.PipelineRef != nil && pr.Spec.PipelineRef.Name != "":
 		pr.ObjectMeta.Labels[pipeline.PipelineLabelKey] = pr.Spec.PipelineRef.Name
@@ -1426,7 +1431,9 @@ func storePipelineSpecAndMergeMeta(ctx context.Context, pr *v1.PipelineRun, ps *
 
 		// Propagate labels from Pipeline to PipelineRun. PipelineRun labels take precedences over Pipeline.
 		pr.ObjectMeta.Labels = kmap.Union(meta.Labels, pr.ObjectMeta.Labels)
-		pr.ObjectMeta.Labels[pipeline.PipelineLabelKey] = meta.Name
+		if len(meta.Name) > 0 {
+			pr.ObjectMeta.Labels[pipeline.PipelineLabelKey] = meta.Name
+		}
 
 		// Propagate annotations from Pipeline to PipelineRun. PipelineRun annotations take precedences over Pipeline.
 		pr.ObjectMeta.Annotations = kmap.Union(kmap.ExcludeKeys(meta.Annotations, tknreconciler.KubectlLastAppliedAnnotationKey), pr.ObjectMeta.Annotations)

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -3684,7 +3684,6 @@ metadata:
     PipelineRunAnnotation: PipelineRunValue
   labels:
     PipelineRunLabel: PipelineRunValue
-    tekton.dev/pipeline: WillNotBeUsed
   name: test-pipeline-run-with-labels
   namespace: foo
 spec:
@@ -8484,6 +8483,132 @@ spec:
 		}
 		if !tc.wantFailed && reconciledRun.Status.GetCondition(apis.ConditionSucceeded).IsFalse() {
 			t.Errorf("Expected PipelineRun to not be failed but has condition status false")
+		}
+	}
+}
+
+func TestReconcile_RemotePipeline_PipelineNameLabel(t *testing.T) {
+	names.TestingSeed()
+
+	namespace := "foo"
+	prName := "test-pipeline-run-success"
+	trName := "test-pipeline-run-success-unit-test-1"
+
+	prs := []*v1.PipelineRun{parse.MustParseV1PipelineRun(t, `
+metadata:
+  name: test-pipeline-run-success
+  namespace: foo
+spec:
+  pipelineRef:
+    resolver: bar
+  taskRunTemplate:
+    serviceAccountName: test-sa
+  timeout: 1h0m0s
+`)}
+	ps := parse.MustParseV1Pipeline(t, `
+metadata:
+  name: test-pipeline
+  namespace: foo
+spec:
+  tasks:
+  - name: unit-test-1
+    taskRef:
+      resolver: bar
+`)
+	notNamePipeline := parse.MustParseV1Pipeline(t, `
+metadata:
+  namespace: foo
+spec:
+  tasks:
+  - name: unit-test-1
+    taskRef:
+      resolver: bar
+`)
+
+	remoteTask := parse.MustParseV1Task(t, `
+metadata:
+  name: unit-test-task
+  namespace: foo
+`)
+
+	pipelineBytes, err := yaml.Marshal(ps)
+	if err != nil {
+		t.Fatal("fail to marshal pipeline", err)
+	}
+	notNamePipelineBytes, err := yaml.Marshal(notNamePipeline)
+	if err != nil {
+		t.Fatal("fail to marshal pipeline", err)
+	}
+
+	taskBytes, err := yaml.Marshal(remoteTask)
+	if err != nil {
+		t.Fatal("fail to marshal task", err)
+	}
+
+	pipelineReq := getResolvedResolutionRequest(t, "bar", pipelineBytes, "foo", prName)
+	notNamePipelineReq := getResolvedResolutionRequest(t, "bar", notNamePipelineBytes, "foo", prName)
+	taskReq := getResolvedResolutionRequest(t, "bar", taskBytes, "foo", trName)
+
+	tcs := []struct {
+		name             string
+		wantPipelineName string
+		pipelineReq      resolutionv1beta1.ResolutionRequest
+		taskReq          resolutionv1beta1.ResolutionRequest
+	}{{
+		name: "remote pipeline contains name",
+		// Use the name from the remote pipeline
+		wantPipelineName: ps.Name,
+		pipelineReq:      pipelineReq,
+		taskReq:          taskReq,
+	}, {
+		name:             "remote pipeline without name",
+		wantPipelineName: prs[0].Name,
+		pipelineReq:      notNamePipelineReq,
+		taskReq:          taskReq,
+	}}
+
+	for _, tc := range tcs {
+		// Unlike the tests above, we do *not* locally define our pipeline or unit-test task.
+		d := test.Data{
+			PipelineRuns: prs,
+			ServiceAccounts: []*corev1.ServiceAccount{{
+				ObjectMeta: metav1.ObjectMeta{Name: prs[0].Spec.TaskRunTemplate.ServiceAccountName, Namespace: namespace},
+			}},
+			ConfigMaps: []*corev1.ConfigMap{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: config.GetFeatureFlagsConfigName(), Namespace: system.Namespace()},
+					Data: map[string]string{
+						"enable-api-fields": "beta",
+					},
+				},
+			},
+			ResolutionRequests: []*resolutionv1beta1.ResolutionRequest{&tc.taskReq, &tc.pipelineReq},
+		}
+
+		prt := newPipelineRunTest(t, d)
+		defer prt.Cancel()
+
+		wantEvents := []string{
+			"Normal Started",
+			"Normal Running Tasks Completed: 0",
+		}
+		reconciledRun, _ := prt.reconcileRun(namespace, prName, wantEvents, false)
+		if len(reconciledRun.Labels) == 0 {
+			t.Errorf("the pipeline label in pr is not set")
+		}
+		pName := reconciledRun.Labels[pipeline.PipelineLabelKey]
+		if reconciledRun.Labels[pipeline.PipelineLabelKey] != tc.wantPipelineName {
+			t.Errorf("want pipeline name %s, but got %s", tc.wantPipelineName, pName)
+		}
+
+		// Verify the pipeline name label after the second `reconcile`, to prevent it from being overwritten again.
+		reconciledRun, _ = prt.reconcileRun(namespace, prName, wantEvents, false)
+		if len(reconciledRun.Labels) == 0 {
+			t.Errorf("the pipeline label in pr is not set")
+		}
+		pName = reconciledRun.Labels[pipeline.PipelineLabelKey]
+		if reconciledRun.Labels[pipeline.PipelineLabelKey] != tc.wantPipelineName {
+			t.Errorf("want pipeline name %s, but got %s", tc.wantPipelineName, pName)
 		}
 	}
 }


### PR DESCRIPTION
Fixes: #7730 

_https://github.com/tektoncd/pipeline/issues/7730#issuecomment-1972787379_

Prior to this PR, the `propagatePipelineNameLabelToPipelineRun` 
function will continuously set the pipeline name label during 
each `reconcile` process. This may override the results by the 
`storePipelineSpecAndMergeMeta` function. This may cause some 
remote resource names to not be set correctly.

This commit, when the pipeline name label has been set, the next 
`reconcile` will not be reset again.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
