### PR TITLE
updating releases file to include 0.53.4 and 0.56.2

### DIFF
--- a/releases.md
+++ b/releases.md
@@ -50,17 +50,17 @@ Further documentation available:
 
 ### v0.56 (LTS)
 
-- **Latest Release**: [v0.56.1][v0.56-1] (2024-02-13) ([docs][v0.56-1-docs], [examples][v0.56-1-examples])
+- **Latest Release**: [v0.56.2][v0.56-2] (2024-03-05) ([docs][v0.56-2-docs], [examples][v0.56-2-examples])
 - **Initial Release**: [v0.56.0][v0.56-0] (2024-01-19)
 - **Estimated End of Life**: 2025-01-19
-- **Patch Releases**: [v0.56.0][v0.56-0]
+- **Patch Releases**: [v0.56.0][v0.56-0], [v0.56.1][v0.56-1]
 
 ### v0.53 (LTS)
 
-- **Latest Release**: [v0.53.2][v0.53-2] (2023-11-16) ([docs][v0.53-2-docs], [examples][v0.53-2-examples])
+- **Latest Release**: [v0.53.4][v0.53-4] (2024-03-05) ([docs][v0.53-4-docs], [examples][v0.53-4-examples])
 - **Initial Release**: [v0.53.0][v0.53-0] (2023-10-26)
 - **Estimated End of Life**: 2024-10-25
-- **Patch Releases**: [v0.53.0][v0.53-0], [v0.53.1][v0.53-1], [v0.53.2][v0.53-2]
+- **Patch Releases**: [v0.53.0][v0.53-0], [v0.53.1][v0.53-1], [v0.53.2][v0.53-2], [v0.53.3][v0.53-3]
 
 ### v0.50 (LTS)
 
@@ -195,10 +195,13 @@ Older releases are EOL and available on [GitHub][tekton-pipeline-releases].
 [release-notes-standards]:
     https://github.com/tektoncd/community/blob/main/standards.md#release-notes
 
-[v0.57-0]: https://github.com/tektoncd/pipeline/releases/tag/v0.57.0    
+[v0.57-0]: https://github.com/tektoncd/pipeline/releases/tag/v0.57.0
+[v0.56-2]: https://github.com/tektoncd/pipeline/releases/tag/v0.56.2
 [v0.56-1]: https://github.com/tektoncd/pipeline/releases/tag/v0.56.1
 [v0.56-0]: https://github.com/tektoncd/pipeline/releases/tag/v0.56.0
 [v0.54-0]: https://github.com/tektoncd/pipeline/releases/tag/v0.54.0
+[v0.53-4]: https://github.com/tektoncd/pipeline/releases/tag/v0.53.4
+[v0.53-3]: https://github.com/tektoncd/pipeline/releases/tag/v0.53.3
 [v0.53-2]: https://github.com/tektoncd/pipeline/releases/tag/v0.53.2
 [v0.53-1]: https://github.com/tektoncd/pipeline/releases/tag/v0.53.1
 [v0.53-0]: https://github.com/tektoncd/pipeline/releases/tag/v0.53.0
@@ -244,26 +247,18 @@ Older releases are EOL and available on [GitHub][tekton-pipeline-releases].
 [v0-37-0]: https://github.com/tektoncd/pipeline/releases/tag/v0.37.0
 
 [v0.57-0-docs]: https://github.com/tektoncd/pipeline/tree/v0.57.0/docs#tekton-pipelines
-[v0.56-1-docs]: https://github.com/tektoncd/pipeline/tree/v0.56.1/docs#tekton-pipelines
-[v0.56-0-docs]: https://github.com/tektoncd/pipeline/tree/v0.56.0/docs#tekton-pipelines
+[v0.56-2-docs]: https://github.com/tektoncd/pipeline/tree/v0.56.2/docs#tekton-pipelines
 [v0.54-0-docs]: https://github.com/tektoncd/pipeline/tree/v0.54.0/docs#tekton-pipelines
-[v0.53-0-docs]: https://github.com/tektoncd/pipeline/tree/v0.53.0/docs#tekton-pipelines
+[v0.53-4-docs]: https://github.com/tektoncd/pipeline/tree/v0.53.4/docs#tekton-pipelines
 [v0.52-0-docs]: https://github.com/tektoncd/pipeline/tree/v0.52.0/docs#tekton-pipelines
 [v0.51-0-docs]: https://github.com/tektoncd/pipeline/tree/v0.51.0/docs#tekton-pipelines
 [v0.50-5-docs]: https://github.com/tektoncd/pipeline/tree/v0.50.5/docs#tekton-pipelines
-[v0.50-4-docs]: https://github.com/tektoncd/pipeline/tree/v0.50.4/docs#tekton-pipelines
-[v0.50-3-docs]: https://github.com/tektoncd/pipeline/tree/v0.50.3/docs#tekton-pipelines
-[v0.50-2-docs]: https://github.com/tektoncd/pipeline/tree/v0.50.2/docs#tekton-pipelines
-[v0.50-1-docs]: https://github.com/tektoncd/pipeline/tree/v0.50.1/docs#tekton-pipelines
-[v0.50-0-docs]: https://github.com/tektoncd/pipeline/tree/v0.50.0/docs#tekton-pipelines
 [v0-49-0-docs]: https://github.com/tektoncd/pipeline/tree/v0.49.0/docs#tekton-pipelines
 [v0-48-0-docs]: https://github.com/tektoncd/pipeline/tree/v0.48.0/docs#tekton-pipelines
 [v0-47-3-docs]: https://github.com/tektoncd/pipeline/tree/v0.47.3/docs#tekton-pipelines
 [v0-46-0-docs]: https://github.com/tektoncd/pipeline/tree/v0.46.0/docs#tekton-pipelines
 [v0-45-0-docs]: https://github.com/tektoncd/pipeline/tree/v0.45.0/docs#tekton-pipelines
 [v0-44-4-docs]: https://github.com/tektoncd/pipeline/tree/v0.44.4/docs#tekton-pipelines
-[v0-43-0-docs]: https://github.com/tektoncd/pipeline/tree/v0.43.0/docs#tekton-pipelines
-[v0-43-1-docs]: https://github.com/tektoncd/pipeline/tree/v0.43.1/docs#tekton-pipelines
 [v0-43-2-docs]: https://github.com/tektoncd/pipeline/tree/v0.43.2/docs#tekton-pipelines
 [v0-42-0-docs]: https://github.com/tektoncd/pipeline/tree/v0.42.0/docs#tekton-pipelines
 [v0-41-3-docs]: https://github.com/tektoncd/pipeline/tree/v0.41.3/docs#tekton-pipelines
@@ -273,20 +268,12 @@ Older releases are EOL and available on [GitHub][tekton-pipeline-releases].
 [v0-37-5-docs]: https://github.com/tektoncd/pipeline/tree/v0.37.5/docs#tekton-pipelines
 
 [v0.57-0-examples]: https://github.com/tektoncd/pipeline/tree/v0.57.0/examples#examples
-[v0.56-1-examples]: https://github.com/tektoncd/pipeline/tree/v0.56.1/examples#examples
-[v0.56-0-examples]: https://github.com/tektoncd/pipeline/tree/v0.56.0/examples#examples
+[v0.56-2-examples]: https://github.com/tektoncd/pipeline/tree/v0.56.2/examples#examples
 [v0.54-0-examples]: https://github.com/tektoncd/pipeline/tree/v0.54.0/examples#examples
-[v0.53-2-examples]: https://github.com/tektoncd/pipeline/tree/v0.53.2/examples#examples
-[v0.53-1-examples]: https://github.com/tektoncd/pipeline/tree/v0.53.1/examples#examples
-[v0.53-0-examples]: https://github.com/tektoncd/pipeline/tree/v0.53.0/examples#examples
+[v0.53-4-examples]: https://github.com/tektoncd/pipeline/tree/v0.53.4/examples#examples
 [v0.52-0-examples]: https://github.com/tektoncd/pipeline/tree/v0.52.0/examples#examples
 [v0.51-0-examples]: https://github.com/tektoncd/pipeline/tree/v0.51.0/examples#examples
 [v0.50-5-examples]: https://github.com/tektoncd/pipeline/tree/v0.50.5/examples#examples
-[v0.50-4-examples]: https://github.com/tektoncd/pipeline/tree/v0.50.4/examples#examples
-[v0.50-3-examples]: https://github.com/tektoncd/pipeline/tree/v0.50.3/examples#examples
-[v0.50-2-examples]: https://github.com/tektoncd/pipeline/tree/v0.50.2/examples#examples
-[v0.50-1-examples]: https://github.com/tektoncd/pipeline/tree/v0.50.1/examples#examples
-[v0.50-0-examples]: https://github.com/tektoncd/pipeline/tree/v0.50.0/examples#examples
 [v0-49-0-examples]: https://github.com/tektoncd/pipeline/tree/v0.49.0/examples#examples
 [v0-48-0-examples]: https://github.com/tektoncd/pipeline/tree/v0.48.0/examples#examples
 [v0-47-3-examples]: https://github.com/tektoncd/pipeline/tree/v0.47.3/examples#examples


### PR DESCRIPTION
Document two patch releases - 0.53.4 and 0.56.2

Cleaning up unused references to older releases, docs and examples

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Document two patch releases - 0.53.4 and 0.56.2

Cleaning up unused references to older releases, docs and examples

/kind documentation


# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
