### PR TITLE
fix: pipeline execution status test case index error

### DIFF
--- a/pkg/apis/pipeline/v1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1/pipeline_validation.go
@@ -504,7 +504,7 @@ func validateExecutionStatusVariables(tasks []PipelineTask, finallyTasks []Pipel
 // dag tasks cannot have param value as $(tasks.pipelineTask.status)
 func validateExecutionStatusVariablesInTasks(tasks []PipelineTask) (errs *apis.FieldError) {
 	for idx, t := range tasks {
-		errs = errs.Also(t.validateExecutionStatusVariablesDisallowed()).ViaIndex(idx)
+		errs = errs.Also(t.validateExecutionStatusVariablesDisallowed().ViaIndex(idx))
 	}
 	return errs
 }

--- a/pkg/apis/pipeline/v1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1/pipeline_validation_test.go
@@ -3535,6 +3535,25 @@ func TestPipelineTasksExecutionStatus(t *testing.T) {
 			Paths:   []string{"tasks[0].params[tasks-status].value"},
 		},
 	}, {
+		name: "invalid array variable in multi dag tasks accessing aggregate tasks status",
+		tasks: []PipelineTask{
+			{
+				Name:    "foo",
+				TaskRef: &TaskRef{Name: "foo-task"},
+				Params: Params{{
+					Name: "tasks-status", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"$(tasks.status)"}},
+				}},
+			},
+			{
+				Name:    "bar",
+				TaskRef: &TaskRef{Name: "foo-task"},
+			},
+		},
+		expectedError: apis.FieldError{
+			Message: `invalid value: pipeline tasks can not refer to execution status of any other pipeline task or aggregate status of tasks`,
+			Paths:   []string{"tasks[0].params[tasks-status].value"},
+		},
+	}, {
 		name: "invalid string variable in finally accessing missing pipelineTask status",
 		finalTasks: []PipelineTask{{
 			Name:    "bar",

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation.go
@@ -507,7 +507,7 @@ func validateExecutionStatusVariables(tasks []PipelineTask, finallyTasks []Pipel
 // dag tasks cannot have param value as $(tasks.pipelineTask.status)
 func validateExecutionStatusVariablesInTasks(tasks []PipelineTask) (errs *apis.FieldError) {
 	for idx, t := range tasks {
-		errs = errs.Also(t.validateExecutionStatusVariablesDisallowed()).ViaIndex(idx)
+		errs = errs.Also(t.validateExecutionStatusVariablesDisallowed().ViaIndex(idx))
 	}
 	return errs
 }

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
@@ -3578,6 +3578,25 @@ func TestPipelineTasksExecutionStatus(t *testing.T) {
 			Paths:   []string{"tasks[0].params[tasks-status].value"},
 		},
 	}, {
+		name: "invalid array variable in multi dag tasks accessing aggregate tasks status",
+		tasks: []PipelineTask{
+			{
+				Name:    "foo",
+				TaskRef: &TaskRef{Name: "foo-task"},
+				Params: Params{{
+					Name: "tasks-status", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"$(tasks.status)"}},
+				}},
+			},
+			{
+				Name:    "bar",
+				TaskRef: &TaskRef{Name: "foo-task"},
+			},
+		},
+		expectedError: apis.FieldError{
+			Message: `invalid value: pipeline tasks can not refer to execution status of any other pipeline task or aggregate status of tasks`,
+			Paths:   []string{"tasks[0].params[tasks-status].value"},
+		},
+	}, {
 		name: "invalid string variable in finally accessing missing pipelineTask status",
 		finalTasks: []PipelineTask{{
 			Name:    "bar",


### PR DESCRIPTION

![image](https://github.com/tektoncd/pipeline/assets/19320253/de7b6e38-fc0d-461b-bb7b-86790672a274)


When creating a pipeline, the index in the prompt content provided is incorrect.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
