### PR TITLE
Fix reason of PipelineRun status for PipelineRun having tasks timeout

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -2891,20 +2891,21 @@ status:
 		defer prt.Cancel()
 
 		wantEvents := []string{
-			"Normal Started",
+			"Warning Failed PipelineRun",
 		}
 		reconciledRun, clients := prt.reconcileRun("foo", "test-pipeline-run-with-timeout", wantEvents, false)
 
-		if reconciledRun.Status.CompletionTime != nil {
-			t.Errorf("Expected nil CompletionTime on PipelineRun but was %s", reconciledRun.Status.CompletionTime)
+		if reconciledRun.Status.CompletionTime == nil {
+			t.Errorf("Expected CompletionTime on PipelineRun but was %s", reconciledRun.Status.CompletionTime)
 		}
 
-		// The PipelineRun should be running.
-		if reconciledRun.Status.GetCondition(apis.ConditionSucceeded).Reason != v1.PipelineRunReasonRunning.String() {
-			t.Errorf("Expected PipelineRun to be running, but condition reason is %s", reconciledRun.Status.GetCondition(apis.ConditionSucceeded).Reason)
+		// The PipelineRun should be timeout.
+		if reconciledRun.Status.GetCondition(apis.ConditionSucceeded).Reason != v1.PipelineRunReasonTimedOut.String() {
+			t.Errorf("Expected PipelineRun to be time out, but condition reason is %s", reconciledRun.Status.GetCondition(apis.ConditionSucceeded).Reason)
 		}
 
 		// Check that there is a skipped task for the expected reason
+
 		if len(reconciledRun.Status.SkippedTasks) != 1 {
 			t.Errorf("expected one skipped task, found %d", len(reconciledRun.Status.SkippedTasks))
 		} else if reconciledRun.Status.SkippedTasks[0].Reason != v1.TasksTimedOutSkip {
@@ -3031,7 +3032,7 @@ spec:
   pipelineRef:
     name: test-pipeline-with-finally
   timeouts:
-    tasks: 5m
+    tasks: 25m
     pipeline: 20m
 status:
   finallyStartTime: "2021-12-31T23:44:59Z"
@@ -3259,7 +3260,7 @@ spec:
   pipelineRef:
     name: test-pipeline-with-finally
   timeouts:
-    tasks: 5m
+    tasks: 25m
     pipeline: 20m
 status:
   startTime: "2021-12-31T23:40:00Z"
@@ -3308,7 +3309,7 @@ spec:
   pipelineRef:
     name: test-pipeline-with-finally
   timeouts:
-    tasks: 5m
+    tasks: 25m
     pipeline: 20m
 status:
   startTime: "2021-12-31T23:40:00Z"
@@ -3348,7 +3349,7 @@ spec:
   pipelineRef:
     name: test-pipeline-with-finally
   timeouts:
-    tasks: 5m
+    tasks: 25m
     pipeline: 20m
 status:
   startTime: "2021-12-31T23:40:00Z"

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
@@ -497,6 +497,15 @@ func (facts *PipelineRunFacts) GetPipelineConditionStatus(ctx context.Context, p
 		}
 	}
 
+	if pr.HaveTasksTimedOut(ctx, c) {
+		return &apis.Condition{
+			Type:    apis.ConditionSucceeded,
+			Status:  corev1.ConditionFalse,
+			Reason:  v1.PipelineRunReasonTimedOut.String(),
+			Message: fmt.Sprintf("PipelineRun %q failed due to tasks failed to finish within %q", pr.Name, pr.TasksTimeout().Duration.String()),
+		}
+	}
+
 	// report the count in PipelineRun Status
 	// get the count of successful tasks, failed tasks, cancelled tasks, skipped task, and incomplete tasks
 	s := facts.getPipelineTasksCount()

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
@@ -2141,6 +2141,39 @@ func TestGetPipelineConditionStatus_PipelineTimeouts(t *testing.T) {
 	}
 }
 
+// pipeline should result in timeout if its runtime exceeds its spec.Timeouts.Tasks based on its status.Timeout
+func TestGetPipelineConditionStatus_PipelineTasksTimeouts(t *testing.T) {
+	d, err := dagFromState(oneFinishedState)
+	if err != nil {
+		t.Fatalf("Unexpected error while building DAG for state %v: %v", oneFinishedState, err)
+	}
+	pr := &v1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "pipelinerun-no-tasks-started"},
+		Spec: v1.PipelineRunSpec{
+			Timeouts: &v1.TimeoutFields{
+				Tasks: &metav1.Duration{Duration: 1 * time.Minute},
+			},
+		},
+		Status: v1.PipelineRunStatus{
+			PipelineRunStatusFields: v1.PipelineRunStatusFields{
+				StartTime: &metav1.Time{Time: now.Add(-2 * time.Minute)},
+			},
+		},
+	}
+	facts := PipelineRunFacts{
+		State:           oneFinishedState,
+		TasksGraph:      d,
+		FinalTasksGraph: &dag.Graph{},
+		TimeoutsState: PipelineRunTimeoutsState{
+			Clock: testClock,
+		},
+	}
+	c := facts.GetPipelineConditionStatus(t.Context(), pr, zap.NewNop().Sugar(), testClock)
+	if c.Status != corev1.ConditionFalse && c.Reason != v1.PipelineRunReasonTimedOut.String() {
+		t.Fatalf("Expected to get status %s but got %s for state %v", corev1.ConditionFalse, c.Status, oneFinishedState)
+	}
+}
+
 func TestGetPipelineConditionStatus_OnError(t *testing.T) {
 	var oneFailedStateOnError = PipelineRunState{{
 		PipelineTask: &v1.PipelineTask{

--- a/test/timeout_test.go
+++ b/test/timeout_test.go
@@ -511,7 +511,7 @@ spec:
 	}
 
 	t.Logf("Waiting for PipelineRun %s in namespace %s to be failed", pipelineRun.Name, namespace)
-	if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, timeout, FailedWithReason(v1.PipelineRunReasonFailed.String(), pipelineRun.Name), "PipelineRunFailed", v1Version); err != nil {
+	if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, timeout, FailedWithReason(v1.PipelineRunReasonTimedOut.String(), pipelineRun.Name), "PipelineRunFailed", v1Version); err != nil {
 		t.Errorf("Error waiting for PipelineRun %s to finish: %s", pipelineRun.Name, err)
 	}
 


### PR DESCRIPTION
This patch fixes to set the reason of PipelineRun
status to PipelineRunTimeout if the tasks of a PipelineRun
timeout because of the timeout.tasks parameter

Fixes: #7573

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
 Set the reason of PipelineRun status to PipelineRunTimeout if the tasks of a PipelineRun is timeout
```
