### PR TITLE
 fix: the params in step replace other fields in step that are not in stepaction

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/stepaction_types.go
+++ b/pkg/apis/pipeline/v1alpha1/stepaction_types.go
@@ -142,6 +142,21 @@ type StepActionSpec struct {
 	VolumeMounts []corev1.VolumeMount `json:"volumeMounts,omitempty" patchStrategy:"merge" patchMergeKey:"mountPath" protobuf:"bytes,9,rep,name=volumeMounts"`
 }
 
+// ToStep converts the StepActionSpec to a Step struct
+func (ss *StepActionSpec) ToStep() *v1.Step {
+	return &v1.Step{
+		Image:           ss.Image,
+		Command:         ss.Command,
+		Args:            ss.Args,
+		WorkingDir:      ss.WorkingDir,
+		Script:          ss.Script,
+		Env:             ss.Env,
+		VolumeMounts:    ss.VolumeMounts,
+		SecurityContext: ss.SecurityContext,
+		Results:         ss.Results,
+	}
+}
+
 // StepActionObject is implemented by StepAction
 type StepActionObject interface {
 	apis.Defaultable

--- a/pkg/reconciler/taskrun/resources/taskspec.go
+++ b/pkg/reconciler/taskrun/resources/taskspec.go
@@ -114,31 +114,33 @@ func GetStepActionsData(ctx context.Context, taskSpec v1.TaskSpec, taskRun *v1.T
 			stepActionSpec := stepAction.StepActionSpec()
 			stepActionSpec.SetDefaults(ctx)
 
-			s.Image = stepActionSpec.Image
-			s.SecurityContext = stepActionSpec.SecurityContext
-			if len(stepActionSpec.Command) > 0 {
-				s.Command = stepActionSpec.Command
-			}
-			if len(stepActionSpec.Args) > 0 {
-				s.Args = stepActionSpec.Args
-			}
-			if stepActionSpec.Script != "" {
-				s.Script = stepActionSpec.Script
-			}
-			s.WorkingDir = stepActionSpec.WorkingDir
-			if stepActionSpec.Env != nil {
-				s.Env = stepActionSpec.Env
-			}
-			if len(stepActionSpec.VolumeMounts) > 0 {
-				s.VolumeMounts = stepActionSpec.VolumeMounts
-			}
-			if len(stepActionSpec.Results) > 0 {
-				s.Results = stepActionSpec.Results
-			}
+			stepFromStepAction := stepActionSpec.ToStep()
 			if err := validateStepHasStepActionParameters(s.Params, stepActionSpec.Params); err != nil {
 				return nil, err
 			}
-			s = applyStepActionParameters(s, &taskSpec, taskRun, s.Params, stepActionSpec.Params)
+			stepFromStepAction = applyStepActionParameters(stepFromStepAction, &taskSpec, taskRun, s.Params, stepActionSpec.Params)
+
+			s.Image = stepFromStepAction.Image
+			s.SecurityContext = stepFromStepAction.SecurityContext
+			if len(stepFromStepAction.Command) > 0 {
+				s.Command = stepFromStepAction.Command
+			}
+			if len(stepFromStepAction.Args) > 0 {
+				s.Args = stepFromStepAction.Args
+			}
+			if stepFromStepAction.Script != "" {
+				s.Script = stepFromStepAction.Script
+			}
+			s.WorkingDir = stepFromStepAction.WorkingDir
+			if stepFromStepAction.Env != nil {
+				s.Env = stepFromStepAction.Env
+			}
+			if len(stepFromStepAction.VolumeMounts) > 0 {
+				s.VolumeMounts = stepFromStepAction.VolumeMounts
+			}
+			if len(stepFromStepAction.Results) > 0 {
+				s.Results = stepFromStepAction.Results
+			}
 			s.Params = nil
 			s.Ref = nil
 			steps = append(steps, *s)


### PR DESCRIPTION
Fixes: #7753 

Prior to this PR, the `step` contains `params`, these `params` are 
passed to `stepaction`, but it may be passed to other fields in `step`, 
such as: `StdoutConfig`.

This commit will only pass the fields in `stepaction` and replace 
these fields with `params` in `step`.

/kind bug
/assign @chitrangpatel 

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Pass only the fields in `stepaction` and replace these fields with the `params` in step.
```
