### PR TITLE
fix: do not set default kind when taskRef resolver is present

### DIFF
--- a/pkg/apis/pipeline/v1/pipeline_defaults.go
+++ b/pkg/apis/pipeline/v1/pipeline_defaults.go
@@ -50,11 +50,11 @@ func (ps *PipelineSpec) SetDefaults(ctx context.Context) {
 func (pt *PipelineTask) SetDefaults(ctx context.Context) {
 	cfg := config.FromContextOrDefaults(ctx)
 	if pt.TaskRef != nil {
-		if pt.TaskRef.Kind == "" {
-			pt.TaskRef.Kind = NamespacedTaskKind
-		}
 		if pt.TaskRef.Name == "" && pt.TaskRef.Resolver == "" {
 			pt.TaskRef.Resolver = ResolverName(cfg.Defaults.DefaultResolverType)
+		}
+		if pt.TaskRef.Kind == "" && pt.TaskRef.Resolver == "" {
+			pt.TaskRef.Kind = NamespacedTaskKind
 		}
 	}
 	if pt.TaskSpec != nil {

--- a/pkg/apis/pipeline/v1/pipeline_defaults_test.go
+++ b/pkg/apis/pipeline/v1/pipeline_defaults_test.go
@@ -207,7 +207,6 @@ func TestPipelineTask_SetDefaults(t *testing.T) {
 		want: &v1.PipelineTask{
 			Name: "foo",
 			TaskRef: &v1.TaskRef{
-				Kind: v1.NamespacedTaskKind,
 				ResolverRef: v1.ResolverRef{
 					Resolver: "git",
 				},
@@ -229,7 +228,6 @@ func TestPipelineTask_SetDefaults(t *testing.T) {
 		want: &v1.PipelineTask{
 			Name: "foo",
 			TaskRef: &v1.TaskRef{
-				Kind: v1.NamespacedTaskKind,
 				ResolverRef: v1.ResolverRef{
 					Resolver: "custom resolver",
 				},

--- a/pkg/apis/pipeline/v1/taskrun_defaults.go
+++ b/pkg/apis/pipeline/v1/taskrun_defaults.go
@@ -59,11 +59,11 @@ func (tr *TaskRun) SetDefaults(ctx context.Context) {
 func (trs *TaskRunSpec) SetDefaults(ctx context.Context) {
 	cfg := config.FromContextOrDefaults(ctx)
 	if trs.TaskRef != nil {
-		if trs.TaskRef.Kind == "" {
-			trs.TaskRef.Kind = NamespacedTaskKind
-		}
 		if trs.TaskRef.Name == "" && trs.TaskRef.Resolver == "" {
 			trs.TaskRef.Resolver = ResolverName(cfg.Defaults.DefaultResolverType)
+		}
+		if trs.TaskRef.Kind == "" && trs.TaskRef.Resolver == "" {
+			trs.TaskRef.Kind = NamespacedTaskKind
 		}
 	}
 

--- a/pkg/apis/pipeline/v1/taskrun_defaults_test.go
+++ b/pkg/apis/pipeline/v1/taskrun_defaults_test.go
@@ -349,7 +349,6 @@ func TestTaskRunDefaulting(t *testing.T) {
 			},
 			Spec: v1.TaskRunSpec{
 				TaskRef: &v1.TaskRef{
-					Kind: "Task",
 					ResolverRef: v1.ResolverRef{
 						Resolver: "git",
 					},
@@ -378,7 +377,6 @@ func TestTaskRunDefaulting(t *testing.T) {
 			},
 			Spec: v1.TaskRunSpec{
 				TaskRef: &v1.TaskRef{
-					Kind: "Task",
 					ResolverRef: v1.ResolverRef{
 						Resolver: "custom resolver",
 					},

--- a/pkg/apis/pipeline/v1beta1/pipeline_defaults.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_defaults.go
@@ -50,11 +50,11 @@ func (ps *PipelineSpec) SetDefaults(ctx context.Context) {
 func (pt *PipelineTask) SetDefaults(ctx context.Context) {
 	cfg := config.FromContextOrDefaults(ctx)
 	if pt.TaskRef != nil {
-		if pt.TaskRef.Kind == "" {
-			pt.TaskRef.Kind = NamespacedTaskKind
-		}
 		if pt.TaskRef.Name == "" && pt.TaskRef.Resolver == "" {
 			pt.TaskRef.Resolver = ResolverName(cfg.Defaults.DefaultResolverType)
+		}
+		if pt.TaskRef.Kind == "" && pt.TaskRef.Resolver == "" {
+			pt.TaskRef.Kind = NamespacedTaskKind
 		}
 	}
 	if pt.TaskSpec != nil {

--- a/pkg/apis/pipeline/v1beta1/pipeline_defaults_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_defaults_test.go
@@ -207,7 +207,6 @@ func TestPipelineTask_SetDefaults(t *testing.T) {
 		want: &v1beta1.PipelineTask{
 			Name: "foo",
 			TaskRef: &v1beta1.TaskRef{
-				Kind: v1beta1.NamespacedTaskKind,
 				ResolverRef: v1beta1.ResolverRef{
 					Resolver: "git",
 				},
@@ -229,7 +228,6 @@ func TestPipelineTask_SetDefaults(t *testing.T) {
 		want: &v1beta1.PipelineTask{
 			Name: "foo",
 			TaskRef: &v1beta1.TaskRef{
-				Kind: v1beta1.NamespacedTaskKind,
 				ResolverRef: v1beta1.ResolverRef{
 					Resolver: "custom resolver",
 				},

--- a/pkg/apis/pipeline/v1beta1/taskref_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/taskref_conversion.go
@@ -49,6 +49,7 @@ func (tr *TaskRef) ConvertFrom(ctx context.Context, source v1.TaskRef) {
 // default and it will be in beta before the stored version of CRD getting swapped to v1.
 func (tr TaskRef) convertBundleToResolver(sink *v1.TaskRef) {
 	if tr.Bundle != "" {
+		sink.Kind = ""
 		sink.ResolverRef = v1.ResolverRef{
 			Resolver: "bundles",
 			Params: v1.Params{{

--- a/pkg/apis/pipeline/v1beta1/taskrun_defaults.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_defaults.go
@@ -59,11 +59,11 @@ func (tr *TaskRun) SetDefaults(ctx context.Context) {
 func (trs *TaskRunSpec) SetDefaults(ctx context.Context) {
 	cfg := config.FromContextOrDefaults(ctx)
 	if trs.TaskRef != nil {
-		if trs.TaskRef.Kind == "" {
-			trs.TaskRef.Kind = NamespacedTaskKind
-		}
 		if trs.TaskRef.Name == "" && trs.TaskRef.Resolver == "" {
 			trs.TaskRef.Resolver = ResolverName(cfg.Defaults.DefaultResolverType)
+		}
+		if trs.TaskRef.Kind == "" && trs.TaskRef.Resolver == "" {
+			trs.TaskRef.Kind = NamespacedTaskKind
 		}
 	}
 

--- a/pkg/apis/pipeline/v1beta1/taskrun_defaults_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_defaults_test.go
@@ -359,7 +359,6 @@ func TestTaskRunDefaulting(t *testing.T) {
 			},
 			Spec: v1beta1.TaskRunSpec{
 				TaskRef: &v1beta1.TaskRef{
-					Kind: "Task",
 					ResolverRef: v1beta1.ResolverRef{
 						Resolver: "git",
 					},
@@ -388,7 +387,6 @@ func TestTaskRunDefaulting(t *testing.T) {
 			},
 			Spec: v1beta1.TaskRunSpec{
 				TaskRef: &v1beta1.TaskRef{
-					Kind: "Task",
 					ResolverRef: v1beta1.ResolverRef{
 						Resolver: "custom resolver",
 					},

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -8380,7 +8380,6 @@ metadata:
 spec:
   serviceAccountName: test-sa
   taskRef:
-    kind: Task
     resolver: bar
 `)
 

--- a/pkg/reconciler/pipelinerun/pipelinespec/pipelinespec_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinespec/pipelinespec_test.go
@@ -203,7 +203,6 @@ func TestGetPipelineData_ResolutionSuccess(t *testing.T) {
 				Tasks: []v1.PipelineTask{{
 					Name: "pt1",
 					TaskRef: &v1.TaskRef{
-						Kind: "Task",
 						ResolverRef: v1.ResolverRef{
 							Resolver: "foo",
 						},

--- a/test/conversion_test.go
+++ b/test/conversion_test.go
@@ -710,7 +710,6 @@ spec:
   serviceAccountName: default
   timeout: 1h
   taskRef:
-    kind: Task
     resolver: bundles
     params:
     - name: bundle
@@ -746,10 +745,9 @@ metadata:
   namespace: %s
 spec:
   taskRunTemplate:
-  timeouts: 
+  timeouts:
     pipeline: 1h
   pipelineRef:
-    kind: Pipeline
     resolver: bundles
     params:
     - name: bundle
@@ -767,7 +765,6 @@ status:
     tasks:
     - name: hello-world
       taskRef:
-        kind: Task
         resolver: bundles
         params:
         - name: bundle
@@ -788,7 +785,6 @@ metadata:
 spec:
   timeout: 1h
   taskRef:
-    kind: Task
     resolver: bundles
     params:
     - name: bundle
@@ -822,10 +818,9 @@ metadata:
   name: %s
   namespace: %s
 spec:
-  timeouts: 
+  timeouts:
     pipeline: 1h
   pipelineRef:
-    kind: Pipeline
     resolver: bundles
     params:
     - name: bundle
@@ -843,7 +838,6 @@ status:
     tasks:
     - name: hello-world
       taskRef:
-        kind: Task
         resolver: bundles
         params:
         - name: bundle


### PR DESCRIPTION
fix #7762

Do not set default kind when taskRef resolver is present, keep the original configuration of the user.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
fix: do not set default kind when taskRef resolver is present
```

/kind bug