### PR TITLE
Fix:  add notes for why not to import the dependency pkg for OptimisticLockErrorMsg

### DIFF
--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -1079,9 +1079,10 @@ func isResourceQuotaConflictError(err error) bool {
 }
 
 const (
-	// TODO(#7466) Currently this appears as a local constant due to upstream dependencies bump blocker.
-	// This shall reference to k8s.io/apiserver/pkg/registry/generic/registry.OptimisticLockErrorMsg
-	// once #7464 is unblocked.
+	// optimisticLockErrorMsg is an error message exported from k8s.io/apiserver/pkg/registry/generic/registry.OptimisticLockErrorMsg
+	// We made a tradeoff here because importing the package would introduce approximately 94klines
+	// of code as a new dependency, and it would only be used to export one constant in one place.
+	// In future we might find a better way to maintain consistency for this upstream error message.
 	optimisticLockErrorMsg = "the object has been modified; please apply your changes to the latest version and try again"
 )
 


### PR DESCRIPTION
Fix https://github.com/tektoncd/pipeline/issues/7466

/kind cleanup

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

* Import `k8s.io/apiserver/pkg/registry/generic/registry` to use `OptimisticLockErrorMsg`
* Update the related test case
* Remove the local constant defination
* Update package dependencies by using `./hack/update-deps.sh`

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
