### PR TITLE
Do not register `StepAction` for conversion

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -153,7 +153,6 @@ func newConfigValidationController(name string) func(context.Context, configmap.
 
 func newConversionController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
 	var (
-		v1alpha1GroupVersion           = v1alpha1.SchemeGroupVersion.Version
 		v1beta1GroupVersion            = v1beta1.SchemeGroupVersion.Version
 		v1GroupVersion                 = v1.SchemeGroupVersion.Version
 		resolutionv1alpha1GroupVersion = resolutionv1alpha1.SchemeGroupVersion.Version
@@ -171,10 +170,6 @@ func newConversionController(ctx context.Context, cmw configmap.Watcher) *contro
 		// conversions to and from all types.
 		// "Zygotes" are the supported versions.
 		map[schema.GroupKind]conversion.GroupKindConversion{
-			v1alpha1.Kind("StepAction"): {
-				DefinitionName: pipeline.StepActionResource.String(),
-				HubVersion:     v1alpha1GroupVersion,
-			},
 			v1.Kind("Task"): {
 				DefinitionName: pipeline.TaskResource.String(),
 				HubVersion:     v1beta1GroupVersion,


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

`StepAction` only exists in `v1alpha1` and thus doesn't need to be
registered in the conversion webhook.

Prior to this commit, the webhook errors out (several times) with the
following:

```
custom resource \"stepactions.tekton.dev\" isn't configured for webhook conversion
```

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

Fixes #7794

/kind bug

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Removed StepAction from the conversion webhook to reduce the log spam that it isn't configured for it.
```
