### PR TITLE
Remove conversion configuration for `ClusterTask`

### DIFF
--- a/config/300-crds/300-clustertask.yaml
+++ b/config/300-crds/300-clustertask.yaml
@@ -51,11 +51,3 @@ spec:
     - tekton
     - tekton-pipelines
   scope: Cluster
-  conversion:
-    strategy: Webhook
-    webhook:
-      conversionReviewVersions: ["v1beta1"]
-      clientConfig:
-        service:
-          name: tekton-pipelines-webhook
-          namespace: tekton-pipelines


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

`ClusterTask` only exists in `v1beta1` and will never have a `v1` thus
doesn't need to be registered in the conversion webhook.

Prior to this commit, some tooling (like
https://github.com/openshift/cluster-kube-apiserver-operator/) might
assume there is a conversion webhook and then fail to communicate with
it (because we do not register `ClusterTask` in the conversion webhook
part) ; generating a lot of spam log.

As a rules of thumb, if we are not registering/refering an object in
`newConversionController` (in `cmd/webhook/main.go`), the `conversion`
field in the CRD shouldn't be defined either.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/kind bug

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Remove conversion webhook configuration from the ClusterTask CRD, it doesn't need it.
```
