### PR TITLE
Add reason tag to duration metrics

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -14,13 +14,13 @@ We expose several kinds of exporters, including Prometheus, Google Stackdriver, 
 | Name                                                                                    | Type | Labels/Tags                                     | Status |
 |-----------------------------------------------------------------------------------------| ----------- |-------------------------------------------------| ----------- |
 | `tekton_pipelines_controller_pipelinerun_duration_seconds_[bucket, sum, count]`         | Histogram/LastValue(Gauge) | `*pipeline`=&lt;pipeline_name&gt; <br> `*pipelinerun`=&lt;pipelinerun_name&gt; <br> `status`=&lt;status&gt; <br> `namespace`=&lt;pipelinerun-namespace&gt; | experimental |
-| `tekton_pipelines_controller_pipelinerun_taskrun_duration_seconds_[bucket, sum, count]` | Histogram/LastValue(Gauge) | `*pipeline`=&lt;pipeline_name&gt; <br> `*pipelinerun`=&lt;pipelinerun_name&gt; <br> `status`=&lt;status&gt; <br> `*task`=&lt;task_name&gt; <br> `*taskrun`=&lt;taskrun_name&gt;<br> `namespace`=&lt;pipelineruns-taskruns-namespace&gt; | experimental |
-| `tekton_pipelines_controller_pipelinerun_count` | Counter | `status`=&lt;status&gt;                         | deprecate |
+| `tekton_pipelines_controller_pipelinerun_taskrun_duration_seconds_[bucket, sum, count]` | Histogram/LastValue(Gauge) | `*pipeline`=&lt;pipeline_name&gt; <br> `*pipelinerun`=&lt;pipelinerun_name&gt; <br> `status`=&lt;status&gt; <br> `*task`=&lt;task_name&gt; <br> `*taskrun`=&lt;taskrun_name&gt;<br> `namespace`=&lt;pipelineruns-taskruns-namespace&gt;  <br> `*reason`=&lt;reason&gt; | experimental |
+| `tekton_pipelines_controller_pipelinerun_count` | Counter | `status`=&lt;status&gt;  <br> `*reason`=&lt;reason&gt; | deprecate |
 | `tekton_pipelines_controller_pipelinerun_total` | Counter | `status`=&lt;status&gt;                         | experimental |
 | `tekton_pipelines_controller_running_pipelineruns_count` | Gauge |                                                 | deprecate |
 | `tekton_pipelines_controller_running_pipelineruns` | Gauge |                                                 | experimental |
-| `tekton_pipelines_controller_taskrun_duration_seconds_[bucket, sum, count]` | Histogram/LastValue(Gauge) | `status`=&lt;status&gt; <br> `*task`=&lt;task_name&gt; <br> `*taskrun`=&lt;taskrun_name&gt;<br> `namespace`=&lt;pipelineruns-taskruns-namespace&gt; | experimental |
-| `tekton_pipelines_controller_taskrun_count` | Counter | `status`=&lt;status&gt;                         | deprecate |
+| `tekton_pipelines_controller_taskrun_duration_seconds_[bucket, sum, count]` | Histogram/LastValue(Gauge) | `status`=&lt;status&gt; <br> `*task`=&lt;task_name&gt; <br> `*taskrun`=&lt;taskrun_name&gt;<br> `namespace`=&lt;pipelineruns-taskruns-namespace&gt; <br> `*reason`=&lt;reason&gt; | experimental |
+| `tekton_pipelines_controller_taskrun_count` | Counter | `status`=&lt;status&gt; <br> `*reason`=&lt;reason&gt; | deprecate |
 | `tekton_pipelines_controller_taskrun_total` | Counter | `status`=&lt;status&gt;                         | experimental |
 | `tekton_pipelines_controller_running_taskruns_count` | Gauge |                                                 | deprecate |
 | `tekton_pipelines_controller_running_taskruns` | Gauge |                                                 | experimental |

--- a/pkg/pipelinerunmetrics/metrics.go
+++ b/pkg/pipelinerunmetrics/metrics.go
@@ -174,6 +174,12 @@ func viewRegister(cfg *config.Metrics) error {
 		}
 	}
 
+	prCountViewTags := []tag.Key{statusTag}
+	if cfg.CountWithReason {
+		prCountViewTags = append(prCountViewTags, reasonTag)
+		prunTag = append(prunTag, reasonTag)
+	}
+
 	prDurationView = &view.View{
 		Description: prDuration.Description(),
 		Measure:     prDuration,
@@ -181,10 +187,6 @@ func viewRegister(cfg *config.Metrics) error {
 		TagKeys:     append([]tag.Key{statusTag, namespaceTag}, prunTag...),
 	}
 
-	prCountViewTags := []tag.Key{statusTag}
-	if cfg.CountWithReason {
-		prCountViewTags = append(prCountViewTags, reasonTag)
-	}
 	prCountView = &view.View{
 		Description: prCount.Description(),
 		Measure:     prCount,

--- a/pkg/pipelinerunmetrics/metrics_test.go
+++ b/pkg/pipelinerunmetrics/metrics_test.go
@@ -339,6 +339,7 @@ func TestRecordPipelineRunDurationCount(t *testing.T) {
 			"pipeline":    "pipeline-1",
 			"pipelinerun": "pipelinerun-1",
 			"namespace":   "ns",
+			"reason":      "Failed",
 			"status":      "failed",
 		},
 		expectedCountTags: map[string]string{
@@ -375,6 +376,7 @@ func TestRecordPipelineRunDurationCount(t *testing.T) {
 			"pipelinerun": "pipelinerun-1",
 			"namespace":   "ns",
 			"status":      "cancelled",
+			"reason":      ReasonCancelled.String(),
 		},
 		expectedCountTags: map[string]string{
 			"status": "cancelled",

--- a/pkg/taskrunmetrics/metrics.go
+++ b/pkg/taskrunmetrics/metrics.go
@@ -212,6 +212,12 @@ func viewRegister(cfg *config.Metrics) error {
 		}
 	}
 
+	trCountViewTags := []tag.Key{statusTag}
+	if cfg.CountWithReason {
+		trCountViewTags = append(trCountViewTags, reasonTag)
+		trunTag = append(trunTag, reasonTag)
+	}
+
 	trDurationView = &view.View{
 		Description: trDuration.Description(),
 		Measure:     trDuration,
@@ -225,10 +231,6 @@ func viewRegister(cfg *config.Metrics) error {
 		TagKeys:     append([]tag.Key{statusTag, namespaceTag}, append(trunTag, prunTag...)...),
 	}
 
-	trCountViewTags := []tag.Key{statusTag}
-	if cfg.CountWithReason {
-		trCountViewTags = append(trCountViewTags, reasonTag)
-	}
 	trCountView = &view.View{
 		Description: trCount.Description(),
 		Measure:     trCount,

--- a/pkg/taskrunmetrics/metrics_test.go
+++ b/pkg/taskrunmetrics/metrics_test.go
@@ -391,6 +391,7 @@ func TestRecordTaskRunDurationCount(t *testing.T) {
 			"task":        "task-1",
 			"taskrun":     "taskrun-1",
 			"namespace":   "ns",
+			"reason":      "TaskRunImagePullFailed",
 			"status":      "failed",
 		},
 		expectedCountTags: map[string]string{


### PR DESCRIPTION
Added reason tag to duration metrics. Different failures cause differences in the time taken by pipelineruns and taskruns.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
The reason tag has been added to the duration metrics of taskrun and pipelinerun.
```
