### PR TITLE
[StepActions] when using a stepTemplate the ref gets removed

### DIFF
--- a/pkg/apis/pipeline/v1/merge.go
+++ b/pkg/apis/pipeline/v1/merge.go
@@ -60,7 +60,7 @@ func MergeStepsWithStepTemplate(template *StepTemplate, steps []Step) ([]Step, e
 		amendConflictingContainerFields(&merged, s)
 
 		// Pass through original step Script, for later conversion.
-		newStep := Step{Script: s.Script, OnError: s.OnError, Timeout: s.Timeout, StdoutConfig: s.StdoutConfig, StderrConfig: s.StderrConfig, Results: s.Results, Params: s.Params}
+		newStep := Step{Script: s.Script, OnError: s.OnError, Timeout: s.Timeout, StdoutConfig: s.StdoutConfig, StderrConfig: s.StderrConfig, Results: s.Results, Params: s.Params, Ref: s.Ref}
 		newStep.SetContainerFields(merged)
 		steps[i] = newStep
 	}

--- a/pkg/apis/pipeline/v1/merge_test.go
+++ b/pkg/apis/pipeline/v1/merge_test.go
@@ -19,6 +19,8 @@ package v1_test
 import (
 	"testing"
 
+	"k8s.io/utils/pointer"
+
 	"github.com/google/go-cmp/cmp"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/test/diff"
@@ -144,6 +146,36 @@ func TestMergeStepsWithStepTemplate(t *testing.T) {
 		}},
 		expected: []v1.Step{{
 			Command: []string{"/somecmd"}, Image: "some-image",
+			OnError: "foo",
+			Results: []v1.StepResult{{
+				Name: "result",
+			}},
+			Params: v1.Params{{
+				Name: "param",
+			}},
+		}},
+	}, {
+		name: "ref-should-not-be-removed",
+		template: &v1.StepTemplate{
+			SecurityContext: &corev1.SecurityContext{
+				RunAsNonRoot: pointer.Bool(true),
+			},
+		},
+		steps: []v1.Step{{
+			Ref:     &v1.Ref{Name: "my-step-action"},
+			OnError: "foo",
+			Results: []v1.StepResult{{
+				Name: "result",
+			}},
+			Params: v1.Params{{
+				Name: "param",
+			}},
+		}},
+		expected: []v1.Step{{
+			SecurityContext: &corev1.SecurityContext{
+				RunAsNonRoot: pointer.Bool(true),
+			},
+			Ref:     &v1.Ref{Name: "my-step-action"},
 			OnError: "foo",
 			Results: []v1.StepResult{{
 				Name: "result",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

There appears to be a bug when using `StepActions` and `stepTemplate`, the ref gets removed during the merge command.

This should probably also be backported to 0.56 LTS

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
