### PR TITLE
Initiate Conformance Test Suite

### DIFF
--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -1,0 +1,122 @@
+//go:build conformance
+// +build conformance
+
+/*
+Copyright 2024 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+The following tests are the OSS conformance test suite.
+For a more detailed reference of the Tekton Conformance API spec please refer
+to https://github.com/tektoncd/pipeline/blob/main/docs/api-spec.md.
+
+Please implement the `ProcessAndSendToTekton` with the respective conformant
+Tekton service corresponding to the function signature below:
+
+// ProcessAndSendToTekton takes in vanilla Tekton PipelineRun and TaskRun,
+// waits for the object to succeed and outputs the final PipelineRun and
+// TaskRun with status.
+// The parameters are inputYAML and its Primitive type {PipelineRun, TaskRun}
+// And the return values will be the output YAML string and errors.
+func ProcessAndSendToTekton(inputYAML, primitiveType string, customInputs ...interface{}) (string, error) {
+}
+
+Once `ProcessAndSendToTekton` is implemented, please use the following for
+triggering the test and record the corresponding outputs:
+go test -v -tags=conformance -count=1 ./test -run ^Test
+*/
+
+package conformance_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/tektoncd/pipeline/test/parse"
+	"knative.dev/pkg/test/helpers"
+)
+
+const (
+	succeedConditionStatus = "True"
+	conformanceVersion     = "v1"
+)
+
+// TestTaskRunConditions examines population of Conditions
+// fields. It creates the a TaskRun with minimal specifications and checks the
+// required Condition Status and Type.
+func TestTaskRunConditions(t *testing.T) {
+	t.Parallel()
+
+	inputYAML := fmt.Sprintf(`
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  name: %s
+spec:
+  taskSpec:
+    steps:
+    - name: add
+      image: ubuntu
+      script: |
+        echo Hello world!
+`, helpers.ObjectNameForTest(t))
+
+	// The execution of Pipeline CRDs that should be implemented by Vendor service
+	outputYAML, err := ProcessAndSendToTekton(inputYAML, TaskRunInputType, t)
+	if err != nil {
+		t.Fatalf("Vendor service failed processing inputYAML: %s", err)
+	}
+
+	// Parse and validate output YAML
+	resolvedTR := parse.MustParseV1TaskRun(t, outputYAML)
+
+	if err := checkTaskRunConditionSucceeded(resolvedTR.Status, succeedConditionStatus, "Succeeded"); err != nil {
+		t.Error(err)
+	}
+}
+
+// TestPipelineRunConditions examines population of Conditions
+// fields. It creates the a PipelineRun with minimal specifications and checks the
+// required Condition Status and Type.
+func TestPipelineRunConditions(t *testing.T) {
+	t.Parallel()
+
+	inputYAML := fmt.Sprintf(`
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: %s
+spec:
+  pipelineSpec:
+    tasks:
+    - name: pipeline-task-0
+      taskSpec:
+        steps:
+        - name: add
+          image: ubuntu
+          script: |
+            echo Hello world!
+`, helpers.ObjectNameForTest(t))
+
+	// The execution of Pipeline CRDs that should be implemented by Vendor service
+	outputYAML, err := ProcessAndSendToTekton(inputYAML, PipelineRunInputType, t)
+	if err != nil {
+		t.Fatalf("Vendor service failed processing inputYAML: %s", err)
+	}
+
+	// Parse and validate output YAML
+	resolvedPR := parse.MustParseV1PipelineRun(t, outputYAML)
+
+	if err := checkPipelineRunConditionSucceeded(resolvedPR.Status, succeedConditionStatus, "Succeeded"); err != nil {
+		t.Error(err)
+	}
+}

--- a/test/conformance/util.go
+++ b/test/conformance/util.go
@@ -1,0 +1,75 @@
+//go:build conformance
+// +build conformance
+
+/*
+Copyright 2024 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conformance_test
+
+import (
+	"fmt"
+
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+)
+
+// checkTaskRunConditionSucceeded checks the TaskRun Succeeded Condition;
+// expectedSucceeded is a corev1.ConditionStatus(string), which is either "True" or "False"
+// expectedReason is string, the expected Condition.Reason
+func checkTaskRunConditionSucceeded(trStatus v1.TaskRunStatus, expectedSucceededStatus string, expectedReason string) error {
+	hasSucceededConditionType := false
+
+	for _, cond := range trStatus.Conditions {
+		if cond.Type == "Succeeded" {
+			if string(cond.Status) != expectedSucceededStatus {
+				return fmt.Errorf("Expect vendor service to populate Condition %s but got: %s", expectedSucceededStatus, cond.Status)
+			}
+			if cond.Reason != expectedReason {
+				return fmt.Errorf("Expect vendor service to populate Condition Reason %s but got: %s", expectedReason, cond.Reason)
+			}
+
+			hasSucceededConditionType = true
+		}
+	}
+
+	if !hasSucceededConditionType {
+		return fmt.Errorf("Expect vendor service to populate Succeeded Condition but not apparent in TaskRunStatus")
+	}
+
+	return nil
+}
+
+// checkPipelineRunConditionSucceeded checks the PipelineRun Succeeded Condition;
+// expectedSucceeded is a corev1.ConditionStatus(string), which is either "True" or "False"
+// expectedReason is string, the expected Condition.Reason
+func checkPipelineRunConditionSucceeded(prStatus v1.PipelineRunStatus, expectedSucceededStatus string, expectedReason string) error {
+	hasSucceededConditionType := false
+
+	for _, cond := range prStatus.Conditions {
+		if cond.Type == "Succeeded" {
+			if string(cond.Status) != expectedSucceededStatus {
+				return fmt.Errorf("Expect vendor service to populate Condition %s but got: %s", expectedSucceededStatus, cond.Status)
+			}
+			if cond.Reason != expectedReason {
+				return fmt.Errorf("Expect vendor service to populate Condition Reason %s but got: %s", expectedReason, cond.Reason)
+			}
+
+			hasSucceededConditionType = true
+		}
+	}
+
+	if !hasSucceededConditionType {
+		return fmt.Errorf("Expect vendor service to populate Succeeded Condition but not apparent in PipelineRunStatus")
+	}
+
+	return nil
+}

--- a/test/conformance_test.go
+++ b/test/conformance_test.go
@@ -38,6 +38,9 @@ import (
 
 type conditionFn func(name string) ConditionAccessorFn
 
+// TestTaskRun examines the conformance of Tekton pipeline @HEAD. It does not
+// searve as part of the OSS conformance test suite but aims to keep the
+// devel conformant and to prevent regressions.
 func TestTaskRun(t *testing.T) {
 	ctx := context.Background()
 	ctx, cancel := context.WithCancel(ctx)
@@ -76,6 +79,7 @@ spec:
 					Reason:   "Completed",
 				},
 			},
+			TerminationReason: "Completed",
 		}},
 	}, {
 		name: "failed-task-run",
@@ -105,6 +109,7 @@ spec:
 					Reason:   "Completed",
 				},
 			},
+			TerminationReason: "Completed",
 		}, {
 			ContainerState: corev1.ContainerState{
 				Terminated: &corev1.ContainerStateTerminated{
@@ -112,6 +117,7 @@ spec:
 					Reason:   "Error",
 				},
 			},
+			TerminationReason: "Error",
 		}, {
 			ContainerState: corev1.ContainerState{
 				Terminated: &corev1.ContainerStateTerminated{
@@ -119,6 +125,7 @@ spec:
 					Reason:   "Error",
 				},
 			},
+			TerminationReason: "Skipped",
 		}},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -182,7 +189,7 @@ spec:
 			}
 
 			ignoreTerminatedFields := cmpopts.IgnoreFields(corev1.ContainerStateTerminated{}, "StartedAt", "FinishedAt", "ContainerID")
-			ignoreStepFields := cmpopts.IgnoreFields(v1.StepState{}, "ImageID", "Name", "ContainerName")
+			ignoreStepFields := cmpopts.IgnoreFields(v1.StepState{}, "ImageID", "Name", "Container")
 			if d := cmp.Diff(tr.Status.Steps, tc.expectedStepState, ignoreTerminatedFields, ignoreStepFields); d != "" {
 				t.Fatalf("-got, +want: %v", d)
 			}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
This commit initiates the OSS conformance test suite. It sets the
standards for incrementing the V1 conformance test with the two simple
test cases.

/kind misc
part of #7828 
# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [n/a] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [n/a] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
