### PR TITLE
Conformance V1: make SideCarState Required

### DIFF
--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -400,9 +400,9 @@ A `ParamValue` may be a string, a list of string, or a map of string to string.
 
 | Field            | Type                                | Requirement | Notes                         |
 |------------------|-------------------------------------|-------------|-------------------------------|
-| `name`           | string                              | RECOMMENDED | Name of the SidecarState.     |
-| `imageID`        | string                              | RECOMMENDED | Image ID of the SidecarState. |
-| `containerState` | [`ContainerState`](#containerstate) | RECOMMENDED | State of the container.       |
+| `name`           | string                              | REQUIRED    | Name of the SidecarState.     |
+| `imageID`        | string                              | REQUIRED    | Image ID of the SidecarState. |
+| `containerState` | [`ContainerState`](#containerstate) | REQUIRED    | State of the container.       |
 
 ### PipelineRunSpec
 


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This commit makes the SideCarState fields as `REQUIRED` given that the existing `StepState` fields are `REQUIRED` and there shall not be specific reason why `SidecarState` is an exception. Moreover it adds on to the complexity of Conformance verification test to examine the corresponding functionalities of the sidecars.

/kind documentation
part of #7828
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
