### PR TITLE
fix: stepresult intepolations does not accept multiple matches

### DIFF
--- a/pkg/entrypoint/entrypointer_test.go
+++ b/pkg/entrypoint/entrypointer_test.go
@@ -780,15 +780,24 @@ func TestApplyStepResultSubstitutions_Env(t *testing.T) {
 		envValue:   "$(steps.foo.results.res.hello)",
 		want:       "World",
 		wantErr:    false,
-	}, {
-		name:       "bad-result-format",
-		stepName:   "foo",
-		resultName: "res",
-		result:     "{\"hello\":\"World\"}",
-		envValue:   "echo $(steps.foo.results.res.hello.bar)",
-		want:       "echo $(steps.foo.results.res.hello.bar)",
-		wantErr:    true,
-	}}
+	},
+		{
+			name:       "interpolation multiple matches",
+			stepName:   "foo",
+			resultName: "res",
+			result:     `{"first":"hello", "second":"world"}`,
+			envValue:   "$(steps.foo.results.res.first)-$(steps.foo.results.res.second)",
+			want:       "hello-world",
+			wantErr:    false,
+		}, {
+			name:       "bad-result-format",
+			stepName:   "foo",
+			resultName: "res",
+			result:     "{\"hello\":\"World\"}",
+			envValue:   "echo $(steps.foo.results.res.hello.bar)",
+			want:       "echo $(steps.foo.results.res.hello.bar)",
+			wantErr:    true,
+		}}
 	stepDir := createTmpDir(t, "env-steps")
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -869,7 +878,32 @@ func TestApplyStepResultSubstitutions_Command(t *testing.T) {
 		command:    []string{"echo $(steps.foo.results.res.hello.bar)"},
 		want:       []string{"echo $(steps.foo.results.res.hello.bar)"},
 		wantErr:    true,
-	}}
+	}, {
+		name:       "array param no index, with extra string",
+		stepName:   "foo",
+		resultName: "res",
+		result:     "[\"Hello\",\"World\"]",
+		command:    []string{"start", "$(steps.foo.results.res[*])bbb", "stop"},
+		want:       []string{"start", "$(steps.foo.results.res[*])bbb", "stop"},
+		wantErr:    true,
+	}, {
+		name:       "array param, multiple matches",
+		stepName:   "foo",
+		resultName: "res",
+		result:     "[\"Hello\",\"World\"]",
+		command:    []string{"$(steps.foo.results.res[0])-$(steps.foo.results.res[1])"},
+		want:       []string{"Hello-World"},
+		wantErr:    false,
+	}, {
+		name:       "object param, multiple matches",
+		stepName:   "foo",
+		resultName: "res",
+		result:     `{"first":"hello", "second":"world"}`,
+		command:    []string{"$(steps.foo.results.res.first)-$(steps.foo.results.res.second)"},
+		want:       []string{"hello-world"},
+		wantErr:    false,
+	},
+	}
 	stepDir := createTmpDir(t, "command-steps")
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/internal/resultref/resultref.go
+++ b/pkg/internal/resultref/resultref.go
@@ -42,7 +42,7 @@ const (
 
 	// arrayIndexing will match all `[int]` and `[*]` for parseExpression
 	arrayIndexing          = `\[([0-9])*\*?\]`
-	stepResultUsagePattern = `\$\(steps\..*\.results\..*\)`
+	stepResultUsagePattern = `\$\(steps\..*?\.results\..*?\)`
 )
 
 // arrayIndexingRegex is used to match `[int]` and `[*]`


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
fixes: #7764

- This pr enables users to use multiple step results for interpolation in step command and environment variables, for examples, users can do something like `"$(steps.foo.results.res.first)-$(steps.foo.results.res.second)"` set env variables for step. 


<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
 fix: cannot use multiple step results at the same time for interpolation. 
```
