### PR TITLE
validate TaskRun retries in TestRunSpec is greater than or equal to zero

### DIFF
--- a/pkg/apis/pipeline/v1/taskrun_validation.go
+++ b/pkg/apis/pipeline/v1/taskrun_validation.go
@@ -96,7 +96,9 @@ func (ts *TaskRunSpec) Validate(ctx context.Context) (errs *apis.FieldError) {
 			errs = errs.Also(apis.ErrInvalidValue(fmt.Sprintf("statusMessage should not be set if status is not set, but it is currently set to %s", ts.StatusMessage), "statusMessage"))
 		}
 	}
-
+	if ts.Retries < 0 {
+		errs = errs.Also(apis.ErrInvalidValue(fmt.Sprintf("%d should be >= 0", ts.Retries), "retries"))
+	}
 	if ts.Timeout != nil {
 		// timeout should be a valid duration of at least 0.
 		if ts.Timeout.Duration < 0 {

--- a/pkg/apis/pipeline/v1/taskrun_validation_test.go
+++ b/pkg/apis/pipeline/v1/taskrun_validation_test.go
@@ -559,6 +559,15 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 		},
 		wantErr: apis.ErrInvalidValue("-48h0m0s should be >= 0", "timeout"),
 	}, {
+		name: "negative pipeline retries",
+		spec: v1.TaskRunSpec{
+			TaskRef: &v1.TaskRef{
+				Name: "taskrefname",
+			},
+			Retries: -3,
+		},
+		wantErr: apis.ErrInvalidValue("-3 should be >= 0", "retries"),
+	}, {
 		name: "wrong taskrun cancel",
 		spec: v1.TaskRunSpec{
 			TaskRef: &v1.TaskRef{
@@ -821,6 +830,18 @@ func TestTaskRunSpec_Validate(t *testing.T) {
 		name: "no timeout",
 		spec: v1.TaskRunSpec{
 			Timeout: &metav1.Duration{Duration: 0},
+			TaskSpec: &v1.TaskSpec{
+				Steps: []v1.Step{{
+					Name:  "mystep",
+					Image: "myimage",
+				}},
+			},
+		},
+	}, {
+		name: "with positive retries",
+		spec: v1.TaskRunSpec{
+			Timeout: &metav1.Duration{Duration: 0},
+			Retries: 3,
 			TaskSpec: &v1.TaskSpec{
 				Steps: []v1.Step{{
 					Name:  "mystep",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
fixes: [#7778](https://github.com/tektoncd/pipeline/issues/7778)     
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
+ this pr verifies the Retries in TaskRunSpec to ensure that its value is not less than zero.
At the same time, two test cases are added to verify when the value is greater than zero and less than zero.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
fix: the retries value has not been verified
```
