### PR TITLE
Add a feature flag to disable inline spec

### DIFF
--- a/config/config-feature-flags.yaml
+++ b/config/config-feature-flags.yaml
@@ -131,3 +131,9 @@ data:
   enable-artifacts: "false"
   # Setting this flag to "true" will enable the built-in param input validation via param enum.
   enable-param-enum: "false"
+  # Setting this flag to "pipeline,pipelinerun,taskrun" will prevent users from creating
+  # embedded spec Taskruns or Pipelineruns for Pipeline, Pipelinerun and taskrun
+  # respectively. We can specify "pipeline" to disable for Pipeline resource only.
+  # "pipelinerun" for Pipelinerun and "taskrun" for Taskrun. Or a combination of
+  # these.
+  disable-inline-spec: ""

--- a/docs/additional-configs.md
+++ b/docs/additional-configs.md
@@ -32,6 +32,7 @@ installation.
   - [Verify Tekton Resources](#verify-tekton-resources)
   - [Pipelinerun with Affinity Assistant](#pipelineruns-with-affinity-assistant)
   - [TaskRuns with `imagePullBackOff` Timeout](#taskruns-with-imagepullbackoff-timeout)
+  - [Disabling Inline Spec in TaskRun and PipelineRun](#disabling-inline-spec-in-taskrun-and-pipelinerun)
   - [Next steps](#next-steps)
 
 
@@ -692,6 +693,31 @@ metadata:
 data:
   default-imagepullbackoff-timeout: "5"
 ```
+
+## Disabling Inline Spec in Pipeline, TaskRun and PipelineRun
+
+Tekton users may embed the specification of a `Task` (via `taskSpec`) or a `Pipeline` (via `pipelineSpec`) as an alternative to referring to an external resource via `taskRef` and `pipelineRef` respectively.  This behaviour can be selectively disabled for three Tekton resources: `TaskRun`, `PipelineRun` and `Pipeline`.
+
+ In certain clusters and scenarios, an admin might want to disable the customisation of `Tasks` and `Pipelines` and only allow users to run pre-defined resources. To achieve that the admin should disable embedded specification via the `disable-inline-spec` flag, and remote resolvers too.
+
+To disable inline specification, set the `disable-inline-spec` flag to `"pipeline,pipelinerun,taskrun"`
+in the `feature-flags` configmap.
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: feature-flags
+  namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
+data:
+  disable-inline-spec: "pipeline,pipelinerun,taskrun"
+```
+
+Inline specifications can be disabled for specific resources only. To achieve that, set the disable-inline-spec flag to a comma-separated list of the desired resources. Valid values are pipeline, pipelinerun and taskrun.
+
+The default value of disable-inline-spec is "", which means inline specification is enabled in all cases.
 
 ## Next steps
 

--- a/docs/pipeline-api.md
+++ b/docs/pipeline-api.md
@@ -733,6 +733,8 @@ PipelineSpec
 </td>
 <td>
 <em>(Optional)</em>
+<p>Specifying PipelineSpec can be disabled by setting
+<code>disable-inline-spec</code> feature flag..</p>
 </td>
 </tr>
 <tr>
@@ -1155,6 +1157,8 @@ TaskSpec
 </td>
 <td>
 <em>(Optional)</em>
+<p>Specifying PipelineSpec can be disabled by setting
+<code>disable-inline-spec</code> feature flag..</p>
 </td>
 </tr>
 <tr>
@@ -2308,6 +2312,8 @@ PipelineSpec
 </td>
 <td>
 <em>(Optional)</em>
+<p>Specifying PipelineSpec can be disabled by setting
+<code>disable-inline-spec</code> feature flag..</p>
 </td>
 </tr>
 <tr>
@@ -2846,7 +2852,9 @@ EmbeddedTask
 </td>
 <td>
 <em>(Optional)</em>
-<p>TaskSpec is a specification of a task</p>
+<p>TaskSpec is a specification of a task
+Specifying TaskSpec can be disabled by setting
+<code>disable-inline-spec</code> feature flag..</p>
 </td>
 </tr>
 <tr>
@@ -2973,7 +2981,9 @@ PipelineSpec
 <td>
 <em>(Optional)</em>
 <p>PipelineSpec is a specification of a pipeline
-Note: PipelineSpec is in preview mode and not yet supported</p>
+Note: PipelineSpec is in preview mode and not yet supported
+Specifying PipelineSpec can be disabled by setting
+<code>disable-inline-spec</code> feature flag..</p>
 </td>
 </tr>
 <tr>
@@ -5489,6 +5499,8 @@ TaskSpec
 </td>
 <td>
 <em>(Optional)</em>
+<p>Specifying PipelineSpec can be disabled by setting
+<code>disable-inline-spec</code> feature flag..</p>
 </td>
 </tr>
 <tr>
@@ -8985,6 +8997,8 @@ PipelineSpec
 </td>
 <td>
 <em>(Optional)</em>
+<p>Specifying PipelineSpec can be disabled by setting
+<code>disable-inline-spec</code> feature flag..</p>
 </td>
 </tr>
 <tr>
@@ -9483,6 +9497,8 @@ TaskSpec
 </td>
 <td>
 <em>(Optional)</em>
+<p>Specifying PipelineSpec can be disabled by setting
+<code>disable-inline-spec</code> feature flag..</p>
 </td>
 </tr>
 <tr>
@@ -11115,6 +11131,8 @@ PipelineSpec
 </td>
 <td>
 <em>(Optional)</em>
+<p>Specifying PipelineSpec can be disabled by setting
+<code>disable-inline-spec</code> feature flag..</p>
 </td>
 </tr>
 <tr>
@@ -11746,7 +11764,9 @@ EmbeddedTask
 </td>
 <td>
 <em>(Optional)</em>
-<p>TaskSpec is a specification of a task</p>
+<p>TaskSpec is a specification of a task
+Specifying TaskSpec can be disabled by setting
+<code>disable-inline-spec</code> feature flag..</p>
 </td>
 </tr>
 <tr>
@@ -11887,7 +11907,9 @@ PipelineSpec
 <td>
 <em>(Optional)</em>
 <p>PipelineSpec is a specification of a pipeline
-Note: PipelineSpec is in preview mode and not yet supported</p>
+Note: PipelineSpec is in preview mode and not yet supported
+Specifying TaskSpec can be disabled by setting
+<code>disable-inline-spec</code> feature flag..</p>
 </td>
 </tr>
 <tr>
@@ -14915,6 +14937,8 @@ TaskSpec
 </td>
 <td>
 <em>(Optional)</em>
+<p>Specifying PipelineSpec can be disabled by setting
+<code>disable-inline-spec</code> feature flag..</p>
 </td>
 </tr>
 <tr>

--- a/pkg/apis/config/feature_flags.go
+++ b/pkg/apis/config/feature_flags.go
@@ -68,6 +68,8 @@ const (
 	DefaultRunningInEnvWithInjectedSidecars = true
 	// DefaultAwaitSidecarReadiness is the default value for "await-sidecar-readiness".
 	DefaultAwaitSidecarReadiness = true
+	// DefaultDisableInlineSpec is the default value of "disable-inline-spec"
+	DefaultDisableInlineSpec = ""
 	// DefaultRequireGitSSHSecretKnownHosts is the default value for "require-git-ssh-secret-known-hosts".
 	DefaultRequireGitSSHSecretKnownHosts = false
 	// DefaultEnableTektonOciBundles is the default value for "enable-tekton-oci-bundles".
@@ -106,6 +108,10 @@ const (
 
 	// EnableParamEnum is the flag to enabled enum in params
 	EnableParamEnum = "enable-param-enum"
+
+	// DisableInlineSpec is the flag to disable embedded spec
+	// in Taskrun or Pipelinerun
+	DisableInlineSpec = "disable-inline-spec"
 
 	disableAffinityAssistantKey         = "disable-affinity-assistant"
 	disableCredsInitKey                 = "disable-creds-init"
@@ -193,6 +199,7 @@ type FeatureFlags struct {
 	EnableStepActions         bool
 	EnableParamEnum           bool
 	EnableArtifacts           bool
+	DisableInlineSpec         string
 }
 
 // GetFeatureFlagsConfigName returns the name of the configmap containing all
@@ -291,6 +298,10 @@ func NewFeatureFlagsFromMap(cfgMap map[string]string) (*FeatureFlags, error) {
 	if err := setPerFeatureFlag(EnableArtifacts, DefaultEnableArtifacts, &tc.EnableArtifacts); err != nil {
 		return nil, err
 	}
+	if err := setFeatureInlineSpec(cfgMap, DisableInlineSpec, DefaultDisableInlineSpec, &tc.DisableInlineSpec); err != nil {
+		return nil, err
+	}
+
 	// Given that they are alpha features, Tekton Bundles and Custom Tasks should be switched on if
 	// enable-api-fields is "alpha". If enable-api-fields is not "alpha" then fall back to the value of
 	// each feature's individual flag.
@@ -362,6 +373,15 @@ func setEnforceNonFalsifiability(cfgMap map[string]string, feature *string) erro
 	default:
 		return fmt.Errorf("invalid value for feature flag %q: %q", enforceNonfalsifiability, value)
 	}
+}
+
+func setFeatureInlineSpec(cfgMap map[string]string, key string, defaultValue string, feature *string) error {
+	if cfg, ok := cfgMap[key]; ok {
+		*feature = cfg
+		return nil
+	}
+	*feature = strings.ReplaceAll(defaultValue, " ", "")
+	return nil
 }
 
 // setResultExtractionMethod sets the "results-from" flag based on the content of a given map.

--- a/pkg/apis/config/feature_flags_test.go
+++ b/pkg/apis/config/feature_flags_test.go
@@ -57,6 +57,7 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 				EnableCELInWhenExpression:        config.DefaultEnableCELInWhenExpression.Enabled,
 				EnableStepActions:                config.DefaultEnableStepActions.Enabled,
 				EnableParamEnum:                  config.DefaultEnableParamEnum.Enabled,
+				DisableInlineSpec:                config.DefaultDisableInlineSpec,
 			},
 			fileName: config.GetFeatureFlagsConfigName(),
 		},
@@ -81,6 +82,7 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 				EnableStepActions:                true,
 				EnableArtifacts:                  true,
 				EnableParamEnum:                  true,
+				DisableInlineSpec:                "pipeline,pipelinerun,taskrun",
 			},
 			fileName: "feature-flags-all-flags-set",
 		},
@@ -107,6 +109,7 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 				EnableCELInWhenExpression:        config.DefaultEnableCELInWhenExpression.Enabled,
 				EnableStepActions:                config.DefaultEnableStepActions.Enabled,
 				EnableParamEnum:                  config.DefaultEnableParamEnum.Enabled,
+				DisableInlineSpec:                config.DefaultDisableInlineSpec,
 			},
 			fileName: "feature-flags-enable-api-fields-overrides-bundles-and-custom-tasks",
 		},
@@ -128,6 +131,7 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 				SetSecurityContext:               config.DefaultSetSecurityContext,
 				Coschedule:                       config.DefaultCoschedule,
 				EnableParamEnum:                  config.DefaultEnableParamEnum.Enabled,
+				DisableInlineSpec:                config.DefaultDisableInlineSpec,
 			},
 			fileName: "feature-flags-bundles-and-custom-tasks",
 		},
@@ -149,6 +153,7 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 				SetSecurityContext:               config.DefaultSetSecurityContext,
 				Coschedule:                       config.DefaultCoschedule,
 				EnableParamEnum:                  config.DefaultEnableParamEnum.Enabled,
+				DisableInlineSpec:                config.DefaultDisableInlineSpec,
 			},
 			fileName: "feature-flags-beta-api-fields",
 		},
@@ -169,6 +174,7 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 				EnableCELInWhenExpression:        config.DefaultEnableCELInWhenExpression.Enabled,
 				EnableStepActions:                config.DefaultEnableStepActions.Enabled,
 				EnableParamEnum:                  config.DefaultEnableParamEnum.Enabled,
+				DisableInlineSpec:                config.DefaultDisableInlineSpec,
 			},
 			fileName: "feature-flags-enforce-nonfalsifiability-spire",
 		},
@@ -188,6 +194,7 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 				EnableCELInWhenExpression:        config.DefaultEnableCELInWhenExpression.Enabled,
 				EnableStepActions:                config.DefaultEnableStepActions.Enabled,
 				EnableParamEnum:                  config.DefaultEnableParamEnum.Enabled,
+				DisableInlineSpec:                config.DefaultDisableInlineSpec,
 			},
 			fileName: "feature-flags-results-via-sidecar-logs",
 		},
@@ -224,6 +231,7 @@ func TestNewFeatureFlagsFromEmptyConfigMap(t *testing.T) {
 		EnableCELInWhenExpression:        config.DefaultEnableCELInWhenExpression.Enabled,
 		EnableStepActions:                config.DefaultEnableStepActions.Enabled,
 		EnableParamEnum:                  config.DefaultEnableParamEnum.Enabled,
+		DisableInlineSpec:                config.DefaultDisableInlineSpec,
 	}
 	verifyConfigFileWithExpectedFeatureFlagsConfig(t, FeatureFlagsConfigEmptyName, expectedConfig)
 }
@@ -311,7 +319,9 @@ func TestNewFeatureFlagsConfigMapErrors(t *testing.T) {
 		t.Run(tc.fileName, func(t *testing.T) {
 			cm := test.ConfigMapFromTestFile(t, tc.fileName)
 			_, err := config.NewFeatureFlagsFromConfigMap(cm)
-			if d := cmp.Diff(tc.want, err.Error()); d != "" {
+			if err == nil {
+				t.Error("failed to get:", tc.want)
+			} else if d := cmp.Diff(tc.want, err.Error()); d != "" {
 				t.Errorf("failed to get expected error; diff:\n%s", diff.PrintWantGot(d))
 			}
 		})

--- a/pkg/apis/config/testdata/feature-flags-all-flags-set.yaml
+++ b/pkg/apis/config/testdata/feature-flags-all-flags-set.yaml
@@ -36,3 +36,4 @@ data:
   enable-step-actions: "true"
   enable-param-enum: "true"
   enable-artifacts: "true"
+  disable-inline-spec: "pipeline,pipelinerun,taskrun"

--- a/pkg/apis/pipeline/v1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1/openapi_generated.go
@@ -1307,7 +1307,8 @@ func schema_pkg_apis_pipeline_v1_PipelineRunSpec(ref common.ReferenceCallback) c
 					},
 					"pipelineSpec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineSpec"),
+							Description: "Specifying PipelineSpec can be disabled by setting `disable-inline-spec` feature flag..",
+							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineSpec"),
 						},
 					},
 					"params": {
@@ -1881,7 +1882,7 @@ func schema_pkg_apis_pipeline_v1_PipelineTask(ref common.ReferenceCallback) comm
 					},
 					"taskSpec": {
 						SchemaProps: spec.SchemaProps{
-							Description: "TaskSpec is a specification of a task",
+							Description: "TaskSpec is a specification of a task Specifying TaskSpec can be disabled by setting `disable-inline-spec` feature flag..",
 							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.EmbeddedTask"),
 						},
 					},
@@ -1984,7 +1985,7 @@ func schema_pkg_apis_pipeline_v1_PipelineTask(ref common.ReferenceCallback) comm
 					},
 					"pipelineSpec": {
 						SchemaProps: spec.SchemaProps{
-							Description: "PipelineSpec is a specification of a pipeline Note: PipelineSpec is in preview mode and not yet supported",
+							Description: "PipelineSpec is a specification of a pipeline Note: PipelineSpec is in preview mode and not yet supported Specifying PipelineSpec can be disabled by setting `disable-inline-spec` feature flag..",
 							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineSpec"),
 						},
 					},
@@ -3899,7 +3900,8 @@ func schema_pkg_apis_pipeline_v1_TaskRunSpec(ref common.ReferenceCallback) commo
 					},
 					"taskSpec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskSpec"),
+							Description: "Specifying PipelineSpec can be disabled by setting `disable-inline-spec` feature flag..",
+							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskSpec"),
 						},
 					},
 					"status": {

--- a/pkg/apis/pipeline/v1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1/pipeline_types.go
@@ -199,6 +199,8 @@ type PipelineTask struct {
 	TaskRef *TaskRef `json:"taskRef,omitempty"`
 
 	// TaskSpec is a specification of a task
+	// Specifying TaskSpec can be disabled by setting
+	// `disable-inline-spec` feature flag..
 	// +optional
 	TaskSpec *EmbeddedTask `json:"taskSpec,omitempty"`
 
@@ -243,6 +245,8 @@ type PipelineTask struct {
 
 	// PipelineSpec is a specification of a pipeline
 	// Note: PipelineSpec is in preview mode and not yet supported
+	// Specifying PipelineSpec can be disabled by setting
+	// `disable-inline-spec` feature flag..
 	// +optional
 	PipelineSpec *PipelineSpec `json:"pipelineSpec,omitempty"`
 

--- a/pkg/apis/pipeline/v1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1/pipeline_validation_test.go
@@ -285,6 +285,86 @@ func TestPipeline_Validate_Failure(t *testing.T) {
 			Message: `expected exactly one, got multiple`,
 			Paths:   []string{"spec.tasks[0].pipelineRef, spec.tasks[0].pipelineSpec"},
 		},
+	}, {
+		name: "pipelineSpec when disable-inline-spec",
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Tasks: []PipelineTask{
+					{
+						Name:         "foo",
+						PipelineSpec: &PipelineSpec{Description: "foo-pipeline-description"},
+					},
+				},
+			},
+		},
+		expectedError: *apis.ErrDisallowedFields("spec.tasks[0]" + "." + "pipelineSpec"),
+		wc: func(ctx context.Context) context.Context {
+			return cfgtesting.SetFeatureFlags(ctx, t,
+				map[string]string{
+					"disable-inline-spec": "pipeline",
+					"enable-api-fields":   "alpha"})
+		},
+	}, {
+		name: "pipelineSpec when disable-inline-spec all",
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Tasks: []PipelineTask{
+					{
+						Name:         "foo",
+						PipelineSpec: &PipelineSpec{Description: "foo-pipeline-description"},
+					},
+				},
+			},
+		},
+		expectedError: *apis.ErrDisallowedFields("spec.tasks[0]" + "." + "pipelineSpec"),
+		wc: func(ctx context.Context) context.Context {
+			return cfgtesting.SetFeatureFlags(ctx, t,
+				map[string]string{
+					"disable-inline-spec": "pipeline,taskrun,pipelinerun",
+					"enable-api-fields":   "alpha"})
+		},
+	}, {
+		name: "taskSpec when disable-inline-spec",
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Description: "inline task",
+				Tasks: []PipelineTask{{
+					Name:     "task-spec",
+					TaskSpec: &EmbeddedTask{TaskSpec: getTaskSpec()},
+				}},
+			},
+		},
+		expectedError: *apis.ErrDisallowedFields("spec.tasks[0]" + "." + "taskSpec"),
+		wc: func(ctx context.Context) context.Context {
+			return config.ToContext(ctx, &config.Config{
+				FeatureFlags: &config.FeatureFlags{
+					DisableInlineSpec: "pipeline",
+				},
+			})
+		},
+	}, {
+		name: "taskSpec when disable-inline-spec all",
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Description: "inline task",
+				Tasks: []PipelineTask{{
+					Name:     "task-spec",
+					TaskSpec: &EmbeddedTask{TaskSpec: getTaskSpec()},
+				}},
+			},
+		},
+		expectedError: *apis.ErrDisallowedFields("spec.tasks[0]" + "." + "taskSpec"),
+		wc: func(ctx context.Context) context.Context {
+			return config.ToContext(ctx, &config.Config{
+				FeatureFlags: &config.FeatureFlags{
+					DisableInlineSpec: "pipeline,pipelinerun,taskrun",
+				},
+			})
+		},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/apis/pipeline/v1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1/pipelinerun_types.go
@@ -249,6 +249,8 @@ func (pr *PipelineRun) HasVolumeClaimTemplate() bool {
 type PipelineRunSpec struct {
 	// +optional
 	PipelineRef *PipelineRef `json:"pipelineRef,omitempty"`
+	// Specifying PipelineSpec can be disabled by setting
+	// `disable-inline-spec` feature flag..
 	// +optional
 	PipelineSpec *PipelineSpec `json:"pipelineSpec,omitempty"`
 	// Params is a list of parameter names and values.

--- a/pkg/apis/pipeline/v1/pipelinerun_validation.go
+++ b/pkg/apis/pipeline/v1/pipelinerun_validation.go
@@ -19,6 +19,8 @@ package v1
 import (
 	"context"
 	"fmt"
+	"slices"
+	"strings"
 	"time"
 
 	"github.com/tektoncd/pipeline/pkg/apis/config"
@@ -66,6 +68,10 @@ func (ps *PipelineRunSpec) Validate(ctx context.Context) (errs *apis.FieldError)
 
 	// Validate PipelineSpec if it's present
 	if ps.PipelineSpec != nil {
+		if slices.Contains(strings.Split(
+			config.FromContextOrDefaults(ctx).FeatureFlags.DisableInlineSpec, ","), "pipelinerun") {
+			errs = errs.Also(apis.ErrDisallowedFields("pipelineSpec"))
+		}
 		errs = errs.Also(ps.PipelineSpec.Validate(ctx).ViaField("pipelineSpec"))
 	}
 

--- a/pkg/apis/pipeline/v1/pipelinerun_validation_test.go
+++ b/pkg/apis/pipeline/v1/pipelinerun_validation_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/pipeline/pkg/apis/config"
 	cfgtesting "github.com/tektoncd/pipeline/pkg/apis/config/testing"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
@@ -877,6 +878,44 @@ func TestPipelineRunSpec_Invalidate(t *testing.T) {
 				}}},
 		},
 		wantErr: apis.ErrMultipleOneOf("pipelineRef", "pipelineSpec"),
+	}, {
+		name: "pipelineSpec when inline disabled all",
+		spec: v1.PipelineRunSpec{
+			PipelineSpec: &v1.PipelineSpec{
+				Tasks: []v1.PipelineTask{{
+					Name: "mytask",
+					TaskRef: &v1.TaskRef{
+						Name: "mytask",
+					},
+				}}},
+		},
+		wantErr: apis.ErrDisallowedFields("pipelineSpec"),
+		withContext: func(ctx context.Context) context.Context {
+			return config.ToContext(ctx, &config.Config{
+				FeatureFlags: &config.FeatureFlags{
+					DisableInlineSpec: "taskrun,pipelinerun,pipeline",
+				},
+			})
+		},
+	}, {
+		name: "pipelineSpec when inline disabled",
+		spec: v1.PipelineRunSpec{
+			PipelineSpec: &v1.PipelineSpec{
+				Tasks: []v1.PipelineTask{{
+					Name: "mytask",
+					TaskRef: &v1.TaskRef{
+						Name: "mytask",
+					},
+				}}},
+		},
+		wantErr: apis.ErrDisallowedFields("pipelineSpec"),
+		withContext: func(ctx context.Context) context.Context {
+			return config.ToContext(ctx, &config.Config{
+				FeatureFlags: &config.FeatureFlags{
+					DisableInlineSpec: "pipelinerun",
+				},
+			})
+		},
 	}, {
 		name: "workspaces may only appear once",
 		spec: v1.PipelineRunSpec{

--- a/pkg/apis/pipeline/v1/swagger.json
+++ b/pkg/apis/pipeline/v1/swagger.json
@@ -649,6 +649,7 @@
           "$ref": "#/definitions/v1.PipelineRef"
         },
         "pipelineSpec": {
+          "description": "Specifying PipelineSpec can be disabled by setting `disable-inline-spec` feature flag..",
           "$ref": "#/definitions/v1.PipelineSpec"
         },
         "status": {
@@ -949,7 +950,7 @@
           "$ref": "#/definitions/v1.PipelineRef"
         },
         "pipelineSpec": {
-          "description": "PipelineSpec is a specification of a pipeline Note: PipelineSpec is in preview mode and not yet supported",
+          "description": "PipelineSpec is a specification of a pipeline Note: PipelineSpec is in preview mode and not yet supported Specifying PipelineSpec can be disabled by setting `disable-inline-spec` feature flag..",
           "$ref": "#/definitions/v1.PipelineSpec"
         },
         "retries": {
@@ -971,7 +972,7 @@
           "$ref": "#/definitions/v1.TaskRef"
         },
         "taskSpec": {
-          "description": "TaskSpec is a specification of a task",
+          "description": "TaskSpec is a specification of a task Specifying TaskSpec can be disabled by setting `disable-inline-spec` feature flag..",
           "$ref": "#/definitions/v1.EmbeddedTask"
         },
         "timeout": {
@@ -2054,6 +2055,7 @@
           "$ref": "#/definitions/v1.TaskRef"
         },
         "taskSpec": {
+          "description": "Specifying PipelineSpec can be disabled by setting `disable-inline-spec` feature flag..",
           "$ref": "#/definitions/v1.TaskSpec"
         },
         "timeout": {

--- a/pkg/apis/pipeline/v1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1/taskrun_types.go
@@ -44,6 +44,8 @@ type TaskRunSpec struct {
 	// no more than one of the TaskRef and TaskSpec may be specified.
 	// +optional
 	TaskRef *TaskRef `json:"taskRef,omitempty"`
+	// Specifying PipelineSpec can be disabled by setting
+	// `disable-inline-spec` feature flag..
 	// +optional
 	TaskSpec *TaskSpec `json:"taskSpec,omitempty"`
 	// Used for cancelling a TaskRun (and maybe more later on)

--- a/pkg/apis/pipeline/v1/taskrun_validation.go
+++ b/pkg/apis/pipeline/v1/taskrun_validation.go
@@ -61,6 +61,10 @@ func (ts *TaskRunSpec) Validate(ctx context.Context) (errs *apis.FieldError) {
 	}
 	// Validate TaskSpec if it's present.
 	if ts.TaskSpec != nil {
+		if slices.Contains(strings.Split(
+			config.FromContextOrDefaults(ctx).FeatureFlags.DisableInlineSpec, ","), "taskrun") {
+			errs = errs.Also(apis.ErrDisallowedFields("taskSpec"))
+		}
 		errs = errs.Also(ts.TaskSpec.Validate(ctx).ViaField("taskSpec"))
 	}
 

--- a/pkg/apis/pipeline/v1/taskrun_validation_test.go
+++ b/pkg/apis/pipeline/v1/taskrun_validation_test.go
@@ -550,6 +550,42 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 		},
 		wantErr: apis.ErrMultipleOneOf("taskRef", "taskSpec"),
 	}, {
+		name: "taskspec when inline disabled",
+		spec: v1.TaskRunSpec{
+			TaskSpec: &v1.TaskSpec{
+				Steps: []v1.Step{{
+					Name:  "mystep",
+					Image: "myimage",
+				}},
+			},
+		},
+		wantErr: apis.ErrDisallowedFields("taskSpec"),
+		wc: func(ctx context.Context) context.Context {
+			return config.ToContext(ctx, &config.Config{
+				FeatureFlags: &config.FeatureFlags{
+					DisableInlineSpec: "taskrun",
+				},
+			})
+		},
+	}, {
+		name: "taskspec when inline disabled all",
+		spec: v1.TaskRunSpec{
+			TaskSpec: &v1.TaskSpec{
+				Steps: []v1.Step{{
+					Name:  "mystep",
+					Image: "myimage",
+				}},
+			},
+		},
+		wantErr: apis.ErrDisallowedFields("taskSpec"),
+		wc: func(ctx context.Context) context.Context {
+			return config.ToContext(ctx, &config.Config{
+				FeatureFlags: &config.FeatureFlags{
+					DisableInlineSpec: "taskrun,pipelinerun,pipeline",
+				},
+			})
+		},
+	}, {
 		name: "negative pipeline timeout",
 		spec: v1.TaskRunSpec{
 			TaskRef: &v1.TaskRef{

--- a/pkg/apis/pipeline/v1beta1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1beta1/openapi_generated.go
@@ -1952,7 +1952,8 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineRunSpec(ref common.ReferenceCallba
 					},
 					"pipelineSpec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineSpec"),
+							Description: "Specifying PipelineSpec can be disabled by setting `disable-inline-spec` feature flag..",
+							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineSpec"),
 						},
 					},
 					"resources": {
@@ -2631,7 +2632,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineTask(ref common.ReferenceCallback)
 					},
 					"taskSpec": {
 						SchemaProps: spec.SchemaProps{
-							Description: "TaskSpec is a specification of a task",
+							Description: "TaskSpec is a specification of a task Specifying TaskSpec can be disabled by setting `disable-inline-spec` feature flag..",
 							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.EmbeddedTask"),
 						},
 					},
@@ -2740,7 +2741,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineTask(ref common.ReferenceCallback)
 					},
 					"pipelineSpec": {
 						SchemaProps: spec.SchemaProps{
-							Description: "PipelineSpec is a specification of a pipeline Note: PipelineSpec is in preview mode and not yet supported",
+							Description: "PipelineSpec is a specification of a pipeline Note: PipelineSpec is in preview mode and not yet supported Specifying TaskSpec can be disabled by setting `disable-inline-spec` feature flag..",
 							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineSpec"),
 						},
 					},
@@ -5161,7 +5162,8 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunSpec(ref common.ReferenceCallback) 
 					},
 					"taskSpec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskSpec"),
+							Description: "Specifying PipelineSpec can be disabled by setting `disable-inline-spec` feature flag..",
+							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskSpec"),
 						},
 					},
 					"status": {

--- a/pkg/apis/pipeline/v1beta1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types.go
@@ -209,6 +209,8 @@ type PipelineTask struct {
 	TaskRef *TaskRef `json:"taskRef,omitempty"`
 
 	// TaskSpec is a specification of a task
+	// Specifying TaskSpec can be disabled by setting
+	// `disable-inline-spec` feature flag..
 	// +optional
 	TaskSpec *EmbeddedTask `json:"taskSpec,omitempty"`
 
@@ -257,6 +259,8 @@ type PipelineTask struct {
 
 	// PipelineSpec is a specification of a pipeline
 	// Note: PipelineSpec is in preview mode and not yet supported
+	// Specifying TaskSpec can be disabled by setting
+	// `disable-inline-spec` feature flag..
 	// +optional
 	PipelineSpec *PipelineSpec `json:"pipelineSpec,omitempty"`
 

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/utils/strings/slices"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/webhook/resourcesemantics"
 )
@@ -177,6 +178,8 @@ func (pt PipelineTask) ValidateName() *apis.FieldError {
 func (pt PipelineTask) Validate(ctx context.Context) (errs *apis.FieldError) {
 	errs = errs.Also(pt.validateRefOrSpec(ctx))
 
+	errs = errs.Also(pt.validateEnabledInlineSpec(ctx))
+
 	errs = errs.Also(pt.validateEmbeddedOrType())
 
 	if pt.Resources != nil {
@@ -218,6 +221,24 @@ func (pt PipelineTask) Validate(ctx context.Context) (errs *apis.FieldError) {
 		errs = errs.Also(pt.validateTask(ctx))
 	}
 	return //nolint:nakedret
+}
+
+// validateEnabledInlineSpec validates that pipelineSpec or taskSpec is allowed by checking
+// disable-inline-spec field
+func (pt PipelineTask) validateEnabledInlineSpec(ctx context.Context) (errs *apis.FieldError) {
+	if pt.TaskSpec != nil {
+		if slices.Contains(strings.Split(
+			config.FromContextOrDefaults(ctx).FeatureFlags.DisableInlineSpec, ","), "pipeline") {
+			errs = errs.Also(apis.ErrDisallowedFields("taskSpec"))
+		}
+	}
+	if pt.PipelineSpec != nil {
+		if slices.Contains(strings.Split(
+			config.FromContextOrDefaults(ctx).FeatureFlags.DisableInlineSpec, ","), "pipeline") {
+			errs = errs.Also(apis.ErrDisallowedFields("pipelineSpec"))
+		}
+	}
+	return errs
 }
 
 func (pt *PipelineTask) validateMatrix(ctx context.Context) (errs *apis.FieldError) {

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
@@ -252,6 +252,8 @@ func (pr *PipelineRun) HasVolumeClaimTemplate() bool {
 type PipelineRunSpec struct {
 	// +optional
 	PipelineRef *PipelineRef `json:"pipelineRef,omitempty"`
+	// Specifying PipelineSpec can be disabled by setting
+	// `disable-inline-spec` feature flag..
 	// +optional
 	PipelineSpec *PipelineSpec `json:"pipelineSpec,omitempty"`
 	// Resources is a list of bindings specifying which actual instances of

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_validation.go
@@ -19,6 +19,7 @@ package v1beta1
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/tektoncd/pipeline/pkg/apis/config"
@@ -27,6 +28,7 @@ import (
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/strings/slices"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/webhook/resourcesemantics"
 )
@@ -71,6 +73,10 @@ func (ps *PipelineRunSpec) Validate(ctx context.Context) (errs *apis.FieldError)
 
 	// Validate PipelineSpec if it's present
 	if ps.PipelineSpec != nil {
+		if slices.Contains(strings.Split(
+			config.FromContextOrDefaults(ctx).FeatureFlags.DisableInlineSpec, ","), "pipelinerun") {
+			errs = errs.Also(apis.ErrDisallowedFields("pipelineSpec"))
+		}
 		errs = errs.Also(ps.PipelineSpec.Validate(ctx).ViaField("pipelineSpec"))
 	}
 

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_validation_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/pipeline/pkg/apis/config"
 	cfgtesting "github.com/tektoncd/pipeline/pkg/apis/config/testing"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -996,6 +997,44 @@ func TestPipelineRunSpec_Invalidate(t *testing.T) {
 				}}},
 		},
 		wantErr: apis.ErrMultipleOneOf("pipelineRef", "pipelineSpec"),
+	}, {
+		name: "pipelineSpec when inline disabled all",
+		spec: v1beta1.PipelineRunSpec{
+			PipelineSpec: &v1beta1.PipelineSpec{
+				Tasks: []v1beta1.PipelineTask{{
+					Name: "mytask",
+					TaskRef: &v1beta1.TaskRef{
+						Name: "mytask",
+					},
+				}}},
+		},
+		wantErr: apis.ErrDisallowedFields("pipelineSpec"),
+		withContext: func(ctx context.Context) context.Context {
+			return config.ToContext(ctx, &config.Config{
+				FeatureFlags: &config.FeatureFlags{
+					DisableInlineSpec: "taskrun,pipelinerun,pipeline",
+				},
+			})
+		},
+	}, {
+		name: "pipelineSpec when inline disabled",
+		spec: v1beta1.PipelineRunSpec{
+			PipelineSpec: &v1beta1.PipelineSpec{
+				Tasks: []v1beta1.PipelineTask{{
+					Name: "mytask",
+					TaskRef: &v1beta1.TaskRef{
+						Name: "mytask",
+					},
+				}}},
+		},
+		wantErr: apis.ErrDisallowedFields("pipelineSpec"),
+		withContext: func(ctx context.Context) context.Context {
+			return config.ToContext(ctx, &config.Config{
+				FeatureFlags: &config.FeatureFlags{
+					DisableInlineSpec: "pipelinerun",
+				},
+			})
+		},
 	}, {
 		name: "workspaces may only appear once",
 		spec: v1beta1.PipelineRunSpec{

--- a/pkg/apis/pipeline/v1beta1/swagger.json
+++ b/pkg/apis/pipeline/v1beta1/swagger.json
@@ -990,6 +990,7 @@
           "$ref": "#/definitions/v1beta1.PipelineRef"
         },
         "pipelineSpec": {
+          "description": "Specifying PipelineSpec can be disabled by setting `disable-inline-spec` feature flag..",
           "$ref": "#/definitions/v1beta1.PipelineSpec"
         },
         "podTemplate": {
@@ -1342,7 +1343,7 @@
           "$ref": "#/definitions/v1beta1.PipelineRef"
         },
         "pipelineSpec": {
-          "description": "PipelineSpec is a specification of a pipeline Note: PipelineSpec is in preview mode and not yet supported",
+          "description": "PipelineSpec is a specification of a pipeline Note: PipelineSpec is in preview mode and not yet supported Specifying TaskSpec can be disabled by setting `disable-inline-spec` feature flag..",
           "$ref": "#/definitions/v1beta1.PipelineSpec"
         },
         "resources": {
@@ -1368,7 +1369,7 @@
           "$ref": "#/definitions/v1beta1.TaskRef"
         },
         "taskSpec": {
-          "description": "TaskSpec is a specification of a task",
+          "description": "TaskSpec is a specification of a task Specifying TaskSpec can be disabled by setting `disable-inline-spec` feature flag..",
           "$ref": "#/definitions/v1beta1.EmbeddedTask"
         },
         "timeout": {
@@ -2872,6 +2873,7 @@
           "$ref": "#/definitions/v1beta1.TaskRef"
         },
         "taskSpec": {
+          "description": "Specifying PipelineSpec can be disabled by setting `disable-inline-spec` feature flag..",
           "$ref": "#/definitions/v1beta1.TaskSpec"
         },
         "timeout": {

--- a/pkg/apis/pipeline/v1beta1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_types.go
@@ -49,6 +49,8 @@ type TaskRunSpec struct {
 	// no more than one of the TaskRef and TaskSpec may be specified.
 	// +optional
 	TaskRef *TaskRef `json:"taskRef,omitempty"`
+	// Specifying PipelineSpec can be disabled by setting
+	// `disable-inline-spec` feature flag..
 	// +optional
 	TaskSpec *TaskSpec `json:"taskSpec,omitempty"`
 	// Used for cancelling a TaskRun (and maybe more later on)

--- a/pkg/apis/pipeline/v1beta1/taskrun_validation.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_validation.go
@@ -61,6 +61,10 @@ func (ts *TaskRunSpec) Validate(ctx context.Context) (errs *apis.FieldError) {
 	}
 	// Validate TaskSpec if it's present.
 	if ts.TaskSpec != nil {
+		if slices.Contains(strings.Split(
+			config.FromContextOrDefaults(ctx).FeatureFlags.DisableInlineSpec, ","), "taskrun") {
+			errs = errs.Also(apis.ErrDisallowedFields("taskSpec"))
+		}
 		errs = errs.Also(ts.TaskSpec.Validate(ctx).ViaField("taskSpec"))
 	}
 

--- a/pkg/apis/pipeline/v1beta1/taskrun_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_validation_test.go
@@ -566,6 +566,42 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 		},
 		wantErr: apis.ErrInvalidValue(fmt.Sprintf("statusMessage should not be set if status is not set, but it is currently set to %s", invalidStatusMessage), "statusMessage"),
 	}, {
+		name: "taskspec when inline disabled",
+		spec: v1beta1.TaskRunSpec{
+			TaskSpec: &v1beta1.TaskSpec{
+				Steps: []v1beta1.Step{{
+					Name:  "mystep",
+					Image: "myimage",
+				}},
+			},
+		},
+		wantErr: apis.ErrDisallowedFields("taskSpec"),
+		wc: func(ctx context.Context) context.Context {
+			return config.ToContext(ctx, &config.Config{
+				FeatureFlags: &config.FeatureFlags{
+					DisableInlineSpec: "taskrun",
+				},
+			})
+		},
+	}, {
+		name: "taskspec when inline disabled all",
+		spec: v1beta1.TaskRunSpec{
+			TaskSpec: &v1beta1.TaskSpec{
+				Steps: []v1beta1.Step{{
+					Name:  "mystep",
+					Image: "myimage",
+				}},
+			},
+		},
+		wantErr: apis.ErrDisallowedFields("taskSpec"),
+		wc: func(ctx context.Context) context.Context {
+			return config.ToContext(ctx, &config.Config{
+				FeatureFlags: &config.FeatureFlags{
+					DisableInlineSpec: "taskrun,pipelinerun,pipeline",
+				},
+			})
+		},
+	}, {
 		name: "invalid taskspec",
 		spec: v1beta1.TaskRunSpec{
 			TaskSpec: &v1beta1.TaskSpec{

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -1703,6 +1703,7 @@ status:
         ResultExtractionMethod: "termination-message"
         MaxResultSize: 4096
         Coschedule: "workspaces"
+        DisableInlineSpec: ""
   provenance:
     featureFlags:
       RunningInEnvWithInjectedSidecars: true
@@ -1715,6 +1716,7 @@ status:
       ResultExtractionMethod: "termination-message"
       MaxResultSize: 4096
       Coschedule: "workspaces"
+      DisableInlineSpec: ""
 `, pipelineErrors.UserErrorLabel, pipelineErrors.UserErrorLabel))
 		reconciliatonError = fmt.Errorf("1 error occurred:\n\t* Provided results don't match declared results; may be invalid JSON or missing result declaration:  \"aResult\": task result is expected to be \"array\" type but was initialized to a different type \"string\"")
 		toBeRetriedTaskRun = parse.MustParseV1TaskRun(t, `
@@ -1768,6 +1770,7 @@ status:
       ResultExtractionMethod: "termination-message"
       MaxResultSize: 4096
       Coschedule: "workspaces"
+      DisableInlineSpec: ""
 `)
 		toBeRetriedWithResultsTaskRun = parse.MustParseV1TaskRun(t, `
 metadata:


### PR DESCRIPTION
By default, the inline specs will be enabled. Only if the flag is set to true, the inline spec would be disabled. This is to increase security of pipelines.

Fixes #5359

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Add a feature flag `disable-inline-spec` to disable embedded spec in Pipeline(PipelineSpec/TaskSpec), Taskrun(TaskSpec), and Pipelinerun. (PipelineSpec)  By default, the inline specs will be enabled. Only if the flag is set to "pipeline", "pipelinerun" and "taskrun" or a combination like "pipeline,pipelinerun" would the inline spec be disabled for Pipeline, PipelineRun, or TaskRun.
```
