### PR TITLE
fix: merge podTemplates filed more specific, such as tolerations, nodeselector and so on.

### DIFF
--- a/pkg/apis/pipeline/pod/template.go
+++ b/pkg/apis/pipeline/pod/template.go
@@ -223,6 +223,62 @@ func MergePodTemplateWithDefault(tpl, defaultTpl *PodTemplate) *PodTemplate {
 	}
 }
 
+// Similar to MergePodTemplateWithDefault, but more fine-grained. When the value
+// type is map or slice, we will merge their values first. If there is the same
+// value, the value from tpl will overwrite the value from defaultTpl.
+func ExpandedMergePodTemplateWithDefault(tpl, defaultTpl *PodTemplate) *PodTemplate {
+	switch {
+	case defaultTpl == nil:
+		// No configured default, just return the template
+		return tpl
+	case tpl == nil:
+		// No template, just return the default template
+		return defaultTpl
+	default:
+		// Otherwise, merge fields
+		if tpl.NodeSelector==nil{
+			tpl.NodeSelector = defaultTpl.NodeSelector
+		}else{
+			tpl.NodeSelector = mergeMaps(defaultTpl.NodeSelector, tpl.NodeSelector)
+		}
+		
+		tpl.Env = mergeByName(defaultTpl.Env, tpl.Env)
+		tpl.Tolerations = mergeByName(defaultTpl.Tolerations, tpl.Tolerations)
+		if tpl.SecurityContext == nil {
+			tpl.SecurityContext = defaultTpl.SecurityContext
+		}
+		tpl.Volumes = mergeByName(defaultTpl.Volumes, tpl.Volumes)
+		if tpl.RuntimeClassName == nil {
+			tpl.RuntimeClassName = defaultTpl.RuntimeClassName
+		}
+		if tpl.AutomountServiceAccountToken == nil {
+			tpl.AutomountServiceAccountToken = defaultTpl.AutomountServiceAccountToken
+		}
+		if tpl.DNSPolicy == nil {
+			tpl.DNSPolicy = defaultTpl.DNSPolicy
+		}
+		if tpl.DNSConfig == nil {
+			tpl.DNSConfig = defaultTpl.DNSConfig
+		}
+		if tpl.EnableServiceLinks == nil {
+			tpl.EnableServiceLinks = defaultTpl.EnableServiceLinks
+		}
+		if tpl.PriorityClassName == nil {
+			tpl.PriorityClassName = defaultTpl.PriorityClassName
+		}
+		if tpl.SchedulerName == "" {
+			tpl.SchedulerName = defaultTpl.SchedulerName
+		}
+		tpl.ImagePullSecrets = mergeByName(defaultTpl.ImagePullSecrets, tpl.ImagePullSecrets)
+		tpl.HostAliases = mergeByName(defaultTpl.HostAliases, tpl.HostAliases)
+		if !tpl.HostNetwork && defaultTpl.HostNetwork {
+			tpl.HostNetwork = true
+		}
+		tpl.TopologySpreadConstraints = mergeByName(defaultTpl.TopologySpreadConstraints, tpl.TopologySpreadConstraints)
+		return tpl
+	}
+}
+
 // AAPodTemplate holds pod specific configuration for the affinity-assistant
 type AAPodTemplate = AffinityAssistantTemplate
 
@@ -249,6 +305,24 @@ func MergeAAPodTemplateWithDefault(tpl, defaultTpl *AAPodTemplate) *AAPodTemplat
 		}
 		return tpl
 	}
+}
+
+// mergeMaps takes two maps with the same key and value types
+// and merges them, giving priority to the items in the override map.
+func mergeMaps[K comparable, V any](base, overrides map[K]V) map[K]V {
+	result := make(map[K]V)
+
+	// Add all elements from base to the result
+	for key, value := range base {
+		result[key] = value
+	}
+
+	// Add all elements from overrides to the result, overwriting any existing keys
+	for key, value := range overrides {
+		result[key] = value
+	}
+
+	return result
 }
 
 // mergeByName merges two slices of items with names based on the getName
@@ -291,6 +365,14 @@ func getName(item interface{}) string {
 	case corev1.EnvVar:
 		return item.Name
 	case corev1.Volume:
+		return item.Name
+	case corev1.Toleration:
+		return item.Key
+	case corev1.TopologySpreadConstraint:
+		return item.TopologyKey
+	case corev1.HostAlias:
+		return item.IP
+	case corev1.LocalObjectReference:
 		return item.Name
 	default:
 		return ""

--- a/pkg/apis/pipeline/v1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1/pipelinerun_types.go
@@ -660,7 +660,7 @@ func (pr *PipelineRun) GetTaskRunSpec(pipelineTaskName string) PipelineTaskRunSp
 		if task.PipelineTaskName == pipelineTaskName {
 			// merge podTemplates specified in pipelineRun.spec.taskRunSpecs[].podTemplate and pipelineRun.spec.podTemplate
 			// with taskRunSpecs taking higher precedence
-			s.PodTemplate = pod.MergePodTemplateWithDefault(task.PodTemplate, s.PodTemplate)
+			s.PodTemplate = pod.ExpandedMergePodTemplateWithDefault(task.PodTemplate, s.PodTemplate)
 			if task.ServiceAccountName != "" {
 				s.ServiceAccountName = task.ServiceAccountName
 			}

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
@@ -624,7 +624,7 @@ func (pr *PipelineRun) GetTaskRunSpec(pipelineTaskName string) PipelineTaskRunSp
 		if task.PipelineTaskName == pipelineTaskName {
 			// merge podTemplates specified in pipelineRun.spec.taskRunSpecs[].podTemplate and pipelineRun.spec.podTemplate
 			// with taskRunSpecs taking higher precedence
-			s.TaskPodTemplate = pod.MergePodTemplateWithDefault(task.TaskPodTemplate, s.TaskPodTemplate)
+			s.TaskPodTemplate = pod.ExpandedMergePodTemplateWithDefault(task.TaskPodTemplate, s.TaskPodTemplate)
 			if task.TaskServiceAccountName != "" {
 				s.TaskServiceAccountName = task.TaskServiceAccountName
 			}

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_types_test.go
@@ -723,6 +723,112 @@ func TestPipelineRun_GetTaskRunSpec(t *testing.T) {
 					SchedulerName: "task-2-schedule",
 				},
 			},
+		}, {
+			name: "verify whether tolerations are merged correctly",
+			pr: &v1beta1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{Name: "pr"},
+				Spec: v1beta1.PipelineRunSpec{
+					PodTemplate: &pod.Template{
+						Tolerations: []corev1.Toleration{
+							{
+								Key:      "arch",
+								Operator: corev1.TolerationOpEqual,
+								Effect:   corev1.TaintEffectPreferNoSchedule,
+								Value:    "arm64",
+							},
+						},
+					},
+					ServiceAccountName: "defaultSA",
+					PipelineRef:        &v1beta1.PipelineRef{Name: "prs"},
+					TaskRunSpecs: []v1beta1.PipelineTaskRunSpec{{
+						PipelineTaskName:       "different-tolerations",
+						TaskServiceAccountName: "different-tolerations-service-account",
+						TaskPodTemplate: &pod.Template{
+							Tolerations: []corev1.Toleration{
+								{
+									Key:      "pipeline-priority",
+									Operator: corev1.TolerationOpEqual,
+									Effect:   corev1.TaintEffectNoSchedule,
+									Value:    "low",
+								},
+							},
+						},
+					}, {
+						PipelineTaskName:       "same-tolerations",
+						TaskServiceAccountName: "same-tolerations-service-account",
+						TaskPodTemplate: &pod.Template{
+							Tolerations: []corev1.Toleration{
+								{
+									Key:      "arch",
+									Operator: corev1.TolerationOpEqual,
+									Effect:   corev1.TaintEffectPreferNoSchedule,
+									Value:    "amd64",
+								},
+							},
+						},
+					}},
+				},
+			},
+			expectedPodTemplates: map[string]*pod.PodTemplate{
+				"different-tolerations": {
+					Tolerations: []corev1.Toleration{
+						{
+							Key:      "pipeline-priority",
+							Operator: corev1.TolerationOpEqual,
+							Effect:   corev1.TaintEffectNoSchedule,
+							Value:    "low",
+						}, {
+							Key:      "arch",
+							Operator: corev1.TolerationOpEqual,
+							Effect:   corev1.TaintEffectPreferNoSchedule,
+							Value:    "arm64",
+						},
+					},
+				},
+				"same-tolerations": {
+					Tolerations: []corev1.Toleration{
+						{
+							Key:      "arch",
+							Operator: corev1.TolerationOpEqual,
+							Effect:   corev1.TaintEffectPreferNoSchedule,
+							Value:    "amd64",
+						},
+					},
+				},
+			},
+		}, {
+			name: "verify whether nodeselector are merged correctly",
+			pr: &v1beta1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{Name: "pr"},
+				Spec: v1beta1.PipelineRunSpec{
+					PodTemplate: &pod.Template{
+						NodeSelector: map[string]string{"disktype": "ssd"},
+					},
+					ServiceAccountName: "defaultSA",
+					PipelineRef: &v1beta1.PipelineRef{Name: "prs"},
+					TaskRunSpecs: []v1beta1.PipelineTaskRunSpec{{
+						PipelineTaskName:   "different-nodeselector",
+						TaskServiceAccountName: "different-nodeselector-service-account",
+						TaskPodTemplate: &pod.Template{
+							NodeSelector: map[string]string{"disktype": "hdd"},
+						},
+					}, {
+						PipelineTaskName:   "same-nodeselector",
+						TaskServiceAccountName: "same-nodeselector-service-account",
+						TaskPodTemplate: &pod.Template{
+							NodeSelector: map[string]string{"kubernetes.io/os": "linux"},
+						},
+					}},
+				},
+			},
+			expectedPodTemplates: map[string]*pod.PodTemplate{
+				"different-nodeselector": {
+					NodeSelector: map[string]string{"disktype": "hdd"},
+				},
+				"same-nodeselector": {
+					NodeSelector: map[string]string{"disktype": "ssd", "kubernetes.io/os": "linux"},
+				},
+			},
 		},
 	} {
 		for taskName := range tt.expectedPodTemplates {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
fixes: [#7127](https://github.com/tektoncd/pipeline/issues/7127)
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
#### Background:
In the original implementation, template replacement is simply replacing pipelineRun.spec.podTemplate with pipelineRun.spec.taskRunSpecs[].taskPodTemplate,the specific description can be seen here:[Issue #6846](https://github.com/tektoncd/pipeline/issues/6846).

To solve the problem [#6846](https://github.com/tektoncd/pipeline/issues/6846). In [pr #6862](https://github.com/tektoncd/pipeline/pull/6862), the function [MergePodTemplateWithDefault](https://github.com/tektoncd/pipeline/blob/a0905b71a3e749351acbd7102f8cda87d04089b9/pkg/apis/pipeline/pod/template.go#L165) is called to merge podtemplate, In this function, two parameters named tpl and defaultTpl are passed in. It only merges volumes and envs, the judgment logic of the remaining fields is if the same field is set on both templates, the value from tpl will overwrite the value from defaultTpl, which leads to the occurrence of problem [#7127](https://github.com/tektoncd/pipeline/issues/7127)

#### Solution:
Here I created a new function named ExpandedMergePodTemplateWithDefault, which can merge fields such as NodeSelector, Tolerations ,ImagePullSecrets and so on. If there is a conflict when these fields are merged, we will use the value in the field corresponding to the incoming parameter with high priority (similar to the implementation of the original function, that is, the second default of the incoming parameter is higher priority). The reason why it is not modified on the original function is that the original function is referenced in multiple places. If it is modified directly, it may cause unknown problems.

In this pr, I replaced the merge function called in function [GetTaskRunSpec](https://github.com/tektoncd/pipeline/blob/a0905b71a3e749351acbd7102f8cda87d04089b9/pkg/apis/pipeline/v1/pipelinerun_types.go#L663) with my newly defined function and wrote a test function for my newly defined function and added multiple test cases to the original [TestPipelineRun_GetTaskRunSpec](https://github.com/tektoncd/pipeline/blob/a0905b71a3e749351acbd7102f8cda87d04089b9/pkg/apis/pipeline/v1/pipelinerun_types_test.go#L630) test function

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
PodTemplate filed such as tolerations, nodeselector will be merged between pipelineRun.spec.podTemplate and pipelineRun.spec.taskRunSpecs[]
```
