### PR TITLE
release: add a small script to "automate" bugfix releases

### DIFF
--- a/tekton/bugfix-release.sh
+++ b/tekton/bugfix-release.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+RELEASE_BRANCH=${1:-$(git rev-parse --abbrev-ref HEAD)}
+shift
+
+echo "> Make sure our remotes are up-to-date"
+git fetch -p --all
+
+TEKTON_RELEASE_GIT_SHA=$(git rev-parse "${RELEASE_BRANCH}")
+TEKTON_OLD_VERSION=$(git describe --tags --abbrev=0 "${TEKTON_RELEASE_GIT_SHA}")
+TEKTON_OLD_VERSION_COMMIT_SHA=$(git rev-list -n 1 "${TEKTON_OLD_VERSION}")
+TEKTON_RELEASE_NAME=$(gh release view v0.47.7 --json name | jq .name | sed -e 's/.*\\"\(.*\)\\"\"/\1/')
+
+if [[ "${TEKTON_RELEASE_GIT_SHA}" == "${TEKTON_OLD_VERSION_COMMIT_SHA}" ]]; then
+    echo "> No new commit in ${RELEASE_BRANCH} (${TEKTON_RELEASE_GIT_SHA}==${TEKTON_OLD_VERSION_COMMIT_SHA})"
+    return 0
+fi
+
+TEKTON_VERSION=$(echo ${TEKTON_OLD_VERSION} | awk -F. -v OFS=. '{$NF += 1 ; print}')
+
+echo "> Old version : ${TEKTON_OLD_VERSION}"
+echo "> Old version commit : ${TEKTON_OLD_VERSION_COMMIT_SHA}"
+echo "> New version : ${TEKTON_VERSION}"
+echo "> New version commit: ${TEKTON_RELEASE_GIT_SHA}"
+echo "> Tekton Release Name: ${TEKTON_RELEASE_NAME}"
+
+# Might be overkill
+git --no-pager diff "${TEKTON_OLD_VERSION_COMMIT_SHA}" "${TEKTON_RELEASE_GIT_SHA}"
+
+cat <<EOF > workspace-template.yaml
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+EOF
+
+echo "> Starting the release pipeline"
+tkn pipeline start pipeline-release \
+  --serviceaccount=release-right-meow \
+  --param=gitRevision="${TEKTON_RELEASE_GIT_SHA}" \
+  --param=serviceAccountPath=release.json \
+  --param=versionTag="${TEKTON_VERSION}" \
+  --param=releaseBucket=gs://tekton-releases/pipeline \
+  --param=releaseAsLatest="false" \
+  --workspace name=release-secret,secret=release-secret \
+  --workspace name=workarea,volumeClaimTemplateFile=workspace-template.yaml --use-param-defaults --pipeline-timeout 3h --showlog
+
+RELEASE_FILE=https://storage.googleapis.com/tekton-releases/pipeline/previous/${TEKTON_VERSION}/release.yaml
+CONTROLLER_IMAGE_SHA=$(curl $RELEASE_FILE | egrep 'gcr.io.*controller' | cut -d'@' -f2)
+REKOR_UUID=$(rekor-cli search --sha $CONTROLLER_IMAGE_SHA | grep -v Found | head -1)
+echo -e "CONTROLLER_IMAGE_SHA: ${CONTROLLER_IMAGE_SHA}\nREKOR_UUID: ${REKOR_UUID}"
+
+echo "> Starting the release-draft pipeline"
+tkn pipeline start release-draft \
+  --workspace name=shared,volumeClaimTemplateFile=workspace-template.yaml \
+  --workspace name=credentials,secret=release-secret \
+  -p package="tektoncd/pipeline" \
+  -p git-revision="${TEKTON_RELEASE_GIT_SHA}" \
+  -p release-tag="${TEKTON_VERSION}" \
+  -p previous-release-tag="${TEKTON_OLD_VERSION}" \
+  -p release-name="${TEKTON_RELEASE_NAME}" \
+  -p bucket="gs://tekton-releases/pipeline" \
+  -p rekor-uuid="$REKOR_UUID" \
+  --showlog


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Adding a `bugfix-release.sh` script to automate bugfix releases. Today
it is meant to be started by a maintainer, like the following

```
./tekton/bugfix-release upstream/release-v0.47.x
```

- It will detect the old version, and commit related to the version
- It will compute the new version number
- It will detect the release name
- If there is no different between the old version and the new
  one (aka, no commit in the release branch since last release), it
  will be exit gracefully.

The idea is that, from there, we can automate the bugfix release
completely. We could run this script weekly for each "supported"
release branch, and it would automatically do the release for us.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/kind misc

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
