### PR TITLE
Enable Param Substitution in StepAction resolver reference params

### DIFF
--- a/examples/v1/taskruns/alpha/stepaction-git-resolver.yaml
+++ b/examples/v1/taskruns/alpha/stepaction-git-resolver.yaml
@@ -4,6 +4,13 @@ kind: TaskRun
 metadata:
   generateName: step-action-run-
 spec:
+  params:
+    - name: pathInRepo
+      value: basic_step.yaml
+    - name: revision
+      value: main
+    - name: repoUrl
+      value: https://github.com/chitrangpatel/repo1M.git
   TaskSpec:
     steps:
       - name: action-runner
@@ -11,8 +18,8 @@ spec:
           resolver: git
           params:
             - name: url
-              value: https://github.com/chitrangpatel/repo1M.git
+              value: $(params.repoUrl)
             - name: revision
-              value: main
+              value: $(params.revision)
             - name: pathInRepo
-              value: basic_step.yaml
+              value: $(params.pathInRepo)


### PR DESCRIPTION
Fixes https://github.com/tektoncd/pipeline/issues/7865.

This PR allows param substitution in Step Ref Resolver params. This is already possible in TaskRef and PipelineRef as highlighted in the above issue. This was missed in the original design. I think of this as a bug since based on TaskRef and PipelineRef, it feels like a loose end. For consistency, we should be able to perform these substitutions.


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Enable Param Substitution in StepAction resolver reference params
```
