### PR TITLE
v1beta1 fields updated to v1 in docs and examples

### DIFF
--- a/docs/pipeline-api.md
+++ b/docs/pipeline-api.md
@@ -12193,7 +12193,7 @@ string
 </tr>
 <tr>
 <td>
-<code>taskServiceAccountName</code><br/>
+<code>serviceAccountName</code><br/>
 <em>
 string
 </em>
@@ -12203,7 +12203,7 @@ string
 </tr>
 <tr>
 <td>
-<code>taskPodTemplate</code><br/>
+<code>podTemplate</code><br/>
 <em>
 <a href="#tekton.dev/unversioned.Template">
 Template

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -36,12 +36,12 @@ In order to ensure that Tasks are scheduled to a node with the correct host OS, 
 
 ### Node Selectors
 
-Node selectors are the simplest way to schedule pods to a Windows or Linux node. By default, Kubernetes nodes include a label `kubernetes.io/os` to identify the host OS. The Kubelet populates this with `runtime.GOOS` as defined by Go. Use `spec.podTemplate.nodeSelector` (or `spec.taskRunSpecs[i].taskPodTemplate.nodeSelector` in a PipelineRun) to schedule Tasks to a node with a specific label and value.
+Node selectors are the simplest way to schedule pods to a Windows or Linux node. By default, Kubernetes nodes include a label `kubernetes.io/os` to identify the host OS. The Kubelet populates this with `runtime.GOOS` as defined by Go. Use `spec.podTemplate.nodeSelector` (or `spec.taskRunSpecs[i].podTemplate.nodeSelector` in a PipelineRun) to schedule Tasks to a node with a specific label and value.
 
 For example:
 
 ``` yaml
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
   name: windows-taskrun
@@ -52,7 +52,7 @@ spec:
     nodeSelector:
       kubernetes.io/os: windows
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
   name: linux-taskrun
@@ -71,7 +71,7 @@ Node affinity can be used as an alternative method of defining the OS requiremen
 For example:
 
 ```yaml
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
   name: windows-taskrun
@@ -89,7 +89,7 @@ spec:
                   values:
                   - windows
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
   name: linux-taskrun

--- a/examples/v1/pipelineruns/no-ci/pipelinerun-taskrunspecs.yaml
+++ b/examples/v1/pipelineruns/no-ci/pipelinerun-taskrunspecs.yaml
@@ -74,7 +74,7 @@ spec:
   - pipelineTaskName: first-add-taskspec
     serviceAccountName: 'default'
   - pipelineTaskName: second-add-taskspec
-    taskPodTemplate:
+    podTemplate:
       nodeSelector:
         disktype: ssd
   params:

--- a/examples/v1/pipelineruns/no-ci/windows-node-affinity.yaml
+++ b/examples/v1/pipelineruns/no-ci/windows-node-affinity.yaml
@@ -31,7 +31,7 @@ spec:
     name: windows-pipeline-na
   taskRunSpecs:
     - pipelineTaskName: windows-task-na
-      taskPodTemplate:
+      podTemplate:
         affinity:
           nodeAffinity:
             requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/v1/pipelineruns/no-ci/windows-node-selectors.yaml
+++ b/examples/v1/pipelineruns/no-ci/windows-node-selectors.yaml
@@ -31,6 +31,6 @@ spec:
     name: windows-pipeline-ns
   taskRunSpecs:
     - pipelineTaskName: windows-task-ns
-      taskPodTemplate:
+      podTemplate:
         nodeSelector:
           kubernetes.io/os: windows


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

Docs and examples for using Windows tasks mix use of v1beta1 and v1 API - both updated to correctly use v1.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
