### PR TITLE
fix: set correct metrics name when using a task resolver

### DIFF
--- a/pkg/taskrunmetrics/metrics.go
+++ b/pkg/taskrunmetrics/metrics.go
@@ -382,7 +382,17 @@ func (r *Recorder) DurationAndCount(ctx context.Context, tr *v1.TaskRun, beforeC
 
 	taskName := anonymous
 	if tr.Spec.TaskRef != nil {
-		taskName = tr.Spec.TaskRef.Name
+		if len(tr.Spec.TaskRef.Params) > 0 {
+			for _, p := range tr.Spec.TaskRef.Params {
+				if p.Name == "name" {
+					taskName = p.Value.StringVal
+				}
+			}
+		} else {
+			taskName = tr.Spec.TaskRef.Name
+		}
+	} else if tr.Spec.TaskSpec.DisplayName != "" {
+		taskName = tr.Spec.TaskSpec.DisplayName
 	}
 
 	cond := tr.Status.GetCondition(apis.ConditionSucceeded)
@@ -506,7 +516,17 @@ func (r *Recorder) RecordPodLatency(ctx context.Context, pod *corev1.Pod, tr *v1
 	latency := scheduledTime.Sub(pod.CreationTimestamp.Time)
 	taskName := anonymous
 	if tr.Spec.TaskRef != nil {
-		taskName = tr.Spec.TaskRef.Name
+		if len(tr.Spec.TaskRef.Params) > 0 {
+			for _, p := range tr.Spec.TaskRef.Params {
+				if p.Name == "name" {
+					taskName = p.Value.StringVal
+				}
+			}
+		} else {
+			taskName = tr.Spec.TaskRef.Name
+		}
+	} else if tr.Spec.TaskSpec.DisplayName != "" {
+		taskName = tr.Spec.TaskSpec.DisplayName
 	}
 
 	ctx, err := tag.New(

--- a/pkg/taskrunmetrics/metrics_test.go
+++ b/pkg/taskrunmetrics/metrics_test.go
@@ -171,236 +171,312 @@ func TestRecordTaskRunDurationCount(t *testing.T) {
 		expectedCount:    1,
 		beforeCondition:  nil,
 		countWithReason:  false,
-	}, {
-		name: "for succeeded taskrun with before condition",
-		taskRun: &v1.TaskRun{
-			ObjectMeta: metav1.ObjectMeta{Name: "taskrun-1", Namespace: "ns"},
-			Spec: v1.TaskRunSpec{
-				TaskRef: &v1.TaskRef{Name: "task-1"},
-			},
-			Status: v1.TaskRunStatus{
-				Status: duckv1.Status{
-					Conditions: duckv1.Conditions{{
-						Type:   apis.ConditionSucceeded,
-						Status: corev1.ConditionTrue,
-					}},
+	},
+		{
+			name: "for succeeded taskrun with inline task spec",
+			taskRun: &v1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{Name: "taskrun-1", Namespace: "ns"},
+				Spec: v1.TaskRunSpec{
+					TaskSpec: &v1.TaskSpec{
+						DisplayName: "inline-task-1",
+					},
 				},
-				TaskRunStatusFields: v1.TaskRunStatusFields{
-					StartTime:      &startTime,
-					CompletionTime: &completionTime,
-				},
-			},
-		},
-		metricName: "taskrun_duration_seconds",
-		expectedDurationTags: map[string]string{
-			"task":      "task-1",
-			"taskrun":   "taskrun-1",
-			"namespace": "ns",
-			"status":    "success",
-		},
-		expectedCountTags: map[string]string{
-			"status": "success",
-		},
-		expectedDuration: 60,
-		expectedCount:    1,
-		beforeCondition: &apis.Condition{
-			Type:   apis.ConditionReady,
-			Status: corev1.ConditionUnknown,
-		},
-		countWithReason: false,
-	}, {
-		name: "for succeeded taskrun recount",
-		taskRun: &v1.TaskRun{
-			ObjectMeta: metav1.ObjectMeta{Name: "taskrun-1", Namespace: "ns"},
-			Spec: v1.TaskRunSpec{
-				TaskRef: &v1.TaskRef{Name: "task-1"},
-			},
-			Status: v1.TaskRunStatus{
-				Status: duckv1.Status{
-					Conditions: duckv1.Conditions{{
-						Type:   apis.ConditionSucceeded,
-						Status: corev1.ConditionTrue,
-					}},
-				},
-				TaskRunStatusFields: v1.TaskRunStatusFields{
-					StartTime:      &startTime,
-					CompletionTime: &completionTime,
+				Status: v1.TaskRunStatus{
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{{
+							Type:   apis.ConditionSucceeded,
+							Status: corev1.ConditionTrue,
+						}},
+					},
+					TaskRunStatusFields: v1.TaskRunStatusFields{
+						StartTime:      &startTime,
+						CompletionTime: &completionTime,
+					},
 				},
 			},
-		},
-		metricName:           "taskrun_duration_seconds",
-		expectedDurationTags: nil,
-		expectedCountTags:    nil,
-		expectedDuration:     0,
-		expectedCount:        0,
-		beforeCondition: &apis.Condition{
-			Type:   apis.ConditionSucceeded,
-			Status: corev1.ConditionTrue,
-		},
-		countWithReason: false,
-	}, {
-		name: "for failed taskrun",
-		taskRun: &v1.TaskRun{
-			ObjectMeta: metav1.ObjectMeta{Name: "taskrun-1", Namespace: "ns"},
-			Spec: v1.TaskRunSpec{
-				TaskRef: &v1.TaskRef{Name: "task-1"},
+			metricName: "taskrun_duration_seconds",
+			expectedDurationTags: map[string]string{
+				"task":      "inline-task-1",
+				"taskrun":   "taskrun-1",
+				"namespace": "ns",
+				"status":    "success",
 			},
-			Status: v1.TaskRunStatus{
-				Status: duckv1.Status{
-					Conditions: duckv1.Conditions{{
-						Type:   apis.ConditionSucceeded,
-						Status: corev1.ConditionFalse,
-					}},
-				},
-				TaskRunStatusFields: v1.TaskRunStatusFields{
-					StartTime:      &startTime,
-					CompletionTime: &completionTime,
-				},
+			expectedCountTags: map[string]string{
+				"status": "success",
 			},
+			expectedDuration: 60,
+			expectedCount:    1,
+			beforeCondition:  nil,
+			countWithReason:  false,
 		},
-		metricName: "taskrun_duration_seconds",
-		expectedDurationTags: map[string]string{
-			"task":      "task-1",
-			"taskrun":   "taskrun-1",
-			"namespace": "ns",
-			"status":    "failed",
-		},
-		expectedCountTags: map[string]string{
-			"status": "failed",
-		},
-		expectedDuration: 60,
-		expectedCount:    1,
-		beforeCondition:  nil,
-		countWithReason:  false,
-	}, {
-		name: "for succeeded taskrun in pipelinerun",
-		taskRun: &v1.TaskRun{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "taskrun-1", Namespace: "ns",
-				Labels: map[string]string{
-					pipeline.PipelineLabelKey:    "pipeline-1",
-					pipeline.PipelineRunLabelKey: "pipelinerun-1",
+		{
+			name: "for succeeded taskrun with bundle ref",
+			taskRun: &v1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{Name: "taskrun-1", Namespace: "ns"},
+				Spec: v1.TaskRunSpec{
+					TaskRef: &v1.TaskRef{
+						ResolverRef: v1.ResolverRef{Params: []v1.Param{
+							{Name: "name", Value: v1.ParamValue{StringVal: "remote-task-1"}},
+						}},
+					},
+				},
+				Status: v1.TaskRunStatus{
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{{
+							Type:   apis.ConditionSucceeded,
+							Status: corev1.ConditionTrue,
+						}},
+					},
+					TaskRunStatusFields: v1.TaskRunStatusFields{
+						StartTime:      &startTime,
+						CompletionTime: &completionTime,
+					},
 				},
 			},
-			Spec: v1.TaskRunSpec{
-				TaskRef: &v1.TaskRef{Name: "task-1"},
+			metricName: "taskrun_duration_seconds",
+			expectedDurationTags: map[string]string{
+				"task":      "remote-task-1",
+				"taskrun":   "taskrun-1",
+				"namespace": "ns",
+				"status":    "success",
 			},
-			Status: v1.TaskRunStatus{
-				Status: duckv1.Status{
-					Conditions: duckv1.Conditions{{
-						Type:   apis.ConditionSucceeded,
-						Status: corev1.ConditionTrue,
-					}},
-				},
-				TaskRunStatusFields: v1.TaskRunStatusFields{
-					StartTime:      &startTime,
-					CompletionTime: &completionTime,
-				},
+			expectedCountTags: map[string]string{
+				"status": "success",
 			},
-		},
-		metricName: "pipelinerun_taskrun_duration_seconds",
-		expectedDurationTags: map[string]string{
-			"pipeline":    "pipeline-1",
-			"pipelinerun": "pipelinerun-1",
-			"task":        "task-1",
-			"taskrun":     "taskrun-1",
-			"namespace":   "ns",
-			"status":      "success",
-		},
-		expectedCountTags: map[string]string{
-			"status": "success",
-		},
-		expectedDuration: 60,
-		expectedCount:    1,
-		beforeCondition:  nil,
-		countWithReason:  false,
-	}, {
-		name: "for failed taskrun in pipelinerun",
-		taskRun: &v1.TaskRun{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "taskrun-1", Namespace: "ns",
-				Labels: map[string]string{
-					pipeline.PipelineLabelKey:    "pipeline-1",
-					pipeline.PipelineRunLabelKey: "pipelinerun-1",
+			expectedDuration: 60,
+			expectedCount:    1,
+			beforeCondition:  nil,
+			countWithReason:  false,
+		}, {
+			name: "for succeeded taskrun with before condition",
+			taskRun: &v1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{Name: "taskrun-1", Namespace: "ns"},
+				Spec: v1.TaskRunSpec{
+					TaskRef: &v1.TaskRef{Name: "task-1"},
+				},
+				Status: v1.TaskRunStatus{
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{{
+							Type:   apis.ConditionSucceeded,
+							Status: corev1.ConditionTrue,
+						}},
+					},
+					TaskRunStatusFields: v1.TaskRunStatusFields{
+						StartTime:      &startTime,
+						CompletionTime: &completionTime,
+					},
 				},
 			},
-			Spec: v1.TaskRunSpec{
-				TaskRef: &v1.TaskRef{Name: "task-1"},
+			metricName: "taskrun_duration_seconds",
+			expectedDurationTags: map[string]string{
+				"task":      "task-1",
+				"taskrun":   "taskrun-1",
+				"namespace": "ns",
+				"status":    "success",
 			},
-			Status: v1.TaskRunStatus{
-				Status: duckv1.Status{
-					Conditions: duckv1.Conditions{{
-						Type:   apis.ConditionSucceeded,
-						Status: corev1.ConditionFalse,
-					}},
-				},
-				TaskRunStatusFields: v1.TaskRunStatusFields{
-					StartTime:      &startTime,
-					CompletionTime: &completionTime,
-				},
+			expectedCountTags: map[string]string{
+				"status": "success",
 			},
-		},
-		metricName: "pipelinerun_taskrun_duration_seconds",
-		expectedDurationTags: map[string]string{
-			"pipeline":    "pipeline-1",
-			"pipelinerun": "pipelinerun-1",
-			"task":        "task-1",
-			"taskrun":     "taskrun-1",
-			"namespace":   "ns",
-			"status":      "failed",
-		},
-		expectedCountTags: map[string]string{
-			"status": "failed",
-		},
-		expectedDuration: 60,
-		expectedCount:    1,
-		beforeCondition:  nil,
-		countWithReason:  false,
-	}, {
-		name: "for failed taskrun in pipelinerun with reason",
-		taskRun: &v1.TaskRun{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "taskrun-1", Namespace: "ns",
-				Labels: map[string]string{
-					pipeline.PipelineLabelKey:    "pipeline-1",
-					pipeline.PipelineRunLabelKey: "pipelinerun-1",
+			expectedDuration: 60,
+			expectedCount:    1,
+			beforeCondition: &apis.Condition{
+				Type:   apis.ConditionReady,
+				Status: corev1.ConditionUnknown,
+			},
+			countWithReason: false,
+		}, {
+			name: "for succeeded taskrun recount",
+			taskRun: &v1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{Name: "taskrun-1", Namespace: "ns"},
+				Spec: v1.TaskRunSpec{
+					TaskRef: &v1.TaskRef{Name: "task-1"},
+				},
+				Status: v1.TaskRunStatus{
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{{
+							Type:   apis.ConditionSucceeded,
+							Status: corev1.ConditionTrue,
+						}},
+					},
+					TaskRunStatusFields: v1.TaskRunStatusFields{
+						StartTime:      &startTime,
+						CompletionTime: &completionTime,
+					},
 				},
 			},
-			Spec: v1.TaskRunSpec{
-				TaskRef: &v1.TaskRef{Name: "task-1"},
+			metricName:           "taskrun_duration_seconds",
+			expectedDurationTags: nil,
+			expectedCountTags:    nil,
+			expectedDuration:     0,
+			expectedCount:        0,
+			beforeCondition: &apis.Condition{
+				Type:   apis.ConditionSucceeded,
+				Status: corev1.ConditionTrue,
 			},
-			Status: v1.TaskRunStatus{
-				Status: duckv1.Status{
-					Conditions: duckv1.Conditions{{
-						Type:   apis.ConditionSucceeded,
-						Status: corev1.ConditionFalse,
-						Reason: "TaskRunImagePullFailed",
-					}},
+			countWithReason: false,
+		}, {
+			name: "for failed taskrun",
+			taskRun: &v1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{Name: "taskrun-1", Namespace: "ns"},
+				Spec: v1.TaskRunSpec{
+					TaskRef: &v1.TaskRef{Name: "task-1"},
 				},
-				TaskRunStatusFields: v1.TaskRunStatusFields{
-					StartTime:      &startTime,
-					CompletionTime: &completionTime,
+				Status: v1.TaskRunStatus{
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{{
+							Type:   apis.ConditionSucceeded,
+							Status: corev1.ConditionFalse,
+						}},
+					},
+					TaskRunStatusFields: v1.TaskRunStatusFields{
+						StartTime:      &startTime,
+						CompletionTime: &completionTime,
+					},
 				},
 			},
-		},
-		metricName: "pipelinerun_taskrun_duration_seconds",
-		expectedDurationTags: map[string]string{
-			"pipeline":    "pipeline-1",
-			"pipelinerun": "pipelinerun-1",
-			"task":        "task-1",
-			"taskrun":     "taskrun-1",
-			"namespace":   "ns",
-			"status":      "failed",
-		},
-		expectedCountTags: map[string]string{
-			"status": "failed",
-			"reason": "TaskRunImagePullFailed",
-		},
-		expectedDuration: 60,
-		expectedCount:    1,
-		beforeCondition:  nil,
-		countWithReason:  true,
-	}} {
+			metricName: "taskrun_duration_seconds",
+			expectedDurationTags: map[string]string{
+				"task":      "task-1",
+				"taskrun":   "taskrun-1",
+				"namespace": "ns",
+				"status":    "failed",
+			},
+			expectedCountTags: map[string]string{
+				"status": "failed",
+			},
+			expectedDuration: 60,
+			expectedCount:    1,
+			beforeCondition:  nil,
+			countWithReason:  false,
+		}, {
+			name: "for succeeded taskrun in pipelinerun",
+			taskRun: &v1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "taskrun-1", Namespace: "ns",
+					Labels: map[string]string{
+						pipeline.PipelineLabelKey:    "pipeline-1",
+						pipeline.PipelineRunLabelKey: "pipelinerun-1",
+					},
+				},
+				Spec: v1.TaskRunSpec{
+					TaskRef: &v1.TaskRef{Name: "task-1"},
+				},
+				Status: v1.TaskRunStatus{
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{{
+							Type:   apis.ConditionSucceeded,
+							Status: corev1.ConditionTrue,
+						}},
+					},
+					TaskRunStatusFields: v1.TaskRunStatusFields{
+						StartTime:      &startTime,
+						CompletionTime: &completionTime,
+					},
+				},
+			},
+			metricName: "pipelinerun_taskrun_duration_seconds",
+			expectedDurationTags: map[string]string{
+				"pipeline":    "pipeline-1",
+				"pipelinerun": "pipelinerun-1",
+				"task":        "task-1",
+				"taskrun":     "taskrun-1",
+				"namespace":   "ns",
+				"status":      "success",
+			},
+			expectedCountTags: map[string]string{
+				"status": "success",
+			},
+			expectedDuration: 60,
+			expectedCount:    1,
+			beforeCondition:  nil,
+			countWithReason:  false,
+		}, {
+			name: "for failed taskrun in pipelinerun",
+			taskRun: &v1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "taskrun-1", Namespace: "ns",
+					Labels: map[string]string{
+						pipeline.PipelineLabelKey:    "pipeline-1",
+						pipeline.PipelineRunLabelKey: "pipelinerun-1",
+					},
+				},
+				Spec: v1.TaskRunSpec{
+					TaskRef: &v1.TaskRef{Name: "task-1"},
+				},
+				Status: v1.TaskRunStatus{
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{{
+							Type:   apis.ConditionSucceeded,
+							Status: corev1.ConditionFalse,
+						}},
+					},
+					TaskRunStatusFields: v1.TaskRunStatusFields{
+						StartTime:      &startTime,
+						CompletionTime: &completionTime,
+					},
+				},
+			},
+			metricName: "pipelinerun_taskrun_duration_seconds",
+			expectedDurationTags: map[string]string{
+				"pipeline":    "pipeline-1",
+				"pipelinerun": "pipelinerun-1",
+				"task":        "task-1",
+				"taskrun":     "taskrun-1",
+				"namespace":   "ns",
+				"status":      "failed",
+			},
+			expectedCountTags: map[string]string{
+				"status": "failed",
+			},
+			expectedDuration: 60,
+			expectedCount:    1,
+			beforeCondition:  nil,
+			countWithReason:  false,
+		}, {
+			name: "for failed taskrun in pipelinerun with reason",
+			taskRun: &v1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "taskrun-1", Namespace: "ns",
+					Labels: map[string]string{
+						pipeline.PipelineLabelKey:    "pipeline-1",
+						pipeline.PipelineRunLabelKey: "pipelinerun-1",
+					},
+				},
+				Spec: v1.TaskRunSpec{
+					TaskRef: &v1.TaskRef{Name: "task-1"},
+				},
+				Status: v1.TaskRunStatus{
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{{
+							Type:   apis.ConditionSucceeded,
+							Status: corev1.ConditionFalse,
+							Reason: "TaskRunImagePullFailed",
+						}},
+					},
+					TaskRunStatusFields: v1.TaskRunStatusFields{
+						StartTime:      &startTime,
+						CompletionTime: &completionTime,
+					},
+				},
+			},
+			metricName: "pipelinerun_taskrun_duration_seconds",
+			expectedDurationTags: map[string]string{
+				"pipeline":    "pipeline-1",
+				"pipelinerun": "pipelinerun-1",
+				"task":        "task-1",
+				"taskrun":     "taskrun-1",
+				"namespace":   "ns",
+				"status":      "failed",
+			},
+			expectedCountTags: map[string]string{
+				"status": "failed",
+				"reason": "TaskRunImagePullFailed",
+			},
+			expectedDuration: 60,
+			expectedCount:    1,
+			beforeCondition:  nil,
+			countWithReason:  true,
+		}} {
 		t.Run(c.name, func(t *testing.T) {
 			unregisterMetrics()
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

When looking at the taskrun metrics generated by tekton, there are a lot that have either `task="anonymous"` or `task=""`.  This PR looks into the resolver params to set a "name" against a task.  Where the taskSpec is inlined, we can also use the "DisplayName" if its set.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
