### PR TITLE
add namespace label/tag to non-deprecated throttle metrics

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -11,24 +11,24 @@ The following pipeline metrics are available at `controller-service` on port `90
 
 We expose several kinds of exporters, including Prometheus, Google Stackdriver, and many others. You can set them up using [observability configuration](../config/config-observability.yaml).
 
-| Name                                                                                    | Type | Labels/Tags | Status |
-|-----------------------------------------------------------------------------------------| ----------- | ----------- | ----------- |
+| Name                                                                                    | Type | Labels/Tags                                     | Status |
+|-----------------------------------------------------------------------------------------| ----------- |-------------------------------------------------| ----------- |
 | `tekton_pipelines_controller_pipelinerun_duration_seconds_[bucket, sum, count]`         | Histogram/LastValue(Gauge) | `*pipeline`=&lt;pipeline_name&gt; <br> `*pipelinerun`=&lt;pipelinerun_name&gt; <br> `status`=&lt;status&gt; <br> `namespace`=&lt;pipelinerun-namespace&gt; | experimental |
-| `tekton_pipelines_controller_pipelinerun_taskrun_duration_seconds_[bucket, sum, count]` | Histogram/LastValue(Gauge) | `*pipeline`=&lt;pipeline_name&gt; <br> `*pipelinerun`=&lt;pipelinerun_name&gt; <br> `status`=&lt;status&gt; <br> `*task`=&lt;task_name&gt; <br> `*taskrun`=&lt;taskrun_name&gt;<br> `namespace`=&lt;pipelineruns-taskruns-namespace&gt;| experimental |
-| `tekton_pipelines_controller_pipelinerun_count` | Counter | `status`=&lt;status&gt; | deprecate |
-| `tekton_pipelines_controller_pipelinerun_total` | Counter | `status`=&lt;status&gt; | experimental |
-| `tekton_pipelines_controller_running_pipelineruns_count` | Gauge | | deprecate |
-| `tekton_pipelines_controller_running_pipelineruns` | Gauge | | experimental |
+| `tekton_pipelines_controller_pipelinerun_taskrun_duration_seconds_[bucket, sum, count]` | Histogram/LastValue(Gauge) | `*pipeline`=&lt;pipeline_name&gt; <br> `*pipelinerun`=&lt;pipelinerun_name&gt; <br> `status`=&lt;status&gt; <br> `*task`=&lt;task_name&gt; <br> `*taskrun`=&lt;taskrun_name&gt;<br> `namespace`=&lt;pipelineruns-taskruns-namespace&gt; | experimental |
+| `tekton_pipelines_controller_pipelinerun_count` | Counter | `status`=&lt;status&gt;                         | deprecate |
+| `tekton_pipelines_controller_pipelinerun_total` | Counter | `status`=&lt;status&gt;                         | experimental |
+| `tekton_pipelines_controller_running_pipelineruns_count` | Gauge |                                                 | deprecate |
+| `tekton_pipelines_controller_running_pipelineruns` | Gauge |                                                 | experimental |
 | `tekton_pipelines_controller_taskrun_duration_seconds_[bucket, sum, count]` | Histogram/LastValue(Gauge) | `status`=&lt;status&gt; <br> `*task`=&lt;task_name&gt; <br> `*taskrun`=&lt;taskrun_name&gt;<br> `namespace`=&lt;pipelineruns-taskruns-namespace&gt; | experimental |
-| `tekton_pipelines_controller_taskrun_count` | Counter | `status`=&lt;status&gt; | deprecate |
-| `tekton_pipelines_controller_taskrun_total` | Counter | `status`=&lt;status&gt; | experimental |
-| `tekton_pipelines_controller_running_taskruns_count` | Gauge | | deprecate |
-| `tekton_pipelines_controller_running_taskruns` | Gauge | | experimental |
-| `tekton_pipelines_controller_running_taskruns_throttled_by_quota_count` | Gauge | | deprecate |
-| `tekton_pipelines_controller_running_taskruns_throttled_by_node_count`  | Gauge | | deprecate |
-| `tekton_pipelines_controller_running_taskruns_throttled_by_quota` | Gauge | | experimental |
-| `tekton_pipelines_controller_running_taskruns_throttled_by_node`  | Gauge | | experimental |
-| `tekton_pipelines_controller_client_latency_[bucket, sum, count]` | Histogram | | experimental |
+| `tekton_pipelines_controller_taskrun_count` | Counter | `status`=&lt;status&gt;                         | deprecate |
+| `tekton_pipelines_controller_taskrun_total` | Counter | `status`=&lt;status&gt;                         | experimental |
+| `tekton_pipelines_controller_running_taskruns_count` | Gauge |                                                 | deprecate |
+| `tekton_pipelines_controller_running_taskruns` | Gauge |                                                 | experimental |
+| `tekton_pipelines_controller_running_taskruns_throttled_by_quota_count` | Gauge | <br> `namespace`=&lt;pipelinerun-namespace&gt;  | deprecate |
+| `tekton_pipelines_controller_running_taskruns_throttled_by_node_count`  | Gauge | <br> `namespace`=&lt;pipelinerun-namespace&gt;  | deprecate |
+| `tekton_pipelines_controller_running_taskruns_throttled_by_quota` | Gauge | <br> `namespace`=&lt;pipelinerun-namespace&gt; | experimental |
+| `tekton_pipelines_controller_running_taskruns_throttled_by_node`  | Gauge | <br> `namespace`=&lt;pipelinerun-namespace&gt; | experimental |
+| `tekton_pipelines_controller_client_latency_[bucket, sum, count]` | Histogram |                                                 | experimental |
 
 The Labels/Tag marked as "*" are optional. And there's a choice between Histogram and LastValue(Gauge) for pipelinerun and taskrun duration metrics.
 
@@ -48,7 +48,7 @@ A sample config-map has been provided as [config-observability](./../config/conf
 Following values are available in the configmap:
 
 | configmap data | value | description |
-| ---------- | ----------- | ----------- |
+| -- | ----------- | ----------- |
 | metrics.taskrun.level | `taskrun` | Level of metrics is taskrun |
 | metrics.taskrun.level | `task` | Level of metrics is task and taskrun label isn't present in the metrics |
 | metrics.taskrun.level | `namespace` | Level of metrics is namespace, and task and taskrun label isn't present in the metrics
@@ -60,6 +60,7 @@ Following values are available in the configmap:
 | metrics.pipelinerun.duration-type | `histogram` | `tekton_pipelines_controller_pipelinerun_duration_seconds` is of type histogram |
 | metrics.pipelinerun.duration-type | `lastvalue` | `tekton_pipelines_controller_pipelinerun_duration_seconds` is of type gauge or lastvalue |
 | metrics.count.enable-reason | `false` | Sets if the `reason` label should be included on count metrics |
+| metrics.taskrun.throttle.enable-namespace | `false` | Sets if the `namespace` label should be included on the `tekton_pipelines_controller_running_taskruns_throttled_by_quota` metric |
 
 Histogram value isn't available when pipelinerun or taskrun labels are selected. The Lastvalue or Gauge will be provided. Histogram would serve no purpose because it would generate a single bar. TaskRun and PipelineRun level metrics aren't recommended because they lead to an unbounded cardinality which degrades the observability database.
 

--- a/pkg/apis/config/metrics.go
+++ b/pkg/apis/config/metrics.go
@@ -39,6 +39,9 @@ const (
 	// countWithReasonKey sets if the reason label should be included on count metrics
 	countWithReasonKey = "metrics.count.enable-reason"
 
+	// throttledWithNamespaceKey sets if the namespace label should be included on the taskrun throttled metrics
+	throttledWithNamespaceKey = "metrics.taskrun.throttle.enable-namespace"
+
 	// DefaultTaskrunLevel determines to what level to aggregate metrics
 	// when it isn't specified in configmap
 	DefaultTaskrunLevel = TaskrunLevelAtTask
@@ -96,6 +99,7 @@ type Metrics struct {
 	DurationTaskrunType     string
 	DurationPipelinerunType string
 	CountWithReason         bool
+	ThrottleWithNamespace   bool
 }
 
 // GetMetricsConfigName returns the name of the configmap containing all
@@ -129,6 +133,7 @@ func newMetricsFromMap(cfgMap map[string]string) (*Metrics, error) {
 		DurationTaskrunType:     DefaultDurationTaskrunType,
 		DurationPipelinerunType: DefaultDurationPipelinerunType,
 		CountWithReason:         false,
+		ThrottleWithNamespace:   false,
 	}
 
 	if taskrunLevel, ok := cfgMap[metricsTaskrunLevelKey]; ok {
@@ -147,6 +152,10 @@ func newMetricsFromMap(cfgMap map[string]string) (*Metrics, error) {
 
 	if countWithReason, ok := cfgMap[countWithReasonKey]; ok && countWithReason != "false" {
 		tc.CountWithReason = true
+	}
+
+	if throttleWithNamespace, ok := cfgMap[throttledWithNamespaceKey]; ok && throttleWithNamespace != "false" {
+		tc.ThrottleWithNamespace = true
 	}
 
 	return &tc, nil

--- a/pkg/apis/config/metrics_test.go
+++ b/pkg/apis/config/metrics_test.go
@@ -39,6 +39,7 @@ func TestNewMetricsFromConfigMap(t *testing.T) {
 				DurationTaskrunType:     config.DurationPipelinerunTypeHistogram,
 				DurationPipelinerunType: config.DurationPipelinerunTypeHistogram,
 				CountWithReason:         false,
+				ThrottleWithNamespace:   false,
 			},
 			fileName: config.GetMetricsConfigName(),
 		},
@@ -49,6 +50,7 @@ func TestNewMetricsFromConfigMap(t *testing.T) {
 				DurationTaskrunType:     config.DurationTaskrunTypeHistogram,
 				DurationPipelinerunType: config.DurationPipelinerunTypeLastValue,
 				CountWithReason:         false,
+				ThrottleWithNamespace:   false,
 			},
 			fileName: "config-observability-namespacelevel",
 		},
@@ -59,8 +61,20 @@ func TestNewMetricsFromConfigMap(t *testing.T) {
 				DurationTaskrunType:     config.DurationTaskrunTypeHistogram,
 				DurationPipelinerunType: config.DurationPipelinerunTypeLastValue,
 				CountWithReason:         true,
+				ThrottleWithNamespace:   false,
 			},
 			fileName: "config-observability-reason",
+		},
+		{
+			expectedConfig: &config.Metrics{
+				TaskrunLevel:            config.TaskrunLevelAtNS,
+				PipelinerunLevel:        config.PipelinerunLevelAtNS,
+				DurationTaskrunType:     config.DurationTaskrunTypeHistogram,
+				DurationPipelinerunType: config.DurationPipelinerunTypeLastValue,
+				CountWithReason:         true,
+				ThrottleWithNamespace:   true,
+			},
+			fileName: "config-observability-throttle",
 		},
 	}
 
@@ -77,6 +91,7 @@ func TestNewMetricsFromEmptyConfigMap(t *testing.T) {
 		DurationTaskrunType:     config.DurationPipelinerunTypeHistogram,
 		DurationPipelinerunType: config.DurationPipelinerunTypeHistogram,
 		CountWithReason:         false,
+		ThrottleWithNamespace:   false,
 	}
 	verifyConfigFileWithExpectedMetricsConfig(t, MetricsConfigEmptyName, expectedConfig)
 }

--- a/pkg/apis/config/testdata/config-observability-throttle.yaml
+++ b/pkg/apis/config/testdata/config-observability-throttle.yaml
@@ -1,0 +1,32 @@
+# Copyright 2019 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-observability
+  namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
+data:
+  metrics.backend-destination: prometheus
+  metrics.stackdriver-project-id: "<your stackdriver project id>"
+  metrics.allow-stackdriver-custom-metrics: "false"
+  metrics.taskrun.level: "namespace"
+  metrics.taskrun.duration-type: "histogram"
+  metrics.pipelinerun.level: "namespace"
+  metrics.pipelinerun.duration-type: "lastvalue"
+  metrics.count.enable-reason: "true"
+  metrics.taskrun.throttle.enable-namespace: "true"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Back when implementing https://github.com/tektoncd/pipeline/pull/6744 for https://github.com/tektoncd/pipeline/issues/6631 we failed to realize that with k8s quota policies being namespace scoped, knowing which namespace the throttled items were in could have some diagnostic value.

Now that we have been using the metric added for a bit, this realization is now very apparent.

This changes introduces the namespace tag.  Also, since last touching this space, the original metric was deprecated and a new one with a shorter name was added.  This change only updates the non-deprecated metric with the new label.

Lastly, the default behavior is preserved, and use of the new label only occurs when explicitly enabled in observability config map.

Fixes https://github.com/tektoncd/pipeline/issues/7878 

/kind feature

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [/ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [/ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ /] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ /] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ /] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ /] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ /] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ /] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Add 'namespace' label/tag to the 'tekton_pipelines_controller_running_taskruns_throttled_by_quota' and 'tekton_pipelines_controller_running_taskruns_throttled_by_node' metrics, as kubernetes quota definitions are namespace scoped, hence certain namespaces may be more susceptible to quota throttling than others, and in a multi-node environment, not all namespaces are necessarily on the same node.

To enable this new label/tag, set 'metrics.taskrun.throttle.enable-namespace' to 'true' in the 'config-observability' ConfigMap
```
