### PR TITLE
feat: Surface artifacts through sidecar container logs. 

### DIFF
--- a/examples/v1/taskruns/alpha/produce-consume-artifacts.yaml
+++ b/examples/v1/taskruns/alpha/produce-consume-artifacts.yaml
@@ -17,7 +17,7 @@ spec:
                 "name":"input-artifacts",
                 "values":[
                   {
-                    "uri":"git:jjjsss",
+                    "uri":"pkg:example.github.com/inputs",
                     "digest":{
                       "sha256":"b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"
                     }
@@ -30,7 +30,7 @@ spec:
                 "name":"image",
                 "values":[
                   {
-                    "uri":"pkg:balba",
+                    "uri":"pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c",
                     "digest":{
                       "sha256":"df85b9e3983fe2ce20ef76ad675ecf435cc99fc9350adc54fa230bae8c32ce48",
                       "sha1":"95588b8f34c31eb7d62c92aaa4e6506639b06ef2"

--- a/pkg/entrypoint/entrypointer.go
+++ b/pkg/entrypoint/entrypointer.go
@@ -300,7 +300,7 @@ func readArtifacts(fp string) ([]result.RunResult, error) {
 	if err != nil {
 		return nil, err
 	}
-	return []result.RunResult{{Key: fp, Value: string(file), ResultType: result.ArtifactsResultType}}, nil
+	return []result.RunResult{{Key: fp, Value: string(file), ResultType: result.StepArtifactsResultType}}, nil
 }
 
 func (e Entrypointer) readResultsFromDisk(ctx context.Context, resultDir string, resultType result.ResultType) error {

--- a/pkg/pod/entrypoint.go
+++ b/pkg/pod/entrypoint.go
@@ -126,7 +126,7 @@ var (
 // Additionally, Step timeouts are added as entrypoint flag.
 func orderContainers(ctx context.Context, commonExtraEntrypointArgs []string, steps []corev1.Container, taskSpec *v1.TaskSpec, breakpointConfig *v1.TaskRunDebug, waitForReadyAnnotation, enableKeepPodOnCancel bool) ([]corev1.Container, error) {
 	if len(steps) == 0 {
-		return nil, errors.New("No steps specified")
+		return nil, errors.New("no steps specified")
 	}
 
 	for i, s := range steps {

--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -1937,7 +1937,7 @@ _EOF_
 			},
 		},
 		{
-			desc:         "sidecar logs enabled",
+			desc:         "sidecar logs enabled, artifacts not enabled",
 			featureFlags: map[string]string{"results-from": "sidecar-logs"},
 			ts: v1.TaskSpec{
 				Results: []v1.TaskResult{{
@@ -1991,6 +1991,8 @@ _EOF_
 						"/tekton/results",
 						"-result-names",
 						"foo",
+						"-step-names",
+						"",
 						"-step-results",
 						"{}",
 					},
@@ -2010,7 +2012,7 @@ _EOF_
 			},
 		},
 		{
-			desc:         "sidecar logs enabled with step results",
+			desc:         "sidecar logs enabled with step results, artifacts not enabled",
 			featureFlags: map[string]string{"results-from": "sidecar-logs"},
 			ts: v1.TaskSpec{
 				Results: []v1.TaskResult{{
@@ -2070,6 +2072,8 @@ _EOF_
 						"/tekton/results",
 						"-result-names",
 						"foo",
+						"-step-names",
+						"",
 						"-step-results",
 						"{\"step-name\":[\"step-foo\"]}",
 					},
@@ -2089,7 +2093,7 @@ _EOF_
 			},
 		},
 		{
-			desc:         "sidecar logs enabled with security context",
+			desc:         "sidecar logs enabled and artifacts not enabled, set security context is true",
 			featureFlags: map[string]string{"results-from": "sidecar-logs", "set-security-context": "true"},
 			ts: v1.TaskSpec{
 				Results: []v1.TaskResult{{
@@ -2143,6 +2147,249 @@ _EOF_
 						"/tekton/results",
 						"-result-names",
 						"foo",
+						"-step-names",
+						"",
+						"-step-results",
+						"{}",
+					},
+					Resources: corev1.ResourceRequirements{
+						Requests: nil,
+					},
+					VolumeMounts: append([]corev1.VolumeMount{
+						{Name: "tekton-internal-bin", ReadOnly: true, MountPath: "/tekton/bin"},
+						{Name: "tekton-internal-run-0", ReadOnly: true, MountPath: "/tekton/run/0"},
+					}, implicitVolumeMounts...),
+					SecurityContext: linuxSecurityContext,
+				}},
+				Volumes: append(implicitVolumes, binVolume, runVolume(0), downwardVolume, corev1.Volume{
+					Name:         "tekton-creds-init-home-0",
+					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
+				}),
+				ActiveDeadlineSeconds: &defaultActiveDeadlineSeconds,
+			},
+		},
+		{
+			desc:         "sidecar logs enabled and artifacts referenced",
+			featureFlags: map[string]string{"results-from": "sidecar-logs", "enable-artifacts": "true"},
+			ts: v1.TaskSpec{
+				Results: []v1.TaskResult{{
+					Name: "foo",
+					Type: v1.ResultsTypeString,
+				}},
+				Steps: []v1.Step{{
+					Name:    "name",
+					Image:   "image",
+					Command: []string{"echo", "aaa", ">>>", "/tekton/steps/step-name/artifacts/provenance.json"}, // avoid entrypoint lookup.
+				}},
+			},
+			want: &corev1.PodSpec{
+				RestartPolicy: corev1.RestartPolicyNever,
+				InitContainers: []corev1.Container{
+					entrypointInitContainer(images.EntrypointImage, []v1.Step{{Name: "name"}}, false /* setSecurityContext */, false /* windows */),
+				},
+				Containers: []corev1.Container{{
+					Name:    "step-name",
+					Image:   "image",
+					Command: []string{"/tekton/bin/entrypoint"},
+					Args: []string{
+						"-wait_file",
+						"/tekton/downward/ready",
+						"-wait_file_content",
+						"-post_file",
+						"/tekton/run/0/out",
+						"-termination_path",
+						"/tekton/termination",
+						"-step_metadata_dir",
+						"/tekton/run/0/status",
+						"-result_from",
+						"sidecar-logs",
+						"-results",
+						"foo",
+						"-entrypoint",
+						"echo",
+						"--",
+						"aaa",
+						">>>",
+						"/tekton/steps/step-name/artifacts/provenance.json",
+					},
+					VolumeMounts: append([]corev1.VolumeMount{binROMount, runMount(0, false), downwardMount, {
+						Name:      "tekton-creds-init-home-0",
+						MountPath: "/tekton/creds",
+					}}, implicitVolumeMounts...),
+					TerminationMessagePath: "/tekton/termination",
+				}, {
+					Name:  pipeline.ReservedResultsSidecarContainerName,
+					Image: "",
+					Command: []string{
+						"/ko-app/sidecarlogresults",
+						"-results-dir",
+						"/tekton/results",
+						"-result-names",
+						"foo",
+						"-step-names",
+						"step-name",
+						"-step-results",
+						"{}",
+					},
+					Resources: corev1.ResourceRequirements{
+						Requests: nil,
+					},
+					VolumeMounts: append([]corev1.VolumeMount{
+						{Name: "tekton-internal-bin", ReadOnly: true, MountPath: "/tekton/bin"},
+						{Name: "tekton-internal-run-0", ReadOnly: true, MountPath: "/tekton/run/0"},
+					}, implicitVolumeMounts...),
+				}},
+				Volumes: append(implicitVolumes, binVolume, runVolume(0), downwardVolume, corev1.Volume{
+					Name:         "tekton-creds-init-home-0",
+					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
+				}),
+				ActiveDeadlineSeconds: &defaultActiveDeadlineSeconds,
+			},
+		},
+		{
+			desc:         "sidecar logs enabled with step results, artifacts referenced",
+			featureFlags: map[string]string{"results-from": "sidecar-logs", "enable-artifacts": "true"},
+			ts: v1.TaskSpec{
+				Results: []v1.TaskResult{{
+					Name: "foo",
+					Type: v1.ResultsTypeString,
+				}},
+				Steps: []v1.Step{{
+					Name: "name",
+					Results: []v1.StepResult{{
+						Name: "step-foo",
+						Type: v1.ResultsTypeString,
+					}},
+					Image:   "image",
+					Command: []string{"echo", "aaa", ">>>", "/tekton/steps/step-name/artifacts/provenance.json"}, //
+				}},
+			},
+			want: &corev1.PodSpec{
+				RestartPolicy: corev1.RestartPolicyNever,
+				InitContainers: []corev1.Container{
+					entrypointInitContainer(images.EntrypointImage, []v1.Step{{Name: "name"}}, false /* setSecurityContext */, false /* windows */),
+				},
+				Containers: []corev1.Container{{
+					Name:    "step-name",
+					Image:   "image",
+					Command: []string{"/tekton/bin/entrypoint"},
+					Args: []string{
+						"-wait_file",
+						"/tekton/downward/ready",
+						"-wait_file_content",
+						"-post_file",
+						"/tekton/run/0/out",
+						"-termination_path",
+						"/tekton/termination",
+						"-step_metadata_dir",
+						"/tekton/run/0/status",
+						"-result_from",
+						"sidecar-logs",
+						"-step_results",
+						"step-foo",
+						"-results",
+						"foo",
+						"-entrypoint",
+						"echo",
+						"--",
+						"aaa",
+						">>>",
+						"/tekton/steps/step-name/artifacts/provenance.json",
+					},
+					VolumeMounts: append([]corev1.VolumeMount{binROMount, runMount(0, false), downwardMount, {
+						Name:      "tekton-creds-init-home-0",
+						MountPath: "/tekton/creds",
+					}}, implicitVolumeMounts...),
+					TerminationMessagePath: "/tekton/termination",
+				}, {
+					Name:  pipeline.ReservedResultsSidecarContainerName,
+					Image: "",
+					Command: []string{
+						"/ko-app/sidecarlogresults",
+						"-results-dir",
+						"/tekton/results",
+						"-result-names",
+						"foo",
+						"-step-names",
+						"step-name",
+						"-step-results",
+						"{\"step-name\":[\"step-foo\"]}",
+					},
+					Resources: corev1.ResourceRequirements{
+						Requests: nil,
+					},
+					VolumeMounts: append([]corev1.VolumeMount{
+						{Name: "tekton-internal-bin", ReadOnly: true, MountPath: "/tekton/bin"},
+						{Name: "tekton-internal-run-0", ReadOnly: true, MountPath: "/tekton/run/0"},
+					}, implicitVolumeMounts...),
+				}},
+				Volumes: append(implicitVolumes, binVolume, runVolume(0), downwardVolume, corev1.Volume{
+					Name:         "tekton-creds-init-home-0",
+					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
+				}),
+				ActiveDeadlineSeconds: &defaultActiveDeadlineSeconds,
+			},
+		},
+		{
+			desc:         "sidecar logs enabled, artifacts referenced and security context set ",
+			featureFlags: map[string]string{"results-from": "sidecar-logs", "set-security-context": "true", "enable-artifacts": "true"},
+			ts: v1.TaskSpec{
+				Results: []v1.TaskResult{{
+					Name: "foo",
+					Type: v1.ResultsTypeString,
+				}},
+				Steps: []v1.Step{{
+					Name:    "name",
+					Image:   "image",
+					Command: []string{"echo", "aaa", ">>>", "/tekton/steps/step-name/artifacts/provenance.json"},
+				}},
+			},
+			want: &corev1.PodSpec{
+				RestartPolicy: corev1.RestartPolicyNever,
+				InitContainers: []corev1.Container{
+					entrypointInitContainer(images.EntrypointImage, []v1.Step{{Name: "name"}}, true /* setSecurityContext */, false /* windows */),
+				},
+				Containers: []corev1.Container{{
+					Name:    "step-name",
+					Image:   "image",
+					Command: []string{"/tekton/bin/entrypoint"},
+					Args: []string{
+						"-wait_file",
+						"/tekton/downward/ready",
+						"-wait_file_content",
+						"-post_file",
+						"/tekton/run/0/out",
+						"-termination_path",
+						"/tekton/termination",
+						"-step_metadata_dir",
+						"/tekton/run/0/status",
+						"-result_from",
+						"sidecar-logs",
+						"-results",
+						"foo",
+						"-entrypoint",
+						"echo",
+						"--",
+						"aaa",
+						">>>",
+						"/tekton/steps/step-name/artifacts/provenance.json",
+					},
+					VolumeMounts: append([]corev1.VolumeMount{binROMount, runMount(0, false), downwardMount, {
+						Name:      "tekton-creds-init-home-0",
+						MountPath: "/tekton/creds",
+					}}, implicitVolumeMounts...),
+					TerminationMessagePath: "/tekton/termination",
+				}, {
+					Name:  pipeline.ReservedResultsSidecarContainerName,
+					Image: "",
+					Command: []string{
+						"/ko-app/sidecarlogresults",
+						"-results-dir",
+						"/tekton/results",
+						"-result-names",
+						"foo",
+						"-step-names",
+						"step-name",
 						"-step-results",
 						"{}",
 					},
@@ -3621,6 +3868,131 @@ func TestUpdateResourceRequirements(t *testing.T) {
 
 			expectedPod := tc.getExpectedPod()
 			if d := cmp.Diff(expectedPod, targetPod); d != "" {
+				t.Errorf("Diff %s", diff.PrintWantGot(d))
+			}
+		})
+	}
+}
+
+func Test_artifactsPathReferenced(t *testing.T) {
+	tests := []struct {
+		name  string
+		steps []v1.Step
+		want  bool
+	}{
+		{
+			name:  "No Steps",
+			steps: []v1.Step{},
+			want:  false,
+		},
+		{
+			name: "No Reference",
+			steps: []v1.Step{
+				{
+					Name:    "name",
+					Script:  "echo hello",
+					Command: []string{"echo", "hello"},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Reference in Script",
+			steps: []v1.Step{
+				{
+					Name:   "name",
+					Script: "echo aaa >> /tekton/steps/step-name/artifacts/provenance.json",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Reference in Args",
+			steps: []v1.Step{
+				{
+					Name:    "name",
+					Command: []string{"cat"},
+					Args:    []string{"/tekton/steps/step-name/artifacts/provenance.json"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Reference in Command",
+			steps: []v1.Step{
+				{
+					Name:    "name",
+					Command: []string{"cat", "/tekton/steps/step-name/artifacts/provenance.json"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Reference in Env",
+			steps: []v1.Step{
+				{
+					Name: "name",
+					Env: []corev1.EnvVar{
+						{
+							Name:  "MY_VAR",
+							Value: "/tekton/steps/step-name/artifacts/provenance.json",
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Unresolved reference in Script",
+			steps: []v1.Step{
+				{
+					Name:   "name",
+					Script: "echo aaa >> $(step.artifacts.path)",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Unresolved reference in Args",
+			steps: []v1.Step{
+				{
+					Name:    "name",
+					Command: []string{"cat"},
+					Args:    []string{"$(step.artifacts.path)"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Unresolved reference in Command",
+			steps: []v1.Step{
+				{
+					Name:    "name",
+					Command: []string{"cat", "$(step.artifacts.path)"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Unresolved reference in Env",
+			steps: []v1.Step{
+				{
+					Name: "name",
+					Env: []corev1.EnvVar{
+						{
+							Name:  "MY_VAR",
+							Value: "$(step.artifacts.path)",
+						},
+					},
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := artifactsPathReferenced(tt.steps)
+			if d := cmp.Diff(tt.want, got); d != "" {
 				t.Errorf("Diff %s", diff.PrintWantGot(d))
 			}
 		})

--- a/pkg/reconciler/taskrun/resources/apply.go
+++ b/pkg/reconciler/taskrun/resources/apply.go
@@ -411,7 +411,7 @@ func ApplyArtifacts(spec *v1.TaskSpec) *v1.TaskSpec {
 func getStepArtifactReplacements(step v1.Step, idx int) map[string]string {
 	stringReplacements := map[string]string{}
 	stepName := pod.StepName(step.Name, idx)
-	stringReplacements["step.artifacts.path"] = filepath.Join(pipeline.StepsDir, stepName, "artifacts", "provenance.json")
+	stringReplacements[pod.StepArtifactPathPattern] = filepath.Join(pipeline.StepsDir, stepName, "artifacts", "provenance.json")
 
 	return stringReplacements
 }

--- a/pkg/result/result.go
+++ b/pkg/result/result.go
@@ -36,8 +36,8 @@ const (
 	// StepResultType default step result value
 	StepResultType ResultType = 4
 
-	// ArtifactsResultType default artifacts result value
-	ArtifactsResultType ResultType = 5
+	// StepArtifactsResultType default artifacts result value
+	StepArtifactsResultType ResultType = 5
 )
 
 // RunResult is used to write key/value pairs to TaskRun pod termination messages.
@@ -91,8 +91,8 @@ func (r *ResultType) UnmarshalJSON(data []byte) error {
 		*r = TaskRunResultType
 	case "InternalTektonResult":
 		*r = InternalTektonResultType
-	case "ArtifactsResult":
-		*r = ArtifactsResultType
+	case "StepArtifactsResult":
+		*r = StepArtifactsResultType
 	default:
 		*r = UnknownResultType
 	}

--- a/pkg/result/result_test.go
+++ b/pkg/result/result_test.go
@@ -44,8 +44,8 @@ func TestRunResult_UnmarshalJSON(t *testing.T) {
 			pr:   RunResult{Key: "resultName", Value: "", ResultType: InternalTektonResultType},
 		}, {
 			name: "type defined as string - ArtifactsResult",
-			data: "{\"key\":\"resultName\",\"value\":\"\", \"type\": \"ArtifactsResult\"}",
-			pr:   RunResult{Key: "resultName", Value: "", ResultType: ArtifactsResultType},
+			data: "{\"key\":\"resultName\",\"value\":\"\", \"type\": \"StepArtifactsResult\"}",
+			pr:   RunResult{Key: "resultName", Value: "", ResultType: StepArtifactsResultType},
 		}, {
 			name: "type defined as int",
 			data: "{\"key\":\"resultName\",\"value\":\"\", \"type\": 1}",

--- a/test/artifacts_test.go
+++ b/test/artifacts_test.go
@@ -40,43 +40,57 @@ var (
 	}
 )
 
-func TestSurfaceArtifactsThroughTerminationMessage(t *testing.T) {
-	featureFlags := getFeatureFlagsBaseOnAPIFlag(t)
-	checkFlagsEnabled := requireAllGates(requireEnableStepArtifactsGate)
-
-	ctx := context.Background()
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	c, namespace := setup(ctx, t)
-	checkFlagsEnabled(ctx, t, c, "")
-	previous := featureFlags.ResultExtractionMethod
-	updateConfigMap(ctx, c.KubeClient, system.Namespace(), config.GetFeatureFlagsConfigName(), map[string]string{
-		"results-from": config.ResultExtractionMethodTerminationMessage,
-	})
-
-	knativetest.CleanupOnInterrupt(func() {
-		updateConfigMap(ctx, c.KubeClient, system.Namespace(), config.GetFeatureFlagsConfigName(), map[string]string{
-			"results-from": previous,
-		})
-		tearDown(ctx, t, c, namespace)
-	}, t.Logf)
-	defer func() {
-		updateConfigMap(ctx, c.KubeClient, system.Namespace(), config.GetFeatureFlagsConfigName(), map[string]string{
-			"results-from": previous,
-		})
-		tearDown(ctx, t, c, namespace)
-	}()
-
-	taskRunName := helpers.ObjectNameForTest(t)
-
-	fqImageName := getTestImage(busyboxImage)
-
-	t.Logf("Creating Task and TaskRun in namespace %s", namespace)
-	task := simpleArtifactProducerTask(t, namespace, fqImageName)
-	if _, err := c.V1TaskClient.Create(ctx, task, metav1.CreateOptions{}); err != nil {
-		t.Fatalf("Failed to create Task: %s", err)
+func TestSurfaceArtifacts(t *testing.T) {
+	tests := []struct {
+		desc                   string
+		resultExtractionMethod string
+	}{
+		{
+			desc:                   "surface artifacts through termination message",
+			resultExtractionMethod: config.ResultExtractionMethodTerminationMessage},
+		{
+			desc:                   "surface artifacts through sidecar logs",
+			resultExtractionMethod: config.ResultExtractionMethodSidecarLogs},
 	}
-	taskRun := parse.MustParseV1TaskRun(t, fmt.Sprintf(`
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			featureFlags := getFeatureFlagsBaseOnAPIFlag(t)
+			checkFlagsEnabled := requireAllGates(requireEnableStepArtifactsGate)
+
+			ctx := context.Background()
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+			c, namespace := setup(ctx, t)
+			checkFlagsEnabled(ctx, t, c, "")
+			previous := featureFlags.ResultExtractionMethod
+			updateConfigMap(ctx, c.KubeClient, system.Namespace(), config.GetFeatureFlagsConfigName(), map[string]string{
+				"results-from": tc.resultExtractionMethod,
+			})
+
+			knativetest.CleanupOnInterrupt(func() {
+				updateConfigMap(ctx, c.KubeClient, system.Namespace(), config.GetFeatureFlagsConfigName(), map[string]string{
+					"results-from": previous,
+				})
+				tearDown(ctx, t, c, namespace)
+			}, t.Logf)
+			defer func() {
+				updateConfigMap(ctx, c.KubeClient, system.Namespace(), config.GetFeatureFlagsConfigName(), map[string]string{
+					"results-from": previous,
+				})
+				tearDown(ctx, t, c, namespace)
+			}()
+
+			taskRunName := helpers.ObjectNameForTest(t)
+
+			fqImageName := getTestImage(busyboxImage)
+
+			t.Logf("Creating Task and TaskRun in namespace %s", namespace)
+			task := simpleArtifactProducerTask(t, namespace, fqImageName)
+			if _, err := c.V1TaskClient.Create(ctx, task, metav1.CreateOptions{}); err != nil {
+				t.Fatalf("Failed to create Task: %s", err)
+			}
+			taskRun := parse.MustParseV1TaskRun(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -84,31 +98,33 @@ spec:
   taskRef:
     name: %s
 `, taskRunName, namespace, task.Name))
-	if _, err := c.V1TaskRunClient.Create(ctx, taskRun, metav1.CreateOptions{}); err != nil {
-		t.Fatalf("Failed to create TaskRun: %s", err)
-	}
+			if _, err := c.V1TaskRunClient.Create(ctx, taskRun, metav1.CreateOptions{}); err != nil {
+				t.Fatalf("Failed to create TaskRun: %s", err)
+			}
 
-	if err := WaitForTaskRunState(ctx, c, taskRunName, TaskRunSucceed(taskRunName), "TaskRunSucceed", v1Version); err != nil {
-		t.Errorf("Error waiting for TaskRun to finish: %s", err)
-	}
+			if err := WaitForTaskRunState(ctx, c, taskRunName, TaskRunSucceed(taskRunName), "TaskRunSucceed", v1Version); err != nil {
+				t.Errorf("Error waiting for TaskRun to finish: %s", err)
+			}
 
-	taskrun, err := c.V1TaskRunClient.Get(ctx, taskRunName, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("Couldn't get expected TaskRun %s: %s", taskRunName, err)
-	}
-	if d := cmp.Diff([]v1.TaskRunStepArtifact{{Name: "input-artifacts",
-		Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"},
-			Uri: "git:jjjsss",
-		}},
-	}}, taskrun.Status.Steps[0].Inputs); d != "" {
-		t.Fatalf(`The expected stepState Inputs does not match created taskrun stepState Inputs. Here is the diff: %v`, d)
-	}
-	if d := cmp.Diff([]v1.TaskRunStepArtifact{{Name: "build-result",
-		Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2", "sha256": "df85b9e3983fe2ce20ef76ad675ecf435cc99fc9350adc54fa230bae8c32ce48"},
-			Uri: "pkg:balba",
-		}},
-	}}, taskrun.Status.Steps[0].Outputs); d != "" {
-		t.Fatalf(`The expected stepState Outputs does not match created taskrun stepState Outputs. Here is the diff: %v`, d)
+			taskrun, err := c.V1TaskRunClient.Get(ctx, taskRunName, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("Couldn't get expected TaskRun %s: %s", taskRunName, err)
+			}
+			if d := cmp.Diff([]v1.TaskRunStepArtifact{{Name: "source",
+				Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"},
+					Uri: "git:jjjsss",
+				}},
+			}}, taskrun.Status.Steps[0].Inputs); d != "" {
+				t.Fatalf(`The expected stepState Inputs does not match created taskrun stepState Inputs. Here is the diff: %v`, d)
+			}
+			if d := cmp.Diff([]v1.TaskRunStepArtifact{{Name: "image",
+				Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2", "sha256": "df85b9e3983fe2ce20ef76ad675ecf435cc99fc9350adc54fa230bae8c32ce48"},
+					Uri: "pkg:balba",
+				}},
+			}}, taskrun.Status.Steps[0].Outputs); d != "" {
+				t.Fatalf(`The expected stepState Outputs does not match created taskrun stepState Outputs. Here is the diff: %v`, d)
+			}
+		})
 	}
 }
 
@@ -185,53 +201,67 @@ spec:
 }
 
 func TestConsumeArtifacts(t *testing.T) {
-	featureFlags := getFeatureFlagsBaseOnAPIFlag(t)
-	checkFlagsEnabled := requireAllGates(map[string]string{
-		"enable-artifacts":    "true",
-		"enable-step-actions": "true",
-	})
-
-	ctx := context.Background()
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	c, namespace := setup(ctx, t)
-	checkFlagsEnabled(ctx, t, c, "")
-	previous := featureFlags.ResultExtractionMethod
-	updateConfigMap(ctx, c.KubeClient, system.Namespace(), config.GetFeatureFlagsConfigName(), map[string]string{
-		"results-from": config.ResultExtractionMethodTerminationMessage,
-	})
-
-	knativetest.CleanupOnInterrupt(func() {
-		updateConfigMap(ctx, c.KubeClient, system.Namespace(), config.GetFeatureFlagsConfigName(), map[string]string{
-			"results-from": previous,
-		})
-		tearDown(ctx, t, c, namespace)
-	}, t.Logf)
-
-	defer func() {
-		updateConfigMap(ctx, c.KubeClient, system.Namespace(), config.GetFeatureFlagsConfigName(), map[string]string{
-			"results-from": previous,
-		})
-		tearDown(ctx, t, c, namespace)
-	}()
-	taskRunName := helpers.ObjectNameForTest(t)
-
-	fqImageName := getTestImage(busyboxImage)
-
-	t.Logf("Creating Task and TaskRun in namespace %s", namespace)
-	task := simpleArtifactProducerTask(t, namespace, fqImageName)
-	task.Spec.Steps = append(task.Spec.Steps,
-		v1.Step{Name: "consume-outputs", Image: fqImageName,
-			Command: []string{"sh", "-c", "echo -n $(steps.hello.outputs) >> $(step.results.result1.path)"},
-			Results: []v1.StepResult{{Name: "result1", Type: v1.ResultsTypeString}}},
-		v1.Step{Name: "consume-inputs", Image: fqImageName,
-			Command: []string{"sh", "-c", "echo -n $(steps.hello.inputs) >> $(step.results.result2.path)"},
-			Results: []v1.StepResult{{Name: "result2", Type: v1.ResultsTypeString}}},
-	)
-	if _, err := c.V1TaskClient.Create(ctx, task, metav1.CreateOptions{}); err != nil {
-		t.Fatalf("Failed to create Task: %s", err)
+	tests := []struct {
+		desc                   string
+		resultExtractionMethod string
+	}{
+		{
+			desc:                   "surface artifacts through termination message",
+			resultExtractionMethod: config.ResultExtractionMethodTerminationMessage},
+		{
+			desc:                   "surface artifacts through sidecar logs",
+			resultExtractionMethod: config.ResultExtractionMethodSidecarLogs},
 	}
-	taskRun := parse.MustParseV1TaskRun(t, fmt.Sprintf(`
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			featureFlags := getFeatureFlagsBaseOnAPIFlag(t)
+			checkFlagsEnabled := requireAllGates(map[string]string{
+				"enable-artifacts":    "true",
+				"enable-step-actions": "true",
+			})
+
+			ctx := context.Background()
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+			c, namespace := setup(ctx, t)
+			checkFlagsEnabled(ctx, t, c, "")
+			previous := featureFlags.ResultExtractionMethod
+			updateConfigMap(ctx, c.KubeClient, system.Namespace(), config.GetFeatureFlagsConfigName(), map[string]string{
+				"results-from": tc.resultExtractionMethod,
+			})
+
+			knativetest.CleanupOnInterrupt(func() {
+				updateConfigMap(ctx, c.KubeClient, system.Namespace(), config.GetFeatureFlagsConfigName(), map[string]string{
+					"results-from": previous,
+				})
+				tearDown(ctx, t, c, namespace)
+			}, t.Logf)
+
+			defer func() {
+				updateConfigMap(ctx, c.KubeClient, system.Namespace(), config.GetFeatureFlagsConfigName(), map[string]string{
+					"results-from": previous,
+				})
+				tearDown(ctx, t, c, namespace)
+			}()
+			taskRunName := helpers.ObjectNameForTest(t)
+
+			fqImageName := getTestImage(busyboxImage)
+
+			t.Logf("Creating Task and TaskRun in namespace %s", namespace)
+			task := simpleArtifactProducerTask(t, namespace, fqImageName)
+			task.Spec.Steps = append(task.Spec.Steps,
+				v1.Step{Name: "consume-outputs", Image: fqImageName,
+					Command: []string{"sh", "-c", "echo -n $(steps.hello.outputs) >> $(step.results.result1.path)"},
+					Results: []v1.StepResult{{Name: "result1", Type: v1.ResultsTypeString}}},
+				v1.Step{Name: "consume-inputs", Image: fqImageName,
+					Command: []string{"sh", "-c", "echo -n $(steps.hello.inputs) >> $(step.results.result2.path)"},
+					Results: []v1.StepResult{{Name: "result2", Type: v1.ResultsTypeString}}},
+			)
+			if _, err := c.V1TaskClient.Create(ctx, task, metav1.CreateOptions{}); err != nil {
+				t.Fatalf("Failed to create Task: %s", err)
+			}
+			taskRun := parse.MustParseV1TaskRun(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -239,27 +269,127 @@ spec:
   taskRef:
     name: %s
 `, taskRunName, namespace, task.Name))
-	if _, err := c.V1TaskRunClient.Create(ctx, taskRun, metav1.CreateOptions{}); err != nil {
-		t.Fatalf("Failed to create TaskRun: %s", err)
+			if _, err := c.V1TaskRunClient.Create(ctx, taskRun, metav1.CreateOptions{}); err != nil {
+				t.Fatalf("Failed to create TaskRun: %s", err)
+			}
+
+			if err := WaitForTaskRunState(ctx, c, taskRunName, TaskRunSucceed(taskRunName), "TaskRunSucceed", v1Version); err != nil {
+				t.Errorf("Error waiting for TaskRun to finish: %s", err)
+			}
+
+			taskrun, err := c.V1TaskRunClient.Get(ctx, taskRunName, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("Couldn't get expected TaskRun %s: %s", taskRunName, err)
+			}
+			wantOut := `[{digest:{sha1:95588b8f34c31eb7d62c92aaa4e6506639b06ef2,sha256:df85b9e3983fe2ce20ef76ad675ecf435cc99fc9350adc54fa230bae8c32ce48},uri:pkg:balba}]`
+			gotOut := taskrun.Status.Steps[1].Results[0].Value.StringVal
+			if d := cmp.Diff(wantOut, gotOut); d != "" {
+				t.Fatalf(`The expected artifact outputs consumption result doesnot match expected. Here is the diff: %v`, d)
+			}
+			wantIn := `[{digest:{sha256:b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0},uri:git:jjjsss}]`
+			gotIn := taskrun.Status.Steps[2].Results[0].Value.StringVal
+			if d := cmp.Diff(wantIn, gotIn); d != "" {
+				t.Fatalf(`The expected artifact Inputs consumption result doesnot match expected. Here is the diff: %v`, d)
+			}
+		})
+	}
+}
+
+func TestStepProduceResultsAndArtifacts(t *testing.T) {
+	tests := []struct {
+		desc                   string
+		resultExtractionMethod string
+	}{
+		{
+			desc:                   "surface artifacts through termination message",
+			resultExtractionMethod: config.ResultExtractionMethodTerminationMessage},
+		{
+			desc:                   "surface artifacts through sidecar logs",
+			resultExtractionMethod: config.ResultExtractionMethodSidecarLogs},
 	}
 
-	if err := WaitForTaskRunState(ctx, c, taskRunName, TaskRunSucceed(taskRunName), "TaskRunSucceed", v1Version); err != nil {
-		t.Errorf("Error waiting for TaskRun to finish: %s", err)
-	}
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			featureFlags := getFeatureFlagsBaseOnAPIFlag(t)
+			checkFlagsEnabled := requireAllGates(map[string]string{
+				"enable-artifacts":    "true",
+				"enable-step-actions": "true",
+			})
 
-	taskrun, err := c.V1TaskRunClient.Get(ctx, taskRunName, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("Couldn't get expected TaskRun %s: %s", taskRunName, err)
-	}
-	wantOut := `[{digest:{sha1:95588b8f34c31eb7d62c92aaa4e6506639b06ef2,sha256:df85b9e3983fe2ce20ef76ad675ecf435cc99fc9350adc54fa230bae8c32ce48},uri:pkg:balba}]`
-	gotOut := taskrun.Status.Steps[1].Results[0].Value.StringVal
-	if d := cmp.Diff(wantOut, gotOut); d != "" {
-		t.Fatalf(`The expected artifact outputs consumption result doesnot match expected. Here is the diff: %v`, d)
-	}
-	wantIn := `[{digest:{sha256:b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0},uri:git:jjjsss}]`
-	gotIn := taskrun.Status.Steps[2].Results[0].Value.StringVal
-	if d := cmp.Diff(wantIn, gotIn); d != "" {
-		t.Fatalf(`The expected artifact Inputs consumption result doesnot match expected. Here is the diff: %v`, d)
+			ctx := context.Background()
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+			c, namespace := setup(ctx, t)
+			checkFlagsEnabled(ctx, t, c, "")
+			previous := featureFlags.ResultExtractionMethod
+			updateConfigMap(ctx, c.KubeClient, system.Namespace(), config.GetFeatureFlagsConfigName(), map[string]string{
+				"results-from": tc.resultExtractionMethod,
+			})
+
+			knativetest.CleanupOnInterrupt(func() {
+				updateConfigMap(ctx, c.KubeClient, system.Namespace(), config.GetFeatureFlagsConfigName(), map[string]string{
+					"results-from": previous,
+				})
+				tearDown(ctx, t, c, namespace)
+			}, t.Logf)
+
+			defer func() {
+				updateConfigMap(ctx, c.KubeClient, system.Namespace(), config.GetFeatureFlagsConfigName(), map[string]string{
+					"results-from": previous,
+				})
+				tearDown(ctx, t, c, namespace)
+			}()
+			taskRunName := helpers.ObjectNameForTest(t)
+
+			fqImageName := getTestImage(busyboxImage)
+
+			t.Logf("Creating Task and TaskRun in namespace %s", namespace)
+			task := produceResultsAndArtifactsTask(t, namespace, fqImageName)
+
+			if _, err := c.V1TaskClient.Create(ctx, task, metav1.CreateOptions{}); err != nil {
+				t.Fatalf("Failed to create Task: %s", err)
+			}
+			taskRun := parse.MustParseV1TaskRun(t, fmt.Sprintf(`
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  taskRef:
+    name: %s
+`, taskRunName, namespace, task.Name))
+			if _, err := c.V1TaskRunClient.Create(ctx, taskRun, metav1.CreateOptions{}); err != nil {
+				t.Fatalf("Failed to create TaskRun: %s", err)
+			}
+
+			if err := WaitForTaskRunState(ctx, c, taskRunName, TaskRunSucceed(taskRunName), "TaskRunSucceed", v1Version); err != nil {
+				t.Errorf("Error waiting for TaskRun to finish: %s", err)
+			}
+
+			taskrun, err := c.V1TaskRunClient.Get(ctx, taskRunName, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("Couldn't get expected TaskRun %s: %s", taskRunName, err)
+			}
+			if d := cmp.Diff([]v1.TaskRunStepArtifact{{Name: "source",
+				Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"},
+					Uri: "git:jjjsss",
+				}},
+			}}, taskrun.Status.Steps[0].Inputs); d != "" {
+				t.Fatalf(`The expected stepState Inputs does not match created taskrun stepState Inputs. Here is the diff: %v`, d)
+			}
+			if d := cmp.Diff([]v1.TaskRunStepArtifact{{Name: "image",
+				Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2", "sha256": "df85b9e3983fe2ce20ef76ad675ecf435cc99fc9350adc54fa230bae8c32ce48"},
+					Uri: "pkg:balba",
+				}},
+			}}, taskrun.Status.Steps[0].Outputs); d != "" {
+				t.Fatalf(`The expected stepState Outputs does not match created taskrun stepState Outputs. Here is the diff: %v`, d)
+			}
+
+			wantResult := `result1Value`
+			gotResult := taskrun.Status.Steps[0].Results[0].Value.StringVal
+			if d := cmp.Diff(wantResult, gotResult); d != "" {
+				t.Fatalf(`The expected artifact outputs consumption result doesnot match expected. Here is the diff: %v`, d)
+			}
+		})
 	}
 }
 
@@ -281,7 +411,7 @@ spec:
           {
             "inputs":[
               {
-                "name":"input-artifacts",
+                "name":"source",
                 "values":[
                   {
                     "uri":"git:jjjsss",
@@ -294,7 +424,7 @@ spec:
             ],
             "outputs":[
               {
-                "name":"build-result",
+                "name":"image",
                 "values":[
                   {
                     "uri":"pkg:balba",
@@ -308,6 +438,58 @@ spec:
             ]
           }
         EOF
+`, helpers.ObjectNameForTest(t), namespace, fqImageName))
+	return task
+}
+
+func produceResultsAndArtifactsTask(t *testing.T, namespace string, fqImageName string) *v1.Task {
+	t.Helper()
+	task := parse.MustParseV1Task(t, fmt.Sprintf(`
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  steps:
+  - name: hello
+    image: %s
+    command: ['/bin/sh']
+    results:
+      - name: result1
+    args: 
+      - "-c"
+      - |
+        cat > $(step.artifacts.path) << EOF
+          {
+            "inputs":[
+              {
+                "name":"source",
+                "values":[
+                  {
+                    "uri":"git:jjjsss",
+                    "digest":{
+                      "sha256":"b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"
+                    }
+                  }
+                ]
+              }
+            ],
+            "outputs":[
+              {
+                "name":"image",
+                "values":[
+                  {
+                    "uri":"pkg:balba",
+                    "digest":{
+                      "sha256":"df85b9e3983fe2ce20ef76ad675ecf435cc99fc9350adc54fa230bae8c32ce48",
+                      "sha1":"95588b8f34c31eb7d62c92aaa4e6506639b06ef2"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        EOF
+        echo -n result1Value >> $(step.results.result1.path)
 `, helpers.ObjectNameForTest(t), namespace, fqImageName))
 	return task
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
 - This Pr uses the similar approach as https://github.com/tektoncd/pipeline/pull/7414 to surface large artifacts to TaskRun.status.steps. 
 -  The flag `result-from:sidecar-logs`  is used to  guard this feature, it is also the same as surfacing step results through sidecar logs. 
 - As we don't have a API to allow users to declare if a step is going to produce artifacts, we check if a step env, command, args, script contains `artifacts path` to determine if we should create an artifact sidecar container should be created for a task. 

# Fixes: #7869      

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Surface artifacts through sidecar container logs.
```


