### PR TITLE
Propagate params in pipelines

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -369,6 +369,45 @@ any resolved `param` value against the `enum` specified in each `PipelineTask` b
 
 See usage in this [example](../examples/v1/pipelineruns/alpha/param-enum.yaml)
 
+#### Propagated Params
+
+Like with embedded [pipelineruns](pipelineruns.md#propagated-parameters), you can propagate `params` declared in the `pipeline` down to the inlined `pipelineTasks` and its inlined `Steps`. Wherever a resource (e.g. a `pipelineTask`) or a `StepAction` is referenced, the parameters need to be passed explicitly. 
+
+For example, the following is a valid yaml.
+
+```yaml
+apiVersion: tekton.dev/v1 # or tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: pipelien-propagated-params
+spec:
+  params:
+    - name: HELLO
+      default: "Hello World!"
+    - name: BYE
+      default: "Bye World!"
+  tasks:
+    - name: echo-hello
+      taskSpec:
+        steps:
+          - name: echo
+            image: ubuntu
+            script: |
+              #!/usr/bin/env bash
+              echo "$(params.HELLO)"
+    - name: echo-bye
+      taskSpec:
+        steps:
+          - name: echo-action
+            ref:
+              name: step-action-echo
+            params:
+              - name: msg
+                value: "$(params.BYE)" 
+```
+The same rules defined in [pipelineruns](pipelineruns.md#propagated-parameters) apply here.
+
+
 ## Adding `Tasks` to the `Pipeline`
 
  Your `Pipeline` definition must reference at least one [`Task`](tasks.md).

--- a/examples/v1/pipelineruns/propagating-workspaces-in-pipelines.yaml
+++ b/examples/v1/pipelineruns/propagating-workspaces-in-pipelines.yaml
@@ -1,0 +1,32 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: workspace-example
+spec:
+  workspaces:
+    - name: shared-data
+  tasks:
+    - name: t1
+      taskSpec:
+        steps:
+          - image: ubuntu
+            command: ["ls"]
+            args: ["$(workspaces.shared-data.path)"]
+---
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: workspace-example-run
+spec:
+  pipelineRef:
+    name: workspace-example
+  workspaces:
+    - name: shared-data
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 16Mi
+          volumeMode: Filesystem

--- a/examples/v1/pipelineruns/propagating_params_in_pipeline.yaml
+++ b/examples/v1/pipelineruns/propagating_params_in_pipeline.yaml
@@ -1,0 +1,37 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: propagating-params-in-pipeline
+spec:
+  params:
+    - name: HELLO
+      default: "Pipeline Hello World!"
+  tasks:
+    - name: echo-hello
+      taskSpec:
+        steps:
+          - name: echo
+            image: ubuntu
+            script: |
+              #!/usr/bin/env bash
+              echo "$(params.HELLO)"
+  finally:
+    - name: echo-hello-finally
+      taskSpec:
+        steps:
+          - name: echo
+            image: ubuntu
+            script: |
+              #!/usr/bin/env bash
+              echo "And Finally ... $(params.HELLO)"
+---
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  generateName: propagating-params-in-pipeline-
+spec:
+  params:
+    - name: HELLO
+      value: "Hello from pipeline run"
+  pipelineRef:
+    name: propagating-params-in-pipeline

--- a/pkg/apis/pipeline/v1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1/pipeline_validation.go
@@ -151,10 +151,10 @@ func (l PipelineTaskList) Validate(ctx context.Context, taskNames sets.String, p
 }
 
 // validateUsageOfDeclaredPipelineTaskParameters validates that all parameters referenced in the pipeline Task are declared by the pipeline Task.
-func (l PipelineTaskList) validateUsageOfDeclaredPipelineTaskParameters(ctx context.Context, path string) (errs *apis.FieldError) {
+func (l PipelineTaskList) validateUsageOfDeclaredPipelineTaskParameters(ctx context.Context, additionalParams []ParamSpec, path string) (errs *apis.FieldError) {
 	for i, t := range l {
 		if t.TaskSpec != nil {
-			errs = errs.Also(ValidateUsageOfDeclaredParameters(ctx, t.TaskSpec.Steps, t.TaskSpec.Params).ViaFieldIndex(path, i))
+			errs = errs.Also(ValidateUsageOfDeclaredParameters(ctx, t.TaskSpec.Steps, append(t.TaskSpec.Params, additionalParams...)).ViaFieldIndex(path, i))
 		}
 	}
 	return errs
@@ -385,8 +385,8 @@ func validatePipelineWorkspacesDeclarations(wss []PipelineWorkspaceDeclaration) 
 
 // validatePipelineParameterUsage validates that parameters referenced in the Pipeline are declared by the Pipeline
 func (ps *PipelineSpec) validatePipelineParameterUsage(ctx context.Context) (errs *apis.FieldError) {
-	errs = errs.Also(PipelineTaskList(ps.Tasks).validateUsageOfDeclaredPipelineTaskParameters(ctx, "tasks"))
-	errs = errs.Also(PipelineTaskList(ps.Finally).validateUsageOfDeclaredPipelineTaskParameters(ctx, "finally"))
+	errs = errs.Also(PipelineTaskList(ps.Tasks).validateUsageOfDeclaredPipelineTaskParameters(ctx, ps.Params, "tasks"))
+	errs = errs.Also(PipelineTaskList(ps.Finally).validateUsageOfDeclaredPipelineTaskParameters(ctx, ps.Params, "finally"))
 	errs = errs.Also(validatePipelineTaskParameterUsage(ps.Tasks, ps.Params).ViaField("tasks"))
 	errs = errs.Also(validatePipelineTaskParameterUsage(ps.Finally, ps.Params).ViaField("finally"))
 	return errs

--- a/pkg/apis/pipeline/v1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1/pipeline_validation_test.go
@@ -114,6 +114,65 @@ func TestPipeline_Validate_Success(t *testing.T) {
 				},
 			},
 		},
+	}, {
+		name: "propagating params into Step",
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "pipelinelinename",
+			},
+			Spec: PipelineSpec{
+				Params: ParamSpecs{{
+					Name: "pipeline-words",
+					Type: ParamTypeArray,
+					Default: &ParamValue{
+						Type:     ParamTypeArray,
+						ArrayVal: []string{"hello", "pipeline"},
+					},
+				}},
+				Tasks: []PipelineTask{{
+					Name: "echoit",
+					TaskSpec: &EmbeddedTask{TaskSpec: TaskSpec{
+						Steps: []Step{{
+							Name:    "echo",
+							Image:   "ubuntu",
+							Command: []string{"echo"},
+							Args:    []string{"$(params.pipeline-words[*])"},
+						}},
+					}},
+				}},
+			},
+		},
+	}, {
+		name: "propagating object params with pipelinespec and taskspec",
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "pipelinelinename",
+			},
+			Spec: PipelineSpec{
+				Params: ParamSpecs{{
+					Name: "pipeline-words",
+					Default: &ParamValue{
+						Type:      ParamTypeObject,
+						ObjectVal: map[string]string{"hello": "pipeline"},
+					},
+					Type: ParamTypeObject,
+					Properties: map[string]PropertySpec{
+						"hello": {Type: ParamTypeString},
+					},
+				}},
+				Tasks: []PipelineTask{{
+					Name: "echoit",
+					TaskSpec: &EmbeddedTask{TaskSpec: TaskSpec{
+						Steps: []Step{{
+							Name:    "echo",
+							Image:   "ubuntu",
+							Command: []string{"echo"},
+							Args:    []string{"$(params.pipeline-words.hello)"},
+						}},
+					}},
+				}},
+			},
+		},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -364,6 +423,78 @@ func TestPipeline_Validate_Failure(t *testing.T) {
 					DisableInlineSpec: "pipeline,pipelinerun,taskrun",
 				},
 			})
+		},
+	}, {
+		name: "propagating params with pipelinespec and taskspec",
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "pipelinename",
+			},
+			Spec: PipelineSpec{
+				Params: ParamSpecs{{
+					Name: "pipeline-words",
+					Type: ParamTypeArray,
+					Default: &ParamValue{
+						Type:     ParamTypeArray,
+						ArrayVal: []string{"hello", "pipeline"},
+					},
+				}},
+				Tasks: []PipelineTask{{
+					Name: "echoit",
+					TaskSpec: &EmbeddedTask{TaskSpec: TaskSpec{
+						Steps: []Step{{
+							Name:    "echo",
+							Image:   "ubuntu",
+							Command: []string{"echo"},
+							Args:    []string{"$(params.random-words[*])"},
+						}},
+					}},
+				}},
+			},
+		},
+		expectedError: apis.FieldError{
+			Message: `non-existent variable in "$(params.random-words[*])"`,
+			Paths:   []string{"spec.tasks[0].steps[0].args[0]"},
+		},
+	}, {
+		name: "propagating params to taskRef",
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "pipelinename",
+			},
+			Spec: PipelineSpec{
+				Params: ParamSpecs{{
+					Name: "hello",
+					Type: ParamTypeString,
+					Default: &ParamValue{
+						Type:      ParamTypeString,
+						StringVal: "hi",
+					},
+				}},
+				Tasks: []PipelineTask{{
+					Name: "echoit",
+					TaskRef: &TaskRef{
+						Name: "remote-task",
+					},
+					Params: Params{{
+						Name: "param1",
+						Value: ParamValue{
+							Type:      ParamTypeString,
+							StringVal: "$(params.param1)",
+						},
+					}, {
+						Name: "holla",
+						Value: ParamValue{
+							Type:      ParamTypeString,
+							StringVal: "$(params.hello)",
+						},
+					}},
+				}},
+			},
+		},
+		expectedError: apis.FieldError{
+			Message: `non-existent variable in "$(params.param1)"`,
+			Paths:   []string{"spec.tasks[0].params[param1]"},
 		},
 	}}
 	for _, tt := range tests {

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation.go
@@ -153,10 +153,10 @@ func (l PipelineTaskList) Validate(ctx context.Context, taskNames sets.String, p
 }
 
 // validateUsageOfDeclaredPipelineTaskParameters validates that all parameters referenced in the pipeline Task are declared by the pipeline Task.
-func (l PipelineTaskList) validateUsageOfDeclaredPipelineTaskParameters(ctx context.Context, path string) (errs *apis.FieldError) {
+func (l PipelineTaskList) validateUsageOfDeclaredPipelineTaskParameters(ctx context.Context, additionalParams []ParamSpec, path string) (errs *apis.FieldError) {
 	for i, t := range l {
 		if t.TaskSpec != nil {
-			errs = errs.Also(ValidateUsageOfDeclaredParameters(ctx, t.TaskSpec.Steps, t.TaskSpec.Params).ViaFieldIndex(path, i))
+			errs = errs.Also(ValidateUsageOfDeclaredParameters(ctx, t.TaskSpec.Steps, append(t.TaskSpec.Params, additionalParams...)).ViaFieldIndex(path, i))
 		}
 	}
 	return errs
@@ -403,8 +403,8 @@ func validatePipelineWorkspacesDeclarations(wss []PipelineWorkspaceDeclaration) 
 
 // validatePipelineParameterUsage validates that parameters referenced in the Pipeline are declared by the Pipeline
 func (ps *PipelineSpec) validatePipelineParameterUsage(ctx context.Context) (errs *apis.FieldError) {
-	errs = errs.Also(PipelineTaskList(ps.Tasks).validateUsageOfDeclaredPipelineTaskParameters(ctx, "tasks"))
-	errs = errs.Also(PipelineTaskList(ps.Finally).validateUsageOfDeclaredPipelineTaskParameters(ctx, "finally"))
+	errs = errs.Also(PipelineTaskList(ps.Tasks).validateUsageOfDeclaredPipelineTaskParameters(ctx, ps.Params, "tasks"))
+	errs = errs.Also(PipelineTaskList(ps.Finally).validateUsageOfDeclaredPipelineTaskParameters(ctx, ps.Params, "finally"))
 	errs = errs.Also(validatePipelineTaskParameterUsage(ps.Tasks, ps.Params).ViaField("tasks"))
 	errs = errs.Also(validatePipelineTaskParameterUsage(ps.Finally, ps.Params).ViaField("finally"))
 	return errs


### PR DESCRIPTION
Prior to this, we allowed parameter propagation in an inlined pipelinerun. However, within a pipeline, we requrie a verbose spec. This was an oversight as indicated in https://github.com/tektoncd/pipeline/issues/7901.
This PR fixes that issue by updating the validation logic in the webhook.

Fixes https://github.com/tektoncd/pipeline/issues/7901.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Enable propagating params in Pipelines.
```

/kind bug