### PR TITLE
Add image replacement for amd64 specific image for entrypoint-resolution test and update docker-in-docker test image for Power.

### DIFF
--- a/test/examples_test.go
+++ b/test/examples_test.go
@@ -280,13 +280,14 @@ func imageNamesMapping() map[string]string {
 		}
 	case "ppc64le":
 		return map[string]string{
-			"registry":                              getTestImage(registryImage),
-			"node":                                  "node:alpine3.11",
-			"gcr.io/cloud-builders/git":             "alpine/git:latest",
-			"docker:dind":                           "ibmcom/docker-ppc64le:19.03-dind",
+			"registry":                  getTestImage(registryImage),
+			"node":                      "node:alpine3.11",
+			"gcr.io/cloud-builders/git": "alpine/git:latest",
+			"docker@sha256:74e78208fc18da48ddf8b569abe21563730845c312130bd0f0b059746a7e10f5": "ibmcom/docker-ppc64le:19.03-dind",
 			"docker":                                "docker:18.06.3",
 			"mikefarah/yq:3":                        "danielxlee/yq:2.4.0",
 			"stedolan/jq":                           "ibmcom/jq-ppc64le:latest",
+			"amd64/ubuntu":                          "ppc64le/ubuntu",
 			"gcr.io/kaniko-project/executor:v1.3.0": getTestImage(kanikoImage),
 		}
 	}


### PR DESCRIPTION
This includes replacing the amd64/ubuntu image for entrypoint-resolution test and update the docker:dind image in the test examples. this is not multi arch image, so use different image for ppc64le platform.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
