### PR TITLE
minor followup to PR 7894

### DIFF
--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -646,6 +646,8 @@ func resolveTask(
 			case errors.Is(err, remote.ErrRequestInProgress):
 				return rt, err
 			case err != nil:
+				// some of the resolvers obtain the name from the parameters instead of from the TaskRef.Name field,
+				// so we account for both locations when constructing the error
 				name := pipelineTask.TaskRef.Name
 				if len(strings.TrimSpace(name)) == 0 {
 					name = resource.GenerateErrorLogString(string(pipelineTask.TaskRef.Resolver), pipelineTask.TaskRef.Params)

--- a/pkg/resolution/resource/name_test.go
+++ b/pkg/resolution/resource/name_test.go
@@ -273,6 +273,20 @@ func TestGenerateErrorLogString(t *testing.T) {
 			},
 		},
 		{
+			name:         "goo-array",
+			resolverType: "bundle",
+			isPresent:    true,
+			params: []v1.Param{
+				{
+					Name: resource.ParamName,
+					Value: v1.ParamValue{
+						Type:     v1.ParamTypeArray,
+						ArrayVal: []string{resource.ParamName, "goo-array"},
+					},
+				},
+			},
+		},
+		{
 			name:         "hoo",
 			resolverType: "cluster",
 			err:          "name could not be marshalled",


### PR DESCRIPTION
- add comment on why we check param when generating error log
- add unit test that covers getting name from non-string param type

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

minor follow up from @afrittoli 's comment in #7894 

@chitrangpatel FYI

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ /] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [/ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ /] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [/ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ /] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ n/a] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [n/a ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
