### PR TITLE
Fix: Faulty Remote Resource Accepted by Remote Resolution

### DIFF
--- a/pkg/remote/resolution/resolver.go
+++ b/pkg/remote/resolution/resolver.go
@@ -24,6 +24,7 @@ import (
 	resolutioncommon "github.com/tektoncd/pipeline/pkg/resolution/common"
 	remoteresource "github.com/tektoncd/pipeline/pkg/resolution/resource"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"knative.dev/pkg/kmeta"
 )
 
@@ -97,7 +98,8 @@ func ResolvedRequest(resolved resolutioncommon.ResolvedResource, err error) (run
 	if err != nil {
 		return nil, nil, &DataAccessError{Original: err}
 	}
-	obj, _, err := scheme.Codecs.UniversalDeserializer().Decode(data, nil, nil)
+	codecs := serializer.NewCodecFactory(scheme.Scheme, serializer.EnableStrict)
+	obj, _, err := codecs.UniversalDeserializer().Decode(data, nil, nil)
 	if err != nil {
 		return nil, nil, &InvalidRuntimeObjectError{Original: err}
 	}


### PR DESCRIPTION
Fixes: https://github.com/tektoncd/pipeline/issues/7951
This PR fixes the issue where a bad remote resource is accepted by remote resolution.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
/kind bug