### PR TITLE
 doc: Make it clearer what the auth documentation is about #7737

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -426,14 +426,21 @@ the credentials specified in the `Secret`.
 
 ## Configuring `docker*` authentication for Docker
 
-This section describes how to configure authentication using the `dockercfg` and `dockerconfigjson` type
-`Secrets` for use with Docker. In the example below, before executing any `Steps` in the `Run`, Tekton creates
-a `~/.docker/config.json` file containing the credentials specified in the `Secret`. When the `Steps` execute,
-Tekton uses those credentials to access the target Docker registry.
-f
-**Note:** If you specify both the Tekton `basic-auth` and the above Kubernetes `Secrets`, Tekton merges all
-credentials from all specified `Secrets` but Tekton's `basic-auth` `Secret` overrides either of the
-Kubernetes `Secrets`.
+This section describes how to configure Docker authentication using the `dockercfg`
+and `dockerconfigjson` Secret types. These Secrets are used as `imagePullSecrets`
+to provide the necessary credentials for Tekton to pull container images from 
+private Docker registries when creating the Pod for a TaskRun or PipelineRun 
+(collectively referred to as "Run").
+
+When a Run is executed, Tekton creates a Pod to run the defined Steps. During 
+this Pod creation phase, Tekton uses the provided `imagePullSecrets` to 
+authenticate with the respective registries and pull the required container images. 
+This image pulling process is a crucial step that happens before the Steps 
+within the Pod can start executing.
+
+Note: If you specify both the Tekton `basic-auth` and the Kubernetes `dockercfg` 
+or `dockerconfigjson` Secrets, Tekton merges all credentials from all specified 
+Secrets, but Tekton's basic-auth Secret overrides the Kubernetes Secrets.
 
 1. Define a `Secret` based on your Docker client configuration file.
    


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This PR addresses the issues raised in [#7737 ](https://github.com/tektoncd/pipeline/issues/7736) regarding the clarity and accuracy of the authentication documentation, specifically the sections related to Docker authentication.

Key Changes:

	Overview Section:

		Provides a comprehensive explanation of the authentication process, including the two stages (Pod Scheduling and Image Pulling, and Step Execution).
		Describes the credential initialization process and the generated credential file locations.

		Configuring Docker Authentication Section:

		Clarifies the role of imagePullSecrets and their usage during the Pod creation phase for pulling images from private registries.
		Includes examples of specifying imagePullSecrets in run.yaml for TaskRun and PipelineRun.

	Benefits:

		Addresses confusion and lack of clarity in the existing documentation.
		Improves understanding of when and how Docker credentials are used, particularly during the Pod creation phase.
		Enhances comprehension of the authentication flow and setup within the container.


# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```