### PR TITLE
Bundle resolver can use ServiceAccount for auth

### DIFF
--- a/config/resolvers/200-clusterrole.yaml
+++ b/config/resolvers/200-clusterrole.yaml
@@ -30,5 +30,5 @@ rules:
     verbs: ["get", "list"]
   # Read-only access to these.
   - apiGroups: [""]
-    resources: ["secrets"]
+    resources: ["secrets", "serviceaccounts"]
     verbs: ["get", "list", "watch"]

--- a/config/resolvers/bundleresolver-config.yaml
+++ b/config/resolvers/bundleresolver-config.yaml
@@ -22,5 +22,7 @@ metadata:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
 data:
+  # the default service account name to use for bundle requests.
+  default-service-account: "default"
   # The default layer kind in the bundle image.
   default-kind: "task"

--- a/pkg/resolution/resolver/bundle/bundle.go
+++ b/pkg/resolution/resolver/bundle/bundle.go
@@ -37,6 +37,7 @@ const (
 // RequestOptions are the options used to request a resource from
 // a remote bundle.
 type RequestOptions struct {
+	ServiceAccount  string
 	ImagePullSecret string
 	Bundle          string
 	EntryName       string

--- a/pkg/resolution/resolver/bundle/config.go
+++ b/pkg/resolution/resolver/bundle/config.go
@@ -16,6 +16,9 @@ package bundle
 const (
 	// ConfigMapName is the bundle resolver's config map
 	ConfigMapName = "bundleresolver-config"
+	// ConfigServiceAccount is the configuration field name for controlling
+	// the Service Account name to use for bundle requests.
+	ConfigServiceAccount = "default-service-account"
 	// ConfigKind is the configuration field name for controlling
 	// what the layer name in the bundle image is.
 	ConfigKind = "default-kind"

--- a/pkg/resolution/resolver/bundle/resolver.go
+++ b/pkg/resolution/resolver/bundle/resolver.go
@@ -22,9 +22,7 @@ import (
 	"time"
 
 	"github.com/google/go-containerregistry/pkg/authn/k8schain"
-	kauth "github.com/google/go-containerregistry/pkg/authn/kubernetes"
 	resolverconfig "github.com/tektoncd/pipeline/pkg/apis/config/resolver"
-	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/apis/resolution/v1beta1"
 	common "github.com/tektoncd/pipeline/pkg/resolution/common"
@@ -79,7 +77,7 @@ func (r *Resolver) GetSelector(context.Context) map[string]string {
 }
 
 // ValidateParams ensures parameters from a request are as expected.
-func (r *Resolver) ValidateParams(ctx context.Context, params []pipelinev1.Param) error {
+func (r *Resolver) ValidateParams(ctx context.Context, params []v1.Param) error {
 	return ValidateParams(ctx, params)
 }
 
@@ -104,8 +102,8 @@ func ResolveRequest(ctx context.Context, kubeClientSet kubernetes.Interface, req
 	namespace := common.RequestNamespace(ctx)
 	kc, err := k8schain.New(ctx, kubeClientSet, k8schain.Options{
 		Namespace:          namespace,
+		ServiceAccountName: opts.ServiceAccount,
 		ImagePullSecrets:   imagePullSecrets,
-		ServiceAccountName: kauth.NoServiceAccount,
 	})
 	if err != nil {
 		return nil, err
@@ -115,7 +113,7 @@ func ResolveRequest(ctx context.Context, kubeClientSet kubernetes.Interface, req
 	return GetEntry(ctx, kc, opts)
 }
 
-func ValidateParams(ctx context.Context, params []pipelinev1.Param) error {
+func ValidateParams(ctx context.Context, params []v1.Param) error {
 	if isDisabled(ctx) {
 		return errors.New(disabledError)
 	}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
- Bundles resolver can read image pull secrets from ServiceAccount via attached secret and directly from specified Secret. 

With https://github.com/tektoncd/pipeline/issues/7159 change ECR private registry users no longer had an easy option to authenticate with ECR, because ECR uses short-lived credentials (up to 12 hours), therefore adding it to a secret doesn't make sense because it would mean implementing an additional mechanism to secret rotation in each namespace. 

Fixes: https://github.com/tektoncd/pipeline/issues/7854
Extends: https://github.com/tektoncd/pipeline/issues/7159

Tested both variants - GCR (Secret) and ECR (ServiceAccount) private registries.

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [X] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [X] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [X] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [X] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [X] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Fix bundle resolver so it could pull OCI image (bundle) manifest from AWS ECR private registry
```
