### PR TITLE
kind/feat: passing artifacts between tasks

### DIFF
--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -8,8 +8,9 @@ weight: 201
 # Artifacts
 
 - [Overview](#overview)
-- [Artifact Provenance Data](#passing-artifacts-between-steps)
+- [Artifact Provenance Data](#artifact-provenance-data)
   - [Passing Artifacts between Steps](#passing-artifacts-between-steps)
+  - [Passing Artifacts between Tasks](#passing-artifacts-between-tasks)
 
 
 
@@ -104,13 +105,59 @@ spec:
           EOF
 ```
 
+The content is written by the `Step` to a file `$(artifacts.path)`:
+
+```yaml
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  generateName: step-artifacts-
+spec:
+  taskSpec:
+    description: |
+      A simple task that populates artifacts to TaskRun stepState
+    steps:
+      - name: artifacts-producer
+        image: bash:latest
+        script: |
+          cat > $(artifacts.path) << EOF
+          {
+            "inputs":[
+              {
+                "name":"source",
+                "values":[
+                  {
+                    "uri":"pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c",
+                    "digest":{
+                      "sha256":"b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"
+                    }
+                  }
+                ]
+              }
+            ],
+            "outputs":[
+              {
+                "name":"image",
+                "values":[
+                  {
+                    "uri":"pkg:oci/nginx:stable-alpine3.17-slim?repository_url=docker.io/library",
+                    "digest":{
+                      "sha256":"df85b9e3983fe2ce20ef76ad675ecf435cc99fc9350adc54fa230bae8c32ce48",
+                      "sha1":"95588b8f34c31eb7d62c92aaa4e6506639b06ef2"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+          EOF
+```
+
 It is recommended to use [purl format](https://github.com/package-url/purl-spec/blob/master/PURL-SPECIFICATION.rst) for artifacts uri as shown in the example. 
 
 ### Passing Artifacts between Steps
 You can pass artifacts from one step to the next using:
-
 - Specific Artifact: `$(steps.<step-name>.inputs.<artifact-category-name>)` or `$(steps.<step-name>.outputs.<artifact-category-name>)`
-- Default (First) Artifact: `$(steps.<step-name>.inputs)` or `$(steps.<step-name>.outputs)` (if <artifact-category-name> is omitted)
 
 The example below shows how to access the previous' step artifacts from another step in the same task
 
@@ -162,12 +209,12 @@ spec:
       - name: artifacts-consumer
         image: bash:latest
         script: |
-          echo $(steps.artifacts-producer.outputs)
+          echo $(steps.artifacts-producer.outputs.image)
 ```
 
 
-The resolved value of `$(steps.<step-name>.outputs.<artifact-category-name>)` or `$(steps.<step-name>.outputs)` is the values of an artifact. For this example, 
-`$(steps.artifacts-producer.outputs)` is resolved to 
+The resolved value of `$(steps.<step-name>.outputs.<artifact-category-name>)` is the values of an artifact. For this example, 
+`$(steps.artifacts-producer.outputs.image)` is resolved to 
 ```json
 [
                   {
@@ -182,62 +229,278 @@ The resolved value of `$(steps.<step-name>.outputs.<artifact-category-name>)` or
 
 
 Upon resolution and execution of the `TaskRun`, the `Status` will look something like:
-```yaml
-"steps": [
+
+```json
+{
+  "artifacts": {
+    "inputs": [
       {
-        "container": "step-artifacts-producer",
-        "imageID": "docker.io/library/bash@sha256:5353512b79d2963e92a2b97d9cb52df72d32f94661aa825fcfa0aede73304743",
-        "inputs": [
+        "name": "source",
+        "values": [
           {
-            "name": "source",
-            "values": [
-              {
-                "digest": {
-                  "sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"
-                },
-                "uri":"pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c",
-              }
-            ]
+            "digest": {
+              "sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"
+            },
+            "uri": "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"
           }
-        ],
-        "name": "artifacts-producer",
-        "outputs": [
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "image",
+        "values": [
           {
-            "name": "image",
-            "values": [
-              {
-                "digest": {
-                  "sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2",
-                  "sha256": "df85b9e3983fe2ce20ef76ad675ecf435cc99fc9350adc54fa230bae8c32ce48"
-                },
-                "uri":"pkg:oci/nginx:stable-alpine3.17-slim?repository_url=docker.io/library",
-              }
-            ]
+            "digest": {
+              "sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2",
+              "sha256": "df85b9e3983fe2ce20ef76ad675ecf435cc99fc9350adc54fa230bae8c32ce48"
+            },
+            "uri": "pkg:oci/nginx:stable-alpine3.17-slim?repository_url=docker.io/library"
           }
-        ],
+        ]
+      }
+    ]
+  },
+  "steps": [
+    {
+      "container": "step-artifacts-producer",
+      "imageID": "docker.io/library/bash@sha256:5353512b79d2963e92a2b97d9cb52df72d32f94661aa825fcfa0aede73304743",
+      "inputs": [
+        {
+          "name": "source",
+          "values": [
+            {
+              "digest": {
+                "sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"
+              },
+              "uri": "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"
+            }
+          ]
+        }
+      ],
+      "name": "artifacts-producer",
+      "outputs": [
+        {
+          "name": "image",
+          "values": [
+            {
+              "digest": {
+                "sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2",
+                "sha256": "df85b9e3983fe2ce20ef76ad675ecf435cc99fc9350adc54fa230bae8c32ce48"
+              },
+              "uri": "pkg:oci/nginx:stable-alpine3.17-slim?repository_url=docker.io/library"
+            }
+          ]
+        }
+      ],
+      "terminated": {
+        "containerID": "containerd://010f02d103d1db48531327a1fe09797c87c1d50b6a216892319b3af93e0f56e7",
+        "exitCode": 0,
+        "finishedAt": "2024-03-18T17:05:06Z",
+        "message": "...",
+        "reason": "Completed",
+        "startedAt": "2024-03-18T17:05:06Z"
+      },
+      "terminationReason": "Completed"
+    },
+    {
+      "container": "step-artifacts-consumer",
+      "imageID": "docker.io/library/bash@sha256:5353512b79d2963e92a2b97d9cb52df72d32f94661aa825fcfa0aede73304743",
+      "name": "artifacts-consumer",
+      "terminated": {
+        "containerID": "containerd://42428aa7e5a507eba924239f213d185dd4bc0882b6f217a79e6792f7fec3586e",
+        "exitCode": 0,
+        "finishedAt": "2024-03-18T17:05:06Z",
+        "reason": "Completed",
+        "startedAt": "2024-03-18T17:05:06Z"
+      },
+      "terminationReason": "Completed"
+    }
+  ]
+}
+
+```
+
+### Passing Artifacts between Tasks
+You can pass artifacts from one task to the another using:
+
+- Specific Artifact: `$(tasks.<task-name>.inputs.<artifact-category-name>)` or `$(tasks.<task-name>.outputs.<artifact-category-name>)`
+
+The example below shows how to access the previous' task artifacts from another task in a pipeline
+
+```yaml
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  generateName: pipelinerun-consume-tasks-artifacts
+spec:
+  pipelineSpec:
+    tasks:
+      - name: produce-artifacts-task
+        taskSpec:
+          description: |
+            A simple task that produces artifacts
+          steps:
+            - name: produce-artifacts
+              image: bash:latest
+              script: |
+                #!/usr/bin/env bash
+                cat > $(artifacts.path) << EOF
+                {
+                  "inputs":[
+                    {
+                      "name":"input-artifacts",
+                      "values":[
+                        {
+                          "uri":"pkg:example.github.com/inputs",
+                          "digest":{
+                            "sha256":"b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "outputs":[
+                    {
+                      "name":"image",
+                      "values":[
+                        {
+                          "uri":"pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c",
+                          "digest":{
+                            "sha256":"df85b9e3983fe2ce20ef76ad675ecf435cc99fc9350adc54fa230bae8c32ce48",
+                            "sha1":"95588b8f34c31eb7d62c92aaa4e6506639b06ef2"
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+                EOF
+      - name: consume-artifacts
+        runAfter:
+          - produce-artifacts-task
+        taskSpec:
+          steps:
+            - name: artifacts-consumer-python
+              image: python:latest
+              script: |
+                #!/usr/bin/env python3
+                import json
+                data = json.loads('$(tasks.produce-artifacts-task.outputs.image)')
+                if data[0]['uri'] != "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c":
+                  exit(1)
+```
+
+
+Similar to Step Artifacts. The resolved value of `$(tasks.<task-name>.outputs.<artifact-category-name>)` is the values of an artifact. For this example,
+`$(tasks.produce-artifacts-task.outputs.image)` is resolved to
+```json
+[
+  {
+    "uri":"pkg:example.github.com/inputs",
+    "digest":{
+      "sha256":"b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"
+    }
+ }
+]
+```
+Upon resolution and execution of the `TaskRun`, the `Status` will look something like:
+```json
+{
+ "artifacts": {
+      "inputs": [
+        {
+          "name": "input-artifacts",
+          "values": [
+            {
+              "digest": {
+                "sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"
+              },
+              "uri": "pkg:example.github.com/inputs"
+            }
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "image",
+          "values": [
+            {
+              "digest": {
+                "sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2",
+                "sha256": "df85b9e3983fe2ce20ef76ad675ecf435cc99fc9350adc54fa230bae8c32ce48"
+              },
+              "uri": "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"
+            }
+          ]
+        }
+      ]
+    },
+    "completionTime": "2024-05-28T14:10:58Z",
+    "conditions": [
+      {
+        "lastTransitionTime": "2024-05-28T14:10:58Z",
+        "message": "All Steps have completed executing",
+        "reason": "Succeeded",
+        "status": "True",
+        "type": "Succeeded"
+      }
+    ],
+    "podName": "pipelinerun-consume-tasks-a41ee44e4f964e95adfd3aea417d52f90-pod",
+    "provenance": {
+      "featureFlags": {
+        "AwaitSidecarReadiness": true,
+        "Coschedule": "workspaces",
+        "DisableAffinityAssistant": false,
+        "DisableCredsInit": false,
+        "DisableInlineSpec": "",
+        "EnableAPIFields": "beta",
+        "EnableArtifacts": true,
+        "EnableCELInWhenExpression": false,
+        "EnableConciseResolverSyntax": false,
+        "EnableKeepPodOnCancel": false,
+        "EnableParamEnum": false,
+        "EnableProvenanceInStatus": true,
+        "EnableStepActions": true,
+        "EnableTektonOCIBundles": false,
+        "EnforceNonfalsifiability": "none",
+        "MaxResultSize": 4096,
+        "RequireGitSSHSecretKnownHosts": false,
+        "ResultExtractionMethod": "termination-message",
+        "RunningInEnvWithInjectedSidecars": true,
+        "ScopeWhenExpressionsToTask": false,
+        "SendCloudEventsForRuns": false,
+        "SetSecurityContext": false,
+        "VerificationNoMatchPolicy": "ignore"
+      }
+    },
+    "startTime": "2024-05-28T14:10:48Z",
+    "steps": [
+      {
+        "container": "step-produce-artifacts",
+        "imageID": "docker.io/library/bash@sha256:23f90212fd89e4c292d7b41386ef1a6ac2b8a02bbc6947680bfe184cbc1a2899",
+        "name": "produce-artifacts",
         "terminated": {
-          "containerID": "containerd://010f02d103d1db48531327a1fe09797c87c1d50b6a216892319b3af93e0f56e7",
+          "containerID": "containerd://1291ce07b175a7897beee6ba62eaa1528427bacb1f76b31435eeba68828c445a",
           "exitCode": 0,
-          "finishedAt": "2024-03-18T17:05:06Z",
+          "finishedAt": "2024-05-28T14:10:57Z",
           "message": "...",
           "reason": "Completed",
-          "startedAt": "2024-03-18T17:05:06Z"
-        },
-        "terminationReason": "Completed"
-      },
-      {
-        "container": "step-artifacts-consumer",
-        "imageID": "docker.io/library/bash@sha256:5353512b79d2963e92a2b97d9cb52df72d32f94661aa825fcfa0aede73304743",
-        "name": "artifacts-consumer",
-        "terminated": {
-          "containerID": "containerd://42428aa7e5a507eba924239f213d185dd4bc0882b6f217a79e6792f7fec3586e",
-          "exitCode": 0,
-          "finishedAt": "2024-03-18T17:05:06Z",
-          "reason": "Completed",
-          "startedAt": "2024-03-18T17:05:06Z"
+          "startedAt": "2024-05-28T14:10:57Z"
         },
         "terminationReason": "Completed"
       }
     ],
-
+    "taskSpec": {
+      "description": "A simple task that produces artifacts\n",
+      "steps": [
+        {
+          "computeResources": {},
+          "image": "bash:latest",
+          "name": "produce-artifacts",
+          "script": "#!/usr/bin/env bash\ncat > /tekton/artifacts/provenance.json << EOF\n{\n  \"inputs\":[\n    {\n      \"name\":\"input-artifacts\",\n      \"values\":[\n        {\n          \"uri\":\"pkg:example.github.com/inputs\",\n          \"digest\":{\n            \"sha256\":\"b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0\"\n          }\n        }\n      ]\n    }\n  ],\n  \"outputs\":[\n    {\n      \"name\":\"image\",\n      \"values\":[\n        {\n          \"uri\":\"pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c\",\n          \"digest\":{\n            \"sha256\":\"df85b9e3983fe2ce20ef76ad675ecf435cc99fc9350adc54fa230bae8c32ce48\",\n            \"sha1\":\"95588b8f34c31eb7d62c92aaa4e6506639b06ef2\"\n          }\n        }\n      ]\n    }\n  ]\n}\nEOF\n"
+        }
+      ]
+    }
+}
 ```

--- a/docs/pipeline-api.md
+++ b/docs/pipeline-api.md
@@ -1428,6 +1428,9 @@ string
 </table>
 <h3 id="tekton.dev/v1.Artifacts">Artifacts
 </h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.TaskRunStatusFields">TaskRunStatusFields</a>)
+</p>
 <div>
 <p>Artifacts represents the collection of input and output artifacts associated with
 a task run or a similar process. Artifacts in this context are units of data or resources
@@ -5898,6 +5901,20 @@ All TaskRunStatus stored in RetriesStatus will have no date within the RetriesSt
 <td>
 <em>(Optional)</em>
 <p>Results are the list of results written out by the task&rsquo;s containers</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>artifacts</code><br/>
+<em>
+<a href="#tekton.dev/v1.Artifacts">
+Artifacts
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Artifacts are the list of artifacts written out by the task&rsquo;s containers</p>
 </td>
 </tr>
 <tr>

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -15,63 +15,66 @@ For instructions on using variable substitutions see the relevant section of [th
 
 ## Variables available in a `Pipeline`
 
-| Variable | Description |
-| -------- | ----------- |
-| `params.<param name>` | The value of the parameter at runtime. |
-| `params['<param name>']` | (see above) |
-| `params["<param name>"]` | (see above) |
-| `params.<param name>[*]` | Get the whole param array or object.|
-| `params['<param name>'][*]` | (see above) |
-| `params["<param name>"][*]` | (see above) |
-| `params.<param name>[i]` | Get the i-th element of param array. This is alpha feature, set `enable-api-fields` to `alpha`  to use it.|
-| `params['<param name>'][i]` | (see above) |
-| `params["<param name>"][i]` | (see above) |
-| `params.<object-param-name>[*]` | Get the value of the whole object param. This is alpha feature, set `enable-api-fields` to `alpha`  to use it.|
-| `params.<object-param-name>.<individual-key-name>` | Get the value of an individual child of an object param. This is alpha feature, set `enable-api-fields` to `alpha`  to use it. |
-| `tasks.<taskName>.matrix.length` | The length of the `Matrix` combination count. |
-| `tasks.<taskName>.results.<resultName>` | The value of the `Task's` result. Can alter `Task` execution order within a `Pipeline`.) |
-| `tasks.<taskName>.results.<resultName>[i]` | The ith value of the `Task's` array result. Can alter `Task` execution order within a `Pipeline`.) |
-| `tasks.<taskName>.results.<resultName>[*]` | The array value of the `Task's` result. Can alter `Task` execution order within a `Pipeline`. Cannot be used in `script`.) |
-| `tasks.<taskName>.results.<resultName>.key` | The `key` value of the `Task's` object result. Can alter `Task` execution order within a `Pipeline`.) |
-| `tasks.<taskName>.matrix.<resultName>.length` | The length of the matrixed `Task's` results. (Can alter `Task` execution order within a `Pipeline`.) |
-| `workspaces.<workspaceName>.bound` | Whether a `Workspace` has been bound or not. "false" if the `Workspace` declaration has `optional: true` and the Workspace binding was omitted by the PipelineRun. |
-| `context.pipelineRun.name` | The name of the `PipelineRun` that this `Pipeline` is running in. |
-| `context.pipelineRun.namespace` | The namespace of the `PipelineRun` that this `Pipeline` is running in. |
-| `context.pipelineRun.uid` | The uid of the `PipelineRun` that this `Pipeline` is running in. |
-| `context.pipeline.name` | The name of this `Pipeline` . |
-| `tasks.<pipelineTaskName>.status` | The execution status of the specified `pipelineTask`, only available in `finally` tasks. The execution status can be set to any one of the values (`Succeeded`, `Failed`, or `None`) described [here](pipelines.md#using-execution-status-of-pipelinetask)|
-| `tasks.status` | An aggregate status of all the `pipelineTasks` under the `tasks` section (excluding the `finally` section). This variable is only available in the `finally` tasks and can have any one of the values (`Succeeded`, `Failed`, `Completed`, or `None`) described [here](pipelines.md#using-aggregate-execution-status-of-all-tasks).  |
-| `context.pipelineTask.retries` | The retries of this `PipelineTask`. |
+| Variable                                           | Description                                                                                                                                                                                                                                                                                                                         |
+|----------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `params.<param name>`                              | The value of the parameter at runtime.                                                                                                                                                                                                                                                                                              |
+| `params['<param name>']`                           | (see above)                                                                                                                                                                                                                                                                                                                         |
+| `params["<param name>"]`                           | (see above)                                                                                                                                                                                                                                                                                                                         |
+| `params.<param name>[*]`                           | Get the whole param array or object.                                                                                                                                                                                                                                                                                                |
+| `params['<param name>'][*]`                        | (see above)                                                                                                                                                                                                                                                                                                                         |
+| `params["<param name>"][*]`                        | (see above)                                                                                                                                                                                                                                                                                                                         |
+| `params.<param name>[i]`                           | Get the i-th element of param array. This is alpha feature, set `enable-api-fields` to `alpha`  to use it.                                                                                                                                                                                                                          |
+| `params['<param name>'][i]`                        | (see above)                                                                                                                                                                                                                                                                                                                         |
+| `params["<param name>"][i]`                        | (see above)                                                                                                                                                                                                                                                                                                                         |
+| `params.<object-param-name>[*]`                    | Get the value of the whole object param. This is alpha feature, set `enable-api-fields` to `alpha`  to use it.                                                                                                                                                                                                                      |
+| `params.<object-param-name>.<individual-key-name>` | Get the value of an individual child of an object param. This is alpha feature, set `enable-api-fields` to `alpha`  to use it.                                                                                                                                                                                                      |
+| `tasks.<taskName>.matrix.length`                   | The length of the `Matrix` combination count.                                                                                                                                                                                                                                                                                       |
+| `tasks.<taskName>.results.<resultName>`            | The value of the `Task's` result. Can alter `Task` execution order within a `Pipeline`.)                                                                                                                                                                                                                                            |
+| `tasks.<taskName>.results.<resultName>[i]`         | The ith value of the `Task's` array result. Can alter `Task` execution order within a `Pipeline`.)                                                                                                                                                                                                                                  |
+| `tasks.<taskName>.results.<resultName>[*]`         | The array value of the `Task's` result. Can alter `Task` execution order within a `Pipeline`. Cannot be used in `script`.)                                                                                                                                                                                                          |
+| `tasks.<taskName>.results.<resultName>.key`        | The `key` value of the `Task's` object result. Can alter `Task` execution order within a `Pipeline`.)                                                                                                                                                                                                                               |
+| `tasks.<taskName>.matrix.<resultName>.length`      | The length of the matrixed `Task's` results. (Can alter `Task` execution order within a `Pipeline`.)                                                                                                                                                                                                                                |
+| `workspaces.<workspaceName>.bound`                 | Whether a `Workspace` has been bound or not. "false" if the `Workspace` declaration has `optional: true` and the Workspace binding was omitted by the PipelineRun.                                                                                                                                                                  |
+| `context.pipelineRun.name`                         | The name of the `PipelineRun` that this `Pipeline` is running in.                                                                                                                                                                                                                                                                   |
+| `context.pipelineRun.namespace`                    | The namespace of the `PipelineRun` that this `Pipeline` is running in.                                                                                                                                                                                                                                                              |
+| `context.pipelineRun.uid`                          | The uid of the `PipelineRun` that this `Pipeline` is running in.                                                                                                                                                                                                                                                                    |
+| `context.pipeline.name`                            | The name of this `Pipeline` .                                                                                                                                                                                                                                                                                                       |
+| `tasks.<pipelineTaskName>.status`                  | The execution status of the specified `pipelineTask`, only available in `finally` tasks. The execution status can be set to any one of the values (`Succeeded`, `Failed`, or `None`) described [here](pipelines.md#using-execution-status-of-pipelinetask)                                                                          |
+| `tasks.status`                                     | An aggregate status of all the `pipelineTasks` under the `tasks` section (excluding the `finally` section). This variable is only available in the `finally` tasks and can have any one of the values (`Succeeded`, `Failed`, `Completed`, or `None`) described [here](pipelines.md#using-aggregate-execution-status-of-all-tasks). |
+| `context.pipelineTask.retries`                     | The retries of this `PipelineTask`.                                                                                                                                                                                                                                                                                                 |
+| `tasks.<taskName>.outputs.<artifactName>`          | The value of a specific output artifact of the `Task`                                                                                                                                                                                                                                                                               |
+| `tasks.<taskName>.inputs.<artifactName>`           | The value of a specific input artifact of the `Task`                                                                                                                                                                                                                                                                                |
 
 ## Variables available in a `Task`
 
-| Variable | Description |
-| -------- | ----------- |
-| `params.<param name>` | The value of the parameter at runtime. |
-| `params['<param name>']` | (see above) |
-| `params["<param name>"]` | (see above) |
-| `params.<param name>[*]` | Get the whole param array or object.|
-| `params['<param name>'][*]` | (see above) |
-| `params["<param name>"][*]` | (see above) |
-| `params.<param name>[i]` | Get the i-th element of param array. This is alpha feature, set `enable-api-fields` to `alpha`  to use it.|
-| `params['<param name>'][i]` | (see above) |
-| `params["<param name>"][i]` | (see above) |
+| Variable                                           | Description                                                                                                                    |
+|----------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
+| `params.<param name>`                              | The value of the parameter at runtime.                                                                                         |
+| `params['<param name>']`                           | (see above)                                                                                                                    |
+| `params["<param name>"]`                           | (see above)                                                                                                                    |
+| `params.<param name>[*]`                           | Get the whole param array or object.                                                                                           |
+| `params['<param name>'][*]`                        | (see above)                                                                                                                    |
+| `params["<param name>"][*]`                        | (see above)                                                                                                                    |
+| `params.<param name>[i]`                           | Get the i-th element of param array. This is alpha feature, set `enable-api-fields` to `alpha`  to use it.                     |
+| `params['<param name>'][i]`                        | (see above)                                                                                                                    |
+| `params["<param name>"][i]`                        | (see above)                                                                                                                    |
 | `params.<object-param-name>.<individual-key-name>` | Get the value of an individual child of an object param. This is alpha feature, set `enable-api-fields` to `alpha`  to use it. |
-| `results.<resultName>.path` | The path to the file where the `Task` writes its results data. |
-| `results['<resultName>'].path` | (see above) |
-| `results["<resultName>"].path` | (see above) |
-| `workspaces.<workspaceName>.path` | The path to the mounted `Workspace`. Empty string if an optional `Workspace` has not been provided by the TaskRun. |
-| `workspaces.<workspaceName>.bound` | Whether a `Workspace` has been bound or not. "false" if an optional`Workspace` has not been provided by the TaskRun. |
-| `workspaces.<workspaceName>.claim` | The name of the `PersistentVolumeClaim` specified as a volume source for the `Workspace`. Empty string for other volume types. |
-| `workspaces.<workspaceName>.volume` | The name of the volume populating the `Workspace`. |
-| `credentials.path` | The path to credentials injected from Secrets with matching annotations. |
-| `context.taskRun.name` | The name of the `TaskRun` that this `Task` is running in. |
-| `context.taskRun.namespace` | The namespace of the `TaskRun` that this `Task` is running in. |
-| `context.taskRun.uid` | The uid of the `TaskRun` that this `Task` is running in. |
-| `context.task.name` | The name of this `Task`. |
-| `context.task.retry-count` | The current retry number of this `Task`. |
-| `steps.step-<stepName>.exitCode.path` | The path to the file where a Step's exit code is stored. |
-| `steps.step-unnamed-<stepIndex>.exitCode.path` | The path to the file where a Step's exit code is stored for a step without any name. |
+| `results.<resultName>.path`                        | The path to the file where the `Task` writes its results data.                                                                 |
+| `results['<resultName>'].path`                     | (see above)                                                                                                                    |
+| `results["<resultName>"].path`                     | (see above)                                                                                                                    |
+| `workspaces.<workspaceName>.path`                  | The path to the mounted `Workspace`. Empty string if an optional `Workspace` has not been provided by the TaskRun.             |
+| `workspaces.<workspaceName>.bound`                 | Whether a `Workspace` has been bound or not. "false" if an optional`Workspace` has not been provided by the TaskRun.           |
+| `workspaces.<workspaceName>.claim`                 | The name of the `PersistentVolumeClaim` specified as a volume source for the `Workspace`. Empty string for other volume types. |
+| `workspaces.<workspaceName>.volume`                | The name of the volume populating the `Workspace`.                                                                             |
+| `credentials.path`                                 | The path to credentials injected from Secrets with matching annotations.                                                       |
+| `context.taskRun.name`                             | The name of the `TaskRun` that this `Task` is running in.                                                                      |
+| `context.taskRun.namespace`                        | The namespace of the `TaskRun` that this `Task` is running in.                                                                 |
+| `context.taskRun.uid`                              | The uid of the `TaskRun` that this `Task` is running in.                                                                       |
+| `context.task.name`                                | The name of this `Task`.                                                                                                       |
+| `context.task.retry-count`                         | The current retry number of this `Task`.                                                                                       |
+| `steps.step-<stepName>.exitCode.path`              | The path to the file where a Step's exit code is stored.                                                                       |
+| `steps.step-unnamed-<stepIndex>.exitCode.path`     | The path to the file where a Step's exit code is stored for a step without any name.                                           |
+| `artifacts.path`                                   | The path to the file where the `Task` writes its artifacts data.                                                               |
 
 ## Fields that accept variable substitutions
 

--- a/examples/v1/pipelineruns/alpha/consume-artifacts-from-task.yaml
+++ b/examples/v1/pipelineruns/alpha/consume-artifacts-from-task.yaml
@@ -1,0 +1,60 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  generateName: pipelinerun-consume-tasks-artifacts
+spec:
+  pipelineSpec:
+    tasks:
+      - name: produce-artifacts-task
+        taskSpec:
+          description: |
+            A simple task that produces artifacts
+          steps:
+            - name: produce-artifacts
+              image: bash:latest
+              script: |
+                #!/usr/bin/env bash
+                cat > $(artifacts.path) << EOF
+                {
+                  "inputs":[
+                    {
+                      "name":"input-artifacts",
+                      "values":[
+                        {
+                          "uri":"pkg:example.github.com/inputs",
+                          "digest":{
+                            "sha256":"b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "outputs":[
+                    {
+                      "name":"image",
+                      "values":[
+                        {
+                          "uri":"pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c",
+                          "digest":{
+                            "sha256":"df85b9e3983fe2ce20ef76ad675ecf435cc99fc9350adc54fa230bae8c32ce48",
+                            "sha1":"95588b8f34c31eb7d62c92aaa4e6506639b06ef2"
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+                EOF
+      - name: consume-artifacts
+        runAfter:
+          - produce-artifacts-task
+        taskSpec:
+          steps:
+            - name: artifacts-consumer-python
+              image: python:latest
+              script: |
+                #!/usr/bin/env python3
+                import json
+                data = json.loads('$(tasks.produce-artifacts-task.outputs.image)')
+                if data[0]['uri'] != "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c":
+                  exit(1)

--- a/examples/v1/taskruns/alpha/task-artifacts.yaml
+++ b/examples/v1/taskruns/alpha/task-artifacts.yaml
@@ -1,16 +1,17 @@
 apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
-  generateName: step-artifacts-
+  generateName: task-run-artifacts
 spec:
   taskSpec:
     description: |
-      A simple task that populates artifacts to TaskRun stepState
+      A simple task that produces artifacts
     steps:
-      - name: artifacts-producer
-        image: docker.io/library/bash:latest
+      - name: produce-artifacts
+        image: bash:latest
         script: |
-          cat > $(step.artifacts.path) << EOF
+          #!/usr/bin/env bash
+          cat > $(artifacts.path) << EOF
           {
             "inputs":[
               {
@@ -41,14 +42,3 @@ spec:
             ]
           }
           EOF
-      - name: artifacts-consumer
-        image: docker.io/library/bash:latest
-        script: |
-          echo $(steps.artifacts-producer.inputs.input-artifacts)
-      - name: artifacts-consumer-python
-        image: docker.io/library/python:latest
-        script: |
-          #!/usr/bin/env python3
-          import json
-          data = json.loads('$(steps.artifacts-producer.outputs.image)')
-          print(data[0]['uri'])

--- a/internal/artifactref/artifactref.go
+++ b/internal/artifactref/artifactref.go
@@ -2,10 +2,17 @@ package artifactref
 
 import "regexp"
 
-// case 1: steps.<step-name>.inputs
-// case 2: steps.<step-name>.outputs
-// case 3: steps.<step-name>.inputs.<artifact-category-name>
-// case 4: steps.<step-name>.outputs.<artifact-category-name>
-const stepArtifactUsagePattern = `\$\(steps\.([^.]+)\.(?:inputs|outputs)(?:\.([^.^\)]+))?\)`
+// case 1: steps.<step-name>.inputs.<artifact-category-name>
+// case 2: steps.<step-name>.outputs.<artifact-category-name>
+const stepArtifactUsagePattern = `\$\(steps\.([^.]+)\.(?:inputs|outputs)\.([^.)]+)\)`
+
+// case 1: tasks.<task-name>.inputs.<artifact-category-name>
+// case 2: tasks.<task-name>.outputs.<artifact-category-name>
+const taskArtifactUsagePattern = `\$\(tasks\.([^.]+)\.(?:inputs|outputs)\.([^.)]+)\)`
+
+const StepArtifactPathPattern = `step.artifacts.path`
+
+const TaskArtifactPathPattern = `artifacts.path`
 
 var StepArtifactRegex = regexp.MustCompile(stepArtifactUsagePattern)
+var TaskArtifactRegex = regexp.MustCompile(taskArtifactUsagePattern)

--- a/internal/sidecarlogresults/sidecarlogresults.go
+++ b/internal/sidecarlogresults/sidecarlogresults.go
@@ -49,6 +49,7 @@ const (
 	stepResultType SidecarLogResultType = "step"
 
 	stepArtifactType           SidecarLogResultType = "stepArtifact"
+	taskArtifactType           SidecarLogResultType = "taskArtifact"
 	sidecarResultNameSeparator string               = "."
 )
 
@@ -285,6 +286,8 @@ func parseResults(resultBytes []byte, maxResultLimit int) (result.RunResult, err
 		resultType = result.StepResultType
 	case stepArtifactType:
 		resultType = result.StepArtifactsResultType
+	case taskArtifactType:
+		resultType = result.TaskRunArtifactsResultType
 	default:
 		return result.RunResult{}, fmt.Errorf("invalid sidecar result type %v. Must be %v or %v or %v", res.Type, taskResultType, stepResultType, stepArtifactType)
 	}

--- a/internal/sidecarlogresults/sidecarlogresults_test.go
+++ b/internal/sidecarlogresults/sidecarlogresults_test.go
@@ -338,6 +338,39 @@ func TestParseResults(t *testing.T) {
           }`,
 			Type: "stepArtifact",
 		},
+		{
+			Name: "task-run-artifacts-result",
+			Value: `{
+            "inputs":[
+              {
+                "name":"input-artifacts",
+                "values":[
+                  {
+                    "uri":"pkg:example.github.com/inputs",
+                    "digest":{
+                      "sha256":"b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"
+                    }
+                  }
+                ]
+              }
+            ],
+            "outputs":[
+              {
+                "name":"image",
+                "values":[
+                  {
+                    "uri":"pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c",
+                    "digest":{
+                      "sha256":"df85b9e3983fe2ce20ef76ad675ecf435cc99fc9350adc54fa230bae8c32ce48",
+                      "sha1":"95588b8f34c31eb7d62c92aaa4e6506639b06ef2"
+                    }
+                  }
+                ]
+              }
+            ]
+          }`,
+			Type: "taskArtifact",
+		},
 	}
 	podLogs := []string{}
 	for _, r := range results {
@@ -400,6 +433,38 @@ func TestParseResults(t *testing.T) {
             ]
           }`,
 		ResultType: result.StepArtifactsResultType,
+	}, {
+		Key: "task-run-artifacts-result",
+		Value: `{
+            "inputs":[
+              {
+                "name":"input-artifacts",
+                "values":[
+                  {
+                    "uri":"pkg:example.github.com/inputs",
+                    "digest":{
+                      "sha256":"b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"
+                    }
+                  }
+                ]
+              }
+            ],
+            "outputs":[
+              {
+                "name":"image",
+                "values":[
+                  {
+                    "uri":"pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c",
+                    "digest":{
+                      "sha256":"df85b9e3983fe2ce20ef76ad675ecf435cc99fc9350adc54fa230bae8c32ce48",
+                      "sha1":"95588b8f34c31eb7d62c92aaa4e6506639b06ef2"
+                    }
+                  }
+                ]
+              }
+            ]
+          }`,
+		ResultType: result.TaskRunArtifactsResultType,
 	}}
 	stepResults := []result.RunResult{}
 	for _, plog := range podLogs {

--- a/pkg/apis/pipeline/paths.go
+++ b/pkg/apis/pipeline/paths.go
@@ -30,4 +30,6 @@ const (
 	StepsDir = "/tekton/steps"
 
 	ScriptDir = "/tekton/scripts"
+
+	ArtifactsDir = "/tekton/artifacts"
 )

--- a/pkg/apis/pipeline/v1/artifact_types.go
+++ b/pkg/apis/pipeline/v1/artifact_types.go
@@ -1,4 +1,24 @@
+/*
+Copyright 2024 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package v1
+
+import (
+	"github.com/google/go-cmp/cmp"
+)
 
 // Algorithm Standard cryptographic hash algorithm
 type Algorithm string
@@ -26,4 +46,73 @@ type TaskRunStepArtifact = Artifact
 type Artifacts struct {
 	Inputs  []Artifact `json:"inputs,omitempty"`
 	Outputs []Artifact `json:"outputs,omitempty"`
+}
+
+func (a *Artifacts) Merge(another Artifacts) {
+	inputMap := make(map[string][]ArtifactValue)
+	var newInputs []Artifact
+
+	for _, v := range a.Inputs {
+		inputMap[v.Name] = v.Values
+	}
+
+	for _, v := range another.Inputs {
+		_, ok := inputMap[v.Name]
+		if !ok {
+			inputMap[v.Name] = []ArtifactValue{}
+		}
+		for _, vv := range v.Values {
+			exists := false
+			for _, av := range inputMap[v.Name] {
+				if cmp.Equal(vv, av) {
+					exists = true
+					break
+				}
+			}
+			if !exists {
+				inputMap[v.Name] = append(inputMap[v.Name], vv)
+			}
+		}
+	}
+
+	for k, v := range inputMap {
+		newInputs = append(newInputs, Artifact{
+			Name:   k,
+			Values: v,
+		})
+	}
+
+	outputMap := make(map[string][]ArtifactValue)
+	var newOutputs []Artifact
+	for _, v := range a.Outputs {
+		outputMap[v.Name] = v.Values
+	}
+
+	for _, v := range another.Outputs {
+		_, ok := outputMap[v.Name]
+		if !ok {
+			outputMap[v.Name] = []ArtifactValue{}
+		}
+		for _, vv := range v.Values {
+			exists := false
+			for _, av := range outputMap[v.Name] {
+				if cmp.Equal(vv, av) {
+					exists = true
+					break
+				}
+			}
+			if !exists {
+				outputMap[v.Name] = append(outputMap[v.Name], vv)
+			}
+		}
+	}
+
+	for k, v := range outputMap {
+		newOutputs = append(newOutputs, Artifact{
+			Name:   k,
+			Values: v,
+		})
+	}
+	a.Inputs = newInputs
+	a.Outputs = newOutputs
 }

--- a/pkg/apis/pipeline/v1/artifact_types_test.go
+++ b/pkg/apis/pipeline/v1/artifact_types_test.go
@@ -1,0 +1,188 @@
+/*
+Copyright 2024 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/tektoncd/pipeline/test/diff"
+)
+
+func TestArtifactsMerge(t *testing.T) {
+	type testCase struct {
+		name     string
+		a1       Artifacts
+		a2       Artifacts
+		expected Artifacts
+	}
+
+	testCases := []testCase{
+		{
+			name: "Merges inputs and outputs with deduplication",
+			a1: Artifacts{
+				Inputs: []Artifact{
+					{
+						Name: "input1",
+						Values: []ArtifactValue{
+							{
+								Digest: map[Algorithm]string{"sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
+								Uri:    "pkg:maven/org.apache.commons/commons-lang3/3.12.0",
+							},
+						},
+					},
+					{
+						Name: "input2",
+						Values: []ArtifactValue{
+							{
+								Digest: map[Algorithm]string{"sha256": "d596377f2d54b3f8b4619f137d08892989893b886742759144582c94157526f1"},
+								Uri:    "pkg:pypi/requests/2.28.2",
+							},
+						},
+					},
+				},
+				Outputs: []Artifact{
+					{
+						Name: "output1",
+						Values: []ArtifactValue{
+							{
+								Digest: map[Algorithm]string{"sha256": "47de7a85905970a45132f48a9247879a15c483477e23a637504694e611135b40e"},
+								Uri:    "pkg:npm/lodash/4.17.21",
+							},
+						},
+					},
+				},
+			},
+			a2: Artifacts{
+				Inputs: []Artifact{
+					{
+						Name: "input1",
+						Values: []ArtifactValue{
+							{
+								Digest: map[Algorithm]string{"sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
+								Uri:    "pkg:maven/org.apache.commons/commons-lang3/3.12.0",
+							},
+							{
+								Digest: map[Algorithm]string{"sha256": "97c13e1812b666824266111701398e56e30d14418a2d9b35987f516a66e2129f"},
+								Uri:    "pkg:nuget/Microsoft.Extensions.Logging/7.0.0",
+							},
+						},
+					},
+					{
+						Name: "input3",
+						Values: []ArtifactValue{
+							{
+								Digest: map[Algorithm]string{"sha256": "13c2b709e3a100726680e53e19666656a89a2f2490e917ba15d6b15475ab7b79"},
+								Uri:    "pkg:debian/openssl/1.1.1",
+							},
+						},
+					},
+				},
+				Outputs: []Artifact{
+					{
+						Name: "output1",
+						Values: []ArtifactValue{
+							{
+								Digest: map[Algorithm]string{"sha256": "698c4539633943f7889f41605003d7fa63833722ebd2b37c7e75df1d3d06941a"},
+								Uri:    "pkg:nuget/Newtonsoft.Json/13.0.3",
+							},
+						},
+					},
+					{
+						Name: "output2",
+						Values: []ArtifactValue{
+							{
+								Digest: map[Algorithm]string{"sha256": "7e406d83706c7193df3e38b66d350e55df6f13d2a28a1d35917a043533a70f5c"},
+								Uri:    "pkg:pypi/pandas/2.0.1",
+							},
+						},
+					},
+				},
+			},
+			expected: Artifacts{
+				Inputs: []Artifact{
+					{
+						Name: "input1",
+						Values: []ArtifactValue{
+							{
+								Digest: map[Algorithm]string{"sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
+								Uri:    "pkg:maven/org.apache.commons/commons-lang3/3.12.0",
+							},
+							{
+								Digest: map[Algorithm]string{"sha256": "97c13e1812b666824266111701398e56e30d14418a2d9b35987f516a66e2129f"},
+								Uri:    "pkg:nuget/Microsoft.Extensions.Logging/7.0.0",
+							},
+						},
+					},
+					{
+						Name: "input2",
+						Values: []ArtifactValue{
+							{
+								Digest: map[Algorithm]string{"sha256": "d596377f2d54b3f8b4619f137d08892989893b886742759144582c94157526f1"},
+								Uri:    "pkg:pypi/requests/2.28.2",
+							},
+						},
+					},
+					{
+						Name: "input3",
+						Values: []ArtifactValue{
+							{
+								Digest: map[Algorithm]string{"sha256": "13c2b709e3a100726680e53e19666656a89a2f2490e917ba15d6b15475ab7b79"},
+								Uri:    "pkg:debian/openssl/1.1.1",
+							},
+						},
+					},
+				},
+				Outputs: []Artifact{
+					{
+						Name: "output1",
+						Values: []ArtifactValue{
+							{
+								Digest: map[Algorithm]string{"sha256": "47de7a85905970a45132f48a9247879a15c483477e23a637504694e611135b40e"},
+								Uri:    "pkg:npm/lodash/4.17.21",
+							},
+							{
+								Digest: map[Algorithm]string{"sha256": "698c4539633943f7889f41605003d7fa63833722ebd2b37c7e75df1d3d06941a"},
+								Uri:    "pkg:nuget/Newtonsoft.Json/13.0.3",
+							},
+						},
+					},
+					{
+						Name: "output2",
+						Values: []ArtifactValue{
+							{
+								Digest: map[Algorithm]string{"sha256": "7e406d83706c7193df3e38b66d350e55df6f13d2a28a1d35917a043533a70f5c"},
+								Uri:    "pkg:pypi/pandas/2.0.1",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.a1.Merge(tc.a2)
+			got := tc.a1
+			if d := cmp.Diff(tc.expected, got, cmpopts.SortSlices(func(a, b Artifact) bool { return a.Name > b.Name })); d != "" {
+				t.Errorf("TestArtifactsMerge() did not produce expected artifacts for test %s: %s", tc.name, diff.PrintWantGot(d))
+			}
+		})
+	}
+}

--- a/pkg/apis/pipeline/v1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1/openapi_generated.go
@@ -4186,6 +4186,18 @@ func schema_pkg_apis_pipeline_v1_TaskRunStatus(ref common.ReferenceCallback) com
 							},
 						},
 					},
+					"artifacts": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
+						SchemaProps: spec.SchemaProps{
+							Description: "Artifacts are the list of artifacts written out by the task's containers",
+							Default:     map[string]interface{}{},
+							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Artifacts"),
+						},
+					},
 					"sidecars": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
@@ -4238,7 +4250,7 @@ func schema_pkg_apis_pipeline_v1_TaskRunStatus(ref common.ReferenceCallback) com
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Provenance", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.SidecarState", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.StepState", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskRunResult", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskRunStatus", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskSpec", "k8s.io/apimachinery/pkg/apis/meta/v1.Time", "knative.dev/pkg/apis.Condition"},
+			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Artifacts", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Provenance", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.SidecarState", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.StepState", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskRunResult", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskRunStatus", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskSpec", "k8s.io/apimachinery/pkg/apis/meta/v1.Time", "knative.dev/pkg/apis.Condition"},
 	}
 }
 
@@ -4326,6 +4338,18 @@ func schema_pkg_apis_pipeline_v1_TaskRunStatusFields(ref common.ReferenceCallbac
 							},
 						},
 					},
+					"artifacts": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
+						SchemaProps: spec.SchemaProps{
+							Description: "Artifacts are the list of artifacts written out by the task's containers",
+							Default:     map[string]interface{}{},
+							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Artifacts"),
+						},
+					},
 					"sidecars": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
@@ -4378,7 +4402,7 @@ func schema_pkg_apis_pipeline_v1_TaskRunStatusFields(ref common.ReferenceCallbac
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Provenance", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.SidecarState", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.StepState", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskRunResult", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskRunStatus", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskSpec", "k8s.io/apimachinery/pkg/apis/meta/v1.Time"},
+			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Artifacts", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Provenance", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.SidecarState", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.StepState", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskRunResult", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskRunStatus", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskSpec", "k8s.io/apimachinery/pkg/apis/meta/v1.Time"},
 	}
 }
 

--- a/pkg/apis/pipeline/v1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1/pipeline_validation.go
@@ -22,6 +22,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/tektoncd/pipeline/internal/artifactref"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/validate"
 	"github.com/tektoncd/pipeline/pkg/internal/resultref"
@@ -89,6 +90,7 @@ func (ps *PipelineSpec) Validate(ctx context.Context) (errs *apis.FieldError) {
 	errs = errs.Also(validateTasksAndFinallySection(ps))
 	errs = errs.Also(validateFinalTasks(ps.Tasks, ps.Finally))
 	errs = errs.Also(validateWhenExpressions(ctx, ps.Tasks, ps.Finally))
+	errs = errs.Also(validateArtifactReference(ctx, ps.Tasks, ps.Finally))
 	errs = errs.Also(validateMatrix(ctx, ps.Tasks).ViaField("tasks"))
 	errs = errs.Also(validateMatrix(ctx, ps.Finally).ViaField("finally"))
 	return errs
@@ -880,6 +882,28 @@ func validateStringResults(results []TaskResult, resultName string) (errs *apis.
 					fmt.Sprintf("Matrixed PipelineTasks emitting results must have an underlying type string, but result %s has type %s in pipelineTask", resultName, string(result.Type)),
 					"",
 				))
+			}
+		}
+	}
+	return errs
+}
+
+// validateArtifactReference ensure that the feature flag enableArtifacts is set to true when using artifacts
+func validateArtifactReference(ctx context.Context, tasks []PipelineTask, finalTasks []PipelineTask) (errs *apis.FieldError) {
+	if config.FromContextOrDefaults(ctx).FeatureFlags.EnableArtifacts {
+		return errs
+	}
+	for i, t := range tasks {
+		for _, v := range t.Params.extractValues() {
+			if len(artifactref.TaskArtifactRegex.FindAllStringSubmatch(v, -1)) > 0 {
+				return errs.Also(apis.ErrGeneric(fmt.Sprintf("feature flag %s should be set to true to use artifacts feature.", config.EnableArtifacts), "").ViaField("params").ViaFieldIndex("tasks", i))
+			}
+		}
+	}
+	for i, t := range finalTasks {
+		for _, v := range t.Params.extractValues() {
+			if len(artifactref.TaskArtifactRegex.FindAllStringSubmatch(v, -1)) > 0 {
+				return errs.Also(apis.ErrGeneric(fmt.Sprintf("feature flag %s should be set to true to use artifacts feature.", config.EnableArtifacts), "").ViaField("params").ViaFieldIndex("finally", i))
 			}
 		}
 	}

--- a/pkg/apis/pipeline/v1/swagger.json
+++ b/pkg/apis/pipeline/v1/swagger.json
@@ -2111,6 +2111,12 @@
             "default": ""
           }
         },
+        "artifacts": {
+          "description": "Artifacts are the list of artifacts written out by the task's containers",
+          "default": {},
+          "$ref": "#/definitions/v1.Artifacts",
+          "x-kubernetes-list-type": "atomic"
+        },
         "completionTime": {
           "description": "CompletionTime is the time the build completed.",
           "$ref": "#/definitions/v1.Time"
@@ -2200,6 +2206,12 @@
         "podName"
       ],
       "properties": {
+        "artifacts": {
+          "description": "Artifacts are the list of artifacts written out by the task's containers",
+          "default": {},
+          "$ref": "#/definitions/v1.Artifacts",
+          "x-kubernetes-list-type": "atomic"
+        },
         "completionTime": {
           "description": "CompletionTime is the time the build completed.",
           "$ref": "#/definitions/v1.Time"

--- a/pkg/apis/pipeline/v1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1/task_validation_test.go
@@ -1787,7 +1787,7 @@ func TestTaskSpecValidateSuccessWithArtifactsRefFlagEnabled(t *testing.T) {
 			name: "reference step artifacts in Env",
 			Steps: []v1.Step{{
 				Image: "busybox",
-				Env:   []corev1.EnvVar{{Name: "AAA", Value: "$(steps.aaa.outputs)"}},
+				Env:   []corev1.EnvVar{{Name: "AAA", Value: "$(steps.aaa.outputs.image)"}},
 			}},
 		},
 		{
@@ -1869,7 +1869,7 @@ func TestTaskSpecValidateErrorWithArtifactsRefFlagNotEnabled(t *testing.T) {
 		{
 			name: "Cannot reference step artifacts in Env without setting enable-artifacts to true",
 			Steps: []v1.Step{{
-				Env: []corev1.EnvVar{{Name: "AAA", Value: "$(steps.aaa.outputs)"}},
+				Env: []corev1.EnvVar{{Name: "AAA", Value: "$(steps.aaa.outputs.image)"}},
 			}},
 			expectedError: apis.FieldError{
 				Message: fmt.Sprintf("feature flag %s should be set to true to use artifacts feature.", config.EnableArtifacts),

--- a/pkg/apis/pipeline/v1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1/taskrun_types.go
@@ -279,6 +279,11 @@ type TaskRunStatusFields struct {
 	// +listType=atomic
 	Results []TaskRunResult `json:"results,omitempty"`
 
+	// Artifacts are the list of artifacts written out by the task's containers
+	// +optional
+	// +listType=atomic
+	Artifacts Artifacts `json:"artifacts,omitempty"`
+
 	// The list has one entry per sidecar in the manifest. Each entry is
 	// represents the imageid of the corresponding sidecar.
 	// +listType=atomic

--- a/pkg/apis/pipeline/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/pipeline/v1/zz_generated.deepcopy.go
@@ -1924,6 +1924,7 @@ func (in *TaskRunStatusFields) DeepCopyInto(out *TaskRunStatusFields) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	in.Artifacts.DeepCopyInto(&out.Artifacts)
 	if in.Sidecars != nil {
 		in, out := &in.Sidecars, &out.Sidecars
 		*out = make([]SidecarState, len(*in))

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
@@ -175,6 +175,31 @@ func TestPipeline_Validate_Success(t *testing.T) {
 				}},
 			},
 		},
+	}, {
+		name: "valid pipeline with pipeline task and final task referencing artifacts in task params with enable-artifacts flag true",
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Description: "this is an invalid pipeline referencing artifacts with enable-artifacts flag true",
+				Tasks: []PipelineTask{{
+					Name:    "pre-task",
+					TaskRef: &TaskRef{Name: "foo-task"},
+				}, {
+					Name: "consume-artifacts-task",
+					Params: Params{{Name: "aaa", Value: ParamValue{
+						Type:      ParamTypeString,
+						StringVal: "$(tasks.produce-artifacts-task.outputs.image)",
+					}}},
+					TaskSpec: &EmbeddedTask{TaskSpec: getTaskSpec()},
+				}},
+			},
+		},
+		wc: func(ctx context.Context) context.Context {
+			return cfgtesting.SetFeatureFlags(ctx, t,
+				map[string]string{
+					"enable-artifacts":  "true",
+					"enable-api-fields": "alpha"})
+		},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1198,6 +1223,59 @@ func TestPipelineSpec_Validate_Failure(t *testing.T) {
 		expectedError: apis.FieldError{
 			Message: `must not set the field(s)`,
 			Paths:   []string{"finally[0].taskSpec.resources"},
+		},
+	}, {
+		name: "invalid pipeline with one pipeline task referencing artifacts in task params with enable-artifacts flag false",
+		ps: &PipelineSpec{
+			Description: "this is an invalid pipeline referencing artifacts with enable-artifacts flag false",
+			Tasks: []PipelineTask{{
+				Name:    "pre-task",
+				TaskRef: &TaskRef{Name: "foo-task"},
+			}, {
+				Name: "consume-artifacts-task",
+				Params: Params{{Name: "aaa", Value: ParamValue{
+					Type:      ParamTypeString,
+					StringVal: "$(tasks.produce-artifacts-task.outputs.image)",
+				}}},
+				TaskSpec: &EmbeddedTask{TaskSpec: getTaskSpec()},
+			}},
+		},
+		expectedError: apis.FieldError{
+			Message: `feature flag enable-artifacts should be set to true to use artifacts feature.`,
+			Paths:   []string{"tasks[1].params"},
+		},
+		wc: func(ctx context.Context) context.Context {
+			return cfgtesting.SetFeatureFlags(ctx, t,
+				map[string]string{
+					"enable-artifacts":  "false",
+					"enable-api-fields": "alpha"})
+		},
+	}, {
+		name: "invalid pipeline with one final pipeline task referencing artifacts in params with enable-artifacts flag false",
+		ps: &PipelineSpec{
+			Description: "this is an invalid pipeline referencing artifacts with enable-artifacts flag false",
+			Tasks: []PipelineTask{{
+				Name:    "pre-task",
+				TaskRef: &TaskRef{Name: "foo-task"},
+			}},
+			Finally: []PipelineTask{{
+				Name: "consume-artifacts-task",
+				Params: Params{{Name: "aaa", Value: ParamValue{
+					Type:      ParamTypeString,
+					StringVal: "$(tasks.produce-artifacts-task.outputs.image)",
+				}}},
+				TaskSpec: &EmbeddedTask{TaskSpec: getTaskSpec()},
+			}},
+		},
+		wc: func(ctx context.Context) context.Context {
+			return cfgtesting.SetFeatureFlags(ctx, t,
+				map[string]string{
+					"enable-artifacts":  "false",
+					"enable-api-fields": "alpha"})
+		},
+		expectedError: apis.FieldError{
+			Message: `feature flag enable-artifacts should be set to true to use artifacts feature.`,
+			Paths:   []string{"finally[0].params"},
 		},
 	}}
 	for _, tt := range tests {

--- a/pkg/apis/pipeline/v1beta1/task_validation.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation.go
@@ -304,7 +304,11 @@ func errorIfStepResultReferenceinField(value, fieldName string) (errs *apis.Fiel
 }
 
 func stepArtifactReferenceExists(src string) bool {
-	return len(artifactref.StepArtifactRegex.FindAllStringSubmatch(src, -1)) > 0 || strings.Contains(src, "$(step.artifacts.path)")
+	return len(artifactref.StepArtifactRegex.FindAllStringSubmatch(src, -1)) > 0 || strings.Contains(src, "$("+artifactref.StepArtifactPathPattern+")")
+}
+
+func taskArtifactReferenceExists(src string) bool {
+	return len(artifactref.TaskArtifactRegex.FindAllStringSubmatch(src, -1)) > 0 || strings.Contains(src, "$("+artifactref.TaskArtifactPathPattern+")")
 }
 
 func errorIfStepArtifactReferencedInField(value, fieldName string) (errs *apis.FieldError) {
@@ -371,7 +375,7 @@ func validateStepResultReference(s Step) (errs *apis.FieldError) {
 }
 
 func validateStep(ctx context.Context, s Step, names sets.String) (errs *apis.FieldError) {
-	if err := validateStepArtifactsReferences(ctx, s); err != nil {
+	if err := validateArtifactsReferencesInStep(ctx, s); err != nil {
 		return err
 	}
 
@@ -528,7 +532,7 @@ func validateStep(ctx context.Context, s Step, names sets.String) (errs *apis.Fi
 	return errs
 }
 
-func validateStepArtifactsReferences(ctx context.Context, s Step) *apis.FieldError {
+func validateArtifactsReferencesInStep(ctx context.Context, s Step) *apis.FieldError {
 	if !config.FromContextOrDefaults(ctx).FeatureFlags.EnableArtifacts {
 		var t []string
 		t = append(t, s.Script)
@@ -537,7 +541,7 @@ func validateStepArtifactsReferences(ctx context.Context, s Step) *apis.FieldErr
 		for _, e := range s.Env {
 			t = append(t, e.Value)
 		}
-		if slices.ContainsFunc(t, stepArtifactReferenceExists) {
+		if slices.ContainsFunc(t, stepArtifactReferenceExists) || slices.ContainsFunc(t, taskArtifactReferenceExists) {
 			return apis.ErrGeneric(fmt.Sprintf("feature flag %s should be set to true to use artifacts feature.", config.EnableArtifacts), "")
 		}
 	}

--- a/pkg/apis/pipeline/v1beta1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation_test.go
@@ -2623,7 +2623,7 @@ func TestTaskSpecValidateSuccessWithArtifactsRefFlagEnabled(t *testing.T) {
 			name: "reference step artifacts in Env",
 			Steps: []v1beta1.Step{{
 				Image: "busybox",
-				Env:   []corev1.EnvVar{{Name: "AAA", Value: "$(steps.aaa.outputs)"}},
+				Env:   []corev1.EnvVar{{Name: "AAA", Value: "$(steps.aaa.outputs.image)"}},
 			}},
 		},
 		{
@@ -2705,7 +2705,7 @@ func TestTaskSpecValidateErrorWithArtifactsRefFlagNotEnabled(t *testing.T) {
 		{
 			name: "Cannot reference step artifacts in Env without setting enable-artifacts to true",
 			Steps: []v1beta1.Step{{
-				Env: []corev1.EnvVar{{Name: "AAA", Value: "$(steps.aaa.outputs)"}},
+				Env: []corev1.EnvVar{{Name: "AAA", Value: "$(steps.aaa.outputs.image)"}},
 			}},
 			expectedError: apis.FieldError{
 				Message: fmt.Sprintf("feature flag %s should be set to true to use artifacts feature.", config.EnableArtifacts),

--- a/pkg/pod/status_test.go
+++ b/pkg/pod/status_test.go
@@ -559,6 +559,31 @@ func TestMakeTaskRunStatus_StepArtifacts(t *testing.T) {
 						},
 						Results: []v1.TaskRunResult{},
 					}},
+					Artifacts: v1.Artifacts{
+						Inputs: []v1.Artifact{
+							{
+								Name: "input-artifacts",
+								Values: []v1.ArtifactValue{{
+									Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"},
+									Uri:    "git:jjjsss",
+								},
+								},
+							},
+						},
+						Outputs: []v1.Artifact{
+							{
+								Name: "build-results",
+								Values: []v1.ArtifactValue{{
+									Digest: map[v1.Algorithm]string{
+										"sha1":   "95588b8f34c31eb7d62c92aaa4e6506639b06ef2",
+										"sha256": "df85b9e3983fe2ce20ef76ad675ecf435cc99fc9350adc54fa230bae8c32ce48",
+									},
+									Uri: "pkg:balba",
+								},
+								},
+							},
+						},
+					},
 					Sidecars: []v1.SidecarState{},
 					// We don't actually care about the time, just that it's not nil
 					CompletionTime: &metav1.Time{Time: time.Now()},

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -894,6 +894,13 @@ func (c *Reconciler) runNextSchedulableTask(ctx context.Context, pr *v1.Pipeline
 		// propagate previous task results
 		resources.PropagateResults(rpt, pipelineRunFacts.State)
 
+		// propagate previous task artifacts
+		err = resources.PropagateArtifacts(rpt, pipelineRunFacts.State)
+		if err != nil {
+			logger.Errorf("Failed to propagate artifacts due to error: %v", err)
+			return controller.NewPermanentError(err)
+		}
+
 		// Validate parameter types in matrix after apply substitutions from Task Results
 		if rpt.PipelineTask.IsMatrixed() {
 			if err := resources.ValidateParameterTypesInMatrix(pipelineRunFacts.State); err != nil {

--- a/pkg/reconciler/pipelinerun/resources/apply_test.go
+++ b/pkg/reconciler/pipelinerun/resources/apply_test.go
@@ -4750,6 +4750,162 @@ func TestPropagateResults(t *testing.T) {
 	}
 }
 
+func TestPropagateArtifacts(t *testing.T) {
+	for _, tt := range []struct {
+		name                 string
+		resolvedTask         *resources.ResolvedPipelineTask
+		runStates            resources.PipelineRunState
+		expectedResolvedTask *resources.ResolvedPipelineTask
+		wantErr              bool
+	}{
+		{
+			name: "not propagate artifact when resolved task is nil",
+			resolvedTask: &resources.ResolvedPipelineTask{
+				ResolvedTask: nil,
+			},
+			runStates: resources.PipelineRunState{},
+			expectedResolvedTask: &resources.ResolvedPipelineTask{
+				ResolvedTask: nil,
+			},
+		}, {
+			name: "not propagate artifact when taskSpec is nil",
+			resolvedTask: &resources.ResolvedPipelineTask{
+				ResolvedTask: &taskresources.ResolvedTask{
+					TaskSpec: nil,
+				},
+			},
+			runStates: resources.PipelineRunState{},
+			expectedResolvedTask: &resources.ResolvedPipelineTask{
+				ResolvedTask: &taskresources.ResolvedTask{
+					TaskSpec: nil,
+				},
+			},
+		},
+		{
+			name: "propagate artifacts inputs",
+			resolvedTask: &resources.ResolvedPipelineTask{
+				ResolvedTask: &taskresources.ResolvedTask{
+					TaskSpec: &v1.TaskSpec{
+						Steps: []v1.Step{
+							{
+								Name:    "get-artifacts-inputs-from-pt1",
+								Command: []string{"$(tasks.pt1.inputs.source)"},
+								Args:    []string{"$(tasks.pt1.inputs.source)"},
+							},
+						},
+					},
+				},
+			},
+			runStates: resources.PipelineRunState{
+				{
+					PipelineTask: &v1.PipelineTask{
+						Name: "pt1",
+					},
+					TaskRuns: []*v1.TaskRun{
+						{
+							Status: v1.TaskRunStatus{
+								Status: duckv1.Status{
+									Conditions: duckv1.Conditions{
+										{
+											Type:   apis.ConditionSucceeded,
+											Status: corev1.ConditionTrue,
+										},
+									},
+								},
+								TaskRunStatusFields: v1.TaskRunStatusFields{
+									Artifacts: v1.Artifacts{
+										Inputs:  []v1.Artifact{{Name: "source", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}},
+										Outputs: nil,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedResolvedTask: &resources.ResolvedPipelineTask{
+				ResolvedTask: &taskresources.ResolvedTask{
+					TaskSpec: &v1.TaskSpec{
+						Steps: []v1.Step{
+							{
+								Name:    "get-artifacts-inputs-from-pt1",
+								Command: []string{`[{"digest":{"sha256":"b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"},"uri":"pkg:example.github.com/inputs"}]`},
+								Args:    []string{`[{"digest":{"sha256":"b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"},"uri":"pkg:example.github.com/inputs"}]`},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "propagate artifacts outputs",
+			resolvedTask: &resources.ResolvedPipelineTask{
+				ResolvedTask: &taskresources.ResolvedTask{
+					TaskSpec: &v1.TaskSpec{
+						Steps: []v1.Step{
+							{
+								Name:    "get-artifacts-outputs-from-pt1",
+								Command: []string{"$(tasks.pt1.outputs.image)"},
+								Args:    []string{"$(tasks.pt1.outputs.image)"},
+							},
+						},
+					},
+				},
+			},
+			runStates: resources.PipelineRunState{
+				{
+					PipelineTask: &v1.PipelineTask{
+						Name: "pt1",
+					},
+					TaskRuns: []*v1.TaskRun{
+						{
+							Status: v1.TaskRunStatus{
+								Status: duckv1.Status{
+									Conditions: duckv1.Conditions{
+										{
+											Type:   apis.ConditionSucceeded,
+											Status: corev1.ConditionTrue,
+										},
+									},
+								},
+								TaskRunStatusFields: v1.TaskRunStatusFields{
+									Artifacts: v1.Artifacts{
+										Inputs:  []v1.Artifact{{Name: "source", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}},
+										Outputs: []v1.Artifact{{Name: "image", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedResolvedTask: &resources.ResolvedPipelineTask{
+				ResolvedTask: &taskresources.ResolvedTask{
+					TaskSpec: &v1.TaskSpec{
+						Steps: []v1.Step{
+							{
+								Name:    "get-artifacts-outputs-from-pt1",
+								Command: []string{`[{"digest":{"sha1":"95588b8f34c31eb7d62c92aaa4e6506639b06ef2"},"uri":"pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}]`},
+								Args:    []string{`[{"digest":{"sha1":"95588b8f34c31eb7d62c92aaa4e6506639b06ef2"},"uri":"pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}]`},
+							},
+						},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			err := resources.PropagateArtifacts(tt.resolvedTask, tt.runStates)
+			if tt.wantErr != (err != nil) {
+				t.Fatalf("Failed to check err want %t, got %v", tt.wantErr, err)
+			}
+			if d := cmp.Diff(tt.expectedResolvedTask, tt.resolvedTask); d != "" {
+				t.Fatalf("TestPropagateArtifacts() %s", diff.PrintWantGot(d))
+			}
+		})
+	}
+}
+
 func TestApplyParametersToWorkspaceBindings(t *testing.T) {
 	testCases := []struct {
 		name       string

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
@@ -3146,6 +3146,300 @@ func TestPipelineRunState_GetResultsFuncs(t *testing.T) {
 	}
 }
 
+func TestPipelineRunState_GetTaskRunsArtifacts(t *testing.T) {
+	testCases := []struct {
+		name              string
+		state             PipelineRunState
+		expectedArtifacts map[string]v1.Artifacts
+	}{
+		{
+			name: "successful-task-with-artifacts",
+			state: PipelineRunState{{
+				TaskRunNames: []string{"successful-task-with-artifacts"},
+				PipelineTask: &v1.PipelineTask{
+					Name: "successful-task-with-artifacts-1",
+				},
+				TaskRuns: []*v1.TaskRun{{
+					Status: v1.TaskRunStatus{
+						Status: duckv1.Status{Conditions: []apis.Condition{{
+							Type:   apis.ConditionSucceeded,
+							Status: corev1.ConditionTrue,
+						}}},
+						TaskRunStatusFields: v1.TaskRunStatusFields{
+							Artifacts: v1.Artifacts{
+								Inputs:  []v1.Artifact{{Name: "source", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}},
+								Outputs: []v1.Artifact{{Name: "image", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}},
+							},
+						}},
+				}},
+			}},
+			expectedArtifacts: map[string]v1.Artifacts{"successful-task-with-artifacts-1": {
+				Inputs:  []v1.Artifact{{Name: "source", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}},
+				Outputs: []v1.Artifact{{Name: "image", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}},
+			}},
+		},
+		{
+			name: "two-successful-tasks-with-artifacts",
+			state: PipelineRunState{{
+				TaskRunNames: []string{"first-successful-task-with-artifacts"},
+				PipelineTask: &v1.PipelineTask{
+					Name: "successful-task-with-artifacts-1",
+				},
+				TaskRuns: []*v1.TaskRun{{
+					Status: v1.TaskRunStatus{
+						Status: duckv1.Status{Conditions: []apis.Condition{{
+							Type:   apis.ConditionSucceeded,
+							Status: corev1.ConditionTrue,
+						}}},
+						TaskRunStatusFields: v1.TaskRunStatusFields{
+							Artifacts: v1.Artifacts{
+								Inputs:  []v1.Artifact{{Name: "source", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}},
+								Outputs: []v1.Artifact{{Name: "image", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}},
+							},
+						}},
+				}},
+			}, {
+				TaskRunNames: []string{"second-successful-task-with-artifacts"},
+				PipelineTask: &v1.PipelineTask{
+					Name: "successful-task-with-artifacts-2",
+				},
+				TaskRuns: []*v1.TaskRun{{
+					Status: v1.TaskRunStatus{
+						Status: duckv1.Status{Conditions: []apis.Condition{{
+							Type:   apis.ConditionSucceeded,
+							Status: corev1.ConditionTrue,
+						}}},
+						TaskRunStatusFields: v1.TaskRunStatusFields{
+							Artifacts: v1.Artifacts{
+								Inputs:  []v1.Artifact{{Name: "source2", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}},
+								Outputs: []v1.Artifact{{Name: "image2", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}},
+							},
+						}},
+				}},
+			}},
+			expectedArtifacts: map[string]v1.Artifacts{"successful-task-with-artifacts-1": {
+				Inputs:  []v1.Artifact{{Name: "source", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}},
+				Outputs: []v1.Artifact{{Name: "image", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}},
+			}, "successful-task-with-artifacts-2": {
+				Inputs:  []v1.Artifact{{Name: "source2", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}},
+				Outputs: []v1.Artifact{{Name: "image2", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}},
+			}},
+		},
+		{
+			name: "Skip retrieving artifacts from unsuccessful task",
+			state: PipelineRunState{{
+				TaskRunNames: []string{"unsuccessful-task-with-artifacts"},
+				PipelineTask: &v1.PipelineTask{
+					Name: "unsuccessful-task-with-artifacts-1",
+				},
+				TaskRuns: []*v1.TaskRun{{
+					Status: v1.TaskRunStatus{
+						Status: duckv1.Status{Conditions: []apis.Condition{{
+							Type:   apis.ConditionSucceeded,
+							Status: corev1.ConditionFalse,
+						}}},
+						TaskRunStatusFields: v1.TaskRunStatusFields{
+							Artifacts: v1.Artifacts{
+								Inputs:  []v1.Artifact{{Name: "source", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}},
+								Outputs: []v1.Artifact{{Name: "image", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}},
+							},
+						}},
+				}},
+			}},
+			expectedArtifacts: map[string]v1.Artifacts{},
+		},
+		{
+			name: "One successful task and one failed task, only retrieving artifacts from the successful one",
+			state: PipelineRunState{
+				{
+					TaskRunNames: []string{"successful-task-with-artifacts"},
+					PipelineTask: &v1.PipelineTask{
+						Name: "successful-task-with-artifacts-1",
+					},
+					TaskRuns: []*v1.TaskRun{{
+						Status: v1.TaskRunStatus{
+							Status: duckv1.Status{Conditions: []apis.Condition{{
+								Type:   apis.ConditionSucceeded,
+								Status: corev1.ConditionTrue,
+							}}},
+							TaskRunStatusFields: v1.TaskRunStatusFields{
+								Artifacts: v1.Artifacts{
+									Inputs:  []v1.Artifact{{Name: "source", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}},
+									Outputs: []v1.Artifact{{Name: "image", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}},
+								},
+							}},
+					}},
+				},
+				{
+					TaskRunNames: []string{"unsuccessful-task-with-artifacts"},
+					PipelineTask: &v1.PipelineTask{
+						Name: "unsuccessful-task-with-artifacts-1",
+					},
+					TaskRuns: []*v1.TaskRun{{
+						Status: v1.TaskRunStatus{
+							Status: duckv1.Status{Conditions: []apis.Condition{{
+								Type:   apis.ConditionSucceeded,
+								Status: corev1.ConditionFalse,
+							}}},
+							TaskRunStatusFields: v1.TaskRunStatusFields{
+								Artifacts: v1.Artifacts{
+									Inputs:  []v1.Artifact{{Name: "source0", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}},
+									Outputs: []v1.Artifact{{Name: "image0", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}},
+								},
+							}},
+					}},
+				}},
+			expectedArtifacts: map[string]v1.Artifacts{"successful-task-with-artifacts-1": {
+				Inputs:  []v1.Artifact{{Name: "source", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}},
+				Outputs: []v1.Artifact{{Name: "image", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}},
+			}},
+		},
+		{
+			name: "One standard successful taskRun with artifacts and one custom task, custom task has no effect",
+			state: PipelineRunState{{
+				CustomRunNames: []string{"successful-run-without-results"},
+				CustomTask:     true,
+				PipelineTask: &v1.PipelineTask{
+					Name: "successful-run-without-results-1",
+				},
+				CustomRuns: []*v1beta1.CustomRun{
+					{
+						Status: v1beta1.CustomRunStatus{
+							Status: duckv1.Status{Conditions: []apis.Condition{{
+								Type:   apis.ConditionSucceeded,
+								Status: corev1.ConditionTrue,
+							}}},
+							CustomRunStatusFields: v1beta1.CustomRunStatusFields{},
+						},
+					}},
+			},
+				{
+					TaskRunNames: []string{"successful-task-with-artifacts"},
+					PipelineTask: &v1.PipelineTask{
+						Name: "successful-task-with-artifacts-1",
+					},
+					TaskRuns: []*v1.TaskRun{{
+						Status: v1.TaskRunStatus{
+							Status: duckv1.Status{Conditions: []apis.Condition{{
+								Type:   apis.ConditionSucceeded,
+								Status: corev1.ConditionTrue,
+							}}},
+							TaskRunStatusFields: v1.TaskRunStatusFields{
+								Artifacts: v1.Artifacts{
+									Inputs:  []v1.Artifact{{Name: "source", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}},
+									Outputs: []v1.Artifact{{Name: "image", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}},
+								},
+							}},
+					}},
+				},
+			},
+			expectedArtifacts: map[string]v1.Artifacts{"successful-task-with-artifacts-1": {
+				Inputs:  []v1.Artifact{{Name: "source", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}},
+				Outputs: []v1.Artifact{{Name: "image", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}},
+			}},
+		},
+		{
+			name: "matrixed tasks",
+			state: PipelineRunState{{
+				TaskRunNames: []string{
+					"matrixed-task-run-0",
+					"matrixed-task-run-1",
+					"matrixed-task-run-2",
+					"matrixed-task-run-3",
+				},
+				PipelineTask: &v1.PipelineTask{
+					Name: "matrixed-task-with-artifacts",
+					TaskRef: &v1.TaskRef{
+						Name:       "task",
+						Kind:       "Task",
+						APIVersion: "v1",
+					},
+					Matrix: &v1.Matrix{
+						Params: v1.Params{{
+							Name:  "foobar",
+							Value: v1.ParamValue{Type: v1.ParamTypeArray, ArrayVal: []string{"foo", "bar"}},
+						}, {
+							Name:  "quxbaz",
+							Value: v1.ParamValue{Type: v1.ParamTypeArray, ArrayVal: []string{"qux", "baz"}},
+						}}},
+				},
+				TaskRuns: []*v1.TaskRun{{
+					TypeMeta:   metav1.TypeMeta{APIVersion: "tekton.dev/v1"},
+					ObjectMeta: metav1.ObjectMeta{Name: "matrixed-task-run-0"},
+					Status: v1.TaskRunStatus{
+						Status: duckv1.Status{Conditions: []apis.Condition{{
+							Type:   apis.ConditionSucceeded,
+							Status: corev1.ConditionTrue,
+							Reason: v1.TaskRunReasonSuccessful.String(),
+						}}},
+						TaskRunStatusFields: v1.TaskRunStatusFields{
+							Artifacts: v1.Artifacts{
+								Inputs:  []v1.Artifact{{Name: "source1", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}},
+								Outputs: []v1.Artifact{{Name: "image1", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}},
+							},
+						}},
+				}, {
+					TypeMeta:   metav1.TypeMeta{APIVersion: "tekton.dev/v1"},
+					ObjectMeta: metav1.ObjectMeta{Name: "matrixed-task-run-1"},
+					Status: v1.TaskRunStatus{
+						Status: duckv1.Status{Conditions: []apis.Condition{{
+							Type:   apis.ConditionSucceeded,
+							Status: corev1.ConditionTrue,
+							Reason: v1.TaskRunReasonSuccessful.String(),
+						}}},
+						TaskRunStatusFields: v1.TaskRunStatusFields{
+							Artifacts: v1.Artifacts{
+								Inputs:  []v1.Artifact{{Name: "source2", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}},
+								Outputs: []v1.Artifact{{Name: "image2", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}},
+							},
+						}},
+				}, {
+					TypeMeta:   metav1.TypeMeta{APIVersion: "tekton.dev/v1"},
+					ObjectMeta: metav1.ObjectMeta{Name: "matrixed-task-run-2"},
+					Status: v1.TaskRunStatus{
+						Status: duckv1.Status{Conditions: []apis.Condition{{
+							Type:   apis.ConditionSucceeded,
+							Status: corev1.ConditionTrue,
+							Reason: v1.TaskRunReasonSuccessful.String(),
+						}}},
+						TaskRunStatusFields: v1.TaskRunStatusFields{
+							Artifacts: v1.Artifacts{
+								Inputs:  []v1.Artifact{{Name: "source3", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}},
+								Outputs: []v1.Artifact{{Name: "image3", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}},
+							},
+						}},
+				}, {
+					TypeMeta:   metav1.TypeMeta{APIVersion: "tekton.dev/v1"},
+					ObjectMeta: metav1.ObjectMeta{Name: "matrixed-task-run-3"},
+					Status: v1.TaskRunStatus{
+						Status: duckv1.Status{Conditions: []apis.Condition{{
+							Type:   apis.ConditionSucceeded,
+							Status: corev1.ConditionTrue,
+							Reason: v1.TaskRunReasonSuccessful.String(),
+						}}},
+						TaskRunStatusFields: v1.TaskRunStatusFields{
+							Artifacts: v1.Artifacts{
+								Inputs:  []v1.Artifact{{Name: "source4", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}},
+								Outputs: []v1.Artifact{{Name: "image4", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}},
+							},
+						}},
+				}},
+			}},
+			expectedArtifacts: map[string]v1.Artifacts{"matrixed-task-with-artifacts": {
+				Inputs:  []v1.Artifact{{Name: "source1", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}, {Name: "source2", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}, {Name: "source3", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}, {Name: "source4", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}},
+				Outputs: []v1.Artifact{{Name: "image1", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}, {Name: "image2", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}, {Name: "image3", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}, {Name: "image4", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}},
+			}},
+		},
+	}
+
+	for _, tt := range testCases {
+		got := tt.state.GetTaskRunsArtifacts()
+		if d := cmp.Diff(tt.expectedArtifacts, got, cmpopts.SortSlices(func(a, b v1.Artifact) bool { return a.Name > b.Name })); d != "" {
+			t.Errorf("GetTaskRunsArtifacts() did not produce expected artifacts for test %s: %s", tt.name, diff.PrintWantGot(d))
+		}
+	}
+}
+
 func TestPipelineRunState_GetChildReferences(t *testing.T) {
 	testCases := []struct {
 		name      string

--- a/pkg/reconciler/taskrun/resources/apply.go
+++ b/pkg/reconciler/taskrun/resources/apply.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/tektoncd/pipeline/internal/artifactref"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/container"
@@ -399,19 +400,20 @@ func getTaskResultReplacements(spec *v1.TaskSpec) map[string]string {
 	return stringReplacements
 }
 
-// ApplyArtifacts replaces the occurrences of step.artifacts.path with the absolute tekton internal path
+// ApplyArtifacts replaces the occurrences of artifacts.path and step.artifacts.path with the absolute tekton internal path
 func ApplyArtifacts(spec *v1.TaskSpec) *v1.TaskSpec {
 	for i := range spec.Steps {
-		stringReplacements := getStepArtifactReplacements(spec.Steps[i], i)
+		stringReplacements := getArtifactReplacements(spec.Steps[i], i)
 		container.ApplyStepReplacements(&spec.Steps[i], stringReplacements, map[string][]string{})
 	}
 	return spec
 }
 
-func getStepArtifactReplacements(step v1.Step, idx int) map[string]string {
+func getArtifactReplacements(step v1.Step, idx int) map[string]string {
 	stringReplacements := map[string]string{}
 	stepName := pod.StepName(step.Name, idx)
-	stringReplacements[pod.StepArtifactPathPattern] = filepath.Join(pipeline.StepsDir, stepName, "artifacts", "provenance.json")
+	stringReplacements[artifactref.StepArtifactPathPattern] = filepath.Join(pipeline.StepsDir, stepName, "artifacts", "provenance.json")
+	stringReplacements[artifactref.TaskArtifactPathPattern] = filepath.Join(pipeline.ArtifactsDir, "provenance.json")
 
 	return stringReplacements
 }

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -313,6 +313,13 @@ var (
 			EmptyDir: &corev1.EmptyDirVolumeSource{},
 		},
 	}
+
+	artifactsVolume = corev1.Volume{
+		Name: "tekton-internal-artifacts",
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		},
+	}
 	downwardVolume = corev1.Volume{
 		Name: "tekton-internal-downward",
 		VolumeSource: corev1.VolumeSource{
@@ -5892,6 +5899,10 @@ func podVolumeMounts(idx, totalSteps int) []corev1.VolumeMount {
 		MountPath: "/tekton/steps",
 		ReadOnly:  true,
 	})
+	mnts = append(mnts, corev1.VolumeMount{
+		Name:      "tekton-internal-artifacts",
+		MountPath: "/tekton/artifacts",
+	})
 
 	return mnts
 }
@@ -5986,6 +5997,7 @@ func expectedPod(podName, taskName, taskRunName, ns, saName string, isClusterTas
 				workspaceVolume,
 				homeVolume,
 				resultsVolume,
+				artifactsVolume,
 				stepsVolume,
 				binVolume,
 				downwardVolume,

--- a/pkg/result/result.go
+++ b/pkg/result/result.go
@@ -36,8 +36,11 @@ const (
 	// StepResultType default step result value
 	StepResultType ResultType = 4
 
-	// StepArtifactsResultType default artifacts result value
+	// StepArtifactsResultType default step artifacts result value
 	StepArtifactsResultType ResultType = 5
+
+	// TaskRunArtifactsResultType default taskRun artifacts result value
+	TaskRunArtifactsResultType ResultType = 6
 )
 
 // RunResult is used to write key/value pairs to TaskRun pod termination messages.
@@ -93,6 +96,8 @@ func (r *ResultType) UnmarshalJSON(data []byte) error {
 		*r = InternalTektonResultType
 	case "StepArtifactsResult":
 		*r = StepArtifactsResultType
+	case "TaskRunArtifactsResult":
+		*r = TaskRunArtifactsResultType
 	default:
 		*r = UnknownResultType
 	}

--- a/pkg/result/result_test.go
+++ b/pkg/result/result_test.go
@@ -43,9 +43,13 @@ func TestRunResult_UnmarshalJSON(t *testing.T) {
 			data: "{\"key\":\"resultName\",\"value\":\"\", \"type\": \"InternalTektonResult\"}",
 			pr:   RunResult{Key: "resultName", Value: "", ResultType: InternalTektonResultType},
 		}, {
-			name: "type defined as string - ArtifactsResult",
+			name: "type defined as string - StepArtifactsResultType",
 			data: "{\"key\":\"resultName\",\"value\":\"\", \"type\": \"StepArtifactsResult\"}",
 			pr:   RunResult{Key: "resultName", Value: "", ResultType: StepArtifactsResultType},
+		}, {
+			name: "type defined as string - TaskRunArtifactResult",
+			data: "{\"key\":\"resultName\",\"value\":\"\", \"type\": \"TaskRunArtifactsResult\"}",
+			pr:   RunResult{Key: "resultName", Value: "", ResultType: TaskRunArtifactsResultType},
 		}, {
 			name: "type defined as int",
 			data: "{\"key\":\"resultName\",\"value\":\"\", \"type\": 1}",

--- a/test/artifacts_test.go
+++ b/test/artifacts_test.go
@@ -252,10 +252,10 @@ func TestConsumeArtifacts(t *testing.T) {
 			task := simpleArtifactProducerTask(t, namespace, fqImageName)
 			task.Spec.Steps = append(task.Spec.Steps,
 				v1.Step{Name: "consume-outputs", Image: fqImageName,
-					Command: []string{"sh", "-c", "echo -n $(steps.hello.outputs) >> $(step.results.result1.path)"},
+					Command: []string{"sh", "-c", "echo -n $(steps.hello.outputs.image) >> $(step.results.result1.path)"},
 					Results: []v1.StepResult{{Name: "result1", Type: v1.ResultsTypeString}}},
 				v1.Step{Name: "consume-inputs", Image: fqImageName,
-					Command: []string{"sh", "-c", "echo -n $(steps.hello.inputs) >> $(step.results.result2.path)"},
+					Command: []string{"sh", "-c", "echo -n $(steps.hello.inputs.source) >> $(step.results.result2.path)"},
 					Results: []v1.StepResult{{Name: "result2", Type: v1.ResultsTypeString}}},
 			)
 			if _, err := c.V1TaskClient.Create(ctx, task, metav1.CreateOptions{}); err != nil {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
fixes: #7870
# Changes

 - Support passing artifacts between tasks as described in this [tep](https://github.com/tektoncd/community/blob/main/teps/0147-tekton-artifacts-phase1.md#between-tasks)
 - Task author can write task artifacts to `$(artifacts.path)`
 - Tasks can consume artifacts from another tasks with similar syntax introduced for step Artifacts

   -  Specific Artifact: `$(tasks.<task-name>.outputs.<artifacts-category-name>)`,  , `$(tasks.<task-name>.inputs.<artifacts-category-name>)`
 - Note that both stepArtifacts which are written to `$(step.artifacts.path)` and task artifacts which are written to `$(artifacts.path)` are aggregated into TaskRun.Status.Artifacts with deduplication. 

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Support passing artifacts between tasks in a pipeline
```
