### PR TITLE
Fix Validation Error Merging StepTemplates with StepRef

### DIFF
--- a/examples/v1/taskruns/beta/stepactions-steptemplate.yaml
+++ b/examples/v1/taskruns/beta/stepactions-steptemplate.yaml
@@ -1,0 +1,21 @@
+apiVersion: tekton.dev/v1beta1
+kind: StepAction
+metadata:
+  name: step-action
+spec:
+  image: alpine
+  command: ["env"]
+---
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  name: task-run
+spec:
+  taskSpec:
+    steps:
+      - ref:
+          name: step-action
+    stepTemplate:
+      env:
+        - name: foo
+          value: bar

--- a/pkg/apis/pipeline/v1/merge.go
+++ b/pkg/apis/pipeline/v1/merge.go
@@ -46,6 +46,11 @@ func MergeStepsWithStepTemplate(template *StepTemplate, steps []Step) ([]Step, e
 	}
 
 	for i, s := range steps {
+		// If the stepaction has not been fetched yet then do not merge.
+		// Skip over to the next one
+		if s.Ref != nil {
+			continue
+		}
 		merged := corev1.Container{}
 		err := mergeObjWithTemplateBytes(md, s.ToK8sContainer(), &merged)
 		if err != nil {

--- a/pkg/apis/pipeline/v1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1/task_validation_test.go
@@ -30,6 +30,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/pointer"
 	"knative.dev/pkg/apis"
 )
 
@@ -332,6 +333,41 @@ func TestTaskSpecValidate(t *testing.T) {
 				#!/usr/bin/env bash
 				hello world`,
 			}},
+		},
+	}, {
+		name: "step template included in validation with stepaction",
+		fields: fields{
+			Steps: []v1.Step{{
+				Name: "astep",
+				Ref: &v1.Ref{
+					Name: "stepAction",
+				},
+			}},
+			StepTemplate: &v1.StepTemplate{
+				Image: "some-image",
+				SecurityContext: &corev1.SecurityContext{
+					RunAsNonRoot: pointer.Bool(true),
+				},
+				VolumeMounts: []corev1.VolumeMount{{
+					Name:      "data",
+					MountPath: "/workspace/data",
+				}},
+				Env: []corev1.EnvVar{{
+					Name:  "KEEP_THIS",
+					Value: "A_VALUE",
+				}, {
+					Name: "SOME_KEY_1",
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							Key:                  "A_KEY",
+							LocalObjectReference: corev1.LocalObjectReference{Name: "A_NAME"},
+						},
+					},
+				}, {
+					Name:  "SOME_KEY_2",
+					Value: "VALUE_2",
+				}},
+			},
 		},
 	}, {
 		name: "valid step with parameterized script",

--- a/pkg/apis/pipeline/v1beta1/merge.go
+++ b/pkg/apis/pipeline/v1beta1/merge.go
@@ -47,6 +47,11 @@ func MergeStepsWithStepTemplate(template *StepTemplate, steps []Step) ([]Step, e
 	}
 
 	for i, s := range steps {
+		// If the stepaction has not been fetched yet then do not merge.
+		// Skip over to the next one
+		if s.Ref != nil {
+			continue
+		}
 		merged := corev1.Container{}
 		err := mergeObjWithTemplateBytes(md, s.ToK8sContainer(), &merged)
 		if err != nil {

--- a/pkg/apis/pipeline/v1beta1/merge_test.go
+++ b/pkg/apis/pipeline/v1beta1/merge_test.go
@@ -20,10 +20,12 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	v1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/test/diff"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/utils/pointer"
 )
 
 func TestMergeStepsWithStepTemplate(t *testing.T) {
@@ -125,6 +127,52 @@ func TestMergeStepsWithStepTemplate(t *testing.T) {
 			VolumeMounts: []corev1.VolumeMount{{
 				Name:      "data",
 				MountPath: "/workspace/data",
+			}},
+		}},
+	}, {
+		name: "step-ref-should-not-be-merged-with-steptemplate",
+		template: &v1beta1.StepTemplate{
+			SecurityContext: &corev1.SecurityContext{
+				RunAsNonRoot: pointer.Bool(true),
+			},
+			VolumeMounts: []corev1.VolumeMount{{
+				Name:      "data",
+				MountPath: "/workspace/data",
+			}},
+			Env: []corev1.EnvVar{{
+				Name:  "KEEP_THIS",
+				Value: "A_VALUE",
+			}, {
+				Name: "SOME_KEY_1",
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						Key:                  "A_KEY",
+						LocalObjectReference: corev1.LocalObjectReference{Name: "A_NAME"},
+					},
+				},
+			}, {
+				Name:  "SOME_KEY_2",
+				Value: "VALUE_2",
+			}},
+		},
+		steps: []v1beta1.Step{{
+			Ref:     &v1beta1.Ref{Name: "my-step-action"},
+			OnError: "foo",
+			Results: []v1.StepResult{{
+				Name: "result",
+			}},
+			Params: v1beta1.Params{{
+				Name: "param",
+			}},
+		}},
+		expected: []v1beta1.Step{{
+			Ref:     &v1beta1.Ref{Name: "my-step-action"},
+			OnError: "foo",
+			Results: []v1.StepResult{{
+				Name: "result",
+			}},
+			Params: v1beta1.Params{{
+				Name: "param",
 			}},
 		}},
 	}, {

--- a/pkg/apis/pipeline/v1beta1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation_test.go
@@ -34,6 +34,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/pointer"
 	"knative.dev/pkg/apis"
 )
 
@@ -336,6 +337,41 @@ func TestTaskSpecValidate(t *testing.T) {
 				#!/usr/bin/env bash
 				hello world`,
 			}},
+		},
+	}, {
+		name: "step template included in validation with stepaction",
+		fields: fields{
+			Steps: []v1beta1.Step{{
+				Name: "astep",
+				Ref: &v1beta1.Ref{
+					Name: "stepAction",
+				},
+			}},
+			StepTemplate: &v1beta1.StepTemplate{
+				Image: "some-image",
+				SecurityContext: &corev1.SecurityContext{
+					RunAsNonRoot: pointer.Bool(true),
+				},
+				VolumeMounts: []corev1.VolumeMount{{
+					Name:      "data",
+					MountPath: "/workspace/data",
+				}},
+				Env: []corev1.EnvVar{{
+					Name:  "KEEP_THIS",
+					Value: "A_VALUE",
+				}, {
+					Name: "SOME_KEY_1",
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							Key:                  "A_KEY",
+							LocalObjectReference: corev1.LocalObjectReference{Name: "A_NAME"},
+						},
+					},
+				}, {
+					Name:  "SOME_KEY_2",
+					Value: "VALUE_2",
+				}},
+			},
 		},
 	}, {
 		name: "valid step with parameterized script",


### PR DESCRIPTION
Prior to this, when validating a Step, we were merging the StepTemplate fields into the Step. For inlined-Steps,
this is fine. However, when referencing a StepAction, we end up merging StepTemplate with a StepRef.
This leads to broken validation. In reality this should be skipped at web-hook validation since the 
StepAction has not been fetched yet and so there is not enough information at that time to do this validation correctly.
This is what this PR fixes. See the issue below for more details.

Fixes https://github.com/tektoncd/pipeline/issues/7981

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Fix Validation Error Merging StepTemplates with Step's Ref
```
/kind bug