### PR TITLE
WorkingDir inherit permissions of parent directory

### DIFF
--- a/cmd/workingdirinit/main.go
+++ b/cmd/workingdirinit/main.go
@@ -17,6 +17,8 @@ limitations under the License.
 package main
 
 import (
+	"fmt"
+	"io/fs"
 	"log"
 	"os"
 	"path/filepath"
@@ -24,20 +26,82 @@ import (
 	"strings"
 )
 
+// exists returns whether the given file or directory exists
+func exists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, err
+}
+
+func getPermissions(path string) (fs.FileMode, error) {
+	fileInfo, err := os.Stat(path)
+	if err != nil {
+		return fs.FileMode(0o666), err
+	}
+	return fileInfo.Mode(), nil
+}
+
+func createPath(path string) error {
+	// Check if the path already exists.
+	ex, err := exists(path)
+	if err != nil {
+		return fmt.Errorf("error accessing path %s: %w", path, err)
+	}
+	// Path already exists, so no subdirectory to create. Skip the rest.
+	if ex {
+		return nil
+	}
+	// Find the innermost parent directory to get the permissions to apply to the child directories.
+	parts := strings.Split(path, string(filepath.Separator))
+	parent := path
+	i := 0
+	// If we reach the file system root then we could not find any existing Dir.
+	// In this case, workingDir Init cannot handle it. Let k8s handle the creation instead.
+	for parent != "/" {
+		parent = filepath.Dir(parent)
+		if ex, err := exists(parent); err != nil {
+			return fmt.Errorf("error accessing path %s: %w", parent, err)
+		} else if ex {
+			// We need to get its permissions and apply it to the child directories.
+			perm, err := getPermissions(parent)
+			if err != nil {
+				return fmt.Errorf("error accessing path %s: %w", parent, err)
+			}
+			// Create the path
+			if err := os.MkdirAll(path, perm); err != nil {
+				return fmt.Errorf("failed to mkdir %q: %w", path, err)
+			}
+			// walk up again and set the permissions of the parent to the child directories
+			d := parent
+			idx := len(parts) - i - 1
+			for j := idx; j < len(parts); j++ {
+				d = filepath.Join(d, parts[j])
+				if err := os.Chmod(d, perm); err != nil {
+					return fmt.Errorf("failed to chmod %q: %w", d, err)
+				}
+			}
+			return nil
+		}
+		i += 1
+	}
+	return nil
+}
+
 func main() {
 	for i, d := range os.Args {
 		// os.Args[0] is the path to this executable, so we should skip it
 		if i == 0 {
 			continue
 		}
-
-		ws := cleanPath("/workspace/")
 		p := cleanPath(d)
-
-		if !filepath.IsAbs(p) || strings.HasPrefix(p, ws+string(filepath.Separator)) {
-			if err := os.MkdirAll(p, 0755); err != nil {
-				log.Fatalf("Failed to mkdir %q: %v", p, err)
-			}
+		err := createPath(p)
+		if err != nil {
+			log.Fatalf("Failed to create path %s: %v", p, err)
 		}
 	}
 }

--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -473,7 +473,6 @@ func TestPodBuild(t *testing.T) {
 						Image:        images.WorkingDirInitImage,
 						Command:      []string{"/ko-app/workingdirinit"},
 						Args:         []string{filepath.Join(pipeline.WorkspaceDir, "test")},
-						WorkingDir:   pipeline.WorkspaceDir,
 						VolumeMounts: implicitVolumeMounts,
 					},
 				},


### PR DESCRIPTION
Prior to this PR, workingDirInit did not deal handle permissions of nested child directories in workingDirs. This PR provides the same permissions as that of the existing parent directory. This allows non-root users to also create relative sub diectories in a workspace if used as a workingDir. 

Fixes https://github.com/tektoncd/pipeline/issues/7804.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

If the complete path in used as the workingDir already exists, the permissions are not modified.
Only non-existent child directories are created with the same permissions as the existing parent.

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
WorkingDir inherit permissions of parent directory
```
/kind bug