### PR TITLE
Fix: Update GetNameAndNamespace Parameters

### DIFF
--- a/pkg/remote/resolution/resolver.go
+++ b/pkg/remote/resolution/resolver.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"github.com/tektoncd/pipeline/pkg/apis/resolution/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned/scheme"
 	"github.com/tektoncd/pipeline/pkg/remote"
 	resolutioncommon "github.com/tektoncd/pipeline/pkg/resolution/common"
@@ -73,7 +74,10 @@ func (resolver *Resolver) List(_ context.Context) ([]remote.ResolvedObject, erro
 }
 
 func buildRequest(resolverName string, owner kmeta.OwnerRefable, name string, namespace string, params v1.Params) (*resolutionRequest, error) {
-	name, namespace, err := remoteresource.GetNameAndNamespace(resolverName, owner, name, namespace, params)
+	rr := &v1beta1.ResolutionRequestSpec{
+		Params: params,
+	}
+	name, namespace, err := remoteresource.GetNameAndNamespace(resolverName, owner, name, namespace, rr)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/remoteresolution/remote/resolution/resolver.go
+++ b/pkg/remoteresolution/remote/resolution/resolver.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"github.com/tektoncd/pipeline/pkg/apis/resolution/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/remote"
 	resolution "github.com/tektoncd/pipeline/pkg/remote/resolution"
 	remoteresource "github.com/tektoncd/pipeline/pkg/remoteresolution/resource"
@@ -69,15 +70,21 @@ func (resolver *Resolver) List(_ context.Context) ([]remote.ResolvedObject, erro
 func buildRequest(resolverName string, owner kmeta.OwnerRefable, resolverPayload *remoteresource.ResolverPayload) (*resolutionRequest, error) {
 	var name string
 	var namespace string
+	var url string
 	var params v1.Params
 	if resolverPayload != nil {
 		name = resolverPayload.Name
 		namespace = resolverPayload.Namespace
 		if resolverPayload.ResolutionSpec != nil {
 			params = resolverPayload.ResolutionSpec.Params
+			url = resolverPayload.ResolutionSpec.URL
 		}
 	}
-	name, namespace, err := resource.GetNameAndNamespace(resolverName, owner, name, namespace, params)
+	rr := &v1beta1.ResolutionRequestSpec{
+		Params: params,
+		URL:    url,
+	}
+	name, namespace, err := resource.GetNameAndNamespace(resolverName, owner, name, namespace, rr)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/remoteresolution/remote/resolution/resolver_test.go
+++ b/pkg/remoteresolution/remote/resolution/resolver_test.go
@@ -20,6 +20,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	resv1beta1 "github.com/tektoncd/pipeline/pkg/apis/resolution/v1beta1"
+
 	"github.com/tektoncd/pipeline/pkg/remote"
 	"github.com/tektoncd/pipeline/pkg/remote/resolution"
 	remoteresource "github.com/tektoncd/pipeline/pkg/remoteresolution/resource"
@@ -142,12 +144,18 @@ func TestBuildRequestV2(t *testing.T) {
 		name            string
 		targetName      string
 		targetNamespace string
+		url             string
 	}{{
 		name: "just owner",
 	}, {
 		name:            "with target name and namespace",
 		targetName:      "some-object",
 		targetNamespace: "some-ns",
+	}, {
+		name:            "with target name, namespace, and url",
+		targetName:      "some-object",
+		targetNamespace: "some-ns",
+		url:             "scheme://value",
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			owner := &v1beta1.PipelineRun{
@@ -158,6 +166,7 @@ func TestBuildRequestV2(t *testing.T) {
 			}
 
 			rr := &remoteresource.ResolverPayload{Name: tc.targetName, Namespace: tc.targetNamespace}
+			rr.ResolutionSpec = &resv1beta1.ResolutionRequestSpec{URL: tc.url}
 			req, err := buildRequest("git", owner, rr)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)

--- a/pkg/resolution/resource/name.go
+++ b/pkg/resolution/resource/name.go
@@ -50,7 +50,10 @@ func GenerateDeterministicName(prefix, base string, params v1.Params) (string, e
 	return GenerateDeterministicNameFromSpec(prefix, base, &v1beta1.ResolutionRequestSpec{Params: params})
 }
 
-func GetNameAndNamespace(resolverName string, owner kmeta.OwnerRefable, name string, namespace string, params v1.Params) (string, string, error) {
+// GetNameAndNamespace determines the name and namespace for a resource request.
+// It prioritizes explicit values, falling back to the owning object and "default" namespace.
+// If needed, it generates a deterministic name to prevent duplicate requests within a context.
+func GetNameAndNamespace(resolverName string, owner kmeta.OwnerRefable, name string, namespace string, req *v1beta1.ResolutionRequestSpec) (string, string, error) {
 	if name == "" {
 		name = owner.GetObjectMeta().GetName()
 		namespace = owner.GetObjectMeta().GetNamespace()
@@ -62,7 +65,7 @@ func GetNameAndNamespace(resolverName string, owner kmeta.OwnerRefable, name str
 	// prevents multiple requests being issued for the same
 	// pipelinerun's pipelineRef or taskrun's taskRef.
 	remoteResourceBaseName := namespace + "/" + name
-	name, err := GenerateDeterministicNameFromSpec(resolverName, remoteResourceBaseName, &v1beta1.ResolutionRequestSpec{Params: params})
+	name, err := GenerateDeterministicNameFromSpec(resolverName, remoteResourceBaseName, req)
 	if err != nil {
 		return "", "", fmt.Errorf("error generating name for taskrun %s/%s: %w", namespace, name, err)
 	}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

Fix for issue #7980 Pipelines ignoring following name fields on resolvers 


Fixes: https://github.com/tektoncd/pipeline/issues/7980

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
