### PR TITLE
Fix: Allow less strict validation of the Resolver Name during Webhook.

### DIFF
--- a/pkg/apis/pipeline/v1/container_validation.go
+++ b/pkg/apis/pipeline/v1/container_validation.go
@@ -18,10 +18,10 @@ package v1
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"regexp"
 	"strings"
-
-	"net/url"
 
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -91,6 +91,9 @@ func (ref *Ref) Validate(ctx context.Context) (errs *apis.FieldError) {
 
 // RefNameLikeUrl checks if the name is url parsable and returns an error if it isn't.
 func RefNameLikeUrl(name string) error {
-	_, err := url.ParseRequestURI(name)
-	return err
+	schemeRegex := regexp.MustCompile(`[\w-]+:\/\/*`)
+	if !schemeRegex.MatchString(name) {
+		return errors.New("invalid URI for request")
+	}
+	return nil
 }

--- a/pkg/apis/pipeline/v1/container_validation_test.go
+++ b/pkg/apis/pipeline/v1/container_validation_test.go
@@ -48,6 +48,10 @@ func TestRef_Valid(t *testing.T) {
 		name: "simple ref",
 		ref:  &v1.Ref{Name: "refname"},
 	}, {
+		name: "ref name - consice syntax",
+		ref:  &v1.Ref{Name: "foo://baz:ver", ResolverRef: v1.ResolverRef{Resolver: "git"}},
+		wc:   enableConciseResolverSyntax,
+	}, {
 		name: "beta feature: valid resolver",
 		ref:  &v1.Ref{ResolverRef: v1.ResolverRef{Resolver: "git"}},
 		wc:   cfgtesting.EnableBetaAPIFields,
@@ -110,7 +114,7 @@ func TestRef_Invalid(t *testing.T) {
 				Resolver: "git",
 			},
 		},
-		wantErr: apis.ErrInvalidValue(`parse "foo": invalid URI for request`, "name"),
+		wantErr: apis.ErrInvalidValue(`invalid URI for request`, "name"),
 		wc:      enableConciseResolverSyntax,
 	}, {
 		name: "ref with url-like name without resolver",

--- a/pkg/apis/pipeline/v1/pipeline_types_test.go
+++ b/pkg/apis/pipeline/v1/pipeline_types_test.go
@@ -619,7 +619,7 @@ func TestPipelineTask_ValidateRegularTask_Failure(t *testing.T) {
 			TaskRef: &TaskRef{Name: "foo", ResolverRef: ResolverRef{Resolver: "git"}},
 		},
 		expectedError: apis.FieldError{
-			Message: `invalid value: parse "foo": invalid URI for request`,
+			Message: `invalid value: invalid URI for request`,
 			Paths:   []string{"taskRef.name"},
 		},
 		configMap: map[string]string{"enable-concise-resolver-syntax": "true"},

--- a/pkg/apis/pipeline/v1/pipelineref_validation_test.go
+++ b/pkg/apis/pipeline/v1/pipelineref_validation_test.go
@@ -79,7 +79,7 @@ func TestPipelineRef_Invalid(t *testing.T) {
 				Resolver: "git",
 			},
 		},
-		wantErr:     apis.ErrInvalidValue(`parse "foo": invalid URI for request`, "name"),
+		wantErr:     apis.ErrInvalidValue(`invalid URI for request`, "name"),
 		withContext: enableConciseResolverSyntax,
 	}, {
 		name: "pipelineRef with url-like name without resolver",

--- a/pkg/apis/pipeline/v1/taskref_validation_test.go
+++ b/pkg/apis/pipeline/v1/taskref_validation_test.go
@@ -127,7 +127,7 @@ func TestTaskRef_Invalid(t *testing.T) {
 				Resolver: "git",
 			},
 		},
-		wantErr: apis.ErrInvalidValue(`parse "foo": invalid URI for request`, "name"),
+		wantErr: apis.ErrInvalidValue(`invalid URI for request`, "name"),
 		wc:      enableConciseResolverSyntax,
 	}, {
 		name: "taskRef with url-like name without resolver",

--- a/pkg/apis/pipeline/v1beta1/container_validation.go
+++ b/pkg/apis/pipeline/v1beta1/container_validation.go
@@ -18,10 +18,10 @@ package v1beta1
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"regexp"
 	"strings"
-
-	"net/url"
 
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -91,6 +91,9 @@ func (ref *Ref) Validate(ctx context.Context) (errs *apis.FieldError) {
 
 // RefNameLikeUrl checks if the name is url parsable and returns an error if it isn't.
 func RefNameLikeUrl(name string) error {
-	_, err := url.ParseRequestURI(name)
-	return err
+	schemeRegex := regexp.MustCompile(`[\w-]+:\/\/*`)
+	if !schemeRegex.MatchString(name) {
+		return errors.New("invalid URI for request")
+	}
+	return nil
 }

--- a/pkg/apis/pipeline/v1beta1/container_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/container_validation_test.go
@@ -48,6 +48,10 @@ func TestRef_Valid(t *testing.T) {
 		name: "simple ref",
 		ref:  &v1beta1.Ref{Name: "refname"},
 	}, {
+		name: "ref name - consice syntax",
+		ref:  &v1beta1.Ref{Name: "foo://baz:ver", ResolverRef: v1beta1.ResolverRef{Resolver: "git"}},
+		wc:   enableConciseResolverSyntax,
+	}, {
 		name: "beta feature: valid resolver",
 		ref:  &v1beta1.Ref{ResolverRef: v1beta1.ResolverRef{Resolver: "git"}},
 		wc:   cfgtesting.EnableBetaAPIFields,
@@ -110,7 +114,7 @@ func TestRef_Invalid(t *testing.T) {
 				Resolver: "git",
 			},
 		},
-		wantErr: apis.ErrInvalidValue(`parse "foo": invalid URI for request`, "name"),
+		wantErr: apis.ErrInvalidValue(`invalid URI for request`, "name"),
 		wc:      enableConciseResolverSyntax,
 	}, {
 		name: "ref with url-like name without resolver",

--- a/pkg/apis/pipeline/v1beta1/pipeline_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types_test.go
@@ -662,7 +662,7 @@ func TestPipelineTask_ValidateRegularTask_Failure(t *testing.T) {
 			TaskRef: &TaskRef{Name: "foo", ResolverRef: ResolverRef{Resolver: "git"}},
 		},
 		expectedError: apis.FieldError{
-			Message: `invalid value: parse "foo": invalid URI for request`,
+			Message: `invalid value: invalid URI for request`,
 			Paths:   []string{"taskRef.name"},
 		},
 		configMap: map[string]string{"enable-concise-resolver-syntax": "true"},

--- a/pkg/apis/pipeline/v1beta1/pipelineref_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelineref_validation_test.go
@@ -105,7 +105,7 @@ func TestPipelineRef_Invalid(t *testing.T) {
 				Resolver: "git",
 			},
 		},
-		wantErr:     apis.ErrInvalidValue(`parse "foo": invalid URI for request`, "name"),
+		wantErr:     apis.ErrInvalidValue(`invalid URI for request`, "name"),
 		withContext: enableConciseResolverSyntax,
 	}, {
 		name: "pipelineRef with url-like name without resolver",

--- a/pkg/apis/pipeline/v1beta1/taskref_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskref_validation_test.go
@@ -120,7 +120,7 @@ func TestTaskRef_Invalid(t *testing.T) {
 				Resolver: "git",
 			},
 		},
-		wantErr: apis.ErrInvalidValue(`parse "foo": invalid URI for request`, "name"),
+		wantErr: apis.ErrInvalidValue(`invalid URI for request`, "name"),
 		wc:      enableConciseResolverSyntax,
 	}, {
 		name: "taskRef with url-like name without resolver",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
Fix for issue #7986 Too Strict validation of the Resolver Name during Webhook Validation

Fixes https://github.com/tektoncd/pipeline/issues/7986

/kind bug
# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
