### PR TITLE
Fix: Identify workspace usage in a Task

### DIFF
--- a/pkg/workspace/apply.go
+++ b/pkg/workspace/apply.go
@@ -242,6 +242,10 @@ func findWorkspaceSubstitutionLocationsInSidecars(sidecars []v1.Sidecar) sets.St
 		for i := range sidecar.Command {
 			locationsToCheck.Insert(sidecar.Command[i])
 		}
+		locationsToCheck.Insert(sidecar.WorkingDir)
+		for _, e := range sidecar.Env {
+			locationsToCheck.Insert(e.Value)
+		}
 	}
 	return locationsToCheck
 }
@@ -258,6 +262,18 @@ func findWorkspaceSubstitutionLocationsInSteps(steps []v1.Step) sets.String {
 		for i := range step.Command {
 			locationsToCheck.Insert(step.Command[i])
 		}
+
+		locationsToCheck.Insert(step.WorkingDir)
+		for _, e := range step.Env {
+			locationsToCheck.Insert(e.Value)
+		}
+		for _, p := range step.Params {
+			locationsToCheck.Insert(p.Value.ArrayVal...)
+			for k := range p.Value.ObjectVal {
+				locationsToCheck.Insert(p.Value.ObjectVal[k])
+			}
+			locationsToCheck.Insert(p.Value.StringVal)
+		}
 	}
 	return locationsToCheck
 }
@@ -271,6 +287,11 @@ func findWorkspaceSubstitutionLocationsInStepTemplate(stepTemplate *v1.StepTempl
 		}
 		for i := range stepTemplate.Command {
 			locationsToCheck.Insert(stepTemplate.Command[i])
+		}
+
+		locationsToCheck.Insert(stepTemplate.WorkingDir)
+		for _, e := range stepTemplate.Env {
+			locationsToCheck.Insert(e.Value)
 		}
 	}
 	return locationsToCheck

--- a/pkg/workspace/apply_test.go
+++ b/pkg/workspace/apply_test.go
@@ -1266,6 +1266,104 @@ func TestFindWorkspacesUsedByTask(t *testing.T) {
 			"steptemplate-args",
 			"steptemplate-command",
 		),
+	}, {
+		name: "workspace used in step env",
+		ts: &v1.TaskSpec{
+			Steps: []v1.Step{{
+				Name:  "step-name",
+				Image: "step-image",
+				Env: []corev1.EnvVar{{
+					Name:  "path",
+					Value: "$(workspaces.env-ws.path)",
+				}},
+				Command: []string{"ls"},
+			}},
+		},
+		want: sets.NewString(
+			"env-ws",
+		),
+	}, {
+		name: "workspace used in step workingDir",
+		ts: &v1.TaskSpec{
+			Steps: []v1.Step{{
+				Name:       "step-name",
+				Image:      "step-image",
+				WorkingDir: "$(workspaces.shared.path)",
+				Command:    []string{"ls"},
+			}},
+		},
+		want: sets.NewString(
+			"shared",
+		),
+	}, {
+		name: "workspace used in step Params for stepactions",
+		ts: &v1.TaskSpec{
+			Steps: []v1.Step{{
+				Name: "step-name",
+				Params: []v1.Param{{
+					Name:  "path",
+					Value: *v1.NewStructuredValues("$(workspaces.shared.path)"),
+				}},
+				Ref: &v1.Ref{
+					Name: "step-action",
+				},
+			}},
+		},
+		want: sets.NewString(
+			"shared",
+		),
+	}, {
+		name: "workspace used in sidecar env",
+		ts: &v1.TaskSpec{
+			Sidecars: []v1.Sidecar{{
+				Name:  "step-name",
+				Image: "step-image",
+				Env: []corev1.EnvVar{{
+					Name:  "path",
+					Value: "$(workspaces.env-ws.path)",
+				}},
+				Command: []string{"ls"},
+			}},
+		},
+		want: sets.NewString(
+			"env-ws",
+		),
+	}, {
+		name: "workspace used in sidecar workingDir",
+		ts: &v1.TaskSpec{
+			Sidecars: []v1.Sidecar{{
+				Name:       "step-name",
+				Image:      "step-image",
+				WorkingDir: "$(workspaces.shared.path)",
+				Command:    []string{"ls"},
+			}},
+		},
+		want: sets.NewString(
+			"shared",
+		),
+	}, {
+		name: "workspace used in stepTemplate env",
+		ts: &v1.TaskSpec{
+			StepTemplate: &v1.StepTemplate{
+				Env: []corev1.EnvVar{{
+					Name:  "path",
+					Value: "$(workspaces.env-ws.path)",
+				}},
+			},
+		},
+		want: sets.NewString(
+			"env-ws",
+		),
+	}, {
+		name: "workspace used in stepTemplate workingDir",
+		ts: &v1.TaskSpec{
+			StepTemplate: &v1.StepTemplate{
+				WorkingDir: "$(workspaces.shared.path)",
+			},
+		},
+		want: sets.NewString(
+			"shared",
+		),
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Prior to this, when identifying whether a Task used a workspace, we limited the check to command, args and scripts in steps, stepTemplates and sidecars. This was done to propagate workspaces into the Tasks that use it instead of blindly propagating it to all the Tasks. However, the workspace path can also be used as a param to a StepAction or env cariables in steps and sidecars and also workingDirs. This PR fixes that.

Fixes https://github.com/tektoncd/pipeline/issues/8008.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Fix: Identify workspace usage in a Task
```
/kind bug