### PR TITLE
[release-v0.53.x] Fix: Identify workspace usage in a Task

### DIFF
--- a/pkg/workspace/apply.go
+++ b/pkg/workspace/apply.go
@@ -225,6 +225,10 @@ func findWorkspaceSubstitutionLocationsInSidecars(sidecars []v1.Sidecar) sets.St
 		for i := range sidecar.Command {
 			locationsToCheck.Insert(sidecar.Command[i])
 		}
+		locationsToCheck.Insert(sidecar.WorkingDir)
+		for _, e := range sidecar.Env {
+			locationsToCheck.Insert(e.Value)
+		}
 	}
 	return locationsToCheck
 }
@@ -241,6 +245,11 @@ func findWorkspaceSubstitutionLocationsInSteps(steps []v1.Step) sets.String {
 		for i := range step.Command {
 			locationsToCheck.Insert(step.Command[i])
 		}
+
+		locationsToCheck.Insert(step.WorkingDir)
+		for _, e := range step.Env {
+			locationsToCheck.Insert(e.Value)
+		}
 	}
 	return locationsToCheck
 }
@@ -254,6 +263,11 @@ func findWorkspaceSubstitutionLocationsInStepTemplate(stepTemplate *v1.StepTempl
 		}
 		for i := range stepTemplate.Command {
 			locationsToCheck.Insert(stepTemplate.Command[i])
+		}
+
+		locationsToCheck.Insert(stepTemplate.WorkingDir)
+		for _, e := range stepTemplate.Env {
+			locationsToCheck.Insert(e.Value)
 		}
 	}
 	return locationsToCheck

--- a/pkg/workspace/apply_test.go
+++ b/pkg/workspace/apply_test.go
@@ -1225,6 +1225,87 @@ func TestFindWorkspacesUsedByTask(t *testing.T) {
 			"steptemplate-args",
 			"steptemplate-command",
 		),
+	}, {
+		name: "workspace used in step env",
+		ts: &v1.TaskSpec{
+			Steps: []v1.Step{{
+				Name:  "step-name",
+				Image: "step-image",
+				Env: []corev1.EnvVar{{
+					Name:  "path",
+					Value: "$(workspaces.env-ws.path)",
+				}},
+				Command: []string{"ls"},
+			}},
+		},
+		want: sets.NewString(
+			"env-ws",
+		),
+	}, {
+		name: "workspace used in step workingDir",
+		ts: &v1.TaskSpec{
+			Steps: []v1.Step{{
+				Name:       "step-name",
+				Image:      "step-image",
+				WorkingDir: "$(workspaces.shared.path)",
+				Command:    []string{"ls"},
+			}},
+		},
+		want: sets.NewString(
+			"shared",
+		),
+	}, {
+		name: "workspace used in sidecar env",
+		ts: &v1.TaskSpec{
+			Sidecars: []v1.Sidecar{{
+				Name:  "step-name",
+				Image: "step-image",
+				Env: []corev1.EnvVar{{
+					Name:  "path",
+					Value: "$(workspaces.env-ws.path)",
+				}},
+				Command: []string{"ls"},
+			}},
+		},
+		want: sets.NewString(
+			"env-ws",
+		),
+	}, {
+		name: "workspace used in sidecar workingDir",
+		ts: &v1.TaskSpec{
+			Sidecars: []v1.Sidecar{{
+				Name:       "step-name",
+				Image:      "step-image",
+				WorkingDir: "$(workspaces.shared.path)",
+				Command:    []string{"ls"},
+			}},
+		},
+		want: sets.NewString(
+			"shared",
+		),
+	}, {
+		name: "workspace used in stepTemplate env",
+		ts: &v1.TaskSpec{
+			StepTemplate: &v1.StepTemplate{
+				Env: []corev1.EnvVar{{
+					Name:  "path",
+					Value: "$(workspaces.env-ws.path)",
+				}},
+			},
+		},
+		want: sets.NewString(
+			"env-ws",
+		),
+	}, {
+		name: "workspace used in stepTemplate workingDir",
+		ts: &v1.TaskSpec{
+			StepTemplate: &v1.StepTemplate{
+				WorkingDir: "$(workspaces.shared.path)",
+			},
+		},
+		want: sets.NewString(
+			"shared",
+		),
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

Manual cherry-pick of https://github.com/tektoncd/pipeline/pull/8016 to resolve errors.

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Fix: Identify workspace usage in a Task
```
/kind bug