### PR TITLE
Add a flag on controllers to configure resyncPeriod

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -56,6 +56,7 @@ func main() {
 	flag.StringVar(&opts.Images.ShellImage, "shell-image", "", "The container image containing a shell")
 	flag.StringVar(&opts.Images.ShellImageWin, "shell-image-win", "", "The container image containing a windows shell")
 	flag.StringVar(&opts.Images.WorkingDirInitImage, "workingdirinit-image", "", "The container image containing our working dir init binary.")
+	flag.DurationVar(&opts.ResyncPeriod, "resync-period", controller.DefaultResyncPeriod, "The period between two resync run (going through all objects)")
 
 	// This parses flags.
 	cfg := injection.ParseAndGetRESTConfigOrDie()
@@ -98,6 +99,8 @@ func main() {
 	}()
 
 	ctx = filteredinformerfactory.WithSelectors(ctx, v1beta1.ManagedByLabelKey)
+	ctx = controller.WithResyncPeriod(ctx, opts.ResyncPeriod)
+
 	sharedmain.MainWithConfig(ctx, ControllerLogKey, cfg,
 		taskrun.NewController(opts, clock.RealClock{}),
 		pipelinerun.NewController(opts, clock.RealClock{}),

--- a/docs/tekton-controller-flags.md
+++ b/docs/tekton-controller-flags.md
@@ -1,0 +1,82 @@
+<!--
+---
+linkTitle: "Tekton Controllers flags"
+weight: 105
+---
+-->
+
+# Tekton Controllers flags
+
+The different controllers `tektoncd/pipeline` ships comes with a set of flags
+that can be changed (in the `yaml` payloads) for advanced use cases. This page
+is documenting them.
+
+## Common set of flags
+
+The following flags are available on all "controllers", aka `controller`, `webhook`, `events` and `resolvers`.
+
+```
+  -add_dir_header
+        If true, adds the file directory to the header of the log messages
+  -alsologtostderr
+        log to standard error as well as files (no effect when -logtostderr=true)
+  -cluster string
+        Defaults to the current cluster in kubeconfig.
+  -disable-ha
+        Whether to disable high-availability functionality for this component.  This flag will be deprecated and removed when we have promoted this feature to stable, so do not pass it without filing an issue upstream!
+  -kube-api-burst int
+        Maximum burst for throttle.
+  -kube-api-qps float
+        Maximum QPS to the server from the client.
+  -kubeconfig string
+        Path to a kubeconfig. Only required if out-of-cluster.
+  -log_backtrace_at value
+        when logging hits line file:N, emit a stack trace
+  -log_dir string
+        If non-empty, write log files in this directory (no effect when -logtostderr=true)
+  -log_file string
+        If non-empty, use this log file (no effect when -logtostderr=true)
+  -log_file_max_size uint
+        Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
+  -logtostderr
+        log to standard error instead of files (default true)
+  -one_output
+        If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
+  -server string
+        The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.
+  -skip_headers
+        If true, avoid header prefixes in the log messages
+  -skip_log_headers
+        If true, avoid headers when opening log files (no effect when -logtostderr=true)
+  -stderrthreshold value
+        logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
+  -v value
+        number for the log level verbosity
+  -vmodule value
+        comma-separated list of pattern=N settings for file-filtered logging
+```
+
+## `controller`
+
+The main controller binary has additional flags to configure its behavior.
+
+```
+  -entrypoint-image string
+        The container image containing our entrypoint binary.
+  -namespace string
+        Namespace to restrict informer to. Optional, defaults to all namespaces.
+  -nop-image string
+        The container image used to stop sidecars
+  -resync-period duration
+        The period between two resync run (going through all objects) (default 10h0m0s)
+  -shell-image string
+        The container image containing a shell
+  -shell-image-win string
+        The container image containing a windows shell
+  -sidecarlogresults-image string
+        The container image containing the binary for accessing results.
+  -threads-per-controller int
+        Threads (goroutines) to create per controller (default 2)
+  -workingdirinit-image string
+        The container image containing our working dir init binary.
+```

--- a/pkg/apis/pipeline/options.go
+++ b/pkg/apis/pipeline/options.go
@@ -16,8 +16,11 @@ limitations under the License.
 
 package pipeline
 
+import "time"
+
 // Options holds options passed to the Tekton Pipeline controllers
 // typically via command-line flags.
 type Options struct {
-	Images Images
+	Images       Images
+	ResyncPeriod time.Duration
 }


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This should allow advanced user/cluster-admin to configure the
resyncPeriod to a value that fit their cluster instead of relying on
the default 10h one.

This is related to https://github.com/tektoncd/pipeline/issues/3676.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/kind feature
/wip

Probably needs some doc updates, will do if this approach seems ok.

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Add the ability to configure the global resync period of controllers (TaskRun, PipelineRun, …) through a flag.
```
