### PR TITLE
feat(matrix): Fix matrix param type mismatch problem for ref array result from customrun scenario

### DIFF
--- a/pkg/reconciler/pipelinerun/resources/resultrefresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/resultrefresolution_test.go
@@ -841,3 +841,53 @@ func TestValidateArrayResultsIndex(t *testing.T) {
 		})
 	}
 }
+
+func TestParamValueFromCustomRunResult(t *testing.T) {
+	type args struct {
+		result string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *v1.ParamValue
+	}{
+		{
+			name: "multiple array elements result",
+			args: args{
+				result: `["amd64", "arm64"]`,
+			},
+			want: &v1.ParamValue{
+				Type:     "array",
+				ArrayVal: []string{"amd64", "arm64"},
+			},
+		},
+		{
+			name: "single array elements result",
+			args: args{
+				result: `[ "amd64" ]`,
+			},
+			want: &v1.ParamValue{
+				Type:     "array",
+				ArrayVal: []string{"amd64"},
+			},
+		},
+		{
+			name: "simple string result",
+			args: args{
+				result: "amd64",
+			},
+			want: &v1.ParamValue{
+				Type:      "string",
+				StringVal: "amd64",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := paramValueFromCustomRunResult(tt.args.result)
+			if d := cmp.Diff(tt.want, got); d != "" {
+				t.Fatalf("paramValueFromCustomRunResult %s", diff.PrintWantGot(d))
+			}
+		})
+	}
+}


### PR DESCRIPTION
fix #8022 

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Adjust `resolveCustomResultRef` implementation in Tekton to handle array results from CustomRun tasks correctly. This change resolves a type mismatch issue when using array results as matrix parameters, ensuring compatibility and proper functioning in scenarios where previous CustomRun emits array results.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
