### PR TITLE
Fix: Example Test point to Catalog StepAction

### DIFF
--- a/examples/v1/taskruns/beta/stepaction-git-resolver.yaml
+++ b/examples/v1/taskruns/beta/stepaction-git-resolver.yaml
@@ -6,11 +6,11 @@ metadata:
 spec:
   params:
     - name: pathInRepo
-      value: basic_step.yaml
+      value: stepaction/git-clone/0.1/git-clone.yaml
     - name: revision
       value: main
     - name: repoUrl
-      value: https://github.com/chitrangpatel/repo1M.git
+      value: https://github.com/tektoncd/catalog.git
   TaskSpec:
     steps:
       - name: action-runner
@@ -23,3 +23,10 @@ spec:
               value: $(params.revision)
             - name: pathInRepo
               value: $(params.pathInRepo)
+        params:
+          - name: url
+            value: https://github.com/kelseyhightower/nocode
+          - name: revision
+            value: master
+          - name: output-path
+            value: /workspace


### PR DESCRIPTION
Prior to this, the e2e test was pointing to chitrangpatel's private repository. This unintentionally broke our CI since the example test started to fail.
Now that we have a catalog of StepActions, point there instead.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
/kind bug