### PR TITLE
chore: remove unsupported configurations `ScopeWhenExpressionsToTask`

### DIFF
--- a/pkg/apis/config/feature_flags.go
+++ b/pkg/apis/config/feature_flags.go
@@ -185,12 +185,12 @@ type FeatureFlags struct {
 	RunningInEnvWithInjectedSidecars bool
 	RequireGitSSHSecretKnownHosts    bool
 	// EnableTektonOCIBundles           bool // Deprecated: this is now ignored
-	ScopeWhenExpressionsToTask bool
-	EnableAPIFields            string
-	SendCloudEventsForRuns     bool
-	AwaitSidecarReadiness      bool
-	EnforceNonfalsifiability   string
-	EnableKeepPodOnCancel      bool
+	// ScopeWhenExpressionsToTask       bool // Deprecated: this is now ignored
+	EnableAPIFields          string
+	SendCloudEventsForRuns   bool
+	AwaitSidecarReadiness    bool
+	EnforceNonfalsifiability string
+	EnableKeepPodOnCancel    bool
 	// VerificationNoMatchPolicy is the feature flag for "trusted-resources-verification-no-match-policy"
 	// VerificationNoMatchPolicy can be set to "ignore", "warn" and "fail" values.
 	// ignore: skip trusted resources verification when no matching verification policies found


### PR DESCRIPTION
This feature flag has been completely removed in v0.35.

Ref:
- https://github.com/tektoncd/pipeline/pull/4715
- https://github.com/tektoncd/operator/pull/2223

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```

/kind misc