### PR TITLE
Handle error conditions in CheckMissingResultReferences

### DIFF
--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -797,14 +797,23 @@ func isCustomRunCancelledByPipelineRunTimeout(cr *v1beta1.CustomRun) bool {
 func CheckMissingResultReferences(pipelineRunState PipelineRunState, targets PipelineRunState) error {
 	for _, target := range targets {
 		for _, resultRef := range v1.PipelineTaskResultRefs(target.PipelineTask) {
-			referencedPipelineTask := pipelineRunState.ToMap()[resultRef.PipelineTask]
+			referencedPipelineTask, ok := pipelineRunState.ToMap()[resultRef.PipelineTask]
+			if !ok {
+				return fmt.Errorf("Result reference error: Could not find ref \"%s\" in internal pipelineRunState", resultRef.PipelineTask)
+			}
 			if referencedPipelineTask.IsCustomTask() {
+				if len(referencedPipelineTask.CustomRuns) == 0 {
+					return fmt.Errorf("Result reference error: Internal result ref \"%s\" has zero-length CustomRuns", resultRef.PipelineTask)
+				}
 				customRun := referencedPipelineTask.CustomRuns[0]
 				_, err := findRunResultForParam(customRun, resultRef)
 				if err != nil {
 					return err
 				}
 			} else {
+				if len(referencedPipelineTask.TaskRuns) == 0 {
+					return fmt.Errorf("Result reference error: Internal result ref \"%s\" has zero-length TaskRuns", resultRef.PipelineTask)
+				}
 				taskRun := referencedPipelineTask.TaskRuns[0]
 				_, err := findTaskResultForParam(taskRun, resultRef)
 				if err != nil {


### PR DESCRIPTION
Before this change, it was possible for a PipelineRun to exist which would cause the controller to crash in CheckMissingResultReferences.

# Changes

Handle error conditions in CheckMissingResultReferences, fixing https://github.com/tektoncd/pipeline/issues/8083

Plus, added tests to cover the scenarios.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] ~~Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps~~
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] ~~Release notes contains the string "action required" if the change requires additional action from users switching to the new release~~

# Release Notes

```release-note
Improved error handling for some invalid result reference scenarios.
```
