### PR TITLE
Perform matrix results validation on only result ref params

### DIFF
--- a/pkg/apis/pipeline/v1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1/pipeline_validation.go
@@ -810,6 +810,10 @@ func findAndValidateResultRefsForMatrix(tasks []PipelineTask, taskMapping map[st
 func validateMatrixedPipelineTaskConsumed(expressions []string, taskMapping map[string]PipelineTask) (resultRefs []*ResultRef, errs *apis.FieldError) {
 	var filteredExpressions []string
 	for _, expression := range expressions {
+		// if it is not matrix result ref expression, skip
+		if !resultref.LooksLikeResultRef(expression) {
+			continue
+		}
 		// ie. "tasks.<pipelineTaskName>.results.<resultName>[*]"
 		subExpressions := strings.Split(expression, ".")
 		pipelineTask := subExpressions[1] // pipelineTaskName

--- a/pkg/apis/pipeline/v1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1/pipeline_validation_test.go
@@ -175,6 +175,129 @@ func TestPipeline_Validate_Success(t *testing.T) {
 				}},
 			},
 		},
+	}, {
+		name: "param with different type of values without matrix",
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "pipelinelinename",
+			},
+			Spec: PipelineSpec{
+				Params: ParamSpecs{{
+					Name: "pipeline-words",
+					Default: &ParamValue{
+						Type:      ParamTypeObject,
+						ObjectVal: map[string]string{"hello": "pipeline"},
+					},
+					Type: ParamTypeObject,
+					Properties: map[string]PropertySpec{
+						"hello": {Type: ParamTypeString},
+					},
+				}},
+				Tasks: []PipelineTask{{
+					Name: "echoit",
+					TaskSpec: &EmbeddedTask{TaskSpec: TaskSpec{
+						Steps: []Step{{
+							Name:    "echo",
+							Image:   "ubuntu",
+							Command: []string{"echo"},
+							Args:    []string{"$(params.pipeline-words.hello)"},
+						}},
+					}},
+					Params: Params{
+						{
+							Name: "name",
+							Value: ParamValue{
+								Type:      ParamTypeString,
+								StringVal: "$(params.pipeline-words.hello)",
+							},
+						},
+						{
+							Name: "name2",
+							Value: ParamValue{
+								Type:      ParamTypeString,
+								StringVal: "$(tasks.pipeline-words.results.hello) + $(pipeline-words)",
+							},
+						},
+					},
+					RunAfter: []string{"pipeline-words"},
+				}, {
+					Name: "pipeline-words",
+					TaskSpec: &EmbeddedTask{TaskSpec: TaskSpec{
+						Steps: []Step{{
+							Name:    "echo",
+							Image:   "ubuntu",
+							Command: []string{"echo"},
+							Args:    []string{"$(params.pipeline-words.hello)"},
+						}},
+					}},
+				}},
+			},
+		},
+	}, {
+		name: "param with different type of values with matrix",
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "pipelinelinename",
+			},
+			Spec: PipelineSpec{
+				Params: ParamSpecs{{
+					Name: "pipeline-words",
+					Default: &ParamValue{
+						Type:      ParamTypeObject,
+						ObjectVal: map[string]string{"hello": "pipeline"},
+					},
+					Type: ParamTypeObject,
+					Properties: map[string]PropertySpec{
+						"hello": {Type: ParamTypeString},
+					},
+				}},
+				Tasks: []PipelineTask{{
+					Name: "echoit",
+					TaskSpec: &EmbeddedTask{TaskSpec: TaskSpec{
+						Steps: []Step{{
+							Name:    "echo",
+							Image:   "ubuntu",
+							Command: []string{"echo"},
+							Args:    []string{"$(params.pipeline-words.hello)"},
+						}},
+					}},
+					Params: Params{
+						{
+							Name: "name",
+							Value: ParamValue{
+								Type:      ParamTypeString,
+								StringVal: "$(params.pipeline-words.hello)",
+							},
+						},
+						{
+							Name: "name2",
+							Value: ParamValue{
+								Type:      ParamTypeString,
+								StringVal: "$(tasks.pipeline-words.results.hello[*]) + $(pipeline-words)",
+							},
+						},
+					},
+					RunAfter: []string{"pipeline-words"},
+				}, {
+					Name: "pipeline-words",
+					TaskSpec: &EmbeddedTask{TaskSpec: TaskSpec{
+						Steps: []Step{{
+							Name:    "echo",
+							Image:   "ubuntu",
+							Command: []string{"echo"},
+							Args:    []string{"$(params.pipeline-words.hello)"},
+						}},
+					}},
+					Matrix: &Matrix{
+						Params: Params{{
+							Name: "GOARCH", Value: ParamValue{ArrayVal: []string{"linux/amd64", "linux/ppc64le", "linux/s390x"}},
+						}, {
+							Name: "version", Value: ParamValue{ArrayVal: []string{"go1.17", "go1.18.1"}},
+						}},
+						Include: IncludeParamsList{{}}},
+				}},
+			},
+		},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This will add a check to skip the validation of normal params
while doing the validation for matrix task result ref as params

Fixes #8086

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Perform matrix results validation on only result ref params
```
