### PR TITLE
Add isBuildArtifact field to Artifacts

### DIFF
--- a/docs/pipeline-api.md
+++ b/docs/pipeline-api.md
@@ -1370,6 +1370,7 @@ string
 </em>
 </td>
 <td>
+<p>The artifact&rsquo;s identifying category name</p>
 </td>
 </tr>
 <tr>
@@ -1382,7 +1383,18 @@ string
 </em>
 </td>
 <td>
-<p>The artifact&rsquo;s identifying category name</p>
+<p>A collection of values related to the artifact</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>buildOutput</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>Indicate if the artifact is a build output or a by-product</p>
 </td>
 </tr>
 </tbody>
@@ -10047,6 +10059,7 @@ string
 </em>
 </td>
 <td>
+<p>The artifact&rsquo;s identifying category name</p>
 </td>
 </tr>
 <tr>
@@ -10059,7 +10072,18 @@ string
 </em>
 </td>
 <td>
-<p>The artifact&rsquo;s identifying category name</p>
+<p>A collection of values related to the artifact</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>buildOutput</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>Indicate if the artifact is a build output or a by-product</p>
 </td>
 </tr>
 </tbody>

--- a/examples/v1/taskruns/alpha/produce-consume-artifacts.yaml
+++ b/examples/v1/taskruns/alpha/produce-consume-artifacts.yaml
@@ -6,6 +6,9 @@ spec:
   taskSpec:
     description: |
       A simple task that populates artifacts to TaskRun stepState
+    params:
+      - name: buildOutput
+        default: true
     steps:
       - name: artifacts-producer
         image: docker.io/library/bash:5.2.26
@@ -28,6 +31,7 @@ spec:
             "outputs":[
               {
                 "name":"image",
+                "buildOutput": $(params.buildOutput),
                 "values":[
                   {
                     "uri":"pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c",

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/tektoncd/pipeline
 
 go 1.22
+
 toolchain go1.22.5
 
 require (

--- a/pkg/apis/pipeline/v1/artifact_types_test.go
+++ b/pkg/apis/pipeline/v1/artifact_types_test.go
@@ -95,7 +95,8 @@ func TestArtifactsMerge(t *testing.T) {
 				},
 				Outputs: []Artifact{
 					{
-						Name: "output1",
+						Name:        "output1",
+						BuildOutput: true,
 						Values: []ArtifactValue{
 							{
 								Digest: map[Algorithm]string{"sha256": "698c4539633943f7889f41605003d7fa63833722ebd2b37c7e75df1d3d06941a"},
@@ -104,7 +105,8 @@ func TestArtifactsMerge(t *testing.T) {
 						},
 					},
 					{
-						Name: "output2",
+						Name:        "output2",
+						BuildOutput: true,
 						Values: []ArtifactValue{
 							{
 								Digest: map[Algorithm]string{"sha256": "7e406d83706c7193df3e38b66d350e55df6f13d2a28a1d35917a043533a70f5c"},
@@ -150,7 +152,8 @@ func TestArtifactsMerge(t *testing.T) {
 				},
 				Outputs: []Artifact{
 					{
-						Name: "output1",
+						Name:        "output1",
+						BuildOutput: true,
 						Values: []ArtifactValue{
 							{
 								Digest: map[Algorithm]string{"sha256": "47de7a85905970a45132f48a9247879a15c483477e23a637504694e611135b40e"},
@@ -163,7 +166,8 @@ func TestArtifactsMerge(t *testing.T) {
 						},
 					},
 					{
-						Name: "output2",
+						Name:        "output2",
+						BuildOutput: true,
 						Values: []ArtifactValue{
 							{
 								Digest: map[Algorithm]string{"sha256": "7e406d83706c7193df3e38b66d350e55df6f13d2a28a1d35917a043533a70f5c"},

--- a/pkg/apis/pipeline/v1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1/openapi_generated.go
@@ -395,13 +395,14 @@ func schema_pkg_apis_pipeline_v1_Artifact(ref common.ReferenceCallback) common.O
 				Properties: map[string]spec.Schema{
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "The artifact's identifying category name",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"values": {
 						SchemaProps: spec.SchemaProps{
-							Description: "The artifact's identifying category name",
+							Description: "A collection of values related to the artifact",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -411,6 +412,13 @@ func schema_pkg_apis_pipeline_v1_Artifact(ref common.ReferenceCallback) common.O
 									},
 								},
 							},
+						},
+					},
+					"buildOutput": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Indicate if the artifact is a build output or a by-product",
+							Type:        []string{"boolean"},
+							Format:      "",
 						},
 					},
 				},

--- a/pkg/apis/pipeline/v1/swagger.json
+++ b/pkg/apis/pipeline/v1/swagger.json
@@ -155,11 +155,16 @@
       "description": "TaskRunStepArtifact represents an artifact produced or used by a step within a task run. It directly uses the Artifact type for its structure.",
       "type": "object",
       "properties": {
+        "buildOutput": {
+          "description": "Indicate if the artifact is a build output or a by-product",
+          "type": "boolean"
+        },
         "name": {
+          "description": "The artifact's identifying category name",
           "type": "string"
         },
         "values": {
-          "description": "The artifact's identifying category name",
+          "description": "A collection of values related to the artifact",
           "type": "array",
           "items": {
             "default": {},

--- a/pkg/apis/pipeline/v1beta1/artifact_types.go
+++ b/pkg/apis/pipeline/v1beta1/artifact_types.go
@@ -6,8 +6,12 @@ type Algorithm string
 // Artifact represents an artifact within a system, potentially containing multiple values
 // associated with it.
 type Artifact struct {
-	Name   string          `json:"name,omitempty"`   // The artifact's identifying category name
-	Values []ArtifactValue `json:"values,omitempty"` // A collection of values related to the artifact
+	// The artifact's identifying category name
+	Name string `json:"name,omitempty"`
+	// A collection of values related to the artifact
+	Values []ArtifactValue `json:"values,omitempty"`
+	// Indicate if the artifact is a build output or a by-product
+	BuildOutput bool `json:"buildOutput,omitempty"`
 }
 
 // ArtifactValue represents a specific value or data element within an Artifact.

--- a/pkg/apis/pipeline/v1beta1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1beta1/openapi_generated.go
@@ -422,13 +422,14 @@ func schema_pkg_apis_pipeline_v1beta1_Artifact(ref common.ReferenceCallback) com
 				Properties: map[string]spec.Schema{
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "The artifact's identifying category name",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"values": {
 						SchemaProps: spec.SchemaProps{
-							Description: "The artifact's identifying category name",
+							Description: "A collection of values related to the artifact",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -438,6 +439,13 @@ func schema_pkg_apis_pipeline_v1beta1_Artifact(ref common.ReferenceCallback) com
 									},
 								},
 							},
+						},
+					},
+					"buildOutput": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Indicate if the artifact is a build output or a by-product",
+							Type:        []string{"boolean"},
+							Format:      "",
 						},
 					},
 				},

--- a/pkg/apis/pipeline/v1beta1/swagger.json
+++ b/pkg/apis/pipeline/v1beta1/swagger.json
@@ -155,11 +155,16 @@
       "description": "TaskRunStepArtifact represents an artifact produced or used by a step within a task run. It directly uses the Artifact type for its structure.",
       "type": "object",
       "properties": {
+        "buildOutput": {
+          "description": "Indicate if the artifact is a build output or a by-product",
+          "type": "boolean"
+        },
         "name": {
+          "description": "The artifact's identifying category name",
           "type": "string"
         },
         "values": {
-          "description": "The artifact's identifying category name",
+          "description": "A collection of values related to the artifact",
           "type": "array",
           "items": {
             "default": {},

--- a/test/artifacts_test.go
+++ b/test/artifacts_test.go
@@ -117,7 +117,7 @@ spec:
 			}}, taskrun.Status.Steps[0].Inputs); d != "" {
 				t.Fatalf(`The expected stepState Inputs does not match created taskrun stepState Inputs. Here is the diff: %v`, d)
 			}
-			if d := cmp.Diff([]v1.TaskRunStepArtifact{{Name: "image",
+			if d := cmp.Diff([]v1.TaskRunStepArtifact{{Name: "image", BuildOutput: true,
 				Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2", "sha256": "df85b9e3983fe2ce20ef76ad675ecf435cc99fc9350adc54fa230bae8c32ce48"},
 					Uri: "pkg:balba",
 				}},
@@ -191,7 +191,7 @@ spec:
 	}}, taskrun.Status.Steps[0].Inputs); d != "" {
 		t.Fatalf(`The expected stepState Inputs does not match created taskrun stepState Inputs. Here is the diff: %v`, d)
 	}
-	if d := cmp.Diff([]v1.TaskRunStepArtifact{{Name: "build-result",
+	if d := cmp.Diff([]v1.TaskRunStepArtifact{{Name: "build-result", BuildOutput: false,
 		Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2", "sha256": "df85b9e3983fe2ce20ef76ad675ecf435cc99fc9350adc54fa230bae8c32ce48"},
 			Uri: "pkg:balba",
 		}},
@@ -425,6 +425,7 @@ spec:
             "outputs":[
               {
                 "name":"image",
+                "buildOutput":true,
                 "values":[
                   {
                     "uri":"pkg:balba",
@@ -523,6 +524,7 @@ spec:
             "outputs":[
               {
                 "name":"build-result",
+                "buildOutput":false,
                 "values":[
                   {
                     "uri":"pkg:balba",


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
As justified in TEP https://github.com/tektoncd/community/pull/1155, this PR adds `isBuildArtifact` field to Artifacts.
This field will allow Tekton Chains to understand user's desire and appropriate add the artifact as a subject or a byProduct in the SLSA provenance.
# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Add `isBuildArtifact` field to Artifacts.
```
/kind feature