### PR TITLE
Capture Remote StepAction Location in TaskRun Status

### DIFF
--- a/docs/pipeline-api.md
+++ b/docs/pipeline-api.md
@@ -3437,7 +3437,7 @@ ParamType
 <h3 id="tekton.dev/v1.Provenance">Provenance
 </h3>
 <p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineRunStatusFields">PipelineRunStatusFields</a>, <a href="#tekton.dev/v1.TaskRunStatusFields">TaskRunStatusFields</a>)
+(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineRunStatusFields">PipelineRunStatusFields</a>, <a href="#tekton.dev/v1.StepState">StepState</a>, <a href="#tekton.dev/v1.TaskRunStatusFields">TaskRunStatusFields</a>)
 </p>
 <div>
 <p>Provenance contains metadata about resources used in the TaskRun/PipelineRun
@@ -4850,6 +4850,18 @@ string
 <em>
 <a href="#tekton.dev/v1.TaskRunResult">
 []TaskRunResult
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>provenance</code><br/>
+<em>
+<a href="#tekton.dev/v1.Provenance">
+Provenance
 </a>
 </em>
 </td>
@@ -12776,7 +12788,7 @@ ParamType
 <h3 id="tekton.dev/v1beta1.Provenance">Provenance
 </h3>
 <p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineRunStatusFields">PipelineRunStatusFields</a>, <a href="#tekton.dev/v1beta1.TaskRunStatusFields">TaskRunStatusFields</a>)
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineRunStatusFields">PipelineRunStatusFields</a>, <a href="#tekton.dev/v1beta1.StepState">StepState</a>, <a href="#tekton.dev/v1beta1.TaskRunStatusFields">TaskRunStatusFields</a>)
 </p>
 <div>
 <p>Provenance contains metadata about resources used in the TaskRun/PipelineRun
@@ -14436,6 +14448,18 @@ string
 <em>
 <a href="#tekton.dev/v1beta1.TaskRunResult">
 []TaskRunResult
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>provenance</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.Provenance">
+Provenance
 </a>
 </em>
 </td>

--- a/pkg/apis/pipeline/v1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1/openapi_generated.go
@@ -3281,6 +3281,11 @@ func schema_pkg_apis_pipeline_v1_StepState(ref common.ReferenceCallback) common.
 							},
 						},
 					},
+					"provenance": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Provenance"),
+						},
+					},
 					"terminationReason": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},
@@ -3317,7 +3322,7 @@ func schema_pkg_apis_pipeline_v1_StepState(ref common.ReferenceCallback) common.
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Artifact", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskRunResult", "k8s.io/api/core/v1.ContainerStateRunning", "k8s.io/api/core/v1.ContainerStateTerminated", "k8s.io/api/core/v1.ContainerStateWaiting"},
+			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Artifact", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Provenance", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskRunResult", "k8s.io/api/core/v1.ContainerStateRunning", "k8s.io/api/core/v1.ContainerStateTerminated", "k8s.io/api/core/v1.ContainerStateWaiting"},
 	}
 }
 

--- a/pkg/apis/pipeline/v1/swagger.json
+++ b/pkg/apis/pipeline/v1/swagger.json
@@ -1675,6 +1675,9 @@
             "$ref": "#/definitions/v1.Artifact"
           }
         },
+        "provenance": {
+          "$ref": "#/definitions/v1.Provenance"
+        },
         "results": {
           "type": "array",
           "items": {

--- a/pkg/apis/pipeline/v1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1/taskrun_types.go
@@ -364,6 +364,7 @@ type StepState struct {
 	Container             string                `json:"container,omitempty"`
 	ImageID               string                `json:"imageID,omitempty"`
 	Results               []TaskRunStepResult   `json:"results,omitempty"`
+	Provenance            *Provenance           `json:"provenance,omitempty"`
 	TerminationReason     string                `json:"terminationReason,omitempty"`
 	Inputs                []TaskRunStepArtifact `json:"inputs,omitempty"`
 	Outputs               []TaskRunStepArtifact `json:"outputs,omitempty"`

--- a/pkg/apis/pipeline/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/pipeline/v1/zz_generated.deepcopy.go
@@ -1460,6 +1460,11 @@ func (in *StepState) DeepCopyInto(out *StepState) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Provenance != nil {
+		in, out := &in.Provenance, &out.Provenance
+		*out = new(Provenance)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Inputs != nil {
 		in, out := &in.Inputs, &out.Inputs
 		*out = make([]Artifact, len(*in))

--- a/pkg/apis/pipeline/v1beta1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1beta1/openapi_generated.go
@@ -4442,6 +4442,11 @@ func schema_pkg_apis_pipeline_v1beta1_StepState(ref common.ReferenceCallback) co
 							},
 						},
 					},
+					"provenance": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Provenance"),
+						},
+					},
 					"inputs": {
 						SchemaProps: spec.SchemaProps{
 							Type: []string{"array"},
@@ -4472,7 +4477,7 @@ func schema_pkg_apis_pipeline_v1beta1_StepState(ref common.ReferenceCallback) co
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Artifact", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskRunResult", "k8s.io/api/core/v1.ContainerStateRunning", "k8s.io/api/core/v1.ContainerStateTerminated", "k8s.io/api/core/v1.ContainerStateWaiting"},
+			"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Artifact", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Provenance", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskRunResult", "k8s.io/api/core/v1.ContainerStateRunning", "k8s.io/api/core/v1.ContainerStateTerminated", "k8s.io/api/core/v1.ContainerStateWaiting"},
 	}
 }
 

--- a/pkg/apis/pipeline/v1beta1/swagger.json
+++ b/pkg/apis/pipeline/v1beta1/swagger.json
@@ -2437,6 +2437,9 @@
             "$ref": "#/definitions/v1beta1.Artifact"
           }
         },
+        "provenance": {
+          "$ref": "#/definitions/v1beta1.Provenance"
+        },
         "results": {
           "type": "array",
           "items": {

--- a/pkg/apis/pipeline/v1beta1/taskrun_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_conversion.go
@@ -345,6 +345,12 @@ func (ss StepState) convertTo(ctx context.Context, sink *v1.StepState) {
 	sink.ImageID = ss.ImageID
 	sink.Results = nil
 
+	if ss.Provenance != nil {
+		new := v1.Provenance{}
+		ss.Provenance.convertTo(ctx, &new)
+		sink.Provenance = &new
+	}
+
 	if ss.ContainerState.Terminated != nil {
 		sink.TerminationReason = ss.ContainerState.Terminated.Reason
 	}
@@ -378,6 +384,11 @@ func (ss *StepState) convertFrom(ctx context.Context, source v1.StepState) {
 		new := TaskRunStepResult{}
 		new.convertFrom(ctx, r)
 		ss.Results = append(ss.Results, new)
+	}
+	if source.Provenance != nil {
+		new := Provenance{}
+		new.convertFrom(ctx, *source.Provenance)
+		ss.Provenance = &new
 	}
 	for _, o := range source.Outputs {
 		new := TaskRunStepArtifact{}

--- a/pkg/apis/pipeline/v1beta1/taskrun_conversion_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_conversion_test.go
@@ -127,6 +127,27 @@ func TestTaskRunConversion(t *testing.T) {
 				},
 			},
 		}, {
+			name: "taskrun with provenance in step state",
+			in: &v1beta1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "bar",
+				},
+				Spec: v1beta1.TaskRunSpec{},
+				Status: v1beta1.TaskRunStatus{
+					TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+						Steps: []v1beta1.StepState{{
+							Provenance: &v1beta1.Provenance{
+								RefSource: &v1beta1.RefSource{
+									URI:    "test-uri",
+									Digest: map[string]string{"sha256": "digest"},
+								},
+							},
+						}},
+					},
+				},
+			},
+		}, {
 			name: "taskrun conversion all non deprecated fields",
 			in: &v1beta1.TaskRun{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/apis/pipeline/v1beta1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_types.go
@@ -372,6 +372,7 @@ type StepState struct {
 	ContainerName         string                `json:"container,omitempty"`
 	ImageID               string                `json:"imageID,omitempty"`
 	Results               []TaskRunStepResult   `json:"results,omitempty"`
+	Provenance            *Provenance           `json:"provenance,omitempty"`
 	Inputs                []TaskRunStepArtifact `json:"inputs,omitempty"`
 	Outputs               []TaskRunStepArtifact `json:"outputs,omitempty"`
 }

--- a/pkg/apis/pipeline/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/pipeline/v1beta1/zz_generated.deepcopy.go
@@ -2029,6 +2029,11 @@ func (in *StepState) DeepCopyInto(out *StepState) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Provenance != nil {
+		in, out := &in.Provenance, &out.Provenance
+		*out = new(Provenance)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Inputs != nil {
 		in, out := &in.Inputs, &out.Inputs
 		*out = make([]Artifact, len(*in))

--- a/pkg/pod/entrypoint.go
+++ b/pkg/pod/entrypoint.go
@@ -352,8 +352,8 @@ func IsContainerStep(name string) bool { return strings.HasPrefix(name, stepPref
 // represents a sidecar.
 func IsContainerSidecar(name string) bool { return strings.HasPrefix(name, sidecarPrefix) }
 
-// trimStepPrefix returns the container name, stripped of its step prefix.
-func trimStepPrefix(name string) string { return strings.TrimPrefix(name, stepPrefix) }
+// TrimStepPrefix returns the container name, stripped of its step prefix.
+func TrimStepPrefix(name string) string { return strings.TrimPrefix(name, stepPrefix) }
 
 // TrimSidecarPrefix returns the container name, stripped of its sidecar
 // prefix.

--- a/pkg/reconciler/taskrun/resources/taskspec.go
+++ b/pkg/reconciler/taskrun/resources/taskspec.go
@@ -25,6 +25,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	clientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	resolutionutil "github.com/tektoncd/pipeline/pkg/internal/resolution"
+	"github.com/tektoncd/pipeline/pkg/pod"
 	remoteresource "github.com/tektoncd/pipeline/pkg/remoteresolution/resource"
 	"github.com/tektoncd/pipeline/pkg/trustedresources"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -103,13 +104,39 @@ func GetTaskData(ctx context.Context, taskRun *v1.TaskRun, getTask GetTask) (*re
 // GetStepActionsData extracts the StepActions and merges them with the inlined Step specification.
 func GetStepActionsData(ctx context.Context, taskSpec v1.TaskSpec, taskRun *v1.TaskRun, tekton clientset.Interface, k8s kubernetes.Interface, requester remoteresource.Requester) ([]v1.Step, error) {
 	steps := []v1.Step{}
-	for _, step := range taskSpec.Steps {
+	for i, step := range taskSpec.Steps {
 		s := step.DeepCopy()
 		if step.Ref != nil {
 			getStepAction := GetStepActionFunc(tekton, k8s, requester, taskRun, s)
-			stepAction, _, err := getStepAction(ctx, s.Ref.Name)
+			stepAction, source, err := getStepAction(ctx, s.Ref.Name)
 			if err != nil {
 				return nil, err
+			}
+			// update stepstate with remote origin information
+			if source != nil {
+				found := false
+				for i, st := range taskRun.Status.Steps {
+					if st.Name == s.Name {
+						found = true
+						if st.Provenance != nil {
+							taskRun.Status.Steps[i].Provenance.RefSource = source
+						} else {
+							taskRun.Status.Steps[i].Provenance = &v1.Provenance{RefSource: source}
+						}
+						break
+					}
+				}
+				if !found {
+					stp := v1.StepState{
+						Name:       pod.TrimStepPrefix(pod.StepName(s.Name, i)),
+						Provenance: &v1.Provenance{RefSource: source},
+					}
+					if len(taskRun.Status.Steps) == 0 {
+						taskRun.Status.Steps = []v1.StepState{stp}
+					} else {
+						taskRun.Status.Steps = append(taskRun.Status.Steps, stp)
+					}
+				}
 			}
 			stepActionSpec := stepAction.StepActionSpec()
 			stepActionSpec.SetDefaults(ctx)


### PR DESCRIPTION
Prior to this, we captured remote Task and pipeline origin information (uri and digest) in the TaskRun/PipelineRun Status. This allowed Chains to pull this information and insert it into the intoto provenance. A similar capability was missing for the newly implemented StepActions. This PR fixes that gap.

Fixes https://github.com/tektoncd/pipeline/issues/8091

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Capture Remote StepAction Location in TaskRun Status
```
/kind feature