### PR TITLE
DryRunValidate returns the mutated object

### DIFF
--- a/pkg/reconciler/apiserver/apiserver.go
+++ b/pkg/reconciler/apiserver/apiserver.go
@@ -25,7 +25,7 @@ var (
 // DryRunValidate validates the obj by issuing a dry-run create request for it in the given namespace.
 // This allows validating admission webhooks to process the object without actually creating it.
 // obj must be a v1/v1beta1 Task or Pipeline.
-func DryRunValidate(ctx context.Context, namespace string, obj runtime.Object, tekton clientset.Interface) error {
+func DryRunValidate(ctx context.Context, namespace string, obj runtime.Object, tekton clientset.Interface) (runtime.Object, error) {
 	dryRunObjName := uuid.NewString() // Use a randomized name for the Pipeline/Task in case there is already another Pipeline/Task of the same name
 
 	switch obj := obj.(type) {
@@ -33,49 +33,61 @@ func DryRunValidate(ctx context.Context, namespace string, obj runtime.Object, t
 		dryRunObj := obj.DeepCopy()
 		dryRunObj.Name = dryRunObjName
 		dryRunObj.Namespace = namespace // Make sure the namespace is the same as the PipelineRun
-		if _, err := tekton.TektonV1().Pipelines(namespace).Create(ctx, dryRunObj, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}}); err != nil {
-			return handleDryRunCreateErr(err, obj.Name)
+		mutatedObj, err := tekton.TektonV1().Pipelines(namespace).Create(ctx, dryRunObj, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}})
+		if err != nil {
+			return nil, handleDryRunCreateErr(err, obj.Name)
 		}
+		return mutatedObj, nil
 	case *v1beta1.Pipeline:
 		dryRunObj := obj.DeepCopy()
 		dryRunObj.Name = dryRunObjName
 		dryRunObj.Namespace = namespace // Make sure the namespace is the same as the PipelineRun
-		if _, err := tekton.TektonV1beta1().Pipelines(namespace).Create(ctx, dryRunObj, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}}); err != nil {
-			return handleDryRunCreateErr(err, obj.Name)
+		mutatedObj, err := tekton.TektonV1beta1().Pipelines(namespace).Create(ctx, dryRunObj, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}})
+		if err != nil {
+			return nil, handleDryRunCreateErr(err, obj.Name)
 		}
-
+		return mutatedObj, nil
 	case *v1.Task:
 		dryRunObj := obj.DeepCopy()
 		dryRunObj.Name = dryRunObjName
 		dryRunObj.Namespace = namespace // Make sure the namespace is the same as the TaskRun
-		if _, err := tekton.TektonV1().Tasks(namespace).Create(ctx, dryRunObj, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}}); err != nil {
-			return handleDryRunCreateErr(err, obj.Name)
+		mutatedObj, err := tekton.TektonV1().Tasks(namespace).Create(ctx, dryRunObj, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}})
+		if err != nil {
+			return nil, handleDryRunCreateErr(err, obj.Name)
 		}
+		return mutatedObj, nil
 	case *v1beta1.Task:
 		dryRunObj := obj.DeepCopy()
 		dryRunObj.Name = dryRunObjName
 		dryRunObj.Namespace = namespace // Make sure the namespace is the same as the TaskRun
-		if _, err := tekton.TektonV1beta1().Tasks(namespace).Create(ctx, dryRunObj, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}}); err != nil {
-			return handleDryRunCreateErr(err, obj.Name)
+		mutatedObj, err := tekton.TektonV1beta1().Tasks(namespace).Create(ctx, dryRunObj, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}})
+		if err != nil {
+			return nil, handleDryRunCreateErr(err, obj.Name)
 		}
+		return mutatedObj, nil
 	case *v1alpha1.StepAction:
 		dryRunObj := obj.DeepCopy()
 		dryRunObj.Name = dryRunObjName
 		dryRunObj.Namespace = namespace // Make sure the namespace is the same as the StepAction
-		if _, err := tekton.TektonV1alpha1().StepActions(namespace).Create(ctx, dryRunObj, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}}); err != nil {
-			return handleDryRunCreateErr(err, obj.Name)
+		mutatedObj, err := tekton.TektonV1alpha1().StepActions(namespace).Create(ctx, dryRunObj, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}})
+		if err != nil {
+			return nil, handleDryRunCreateErr(err, obj.Name)
 		}
+		return mutatedObj, nil
+
 	case *v1beta1.StepAction:
 		dryRunObj := obj.DeepCopy()
 		dryRunObj.Name = dryRunObjName
 		dryRunObj.Namespace = namespace // Make sure the namespace is the same as the StepAction
-		if _, err := tekton.TektonV1beta1().StepActions(namespace).Create(ctx, dryRunObj, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}}); err != nil {
-			return handleDryRunCreateErr(err, obj.Name)
+		mutatedObj, err := tekton.TektonV1beta1().StepActions(namespace).Create(ctx, dryRunObj, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}})
+		if err != nil {
+			return nil, handleDryRunCreateErr(err, obj.Name)
 		}
+		return mutatedObj, nil
+
 	default:
-		return fmt.Errorf("unsupported object GVK %s", obj.GetObjectKind().GroupVersionKind())
+		return nil, fmt.Errorf("unsupported object GVK %s", obj.GetObjectKind().GroupVersionKind())
 	}
-	return nil
 }
 
 func handleDryRunCreateErr(err error, objectName string) error {

--- a/pkg/reconciler/apiserver/apiserver_test.go
+++ b/pkg/reconciler/apiserver/apiserver_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned/fake"
 	"github.com/tektoncd/pipeline/pkg/reconciler/apiserver"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -23,35 +24,46 @@ func TestDryRunCreate_Valid_DifferentGVKs(t *testing.T) {
 		name    string
 		obj     runtime.Object
 		wantErr bool
+		wantObj runtime.Object
 	}{{
-		name: "v1 task",
-		obj:  &v1.Task{},
+		name:    "v1 task",
+		obj:     &v1.Task{},
+		wantObj: &v1.Task{},
 	}, {
-		name: "v1beta1 task",
-		obj:  &v1beta1.Task{},
+		name:    "v1beta1 task",
+		obj:     &v1beta1.Task{},
+		wantObj: &v1beta1.Task{},
 	}, {
-		name: "v1 pipeline",
-		obj:  &v1.Pipeline{},
+		name:    "v1 pipeline",
+		obj:     &v1.Pipeline{},
+		wantObj: &v1.Pipeline{},
 	}, {
-		name: "v1beta1 pipeline",
-		obj:  &v1beta1.Pipeline{},
+		name:    "v1beta1 pipeline",
+		obj:     &v1beta1.Pipeline{},
+		wantObj: &v1beta1.Pipeline{},
 	}, {
-		name: "v1alpha1 stepaction",
-		obj:  &v1alpha1.StepAction{},
+		name:    "v1alpha1 stepaction",
+		obj:     &v1alpha1.StepAction{},
+		wantObj: &v1alpha1.StepAction{},
 	}, {
-		name: "v1beta1 stepaction",
-		obj:  &v1beta1.StepAction{},
+		name:    "v1beta1 stepaction",
+		obj:     &v1beta1.StepAction{},
+		wantObj: &v1beta1.StepAction{},
 	}, {
 		name:    "unsupported gvk",
 		obj:     &v1beta1.ClusterTask{},
 		wantErr: true,
+		wantObj: nil,
 	}}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			tektonclient := fake.NewSimpleClientset()
-			err := apiserver.DryRunValidate(context.Background(), "default", tc.obj, tektonclient)
+			mutatedObj, err := apiserver.DryRunValidate(context.Background(), "default", tc.obj, tektonclient)
 			if (err != nil) != tc.wantErr {
 				t.Errorf("wantErr was %t but got err %v", tc.wantErr, err)
+			}
+			if d := cmp.Diff(tc.wantObj, mutatedObj, cmpopts.IgnoreFields(metav1.ObjectMeta{}, "Name", "Namespace")); d != "" {
+				t.Errorf("wrong object: %s", d)
 			}
 		})
 	}
@@ -103,7 +115,7 @@ func TestDryRunCreate_Invalid_DifferentGVKs(t *testing.T) {
 			tektonclient.PrependReactor("create", "stepactions", func(action ktesting.Action) (bool, runtime.Object, error) {
 				return true, nil, apierrors.NewBadRequest("bad request")
 			})
-			err := apiserver.DryRunValidate(context.Background(), "default", tc.obj, tektonclient)
+			_, err := apiserver.DryRunValidate(context.Background(), "default", tc.obj, tektonclient)
 			if d := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); d != "" {
 				t.Errorf("wrong error: %s", d)
 			}
@@ -150,7 +162,7 @@ func TestDryRunCreate_DifferentErrTypes(t *testing.T) {
 			tektonclient.PrependReactor("create", "tasks", func(action ktesting.Action) (bool, runtime.Object, error) {
 				return true, nil, tc.webhookErr
 			})
-			err := apiserver.DryRunValidate(context.Background(), "default", &v1.Task{}, tektonclient)
+			_, err := apiserver.DryRunValidate(context.Background(), "default", &v1.Task{}, tektonclient)
 			if d := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); d != "" {
 				t.Errorf("wrong error: %s", d)
 			}

--- a/pkg/reconciler/pipelinerun/resources/pipelineref.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelineref.go
@@ -157,20 +157,24 @@ func readRuntimeObjectAsPipeline(ctx context.Context, namespace string, obj runt
 		// Verify the Pipeline once we fetch from the remote resolution, mutating, validation and conversion of the pipeline should happen after the verification, since signatures are based on the remote pipeline contents
 		vr := trustedresources.VerifyResource(ctx, obj, k8s, refSource, verificationPolicies)
 		// Issue a dry-run request to create the remote Pipeline, so that it can undergo validation from validating admission webhooks
-		// without actually creating the Pipeline on the cluster.
-		if err := apiserver.DryRunValidate(ctx, namespace, obj, tekton); err != nil {
+		// and mutation from mutating admission webhooks without actually creating the Pipeline on the cluster
+		o, err := apiserver.DryRunValidate(ctx, namespace, obj, tekton)
+		if err != nil {
 			return nil, nil, err
 		}
-		p := &v1.Pipeline{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "Pipeline",
-				APIVersion: "tekton.dev/v1",
-			},
+		if mutatedPipeline, ok := o.(*v1beta1.Pipeline); ok {
+			mutatedPipeline.ObjectMeta = obj.ObjectMeta
+			p := &v1.Pipeline{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Pipeline",
+					APIVersion: "tekton.dev/v1",
+				},
+			}
+			if err := mutatedPipeline.ConvertTo(ctx, p); err != nil {
+				return nil, nil, fmt.Errorf("failed to convert v1beta1 obj %s into v1 Pipeline", mutatedPipeline.GetObjectKind().GroupVersionKind().String())
+			}
+			return p, &vr, nil
 		}
-		if err := obj.ConvertTo(ctx, p); err != nil {
-			return nil, nil, fmt.Errorf("failed to convert v1beta1 obj %s into v1 Pipeline", obj.GetObjectKind().GroupVersionKind().String())
-		}
-		return p, &vr, nil
 	case *v1.Pipeline:
 		// Cleanup object from things we don't care about
 		// FIXME: extract this in a function
@@ -179,12 +183,14 @@ func readRuntimeObjectAsPipeline(ctx context.Context, namespace string, obj runt
 		// Avoid forgetting to add it in the future when there is a v2 version, causing similar problems.
 		obj.SetDefaults(ctx)
 		vr := trustedresources.VerifyResource(ctx, obj, k8s, refSource, verificationPolicies)
-		// Issue a dry-run request to create the remote Pipeline, so that it can undergo validation from validating admission webhooks
-		// without actually creating the Pipeline on the cluster
-		if err := apiserver.DryRunValidate(ctx, namespace, obj, tekton); err != nil {
+		o, err := apiserver.DryRunValidate(ctx, namespace, obj, tekton)
+		if err != nil {
 			return nil, nil, err
 		}
-		return obj, &vr, nil
+		if mutatedPipeline, ok := o.(*v1.Pipeline); ok {
+			mutatedPipeline.ObjectMeta = obj.ObjectMeta
+			return mutatedPipeline, &vr, nil
+		}
 	}
 	return nil, nil, errors.New("resource is not a pipeline")
 }


### PR DESCRIPTION
Prior to this, when validating remotely resolved resources, we performed a dry run. When a dry run is performed, the resource is passed through the mutating webhook admission controllers followed by the validating webhook controllers. We only validated the object and inserted the spec of the original object instead of the mutated object. This means that if users have mutating webhook controllers on their cluster then remotely resolved resources are not mutated when passed to the taskrun/pipelinerun. This PR fixes that.

Fixes https://github.com/tektoncd/pipeline/issues/8071

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
DryRunValidate returns the mutated object
```
/kind bug