### PR TITLE
[release-v0.56.x] Perform matrix results validation on only result ref params

### DIFF
--- a/pkg/apis/pipeline/v1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1/pipeline_validation.go
@@ -786,6 +786,10 @@ func findAndValidateResultRefsForMatrix(tasks []PipelineTask, taskMapping map[st
 func validateMatrixedPipelineTaskConsumed(expressions []string, taskMapping map[string]PipelineTask) (resultRefs []*ResultRef, errs *apis.FieldError) {
 	var filteredExpressions []string
 	for _, expression := range expressions {
+		// if it is not matrix result ref expression, skip
+		if !resultref.LooksLikeResultRef(expression) {
+			continue
+		}
 		// ie. "tasks.<pipelineTaskName>.results.<resultName>[*]"
 		subExpressions := strings.Split(expression, ".")
 		pipelineTask := subExpressions[1] // pipelineTaskName


### PR DESCRIPTION
This will add a check to skip the validation of normal params while doing the validation for matrix task result ref as params

Cherry-pick of #8089

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Perform matrix results validation on only result ref params
```
