### PR TITLE
use tagged images to take advantage of the least expensive default image pull policy

### DIFF
--- a/examples/v1/pipelineruns/4808-regression.yaml
+++ b/examples/v1/pipelineruns/4808-regression.yaml
@@ -11,7 +11,7 @@ spec:
       type: string
   steps:
     - name: print-result
-      image: docker.io/library/bash:latest
+      image: docker.io/library/bash:5.2.26
       env:
         - name: PARAM_TO_PRINT
           value: $(params.TO_PRINT)
@@ -39,7 +39,7 @@ spec:
       description: A result string
   steps:
     - name: gen-result
-      image: docker.io/library/bash:latest
+      image: docker.io/library/bash:5.2.26
       env:
         - name: PARAM_STRING_LENGTH
           value: $(params.STRING_LENGTH)

--- a/examples/v1/pipelineruns/6139-regression.yaml
+++ b/examples/v1/pipelineruns/6139-regression.yaml
@@ -15,7 +15,7 @@ spec:
           results:
             - name: result-one
           steps:
-          - image: docker.io/library/alpine
+          - image: docker.io/library/alpine:3.20.1
             script: |
               #!/bin/sh
               echo "Hello world!"
@@ -28,7 +28,7 @@ spec:
           results:
             - name: result-two
           steps:
-          - image: docker.io/library/alpine
+          - image: docker.io/library/alpine:3.20.1
             script: |
               #!/bin/sh
               echo "Goodbye world!"
@@ -43,7 +43,7 @@ spec:
           results:
             - name: result-three
           steps:
-          - image: docker.io/library/alpine
+          - image: docker.io/library/alpine:3.20.1
             script: |
               #!/bin/sh
               echo "Shutdown world!"

--- a/examples/v1/pipelineruns/alpha/param-enum.yaml
+++ b/examples/v1/pipelineruns/alpha/param-enum.yaml
@@ -9,7 +9,7 @@ spec:
     enum: ["v1", "v2", "v3"]
   steps:
   - name: build
-    image: docker.io/library/bash:latest
+    image: docker.io/library/bash:5.2.26
     script: |
       echo "$(params.message)"
 ---

--- a/examples/v1/pipelineruns/alpha/pipelinerun-large-results.yaml
+++ b/examples/v1/pipelineruns/alpha/pipelinerun-large-results.yaml
@@ -20,7 +20,7 @@ spec:
           type: string
   steps:
     - name: step1
-      image: docker.io/library/alpine
+      image: docker.io/library/alpine:3.20.1
       script: |
         # produce a result - a random string with 2,500 characters - result1
         tr -dc A-Za-z0-9 </dev/urandom | head -c 2500 | tee $(results.result1.path);
@@ -63,7 +63,7 @@ spec:
           type: string
   steps:
     - name: step1
-      image: docker.io/library/alpine
+      image: docker.io/library/alpine:3.20.1
       args: [
         "$(params.param3[*])"
       ]

--- a/examples/v1/pipelineruns/alpha/pipelinerun-with-cel-when-expressions.yaml
+++ b/examples/v1/pipelineruns/alpha/pipelinerun-with-cel-when-expressions.yaml
@@ -47,7 +47,7 @@ spec:
               description: indicates whether the file exists or is missing
           steps:
             - name: check-file
-              image: docker.io/library/alpine
+              image: docker.io/library/alpine:3.20.1
               script: |
                 if test -f $(workspaces.source.path)/$(params.path); then
                   printf yes | tee $(results.exists.path)

--- a/examples/v1/pipelineruns/alpha/stepaction-params.yaml
+++ b/examples/v1/pipelineruns/alpha/stepaction-params.yaml
@@ -25,7 +25,7 @@ spec:
         key1: "step-action default key1"
         key2: "step-action default key2"
         key3: "step-action default key3"
-  image: docker.io/library/bash:3.2
+  image: docker.io/library/bash:5.2.26
   args: [
     "echo",
     "$(params.array-param[*])",

--- a/examples/v1/pipelineruns/beta/7392-regression.yaml
+++ b/examples/v1/pipelineruns/beta/7392-regression.yaml
@@ -10,7 +10,7 @@ spec:
     default: []
   steps:
   - name: step1
-    image: docker.io/library/bash:latest
+    image: docker.io/library/bash:5.2.26
     args:
       - --images
       - $(params.arrayVal1[*])
@@ -20,7 +20,7 @@ spec:
         echo $arg
       done
   - name: step2
-    image: docker.io/library/bash:latest
+    image: docker.io/library/bash:5.2.26
     script: |
       #!/usr/bin/env bash
       echo -n '[]' | tee $(results.resultArray.path)

--- a/examples/v1/pipelineruns/beta/ignore-task-error.yaml
+++ b/examples/v1/pipelineruns/beta/ignore-task-error.yaml
@@ -10,7 +10,7 @@ spec:
         taskSpec:
           steps:
             - name: write
-              image: docker.io/library/alpine
+              image: docker.io/library/alpine:3.20.1
               script: |
                 echo "this is a failing task"
                 exit 1
@@ -20,6 +20,6 @@ spec:
         taskSpec:
           steps:
             - name: write
-              image: docker.io/library/alpine
+              image: docker.io/library/alpine:3.20.1
               script: |
                 echo "this is a success task"

--- a/examples/v1/pipelineruns/beta/isolated-workspaces.yaml
+++ b/examples/v1/pipelineruns/beta/isolated-workspaces.yaml
@@ -37,7 +37,7 @@ spec:
         workspaces:
         - name: creds
         steps:
-        - image: docker.io/library/alpine:3.12.0
+        - image: docker.io/library/alpine:3.20.1
           script: |
             if [ ! -d /creds ] ; then
               echo "unable to access creds"
@@ -46,7 +46,7 @@ spec:
           workspaces:
           - name: creds
             mountpath: /creds
-        - image: docker.io/library/alpine:3.12.0
+        - image: docker.io/library/alpine:3.20.1
           script: |
             if [ -d /workspace/creds ] ; then
               echo "this step should not be able to see creds"

--- a/examples/v1/pipelineruns/beta/pipeline-emitting-results.yaml
+++ b/examples/v1/pipelineruns/beta/pipeline-emitting-results.yaml
@@ -13,7 +13,7 @@ spec:
               description: The array results
           steps:
             - name: write-array
-              image: docker.io/library/bash:latest
+              image: docker.io/library/bash:5.2.26
               script: |
                 #!/usr/bin/env bash
                 echo -n "[\"1\",\"2\",\"3\"]" | tee $(results.array-results.path)
@@ -32,7 +32,7 @@ spec:
                 }
           steps:
             - name: write-array
-              image: docker.io/library/bash:latest
+              image: docker.io/library/bash:5.2.26
               script: |
                 #!/usr/bin/env bash
                 echo -n "{\"foo\":\"bar\",\"hello\":\"world\"}" | tee $(results.object-results.path)

--- a/examples/v1/pipelineruns/beta/pipeline-with-when-expressions-using-array-results.yaml
+++ b/examples/v1/pipelineruns/beta/pipeline-with-when-expressions-using-array-results.yaml
@@ -18,7 +18,7 @@ spec:
               description: The array results
           steps:
             - name: write-array
-              image: docker.io/library/bash:latest
+              image: docker.io/library/bash:5.2.26
               script: |
                 #!/usr/bin/env bash
                 image1="abc.dev/notsofamousimage/image"
@@ -34,7 +34,7 @@ spec:
         taskSpec:
           steps:
             - name: say-hi
-              image: docker.io/library/bash:latest
+              image: docker.io/library/bash:5.2.26
               script: |
                 echo "hi"
       - name: task3
@@ -50,7 +50,7 @@ spec:
         taskSpec:
           steps:
             - name: say-hello
-              image: docker.io/library/bash:latest
+              image: docker.io/library/bash:5.2.26
               script: |
                 echo "hello"
       - name: task4
@@ -62,7 +62,7 @@ spec:
         taskSpec:
           steps:
             - name: say-hi
-              image: docker.io/library/bash:latest
+              image: docker.io/library/bash:5.2.26
               script: |
                 echo "hi"
       - name: task5
@@ -74,7 +74,7 @@ spec:
         taskSpec:
           steps:
             - name: do-not-execute
-              image: docker.io/library/bash:latest
+              image: docker.io/library/bash:5.2.26
               script: |
                 exit 1
     finally:
@@ -82,7 +82,7 @@ spec:
         taskSpec:
           steps:
             - name: validate-tasks-section
-              image: docker.io/library/bash:latest
+              image: docker.io/library/bash:5.2.26
               script: |
                 if [[ $(context.task2.status) != "Succeeded" ]]; then
                   echo "task2 should have been succeeded but instead has status - $(context.task2.status)"

--- a/examples/v1/pipelineruns/beta/pipelinerun-with-matrix-and-results.yaml
+++ b/examples/v1/pipelineruns/beta/pipelinerun-with-matrix-and-results.yaml
@@ -12,7 +12,7 @@ spec:
     - name: url
   steps:
     - name: echo
-      image: docker.io/library/alpine
+      image: docker.io/library/alpine:3.20.1
       script: |
         echo "Visit $(params.url) on $(params.platform) using $(params.browser)."
 ---
@@ -32,7 +32,7 @@ spec:
               type: array
           steps:
             - name: produce-a-list-of-platforms
-              image: docker.io/library/bash:latest
+              image: docker.io/library/bash:5.2.26
               script: |
                 #!/usr/bin/env bash
                 echo -n "[\"linux\",\"mac\",\"windows\"]" | tee $(results.platforms.path)
@@ -44,12 +44,12 @@ spec:
             - name: url
           steps:
             - name: produce-a-list-of-browsers
-              image: docker.io/library/bash:latest
+              image: docker.io/library/bash:5.2.26
               script: |
                 #!/usr/bin/env bash
                 echo -n "[\"chrome\",\"safari\",\"firefox\"]" | tee $(results.browsers.path)
             - name: produce-url
-              image: docker.io/library/bash:latest
+              image: docker.io/library/bash:5.2.26
               script: |
                 #!/usr/bin/env bash
                 echo -n "myfavoritesitedotcom" | tee $(results.url.path)

--- a/examples/v1/pipelineruns/beta/pipelinerun-with-matrix-array-references.yaml
+++ b/examples/v1/pipelineruns/beta/pipelinerun-with-matrix-array-references.yaml
@@ -13,7 +13,7 @@ spec:
       default: ""
   steps:
     - name: echo
-      image: docker.io/library/alpine
+      image: docker.io/library/alpine:3.20.1
       script: |
         echo "$(params.platform) and $(params.browser)"
 ---

--- a/examples/v1/pipelineruns/beta/pipelinerun-with-matrix-context-variables.yaml
+++ b/examples/v1/pipelineruns/beta/pipelinerun-with-matrix-context-variables.yaml
@@ -8,7 +8,7 @@ spec:
       type: string
   steps:
     - name: validate
-      image: docker.io/library/alpine
+      image: docker.io/library/alpine:3.20.1
       args: ["$(params.matrixlength)"]
       script: |
         #!/usr/bin/env sh
@@ -32,7 +32,7 @@ spec:
       type: string
   steps:
     - name: validate
-      image: docker.io/library/alpine
+      image: docker.io/library/alpine:3.20.1
       script: |
         #!/usr/bin/env sh
         echo "Validating the length of the matrix results context variable"
@@ -61,7 +61,7 @@ spec:
     - name: IMAGE-URL
   steps:
     - name: produce-results
-      image: docker.io/library/bash:latest
+      image: docker.io/library/bash:5.2.26
       script: |
         #!/usr/bin/env bash
         echo "Building image for $(params.IMAGE)"

--- a/examples/v1/pipelineruns/beta/pipelinerun-with-matrix-emitting-results.yaml
+++ b/examples/v1/pipelineruns/beta/pipelinerun-with-matrix-emitting-results.yaml
@@ -8,7 +8,7 @@ spec:
       type: string
   steps:
     - name: echo
-      image: docker.io/library/alpine
+      image: docker.io/library/alpine:3.20.1
       script: |
         echo "$(params.url)"
 ---
@@ -60,7 +60,7 @@ spec:
       type: string
   steps:
     - name: produce-report-url
-      image: docker.io/library/alpine
+      image: docker.io/library/alpine:3.20.1
       script: |
         echo "Running tests on $(params.platform)-$(params.browser)"
         echo -n "https://api.example/get-report/$(params.platform)-$(params.browser)" | tee $(results.report-url.path)

--- a/examples/v1/pipelineruns/beta/pipelinerun-with-matrix-include-explicit.yaml
+++ b/examples/v1/pipelineruns/beta/pipelinerun-with-matrix-include-explicit.yaml
@@ -11,7 +11,7 @@ spec:
     - name: DOCKERFILE
   steps:
     - name: echo
-      image: docker.io/library/alpine
+      image: docker.io/library/alpine:3.20.1
       script: |
         echo "$(params.IMAGE) and $(params.DOCKERFILE)"
 ---

--- a/examples/v1/pipelineruns/beta/pipelinerun-with-matrix-include.yaml
+++ b/examples/v1/pipelineruns/beta/pipelinerun-with-matrix-include.yaml
@@ -19,7 +19,7 @@ spec:
       default: ''
   steps:
     - name: echo
-      image: docker.io/library/alpine
+      image: docker.io/library/alpine:3.20.1
       script: |
         echo $(params.GOARCH) and $(params.version) flags? $(params.flags) context? $(params.context) package? $(params.package)
 ---

--- a/examples/v1/pipelineruns/beta/pipelinerun-with-matrix.yaml
+++ b/examples/v1/pipelineruns/beta/pipelinerun-with-matrix.yaml
@@ -11,7 +11,7 @@ spec:
     - name: browser
   steps:
     - name: echo
-      image: docker.io/library/alpine
+      image: docker.io/library/alpine:3.20.1
       script: |
         echo "$(params.platform) and $(params.browser)"
 ---
@@ -108,7 +108,7 @@ spec:
             - name: version
             - name: pipelineTask-retries
           steps:
-            - image: docker.io/library/alpine
+            - image: docker.io/library/alpine:3.20.1
               script: |
                 #!/usr/bin/env sh
                 if [ "$(context.task.retry-count)" == "$(params.pipelineTask-retries)" ]; then

--- a/examples/v1/pipelineruns/ignore-step-error.yaml
+++ b/examples/v1/pipelineruns/ignore-step-error.yaml
@@ -21,13 +21,13 @@ spec:
           - name: CONTINUE
           steps:
             # not really doing anything here, just a hurdle to test the "ignore step error"
-            - image: docker.io/library/alpine
+            - image: docker.io/library/alpine:3.20.1
               onError: $(params.CONTINUE)
               name: exit-with-1
               script: |
                 exit 1
             # initialize a task result which will be validated by the next task
-            - image: docker.io/library/alpine
+            - image: docker.io/library/alpine:3.20.1
               name: write-a-result
               onError: continue
               script: |
@@ -46,13 +46,13 @@ spec:
             - name: task1-result
           steps:
             # again, not really doing anything here, just a hurdle to test the "ignore step error"
-            - image: docker.io/library/alpine
+            - image: docker.io/library/alpine:3.20.1
               onError: continue
               name: exit-with-255
               script: |
                 exit 255
             # verify that the task result was produced by the first task, fail if the result does not match
-            - image: docker.io/library/alpine
+            - image: docker.io/library/alpine:3.20.1
               name: verify-a-task-result
               script: |
                 if [ $(params.task1-result) == 123 ]; then
@@ -62,7 +62,7 @@ spec:
                     exit 1
                 fi
             # the last step of a task and one more hurdle
-            - image: docker.io/library/alpine
+            - image: docker.io/library/alpine:3.20.1
               name: exit-with-20
               onError: continue
               script: |
@@ -89,7 +89,7 @@ spec:
         taskSpec:
           steps:
             - name: write
-              image: docker.io/library/alpine
+              image: docker.io/library/alpine:3.20.1
               onError: continue
               script: |
                 ls -1 /tekton/run/
@@ -106,7 +106,7 @@ spec:
         taskSpec:
           steps:
             - name: read
-              image: docker.io/library/alpine
+              image: docker.io/library/alpine:3.20.1
               onError: continue
               script: |
                 cat $(workspaces.myws.path)/foo | grep bar

--- a/examples/v1/pipelineruns/no-ci/pipelinerun-taskrunspecs.yaml
+++ b/examples/v1/pipelineruns/no-ci/pipelinerun-taskrunspecs.yaml
@@ -13,7 +13,7 @@ spec:
       description: the sum of the first and second operand
   steps:
     - name: add
-      image: docker.io/library/alpine
+      image: docker.io/library/alpine:3.20.1
       env:
         - name: OP1
           value: $(params.first)

--- a/examples/v1/pipelineruns/optional-workspaces.yaml
+++ b/examples/v1/pipelineruns/optional-workspaces.yaml
@@ -16,7 +16,7 @@ spec:
     optional: true
   - name: launch
   steps:
-  - image: docker.io/library/node:lts-alpine3.11
+  - image: docker.io/library/node:lts-alpine3.20
     script: |
       #!/usr/bin/env sh
       if [ $(workspaces.prelaunch.bound) == "true" ] ; then
@@ -40,7 +40,7 @@ spec:
   - name: values
     type: array
   steps:
-  - image: docker.io/library/alpine
+  - image: docker.io/library/alpine:3.20.1
     command: ["echo"]
     args: ["$(params.values[*])"]
 ---

--- a/examples/v1/pipelineruns/pipeline-object-param-and-result.yaml
+++ b/examples/v1/pipelineruns/pipeline-object-param-and-result.yaml
@@ -21,7 +21,7 @@ spec:
           type: string
   steps:
     - name: write-result
-      image: docker.io/library/bash:latest
+      image: docker.io/library/bash:5.2.26
       script: |
         #!/usr/bin/env bash
         echo -n "{\"foo\":\"$(params.arg.url)\",\"bar\":\"$(params.arg.commit)\"}" | tee $(results.object-result.path)
@@ -41,7 +41,7 @@ spec:
           type: string
   steps:
     - name: echo-params
-      image: docker.io/library/bash:latest
+      image: docker.io/library/bash:5.2.26
       args: [
         "$(params.arg.foo)",
         "$(params.arg.bar)"

--- a/examples/v1/pipelineruns/pipeline-object-results.yaml
+++ b/examples/v1/pipelineruns/pipeline-object-results.yaml
@@ -18,7 +18,7 @@ spec:
                   type: string
           steps:
             - name: write-object
-              image: docker.io/library/bash:latest
+              image: docker.io/library/bash:5.2.26
               script: |
                 #!/usr/bin/env bash
                 echo -n "{\"url\":\"abc.dev/sampler\",\"digest\":\"19f02276bf8dbdd62f069b922f10c65262cc34b710eea26ff928129a736be791\"}" | tee $(results.object-results.path)
@@ -41,7 +41,7 @@ spec:
                   type: string
           steps:
             - name: validate-object-url
-              image: docker.io/library/bash:latest
+              image: docker.io/library/bash:5.2.26
               args: [
                 "$(params.whole-object.url)"
               ]

--- a/examples/v1/pipelineruns/pipeline-with-displayname.yaml
+++ b/examples/v1/pipelineruns/pipeline-with-displayname.yaml
@@ -18,7 +18,7 @@ spec:
       description: The sum of the two provided integers
   steps:
     - name: sum
-      image: docker.io/library/bash:latest
+      image: docker.io/library/bash:5.2.26
       script: |
         #!/usr/bin/env bash
         echo -n $(( "$(params.a)" + "$(params.b)" )) | tee $(results.sum.path)
@@ -74,7 +74,7 @@ spec:
             type: string
         steps:
           - name: print
-            image: docker.io/library/alpine
+            image: docker.io/library/alpine:3.20.1
             script: |
               echo "$(params.sum)"
 ---

--- a/examples/v1/pipelineruns/pipelinerun-array-results-substitution.yaml
+++ b/examples/v1/pipelineruns/pipelinerun-array-results-substitution.yaml
@@ -18,7 +18,7 @@ spec:
               description: The array results
           steps:
             - name: write-array
-              image: docker.io/library/bash:latest
+              image: docker.io/library/bash:5.2.26
               script: |
                 #!/usr/bin/env bash
                 image1="abc.dev/sampler/busysample@sha256:19f02276bf8dbdd62f069b922f10c65262cc34b710eea26ff928129a736be791"
@@ -44,7 +44,7 @@ spec:
               type: string
           steps:
             - name: validate-images
-              image: docker.io/library/bash:latest
+              image: docker.io/library/bash:5.2.26
               args: [
                 "$(params.images[*])"
               ]

--- a/examples/v1/pipelineruns/pipelinerun-param-array-indexing.yaml
+++ b/examples/v1/pipelineruns/pipelinerun-param-array-indexing.yaml
@@ -26,7 +26,7 @@ spec:
         steps:
           # args must be initialed to "staging"
           - name: validate-environment1
-            image: docker.io/library/bash:latest
+            image: docker.io/library/bash:5.2.26
             args: [
               "$(params.environment1)",
             ]
@@ -63,7 +63,7 @@ spec:
           # this step validates an array param which must have three values
           # also validates indexing into an array param
           - name: validate-environments
-            image: docker.io/library/bash:latest
+            image: docker.io/library/bash:5.2.26
             args: [
               "$(params.environments[*])",
             ]

--- a/examples/v1/pipelineruns/pipelinerun-results-with-params.yaml
+++ b/examples/v1/pipelineruns/pipelinerun-results-with-params.yaml
@@ -16,7 +16,7 @@ spec:
         - name: suffix
         steps:
         - name: generate-suffix
-          image: docker.io/library/alpine
+          image: docker.io/library/alpine:3.20.1
           script: |
             echo -n "suffix" > $(results.suffix.path)
     - name: do-something
@@ -25,7 +25,7 @@ spec:
         - name: arg
         steps:
         - name: do-something
-          image: docker.io/library/alpine
+          image: docker.io/library/alpine:3.20.1
           script: |
             echo "$(params.arg)" | grep "prefix:suffix"
       params:

--- a/examples/v1/pipelineruns/pipelinerun-results.yaml
+++ b/examples/v1/pipelineruns/pipelinerun-results.yaml
@@ -13,7 +13,7 @@ spec:
       description: the sum of the first and second operand
   steps:
     - name: add
-      image: docker.io/library/alpine
+      image: docker.io/library/alpine:3.20.1
       env:
         - name: OP1
           value: $(params.first)

--- a/examples/v1/pipelineruns/pipelinerun-task-execution-status.yaml
+++ b/examples/v1/pipelineruns/pipelinerun-task-execution-status.yaml
@@ -10,7 +10,7 @@ spec:
     - name: task1  # successful task
       taskSpec:
         steps:
-        - image: docker.io/library/ubuntu
+        - image: docker.io/library/ubuntu:24.04
           name: hello
           script: |
             echo "Hello World!"
@@ -21,7 +21,7 @@ spec:
           values: ["true"]
       taskSpec:
         steps:
-          - image: docker.io/library/ubuntu
+          - image: docker.io/library/ubuntu:24.04
             name: success
             script: |
               exit 0
@@ -37,7 +37,7 @@ spec:
           - name: task1Status
           - name: task2Status
         steps:
-          - image: docker.io/library/alpine
+          - image: docker.io/library/alpine:3.20.1
             name: verify-dag-task-status
             script: |
               if [[ $(params.task1Status) != "Succeeded" ||  $(params.task2Status) != "None" ]]; then
@@ -51,7 +51,7 @@ spec:
         params:
           - name: aggregateStatus
         steps:
-          - image: docker.io/library/alpine
+          - image: docker.io/library/alpine:3.20.1
             name: verify-aggregate-tasks-status
             script: |
               if [[ $(params.aggregateStatus) != "Completed" ]]; then

--- a/examples/v1/pipelineruns/pipelinerun-with-extra-params.yaml
+++ b/examples/v1/pipelineruns/pipelinerun-with-extra-params.yaml
@@ -35,7 +35,7 @@ spec:
     description: The second integer
   steps:
   - name: sum
-    image: docker.io/library/bash:latest
+    image: docker.io/library/bash:5.2.26
     script: |
       #!/usr/bin/env bash
       echo -n $(( "$(inputs.params.a)" + "$(inputs.params.b)" ))

--- a/examples/v1/pipelineruns/pipelinerun-with-final-results.yaml
+++ b/examples/v1/pipelineruns/pipelinerun-with-final-results.yaml
@@ -58,7 +58,7 @@ spec:
       description: The product of the two provided integers
   steps:
     - name: product
-      image: docker.io/library/bash:latest
+      image: docker.io/library/bash:5.2.26
       script: |
         #!/usr/bin/env bash
         echo -n $(( "$(params.a)" * "$(params.b)" )) | tee $(results.product.path)

--- a/examples/v1/pipelineruns/pipelinerun-with-final-tasks.yaml
+++ b/examples/v1/pipelineruns/pipelinerun-with-final-tasks.yaml
@@ -174,7 +174,7 @@ spec:
           - name: commit
         steps:
           - name: check-commit-initialized
-            image: docker.io/library/alpine
+            image: docker.io/library/alpine:3.20.1
             script: |
               if [[ ! $(params.commit) ]]; then
                 exit 1

--- a/examples/v1/pipelineruns/pipelinerun-with-params.yaml
+++ b/examples/v1/pipelineruns/pipelinerun-with-params.yaml
@@ -47,7 +47,7 @@ spec:
     description: The second integer
   steps:
   - name: sum
-    image: docker.io/library/bash:latest
+    image: docker.io/library/bash:5.2.26
     script: |
       #!/usr/bin/env bash
       echo -n $(( "$(inputs.params.a)" + "$(inputs.params.b)" ))
@@ -71,7 +71,7 @@ spec:
     description: The second integer
   steps:
   - name: product
-    image: docker.io/library/bash:latest
+    image: docker.io/library/bash:5.2.26
     script: |
       #!/usr/bin/env bash
       echo -n $(( "$(inputs.params.a)" * "$(inputs.params.b)" ))

--- a/examples/v1/pipelineruns/pipelinerun-with-when-expressions.yaml
+++ b/examples/v1/pipelineruns/pipelinerun-with-when-expressions.yaml
@@ -54,7 +54,7 @@ spec:
               description: indicates whether the file exists or is missing
           steps:
             - name: check-file
-              image: docker.io/library/alpine
+              image: docker.io/library/alpine:3.20.1
               script: |
                 if test -f $(workspaces.source.path)/$(params.path); then
                   printf yes | tee $(results.exists.path)
@@ -79,7 +79,7 @@ spec:
         taskSpec:
           steps:
             - name: echo
-              image: docker.io/library/alpine
+              image: docker.io/library/alpine:3.20.1
               script: 'echo hello'
       - name: task-should-be-skipped-1
         when:
@@ -121,7 +121,7 @@ spec:
         taskSpec:
           steps:
             - name: echo
-              image: docker.io/library/alpine
+              image: docker.io/library/alpine:3.20.1
               script: exit 1
     finally:
       - name: finally-task-should-be-skipped-1  # when expression using execution status, evaluates to false

--- a/examples/v1/pipelineruns/propagating-workspaces-in-pipelines.yaml
+++ b/examples/v1/pipelineruns/propagating-workspaces-in-pipelines.yaml
@@ -9,7 +9,7 @@ spec:
     - name: t1
       taskSpec:
         steps:
-          - image: docker.io/library/ubuntu
+          - image: docker.io/library/ubuntu:24.04
             command: ["ls"]
             args: ["$(workspaces.shared-data.path)"]
 ---

--- a/examples/v1/pipelineruns/task_results_example.yaml
+++ b/examples/v1/pipelineruns/task_results_example.yaml
@@ -58,7 +58,7 @@ spec:
       description: The sum of the two provided integers
   steps:
     - name: sum
-      image: docker.io/library/bash:latest
+      image: docker.io/library/bash:5.2.26
       script: |
         #!/usr/bin/env bash
         echo -n $(( "$(params.a)" + "$(params.b)" )) | tee $(results.sum.path)
@@ -85,7 +85,7 @@ spec:
       description: The product of the two provided integers
   steps:
     - name: product
-      image: docker.io/library/bash:latest
+      image: docker.io/library/bash:5.2.26
       script: |
         #!/usr/bin/env bash
         echo -n $(( "$(params.a)" * "$(params.b)" )) | tee $(results.product.path)

--- a/examples/v1/pipelineruns/using-optional-workspaces-in-when-expressions.yaml
+++ b/examples/v1/pipelineruns/using-optional-workspaces-in-when-expressions.yaml
@@ -47,7 +47,7 @@ spec:
         - name: message-of-the-day
           optional: true
         steps:
-        - image: docker.io/library/alpine
+        - image: docker.io/library/alpine:3.20.1
           script: |
             #!/usr/bin/env ash
             for f in "$(workspaces.message-of-the-day.path)"/* ; do
@@ -63,6 +63,6 @@ spec:
       taskSpec:
         steps:
         - name: print-default
-          image: docker.io/library/alpine
+          image: docker.io/library/alpine:3.20.1
           script: |
             echo "No message-of-the-day workspace was provided. This is the default MOTD instead!"

--- a/examples/v1/pipelineruns/using-retries-and-retry-count-variables.yaml
+++ b/examples/v1/pipelineruns/using-retries-and-retry-count-variables.yaml
@@ -19,7 +19,7 @@ spec:
         - name: pipelineTask-retries
         - name: pipelineTask-retry-count
         steps:
-        - image: docker.io/library/alpine:3.12.0
+        - image: docker.io/library/alpine:3.20.1
           script: |
             #!/usr/bin/env sh
             if [ "$(params.pipelineTask-retry-count)" == "$(params.pipelineTask-retries)" ]; then
@@ -33,6 +33,6 @@ spec:
       - retry-me
       taskSpec:
         steps:
-        - image: docker.io/library/busybox
+        - image: docker.io/library/busybox:1.36
           script: |
             echo "hello world"

--- a/examples/v1/pipelineruns/using_context_variables.yaml
+++ b/examples/v1/pipelineruns/using_context_variables.yaml
@@ -28,12 +28,12 @@ spec:
         - name: pipelineRun-namespace
         - name: pipelineTask-retries
         steps:
-        - image: docker.io/library/ubuntu
+        - image: docker.io/library/ubuntu:24.04
           name: print-uid
           script: |
             echo "TaskRun UID: $(context.taskRun.uid)"
             echo "PipelineRun UID from params: $(params.pipeline-uid)"
-        - image: docker.io/library/ubuntu
+        - image: docker.io/library/ubuntu:24.04
           name: print-names
           script: |
             echo "Task name: $(context.task.name)"
@@ -41,7 +41,7 @@ spec:
             echo "Pipeline name from params: $(params.pipeline-name)"
             echo "PipelineRun name from params: $(params.pipelineRun-name)"
             echo "PipelineRun namespace from params: $(params.pipelineRun-namespace)"
-        - image: docker.io/library/ubuntu
+        - image: docker.io/library/ubuntu:24.04
           name: print-retries
           script: |
             echo "PipelineTask retries from params: $(params.pipelineTask-retries)"

--- a/examples/v1/taskruns/alpha/param-enum.yaml
+++ b/examples/v1/taskruns/alpha/param-enum.yaml
@@ -9,7 +9,7 @@ spec:
     default: "v1"
   steps:
   - name: build
-    image: docker.io/library/bash:3.2
+    image: docker.io/library/bash:5.2.26
     script: |
       echo "$(params.message)"
 ---

--- a/examples/v1/taskruns/alpha/produce-consume-artifacts.yaml
+++ b/examples/v1/taskruns/alpha/produce-consume-artifacts.yaml
@@ -8,7 +8,7 @@ spec:
       A simple task that populates artifacts to TaskRun stepState
     steps:
       - name: artifacts-producer
-        image: docker.io/library/bash:latest
+        image: docker.io/library/bash:5.2.26
         script: |
           cat > $(step.artifacts.path) << EOF
           {
@@ -42,11 +42,11 @@ spec:
           }
           EOF
       - name: artifacts-consumer
-        image: docker.io/library/bash:latest
+        image: docker.io/library/bash:5.2.26
         script: |
           echo $(steps.artifacts-producer.inputs.input-artifacts)
       - name: artifacts-consumer-python
-        image: docker.io/library/python:latest
+        image: docker.io/library/python:3.12.4
         script: |
           #!/usr/bin/env python3
           import json

--- a/examples/v1/taskruns/alpha/step-stream-workspace.yaml
+++ b/examples/v1/taskruns/alpha/step-stream-workspace.yaml
@@ -43,26 +43,26 @@ spec:
           - wrong
         stderrConfig:
           path: $(results.error2.path)
-      - image: docker.io/library/bash
+      - image: docker.io/library/bash:5.2.26
         workspaces:
           - name: data
         onError: continue
         args:
           - -c
           - "echo foobar >$(workspaces.data.path)/foobar.txt"
-      - image: docker.io/library/bash
+      - image: docker.io/library/bash:5.2.26
         onError: continue
         args:
           - -c
           - "2>$(results.error.path) >&2 echo -n fooerr"
-      - image: docker.io/library/bash
+      - image: docker.io/library/bash:5.2.26
         workspaces:
           - name: data
         workingDir: $(workspaces.data.path)
         onError: continue
         script: |
           echo local >out.txt
-      - image: docker.io/library/bash
+      - image: docker.io/library/bash:5.2.26
         workspaces:
           - name: data
         onError: continue

--- a/examples/v1/taskruns/array-default.yaml
+++ b/examples/v1/taskruns/array-default.yaml
@@ -23,7 +23,7 @@ spec:
     steps:
       # this step should echo "foo bar foo-default bar-default baz"
       - name: echo-params
-        image: docker.io/library/bash:3.2
+        image: docker.io/library/bash:5.2.26
         args: [
           "echo",
           "$(params.array-to-echo[*])",

--- a/examples/v1/taskruns/beta/emit-array-results.yaml
+++ b/examples/v1/taskruns/beta/emit-array-results.yaml
@@ -12,7 +12,7 @@ spec:
       description: The array results
   steps:
     - name: write-array
-      image: docker.io/library/bash:latest
+      image: docker.io/library/bash:5.2.26
       script: |
         #!/usr/bin/env bash
         echo -n "[\"hello\",\"world\"]" | tee $(results.array-results.path)

--- a/examples/v1/taskruns/beta/large-task-result.yaml
+++ b/examples/v1/taskruns/beta/large-task-result.yaml
@@ -14,13 +14,13 @@ spec:
       - name: result5
     steps:
       - name: step1
-        image: docker.io/library/bash:latest
+        image: docker.io/library/bash:5.2.26
         script: |
           #!/usr/bin/env bash
           cat /dev/urandom | head -c 2500 | base64 | tee $(results.result1.path) #about 1 K result
           cat /dev/urandom | head -c 2500 | base64 | tee $(results.result2.path) #about 4 K result
       - name: step2
-        image: docker.io/library/bash:latest
+        image: docker.io/library/bash:5.2.26
         script: |
           #!/usr/bin/env bash
           cat /dev/urandom | head -c 2500 | base64 | tee $(results.result3.path) #about 1 K result

--- a/examples/v1/taskruns/beta/param_array_indexing.yaml
+++ b/examples/v1/taskruns/beta/param_array_indexing.yaml
@@ -15,7 +15,7 @@ spec:
     steps:
       # this step should echo "foo"
       - name: echo-params-1
-        image: docker.io/library/bash:3.2
+        image: docker.io/library/bash:5.2.26
         args: [
           "echo",
           "$(params.array-to-echo[0])",

--- a/examples/v1/taskruns/beta/stepaction-passing-results.yaml
+++ b/examples/v1/taskruns/beta/stepaction-passing-results.yaml
@@ -15,7 +15,7 @@ spec:
           type: string
         IMAGE_DIGEST:
           type: string
-  image: docker.io/library/bash:3.2
+  image: docker.io/library/bash:5.2.26
   env:
     - name: STRINGPARAM
       value: $(params.param2)
@@ -75,7 +75,7 @@ spec:
                 type: string
               IMAGE_DIGEST:
                 type: string
-        image: docker.io/library/alpine
+        image: docker.io/library/alpine:3.20.1
         script: |
           echo -n "[\"image1\", \"image2\", \"image3\"]" | tee $(step.results.result1.path)
           echo -n "foo" | tee $(step.results.result2.path)

--- a/examples/v1/taskruns/beta/stepaction-results.yaml
+++ b/examples/v1/taskruns/beta/stepaction-results.yaml
@@ -3,7 +3,7 @@ kind: StepAction
 metadata:
   name: step-action
 spec:
-  image: docker.io/library/alpine
+  image: docker.io/library/alpine:3.20.1
   results:
     - name: result1
     - name: result2

--- a/examples/v1/taskruns/beta/stepaction.yaml
+++ b/examples/v1/taskruns/beta/stepaction.yaml
@@ -3,7 +3,7 @@ kind: StepAction
 metadata:
   name: step-action
 spec:
-  image: docker.io/library/alpine
+  image: docker.io/library/alpine:3.20.1
   script: |
     echo "I am a Step Action!!!"
 ---

--- a/examples/v1/taskruns/beta/stepactions-steptemplate.yaml
+++ b/examples/v1/taskruns/beta/stepactions-steptemplate.yaml
@@ -3,7 +3,7 @@ kind: StepAction
 metadata:
   name: step-action
 spec:
-  image: docker.io/library/alpine
+  image: docker.io/library/alpine:3.20.1
   command: ["env"]
 ---
 apiVersion: tekton.dev/v1

--- a/examples/v1/taskruns/beta/workspace-in-sidecar.yaml
+++ b/examples/v1/taskruns/beta/workspace-in-sidecar.yaml
@@ -17,7 +17,7 @@ spec:
     workspaces:
     - name: signals
     steps:
-    - image: docker.io/library/alpine:3.12.0
+    - image: docker.io/library/alpine:3.20.1
       computeResources:
         requests:
           memory: "16Mi"
@@ -33,7 +33,7 @@ spec:
         echo "Sidecar responded: ${response}"
         echo "Step Done."
     sidecars:
-    - image: docker.io/library/alpine:3.12.0
+    - image: docker.io/library/alpine:3.20.1
       computeResources:
         requests:
           memory: "16Mi"

--- a/examples/v1/taskruns/beta/workspace-isolation.yaml
+++ b/examples/v1/taskruns/beta/workspace-isolation.yaml
@@ -18,7 +18,7 @@ spec:
     - name: signals
     steps:
     - name: await-sidecar-signal
-      image: docker.io/library/alpine:3.12.0
+      image: docker.io/library/alpine:3.20.1
       workspaces:
       - name: signals
       script: |
@@ -32,7 +32,7 @@ spec:
         done
         echo "Saw ready file"
     - name: check-signals-access
-      image: docker.io/library/alpine:3.12.0
+      image: docker.io/library/alpine:3.20.1
       script: |
         #!/usr/bin/env ash
         if [ -f "$(workspaces.signals.path)"/start ] ; then
@@ -41,7 +41,7 @@ spec:
         fi
     sidecars:
     - name: await-step-signal
-      image: docker.io/library/alpine:3.12.0
+      image: docker.io/library/alpine:3.20.1
       workspaces:
       - name: signals
       script: |

--- a/examples/v1/taskruns/creds-init-only-mounts-provided-credentials.yaml
+++ b/examples/v1/taskruns/creds-init-only-mounts-provided-credentials.yaml
@@ -30,7 +30,7 @@ spec:
   taskSpec:
     steps:
     - name: check-credentials
-      image: docker.io/library/alpine
+      image: docker.io/library/alpine:3.20.1
       script: |
         #!/usr/bin/env ash
         set -xe

--- a/examples/v1/taskruns/custom-env.yaml
+++ b/examples/v1/taskruns/custom-env.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   taskSpec:
     steps:
-    - image: docker.io/library/ubuntu
+    - image: docker.io/library/ubuntu:24.04
       script: |
         #!/usr/bin/env bash
         [[ $MY_VAR1 == foo ]]

--- a/examples/v1/taskruns/entrypoint-resolution.yaml
+++ b/examples/v1/taskruns/entrypoint-resolution.yaml
@@ -13,17 +13,17 @@ spec:
     # Multi-arch image with no command defined, but with args. We'll look
     # up the commands and pass it to the entrypoint binary via env var, then
     # append the specified args.
-    - image: docker.io/library/ubuntu
+    - image: docker.io/library/ubuntu:24.04
       args: ['-c', 'echo', 'hello']
 
     # Multi-arch image, but since we specify `script` we don't need to look it
     # up and pass it down.
-    - image: docker.io/library/ubuntu
+    - image: docker.io/library/ubuntu:24.04
       script: echo hello
 
     # Multi-arch image, but since we specify `command` and `args` we don't
     # need to look it up and pass it down.
-    - image: docker.io/library/ubuntu
+    - image: docker.io/library/ubuntu:24.04
       command: ['sh', '-c']
       args: ['echo hello']
 

--- a/examples/v1/taskruns/home-is-set.yaml
+++ b/examples/v1/taskruns/home-is-set.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   taskSpec:
     steps:
-    - image: docker.io/library/ubuntu
+    - image: docker.io/library/ubuntu:24.04
       env:
       - name: HOME
         value: /tekton/home

--- a/examples/v1/taskruns/ignore-step-error.yaml
+++ b/examples/v1/taskruns/ignore-step-error.yaml
@@ -6,14 +6,14 @@ spec:
   taskSpec:
     steps:
       # exit with 1 and ignore non zero exit code
-      - image: docker.io/library/alpine
+      - image: docker.io/library/alpine:3.20.1
         onError: continue
         name: exit-with-1
         script: |
           exit 1
       # check if the /tekton/steps/step-<step-name>/exitCode got created and contains the exit code
       # check if the symlink /tekton/steps/0/ got created
-      - image: docker.io/library/alpine
+      - image: docker.io/library/alpine:3.20.1
         name: verify-step-path
         script: |
           exitCode=`cat $(steps.step-exit-with-1.exitCode.path)`

--- a/examples/v1/taskruns/object-param-result.yaml
+++ b/examples/v1/taskruns/object-param-result.yaml
@@ -43,7 +43,7 @@ spec:
             echo "validate the params.gitrepo.commit successfully"
           fi
       - name: write-object-result
-        image: docker.io/library/bash:latest
+        image: docker.io/library/bash:5.2.26
         script: |
           #!/usr/bin/env bash
           echo -n "{\"IMAGE_URL\":\"ar.com\", \"IMAGE_DIGEST\":\"sha234\"}" > $(results.object-results.path)

--- a/examples/v1/taskruns/optional-workspaces.yaml
+++ b/examples/v1/taskruns/optional-workspaces.yaml
@@ -14,7 +14,7 @@ spec:
       optional: true
     steps:
     - name: check-workspaces
-      image: docker.io/library/alpine:3.12.0
+      image: docker.io/library/alpine:3.20.1
       script: |
         if [ "$(workspaces.source-code.bound)" == "true" ]; then
           printf "Source code workspace was provided at %s!\n" "$(workspaces.source-code.path)"

--- a/examples/v1/taskruns/readonly-internal-dir.yaml
+++ b/examples/v1/taskruns/readonly-internal-dir.yaml
@@ -7,9 +7,9 @@ metadata:
 spec:
   taskSpec:
     steps:
-    - image: docker.io/library/ubuntu
+    - image: docker.io/library/ubuntu:24.04
       script: exit 0
-    - image: docker.io/library/ubuntu
+    - image: docker.io/library/ubuntu:24.04
       script: |
         set +e # dont fail the script on error
 
@@ -19,7 +19,7 @@ spec:
           echo "able to write to run directory of non-current step"
           exit 1
         fi
-    - image: docker.io/library/ubuntu
+    - image: docker.io/library/ubuntu:24.04
       script: |
         set +e # dont fail the script on error
 

--- a/examples/v1/taskruns/secret-volume-params.yaml
+++ b/examples/v1/taskruns/secret-volume-params.yaml
@@ -16,7 +16,7 @@ spec:
       description: Name of secret
       type: string
     steps:
-    - image: docker.io/library/ubuntu
+    - image: docker.io/library/ubuntu:24.04
       script: |
         #!/usr/bin/env bash
         SECRET_PASSWORD=$(cat /var/secret/ninja)

--- a/examples/v1/taskruns/secret-volume.yaml
+++ b/examples/v1/taskruns/secret-volume.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   taskSpec:
     steps:
-    - image: docker.io/library/ubuntu
+    - image: docker.io/library/ubuntu:24.04
       script: |
         #!/usr/bin/env bash
         SECRET_PASSWORD=$(cat /var/secret/ninja)

--- a/examples/v1/taskruns/step-script.yaml
+++ b/examples/v1/taskruns/step-script.yaml
@@ -59,13 +59,13 @@ spec:
         cat file
 
     - name: node
-      image: docker.io/library/node
+      image: docker.io/library/node:lts-alpine3.20
       script: |
         #!/usr/bin/env node
         console.log("Hello from Node!")
 
     - name: python
-      image: docker.io/library/python
+      image: docker.io/library/python:3.12.4
       script: |
         #!/usr/bin/env python3
         print("Hello from Python!")
@@ -78,7 +78,7 @@ spec:
 
     # Test that param values are replaced.
     - name: params-applied
-      image: docker.io/library/python
+      image: docker.io/library/python:3.12.4
       script: |
         #!/usr/bin/env python3
         v = '$(params.PARAM)'
@@ -99,7 +99,7 @@ spec:
 
     # Test that multiple dollar signs next to each other are not replaced by Kubernetes
     - name: dollar-signs-allowed
-      image: docker.io/library/python
+      image: docker.io/library/python:3.12.4
       script: |
         #!/usr/bin/env python3
         if '$' != '\u0024':
@@ -118,7 +118,7 @@ spec:
 
     # Test that bash scripts with variable evaluations work as expected
     - name: bash-variable-evaluations
-      image: docker.io/library/bash:5.1.8
+      image: docker.io/library/bash:5.2.26
       script: |
         #!/usr/bin/env bash
         set -xe

--- a/examples/v1/taskruns/steps-run-in-order.yaml
+++ b/examples/v1/taskruns/steps-run-in-order.yaml
@@ -5,8 +5,8 @@ metadata:
 spec:
   taskSpec:
     steps:
-    - image: docker.io/library/busybox
+    - image: docker.io/library/busybox:1.36
       # NB: command is not set, so it must be looked up from the registry.
       args: ['-c', 'sleep 3 && touch foo']
-    - image: docker.io/library/busybox
+    - image: docker.io/library/busybox:1.36
       args: ['-c', 'ls', 'foo']

--- a/examples/v1/taskruns/task-result.yaml
+++ b/examples/v1/taskruns/task-result.yaml
@@ -13,12 +13,12 @@ spec:
         description: The current date in human readable format
     steps:
       - name: print-date-unix-timestamp
-        image: docker.io/library/bash:latest
+        image: docker.io/library/bash:5.2.26
         script: |
           #!/usr/bin/env bash
           date +%s | tee $(results.current-date-unix-timestamp.path)
       - name: print-date-human-readable
-        image: docker.io/library/bash:latest
+        image: docker.io/library/bash:5.2.26
         script: |
           #!/usr/bin/env bash
           date | tee $(results.current-date-human-readable.path)

--- a/examples/v1/taskruns/unnamed-steps.yaml
+++ b/examples/v1/taskruns/unnamed-steps.yaml
@@ -5,9 +5,9 @@ metadata:
 spec:
   taskSpec:
     steps:
-    - image: docker.io/library/ubuntu
+    - image: docker.io/library/ubuntu:24.04
       script: 'true'
-    - image: docker.io/library/ubuntu
+    - image: docker.io/library/ubuntu:24.04
       script: 'true'
-    - image: docker.io/library/ubuntu
+    - image: docker.io/library/ubuntu:24.04
       script: 'true'

--- a/examples/v1/taskruns/using_context_variables.yaml
+++ b/examples/v1/taskruns/using_context_variables.yaml
@@ -5,11 +5,11 @@ metadata:
 spec:
   taskSpec:
     steps:
-    - image: docker.io/library/ubuntu
+    - image: docker.io/library/ubuntu:24.04
       name: print-uid
       script: |
         echo "TaskRunUID name: $(context.taskRun.uid)"
-    - image: docker.io/library/ubuntu
+    - image: docker.io/library/ubuntu:24.04
       name: print-names
       script: |
         echo "Task name: $(context.task.name)"

--- a/examples/v1/taskruns/workspace-in-sidecar.yaml
+++ b/examples/v1/taskruns/workspace-in-sidecar.yaml
@@ -18,7 +18,7 @@ spec:
     workspaces:
     - name: signals
     steps:
-    - image: docker.io/library/alpine:3.12.0
+    - image: docker.io/library/alpine:3.20.1
       computeResources:
         requests:
           memory: "16Mi"
@@ -34,7 +34,7 @@ spec:
         echo "Sidecar responded: ${response}"
         echo "Step Done."
     sidecars:
-    - image: docker.io/library/alpine:3.12.0
+    - image: docker.io/library/alpine:3.20.1
       computeResources:
         requests:
           memory: "16Mi"

--- a/examples/v1beta1/taskruns/clustertask.yaml
+++ b/examples/v1beta1/taskruns/clustertask.yaml
@@ -6,7 +6,7 @@ metadata:
   name: clustertask-v1beta1
 spec:
   steps:
-  - image: docker.io/library/ubuntu
+  - image: docker.io/library/ubuntu:24.04
     script: echo hello
 ---
 apiVersion: tekton.dev/v1beta1

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -12091,7 +12091,7 @@ spec:
       type: array
   steps:
     - name: produce-a-list-of-platforms
-      image: docker.io/library/bash:latest
+      image: docker.io/library/bash:5.2.26
       script: |
         #!/usr/bin/env bash
         echo -n "[\"linux\",\"mac\",\"windows\"]" | tee $(results.platforms.path)
@@ -12576,7 +12576,7 @@ spec:
       type: array
   steps:
     - name: produce-a-list-of-platforms
-      image: docker.io/library/bash:latest
+      image: docker.io/library/bash:5.2.26
       script: |
         #!/usr/bin/env bash
         echo -n "[\"linux\",\"mac\",\"windows\"]" | tee $(results.platforms.path)

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -2762,7 +2762,7 @@ metadata:
 spec:
   taskSpec:
     sidecars:
-    - image: docker.io/library/ubuntu
+    - image: docker.io/library/ubuntu:24.04
     - image: whatever
     steps:
     - image: alpine

--- a/tekton/release-pipeline.yaml
+++ b/tekton/release-pipeline.yaml
@@ -242,7 +242,7 @@ spec:
             description: The full URL of the release file (no tag) in the bucket
         steps:
           - name: create-results
-            image: docker.io/library/alpine
+            image: docker.io/library/alpine:3.20.1
             env:
               - name: RELEASE_BUCKET
                 value: $(params.releaseBucket)

--- a/test/affinity_assistant_test.go
+++ b/test/affinity_assistant_test.go
@@ -56,14 +56,14 @@ spec:
       - name: my-workspace
       taskSpec:
         steps:
-        - image: docker.io/library/busybox
+        - image: docker.io/library/busybox:1.36
           script: echo hello foo
     - name: bar
       workspaces:
       - name: my-workspace
       taskSpec:
         steps:
-        - image: docker.io/library/busybox
+        - image: docker.io/library/busybox:1.36
           script: echo hello bar
   workspaces:
   - name: my-workspace
@@ -151,14 +151,14 @@ spec:
       - name: my-workspace
       taskSpec:
         steps:
-        - image: docker.io/library/busybox
+        - image: docker.io/library/busybox:1.36
           script: echo hello foo
     - name: bar
       workspaces:
       - name: my-workspace2
       taskSpec:
         steps:
-        - image: docker.io/library/busybox
+        - image: docker.io/library/busybox:1.36
           script: echo hello bar
     - name: double-ws
       workspaces:
@@ -166,12 +166,12 @@ spec:
       - name: my-workspace2
       taskSpec:
         steps:
-        - image: docker.io/library/busybox
+        - image: docker.io/library/busybox:1.36
           script: echo double-ws
     - name: no-ws
       taskSpec:
         steps:
-        - image: docker.io/library/busybox
+        - image: docker.io/library/busybox:1.36
         script: echo no-ws
   workspaces:
   - name: my-workspace

--- a/test/cancel_test.go
+++ b/test/cancel_test.go
@@ -65,7 +65,7 @@ spec:
       retries: %d
       taskSpec:
         steps:
-        - image: docker.io/library/busybox
+        - image: docker.io/library/busybox:1.36
           script: 'sleep 5000'
 `, helpers.ObjectNameForTest(t), namespace, numRetries))
 

--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -156,7 +156,7 @@ spec:
       default: param-value
     steps:
     - name: node
-      image: docker.io/library/node
+      image: docker.io/library/node:lts-alpine3.20
       script: |
         #!/usr/bin/env node
         console.log("Hello from Node!")
@@ -167,7 +167,7 @@ spec:
         print "Hello from Perl!"
     # Test that param values are replaced.
     - name: params-applied
-      image: docker.io/library/python
+      image: docker.io/library/python:3.12.4
       script: |
         #!/usr/bin/env python3
         v = '$(params.PARAM)'
@@ -186,7 +186,7 @@ spec:
         [[ $2 == "world" ]]
     # Test that multiple dollar signs next to each other are not replaced by Kubernetes
     - name: dollar-signs-allowed
-      image: docker.io/library/python
+      image: docker.io/library/python:3.12.4
       script: |
         #!/usr/bin/env python3
         if '$' != '\u0024':
@@ -205,7 +205,7 @@ spec:
 
     # Test that bash scripts with variable evaluations work as expected
     - name: bash-variable-evaluations
-      image: docker.io/library/bash:5.1.8
+      image: docker.io/library/bash:5.2.26
       script: |
         #!/usr/bin/env bash
         set -xe
@@ -441,7 +441,7 @@ metadata:
 spec:
   taskSpec:
     steps:
-    - image: docker.io/library/busybox
+    - image: docker.io/library/busybox:1.36
       args: ['-c', 'echo hello']
 `, helpers.ObjectNameForTest(t))
 
@@ -493,7 +493,7 @@ metadata:
 spec:
   taskSpec:
     steps:
-    - image: docker.io/library/busybox
+    - image: docker.io/library/busybox:1.36
       script: exit 1
 `, helpers.ObjectNameForTest(t))
 
@@ -794,7 +794,7 @@ spec:
         type: array
     steps:
     - name: concat-array-params
-      image: docker.io/library/alpine
+      image: docker.io/library/alpine:3.20.1
       command: ["/bin/sh", "-c"]
       args:
       - echo -n $(params.array-to-concat[0])"-"$(params.array-to-concat[1]) | tee $(results.concat-array.path);
@@ -863,12 +863,12 @@ spec:
         default: "string-baz-default"
     steps:
       - name: string-params-to-result
-        image: docker.io/library/bash:3.2
+        image: docker.io/library/bash:5.2.26
         command: ["/bin/sh", "-c"]
         args:
         - echo -n $(params.string-param)"-"$(params.string-default) | tee $(results.string-output.path);
       - name: array-params-to-result
-        image: docker.io/library/bash:3.2
+        image: docker.io/library/bash:5.2.26
         command: ["/bin/sh", "-c"]
         args:
         - echo -n $(params.array-param[0])"-"$(params.array-defaul-param[1]) | tee $(results.array-output.path);
@@ -940,7 +940,7 @@ spec:
       default: "foo"
     steps:
     - name: add
-      image: docker.io/library/alpine
+      image: docker.io/library/alpine:3.20.1
       env:
       - name: OP1
         value: $(params.foo)
@@ -1041,7 +1041,7 @@ spec:
   timeout: 15s
   taskSpec:
     steps:
-    - image: docker.io/library/busybox
+    - image: docker.io/library/busybox:1.36
       command: ['/bin/sh']
       args: ['-c', 'sleep 15001']
 `, helpers.ObjectNameForTest(t))
@@ -1124,7 +1124,7 @@ spec:
           description: The second integer from PipelineTask Param
         steps:
         - name: sum
-          image: docker.io/library/bash:latest
+          image: docker.io/library/bash:5.2.26
           script: |
             #!/usr/bin/env bash
             echo -n $(( "$(inputs.params.op0)" + "$(inputs.params.op1)" ))
@@ -1177,7 +1177,7 @@ spec:
         - name: suffix
         steps:
         - name: generate-suffix
-          image: docker.io/library/alpine
+          image: docker.io/library/alpine:3.20.1
           script: |
             echo -n "suffix" > $(results.suffix.path)
     - name: do-something
@@ -1188,7 +1188,7 @@ spec:
         - name: arg
         steps:
         - name: do-something
-          image: docker.io/library/alpine
+          image: docker.io/library/alpine:3.20.1
           script: |
             echo -n "$(params.arg)" | tee $(results.output.path)
       params:
@@ -1320,7 +1320,7 @@ spec:
       timeout: 15s
       taskSpec:
         steps:
-        - image: docker.io/library/busybox
+        - image: docker.io/library/busybox:1.36
           command: ['/bin/sh']
           args: ['-c', 'sleep 15001']
 `, helpers.ObjectNameForTest(t))
@@ -1359,7 +1359,7 @@ spec:
     - name: timeout
       taskSpec:
         steps:
-        - image: docker.io/library/busybox
+        - image: docker.io/library/busybox:1.36
           command: ['/bin/sh']
           args: ['-c', 'sleep 15001']
 `, helpers.ObjectNameForTest(t))
@@ -1410,7 +1410,7 @@ spec:
               description: The product of the two provided integers
           steps:
             - name: product
-              image: docker.io/library/bash:latest
+              image: docker.io/library/bash:5.2.26
               script: |
                 #!/usr/bin/env bash
                 echo -n $(( "$(params.a)" * "$(params.b)" )) | tee $(results.product.path)
@@ -1427,7 +1427,7 @@ spec:
               description: The product of the two provided integers
           steps:
             - name: product
-              image: docker.io/library/bash:latest
+              image: docker.io/library/bash:5.2.26
               script: |
                 #!/usr/bin/env bash
                 echo -n $(( "$(params.a)" * "$(params.b)" )) | tee $(results.product.path)

--- a/test/conversion_test.go
+++ b/test/conversion_test.go
@@ -224,7 +224,7 @@ spec:
       - name: task1-result
         value: task1-val
     steps:
-      - image: docker.io/library/alpine
+      - image: docker.io/library/alpine:3.20.1
         onError: continue
         name: exit-with-255
         script: |
@@ -278,7 +278,7 @@ spec:
       - name: task1-result
         value: task1-val
     steps:
-      - image: docker.io/library/alpine
+      - image: docker.io/library/alpine:3.20.1
         onError: continue
         name: exit-with-255
         script: |

--- a/test/custom-task-ctrls/wait-task-beta/example_customrun_matrix_results.yaml
+++ b/test/custom-task-ctrls/wait-task-beta/example_customrun_matrix_results.yaml
@@ -11,7 +11,7 @@ spec:
     - name: duration
   steps:
     - name: echo
-      image: docker.io/library/alpine
+      image: docker.io/library/alpine:3.20.1
       script: |
         echo "$(params.duration)"
 ---
@@ -25,7 +25,7 @@ spec:
       type: array
   steps:
     - name: produce-a-list-of-durations
-      image: docker.io/library/bash:latest
+      image: docker.io/library/bash:5.2.26
       script: |
         #!/usr/bin/env bash
         echo -n "[\"10s\",\"2s\",\"5s\"]" | tee $(results.durations.path)

--- a/test/custom-task-ctrls/wait-task-beta/example_pipelinerun.yaml
+++ b/test/custom-task-ctrls/wait-task-beta/example_pipelinerun.yaml
@@ -8,7 +8,7 @@ spec:
     - name: before
       taskSpec:
         steps:
-        - image: docker.io/library/busybox
+        - image: docker.io/library/busybox:1.36
           script: echo before wait
     - name: wait
       taskRef:
@@ -21,6 +21,6 @@ spec:
     - name: after
       taskSpec:
         steps:
-        - image: docker.io/library/busybox
+        - image: docker.io/library/busybox:1.36
           script: echo after wait
       runAfter: ['wait']

--- a/test/dag_test.go
+++ b/test/dag_test.go
@@ -70,9 +70,9 @@ spec:
   results:
     - name: result
   steps:
-  - image: docker.io/library/busybox
+  - image: docker.io/library/busybox:1.36
     script: 'echo $(params["text"])'
-  - image: docker.io/library/busybox
+  - image: docker.io/library/busybox:1.36
     # Sleep for N seconds so that we can check that tasks that
     # should be run in parallel have overlap.
     script: |

--- a/test/duplicate_test.go
+++ b/test/duplicate_test.go
@@ -59,7 +59,7 @@ metadata:
 spec:
   taskSpec:
     steps:
-    - image: docker.io/library/busybox
+    - image: docker.io/library/busybox:1.36
       command: ['/bin/echo']
       args: ['simple']
 `, taskrunName, namespace))

--- a/test/entrypoint_test.go
+++ b/test/entrypoint_test.go
@@ -54,10 +54,10 @@ metadata:
 spec:
   taskSpec:
     steps:
-    - image: docker.io/library/busybox
+    - image: docker.io/library/busybox:1.36
       workingDir: /workspace
       script: 'sleep 3 && touch foo'
-    - image: docker.io/library/ubuntu
+    - image: docker.io/library/ubuntu:24.04
       workingDir: /workspace
       script: 'ls foo'
 `, epTaskRunName, namespace)), metav1.CreateOptions{}); err != nil {

--- a/test/larger_results_sidecar_logs_test.go
+++ b/test/larger_results_sidecar_logs_test.go
@@ -169,7 +169,7 @@ spec:
             - name: result2
           steps:
            - name: step1
-             image: docker.io/library/alpine
+             image: docker.io/library/alpine:3.20.1
              script: |
                echo -n "%s"| tee $(results.result1.path);
                echo -n "%s"| tee $(results.result2.path);
@@ -181,7 +181,7 @@ spec:
           steps:
            - name: step1
              onError: continue
-             image: docker.io/library/alpine
+             image: docker.io/library/alpine:3.20.1
              script: |
                echo -n "%s"| tee $(results.result2.path);
                # trigger an error
@@ -206,7 +206,7 @@ spec:
             - name: large-result
           steps:
             - name: step1
-              image: docker.io/library/alpine
+              image: docker.io/library/alpine:3.20.1
               script: |
                 echo -n "$(params.param1)">> $(results.large-result.path);
                 echo -n "$(params.param2)">> $(results.large-result.path);
@@ -218,7 +218,7 @@ spec:
             - name: result2
           steps:
            - name: step1
-             image: docker.io/library/alpine
+             image: docker.io/library/alpine:3.20.1
              script: |
                echo -n "%s"| tee $(results.result1.path);
                echo -n "%s"| tee $(results.result2.path);
@@ -248,7 +248,7 @@ spec:
               type: string
           steps:
            - name: step1
-             image: docker.io/library/alpine
+             image: docker.io/library/alpine:3.20.1
              script: |
                echo -n "%s"| tee $(results.result1.path);
                echo -n "%s"| tee $(results.result2.path);
@@ -262,7 +262,7 @@ spec:
           steps:
            - name: step1
              onError: continue
-             image: docker.io/library/alpine
+             image: docker.io/library/alpine:3.20.1
              script: |
                echo -n "%s"| tee $(results.result2.path);
                # trigger an error
@@ -288,7 +288,7 @@ spec:
               type: string
           steps:
             - name: step1
-              image: docker.io/library/alpine
+              image: docker.io/library/alpine:3.20.1
               script: |
                 echo -n "$(params.param1)">> $(results.large-result.path);
                 echo -n "$(params.param2)">> $(results.large-result.path);
@@ -302,7 +302,7 @@ spec:
               type: string
           steps:
            - name: step1
-             image: docker.io/library/alpine
+             image: docker.io/library/alpine:3.20.1
              script: |
                echo -n "%s"| tee $(results.result1.path);
                echo -n "%s"| tee $(results.result2.path);
@@ -323,7 +323,7 @@ status:
               type: string
           steps:
             - name: step1
-              image: docker.io/library/alpine
+              image: docker.io/library/alpine:3.20.1
               script: |
                 echo -n "%s"| tee $(results.result1.path);
                 echo -n "%s"| tee $(results.result2.path);
@@ -336,7 +336,7 @@ status:
               type: string
           steps:
             - name: step1
-              image: docker.io/library/alpine
+              image: docker.io/library/alpine:3.20.1
               onError: continue
               script: |
                 echo -n "%s"| tee $(results.result2.path);
@@ -363,7 +363,7 @@ status:
               type: string
           steps:
             - name: step1
-              image: docker.io/library/alpine
+              image: docker.io/library/alpine:3.20.1
               script: |
                 echo -n "$(params.param1)">> $(results.large-result.path);
                 echo -n "$(params.param2)">> $(results.large-result.path);
@@ -377,7 +377,7 @@ status:
               type: string
           steps:
            - name: step1
-             image: docker.io/library/alpine
+             image: docker.io/library/alpine:3.20.1
              script: |
                echo -n "%s"| tee $(results.result1.path);
                echo -n "%s"| tee $(results.result2.path);
@@ -405,7 +405,7 @@ spec:
         type: string
     steps:
       - name: step1
-        image: docker.io/library/alpine
+        image: docker.io/library/alpine:3.20.1
         script: |
           echo -n "%s"| tee $(results.result1.path);
           echo -n "%s"| tee $(results.result2.path);
@@ -423,7 +423,7 @@ status:
         type: string
     steps:
       - name: step1
-        image: docker.io/library/alpine
+        image: docker.io/library/alpine:3.20.1
         script: |
           echo -n "%s"| tee /tekton/results/result1;
           echo -n "%s"| tee /tekton/results/result2;
@@ -454,7 +454,7 @@ spec:
     steps:
       - name: step1
         onError: continue
-        image: docker.io/library/alpine
+        image: docker.io/library/alpine:3.20.1
         script: |
           echo -n "%s"| tee $(results.result2.path);
           # trigger an error
@@ -476,7 +476,7 @@ status:
     steps:
       - name: step1
         onError: continue
-        image: docker.io/library/alpine
+        image: docker.io/library/alpine:3.20.1
         script: |
           echo -n "%s"| tee /tekton/results/result2;
           # trigger an error
@@ -518,7 +518,7 @@ spec:
         type: string
     steps:
      - name: step1
-       image: docker.io/library/alpine
+       image: docker.io/library/alpine:3.20.1
        script: |
          echo -n "$(params.param1)">> $(results.large-result.path);
          echo -n "$(params.param2)">> $(results.large-result.path);
@@ -541,7 +541,7 @@ status:
         type: string
     steps:
      - name: step1
-       image: docker.io/library/alpine
+       image: docker.io/library/alpine:3.20.1
        script: |
          echo -n "%s">> /tekton/results/large-result;
          echo -n "%s">> /tekton/results/large-result;
@@ -568,7 +568,7 @@ spec:
         type: string
     steps:
       - name: step1
-        image: docker.io/library/alpine
+        image: docker.io/library/alpine:3.20.1
         script: |
           echo -n "%s"| tee $(results.result1.path);
           echo -n "%s"| tee $(results.result2.path);
@@ -588,7 +588,7 @@ status:
         type: string
     steps:
       - name: step1
-        image: docker.io/library/alpine
+        image: docker.io/library/alpine:3.20.1
         script: |
           echo -n "%s"| tee /tekton/results/result1;
           echo -n "%s"| tee /tekton/results/result2;

--- a/test/matrix_test.go
+++ b/test/matrix_test.go
@@ -70,7 +70,7 @@ spec:
       default: ""
   steps:
     - name: echo
-      image: docker.io/library/alpine
+      image: docker.io/library/alpine:3.20.1
       script: |
         echo "$(params.GOARCH) and $(params.version)"
 `, namespace))
@@ -85,7 +85,7 @@ spec:
       type: array
   steps:
     - name: produce-a-list-of-results
-      image: docker.io/library/bash:latest
+      image: docker.io/library/bash:5.2.26
       script: |
         #!/usr/bin/env bash
         echo -n "[\"linux/amd64\",\"linux/ppc64le\"]" | tee $(results.GOARCHs.path)
@@ -101,7 +101,7 @@ spec:
       type: array
   steps:
     - name: produce-a-list-of-versions
-      image: docker.io/library/bash:latest
+      image: docker.io/library/bash:5.2.26
       script: |
         #!/usr/bin/env bash
         echo -n "[\"go1.17\",\"go1.18.1\"]" | tee $(results.versions.path)
@@ -403,7 +403,7 @@ spec:
     - name: exit-code
   steps:
     - name: echo
-      image: docker.io/library/alpine
+      image: docker.io/library/alpine:3.20.1
       script: |
         exit "$(params.exit-code)"
 `, namespace))

--- a/test/per_feature_flags_test.go
+++ b/test/per_feature_flags_test.go
@@ -152,9 +152,9 @@ spec:
   results:
   - name: result
   steps:
-  - image: docker.io/library/busybox
+  - image: docker.io/library/busybox:1.36
     script: 'echo $(params["text"])'
-  - image: docker.io/library/busybox
+  - image: docker.io/library/busybox:1.36
     # Sleep for N seconds so that we can check that tasks that
     # should be run in parallel have overlap.
     script: |
@@ -280,7 +280,7 @@ spec:
         params:
         - name: param1
         steps:
-        - image: docker.io/library/busybox
+        - image: docker.io/library/busybox:1.36
           script: 'echo $(params.param1);exit 0'
 `, helpers.ObjectNameForTest(t)))
 

--- a/test/pipelinefinally_test.go
+++ b/test/pipelinefinally_test.go
@@ -696,7 +696,7 @@ metadata:
   namespace: %s
 spec:
   steps:
-  - image: docker.io/library/alpine
+  - image: docker.io/library/alpine:3.20.1
     script: 'exit 0'
 `, helpers.ObjectNameForTest(t), namespace))
 }
@@ -709,7 +709,7 @@ metadata:
   namespace: %s
 spec:
   steps:
-  - image: docker.io/library/alpine
+  - image: docker.io/library/alpine:3.20.1
     script: 'exit 1'
 `, helpers.ObjectNameForTest(t), namespace))
 }
@@ -722,7 +722,7 @@ metadata:
   namespace: %s
 spec:
   steps:
-  - image: docker.io/library/alpine
+  - image: docker.io/library/alpine:3.20.1
     script: 'sleep 5; exit 0'
 `, helpers.ObjectNameForTest(t), namespace))
 }
@@ -735,7 +735,7 @@ metadata:
   namespace: %s
 spec:
   steps:
-  - image: docker.io/library/alpine
+  - image: docker.io/library/alpine:3.20.1
     script: 'exit 0'
   params:
   - name: dagtask1-status
@@ -753,7 +753,7 @@ metadata:
   namespace: %s
 spec:
   steps:
-  - image: docker.io/library/alpine
+  - image: docker.io/library/alpine:3.20.1
     script: 'echo -n "Hello" > $(results.result.path)'
   results:
   - name: result
@@ -768,7 +768,7 @@ metadata:
   namespace: %s
 spec:
   steps:
-  - image: docker.io/library/alpine
+  - image: docker.io/library/alpine:3.20.1
     script: 'sleep 5; echo -n "Hello" > $(results.result.path)'
   results:
   - name: result
@@ -783,7 +783,7 @@ metadata:
   namespace: %s
 spec:
   steps:
-  - image: docker.io/library/alpine
+  - image: docker.io/library/alpine:3.20.1
     script: 'exit 0'
   params:
   - name: %s

--- a/test/pipelinerun_test.go
+++ b/test/pipelinerun_test.go
@@ -68,7 +68,7 @@ spec:
   - name: HELLO
     default: "Hi!"
   steps:
-  - image: docker.io/library/ubuntu
+  - image: docker.io/library/ubuntu:24.04
     script: |
       #!/usr/bin/env bash
       echo "$(params.HELLO)"
@@ -512,7 +512,7 @@ metadata:
   namespace: %s
 spec:
   steps:
-  - image: docker.io/library/ubuntu
+  - image: docker.io/library/ubuntu:24.04
     command: ['/bin/bash']
     args: ['-c', 'echo hello, world']
 `, taskName, namespace)), metav1.CreateOptions{}); err != nil {
@@ -582,10 +582,10 @@ metadata:
   namespace: %s
 spec:
   steps:
-  - image: docker.io/library/busybox
+  - image: docker.io/library/busybox:1.36
     name: write-data-task-0-step-0
     script: echo stuff | tee $(results.result-stuff.path)
-  - image: docker.io/library/busybox
+  - image: docker.io/library/busybox:1.36
     name: write-data-task-0-step-1
     script: echo other | tee $(results.result-other.path)
   results:
@@ -600,10 +600,10 @@ spec:
   params:
   - name: check-stuff
   steps:
-  - image: docker.io/library/busybox
+  - image: docker.io/library/busybox:1.36
     name: read-from-task-0
     script: echo $(params.check-stuff)
-  - image: docker.io/library/busybox
+  - image: docker.io/library/busybox:1.36
     name: write-data-task-1
     script: echo | tee $(results.result-something.path)
   results:
@@ -620,7 +620,7 @@ spec:
   - script: echo $(params.check-other)
     image: docker.io/library/busybox
     name: read-from-task-0
-  - image: docker.io/library/busybox
+  - image: docker.io/library/busybox:1.36
     name: write-data-task-1
     script: echo something | tee $(results.result-else.path)
   results:
@@ -637,7 +637,7 @@ spec:
   - name: workspacepath-else
     value: $(tasks.create-file.results.result-else)
   steps:
-  - image: docker.io/library/busybox
+  - image: docker.io/library/busybox:1.36
     script: echo params.workspacepath-something
 `, helpers.ObjectNameForTest(t), namespace)),
 	}
@@ -971,7 +971,7 @@ metadata:
   namespace: %s
 spec:
   steps:
-  - image: docker.io/library/ubuntu
+  - image: docker.io/library/ubuntu:24.04
     command: ['/bin/bash']
     args: ['-c', 'echo hello, world']
 `, taskName, namespace)), metav1.CreateOptions{}); err != nil {
@@ -1007,7 +1007,7 @@ spec:
           - name: abc
         steps:
         - name: update-sa
-          image: docker.io/library/bash:latest
+          image: docker.io/library/bash:5.2.26
           script: |
             echo 'test' >  $(results.abc.path)
             exit 1

--- a/test/resolvers_test.go
+++ b/test/resolvers_test.go
@@ -588,7 +588,7 @@ spec:
     - name: token
       type: string
     steps:
-    - image: docker.io/alpine/curl
+    - image: docker.io/alpine/curl:8.8.0
       script: |
         #!/bin/ash
         curl -X POST "http://gitea_admin:%s@%s:3000/api/v1/admin/users" -H "accept: application/json" -H "Content-Type: application/json" -d '%s'

--- a/test/retry_test.go
+++ b/test/retry_test.go
@@ -55,7 +55,7 @@ spec:
       retries: %d
       taskSpec:
         steps:
-        - image: docker.io/library/busybox
+        - image: docker.io/library/busybox:1.36
           script: exit 1
 `, pipelineRunName, numRetries)), metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create PipelineRun %q: %v", pipelineRunName, err)

--- a/test/serviceaccount_test.go
+++ b/test/serviceaccount_test.go
@@ -123,17 +123,17 @@ spec:
   - name: task1
     taskSpec:
       steps:
-      - image: docker.io/library/ubuntu
+      - image: docker.io/library/ubuntu:24.04
         script: echo task1
   - name: task2
     taskSpec:
       steps:
-      - image: docker.io/library/ubuntu
+      - image: docker.io/library/ubuntu:24.04
         script: echo task2
   - name: task3
     taskSpec:
       steps:
-      - image: docker.io/library/ubuntu
+      - image: docker.io/library/ubuntu:24.04
         script: echo task3
 `, helpers.ObjectNameForTest(t), namespace))
 	if _, err := c.V1PipelineClient.Create(ctx, pipeline, metav1.CreateOptions{}); err != nil {
@@ -242,7 +242,7 @@ spec:
     taskSpec:
       metadata: {}
       steps:
-      - image: docker.io/library/ubuntu
+      - image: docker.io/library/ubuntu:24.04
         script: echo task1
 `, helpers.ObjectNameForTest(t), namespace))
 	if _, err := c.V1PipelineClient.Create(ctx, pipeline, metav1.CreateOptions{}); err != nil {

--- a/test/start_time_test.go
+++ b/test/start_time_test.go
@@ -56,15 +56,15 @@ metadata:
 spec:
   taskSpec:
     steps:
-    - image: docker.io/library/busybox
+    - image: docker.io/library/busybox:1.36
       script: sleep 2
-    - image: docker.io/library/busybox
+    - image: docker.io/library/busybox:1.36
       script: sleep 2
-    - image: docker.io/library/busybox
+    - image: docker.io/library/busybox:1.36
       script: sleep 2
-    - image: docker.io/library/busybox
+    - image: docker.io/library/busybox:1.36
       script: sleep 2
-    - image: docker.io/library/busybox
+    - image: docker.io/library/busybox:1.36
       script: sleep 2
 `, helpers.ObjectNameForTest(t), namespace)), metav1.CreateOptions{})
 	if err != nil {

--- a/test/status_test.go
+++ b/test/status_test.go
@@ -234,7 +234,7 @@ spec:
   - name: HELLO
     default: "hello world!"
   steps:
-  - image: docker.io/library/ubuntu
+  - image: docker.io/library/ubuntu:24.04
     script: |
       #!/usr/bin/env bash
       echo "$(params.HELLO)"

--- a/test/stepaction_results_test.go
+++ b/test/stepaction_results_test.go
@@ -123,7 +123,7 @@ spec:
   results:
     - name: result1
       type: string
-  image: docker.io/library/alpine
+  image: docker.io/library/alpine:3.20.1
   script: |
     echo -n step-action >> $(step.results.result1.path)
 `, namespace))
@@ -139,7 +139,7 @@ spec:
   taskSpec:
     steps:
      - name: step1
-       image: docker.io/library/alpine
+       image: docker.io/library/alpine:3.20.1
        script: |
          echo -n inlined-step >> $(step.results.result1.path)
        results:
@@ -167,7 +167,7 @@ spec:
   taskSpec:
     steps:
       - name: step1
-        image: docker.io/library/alpine
+        image: docker.io/library/alpine:3.20.1
         script: |
           echo -n inlined-step >> $(step.results.result1.path)
         results:
@@ -192,14 +192,14 @@ status:
   taskSpec:
     steps:
       - name: step1
-        image: docker.io/library/alpine
+        image: docker.io/library/alpine:3.20.1
         results:
           - name: result1
             type: string
         script: |
           echo -n inlined-step >> /tekton/steps/step-step1/results/result1
       - name: step2
-        image: docker.io/library/alpine
+        image: docker.io/library/alpine:3.20.1
         results:
           - name: result1
             type: string

--- a/test/task_results_from_failed_tasks_test.go
+++ b/test/task_results_from_failed_tasks_test.go
@@ -63,7 +63,7 @@ spec:
         params:
         - name: param1
         steps:
-        - image: docker.io/library/busybox
+        - image: docker.io/library/busybox:1.36
           script: 'exit 0'
     - name: finaltask2
       params:
@@ -73,7 +73,7 @@ spec:
         params:
         - name: param1
         steps:
-        - image: docker.io/library/busybox
+        - image: docker.io/library/busybox:1.36
           script: exit 0`, helpers.ObjectNameForTest(t)))
 
 	if _, err := c.V1beta1PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{}); err != nil {

--- a/test/taskrun_test.go
+++ b/test/taskrun_test.go
@@ -61,13 +61,13 @@ metadata:
   namespace: %s
 spec:
   steps:
-  - image: docker.io/library/busybox
+  - image: docker.io/library/busybox:1.36
     command: ['/bin/sh']
     args: ['-c', 'echo hello']
-  - image: docker.io/library/busybox
+  - image: docker.io/library/busybox:1.36
     command: ['/bin/sh']
     args: ['-c', 'exit 1']
-  - image: docker.io/library/busybox
+  - image: docker.io/library/busybox:1.36
     command: ['/bin/sh']
     args: ['-c', 'sleep 30s']
 `, helpers.ObjectNameForTest(t), namespace))
@@ -512,7 +512,7 @@ metadata:
   namespace: %s
 spec:
   steps:
-  - image: docker.io/library/busybox
+  - image: docker.io/library/busybox:1.36
     command: ['/bin/sh']
     args: ['-c', 'exit 1']
     volumeMounts:

--- a/test/tektonbundles_test.go
+++ b/test/tektonbundles_test.go
@@ -74,7 +74,7 @@ metadata:
 spec:
   steps:
   - name: hello
-    image: docker.io/library/alpine
+    image: docker.io/library/alpine:3.20.1
     script: 'echo Hello'
 `, taskName, namespace))
 

--- a/test/timeout_test.go
+++ b/test/timeout_test.go
@@ -57,7 +57,7 @@ metadata:
   namespace: %s
 spec:
   steps:
-  - image: docker.io/library/busybox
+  - image: docker.io/library/busybox:1.36
     command: ['/bin/sh']
     args: ['-c', 'sleep 10']
 `, helpers.ObjectNameForTest(t), namespace))
@@ -277,7 +277,7 @@ metadata:
   namespace: %s
 spec:
   steps:
-  - image: docker.io/library/busybox
+  - image: docker.io/library/busybox:1.36
     command: ['/bin/sh']
     args: ['-c', 'sleep 3000']
 `, helpers.ObjectNameForTest(t), namespace))
@@ -333,7 +333,7 @@ metadata:
   namespace: %s
 spec:
   steps:
-  - image: docker.io/library/busybox
+  - image: docker.io/library/busybox:1.36
     command: ['/bin/sh']
     args: ['-c', 'sleep 1s']
 `, helpers.ObjectNameForTest(t), namespace))
@@ -343,7 +343,7 @@ metadata:
   namespace: %s
 spec:
   steps:
-  - image: docker.io/library/busybox
+  - image: docker.io/library/busybox:1.36
     command: ['/bin/sh']
     args: ['-c', 'sleep 10s']
 `, helpers.ObjectNameForTest(t), namespace))
@@ -454,7 +454,7 @@ metadata:
   namespace: %s
 spec:
   steps:
-  - image: docker.io/library/busybox
+  - image: docker.io/library/busybox:1.36
     command: ['/bin/sh']
     args: ['-c', 'sleep 30']
 `, helpers.ObjectNameForTest(t), namespace))
@@ -469,7 +469,7 @@ metadata:
   namespace: %s
 spec:
   steps:
-  - image: docker.io/library/busybox
+  - image: docker.io/library/busybox:1.36
     command: ['/bin/sh']
     args: ['-c', 'sleep 1']
 `, helpers.ObjectNameForTest(t), namespace))

--- a/test/upgrade/simpleResources.yaml
+++ b/test/upgrade/simpleResources.yaml
@@ -10,18 +10,18 @@ spec:
       default: "response"
   steps:
   - name: echo-param
-    image: docker.io/library/alpine
+    image: docker.io/library/alpine:3.20.1
     script: |
       echo "$(params.rsp)"
   - name: check-workspace
-    image: docker.io/library/alpine
+    image: docker.io/library/alpine:3.20.1
     script: |
       if [ "$(workspaces.workspace.bound)" == "true" ]; then
         echo "Workspace provided"
       fi
   sidecars:
   - name: server
-    image: docker.io/library/alpine:3.12.0
+    image: docker.io/library/alpine:3.20.1
     command: ['/bin/bash']
     workingDir: /foo
     script: echo server
@@ -44,7 +44,7 @@ spec:
           type: string
           default: "1"
       steps:
-        - image: docker.io/library/alpine
+        - image: docker.io/library/alpine:3.20.1
           name: check-workspace
           script: |
             if [ "$(workspaces.workspace.bound)" == "true" ]; then

--- a/test/upgrade_test.go
+++ b/test/upgrade_test.go
@@ -52,11 +52,11 @@ spec:
     default: "response"
   steps:
   - name: echo-param
-    image: docker.io/library/alpine
+    image: docker.io/library/alpine:3.20.1
     script: |
       echo "$(params.rsp)"
   - name: check-workspace
-    image: docker.io/library/alpine
+    image: docker.io/library/alpine:3.20.1
     script: |
       if [ "$(workspaces.taskWorkspace.bound)" == "true" ]; then
         echo "Workspace provided"
@@ -128,12 +128,12 @@ status:
     status: "True"
   taskSpec:
     steps:
-    - image: docker.io/library/alpine
+    - image: docker.io/library/alpine:3.20.1
       name: echo-param
       script: |
        echo "response"
     - name: check-workspace
-      image: docker.io/library/alpine
+      image: docker.io/library/alpine:3.20.1
       script: |
         if [ "true" == "true" ]; then
           echo "Workspace provided"

--- a/test/workingdir_test.go
+++ b/test/workingdir_test.go
@@ -51,7 +51,7 @@ metadata:
   namespace: %s
 spec:
   steps:
-  - image: docker.io/library/ubuntu
+  - image: docker.io/library/ubuntu:24.04
     workingDir: /workspace/HELLOMOTO
     args: ['-c', 'echo YES']
 `, wdTaskName, namespace))
@@ -124,7 +124,7 @@ metadata:
   namespace: %s
 spec:
   steps:
-  - image: docker.io/library/ubuntu
+  - image: docker.io/library/ubuntu:24.04
     workingDir: /HELLOMOTO
     args: ['-c', 'echo YES']
 `, wdTaskName, namespace))

--- a/test/workspace_test.go
+++ b/test/workspace_test.go
@@ -51,7 +51,7 @@ metadata:
   namespace: %s
 spec:
   steps:
-  - image: docker.io/library/alpine
+  - image: docker.io/library/alpine:3.20.1
     script: 'echo foo > /workspace/test/file'
   workspaces:
   - name: test
@@ -129,7 +129,7 @@ metadata:
   namespace: %s
 spec:
   steps:
-  - image: docker.io/library/alpine
+  - image: docker.io/library/alpine:3.20.1
     script: 'cat /workspace/test/file'
   workspaces:
   - name: test
@@ -199,7 +199,7 @@ metadata:
   namespace: %s
 spec:
   steps:
-  - image: docker.io/library/alpine
+  - image: docker.io/library/alpine:3.20.1
     script: 'cat /workspace/test/file'
   workspaces:
   - name: test
@@ -268,7 +268,7 @@ metadata:
   namespace: %s
 spec:
   steps:
-  - image: docker.io/library/alpine
+  - image: docker.io/library/alpine:3.20.1
     name: foo
     command: ['echo']
     args: ['$(workspaces.test.volume)']


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Replace the `latest` tag with the latest version and tag the image to take advantage of the least expensive k8s default image pull policy. The current policy is:

* if you omit the `imagePullPolicy` field, and the tag for the container image is `:latest`, `imagePullPolicy` is automatically set to `Always`
* if you omit the `imagePullPolicy` field, and you don't specify the tag for the container image, `imagePullPolicy` is automatically set to `Always`

With this change, we are relying on the following policy:

* if you omit the `imagePullPolicy` field, and you specify the tag for the container image that isn't `:latest`, the `imagePullPolicy` is automatically set to `IfNotPresent`.

Part of https://github.com/tektoncd/pipeline/issues/4551

/kind misc

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
