### PR TITLE
Cancel PipelineRun only after its children Tasks are stopped

### DIFF
--- a/pkg/apis/pipeline/v1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1/pipelinerun_types.go
@@ -88,6 +88,12 @@ func (pr *PipelineRun) IsCancelled() bool {
 	return pr.Spec.Status == PipelineRunSpecStatusCancelled
 }
 
+// IsCancelling returns true if the PipelineRun's status indicates it is cancelling.
+func (pr *PipelineRun) IsCancelling() bool {
+	succeededCond := pr.Status.GetCondition(apis.ConditionSucceeded)
+	return succeededCond != nil && succeededCond.Reason == PipelineRunReasonCancelling.String()
+}
+
 // IsGracefullyCancelled returns true if the PipelineRun's spec status is set to CancelledRunFinally state
 func (pr *PipelineRun) IsGracefullyCancelled() bool {
 	return pr.Spec.Status == PipelineRunSpecStatusCancelledRunFinally
@@ -340,6 +346,8 @@ const (
 	// This reason may be found with a corev1.ConditionFalse status, if the cancellation was processed successfully
 	// This reason may be found with a corev1.ConditionUnknown status, if the cancellation is being processed or failed
 	PipelineRunReasonCancelled PipelineRunReason = "Cancelled"
+	// PipelineRunReasonCancelling is the reason set when the PipelineRun is cancelling
+	PipelineRunReasonCancelling PipelineRunReason = "Cancelling"
 	// PipelineRunReasonPending is the reason set when the PipelineRun is in the pending state
 	PipelineRunReasonPending PipelineRunReason = "PipelineRunPending"
 	// PipelineRunReasonTimedOut is the reason set when the PipelineRun has timed out


### PR DESCRIPTION
Fixes: #8031

# Changes

With this change, when a PipelineRun is marked as `Cancelled`, it will first patch its children Tasks as `Cancelled`, and only after all of them report they were stopped, the PipelineRun will mark itself as `Cancelled`.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
When a PipelineRun is canceled, Tekton will now wait for all child Tasks to stop before marking the PipelineRun as canceled.
```
