### PR TITLE
Switch the image from docker.io to gcr mirror

### DIFF
--- a/examples/v1/pipelineruns/4808-regression.yaml
+++ b/examples/v1/pipelineruns/4808-regression.yaml
@@ -11,7 +11,7 @@ spec:
       type: string
   steps:
     - name: print-result
-      image: docker.io/library/bash:5.2.26
+      image: mirror.gcr.io/bash
       env:
         - name: PARAM_TO_PRINT
           value: $(params.TO_PRINT)
@@ -39,7 +39,7 @@ spec:
       description: A result string
   steps:
     - name: gen-result
-      image: docker.io/library/bash:5.2.26
+      image: mirror.gcr.io/bash
       env:
         - name: PARAM_STRING_LENGTH
           value: $(params.STRING_LENGTH)

--- a/examples/v1/pipelineruns/6139-regression.yaml
+++ b/examples/v1/pipelineruns/6139-regression.yaml
@@ -15,7 +15,7 @@ spec:
           results:
             - name: result-one
           steps:
-          - image: docker.io/library/alpine:3.20.1
+          - image: mirror.gcr.io/alpine
             script: |
               #!/bin/sh
               echo "Hello world!"
@@ -28,7 +28,7 @@ spec:
           results:
             - name: result-two
           steps:
-          - image: docker.io/library/alpine:3.20.1
+          - image: mirror.gcr.io/alpine
             script: |
               #!/bin/sh
               echo "Goodbye world!"
@@ -43,7 +43,7 @@ spec:
           results:
             - name: result-three
           steps:
-          - image: docker.io/library/alpine:3.20.1
+          - image: mirror.gcr.io/alpine
             script: |
               #!/bin/sh
               echo "Shutdown world!"

--- a/examples/v1/pipelineruns/alpha/param-enum.yaml
+++ b/examples/v1/pipelineruns/alpha/param-enum.yaml
@@ -9,7 +9,7 @@ spec:
     enum: ["v1", "v2", "v3"]
   steps:
   - name: build
-    image: docker.io/library/bash:5.2.26
+    image: mirror.gcr.io/bash
     script: |
       echo "$(params.message)"
 ---

--- a/examples/v1/pipelineruns/alpha/pipelinerun-large-results.yaml
+++ b/examples/v1/pipelineruns/alpha/pipelinerun-large-results.yaml
@@ -20,7 +20,7 @@ spec:
           type: string
   steps:
     - name: step1
-      image: docker.io/library/alpine:3.20.1
+      image: mirror.gcr.io/alpine
       script: |
         # produce a result - a random string with 2,500 characters - result1
         tr -dc A-Za-z0-9 </dev/urandom | head -c 2500 | tee $(results.result1.path);
@@ -63,7 +63,7 @@ spec:
           type: string
   steps:
     - name: step1
-      image: docker.io/library/alpine:3.20.1
+      image: mirror.gcr.io/alpine
       args: [
         "$(params.param3[*])"
       ]

--- a/examples/v1/pipelineruns/alpha/pipelinerun-with-cel-when-expressions.yaml
+++ b/examples/v1/pipelineruns/alpha/pipelinerun-with-cel-when-expressions.yaml
@@ -25,7 +25,7 @@ spec:
               description: The workspace to create the readme file in
           steps:
             - name: write-new-stuff
-              image: docker.io/library/ubuntu
+              image: mirror.gcr.io/ubuntu
               script: 'touch $(workspaces.source.path)/README.md'
       - name: check-file
         params:
@@ -47,7 +47,7 @@ spec:
               description: indicates whether the file exists or is missing
           steps:
             - name: check-file
-              image: docker.io/library/alpine:3.20.1
+              image: mirror.gcr.io/alpine
               script: |
                 if test -f $(workspaces.source.path)/$(params.path); then
                   printf yes | tee $(results.exists.path)
@@ -60,7 +60,7 @@ spec:
         taskSpec:
           steps:
             - name: echo
-              image: docker.io/library/ubuntu
+              image: mirror.gcr.io/ubuntu
               script: 'echo file exists'
       - name: task-should-be-skipped-1
         when:
@@ -68,7 +68,7 @@ spec:
         taskSpec:
           steps:
             - name: echo
-              image: docker.io/library/ubuntu
+              image: mirror.gcr.io/ubuntu
               script: exit 1
       - name: task-should-be-skipped-2  # when expression using parameter, evaluates to false
         when:
@@ -76,7 +76,7 @@ spec:
         taskSpec:
           steps:
             - name: echo
-              image: docker.io/library/ubuntu
+              image: mirror.gcr.io/ubuntu
               script: exit 1
       - name: task-should-be-skipped-3  # task with when expression and run after
         runAfter:
@@ -86,7 +86,7 @@ spec:
         taskSpec:
           steps:
             - name: echo
-              image: docker.io/library/ubuntu
+              image: mirror.gcr.io/ubuntu
               script: exit 1
     finally:
       - name: finally-task-should-be-skipped-1  # when expression using execution status, evaluates to false
@@ -95,7 +95,7 @@ spec:
         taskSpec:
           steps:
             - name: echo
-              image: docker.io/library/ubuntu
+              image: mirror.gcr.io/ubuntu
               script: exit 1
       - name: finally-task-should-be-skipped-2  # when expression using task result, evaluates to false
         when:
@@ -103,7 +103,7 @@ spec:
         taskSpec:
           steps:
             - name: echo
-              image: docker.io/library/ubuntu
+              image: mirror.gcr.io/ubuntu
               script: exit 1
       - name: finally-task-should-be-skipped-3  # when expression using parameter, evaluates to false
         when:
@@ -111,7 +111,7 @@ spec:
         taskSpec:
           steps:
             - name: echo
-              image: docker.io/library/ubuntu
+              image: mirror.gcr.io/ubuntu
               script: exit 1
       - name: finally-task-should-be-skipped-4  # when expression using tasks execution status, evaluates to false
         when:
@@ -119,7 +119,7 @@ spec:
         taskSpec:
           steps:
             - name: echo
-              image: docker.io/library/ubuntu
+              image: mirror.gcr.io/ubuntu
               script: exit 1
       - name: finally-task-should-be-skipped-5  # when expression using tasks execution status, evaluates to false
         when:
@@ -127,7 +127,7 @@ spec:
         taskSpec:
           steps:
             - name: echo
-              image: docker.io/library/ubuntu
+              image: mirror.gcr.io/ubuntu
               script: exit 1
       - name: finally-task-should-be-executed  # when expression using execution status, tasks execution status, param, and results
         when:
@@ -138,7 +138,7 @@ spec:
         taskSpec:
           steps:
             - name: echo
-              image: docker.io/library/ubuntu
+              image: mirror.gcr.io/ubuntu
               script: 'echo finally done'
   params:
     - name: path

--- a/examples/v1/pipelineruns/alpha/stepaction-params.yaml
+++ b/examples/v1/pipelineruns/alpha/stepaction-params.yaml
@@ -25,7 +25,7 @@ spec:
         key1: "step-action default key1"
         key2: "step-action default key2"
         key3: "step-action default key3"
-  image: docker.io/library/bash:5.2.26
+  image: mirror.gcr.io/bash
   args: [
     "echo",
     "$(params.array-param[*])",

--- a/examples/v1/pipelineruns/beta/7392-regression.yaml
+++ b/examples/v1/pipelineruns/beta/7392-regression.yaml
@@ -10,7 +10,7 @@ spec:
     default: []
   steps:
   - name: step1
-    image: docker.io/library/bash:5.2.26
+    image: mirror.gcr.io/bash
     args:
       - --images
       - $(params.arrayVal1[*])
@@ -20,7 +20,7 @@ spec:
         echo $arg
       done
   - name: step2
-    image: docker.io/library/bash:5.2.26
+    image: mirror.gcr.io/bash
     script: |
       #!/usr/bin/env bash
       echo -n '[]' | tee $(results.resultArray.path)

--- a/examples/v1/pipelineruns/beta/ignore-task-error.yaml
+++ b/examples/v1/pipelineruns/beta/ignore-task-error.yaml
@@ -10,7 +10,7 @@ spec:
         taskSpec:
           steps:
             - name: write
-              image: docker.io/library/alpine:3.20.1
+              image: mirror.gcr.io/alpine
               script: |
                 #!/usr/bin/env sh
                 echo "this is a failing task"
@@ -28,7 +28,7 @@ spec:
             - name: param1
           steps:
             - name: write
-              image: docker.io/library/alpine
+              image: mirror.gcr.io/alpine
               script: |
                 #!/usr/bin/env sh
                 echo "this is a failing task if param1 is set bar"
@@ -42,7 +42,7 @@ spec:
         taskSpec:
           steps:
             - name: write
-              image: docker.io/library/alpine:3.20.1
+              image: mirror.gcr.io/alpine
               script: |
                 #!/usr/bin/env sh
                 echo "this is a success task"
@@ -56,7 +56,7 @@ spec:
         taskSpec:
           steps:
             - name: verify-task-reason
-              image: docker.io/library/alpine
+              image: mirror.gcr.io/alpine
               script: |
                 #!/usr/bin/env sh
                 if [[ $(params.echo-continue-task-reason) != "FailureIgnored" ]]; then

--- a/examples/v1/pipelineruns/beta/isolated-workspaces.yaml
+++ b/examples/v1/pipelineruns/beta/isolated-workspaces.yaml
@@ -37,7 +37,7 @@ spec:
         workspaces:
         - name: creds
         steps:
-        - image: docker.io/library/alpine:3.20.1
+        - image: mirror.gcr.io/alpine
           script: |
             if [ ! -d /creds ] ; then
               echo "unable to access creds"
@@ -46,7 +46,7 @@ spec:
           workspaces:
           - name: creds
             mountpath: /creds
-        - image: docker.io/library/alpine:3.20.1
+        - image: mirror.gcr.io/alpine
           script: |
             if [ -d /workspace/creds ] ; then
               echo "this step should not be able to see creds"

--- a/examples/v1/pipelineruns/beta/pipeline-emitting-results.yaml
+++ b/examples/v1/pipelineruns/beta/pipeline-emitting-results.yaml
@@ -13,7 +13,7 @@ spec:
               description: The array results
           steps:
             - name: write-array
-              image: docker.io/library/bash:5.2.26
+              image: mirror.gcr.io/bash
               script: |
                 #!/usr/bin/env bash
                 echo -n "[\"1\",\"2\",\"3\"]" | tee $(results.array-results.path)
@@ -32,7 +32,7 @@ spec:
                 }
           steps:
             - name: write-array
-              image: docker.io/library/bash:5.2.26
+              image: mirror.gcr.io/bash
               script: |
                 #!/usr/bin/env bash
                 echo -n "{\"foo\":\"bar\",\"hello\":\"world\"}" | tee $(results.object-results.path)

--- a/examples/v1/pipelineruns/beta/pipeline-with-when-expressions-using-array-results.yaml
+++ b/examples/v1/pipelineruns/beta/pipeline-with-when-expressions-using-array-results.yaml
@@ -18,7 +18,7 @@ spec:
               description: The array results
           steps:
             - name: write-array
-              image: docker.io/library/bash:5.2.26
+              image: mirror.gcr.io/bash
               script: |
                 #!/usr/bin/env bash
                 image1="abc.dev/notsofamousimage/image"
@@ -34,7 +34,7 @@ spec:
         taskSpec:
           steps:
             - name: say-hi
-              image: docker.io/library/bash:5.2.26
+              image: mirror.gcr.io/bash
               script: |
                 echo "hi"
       - name: task3
@@ -50,7 +50,7 @@ spec:
         taskSpec:
           steps:
             - name: say-hello
-              image: docker.io/library/bash:5.2.26
+              image: mirror.gcr.io/bash
               script: |
                 echo "hello"
       - name: task4
@@ -62,7 +62,7 @@ spec:
         taskSpec:
           steps:
             - name: say-hi
-              image: docker.io/library/bash:5.2.26
+              image: mirror.gcr.io/bash
               script: |
                 echo "hi"
       - name: task5
@@ -74,7 +74,7 @@ spec:
         taskSpec:
           steps:
             - name: do-not-execute
-              image: docker.io/library/bash:5.2.26
+              image: mirror.gcr.io/bash
               script: |
                 exit 1
     finally:
@@ -82,7 +82,7 @@ spec:
         taskSpec:
           steps:
             - name: validate-tasks-section
-              image: docker.io/library/bash:5.2.26
+              image: mirror.gcr.io/bash
               script: |
                 if [[ $(context.task2.status) != "Succeeded" ]]; then
                   echo "task2 should have been succeeded but instead has status - $(context.task2.status)"

--- a/examples/v1/pipelineruns/beta/pipelinerun-with-matrix-and-results.yaml
+++ b/examples/v1/pipelineruns/beta/pipelinerun-with-matrix-and-results.yaml
@@ -12,7 +12,7 @@ spec:
     - name: url
   steps:
     - name: echo
-      image: docker.io/library/alpine:3.20.1
+      image: mirror.gcr.io/alpine
       script: |
         echo "Visit $(params.url) on $(params.platform) using $(params.browser)."
 ---
@@ -32,7 +32,7 @@ spec:
               type: array
           steps:
             - name: produce-a-list-of-platforms
-              image: docker.io/library/bash:5.2.26
+              image: mirror.gcr.io/bash
               script: |
                 #!/usr/bin/env bash
                 echo -n "[\"linux\",\"mac\",\"windows\"]" | tee $(results.platforms.path)
@@ -44,12 +44,12 @@ spec:
             - name: url
           steps:
             - name: produce-a-list-of-browsers
-              image: docker.io/library/bash:5.2.26
+              image: mirror.gcr.io/bash
               script: |
                 #!/usr/bin/env bash
                 echo -n "[\"chrome\",\"safari\",\"firefox\"]" | tee $(results.browsers.path)
             - name: produce-url
-              image: docker.io/library/bash:5.2.26
+              image: mirror.gcr.io/bash
               script: |
                 #!/usr/bin/env bash
                 echo -n "myfavoritesitedotcom" | tee $(results.url.path)

--- a/examples/v1/pipelineruns/beta/pipelinerun-with-matrix-array-references.yaml
+++ b/examples/v1/pipelineruns/beta/pipelinerun-with-matrix-array-references.yaml
@@ -13,7 +13,7 @@ spec:
       default: ""
   steps:
     - name: echo
-      image: docker.io/library/alpine:3.20.1
+      image: mirror.gcr.io/alpine
       script: |
         echo "$(params.platform) and $(params.browser)"
 ---

--- a/examples/v1/pipelineruns/beta/pipelinerun-with-matrix-context-variables.yaml
+++ b/examples/v1/pipelineruns/beta/pipelinerun-with-matrix-context-variables.yaml
@@ -8,7 +8,7 @@ spec:
       type: string
   steps:
     - name: validate
-      image: docker.io/library/alpine:3.20.1
+      image: mirror.gcr.io/alpine
       args: ["$(params.matrixlength)"]
       script: |
         #!/usr/bin/env sh
@@ -32,7 +32,7 @@ spec:
       type: string
   steps:
     - name: validate
-      image: docker.io/library/alpine:3.20.1
+      image: mirror.gcr.io/alpine
       script: |
         #!/usr/bin/env sh
         echo "Validating the length of the matrix results context variable"
@@ -61,7 +61,7 @@ spec:
     - name: IMAGE-URL
   steps:
     - name: produce-results
-      image: docker.io/library/bash:5.2.26
+      image: mirror.gcr.io/bash
       script: |
         #!/usr/bin/env bash
         echo "Building image for $(params.IMAGE)"

--- a/examples/v1/pipelineruns/beta/pipelinerun-with-matrix-emitting-results.yaml
+++ b/examples/v1/pipelineruns/beta/pipelinerun-with-matrix-emitting-results.yaml
@@ -8,7 +8,7 @@ spec:
       type: string
   steps:
     - name: echo
-      image: docker.io/library/alpine:3.20.1
+      image: mirror.gcr.io/alpine
       script: |
         echo "$(params.url)"
 ---
@@ -22,7 +22,7 @@ spec:
       type: array
   steps:
     - name: validate
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       args: ["$(params.url[*])"]
       script: |
         #!/usr/bin/env bash
@@ -60,7 +60,7 @@ spec:
       type: string
   steps:
     - name: produce-report-url
-      image: docker.io/library/alpine:3.20.1
+      image: mirror.gcr.io/alpine
       script: |
         echo "Running tests on $(params.platform)-$(params.browser)"
         echo -n "https://api.example/get-report/$(params.platform)-$(params.browser)" | tee $(results.report-url.path)

--- a/examples/v1/pipelineruns/beta/pipelinerun-with-matrix-include-explicit.yaml
+++ b/examples/v1/pipelineruns/beta/pipelinerun-with-matrix-include-explicit.yaml
@@ -11,7 +11,7 @@ spec:
     - name: DOCKERFILE
   steps:
     - name: echo
-      image: docker.io/library/alpine:3.20.1
+      image: mirror.gcr.io/alpine
       script: |
         echo "$(params.IMAGE) and $(params.DOCKERFILE)"
 ---

--- a/examples/v1/pipelineruns/beta/pipelinerun-with-matrix-include.yaml
+++ b/examples/v1/pipelineruns/beta/pipelinerun-with-matrix-include.yaml
@@ -19,7 +19,7 @@ spec:
       default: ''
   steps:
     - name: echo
-      image: docker.io/library/alpine:3.20.1
+      image: mirror.gcr.io/alpine
       script: |
         echo $(params.GOARCH) and $(params.version) flags? $(params.flags) context? $(params.context) package? $(params.package)
 ---

--- a/examples/v1/pipelineruns/beta/pipelinerun-with-matrix.yaml
+++ b/examples/v1/pipelineruns/beta/pipelinerun-with-matrix.yaml
@@ -11,7 +11,7 @@ spec:
     - name: browser
   steps:
     - name: echo
-      image: docker.io/library/alpine:3.20.1
+      image: mirror.gcr.io/alpine
       script: |
         echo "$(params.platform) and $(params.browser)"
 ---
@@ -75,7 +75,7 @@ spec:
             - name: version
           steps:
             - name: echo
-              image: docker.io/library/ubuntu
+              image: mirror.gcr.io/ubuntu
               script: exit 1
       - name: matrix-with-task-using-onerror
         matrix:
@@ -89,7 +89,7 @@ spec:
             - name: version
           steps:
             - name: echo
-              image: docker.io/library/ubuntu
+              image: mirror.gcr.io/ubuntu
               onError: continue
               script: exit 1
       - name: matrix-with-task-retries
@@ -108,7 +108,7 @@ spec:
             - name: version
             - name: pipelineTask-retries
           steps:
-            - image: docker.io/library/alpine:3.20.1
+            - image: mirror.gcr.io/alpine
               script: |
                 #!/usr/bin/env sh
                 if [ "$(context.task.retry-count)" == "$(params.pipelineTask-retries)" ]; then
@@ -128,5 +128,5 @@ spec:
             - name: version
           steps:
             - name: echo
-              image: docker.io/library/ubuntu
+              image: mirror.gcr.io/ubuntu
               script: exit 1

--- a/examples/v1/pipelineruns/beta/propagated-pipeline-object-param.yaml
+++ b/examples/v1/pipelineruns/beta/propagated-pipeline-object-param.yaml
@@ -19,7 +19,7 @@ spec:
         taskSpec:
           steps:
             - name: write-result
-              image: docker.io/library/bash
+              image: mirror.gcr.io/bash
               args: [
                 "echo",
                 "--url=$(params.gitrepo.url)",

--- a/examples/v1/pipelineruns/ignore-step-error.yaml
+++ b/examples/v1/pipelineruns/ignore-step-error.yaml
@@ -21,13 +21,13 @@ spec:
           - name: CONTINUE
           steps:
             # not really doing anything here, just a hurdle to test the "ignore step error"
-            - image: docker.io/library/alpine:3.20.1
+            - image: mirror.gcr.io/alpine
               onError: $(params.CONTINUE)
               name: exit-with-1
               script: |
                 exit 1
             # initialize a task result which will be validated by the next task
-            - image: docker.io/library/alpine:3.20.1
+            - image: mirror.gcr.io/alpine
               name: write-a-result
               onError: continue
               script: |
@@ -46,13 +46,13 @@ spec:
             - name: task1-result
           steps:
             # again, not really doing anything here, just a hurdle to test the "ignore step error"
-            - image: docker.io/library/alpine:3.20.1
+            - image: mirror.gcr.io/alpine
               onError: continue
               name: exit-with-255
               script: |
                 exit 255
             # verify that the task result was produced by the first task, fail if the result does not match
-            - image: docker.io/library/alpine:3.20.1
+            - image: mirror.gcr.io/alpine
               name: verify-a-task-result
               script: |
                 if [ $(params.task1-result) == 123 ]; then
@@ -62,7 +62,7 @@ spec:
                     exit 1
                 fi
             # the last step of a task and one more hurdle
-            - image: docker.io/library/alpine:3.20.1
+            - image: mirror.gcr.io/alpine
               name: exit-with-20
               onError: continue
               script: |
@@ -89,7 +89,7 @@ spec:
         taskSpec:
           steps:
             - name: write
-              image: docker.io/library/alpine:3.20.1
+              image: mirror.gcr.io/alpine
               onError: continue
               script: |
                 ls -1 /tekton/run/
@@ -106,7 +106,7 @@ spec:
         taskSpec:
           steps:
             - name: read
-              image: docker.io/library/alpine:3.20.1
+              image: mirror.gcr.io/alpine
               onError: continue
               script: |
                 cat $(workspaces.myws.path)/foo | grep bar

--- a/examples/v1/pipelineruns/mapping-workspaces.yaml
+++ b/examples/v1/pipelineruns/mapping-workspaces.yaml
@@ -56,7 +56,7 @@ spec:
   - name: shared-data
   steps:
   - name: fetch-and-write
-    image: docker.io/library/ubuntu
+    image: mirror.gcr.io/ubuntu
     script: |
       if [ "hunter2" = "$(cat $(workspaces.password-vault.path)/password)" ]; then
         cp $(workspaces.recipe-store.path)/recipe.txt $(workspaces.shared-data.path)
@@ -77,7 +77,7 @@ spec:
   - name: filename
   steps:
   - name: print-secrets
-    image: docker.io/library/ubuntu
+    image: mirror.gcr.io/ubuntu
     script: cat $(workspaces.shared-data.path)/$(params.filename)
 ---
 apiVersion: tekton.dev/v1

--- a/examples/v1/pipelineruns/no-ci/csi-workspace.yaml
+++ b/examples/v1/pipelineruns/no-ci/csi-workspace.yaml
@@ -27,7 +27,7 @@ spec:
   - name: secret-password
   steps:
   - name: fetch-csi
-    image: docker.io/library/ubuntu
+    image: mirror.gcr.io/ubuntu
     script: cat $(workspaces.secret-password.path)/db-password
 ---
 apiVersion: tekton.dev/v1

--- a/examples/v1/pipelineruns/no-ci/limitrange.yaml
+++ b/examples/v1/pipelineruns/no-ci/limitrange.yaml
@@ -25,7 +25,7 @@ metadata:
 spec:
   steps:
     - name: echo
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       command:
         - echo
       args:

--- a/examples/v1/pipelineruns/no-ci/pipelinerun-taskrunspecs.yaml
+++ b/examples/v1/pipelineruns/no-ci/pipelinerun-taskrunspecs.yaml
@@ -13,7 +13,7 @@ spec:
       description: the sum of the first and second operand
   steps:
     - name: add
-      image: docker.io/library/alpine:3.20.1
+      image: mirror.gcr.io/alpine
       env:
         - name: OP1
           value: $(params.first)

--- a/examples/v1/pipelineruns/optional-workspaces.yaml
+++ b/examples/v1/pipelineruns/optional-workspaces.yaml
@@ -16,7 +16,7 @@ spec:
     optional: true
   - name: launch
   steps:
-  - image: docker.io/library/node:lts-alpine3.20
+  - image: mirror.gcr.io/node:lts-alpine3.20
     script: |
       #!/usr/bin/env sh
       if [ $(workspaces.prelaunch.bound) == "true" ] ; then
@@ -40,7 +40,7 @@ spec:
   - name: values
     type: array
   steps:
-  - image: docker.io/library/alpine:3.20.1
+  - image: mirror.gcr.io/alpine
     command: ["echo"]
     args: ["$(params.values[*])"]
 ---

--- a/examples/v1/pipelineruns/pipeline-object-param-and-result.yaml
+++ b/examples/v1/pipelineruns/pipeline-object-param-and-result.yaml
@@ -21,7 +21,7 @@ spec:
           type: string
   steps:
     - name: write-result
-      image: docker.io/library/bash:5.2.26
+      image: mirror.gcr.io/bash
       script: |
         #!/usr/bin/env bash
         echo -n "{\"foo\":\"$(params.arg.url)\",\"bar\":\"$(params.arg.commit)\"}" | tee $(results.object-result.path)
@@ -41,7 +41,7 @@ spec:
           type: string
   steps:
     - name: echo-params
-      image: docker.io/library/bash:5.2.26
+      image: mirror.gcr.io/bash
       args: [
         "$(params.arg.foo)",
         "$(params.arg.bar)"

--- a/examples/v1/pipelineruns/pipeline-object-results.yaml
+++ b/examples/v1/pipelineruns/pipeline-object-results.yaml
@@ -18,7 +18,7 @@ spec:
                   type: string
           steps:
             - name: write-object
-              image: docker.io/library/bash:5.2.26
+              image: mirror.gcr.io/bash
               script: |
                 #!/usr/bin/env bash
                 echo -n "{\"url\":\"abc.dev/sampler\",\"digest\":\"19f02276bf8dbdd62f069b922f10c65262cc34b710eea26ff928129a736be791\"}" | tee $(results.object-results.path)
@@ -41,7 +41,7 @@ spec:
                   type: string
           steps:
             - name: validate-object-url
-              image: docker.io/library/bash:5.2.26
+              image: mirror.gcr.io/bash
               args: [
                 "$(params.whole-object.url)"
               ]
@@ -54,7 +54,7 @@ spec:
                   echo "validate the object-url successfully"
                 fi
             - name: validate-whole-object
-              image: docker.io/library/ubuntu
+              image: mirror.gcr.io/ubuntu
               script: |
                 #!/bin/bash
                 EXPECTED_url=abc.dev/sampler

--- a/examples/v1/pipelineruns/pipeline-with-displayname.yaml
+++ b/examples/v1/pipelineruns/pipeline-with-displayname.yaml
@@ -18,7 +18,7 @@ spec:
       description: The sum of the two provided integers
   steps:
     - name: sum
-      image: docker.io/library/bash:5.2.26
+      image: mirror.gcr.io/bash
       script: |
         #!/usr/bin/env bash
         echo -n $(( "$(params.a)" + "$(params.b)" )) | tee $(results.sum.path)
@@ -74,7 +74,7 @@ spec:
             type: string
         steps:
           - name: print
-            image: docker.io/library/alpine:3.20.1
+            image: mirror.gcr.io/alpine
             script: |
               echo "$(params.sum)"
 ---

--- a/examples/v1/pipelineruns/pipelinerun-array-results-substitution.yaml
+++ b/examples/v1/pipelineruns/pipelinerun-array-results-substitution.yaml
@@ -18,7 +18,7 @@ spec:
               description: The array results
           steps:
             - name: write-array
-              image: docker.io/library/bash:5.2.26
+              image: mirror.gcr.io/bash
               script: |
                 #!/usr/bin/env bash
                 image1="abc.dev/sampler/busysample@sha256:19f02276bf8dbdd62f069b922f10c65262cc34b710eea26ff928129a736be791"
@@ -44,7 +44,7 @@ spec:
               type: string
           steps:
             - name: validate-images
-              image: docker.io/library/bash:5.2.26
+              image: mirror.gcr.io/bash
               args: [
                 "$(params.images[*])"
               ]
@@ -74,7 +74,7 @@ spec:
                 fi
                 echo "Done validating the third image"
             - name: validate-image
-              image: docker.io/library/ubuntu
+              image: mirror.gcr.io/ubuntu
               script: |
                 #!/bin/bash
                 VALUE=$(params.image-1)

--- a/examples/v1/pipelineruns/pipelinerun-param-array-indexing.yaml
+++ b/examples/v1/pipelineruns/pipelinerun-param-array-indexing.yaml
@@ -26,7 +26,7 @@ spec:
         steps:
           # args must be initialed to "staging"
           - name: validate-environment1
-            image: docker.io/library/bash:5.2.26
+            image: mirror.gcr.io/bash
             args: [
               "$(params.environment1)",
             ]
@@ -47,7 +47,7 @@ spec:
               fi
           # this step validates string param which must be set to an array element - qa
           - name: validate-environment2
-            image: docker.io/library/ubuntu
+            image: mirror.gcr.io/ubuntu
             script: |
               #!/bin/bash
               VALUE=$(params.environment2)
@@ -63,7 +63,7 @@ spec:
           # this step validates an array param which must have three values
           # also validates indexing into an array param
           - name: validate-environments
-            image: docker.io/library/bash:5.2.26
+            image: mirror.gcr.io/bash
             args: [
               "$(params.environments[*])",
             ]

--- a/examples/v1/pipelineruns/pipelinerun-results-with-params.yaml
+++ b/examples/v1/pipelineruns/pipelinerun-results-with-params.yaml
@@ -16,7 +16,7 @@ spec:
         - name: suffix
         steps:
         - name: generate-suffix
-          image: docker.io/library/alpine:3.20.1
+          image: mirror.gcr.io/alpine
           script: |
             echo -n "suffix" > $(results.suffix.path)
     - name: do-something
@@ -25,7 +25,7 @@ spec:
         - name: arg
         steps:
         - name: do-something
-          image: docker.io/library/alpine:3.20.1
+          image: mirror.gcr.io/alpine
           script: |
             echo "$(params.arg)" | grep "prefix:suffix"
       params:

--- a/examples/v1/pipelineruns/pipelinerun-results.yaml
+++ b/examples/v1/pipelineruns/pipelinerun-results.yaml
@@ -13,7 +13,7 @@ spec:
       description: the sum of the first and second operand
   steps:
     - name: add
-      image: docker.io/library/alpine:3.20.1
+      image: mirror.gcr.io/alpine
       env:
         - name: OP1
           value: $(params.first)

--- a/examples/v1/pipelineruns/pipelinerun-task-execution-status.yaml
+++ b/examples/v1/pipelineruns/pipelinerun-task-execution-status.yaml
@@ -10,7 +10,7 @@ spec:
     - name: task1  # successful task
       taskSpec:
         steps:
-        - image: docker.io/library/ubuntu:24.04
+        - image: mirror.gcr.io/ubuntu
           name: hello
           script: |
             echo "Hello World!"
@@ -21,7 +21,7 @@ spec:
           values: ["true"]
       taskSpec:
         steps:
-          - image: docker.io/library/ubuntu:24.04
+          - image: mirror.gcr.io/ubuntu
             name: success
             script: |
               exit 0
@@ -37,7 +37,7 @@ spec:
           - name: task1Status
           - name: task2Status
         steps:
-          - image: docker.io/library/alpine:3.20.1
+          - image: mirror.gcr.io/alpine
             name: verify-dag-task-status
             script: |
               if [[ $(params.task1Status) != "Succeeded" ||  $(params.task2Status) != "None" ]]; then
@@ -51,7 +51,7 @@ spec:
         params:
           - name: aggregateStatus
         steps:
-          - image: docker.io/library/alpine:3.20.1
+          - image: mirror.gcr.io/alpine
             name: verify-aggregate-tasks-status
             script: |
               if [[ $(params.aggregateStatus) != "Completed" ]]; then

--- a/examples/v1/pipelineruns/pipelinerun-using-different-subpaths-of-workspace.yaml
+++ b/examples/v1/pipelineruns/pipelinerun-using-different-subpaths-of-workspace.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   steps:
     - name: write
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       script: echo bar > $(workspaces.task-ws.path)/foo
   workspaces:
     - name: task-ws
@@ -24,10 +24,10 @@ spec:
     - name: local-ws
   steps:
     - name: read-1
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       script: cat $(workspaces.local-ws.path)/$(params.directory1)/foo | grep bar
     - name: read-2
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       script: cat $(workspaces.local-ws.path)/$(params.directory2)/foo | grep bar
 ---
 apiVersion: tekton.dev/v1

--- a/examples/v1/pipelineruns/pipelinerun-using-parameterized-subpath-of-workspace.yaml
+++ b/examples/v1/pipelineruns/pipelinerun-using-parameterized-subpath-of-workspace.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   steps:
     - name: write
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       script: echo bar > $(workspaces.task-ws.path)/foo
   workspaces:
     - name: task-ws
@@ -24,10 +24,10 @@ spec:
     - name: local-ws
   steps:
     - name: read-1
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       script: cat $(workspaces.local-ws.path)/$(params.directory1)/foo | grep bar
     - name: read-2
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       script: cat $(workspaces.local-ws.path)/$(params.directory2)/foo | grep bar
 ---
 apiVersion: tekton.dev/v1

--- a/examples/v1/pipelineruns/pipelinerun-with-extra-params.yaml
+++ b/examples/v1/pipelineruns/pipelinerun-with-extra-params.yaml
@@ -35,7 +35,7 @@ spec:
     description: The second integer
   steps:
   - name: sum
-    image: docker.io/library/bash:5.2.26
+    image: mirror.gcr.io/bash
     script: |
       #!/usr/bin/env bash
       echo -n $(( "$(inputs.params.a)" + "$(inputs.params.b)" ))

--- a/examples/v1/pipelineruns/pipelinerun-with-final-results.yaml
+++ b/examples/v1/pipelineruns/pipelinerun-with-final-results.yaml
@@ -58,7 +58,7 @@ spec:
       description: The product of the two provided integers
   steps:
     - name: product
-      image: docker.io/library/bash:5.2.26
+      image: mirror.gcr.io/bash
       script: |
         #!/usr/bin/env bash
         echo -n $(( "$(params.a)" * "$(params.b)" )) | tee $(results.product.path)

--- a/examples/v1/pipelineruns/pipelinerun-with-final-tasks.yaml
+++ b/examples/v1/pipelineruns/pipelinerun-with-final-tasks.yaml
@@ -116,18 +116,18 @@ spec:
     - name: source
   steps:
     - name: check-application-dir-has-source
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       script: |
         if [ ! -d "$(workspaces.source.path)/application/" ]; then
           echo "Something went wrong and could not find application source under $(workspaces.source.path)/application/"
           exit 1
         fi
     - name: cleanup-workspace
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       script: |
         rm -rf $(workspaces.source.path)/application/
     - name: verify-application-dir-has-gone
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       script: |
         if [ -d "$(workspaces.source.path)/application/" ]; then
           echo "Something went wrong cleaning up and the application source still exists under $(workspaces.source.path)/application/"
@@ -174,7 +174,7 @@ spec:
           - name: commit
         steps:
           - name: check-commit-initialized
-            image: docker.io/library/alpine:3.20.1
+            image: mirror.gcr.io/alpine
             script: |
               if [[ ! $(params.commit) ]]; then
                 exit 1

--- a/examples/v1/pipelineruns/pipelinerun-with-parallel-tasks-using-pvc.yaml
+++ b/examples/v1/pipelineruns/pipelinerun-with-parallel-tasks-using-pvc.yaml
@@ -106,7 +106,7 @@ spec:
       description: A result message
   steps:
     - name: write
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       script: echo $(params.message) | tee $(workspaces.task-ws.path)/message $(results.message.path)
   workspaces:
     - name: task-ws
@@ -127,7 +127,7 @@ spec:
       description: Input message in upper case
   steps:
     - name: to-upper
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       script: cat $(workspaces.w.path)/$(params.input-path) | tr '[:lower:]' '[:upper:]' | tee $(workspaces.w.path)/upper $(results.message.path)
   workspaces:
     - name: w
@@ -148,7 +148,7 @@ spec:
       description: Input message in lower case
   steps:
     - name: to-lower
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       script: cat $(workspaces.w.path)/$(params.input-path) | tr '[:upper:]' '[:lower:]' | tee $(workspaces.w.path)/lower $(results.message.path)
   workspaces:
     - name: w
@@ -166,7 +166,7 @@ spec:
       type: string
   steps:
     - name: report-result
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       script: echo $(params.result-to-report)
 ---
 apiVersion: tekton.dev/v1
@@ -176,10 +176,10 @@ metadata:
 spec:
   steps:
     - name: validate-upper
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       script: cat $(workspaces.files.path)/upper | grep HELLO\ TEKTON
     - name: validate-lower
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       script: cat $(workspaces.files.path)/lower | grep hello\ tekton
   workspaces:
     - name: files

--- a/examples/v1/pipelineruns/pipelinerun-with-params.yaml
+++ b/examples/v1/pipelineruns/pipelinerun-with-params.yaml
@@ -47,7 +47,7 @@ spec:
     description: The second integer
   steps:
   - name: sum
-    image: docker.io/library/bash:5.2.26
+    image: mirror.gcr.io/bash
     script: |
       #!/usr/bin/env bash
       echo -n $(( "$(inputs.params.a)" + "$(inputs.params.b)" ))
@@ -71,7 +71,7 @@ spec:
     description: The second integer
   steps:
   - name: product
-    image: docker.io/library/bash:5.2.26
+    image: mirror.gcr.io/bash
     script: |
       #!/usr/bin/env bash
       echo -n $(( "$(inputs.params.a)" * "$(inputs.params.b)" ))

--- a/examples/v1/pipelineruns/pipelinerun-with-pipelinespec-and-taskspec.yaml
+++ b/examples/v1/pipelineruns/pipelinerun-with-pipelinespec-and-taskspec.yaml
@@ -12,7 +12,7 @@ spec:
               app: "example"
           steps:
             - name: echo
-              image: docker.io/library/ubuntu
+              image: mirror.gcr.io/ubuntu
               script: |
                 #!/usr/bin/env bash
                 echo "Good Morning!"
@@ -38,7 +38,7 @@ spec:
             default: "Hello World!"
           steps:
             - name: echo
-              image: docker.io/library/ubuntu
+              image: mirror.gcr.io/ubuntu
               script: |
                 #!/usr/bin/env bash
                 echo "$(params.MESSAGE)"
@@ -70,7 +70,7 @@ spec:
             default: "Hello World!"
           steps:
             - name: echo
-              image: docker.io/library/ubuntu
+              image: mirror.gcr.io/ubuntu
               script: |
                 #!/usr/bin/env bash
                 echo "$(params.MESSAGE)"

--- a/examples/v1/pipelineruns/pipelinerun-with-pipelinespec.yaml
+++ b/examples/v1/pipelineruns/pipelinerun-with-pipelinespec.yaml
@@ -9,7 +9,7 @@ spec:
     default: "Hello World"
   steps:
     - name: echo
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       command:
         - echo
       args:

--- a/examples/v1/pipelineruns/pipelinerun-with-when-expressions.yaml
+++ b/examples/v1/pipelineruns/pipelinerun-with-when-expressions.yaml
@@ -32,7 +32,7 @@ spec:
               description: The workspace to create the readme file in
           steps:
             - name: write-new-stuff
-              image: docker.io/library/ubuntu
+              image: mirror.gcr.io/ubuntu
               script: 'touch $(workspaces.source.path)/README.md'
       - name: check-file
         params:
@@ -54,7 +54,7 @@ spec:
               description: indicates whether the file exists or is missing
           steps:
             - name: check-file
-              image: docker.io/library/alpine:3.20.1
+              image: mirror.gcr.io/alpine
               script: |
                 if test -f $(workspaces.source.path)/$(params.path); then
                   printf yes | tee $(results.exists.path)
@@ -69,7 +69,7 @@ spec:
         taskSpec:
           steps:
             - name: echo
-              image: docker.io/library/ubuntu
+              image: mirror.gcr.io/ubuntu
               script: 'echo file exists'
       - name: sample-task-with-array-values
         when:
@@ -79,7 +79,7 @@ spec:
         taskSpec:
           steps:
             - name: echo
-              image: docker.io/library/alpine:3.20.1
+              image: mirror.gcr.io/alpine
               script: 'echo hello'
       - name: task-should-be-skipped-1
         when:
@@ -89,7 +89,7 @@ spec:
         taskSpec:
           steps:
             - name: echo
-              image: docker.io/library/ubuntu
+              image: mirror.gcr.io/ubuntu
               script: exit 1
       - name: task-should-be-skipped-2  # when expression using parameter, evaluates to false
         when:
@@ -99,7 +99,7 @@ spec:
         taskSpec:
           steps:
             - name: echo
-              image: docker.io/library/ubuntu
+              image: mirror.gcr.io/ubuntu
               script: exit 1
       - name: task-should-be-skipped-3  # task with when expression and run after
         runAfter:
@@ -111,7 +111,7 @@ spec:
         taskSpec:
           steps:
             - name: echo
-              image: docker.io/library/ubuntu
+              image: mirror.gcr.io/ubuntu
               script: exit 1
       - name: task-should-be-skipped-4  # task with when expression using array parameter, evaluates to false
         when:
@@ -121,7 +121,7 @@ spec:
         taskSpec:
           steps:
             - name: echo
-              image: docker.io/library/alpine:3.20.1
+              image: mirror.gcr.io/alpine
               script: exit 1
     finally:
       - name: finally-task-should-be-skipped-1  # when expression using execution status, evaluates to false
@@ -132,7 +132,7 @@ spec:
         taskSpec:
           steps:
             - name: echo
-              image: docker.io/library/ubuntu
+              image: mirror.gcr.io/ubuntu
               script: exit 1
       - name: finally-task-should-be-skipped-2  # when expression using task result, evaluates to false
         when:
@@ -142,7 +142,7 @@ spec:
         taskSpec:
           steps:
             - name: echo
-              image: docker.io/library/ubuntu
+              image: mirror.gcr.io/ubuntu
               script: exit 1
       - name: finally-task-should-be-skipped-3  # when expression using parameter, evaluates to false
         when:
@@ -152,7 +152,7 @@ spec:
         taskSpec:
           steps:
             - name: echo
-              image: docker.io/library/ubuntu
+              image: mirror.gcr.io/ubuntu
               script: exit 1
       - name: finally-task-should-be-skipped-4  # when expression using tasks execution status, evaluates to false
         when:
@@ -162,7 +162,7 @@ spec:
         taskSpec:
           steps:
             - name: echo
-              image: docker.io/library/ubuntu
+              image: mirror.gcr.io/ubuntu
               script: exit 1
       - name: finally-task-should-be-skipped-5  # when expression using tasks execution status, evaluates to false
         when:
@@ -172,7 +172,7 @@ spec:
         taskSpec:
           steps:
             - name: echo
-              image: docker.io/library/ubuntu
+              image: mirror.gcr.io/ubuntu
               script: exit 1
       - name: finally-task-should-be-executed  # when expression using execution status, tasks execution status, param, and results
         when:
@@ -191,7 +191,7 @@ spec:
         taskSpec:
           steps:
             - name: echo
-              image: docker.io/library/ubuntu
+              image: mirror.gcr.io/ubuntu
               script: 'echo finally done'
   params:
     - name: path

--- a/examples/v1/pipelineruns/pipelinerun.yaml
+++ b/examples/v1/pipelineruns/pipelinerun.yaml
@@ -161,7 +161,7 @@ spec:
       securityContext:
         runAsUser: 0
     - name: write-url
-      image: docker.io/library/bash:5.1.4@sha256:c523c636b722339f41b6a431b44588ab2f762c5de5ec3bd7964420ff982fb1d9
+      image: mirror.gcr.io/bash:5.1.4@sha256:c523c636b722339f41b6a431b44588ab2f762c5de5ec3bd7964420ff982fb1d9
       script: |
         set -e
         image="$(params.IMAGE)"

--- a/examples/v1/pipelineruns/propagating-workspaces-in-pipelines.yaml
+++ b/examples/v1/pipelineruns/propagating-workspaces-in-pipelines.yaml
@@ -9,7 +9,7 @@ spec:
     - name: t1
       taskSpec:
         steps:
-          - image: docker.io/library/ubuntu:24.04
+          - image: mirror.gcr.io/ubuntu
             command: ["ls"]
             args: ["$(workspaces.shared-data.path)"]
 ---

--- a/examples/v1/pipelineruns/propagating-workspaces.yaml
+++ b/examples/v1/pipelineruns/propagating-workspaces.yaml
@@ -57,7 +57,7 @@ spec:
       taskSpec:
         steps:
         - name: fetch-and-write-secure
-          image: docker.io/library/ubuntu
+          image: mirror.gcr.io/ubuntu
           script: |
             if [ "hunter2" = "$(cat $(workspaces.password-vault.path)/password)" ]; then
               cp $(workspaces.recipe-store.path)/recipe.txt $(workspaces.shared-data.path)
@@ -72,5 +72,5 @@ spec:
       taskSpec:
         steps:
         - name: print-secrets
-          image: docker.io/library/ubuntu
+          image: mirror.gcr.io/ubuntu
           script: cat $(workspaces.shared-data.path)/$(params.filename)

--- a/examples/v1/pipelineruns/propagating_params_implicit_parameters.yaml
+++ b/examples/v1/pipelineruns/propagating_params_implicit_parameters.yaml
@@ -12,7 +12,7 @@ spec:
         taskSpec:
           steps:
             - name: echo
-              image: docker.io/library/ubuntu
+              image: mirror.gcr.io/ubuntu
               script: |
                 #!/usr/bin/env bash
                 echo "$(params.HELLO)"
@@ -21,7 +21,7 @@ spec:
         taskSpec:
           steps:
             - name: echo
-              image: docker.io/library/ubuntu
+              image: mirror.gcr.io/ubuntu
               script: |
                 #!/usr/bin/env bash
                 echo "And Finally ... $(params.HELLO)"

--- a/examples/v1/pipelineruns/propagating_params_in_pipeline.yaml
+++ b/examples/v1/pipelineruns/propagating_params_in_pipeline.yaml
@@ -11,7 +11,7 @@ spec:
       taskSpec:
         steps:
           - name: echo
-            image: docker.io/library/ubuntu
+            image: mirror.gcr.io/ubuntu
             script: |
               #!/usr/bin/env bash
               echo "$(params.HELLO)"
@@ -20,7 +20,7 @@ spec:
       taskSpec:
         steps:
           - name: echo
-            image: docker.io/library/ubuntu
+            image: mirror.gcr.io/ubuntu
             script: |
               #!/usr/bin/env bash
               echo "And Finally ... $(params.HELLO)"

--- a/examples/v1/pipelineruns/propagating_params_with_scope_precedence.yaml
+++ b/examples/v1/pipelineruns/propagating_params_with_scope_precedence.yaml
@@ -15,7 +15,7 @@ spec:
         taskSpec:
           steps:
             - name: echo
-              image: docker.io/library/ubuntu
+              image: mirror.gcr.io/ubuntu
               script: |
                 #!/usr/bin/env bash
                 echo "$(params.HELLO)"
@@ -27,7 +27,7 @@ spec:
         taskSpec:
           steps:
             - name: echo
-              image: docker.io/library/ubuntu
+              image: mirror.gcr.io/ubuntu
               script: |
                 #!/usr/bin/env bash
                 echo "And finally.. $(params.HELLO)"

--- a/examples/v1/pipelineruns/propagating_params_with_scope_precedence_default_only.yaml
+++ b/examples/v1/pipelineruns/propagating_params_with_scope_precedence_default_only.yaml
@@ -15,7 +15,7 @@ spec:
               default: "Default Hello World!"
           steps:
             - name: echo
-              image: docker.io/library/ubuntu
+              image: mirror.gcr.io/ubuntu
               script: |
                 #!/usr/bin/env bash
                 echo "$(params.HELLO)"
@@ -27,7 +27,7 @@ spec:
               default: "Default Hello World!"
           steps:
             - name: echo
-              image: docker.io/library/ubuntu
+              image: mirror.gcr.io/ubuntu
               script: |
                 #!/usr/bin/env bash
                 echo "And finally... $(params.HELLO)"

--- a/examples/v1/pipelineruns/propagating_results_implicit_resultref.yaml
+++ b/examples/v1/pipelineruns/propagating_results_implicit_resultref.yaml
@@ -8,7 +8,7 @@ spec:
       type: string
   steps:
     - name: uid
-      image: docker.io/library/busybox
+      image: mirror.gcr.io/busybox
       command: ["/bin/sh", "-c"]
       args:
         - echo "1001" | tee $(results.uid.path)
@@ -27,7 +27,7 @@ spec:
         taskSpec:
           steps:
             - name: show-uid
-              image: docker.io/library/busybox
+              image: mirror.gcr.io/busybox
               command: ["/bin/sh", "-c"]
               args:
                 - echo $(tasks.add-uid.results.uid)

--- a/examples/v1/pipelineruns/propagating_workspaces_with_referenced_resources.yaml
+++ b/examples/v1/pipelineruns/propagating_workspaces_with_referenced_resources.yaml
@@ -8,7 +8,7 @@ spec:
   - name: shared-data
   steps:
   - name: fetch-and-write
-    image: docker.io/library/ubuntu
+    image: mirror.gcr.io/ubuntu
     script: |
       echo hi >> $(workspaces.shared-data.path)/recipe.txt
 ---
@@ -38,7 +38,7 @@ spec:
       taskSpec:
         steps:
         - name: print-secrets
-          image: docker.io/library/ubuntu
+          image: mirror.gcr.io/ubuntu
           script: cat $(workspaces.shared-data.path)/recipe.txt
       runAfter:
         - fetch-the-recipe

--- a/examples/v1/pipelineruns/task_results_example.yaml
+++ b/examples/v1/pipelineruns/task_results_example.yaml
@@ -58,7 +58,7 @@ spec:
       description: The sum of the two provided integers
   steps:
     - name: sum
-      image: docker.io/library/bash:5.2.26
+      image: mirror.gcr.io/bash
       script: |
         #!/usr/bin/env bash
         echo -n $(( "$(params.a)" + "$(params.b)" )) | tee $(results.sum.path)
@@ -85,7 +85,7 @@ spec:
       description: The product of the two provided integers
   steps:
     - name: product
-      image: docker.io/library/bash:5.2.26
+      image: mirror.gcr.io/bash
       script: |
         #!/usr/bin/env bash
         echo -n $(( "$(params.a)" * "$(params.b)" )) | tee $(results.product.path)

--- a/examples/v1/pipelineruns/using-optional-workspaces-in-when-expressions.yaml
+++ b/examples/v1/pipelineruns/using-optional-workspaces-in-when-expressions.yaml
@@ -47,7 +47,7 @@ spec:
         - name: message-of-the-day
           optional: true
         steps:
-        - image: docker.io/library/alpine:3.20.1
+        - image: mirror.gcr.io/alpine
           script: |
             #!/usr/bin/env ash
             for f in "$(workspaces.message-of-the-day.path)"/* ; do
@@ -63,6 +63,6 @@ spec:
       taskSpec:
         steps:
         - name: print-default
-          image: docker.io/library/alpine:3.20.1
+          image: mirror.gcr.io/alpine
           script: |
             echo "No message-of-the-day workspace was provided. This is the default MOTD instead!"

--- a/examples/v1/pipelineruns/using-retries-and-retry-count-variables.yaml
+++ b/examples/v1/pipelineruns/using-retries-and-retry-count-variables.yaml
@@ -19,7 +19,7 @@ spec:
         - name: pipelineTask-retries
         - name: pipelineTask-retry-count
         steps:
-        - image: docker.io/library/alpine:3.20.1
+        - image: mirror.gcr.io/alpine
           script: |
             #!/usr/bin/env sh
             if [ "$(params.pipelineTask-retry-count)" == "$(params.pipelineTask-retries)" ]; then
@@ -33,6 +33,6 @@ spec:
       - retry-me
       taskSpec:
         steps:
-        - image: docker.io/library/busybox:1.36
+        - image: mirror.gcr.io/busybox
           script: |
             echo "hello world"

--- a/examples/v1/pipelineruns/using_context_variables.yaml
+++ b/examples/v1/pipelineruns/using_context_variables.yaml
@@ -28,12 +28,12 @@ spec:
         - name: pipelineRun-namespace
         - name: pipelineTask-retries
         steps:
-        - image: docker.io/library/ubuntu:24.04
+        - image: mirror.gcr.io/ubuntu
           name: print-uid
           script: |
             echo "TaskRun UID: $(context.taskRun.uid)"
             echo "PipelineRun UID from params: $(params.pipeline-uid)"
-        - image: docker.io/library/ubuntu:24.04
+        - image: mirror.gcr.io/ubuntu
           name: print-names
           script: |
             echo "Task name: $(context.task.name)"
@@ -41,7 +41,7 @@ spec:
             echo "Pipeline name from params: $(params.pipeline-name)"
             echo "PipelineRun name from params: $(params.pipelineRun-name)"
             echo "PipelineRun namespace from params: $(params.pipelineRun-namespace)"
-        - image: docker.io/library/ubuntu:24.04
+        - image: mirror.gcr.io/ubuntu
           name: print-retries
           script: |
             echo "PipelineTask retries from params: $(params.pipelineTask-retries)"

--- a/examples/v1/pipelineruns/workspace-from-volumeclaimtemplate.yaml
+++ b/examples/v1/pipelineruns/workspace-from-volumeclaimtemplate.yaml
@@ -8,7 +8,7 @@ spec:
       taskSpec:
         steps:
           - name: write
-            image: docker.io/library/ubuntu
+            image: mirror.gcr.io/ubuntu
             script: echo bar > $(workspaces.task-ws.path)/foo
         workspaces:
           - name: task-ws
@@ -21,7 +21,7 @@ spec:
       taskSpec:
         steps:
           - name: read
-            image: docker.io/library/ubuntu
+            image: mirror.gcr.io/ubuntu
             script: cat $(workspaces.myws.path)/foo | grep bar
         workspaces:
           - name: myws

--- a/examples/v1/pipelineruns/workspaces-projected.yaml
+++ b/examples/v1/pipelineruns/workspaces-projected.yaml
@@ -56,7 +56,7 @@ spec:
   - name: filedrop
   steps:
   - name: fetch-and-write
-    image: docker.io/library/ubuntu
+    image: mirror.gcr.io/ubuntu
     script: |
       if [ "hunter2" = "$(cat $(workspaces.secure-store.path)/password)" ]; then
         cp $(workspaces.secure-store.path)/recipe.txt $(workspaces.filedrop.path)
@@ -77,7 +77,7 @@ spec:
   - name: filename
   steps:
   - name: print-secrets
-    image: docker.io/library/ubuntu
+    image: mirror.gcr.io/ubuntu
     script: cat $(workspaces.storage.path)/$(params.filename)
 ---
 apiVersion: tekton.dev/v1

--- a/examples/v1/pipelineruns/workspaces.yaml
+++ b/examples/v1/pipelineruns/workspaces.yaml
@@ -56,7 +56,7 @@ spec:
   - name: filedrop
   steps:
   - name: fetch-and-write
-    image: docker.io/library/ubuntu
+    image: mirror.gcr.io/ubuntu
     script: |
       if [ "hunter2" = "$(cat $(workspaces.super-secret-password.path)/password)" ]; then
         cp $(workspaces.secure-store.path)/recipe.txt $(workspaces.filedrop.path)
@@ -77,7 +77,7 @@ spec:
   - name: filename
   steps:
   - name: print-secrets
-    image: docker.io/library/ubuntu
+    image: mirror.gcr.io/ubuntu
     script: cat $(workspaces.storage.path)/$(params.filename)
 ---
 apiVersion: tekton.dev/v1

--- a/examples/v1/taskruns/alpha/param-enum.yaml
+++ b/examples/v1/taskruns/alpha/param-enum.yaml
@@ -9,7 +9,7 @@ spec:
     default: "v1"
   steps:
   - name: build
-    image: docker.io/library/bash:5.2.26
+    image: mirror.gcr.io/bash
     script: |
       echo "$(params.message)"
 ---

--- a/examples/v1/taskruns/alpha/produce-consume-artifacts.yaml
+++ b/examples/v1/taskruns/alpha/produce-consume-artifacts.yaml
@@ -8,7 +8,7 @@ spec:
       A simple task that populates artifacts to TaskRun stepState
     steps:
       - name: artifacts-producer
-        image: docker.io/library/bash:5.2.26
+        image: mirror.gcr.io/bash
         script: |
           cat > $(step.artifacts.path) << EOF
           {
@@ -42,11 +42,11 @@ spec:
           }
           EOF
       - name: artifacts-consumer
-        image: docker.io/library/bash:5.2.26
+        image: mirror.gcr.io/bash
         script: |
           echo $(steps.artifacts-producer.inputs.input-artifacts)
       - name: artifacts-consumer-python
-        image: docker.io/library/python:3.12.4
+        image: mirror.gcr.io/python:3.12.4
         script: |
           #!/usr/bin/env python3
           import json

--- a/examples/v1/taskruns/alpha/step-stream-results.yaml
+++ b/examples/v1/taskruns/alpha/step-stream-results.yaml
@@ -20,7 +20,7 @@ spec:
         image: gcr.io/go-containerregistry/crane
         args:
           - digest
-          - docker.io/library/bash
+          - mirror.gcr.io/bash
         stdoutConfig:
           path: $(results.digest.path)
         stderrConfig:
@@ -28,7 +28,7 @@ spec:
       # This step redirects stdout and stderr to the path for the Task
       # result `combined`.
       - name: error
-        image: docker.io/library/bash
+        image: mirror.gcr.io/bash
         onError: continue
         script: echo "combined message" && nonsense
         stdoutConfig:
@@ -38,7 +38,7 @@ spec:
       # This step prints out the contents of the task results
       # if they exist
       - name: log-results
-        image: docker.io/library/bash
+        image: mirror.gcr.io/bash
         script: |
           if [[ -f $(results.digest.path) ]]
           then

--- a/examples/v1/taskruns/alpha/step-stream-volumes.yaml
+++ b/examples/v1/taskruns/alpha/step-stream-volumes.yaml
@@ -10,7 +10,7 @@ spec:
       - name: data
     steps:
       - name: echo
-        image: docker.io/library/bash
+        image: mirror.gcr.io/bash
         volumeMounts:
           - name: data
             mountPath: /data
@@ -18,7 +18,7 @@ spec:
         stdoutConfig:
           path: /data/step-echo-stdout
       - name: error
-        image: docker.io/library/bash
+        image: mirror.gcr.io/bash
         onError: continue
         volumeMounts:
           - name: data
@@ -29,7 +29,7 @@ spec:
         stderrConfig:
           path: /data/step-error-stderr
       - name: combined
-        image: docker.io/library/bash
+        image: mirror.gcr.io/bash
         onError: continue
         volumeMounts:
           - name: data
@@ -40,7 +40,7 @@ spec:
         stderrConfig:
           path: /data/step-combined
       - name: cat
-        image: docker.io/library/bash
+        image: mirror.gcr.io/bash
         volumeMounts:
           - name: data
             mountPath: /data
@@ -48,7 +48,7 @@ spec:
         stdoutConfig:
           path: /data/step-cat-stdout
       - name: log-data
-        image: docker.io/library/bash
+        image: mirror.gcr.io/bash
         volumeMounts:
           - name: data
             mountPath: /data

--- a/examples/v1/taskruns/alpha/step-stream-workspace.yaml
+++ b/examples/v1/taskruns/alpha/step-stream-workspace.yaml
@@ -18,7 +18,7 @@ spec:
           - name: data
         args:
           - digest
-          - docker.io/library/bash
+          - mirror.gcr.io/bash
         stdoutConfig:
           path: $(results.digest.path)
       - image: gcr.io/go-containerregistry/crane
@@ -26,7 +26,7 @@ spec:
           - name: data
         args:
           - digest
-          - docker.io/library/bash
+          - mirror.gcr.io/bash
         stdoutConfig:
           path: $(workspaces.data.path)/stdout.txt
       - image: gcr.io/go-containerregistry/crane
@@ -43,26 +43,26 @@ spec:
           - wrong
         stderrConfig:
           path: $(results.error2.path)
-      - image: docker.io/library/bash:5.2.26
+      - image: mirror.gcr.io/bash
         workspaces:
           - name: data
         onError: continue
         args:
           - -c
           - "echo foobar >$(workspaces.data.path)/foobar.txt"
-      - image: docker.io/library/bash:5.2.26
+      - image: mirror.gcr.io/bash
         onError: continue
         args:
           - -c
           - "2>$(results.error.path) >&2 echo -n fooerr"
-      - image: docker.io/library/bash:5.2.26
+      - image: mirror.gcr.io/bash
         workspaces:
           - name: data
         workingDir: $(workspaces.data.path)
         onError: continue
         script: |
           echo local >out.txt
-      - image: docker.io/library/bash:5.2.26
+      - image: mirror.gcr.io/bash
         workspaces:
           - name: data
         onError: continue

--- a/examples/v1/taskruns/array-default.yaml
+++ b/examples/v1/taskruns/array-default.yaml
@@ -23,7 +23,7 @@ spec:
     steps:
       # this step should echo "foo bar foo-default bar-default baz"
       - name: echo-params
-        image: docker.io/library/bash:5.2.26
+        image: mirror.gcr.io/bash
         args: [
           "echo",
           "$(params.array-to-echo[*])",

--- a/examples/v1/taskruns/beta/emit-array-results.yaml
+++ b/examples/v1/taskruns/beta/emit-array-results.yaml
@@ -12,12 +12,12 @@ spec:
       description: The array results
   steps:
     - name: write-array
-      image: docker.io/library/bash:5.2.26
+      image: mirror.gcr.io/bash
       script: |
         #!/usr/bin/env bash
         echo -n "[\"hello\",\"world\"]" | tee $(results.array-results.path)
     - name: check-results-array
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       script: |
         #!/bin/bash
         VALUE=$(cat $(results.array-results.path))

--- a/examples/v1/taskruns/beta/large-task-result.yaml
+++ b/examples/v1/taskruns/beta/large-task-result.yaml
@@ -14,13 +14,13 @@ spec:
       - name: result5
     steps:
       - name: step1
-        image: docker.io/library/bash:5.2.26
+        image: mirror.gcr.io/bash
         script: |
           #!/usr/bin/env bash
           cat /dev/urandom | head -c 2500 | base64 | tee $(results.result1.path) #about 1 K result
           cat /dev/urandom | head -c 2500 | base64 | tee $(results.result2.path) #about 4 K result
       - name: step2
-        image: docker.io/library/bash:5.2.26
+        image: mirror.gcr.io/bash
         script: |
           #!/usr/bin/env bash
           cat /dev/urandom | head -c 2500 | base64 | tee $(results.result3.path) #about 1 K result

--- a/examples/v1/taskruns/beta/param_array_indexing.yaml
+++ b/examples/v1/taskruns/beta/param_array_indexing.yaml
@@ -15,14 +15,14 @@ spec:
     steps:
       # this step should echo "foo"
       - name: echo-params-1
-        image: docker.io/library/bash:5.2.26
+        image: mirror.gcr.io/bash
         args: [
           "echo",
           "$(params.array-to-echo[0])",
         ]
       # this step should echo "bar"
       - name: echo-params-2
-        image: docker.io/library/ubuntu
+        image: mirror.gcr.io/ubuntu
         script: |
           #!/bin/bash
           VALUE=$(params.array-to-echo[1])

--- a/examples/v1/taskruns/beta/propagated-object-parameters.yaml
+++ b/examples/v1/taskruns/beta/propagated-object-parameters.yaml
@@ -11,7 +11,7 @@ spec:
   taskSpec:
     steps:
       - name: echo-object-params
-        image: docker.io/library/bash
+        image: mirror.gcr.io/bash
         args: [
           "echo",
           "--url=$(params.gitrepo.url)",

--- a/examples/v1/taskruns/beta/stepaction-params.yaml
+++ b/examples/v1/taskruns/beta/stepaction-params.yaml
@@ -40,7 +40,7 @@ spec:
       value: $(params.object-param.key2)
     - name: objectparamkey3
       value: $(params.object-param.key3)
-  image: docker.io/library/ubuntu
+  image: mirror.gcr.io/ubuntu
   script: |
     #!/bin/bash
     ARRAYVALUE=("${arrayparam0}" "${arrayparam1}" "${arrayparam2}" "${stringparam}" "${objectparamkey1}" "${objectparamkey2}" "${objectparamkey3}")

--- a/examples/v1/taskruns/beta/stepaction-passing-results.yaml
+++ b/examples/v1/taskruns/beta/stepaction-passing-results.yaml
@@ -15,7 +15,7 @@ spec:
           type: string
         IMAGE_DIGEST:
           type: string
-  image: docker.io/library/bash:5.2.26
+  image: mirror.gcr.io/bash
   env:
     - name: STRINGPARAM
       value: $(params.param2)
@@ -75,7 +75,7 @@ spec:
                 type: string
               IMAGE_DIGEST:
                 type: string
-        image: docker.io/library/alpine:3.20.1
+        image: mirror.gcr.io/alpine
         script: |
           echo -n "[\"image1\", \"image2\", \"image3\"]" | tee $(step.results.result1.path)
           echo -n "foo" | tee $(step.results.result2.path)

--- a/examples/v1/taskruns/beta/stepaction-results.yaml
+++ b/examples/v1/taskruns/beta/stepaction-results.yaml
@@ -3,7 +3,7 @@ kind: StepAction
 metadata:
   name: step-action
 spec:
-  image: docker.io/library/alpine:3.20.1
+  image: mirror.gcr.io/alpine
   results:
     - name: result1
     - name: result2

--- a/examples/v1/taskruns/beta/stepaction.yaml
+++ b/examples/v1/taskruns/beta/stepaction.yaml
@@ -3,7 +3,7 @@ kind: StepAction
 metadata:
   name: step-action
 spec:
-  image: docker.io/library/alpine:3.20.1
+  image: mirror.gcr.io/alpine
   script: |
     echo "I am a Step Action!!!"
 ---

--- a/examples/v1/taskruns/beta/stepactions-steptemplate.yaml
+++ b/examples/v1/taskruns/beta/stepactions-steptemplate.yaml
@@ -3,7 +3,7 @@ kind: StepAction
 metadata:
   name: step-action
 spec:
-  image: docker.io/library/alpine:3.20.1
+  image: mirror.gcr.io/alpine
   command: ["env"]
 ---
 apiVersion: tekton.dev/v1

--- a/examples/v1/taskruns/beta/workspace-in-sidecar.yaml
+++ b/examples/v1/taskruns/beta/workspace-in-sidecar.yaml
@@ -17,7 +17,7 @@ spec:
     workspaces:
     - name: signals
     steps:
-    - image: docker.io/library/alpine:3.20.1
+    - image: mirror.gcr.io/alpine
       computeResources:
         requests:
           memory: "16Mi"
@@ -33,7 +33,7 @@ spec:
         echo "Sidecar responded: ${response}"
         echo "Step Done."
     sidecars:
-    - image: docker.io/library/alpine:3.20.1
+    - image: mirror.gcr.io/alpine
       computeResources:
         requests:
           memory: "16Mi"

--- a/examples/v1/taskruns/beta/workspace-isolation.yaml
+++ b/examples/v1/taskruns/beta/workspace-isolation.yaml
@@ -18,7 +18,7 @@ spec:
     - name: signals
     steps:
     - name: await-sidecar-signal
-      image: docker.io/library/alpine:3.20.1
+      image: mirror.gcr.io/alpine
       workspaces:
       - name: signals
       script: |
@@ -32,7 +32,7 @@ spec:
         done
         echo "Saw ready file"
     - name: check-signals-access
-      image: docker.io/library/alpine:3.20.1
+      image: mirror.gcr.io/alpine
       script: |
         #!/usr/bin/env ash
         if [ -f "$(workspaces.signals.path)"/start ] ; then
@@ -41,7 +41,7 @@ spec:
         fi
     sidecars:
     - name: await-step-signal
-      image: docker.io/library/alpine:3.20.1
+      image: mirror.gcr.io/alpine
       workspaces:
       - name: signals
       script: |

--- a/examples/v1/taskruns/configmap.yaml
+++ b/examples/v1/taskruns/configmap.yaml
@@ -13,7 +13,7 @@ spec:
   taskSpec:
     steps:
     - name: secret
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       script: |
         #!/usr/bin/env bash
         [[ $(cat /config/test.data) == $TEST_DATA ]]

--- a/examples/v1/taskruns/creds-init-only-mounts-provided-credentials.yaml
+++ b/examples/v1/taskruns/creds-init-only-mounts-provided-credentials.yaml
@@ -30,7 +30,7 @@ spec:
   taskSpec:
     steps:
     - name: check-credentials
-      image: docker.io/library/alpine:3.20.1
+      image: mirror.gcr.io/alpine
       script: |
         #!/usr/bin/env ash
         set -xe

--- a/examples/v1/taskruns/custom-env.yaml
+++ b/examples/v1/taskruns/custom-env.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   taskSpec:
     steps:
-    - image: docker.io/library/ubuntu:24.04
+    - image: mirror.gcr.io/ubuntu
       script: |
         #!/usr/bin/env bash
         [[ $MY_VAR1 == foo ]]

--- a/examples/v1/taskruns/custom-volume.yaml
+++ b/examples/v1/taskruns/custom-volume.yaml
@@ -6,7 +6,7 @@ spec:
   taskSpec:
     steps:
     - name: write
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       script: |
         #!/usr/bin/env bash
         echo some stuff > /im/a/custom/mount/path/file
@@ -14,7 +14,7 @@ spec:
       - name: custom
         mountPath: /im/a/custom/mount/path
     - name: read
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       script: |
         #!/usr/bin/env bash
         cat /short/and/stout/file | grep stuff

--- a/examples/v1/taskruns/entrypoint-resolution.yaml
+++ b/examples/v1/taskruns/entrypoint-resolution.yaml
@@ -13,17 +13,17 @@ spec:
     # Multi-arch image with no command defined, but with args. We'll look
     # up the commands and pass it to the entrypoint binary via env var, then
     # append the specified args.
-    - image: docker.io/library/ubuntu:24.04
+    - image: mirror.gcr.io/ubuntu
       args: ['-c', 'echo', 'hello']
 
     # Multi-arch image, but since we specify `script` we don't need to look it
     # up and pass it down.
-    - image: docker.io/library/ubuntu:24.04
+    - image: mirror.gcr.io/ubuntu
       script: echo hello
 
     # Multi-arch image, but since we specify `command` and `args` we don't
     # need to look it up and pass it down.
-    - image: docker.io/library/ubuntu:24.04
+    - image: mirror.gcr.io/ubuntu
       command: ['sh', '-c']
       args: ['echo hello']
 

--- a/examples/v1/taskruns/home-is-set.yaml
+++ b/examples/v1/taskruns/home-is-set.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   taskSpec:
     steps:
-    - image: docker.io/library/ubuntu:24.04
+    - image: mirror.gcr.io/ubuntu
       env:
       - name: HOME
         value: /tekton/home

--- a/examples/v1/taskruns/home-volume.yaml
+++ b/examples/v1/taskruns/home-volume.yaml
@@ -6,13 +6,13 @@ spec:
   taskSpec:
     steps:
     - name: write
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       script: echo some stuff > /tekton/home/stuff
     - name: read
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       script: cat /tekton/home/stuff
     - name: override-homevol
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       # /tekton/home/stuff *doesn't* exist, because the specified volumeMount
       # conflicts with it, and the user's explicit declaration wins the tie.
       script: |

--- a/examples/v1/taskruns/ignore-step-error.yaml
+++ b/examples/v1/taskruns/ignore-step-error.yaml
@@ -6,14 +6,14 @@ spec:
   taskSpec:
     steps:
       # exit with 1 and ignore non zero exit code
-      - image: docker.io/library/alpine:3.20.1
+      - image: mirror.gcr.io/alpine
         onError: continue
         name: exit-with-1
         script: |
           exit 1
       # check if the /tekton/steps/step-<step-name>/exitCode got created and contains the exit code
       # check if the symlink /tekton/steps/0/ got created
-      - image: docker.io/library/alpine:3.20.1
+      - image: mirror.gcr.io/alpine
         name: verify-step-path
         script: |
           exitCode=`cat $(steps.step-exit-with-1.exitCode.path)`

--- a/examples/v1/taskruns/no-ci/default-workspaces.yaml
+++ b/examples/v1/taskruns/no-ci/default-workspaces.yaml
@@ -7,11 +7,11 @@ spec:
   - name: source
   steps:
   - name: write-file
-    image: docker.io/library/ubuntu
+    image: mirror.gcr.io/ubuntu
     script: |
       echo "Hello, world!" > /workspace/source/hello.txt || exit 0
   - name: read-file
-    image: docker.io/library/ubuntu
+    image: mirror.gcr.io/ubuntu
     script: |
       grep "Hello, world" /workspace/source/hello.txt
 ---

--- a/examples/v1/taskruns/no-ci/limitrange.yaml
+++ b/examples/v1/taskruns/no-ci/limitrange.yaml
@@ -25,7 +25,7 @@ metadata:
 spec:
   steps:
     - name: echo
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       command:
         - echo
       args:

--- a/examples/v1/taskruns/object-param-result.yaml
+++ b/examples/v1/taskruns/object-param-result.yaml
@@ -24,7 +24,7 @@ spec:
           IMAGE_DIGEST: {type: string}
     steps:
       - name: validate-object-params
-        image: docker.io/library/bash
+        image: mirror.gcr.io/bash
         args: [
           "$(params.gitrepo.url)",
           "$(params.gitrepo.commit)"
@@ -43,7 +43,7 @@ spec:
             echo "validate the params.gitrepo.commit successfully"
           fi
       - name: write-object-result
-        image: docker.io/library/bash:5.2.26
+        image: mirror.gcr.io/bash
         script: |
           #!/usr/bin/env bash
           echo -n "{\"IMAGE_URL\":\"ar.com\", \"IMAGE_DIGEST\":\"sha234\"}" > $(results.object-results.path)

--- a/examples/v1/taskruns/optional-workspaces.yaml
+++ b/examples/v1/taskruns/optional-workspaces.yaml
@@ -14,7 +14,7 @@ spec:
       optional: true
     steps:
     - name: check-workspaces
-      image: docker.io/library/alpine:3.20.1
+      image: mirror.gcr.io/alpine
       script: |
         if [ "$(workspaces.source-code.bound)" == "true" ]; then
           printf "Source code workspace was provided at %s!\n" "$(workspaces.source-code.path)"

--- a/examples/v1/taskruns/propagating_params_implicit.yaml
+++ b/examples/v1/taskruns/propagating_params_implicit.yaml
@@ -10,6 +10,6 @@ spec:
     # There are no explicit params defined here. They are derived from the TaskRun.
     steps:
     - name: default
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       script: |
         echo $(params.message)

--- a/examples/v1/taskruns/propagating_workspaces.yaml
+++ b/examples/v1/taskruns/propagating_workspaces.yaml
@@ -6,7 +6,7 @@ spec:
   taskSpec:
     steps:
       - name: simple-step
-        image: docker.io/library/ubuntu
+        image: mirror.gcr.io/ubuntu
         command:
           - echo
         args:

--- a/examples/v1/taskruns/readonly-internal-dir.yaml
+++ b/examples/v1/taskruns/readonly-internal-dir.yaml
@@ -7,9 +7,9 @@ metadata:
 spec:
   taskSpec:
     steps:
-    - image: docker.io/library/ubuntu:24.04
+    - image: mirror.gcr.io/ubuntu
       script: exit 0
-    - image: docker.io/library/ubuntu:24.04
+    - image: mirror.gcr.io/ubuntu
       script: |
         set +e # dont fail the script on error
 
@@ -19,7 +19,7 @@ spec:
           echo "able to write to run directory of non-current step"
           exit 1
         fi
-    - image: docker.io/library/ubuntu:24.04
+    - image: mirror.gcr.io/ubuntu
       script: |
         set +e # dont fail the script on error
 

--- a/examples/v1/taskruns/run-steps-as-non-root.yaml
+++ b/examples/v1/taskruns/run-steps-as-non-root.yaml
@@ -7,7 +7,7 @@ spec:
     # no securityContext specified so will use
     # securityContext from TaskRun podTemplate
     - name: show-user-1001
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       command:
         - ps
       args:
@@ -15,7 +15,7 @@ spec:
     # securityContext specified so will run as
     # user 2000 instead of 1001
     - name: show-user-2000
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       command:
         - ps
       args:

--- a/examples/v1/taskruns/secret-env.yaml
+++ b/examples/v1/taskruns/secret-env.yaml
@@ -13,7 +13,7 @@ spec:
   taskSpec:
     steps:
     - name: secret
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       script: |
         #!/usr/bin/env bash
         [[ $SECRET_PASSWORD == SECRET_PASSWORD ]]

--- a/examples/v1/taskruns/secret-volume-params.yaml
+++ b/examples/v1/taskruns/secret-volume-params.yaml
@@ -16,7 +16,7 @@ spec:
       description: Name of secret
       type: string
     steps:
-    - image: docker.io/library/ubuntu:24.04
+    - image: mirror.gcr.io/ubuntu
       script: |
         #!/usr/bin/env bash
         SECRET_PASSWORD=$(cat /var/secret/ninja)

--- a/examples/v1/taskruns/secret-volume.yaml
+++ b/examples/v1/taskruns/secret-volume.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   taskSpec:
     steps:
-    - image: docker.io/library/ubuntu:24.04
+    - image: mirror.gcr.io/ubuntu
       script: |
         #!/usr/bin/env bash
         SECRET_PASSWORD=$(cat /var/secret/ninja)

--- a/examples/v1/taskruns/sidecar-interp.yaml
+++ b/examples/v1/taskruns/sidecar-interp.yaml
@@ -12,7 +12,7 @@ spec:
         emptyDir: {}
     sidecars:
       - name: value-sidecar
-        image: docker.io/library/ubuntu
+        image: mirror.gcr.io/ubuntu
         command:
           - /bin/bash
         args:
@@ -23,7 +23,7 @@ spec:
             mountPath: /shared
     steps:
       - name: check-value
-        image: docker.io/library/ubuntu
+        image: mirror.gcr.io/ubuntu
         script: |
           #!/bin/bash
           VALUE=$(cat /shared/value)

--- a/examples/v1/taskruns/sidecar-ready-script.yaml
+++ b/examples/v1/taskruns/sidecar-ready-script.yaml
@@ -6,7 +6,7 @@ spec:
   taskSpec:
     sidecars:
     - name: slow-sidecar
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       script: |
         echo "hello from sidecar" > /shared/message
         sleep 2
@@ -16,7 +16,7 @@ spec:
 
     steps:
     - name: check-ready
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       script: cat /shared/message
       volumeMounts:
       - name: shared

--- a/examples/v1/taskruns/sidecar-ready.yaml
+++ b/examples/v1/taskruns/sidecar-ready.yaml
@@ -6,7 +6,7 @@ spec:
   taskSpec:
     sidecars:
     - name: slow-sidecar
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       command: ['sleep', 'infinity']
       # The sidecar takes 5s to report as Ready, even after it starts.  If the
       # step runs as soon as the sidecar starts, it will fail because
@@ -33,7 +33,7 @@ spec:
 
     steps:
     - name: check-ready
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       # The step will only succeed if the sidecar has written this file, which
       # it does 5s after it starts, before it reports Ready.
       script: cat /shared/ready

--- a/examples/v1/taskruns/step-script.yaml
+++ b/examples/v1/taskruns/step-script.yaml
@@ -10,10 +10,10 @@ spec:
 
     steps:
     - name: noshebang
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       script: echo "no shebang"
     - name: bash
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       env:
       - name: FOO
         value: foooooooo
@@ -33,7 +33,7 @@ spec:
         done
 
     - name: place-file
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       securityContext:
         runAsUser: 8000
       script: |
@@ -41,13 +41,13 @@ spec:
         echo "echo Hello from script file" > /workspace/hello
         chmod +x /workspace/hello
     - name: run-file
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       script: |
         #!/usr/bin/env bash
         /workspace/hello
 
     - name: contains-eof
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       securityContext:
         runAsUser: 16000
       workingDir: /workspace
@@ -59,26 +59,26 @@ spec:
         cat file
 
     - name: node
-      image: docker.io/library/node:lts-alpine3.20
+      image: mirror.gcr.io/node:lts-alpine3.20
       script: |
         #!/usr/bin/env node
         console.log("Hello from Node!")
 
     - name: python
-      image: docker.io/library/python:3.12.4
+      image: mirror.gcr.io/python:3.12.4
       script: |
         #!/usr/bin/env python3
         print("Hello from Python!")
 
     - name: perl
-      image: docker.io/library/perl:devel-bullseye
+      image: mirror.gcr.io/perl:devel-bullseye
       script: |
         #!/usr/bin/perl
         print "Hello from Perl!"
 
     # Test that param values are replaced.
     - name: params-applied
-      image: docker.io/library/python:3.12.4
+      image: mirror.gcr.io/python:3.12.4
       script: |
         #!/usr/bin/env python3
         v = '$(params.PARAM)'
@@ -89,7 +89,7 @@ spec:
 
     # Test that args are allowed and passed to the script as expected.
     - name: args-allowed
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       args: ['hello', 'world']
       script: |
         #!/usr/bin/env bash
@@ -99,7 +99,7 @@ spec:
 
     # Test that multiple dollar signs next to each other are not replaced by Kubernetes
     - name: dollar-signs-allowed
-      image: docker.io/library/python:3.12.4
+      image: mirror.gcr.io/python:3.12.4
       script: |
         #!/usr/bin/env python3
         if '$' != '\u0024':
@@ -118,7 +118,7 @@ spec:
 
     # Test that bash scripts with variable evaluations work as expected
     - name: bash-variable-evaluations
-      image: docker.io/library/bash:5.2.26
+      image: mirror.gcr.io/bash
       script: |
         #!/usr/bin/env bash
         set -xe

--- a/examples/v1/taskruns/steps-run-in-order.yaml
+++ b/examples/v1/taskruns/steps-run-in-order.yaml
@@ -5,8 +5,8 @@ metadata:
 spec:
   taskSpec:
     steps:
-    - image: docker.io/library/busybox:1.36
+    - image: mirror.gcr.io/busybox
       # NB: command is not set, so it must be looked up from the registry.
       args: ['-c', 'sleep 3 && touch foo']
-    - image: docker.io/library/busybox:1.36
+    - image: mirror.gcr.io/busybox
       args: ['-c', 'ls', 'foo']

--- a/examples/v1/taskruns/steptemplate-env-merge.yaml
+++ b/examples/v1/taskruns/steptemplate-env-merge.yaml
@@ -25,7 +25,7 @@ spec:
     steps:
       # Test the environment variables are set in the task
       - name: foo
-        image: docker.io/library/ubuntu
+        image: mirror.gcr.io/ubuntu
         script: |
           #!/usr/bin/env bash
           [[ $FOO == "foo" ]]
@@ -33,7 +33,7 @@ spec:
         - name: FOO
           value: $(params.FOO)
       - name: foobar
-        image: docker.io/library/ubuntu
+        image: mirror.gcr.io/ubuntu
         script: |
           #!/usr/bin/env bash
           [[ $FOOBAR == "foobar" ]]
@@ -41,7 +41,7 @@ spec:
         - name: FOOBAR
           value: $(params.FOOBAR)
       - name: bar
-        image: docker.io/library/ubuntu
+        image: mirror.gcr.io/ubuntu
         script: |
           #!/usr/bin/env bash
           [[ $BAR == "bar" ]]
@@ -50,13 +50,13 @@ spec:
           value: $(params.BAR)
       # Use the env var from the stepTemplate
       - name: qux-no-override
-        image: docker.io/library/ubuntu
+        image: mirror.gcr.io/ubuntu
         script: |
           #!/usr/bin/env bash
           [[ $QUX == "original" ]]
       # Override the env var in the stepTemplate
       - name: qux-override
-        image: docker.io/library/ubuntu
+        image: mirror.gcr.io/ubuntu
         script: |
           #!/usr/bin/env bash
           [[ $QUX == "override" ]]

--- a/examples/v1/taskruns/task-result.yaml
+++ b/examples/v1/taskruns/task-result.yaml
@@ -13,12 +13,12 @@ spec:
         description: The current date in human readable format
     steps:
       - name: print-date-unix-timestamp
-        image: docker.io/library/bash:5.2.26
+        image: mirror.gcr.io/bash
         script: |
           #!/usr/bin/env bash
           date +%s | tee $(results.current-date-unix-timestamp.path)
       - name: print-date-human-readable
-        image: docker.io/library/bash:5.2.26
+        image: mirror.gcr.io/bash
         script: |
           #!/usr/bin/env bash
           date | tee $(results.current-date-human-readable.path)

--- a/examples/v1/taskruns/task-volume-args.yaml
+++ b/examples/v1/taskruns/task-volume-args.yaml
@@ -17,7 +17,7 @@ spec:
       type: string
     steps:
     - name: read
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       script: |
         #!/usr/bin/env bash
         cat /configmap/test.data

--- a/examples/v1/taskruns/template-volume.yaml
+++ b/examples/v1/taskruns/template-volume.yaml
@@ -6,7 +6,7 @@ spec:
   taskSpec:
     steps:
     - name: write
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       script: |
         #!/usr/bin/env bash
         echo some stuff > /im/a/custom/mount/path/file
@@ -14,7 +14,7 @@ spec:
       - name: custom
         mountPath: /im/a/custom/mount/path
     - name: read
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       script: |
         #!/usr/bin/env bash
         cat /short/and/stout/file

--- a/examples/v1/taskruns/unnamed-steps.yaml
+++ b/examples/v1/taskruns/unnamed-steps.yaml
@@ -5,9 +5,9 @@ metadata:
 spec:
   taskSpec:
     steps:
-    - image: docker.io/library/ubuntu:24.04
+    - image: mirror.gcr.io/ubuntu
       script: 'true'
-    - image: docker.io/library/ubuntu:24.04
+    - image: mirror.gcr.io/ubuntu
       script: 'true'
-    - image: docker.io/library/ubuntu:24.04
+    - image: mirror.gcr.io/ubuntu
       script: 'true'

--- a/examples/v1/taskruns/using_context_variables.yaml
+++ b/examples/v1/taskruns/using_context_variables.yaml
@@ -5,11 +5,11 @@ metadata:
 spec:
   taskSpec:
     steps:
-    - image: docker.io/library/ubuntu:24.04
+    - image: mirror.gcr.io/ubuntu
       name: print-uid
       script: |
         echo "TaskRunUID name: $(context.taskRun.uid)"
-    - image: docker.io/library/ubuntu:24.04
+    - image: mirror.gcr.io/ubuntu
       name: print-names
       script: |
         echo "Task name: $(context.task.name)"

--- a/examples/v1/taskruns/workingdir.yaml
+++ b/examples/v1/taskruns/workingdir.yaml
@@ -6,14 +6,14 @@ spec:
   taskSpec:
     steps:
     - name: default
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       workingDir: /workspace
       script: |
         #!/usr/bin/env bash
         [[ $PWD == /workspace ]]
 
     - name: override
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       workingDir: '/a/path/too/far'
       script: |
         #!/usr/bin/env bash

--- a/examples/v1/taskruns/workspace-in-sidecar.yaml
+++ b/examples/v1/taskruns/workspace-in-sidecar.yaml
@@ -18,7 +18,7 @@ spec:
     workspaces:
     - name: signals
     steps:
-    - image: docker.io/library/alpine:3.20.1
+    - image: mirror.gcr.io/alpine
       computeResources:
         requests:
           memory: "16Mi"
@@ -34,7 +34,7 @@ spec:
         echo "Sidecar responded: ${response}"
         echo "Step Done."
     sidecars:
-    - image: docker.io/library/alpine:3.20.1
+    - image: mirror.gcr.io/alpine
       computeResources:
         requests:
           memory: "16Mi"

--- a/examples/v1/taskruns/workspace-readonly.yaml
+++ b/examples/v1/taskruns/workspace-readonly.yaml
@@ -29,19 +29,19 @@ spec:
       readOnly: true
     steps:
     - name: write-allowed
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       script: echo "hello" > $(workspaces.write-allowed.path)/foo
     - name: read-allowed
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       script: cat $(workspaces.write-allowed.path)/foo | grep "hello"
     - name: write-disallowed
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       script:
         echo "goodbye" > $(workspaces.write-disallowed.path)/foo || touch write-failed.txt
         test -f write-failed.txt
     - name: read-again
       # We should get "hello" when reading again because writing "goodbye" to
       # the file should have been disallowed.
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       script:
         cat $(workspaces.write-disallowed.path)/foo | grep "hello"

--- a/examples/v1/taskruns/workspace-volume.yaml
+++ b/examples/v1/taskruns/workspace-volume.yaml
@@ -6,14 +6,14 @@ spec:
   taskSpec:
     steps:
     - name: write
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       script: echo some stuff > /workspace/stuff
     - name: read
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       script: cat /workspace/stuff
 
     - name: override-workspace
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       # /workspace/stuff *doesn't* exist.
       script: |
         #!/usr/bin/env bash

--- a/examples/v1/taskruns/workspace-with-volumeClaimTemplate.yaml
+++ b/examples/v1/taskruns/workspace-with-volumeClaimTemplate.yaml
@@ -6,7 +6,7 @@ spec:
   taskSpec:
     steps:
       - name: list-files
-        image: docker.io/library/ubuntu
+        image: mirror.gcr.io/ubuntu
         script: ls $(workspaces.read-allowed.path)
     workspaces:
       - name: read-allowed

--- a/examples/v1/taskruns/workspace.yaml
+++ b/examples/v1/taskruns/workspace.yaml
@@ -55,28 +55,28 @@ spec:
   taskSpec:
     steps:
     - name: write
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       script: echo $(workspaces.custom.volume) > $(workspaces.custom.path)/foo
     - name: read
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       script: cat $(workspaces.custom.path)/foo | grep $(workspaces.custom.volume)
     - name: write2
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       script: echo $(workspaces.custom2.path) > $(workspaces.custom2.path)/foo
     - name: read2
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       script: cat $(workspaces.custom2.path)/foo | grep $(workspaces.custom2.path)
     - name: write3
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       script: echo $(workspaces.custom3.path) > $(workspaces.custom3.path)/foo
     - name: read3
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       script: cat $(workspaces.custom3.path)/foo | grep $(workspaces.custom3.path)
     - name: readconfigmap
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       script: cat $(workspaces.custom4.path)/my-message.txt | grep "hello world"
     - name: readsecret
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       script: |
         #!/usr/bin/env bash
         set -xe

--- a/examples/v1beta1/pipelineruns/clustertask-pipelinerun.yaml
+++ b/examples/v1beta1/pipelineruns/clustertask-pipelinerun.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   steps:
   - name: task-two-step-one
-    image: docker.io/library/ubuntu
+    image: mirror.gcr.io/ubuntu
     command: ["/bin/bash"]
     args: ['-c', 'echo success']
 ---

--- a/examples/v1beta1/taskruns/clustertask.yaml
+++ b/examples/v1beta1/taskruns/clustertask.yaml
@@ -6,7 +6,7 @@ metadata:
   name: clustertask-v1beta1
 spec:
   steps:
-  - image: docker.io/library/ubuntu:24.04
+  - image: mirror.gcr.io/ubuntu
     script: echo hello
 ---
 apiVersion: tekton.dev/v1beta1

--- a/test/affinity_assistant_test.go
+++ b/test/affinity_assistant_test.go
@@ -56,14 +56,14 @@ spec:
       - name: my-workspace
       taskSpec:
         steps:
-        - image: docker.io/library/busybox:1.36
+        - image: mirror.gcr.io/busybox
           script: echo hello foo
     - name: bar
       workspaces:
       - name: my-workspace
       taskSpec:
         steps:
-        - image: docker.io/library/busybox:1.36
+        - image: mirror.gcr.io/busybox
           script: echo hello bar
   workspaces:
   - name: my-workspace
@@ -151,14 +151,14 @@ spec:
       - name: my-workspace
       taskSpec:
         steps:
-        - image: docker.io/library/busybox:1.36
+        - image: mirror.gcr.io/busybox
           script: echo hello foo
     - name: bar
       workspaces:
       - name: my-workspace2
       taskSpec:
         steps:
-        - image: docker.io/library/busybox:1.36
+        - image: mirror.gcr.io/busybox
           script: echo hello bar
     - name: double-ws
       workspaces:
@@ -166,12 +166,12 @@ spec:
       - name: my-workspace2
       taskSpec:
         steps:
-        - image: docker.io/library/busybox:1.36
+        - image: mirror.gcr.io/busybox
           script: echo double-ws
     - name: no-ws
       taskSpec:
         steps:
-        - image: docker.io/library/busybox:1.36
+        - image: mirror.gcr.io/busybox
         script: echo no-ws
   workspaces:
   - name: my-workspace

--- a/test/cancel_test.go
+++ b/test/cancel_test.go
@@ -65,7 +65,7 @@ spec:
       retries: %d
       taskSpec:
         steps:
-        - image: docker.io/library/busybox:1.36
+        - image: mirror.gcr.io/busybox
           script: 'sleep 5000'
 `, helpers.ObjectNameForTest(t), namespace, numRetries))
 

--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -71,7 +71,7 @@ spec:
   taskSpec:
     steps:
     - name: add
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       script: |
         echo Hello world!
 `, helpers.ObjectNameForTest(t))
@@ -108,7 +108,7 @@ spec:
       taskSpec:
         steps:
         - name: add
-          image: docker.io/library/ubuntu
+          image: mirror.gcr.io/ubuntu
           script: |
             echo Hello world!
 `, helpers.ObjectNameForTest(t))
@@ -156,18 +156,18 @@ spec:
       default: param-value
     steps:
     - name: node
-      image: docker.io/library/node:lts-alpine3.20
+      image: mirror.gcr.io/node:lts-alpine3.20
       script: |
         #!/usr/bin/env node
         console.log("Hello from Node!")
     - name: perl
-      image: docker.io/library/perl:devel-bullseye
+      image: mirror.gcr.io/perl:devel-bullseye
       script: |
         #!/usr/bin/perl
         print "Hello from Perl!"
     # Test that param values are replaced.
     - name: params-applied
-      image: docker.io/library/python:3.12.4
+      image: mirror.gcr.io/python:3.12.4
       script: |
         #!/usr/bin/env python3
         v = '$(params.PARAM)'
@@ -177,7 +177,7 @@ spec:
           exit(1)
     # Test that args are allowed and passed to the script as expected.
     - name: args-allowed
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       args: ['hello', 'world']
       script: |
         #!/usr/bin/env bash
@@ -186,7 +186,7 @@ spec:
         [[ $2 == "world" ]]
     # Test that multiple dollar signs next to each other are not replaced by Kubernetes
     - name: dollar-signs-allowed
-      image: docker.io/library/python:3.12.4
+      image: mirror.gcr.io/python:3.12.4
       script: |
         #!/usr/bin/env python3
         if '$' != '\u0024':
@@ -205,7 +205,7 @@ spec:
 
     # Test that bash scripts with variable evaluations work as expected
     - name: bash-variable-evaluations
-      image: docker.io/library/bash:5.2.26
+      image: mirror.gcr.io/bash
       script: |
         #!/usr/bin/env bash
         set -xe
@@ -258,7 +258,7 @@ spec:
   taskSpec:
     steps:
     - name: bash
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       env:
       - name: %s
         value: %s
@@ -313,7 +313,7 @@ spec:
   taskSpec:
     steps:
     - name: default
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       workingDir: %s
       script: |
         #!/usr/bin/env bash
@@ -321,7 +321,7 @@ spec:
           exit 1
         fi
     - name: override
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       workingDir: %s
       script: |
         #!/usr/bin/env bash
@@ -404,7 +404,7 @@ spec:
   taskSpec:
     steps:
     - name: %s
-      image: docker.io/library/busybox
+      image: mirror.gcr.io/busybox
       args: ['-c', 'echo hello']
 `, helpers.ObjectNameForTest(t), stepName)
 
@@ -441,7 +441,7 @@ metadata:
 spec:
   taskSpec:
     steps:
-    - image: docker.io/library/busybox:1.36
+    - image: mirror.gcr.io/busybox
       args: ['-c', 'echo hello']
 `, helpers.ObjectNameForTest(t))
 
@@ -493,7 +493,7 @@ metadata:
 spec:
   taskSpec:
     steps:
-    - image: docker.io/library/busybox:1.36
+    - image: mirror.gcr.io/busybox
       script: exit 1
 `, helpers.ObjectNameForTest(t))
 
@@ -549,11 +549,11 @@ spec:
   taskSpec:
     sidecars:
     - name: %s
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       script: echo "hello from sidecar"
     steps:
     - name: hello-step
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       script: echo "hello from step"
 `, helpers.ObjectNameForTest(t), sidecarName)
 
@@ -594,7 +594,7 @@ spec:
   taskSpec:
     sidecars:
     - name: slow-sidecar
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       script: |
         echo "hello from sidecar" > /shared/message
       volumeMounts:
@@ -603,7 +603,7 @@ spec:
 
     steps:
     - name: check-ready
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       script: cat /shared/message
       volumeMounts:
       - name: shared
@@ -640,12 +640,12 @@ spec:
   taskSpec:
     sidecars:
     - name: exit-sidecar
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       script: exit 1
 
     steps:
     - name: check-ready
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       script: cat /shared/message
       volumeMounts:
         - name: shared
@@ -686,7 +686,7 @@ spec:
   taskSpec:
     sidecars:
     - name: slow-sidecar
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       command: [/bin/bash]
       args: [-c, "echo 'hello from sidecar' > /shared/message"]
       volumeMounts:
@@ -694,7 +694,7 @@ spec:
         mountPath: /shared
     steps:
     - name: check-ready
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       command:
       - cat
       args:
@@ -746,7 +746,7 @@ spec:
         type: string
     steps:
       - name: "check-param"
-        image: docker.io/library/bash
+        image: mirror.gcr.io/bash
         script: |
           if [[ $(params.string-param) != %s ]]; then
             exit 1
@@ -794,7 +794,7 @@ spec:
         type: array
     steps:
     - name: concat-array-params
-      image: docker.io/library/alpine:3.20.1
+      image: mirror.gcr.io/alpine
       command: ["/bin/sh", "-c"]
       args:
       - echo -n $(params.array-to-concat[0])"-"$(params.array-to-concat[1]) | tee $(results.concat-array.path);
@@ -863,12 +863,12 @@ spec:
         default: "string-baz-default"
     steps:
       - name: string-params-to-result
-        image: docker.io/library/bash:5.2.26
+        image: mirror.gcr.io/bash
         command: ["/bin/sh", "-c"]
         args:
         - echo -n $(params.string-param)"-"$(params.string-default) | tee $(results.string-output.path);
       - name: array-params-to-result
-        image: docker.io/library/bash:5.2.26
+        image: mirror.gcr.io/bash
         command: ["/bin/sh", "-c"]
         args:
         - echo -n $(params.array-param[0])"-"$(params.array-defaul-param[1]) | tee $(results.array-output.path);
@@ -940,7 +940,7 @@ spec:
       default: "foo"
     steps:
     - name: add
-      image: docker.io/library/alpine:3.20.1
+      image: mirror.gcr.io/alpine
       env:
       - name: OP1
         value: $(params.foo)
@@ -984,13 +984,13 @@ spec:
   taskSpec:
     steps:
     - name: write
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       script: echo $(workspaces.custom-workspace.path) > $(workspaces.custom-workspace.path)/foo
     - name: read
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       script: cat $(workspaces.custom-workspace.path)/foo
     - name: check
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       script: |
         if [ "$(cat $(workspaces.custom-workspace.path)/foo)" != "/workspace/custom-workspace" ]; then
           echo $(cat $(workspaces.custom-workspace.path)/foo)
@@ -1041,7 +1041,7 @@ spec:
   timeout: 15s
   taskSpec:
     steps:
-    - image: docker.io/library/busybox:1.36
+    - image: mirror.gcr.io/busybox
       command: ['/bin/sh']
       args: ['-c', 'sleep 15001']
 `, helpers.ObjectNameForTest(t))
@@ -1073,7 +1073,7 @@ spec:
   taskSpec:
     steps:
     - name: add
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       script:
         echo Hello world!
 `, helpers.ObjectNameForTest(t))
@@ -1124,7 +1124,7 @@ spec:
           description: The second integer from PipelineTask Param
         steps:
         - name: sum
-          image: docker.io/library/bash:5.2.26
+          image: mirror.gcr.io/bash
           script: |
             #!/usr/bin/env bash
             echo -n $(( "$(inputs.params.op0)" + "$(inputs.params.op1)" ))
@@ -1177,7 +1177,7 @@ spec:
         - name: suffix
         steps:
         - name: generate-suffix
-          image: docker.io/library/alpine:3.20.1
+          image: mirror.gcr.io/alpine
           script: |
             echo -n "suffix" > $(results.suffix.path)
     - name: do-something
@@ -1188,7 +1188,7 @@ spec:
         - name: arg
         steps:
         - name: do-something
-          image: docker.io/library/alpine:3.20.1
+          image: mirror.gcr.io/alpine
           script: |
             echo -n "$(params.arg)" | tee $(results.output.path)
       params:
@@ -1241,7 +1241,7 @@ spec:
       taskSpec:
         steps:
         - name: write-step
-          image: docker.io/library/ubuntu
+          image: mirror.gcr.io/ubuntu
           script: |
             echo $(workspaces.custom-workspace-write-task.path) > $(workspaces.custom-workspace-write-task.path)/foo
             cat $(workspaces.custom-workspace-write-task.path)/foo
@@ -1254,7 +1254,7 @@ spec:
       taskSpec:
         steps:
         - name: read-step
-          image: docker.io/library/ubuntu
+          image: mirror.gcr.io/ubuntu
           script: cat $(workspaces.custom-workspace-read-task.path)/foo
         workspaces:
         - name: custom-workspace-read-task
@@ -1267,7 +1267,7 @@ spec:
       taskSpec:
         steps:
         - name: check-step
-          image: docker.io/library/ubuntu
+          image: mirror.gcr.io/ubuntu
           script: |
             if [ "$(cat $(workspaces.custom-workspace-check-task.path)/foo)" != "/workspace/custom-workspace-write-task" ]; then
               echo $(cat $(workspaces.custom-workspace-check-task.path)/foo)
@@ -1320,7 +1320,7 @@ spec:
       timeout: 15s
       taskSpec:
         steps:
-        - image: docker.io/library/busybox:1.36
+        - image: mirror.gcr.io/busybox
           command: ['/bin/sh']
           args: ['-c', 'sleep 15001']
 `, helpers.ObjectNameForTest(t))
@@ -1359,7 +1359,7 @@ spec:
     - name: timeout
       taskSpec:
         steps:
-        - image: docker.io/library/busybox:1.36
+        - image: mirror.gcr.io/busybox
           command: ['/bin/sh']
           args: ['-c', 'sleep 15001']
 `, helpers.ObjectNameForTest(t))
@@ -1410,7 +1410,7 @@ spec:
               description: The product of the two provided integers
           steps:
             - name: product
-              image: docker.io/library/bash:5.2.26
+              image: mirror.gcr.io/bash
               script: |
                 #!/usr/bin/env bash
                 echo -n $(( "$(params.a)" * "$(params.b)" )) | tee $(results.product.path)
@@ -1427,7 +1427,7 @@ spec:
               description: The product of the two provided integers
           steps:
             - name: product
-              image: docker.io/library/bash:5.2.26
+              image: mirror.gcr.io/bash
               script: |
                 #!/usr/bin/env bash
                 echo -n $(( "$(params.a)" * "$(params.b)" )) | tee $(results.product.path)
@@ -1482,7 +1482,7 @@ spec:
       taskSpec:
         steps:
         - name: add
-          image: docker.io/library/ubuntu
+          image: mirror.gcr.io/ubuntu
           script:
             echo Hello world!
 `, helpers.ObjectNameForTest(t))
@@ -1521,14 +1521,14 @@ spec:
       taskSpec:
         steps:
         - name: hello-step
-          image: docker.io/library/ubuntu
+          image: mirror.gcr.io/ubuntu
           script:
             echo Hello world!
     - name: %s
       taskSpec:
         steps:
         - name: hell-step
-          image: docker.io/library/ubuntu
+          image: mirror.gcr.io/ubuntu
           script:
             echo Hello world!
 `, prName, pt0, pt1)

--- a/test/conformance_test.go
+++ b/test/conformance_test.go
@@ -193,7 +193,7 @@ spec:
 			if d := cmp.Diff(tr.Status.Steps, tc.expectedStepState, ignoreTerminatedFields, ignoreStepFields); d != "" {
 				t.Fatalf("-got, +want: %v", d)
 			}
-			// Note(chmouel): Sometime we have docker-pullable:// or docker.io/library as prefix, so let only compare the suffix
+			// Note(chmouel): Sometime we have docker-pullable:// or mirror.gcr.io as prefix, so let only compare the suffix
 			if !strings.HasSuffix(tr.Status.Steps[0].ImageID, fqImageName) {
 				t.Fatalf("`ImageID: %s` does not end with `%s`", tr.Status.Steps[0].ImageID, fqImageName)
 			}

--- a/test/conversion_test.go
+++ b/test/conversion_test.go
@@ -94,7 +94,7 @@ spec:
         runAsNonRoot: true
   sidecars:
   - name: server
-    image: docker.io/library/alpine/git:v2.26.2
+    image: mirror.gcr.io/alpine/git:v2.26.2
     command: ['/bin/bash']
     args: ['-c', 'gcloud auth activate-service-account --key-file /var/secret/bucket-secret/bucket-secret-key']
     workingDir: /dir
@@ -170,7 +170,7 @@ spec:
         runAsNonRoot: true
   sidecars:
   - name: server
-    image: docker.io/library/alpine/git:v2.26.2
+    image: mirror.gcr.io/alpine/git:v2.26.2
     command: ['/bin/bash']
     args: ['-c', 'gcloud auth activate-service-account --key-file /var/secret/bucket-secret/bucket-secret-key']
     workingDir: /dir
@@ -224,7 +224,7 @@ spec:
       - name: task1-result
         value: task1-val
     steps:
-      - image: docker.io/library/alpine:3.20.1
+      - image: mirror.gcr.io/alpine
         onError: continue
         name: exit-with-255
         script: |
@@ -246,7 +246,7 @@ spec:
           type: string
       steps:
         - name: verify-status
-          image: docker.io/library/ubuntu
+          image: mirror.gcr.io/ubuntu
           script: |
             if [ $(params.echoStatus) == "Succeeded" ]
             then
@@ -278,7 +278,7 @@ spec:
       - name: task1-result
         value: task1-val
     steps:
-      - image: docker.io/library/alpine:3.20.1
+      - image: mirror.gcr.io/alpine
         onError: continue
         name: exit-with-255
         script: |
@@ -300,7 +300,7 @@ spec:
           type: string
       steps:
         - name: verify-status
-          image: docker.io/library/ubuntu
+          image: mirror.gcr.io/ubuntu
           script: |
             if [ $(params.echoStatus) == "Succeeded" ]
             then
@@ -320,7 +320,7 @@ spec:
   taskSpec:
     steps:
       - name: echo
-        image: docker.io/library/ubuntu
+        image: mirror.gcr.io/ubuntu
         script: |
           #!/usr/bin/env bash
           echo "Hello World!"
@@ -353,7 +353,7 @@ spec:
   taskSpec:
     steps:
     - computeResources: {}
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       name: echo
       script: |
         #!/usr/bin/env bash
@@ -372,7 +372,7 @@ status:
   taskSpec:
     steps:
     - computeResources: {}
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       name: echo
       script: |
         #!/usr/bin/env bash
@@ -408,7 +408,7 @@ spec:
   taskSpec:
     steps:
     - computeResources: {}
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       name: echo
       script: |
         #!/usr/bin/env bash
@@ -438,7 +438,7 @@ spec:
   taskSpec:
     steps:
     - computeResources: {}
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       name: echo
       script: |
         #!/usr/bin/env bash
@@ -454,7 +454,7 @@ status:
   taskSpec:
     steps:
     - computeResources: {}
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       name: echo
       script: |
         #!/usr/bin/env bash
@@ -493,7 +493,7 @@ spec:
       taskSpec:
         steps:
         - name: echo-hello
-          image: docker.io/library/ubuntu
+          image: mirror.gcr.io/ubuntu
           script: |
             ls $(workspaces.dir.path)
             echo hello
@@ -524,7 +524,7 @@ spec:
       taskSpec:
         steps:
         - name: echo-hello
-          image: docker.io/library/ubuntu
+          image: mirror.gcr.io/ubuntu
           script: |
             ls $(workspaces.dir.path)
             echo hello
@@ -540,7 +540,7 @@ status:
         name: cluster-task-pipeline-4
         steps:
         - name: "echo-hello"
-          image: "docker.io/library/ubuntu"
+          image: "mirror.gcr.io/ubuntu"
           script: |
             ls $(workspaces.dir.path)
             echo hello
@@ -578,7 +578,7 @@ spec:
       taskSpec:
         steps:
         - name: echo-hello
-          image: docker.io/library/ubuntu
+          image: mirror.gcr.io/ubuntu
           script: |
             ls $(workspaces.dir.path)
             echo hello
@@ -611,7 +611,7 @@ spec:
       taskSpec:
         steps:
         - name: echo-hello
-          image: docker.io/library/ubuntu
+          image: mirror.gcr.io/ubuntu
           script: |
             ls $(workspaces.dir.path)
             echo hello
@@ -635,7 +635,7 @@ status:
         name: cluster-task-pipeline-4
         steps:
         - name: "echo-hello"
-          image: "docker.io/library/ubuntu"
+          image: "mirror.gcr.io/ubuntu"
           script: |
             ls $(workspaces.dir.path)
             echo hello

--- a/test/custom-task-ctrls/wait-task-beta/example_customrun_matrix_results.yaml
+++ b/test/custom-task-ctrls/wait-task-beta/example_customrun_matrix_results.yaml
@@ -11,7 +11,7 @@ spec:
     - name: duration
   steps:
     - name: echo
-      image: docker.io/library/alpine:3.20.1
+      image: mirror.gcr.io/alpine
       script: |
         echo "$(params.duration)"
 ---
@@ -25,7 +25,7 @@ spec:
       type: array
   steps:
     - name: produce-a-list-of-durations
-      image: docker.io/library/bash:5.2.26
+      image: mirror.gcr.io/bash
       script: |
         #!/usr/bin/env bash
         echo -n "[\"10s\",\"2s\",\"5s\"]" | tee $(results.durations.path)

--- a/test/custom-task-ctrls/wait-task-beta/example_pipelinerun.yaml
+++ b/test/custom-task-ctrls/wait-task-beta/example_pipelinerun.yaml
@@ -8,7 +8,7 @@ spec:
     - name: before
       taskSpec:
         steps:
-        - image: docker.io/library/busybox:1.36
+        - image: mirror.gcr.io/busybox
           script: echo before wait
     - name: wait
       taskRef:
@@ -21,6 +21,6 @@ spec:
     - name: after
       taskSpec:
         steps:
-        - image: docker.io/library/busybox:1.36
+        - image: mirror.gcr.io/busybox
           script: echo after wait
       runAfter: ['wait']

--- a/test/custom_task_test.go
+++ b/test/custom_task_test.go
@@ -111,7 +111,7 @@ spec:
         steps:
         - args: ['-c', 'echo $(input-result-from-custom-task-ref) $(input-result-from-custom-task-spec)']
           command: ['/bin/bash']
-          image: docker.io/library/ubuntu
+          image: mirror.gcr.io/ubuntu
 `, pipelineRunName, betaAPIVersion, kind, betaAPIVersion, kind, customTaskRawSpec)),
 		metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create PipelineRun %q: %v", pipelineRunName, err)

--- a/test/dag_test.go
+++ b/test/dag_test.go
@@ -70,9 +70,9 @@ spec:
   results:
     - name: result
   steps:
-  - image: docker.io/library/busybox:1.36
+  - image: mirror.gcr.io/busybox
     script: 'echo $(params["text"])'
-  - image: docker.io/library/busybox:1.36
+  - image: mirror.gcr.io/busybox
     # Sleep for N seconds so that we can check that tasks that
     # should be run in parallel have overlap.
     script: |

--- a/test/duplicate_test.go
+++ b/test/duplicate_test.go
@@ -59,7 +59,7 @@ metadata:
 spec:
   taskSpec:
     steps:
-    - image: docker.io/library/busybox:1.36
+    - image: mirror.gcr.io/busybox
       command: ['/bin/echo']
       args: ['simple']
 `, taskrunName, namespace))

--- a/test/entrypoint_test.go
+++ b/test/entrypoint_test.go
@@ -54,10 +54,10 @@ metadata:
 spec:
   taskSpec:
     steps:
-    - image: docker.io/library/busybox:1.36
+    - image: mirror.gcr.io/busybox
       workingDir: /workspace
       script: 'sleep 3 && touch foo'
-    - image: docker.io/library/ubuntu:24.04
+    - image: mirror.gcr.io/ubuntu
       workingDir: /workspace
       script: 'ls foo'
 `, epTaskRunName, namespace)), metav1.CreateOptions{}); err != nil {

--- a/test/git-resolver/remote-task.yaml
+++ b/test/git-resolver/remote-task.yaml
@@ -5,6 +5,6 @@ metadata:
 spec:
   steps:
   - name: sleep
-    image: docker.io/library/busybox
+    image: mirror.gcr.io/busybox
     command: ['/bin/sh']
     args: ['-c', 'sleep 10']

--- a/test/ignore_step_error_test.go
+++ b/test/ignore_step_error_test.go
@@ -53,7 +53,7 @@ spec:
     steps:
       - name: failing-step
         onError: continue
-        image: docker.io/library/busybox
+        image: mirror.gcr.io/busybox
         script: 'echo -n 123 | tee $(results.result1.path); exit 1; echo -n 456 | tee $(results.result2.path)'
 `, taskRunName, namespace))
 

--- a/test/ignore_task_error_test.go
+++ b/test/ignore_task_error_test.go
@@ -57,14 +57,14 @@ spec:
           type: string
         steps:
         - name: failing-step
-          image: docker.io/library/busybox
+          image: mirror.gcr.io/busybox
           script: 'exit 1; echo -n 123 | tee $(results.result1.path)'
     - name: order-dep-task
       runAfter: ["failed-ignored-task"]
       taskSpec:
         steps:
         - name: foo
-          image: docker.io/library/busybox
+          image: mirror.gcr.io/busybox
           script: 'echo hello'
     - name: resource-dep-task
       onError: continue
@@ -77,7 +77,7 @@ spec:
           type: string
         steps:
         - name: foo
-          image: docker.io/library/busybox
+          image: mirror.gcr.io/busybox
           script: 'echo $(params.param1)'
 `, prName, namespace))
 

--- a/test/larger_results_sidecar_logs_test.go
+++ b/test/larger_results_sidecar_logs_test.go
@@ -169,7 +169,7 @@ spec:
             - name: result2
           steps:
            - name: step1
-             image: docker.io/library/alpine:3.20.1
+             image: mirror.gcr.io/alpine
              script: |
                echo -n "%s"| tee $(results.result1.path);
                echo -n "%s"| tee $(results.result2.path);
@@ -181,7 +181,7 @@ spec:
           steps:
            - name: step1
              onError: continue
-             image: docker.io/library/alpine:3.20.1
+             image: mirror.gcr.io/alpine
              script: |
                echo -n "%s"| tee $(results.result2.path);
                # trigger an error
@@ -206,7 +206,7 @@ spec:
             - name: large-result
           steps:
             - name: step1
-              image: docker.io/library/alpine:3.20.1
+              image: mirror.gcr.io/alpine
               script: |
                 echo -n "$(params.param1)">> $(results.large-result.path);
                 echo -n "$(params.param2)">> $(results.large-result.path);
@@ -218,7 +218,7 @@ spec:
             - name: result2
           steps:
            - name: step1
-             image: docker.io/library/alpine:3.20.1
+             image: mirror.gcr.io/alpine
              script: |
                echo -n "%s"| tee $(results.result1.path);
                echo -n "%s"| tee $(results.result2.path);
@@ -248,7 +248,7 @@ spec:
               type: string
           steps:
            - name: step1
-             image: docker.io/library/alpine:3.20.1
+             image: mirror.gcr.io/alpine
              script: |
                echo -n "%s"| tee $(results.result1.path);
                echo -n "%s"| tee $(results.result2.path);
@@ -262,7 +262,7 @@ spec:
           steps:
            - name: step1
              onError: continue
-             image: docker.io/library/alpine:3.20.1
+             image: mirror.gcr.io/alpine
              script: |
                echo -n "%s"| tee $(results.result2.path);
                # trigger an error
@@ -288,7 +288,7 @@ spec:
               type: string
           steps:
             - name: step1
-              image: docker.io/library/alpine:3.20.1
+              image: mirror.gcr.io/alpine
               script: |
                 echo -n "$(params.param1)">> $(results.large-result.path);
                 echo -n "$(params.param2)">> $(results.large-result.path);
@@ -302,7 +302,7 @@ spec:
               type: string
           steps:
            - name: step1
-             image: docker.io/library/alpine:3.20.1
+             image: mirror.gcr.io/alpine
              script: |
                echo -n "%s"| tee $(results.result1.path);
                echo -n "%s"| tee $(results.result2.path);
@@ -323,7 +323,7 @@ status:
               type: string
           steps:
             - name: step1
-              image: docker.io/library/alpine:3.20.1
+              image: mirror.gcr.io/alpine
               script: |
                 echo -n "%s"| tee $(results.result1.path);
                 echo -n "%s"| tee $(results.result2.path);
@@ -336,7 +336,7 @@ status:
               type: string
           steps:
             - name: step1
-              image: docker.io/library/alpine:3.20.1
+              image: mirror.gcr.io/alpine
               onError: continue
               script: |
                 echo -n "%s"| tee $(results.result2.path);
@@ -363,7 +363,7 @@ status:
               type: string
           steps:
             - name: step1
-              image: docker.io/library/alpine:3.20.1
+              image: mirror.gcr.io/alpine
               script: |
                 echo -n "$(params.param1)">> $(results.large-result.path);
                 echo -n "$(params.param2)">> $(results.large-result.path);
@@ -377,7 +377,7 @@ status:
               type: string
           steps:
            - name: step1
-             image: docker.io/library/alpine:3.20.1
+             image: mirror.gcr.io/alpine
              script: |
                echo -n "%s"| tee $(results.result1.path);
                echo -n "%s"| tee $(results.result2.path);
@@ -405,7 +405,7 @@ spec:
         type: string
     steps:
       - name: step1
-        image: docker.io/library/alpine:3.20.1
+        image: mirror.gcr.io/alpine
         script: |
           echo -n "%s"| tee $(results.result1.path);
           echo -n "%s"| tee $(results.result2.path);
@@ -423,7 +423,7 @@ status:
         type: string
     steps:
       - name: step1
-        image: docker.io/library/alpine:3.20.1
+        image: mirror.gcr.io/alpine
         script: |
           echo -n "%s"| tee /tekton/results/result1;
           echo -n "%s"| tee /tekton/results/result2;
@@ -454,7 +454,7 @@ spec:
     steps:
       - name: step1
         onError: continue
-        image: docker.io/library/alpine:3.20.1
+        image: mirror.gcr.io/alpine
         script: |
           echo -n "%s"| tee $(results.result2.path);
           # trigger an error
@@ -476,7 +476,7 @@ status:
     steps:
       - name: step1
         onError: continue
-        image: docker.io/library/alpine:3.20.1
+        image: mirror.gcr.io/alpine
         script: |
           echo -n "%s"| tee /tekton/results/result2;
           # trigger an error
@@ -518,7 +518,7 @@ spec:
         type: string
     steps:
      - name: step1
-       image: docker.io/library/alpine:3.20.1
+       image: mirror.gcr.io/alpine
        script: |
          echo -n "$(params.param1)">> $(results.large-result.path);
          echo -n "$(params.param2)">> $(results.large-result.path);
@@ -541,7 +541,7 @@ status:
         type: string
     steps:
      - name: step1
-       image: docker.io/library/alpine:3.20.1
+       image: mirror.gcr.io/alpine
        script: |
          echo -n "%s">> /tekton/results/large-result;
          echo -n "%s">> /tekton/results/large-result;
@@ -568,7 +568,7 @@ spec:
         type: string
     steps:
       - name: step1
-        image: docker.io/library/alpine:3.20.1
+        image: mirror.gcr.io/alpine
         script: |
           echo -n "%s"| tee $(results.result1.path);
           echo -n "%s"| tee $(results.result2.path);
@@ -588,7 +588,7 @@ status:
         type: string
     steps:
       - name: step1
-        image: docker.io/library/alpine:3.20.1
+        image: mirror.gcr.io/alpine
         script: |
           echo -n "%s"| tee /tekton/results/result1;
           echo -n "%s"| tee /tekton/results/result2;

--- a/test/matrix_test.go
+++ b/test/matrix_test.go
@@ -70,7 +70,7 @@ spec:
       default: ""
   steps:
     - name: echo
-      image: docker.io/library/alpine:3.20.1
+      image: mirror.gcr.io/alpine
       script: |
         echo "$(params.GOARCH) and $(params.version)"
 `, namespace))
@@ -85,7 +85,7 @@ spec:
       type: array
   steps:
     - name: produce-a-list-of-results
-      image: docker.io/library/bash:5.2.26
+      image: mirror.gcr.io/bash
       script: |
         #!/usr/bin/env bash
         echo -n "[\"linux/amd64\",\"linux/ppc64le\"]" | tee $(results.GOARCHs.path)
@@ -101,7 +101,7 @@ spec:
       type: array
   steps:
     - name: produce-a-list-of-versions
-      image: docker.io/library/bash:5.2.26
+      image: mirror.gcr.io/bash
       script: |
         #!/usr/bin/env bash
         echo -n "[\"go1.17\",\"go1.18.1\"]" | tee $(results.versions.path)
@@ -403,7 +403,7 @@ spec:
     - name: exit-code
   steps:
     - name: echo
-      image: docker.io/library/alpine:3.20.1
+      image: mirror.gcr.io/alpine
       script: |
         exit "$(params.exit-code)"
 `, namespace))

--- a/test/per_feature_flags_test.go
+++ b/test/per_feature_flags_test.go
@@ -152,9 +152,9 @@ spec:
   results:
   - name: result
   steps:
-  - image: docker.io/library/busybox:1.36
+  - image: mirror.gcr.io/busybox
     script: 'echo $(params["text"])'
-  - image: docker.io/library/busybox:1.36
+  - image: mirror.gcr.io/busybox
     # Sleep for N seconds so that we can check that tasks that
     # should be run in parallel have overlap.
     script: |
@@ -269,7 +269,7 @@ spec:
         - name: result1
         steps:
         - name: failing-step
-          image: docker.io/library/busybox
+          image: mirror.gcr.io/busybox
           script: 'echo -n 123 | tee $(results.result1.path); exit 1'
     finally:
     - name: finaltask1
@@ -280,7 +280,7 @@ spec:
         params:
         - name: param1
         steps:
-        - image: docker.io/library/busybox:1.36
+        - image: mirror.gcr.io/busybox
           script: 'echo $(params.param1);exit 0'
 `, helpers.ObjectNameForTest(t)))
 
@@ -356,14 +356,14 @@ spec:
       taskSpec:
         steps:
         - name: echo
-          image: docker.io/library/ubuntu
+          image: mirror.gcr.io/ubuntu
           script: echo $(params.HELLO)
     finally:
     - name: echo-hello-finally
       taskSpec:
         steps:
         - name: echo
-          image: docker.io/library/ubuntu
+          image: mirror.gcr.io/ubuntu
           script: echo $(params.HELLO)
 `, namespace))
 
@@ -397,14 +397,14 @@ spec:
         taskSpec:
           steps:
             - name: echo
-              image: docker.io/library/ubuntu
+              image: mirror.gcr.io/ubuntu
               script: echo $(params.HELLO)
     finally:
       - name: echo-hello-finally
         taskSpec:
           steps:
             - name: echo
-              image: docker.io/library/ubuntu
+              image: mirror.gcr.io/ubuntu
               script: echo $(params.HELLO)
 status:
   pipelineSpec:
@@ -413,14 +413,14 @@ status:
         taskSpec:
           steps:
             - name: echo
-              image: docker.io/library/ubuntu
+              image: mirror.gcr.io/ubuntu
               script: echo Hello World!
     finally:
       - name: echo-hello-finally
         taskSpec:
           steps:
             - name: echo
-              image: docker.io/library/ubuntu
+              image: mirror.gcr.io/ubuntu
               script: echo Hello World!
 `, namespace))
 
@@ -443,7 +443,7 @@ spec:
   taskSpec:
     steps:
       - name: echo
-        image: docker.io/library/ubuntu
+        image: mirror.gcr.io/ubuntu
         script: echo Hello World!
 status:
    podName: propagated-parameters-fully-echo-hello-pod
@@ -453,7 +453,7 @@ status:
    taskSpec:
      steps:
        - name: echo
-         image: docker.io/library/ubuntu
+         image: mirror.gcr.io/ubuntu
          script: echo Hello World!
 `, namespace))
 
@@ -466,7 +466,7 @@ spec:
   taskSpec:
     steps:
       - name: echo
-        image: docker.io/library/ubuntu
+        image: mirror.gcr.io/ubuntu
         script: echo Hello World!
 status:
    podName: propagated-parameters-fully-echo-hello-finally-pod
@@ -476,7 +476,7 @@ status:
    taskSpec:
      steps:
        - name: echo
-         image: docker.io/library/ubuntu
+         image: mirror.gcr.io/ubuntu
          script: echo Hello World!
 `, namespace))
 

--- a/test/pipelinefinally_test.go
+++ b/test/pipelinefinally_test.go
@@ -696,7 +696,7 @@ metadata:
   namespace: %s
 spec:
   steps:
-  - image: docker.io/library/alpine:3.20.1
+  - image: mirror.gcr.io/alpine
     script: 'exit 0'
 `, helpers.ObjectNameForTest(t), namespace))
 }
@@ -709,7 +709,7 @@ metadata:
   namespace: %s
 spec:
   steps:
-  - image: docker.io/library/alpine:3.20.1
+  - image: mirror.gcr.io/alpine
     script: 'exit 1'
 `, helpers.ObjectNameForTest(t), namespace))
 }
@@ -722,7 +722,7 @@ metadata:
   namespace: %s
 spec:
   steps:
-  - image: docker.io/library/alpine:3.20.1
+  - image: mirror.gcr.io/alpine
     script: 'sleep 5; exit 0'
 `, helpers.ObjectNameForTest(t), namespace))
 }
@@ -735,7 +735,7 @@ metadata:
   namespace: %s
 spec:
   steps:
-  - image: docker.io/library/alpine:3.20.1
+  - image: mirror.gcr.io/alpine
     script: 'exit 0'
   params:
   - name: dagtask1-status
@@ -753,7 +753,7 @@ metadata:
   namespace: %s
 spec:
   steps:
-  - image: docker.io/library/alpine:3.20.1
+  - image: mirror.gcr.io/alpine
     script: 'echo -n "Hello" > $(results.result.path)'
   results:
   - name: result
@@ -768,7 +768,7 @@ metadata:
   namespace: %s
 spec:
   steps:
-  - image: docker.io/library/alpine:3.20.1
+  - image: mirror.gcr.io/alpine
     script: 'sleep 5; echo -n "Hello" > $(results.result.path)'
   results:
   - name: result
@@ -783,7 +783,7 @@ metadata:
   namespace: %s
 spec:
   steps:
-  - image: docker.io/library/alpine:3.20.1
+  - image: mirror.gcr.io/alpine
     script: 'exit 0'
   params:
   - name: %s

--- a/test/pipelinerun_test.go
+++ b/test/pipelinerun_test.go
@@ -68,7 +68,7 @@ spec:
   - name: HELLO
     default: "Hi!"
   steps:
-  - image: docker.io/library/ubuntu:24.04
+  - image: mirror.gcr.io/ubuntu
     script: |
       #!/usr/bin/env bash
       echo "$(params.HELLO)"
@@ -440,7 +440,7 @@ spec:
     taskSpec:
       steps:
       - name: echo
-        image: docker.io/library/ubuntu
+        image: mirror.gcr.io/ubuntu
         script: |
           #!/usr/bin/env bash
           # Sleep for 10s
@@ -450,7 +450,7 @@ spec:
     taskSpec:
       steps:
       - name: echo
-        image: docker.io/library/ubuntu
+        image: mirror.gcr.io/ubuntu
         script: |
           #!/usr/bin/env bash
           # Sleep for another 10s
@@ -512,7 +512,7 @@ metadata:
   namespace: %s
 spec:
   steps:
-  - image: docker.io/library/ubuntu:24.04
+  - image: mirror.gcr.io/ubuntu
     command: ['/bin/bash']
     args: ['-c', 'echo hello, world']
 `, taskName, namespace)), metav1.CreateOptions{}); err != nil {
@@ -582,10 +582,10 @@ metadata:
   namespace: %s
 spec:
   steps:
-  - image: docker.io/library/busybox:1.36
+  - image: mirror.gcr.io/busybox
     name: write-data-task-0-step-0
     script: echo stuff | tee $(results.result-stuff.path)
-  - image: docker.io/library/busybox:1.36
+  - image: mirror.gcr.io/busybox
     name: write-data-task-0-step-1
     script: echo other | tee $(results.result-other.path)
   results:
@@ -600,10 +600,10 @@ spec:
   params:
   - name: check-stuff
   steps:
-  - image: docker.io/library/busybox:1.36
+  - image: mirror.gcr.io/busybox
     name: read-from-task-0
     script: echo $(params.check-stuff)
-  - image: docker.io/library/busybox:1.36
+  - image: mirror.gcr.io/busybox
     name: write-data-task-1
     script: echo | tee $(results.result-something.path)
   results:
@@ -618,9 +618,9 @@ spec:
   - name: check-other
   steps:
   - script: echo $(params.check-other)
-    image: docker.io/library/busybox
+    image: mirror.gcr.io/busybox
     name: read-from-task-0
-  - image: docker.io/library/busybox:1.36
+  - image: mirror.gcr.io/busybox
     name: write-data-task-1
     script: echo something | tee $(results.result-else.path)
   results:
@@ -637,7 +637,7 @@ spec:
   - name: workspacepath-else
     value: $(tasks.create-file.results.result-else)
   steps:
-  - image: docker.io/library/busybox:1.36
+  - image: mirror.gcr.io/busybox
     script: echo params.workspacepath-something
 `, helpers.ObjectNameForTest(t), namespace)),
 	}
@@ -971,7 +971,7 @@ metadata:
   namespace: %s
 spec:
   steps:
-  - image: docker.io/library/ubuntu:24.04
+  - image: mirror.gcr.io/ubuntu
     command: ['/bin/bash']
     args: ['-c', 'echo hello, world']
 `, taskName, namespace)), metav1.CreateOptions{}); err != nil {
@@ -1007,7 +1007,7 @@ spec:
           - name: abc
         steps:
         - name: update-sa
-          image: docker.io/library/bash:5.2.26
+          image: mirror.gcr.io/bash
           script: |
             echo 'test' >  $(results.abc.path)
             exit 1

--- a/test/premption_test.go
+++ b/test/premption_test.go
@@ -62,7 +62,7 @@ spec:
           memory: 5000Gi
   steps:
     - name: echo
-      image: docker.io/library/ubuntu
+      image: mirror.gcr.io/ubuntu
       script: |
         #!/usr/bin/env bash
         echo "Good Morning!" > $(workspaces.task-ws.path)

--- a/test/propagated_params_test.go
+++ b/test/propagated_params_test.go
@@ -150,14 +150,14 @@ spec:
         taskSpec:
           steps:
             - name: echo
-              image: docker.io/library/ubuntu
+              image: mirror.gcr.io/ubuntu
               script: echo $(params.HELLO)
     finally:
       - name: echo-hello-finally
         taskSpec:
           steps:
             - name: echo
-              image: docker.io/library/ubuntu
+              image: mirror.gcr.io/ubuntu
               script: echo $(params.HELLO)
 `, namespace))
 	expectedPipelineRun := parse.MustParseV1PipelineRun(t, fmt.Sprintf(`
@@ -176,14 +176,14 @@ spec:
         taskSpec:
           steps:
             - name: echo
-              image: docker.io/library/ubuntu
+              image: mirror.gcr.io/ubuntu
               script: echo $(params.HELLO)
     finally:
       - name: echo-hello-finally
         taskSpec:
           steps:
             - name: echo
-              image: docker.io/library/ubuntu
+              image: mirror.gcr.io/ubuntu
               script: echo $(params.HELLO)
 status:
   pipelineSpec:
@@ -192,14 +192,14 @@ status:
         taskSpec:
           steps:
             - name: echo
-              image: docker.io/library/ubuntu
+              image: mirror.gcr.io/ubuntu
               script: echo Hello World!
     finally:
       - name: echo-hello-finally
         taskSpec:
           steps:
             - name: echo
-              image: docker.io/library/ubuntu
+              image: mirror.gcr.io/ubuntu
               script: echo Hello World!
 `, namespace))
 	taskRun := parse.MustParseV1TaskRun(t, fmt.Sprintf(`
@@ -211,7 +211,7 @@ spec:
   taskSpec:
     steps:
       - name: echo
-        image: docker.io/library/ubuntu
+        image: mirror.gcr.io/ubuntu
         script: echo Hello World!
 status:
    podName: propagated-parameters-fully-echo-hello-pod
@@ -221,7 +221,7 @@ status:
    taskSpec:
      steps:
        - name: echo
-         image: docker.io/library/ubuntu
+         image: mirror.gcr.io/ubuntu
          script: echo Hello World!
 `, namespace))
 	finallyTaskRun := parse.MustParseV1TaskRun(t, fmt.Sprintf(`
@@ -233,7 +233,7 @@ spec:
   taskSpec:
     steps:
       - name: echo
-        image: docker.io/library/ubuntu
+        image: mirror.gcr.io/ubuntu
         script: echo Hello World!
 status:
    podName: propagated-parameters-fully-echo-hello-finally-pod
@@ -243,7 +243,7 @@ status:
    taskSpec:
      steps:
        - name: echo
-         image: docker.io/library/ubuntu
+         image: mirror.gcr.io/ubuntu
          script: echo Hello World!
 `, namespace))
 	return pipelineRun, expectedPipelineRun, []*v1.TaskRun{taskRun, finallyTaskRun}
@@ -268,7 +268,7 @@ spec:
         taskSpec:
           steps:
             - name: echo
-              image: docker.io/library/ubuntu
+              image: mirror.gcr.io/ubuntu
               script: echo $(params.HELLO)
 `, namespace))
 	expectedPipelineRun := parse.MustParseV1PipelineRun(t, fmt.Sprintf(`
@@ -290,7 +290,7 @@ spec:
         taskSpec:
           steps:
             - name: echo
-              image: docker.io/library/ubuntu
+              image: mirror.gcr.io/ubuntu
               script: echo $(params.HELLO)
 status:
   pipelineSpec:
@@ -302,7 +302,7 @@ status:
         taskSpec:
           steps:
             - name: echo
-              image: docker.io/library/ubuntu
+              image: mirror.gcr.io/ubuntu
               script: echo Hello World!
 `, namespace))
 	taskRun := parse.MustParseV1TaskRun(t, fmt.Sprintf(`
@@ -317,7 +317,7 @@ spec:
   taskSpec:
     steps:
       - name: echo
-        image: docker.io/library/ubuntu
+        image: mirror.gcr.io/ubuntu
         script: echo Hello World!
 status:
   podName: propagated-parameters-task-level-echo-hello-pod
@@ -327,7 +327,7 @@ status:
   taskSpec:
     steps:
       - name: echo
-        image: docker.io/library/ubuntu
+        image: mirror.gcr.io/ubuntu
         script: echo Hello World!
 `, namespace))
 	return pipelineRun, expectedPipelineRun, []*v1.TaskRun{taskRun}
@@ -353,7 +353,7 @@ spec:
               default: "Default Hello World"
           steps:
             - name: echo
-              image: docker.io/library/ubuntu
+              image: mirror.gcr.io/ubuntu
               script: echo $(params.HELLO)
 `, namespace))
 	expectedPipelineRun := parse.MustParseV1PipelineRun(t, fmt.Sprintf(`
@@ -376,7 +376,7 @@ spec:
               default: "Default Hello World"
           steps:
             - name: echo
-              image: docker.io/library/ubuntu
+              image: mirror.gcr.io/ubuntu
               script: echo $(params.HELLO)
 status:
   pipelineSpec:
@@ -389,7 +389,7 @@ status:
               default: "Default Hello World"
           steps:
             - name: echo
-              image: docker.io/library/ubuntu
+              image: mirror.gcr.io/ubuntu
               script: echo Hello World!
 `, namespace))
 	taskRun := parse.MustParseV1TaskRun(t, fmt.Sprintf(`
@@ -405,7 +405,7 @@ spec:
         default: "Default Hello World"
     steps:
       - name: echo
-        image: docker.io/library/ubuntu
+        image: mirror.gcr.io/ubuntu
         script: echo Hello World!
 status:
   podName: propagated-parameters-default-task-level-echo-hello-pod
@@ -419,7 +419,7 @@ status:
        default: "Default Hello World"
     steps:
       - name: echo
-        image: docker.io/library/ubuntu
+        image: mirror.gcr.io/ubuntu
         script: echo Hello World!
 `, namespace))
 	return pipelineRun, expectedPipelineRun, []*v1.TaskRun{taskRun}

--- a/test/propagated_results_test.go
+++ b/test/propagated_results_test.go
@@ -151,17 +151,17 @@ spec:
                 }
           steps:
             - name: add-str-uid
-              image: docker.io/library/busybox
+              image: mirror.gcr.io/busybox
               command: ["/bin/sh", "-c"]
               args:
                 - echo "1001" | tee $(results.strUid.path)
             - name: add-array-uid
-              image: docker.io/library/busybox
+              image: mirror.gcr.io/busybox
               command: ["/bin/sh", "-c"]
               args:
                 - echo "[\"1002\", \"1003\"]" | tee $(results.arrayUid.path)
             - name: add-map-uid
-              image: docker.io/library/busybox
+              image: mirror.gcr.io/busybox
               command: ["/bin/sh", "-c"]
               args:
                 - echo -n "{\"uid\":\"1004\"}" | tee $(results.mapUid.path)
@@ -169,19 +169,19 @@ spec:
         taskSpec:
           steps:
             - name: show-str-uid
-              image: docker.io/library/busybox
+              image: mirror.gcr.io/busybox
               command: ["/bin/sh", "-c"]
               args:
                 - echo
                 - $(tasks.make-uid.results.strUid)
             - name: show-array-uid
-              image: docker.io/library/busybox
+              image: mirror.gcr.io/busybox
               command: ["/bin/sh", "-c"]
               args:
                 - echo
                 - $(tasks.make-uid.results.arrayUid[*])
             - name: show-map-uid
-              image: docker.io/library/busybox
+              image: mirror.gcr.io/busybox
               command: ["/bin/sh", "-c"]
               args:
                 - echo
@@ -212,21 +212,21 @@ spec:
           command:
           - /bin/sh
           - -c
-          image: docker.io/library/busybox
+          image: mirror.gcr.io/busybox
           name: add-str-uid
         - args:
           - echo "[\"1002\", \"1003\"]" | tee $(results.arrayUid.path)
           command:
           - /bin/sh
           - -c
-          image: docker.io/library/busybox
+          image: mirror.gcr.io/busybox
           name: add-array-uid
         - args:
           - echo -n "{\"uid\":\"1004\"}" | tee $(results.mapUid.path)
           command:
           - /bin/sh
           - -c
-          image: docker.io/library/busybox
+          image: mirror.gcr.io/busybox
           name: add-map-uid
     - name: show-uid
       taskSpec:
@@ -237,7 +237,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          image: docker.io/library/busybox
+          image: mirror.gcr.io/busybox
           name: show-str-uid
         - args:
           - echo
@@ -245,7 +245,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          image: docker.io/library/busybox
+          image: mirror.gcr.io/busybox
           name: show-array-uid
         - args:
           - echo
@@ -253,7 +253,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          image: docker.io/library/busybox
+          image: mirror.gcr.io/busybox
           name: show-map-uid
   timeouts:
     pipeline: 1h0m0s
@@ -278,21 +278,21 @@ status:
           command:
           - /bin/sh
           - -c
-          image: docker.io/library/busybox
+          image: mirror.gcr.io/busybox
           name: add-str-uid
         - args:
           - echo "[\"1002\", \"1003\"]" | tee $(results.arrayUid.path)
           command:
           - /bin/sh
           - -c
-          image: docker.io/library/busybox
+          image: mirror.gcr.io/busybox
           name: add-array-uid
         - args:
           - echo -n "{\"uid\":\"1004\"}" | tee $(results.mapUid.path)
           command:
           - /bin/sh
           - -c
-          image: docker.io/library/busybox
+          image: mirror.gcr.io/busybox
           name: add-map-uid
     - name: show-uid
       taskSpec:
@@ -303,7 +303,7 @@ status:
           command:
           - /bin/sh
           - -c
-          image: docker.io/library/busybox
+          image: mirror.gcr.io/busybox
           name: show-str-uid
         - args:
           - echo
@@ -311,7 +311,7 @@ status:
           command:
           - /bin/sh
           - -c
-          image: docker.io/library/busybox
+          image: mirror.gcr.io/busybox
           name: show-array-uid
         - args:
           - echo
@@ -319,7 +319,7 @@ status:
           command:
           - /bin/sh
           - -c
-          image: docker.io/library/busybox
+          image: mirror.gcr.io/busybox
           name: show-map-uid
 `, namespace))
 	makeUidTaskRun := parse.MustParseV1TaskRun(t, fmt.Sprintf(`
@@ -344,21 +344,21 @@ spec:
       command:
       - /bin/sh
       - -c
-      image: docker.io/library/busybox
+      image: mirror.gcr.io/busybox
       name: add-str-uid
     - args:
       - echo "[\"1002\", \"1003\"]" | tee $(results.arrayUid.path)
       command:
       - /bin/sh
       - -c
-      image: docker.io/library/busybox
+      image: mirror.gcr.io/busybox
       name: add-array-uid
     - args:
       - echo -n "{\"uid\":\"1004\"}" | tee $(results.mapUid.path)
       command:
       - /bin/sh
       - -c
-      image: docker.io/library/busybox
+      image: mirror.gcr.io/busybox
       name: add-map-uid
   timeout: 1h0m0s
 status:
@@ -401,21 +401,21 @@ status:
       command:
       - /bin/sh
       - -c
-      image: docker.io/library/busybox
+      image: mirror.gcr.io/busybox
       name: add-str-uid
     - args:
       - echo "[\"1002\", \"1003\"]" | tee /tekton/results/arrayUid
       command:
       - /bin/sh
       - -c
-      image: docker.io/library/busybox
+      image: mirror.gcr.io/busybox
       name: add-array-uid
     - args:
       - echo -n "{\"uid\":\"1004\"}" | tee /tekton/results/mapUid
       command:
       - /bin/sh
       - -c
-      image: docker.io/library/busybox
+      image: mirror.gcr.io/busybox
       name: add-map-uid
 `, namespace))
 	showUidTaskRun := parse.MustParseV1TaskRun(t, fmt.Sprintf(`
@@ -432,7 +432,7 @@ spec:
       command:
       - /bin/sh
       - -c
-      image: docker.io/library/busybox
+      image: mirror.gcr.io/busybox
       name: show-str-uid
     - args:
       - echo
@@ -441,7 +441,7 @@ spec:
       command:
       - /bin/sh
       - -c
-      image: docker.io/library/busybox
+      image: mirror.gcr.io/busybox
       name: show-array-uid
     - args:
       - echo
@@ -449,7 +449,7 @@ spec:
       command:
       - /bin/sh
       - -c
-      image: docker.io/library/busybox
+      image: mirror.gcr.io/busybox
       name: show-map-uid
   timeout: 1h0m0s
 status:
@@ -470,7 +470,7 @@ status:
       command:
       - /bin/sh
       - -c
-      image: docker.io/library/busybox
+      image: mirror.gcr.io/busybox
       name: show-str-uid
     - args:
       - echo
@@ -479,7 +479,7 @@ status:
       command:
       - /bin/sh
       - -c
-      image: docker.io/library/busybox
+      image: mirror.gcr.io/busybox
       name: show-array-uid
     - args:
       - echo
@@ -487,7 +487,7 @@ status:
       command:
       - /bin/sh
       - -c
-      image: docker.io/library/busybox
+      image: mirror.gcr.io/busybox
       name: show-map-uid
 `, namespace))
 	return pipelineRun, expectedPipelineRun, []*v1.TaskRun{makeUidTaskRun, showUidTaskRun}

--- a/test/resolvers_test.go
+++ b/test/resolvers_test.go
@@ -388,7 +388,7 @@ spec:
     taskSpec:
       steps:
       - name: echo
-        image: docker.io/library/ubuntu
+        image: mirror.gcr.io/ubuntu
         script: |
           #!/usr/bin/env bash
           # Sleep for 10s
@@ -588,7 +588,7 @@ spec:
     - name: token
       type: string
     steps:
-    - image: docker.io/alpine/curl:8.8.0
+    - image: docker.io/alpine/curl
       script: |
         #!/bin/ash
         curl -X POST "http://gitea_admin:%s@%s:3000/api/v1/admin/users" -H "accept: application/json" -H "Content-Type: application/json" -d '%s'

--- a/test/resolvers_yaml/pipeline-in-git.yaml
+++ b/test/resolvers_yaml/pipeline-in-git.yaml
@@ -12,7 +12,7 @@ spec:
             app: "example"
         steps:
           - name: echo
-            image: docker.io/library/ubuntu
+            image: mirror.gcr.io/ubuntu
             script: |
               #!/usr/bin/env bash
               echo "Good Morning!"

--- a/test/retry_test.go
+++ b/test/retry_test.go
@@ -55,7 +55,7 @@ spec:
       retries: %d
       taskSpec:
         steps:
-        - image: docker.io/library/busybox:1.36
+        - image: mirror.gcr.io/busybox
           script: exit 1
 `, pipelineRunName, numRetries)), metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create PipelineRun %q: %v", pipelineRunName, err)

--- a/test/serviceaccount_test.go
+++ b/test/serviceaccount_test.go
@@ -123,17 +123,17 @@ spec:
   - name: task1
     taskSpec:
       steps:
-      - image: docker.io/library/ubuntu:24.04
+      - image: mirror.gcr.io/ubuntu
         script: echo task1
   - name: task2
     taskSpec:
       steps:
-      - image: docker.io/library/ubuntu:24.04
+      - image: mirror.gcr.io/ubuntu
         script: echo task2
   - name: task3
     taskSpec:
       steps:
-      - image: docker.io/library/ubuntu:24.04
+      - image: mirror.gcr.io/ubuntu
         script: echo task3
 `, helpers.ObjectNameForTest(t), namespace))
 	if _, err := c.V1PipelineClient.Create(ctx, pipeline, metav1.CreateOptions{}); err != nil {
@@ -242,7 +242,7 @@ spec:
     taskSpec:
       metadata: {}
       steps:
-      - image: docker.io/library/ubuntu:24.04
+      - image: mirror.gcr.io/ubuntu
         script: echo task1
 `, helpers.ObjectNameForTest(t), namespace))
 	if _, err := c.V1PipelineClient.Create(ctx, pipeline, metav1.CreateOptions{}); err != nil {

--- a/test/sidecar_test.go
+++ b/test/sidecar_test.go
@@ -85,11 +85,11 @@ metadata:
 spec:
   steps:
   - name: %s
-    image: docker.io/library/busybox
+    image: mirror.gcr.io/busybox
     command: [%s]
   sidecars:
   - name: %s
-    image: docker.io/library/busybox
+    image: mirror.gcr.io/busybox
     command: [%s]
 `, sidecarTaskName, namespace, primaryContainerName, stringSliceToYAMLArray(test.stepCommand), sidecarContainerName, stringSliceToYAMLArray(test.sidecarCommand)))
 

--- a/test/start_time_test.go
+++ b/test/start_time_test.go
@@ -56,15 +56,15 @@ metadata:
 spec:
   taskSpec:
     steps:
-    - image: docker.io/library/busybox:1.36
+    - image: mirror.gcr.io/busybox
       script: sleep 2
-    - image: docker.io/library/busybox:1.36
+    - image: mirror.gcr.io/busybox
       script: sleep 2
-    - image: docker.io/library/busybox:1.36
+    - image: mirror.gcr.io/busybox
       script: sleep 2
-    - image: docker.io/library/busybox:1.36
+    - image: mirror.gcr.io/busybox
       script: sleep 2
-    - image: docker.io/library/busybox:1.36
+    - image: mirror.gcr.io/busybox
       script: sleep 2
 `, helpers.ObjectNameForTest(t), namespace)), metav1.CreateOptions{})
 	if err != nil {

--- a/test/status_test.go
+++ b/test/status_test.go
@@ -60,7 +60,7 @@ metadata:
 spec:
   steps:
   - name: foo
-    image: docker.io/library/busybox
+    image: mirror.gcr.io/busybox
     command: ['ls', '-la']`, helpers.ObjectNameForTest(t)))
 	if _, err := c.V1TaskClient.Create(ctx, task, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Task: %s", err)
@@ -234,7 +234,7 @@ spec:
   - name: HELLO
     default: "hello world!"
   steps:
-  - image: docker.io/library/ubuntu:24.04
+  - image: mirror.gcr.io/ubuntu
     script: |
       #!/usr/bin/env bash
       echo "$(params.HELLO)"

--- a/test/stepaction_results_test.go
+++ b/test/stepaction_results_test.go
@@ -123,7 +123,7 @@ spec:
   results:
     - name: result1
       type: string
-  image: docker.io/library/alpine:3.20.1
+  image: mirror.gcr.io/alpine
   script: |
     echo -n step-action >> $(step.results.result1.path)
 `, namespace))
@@ -139,7 +139,7 @@ spec:
   taskSpec:
     steps:
      - name: step1
-       image: docker.io/library/alpine:3.20.1
+       image: mirror.gcr.io/alpine
        script: |
          echo -n inlined-step >> $(step.results.result1.path)
        results:
@@ -167,7 +167,7 @@ spec:
   taskSpec:
     steps:
       - name: step1
-        image: docker.io/library/alpine:3.20.1
+        image: mirror.gcr.io/alpine
         script: |
           echo -n inlined-step >> $(step.results.result1.path)
         results:
@@ -192,14 +192,14 @@ status:
   taskSpec:
     steps:
       - name: step1
-        image: docker.io/library/alpine:3.20.1
+        image: mirror.gcr.io/alpine
         results:
           - name: result1
             type: string
         script: |
           echo -n inlined-step >> /tekton/steps/step-step1/results/result1
       - name: step2
-        image: docker.io/library/alpine:3.20.1
+        image: mirror.gcr.io/alpine
         results:
           - name: result1
             type: string

--- a/test/task_results_from_failed_tasks_test.go
+++ b/test/task_results_from_failed_tasks_test.go
@@ -52,7 +52,7 @@ spec:
         - name: result2
         steps:
         - name: failing-step
-          image: docker.io/library/busybox
+          image: mirror.gcr.io/busybox
           script: 'echo -n 123 | tee $(results.result1.path); exit 1; echo -n 456 | tee $(results.result2.path)'
     finally:
     - name: finaltask1
@@ -63,7 +63,7 @@ spec:
         params:
         - name: param1
         steps:
-        - image: docker.io/library/busybox:1.36
+        - image: mirror.gcr.io/busybox
           script: 'exit 0'
     - name: finaltask2
       params:
@@ -73,7 +73,7 @@ spec:
         params:
         - name: param1
         steps:
-        - image: docker.io/library/busybox:1.36
+        - image: mirror.gcr.io/busybox
           script: exit 0`, helpers.ObjectNameForTest(t)))
 
 	if _, err := c.V1beta1PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{}); err != nil {

--- a/test/taskrun_test.go
+++ b/test/taskrun_test.go
@@ -61,13 +61,13 @@ metadata:
   namespace: %s
 spec:
   steps:
-  - image: docker.io/library/busybox:1.36
+  - image: mirror.gcr.io/busybox
     command: ['/bin/sh']
     args: ['-c', 'echo hello']
-  - image: docker.io/library/busybox:1.36
+  - image: mirror.gcr.io/busybox
     command: ['/bin/sh']
     args: ['-c', 'exit 1']
-  - image: docker.io/library/busybox:1.36
+  - image: mirror.gcr.io/busybox
     command: ['/bin/sh']
     args: ['-c', 'sleep 30s']
 `, helpers.ObjectNameForTest(t), namespace))
@@ -512,7 +512,7 @@ metadata:
   namespace: %s
 spec:
   steps:
-  - image: docker.io/library/busybox:1.36
+  - image: mirror.gcr.io/busybox
     command: ['/bin/sh']
     args: ['-c', 'exit 1']
     volumeMounts:

--- a/test/tektonbundles_test.go
+++ b/test/tektonbundles_test.go
@@ -74,7 +74,7 @@ metadata:
 spec:
   steps:
   - name: hello
-    image: docker.io/library/alpine:3.20.1
+    image: mirror.gcr.io/alpine
     script: 'echo Hello'
 `, taskName, namespace))
 

--- a/test/timeout_test.go
+++ b/test/timeout_test.go
@@ -57,7 +57,7 @@ metadata:
   namespace: %s
 spec:
   steps:
-  - image: docker.io/library/busybox:1.36
+  - image: mirror.gcr.io/busybox
     command: ['/bin/sh']
     args: ['-c', 'sleep 10']
 `, helpers.ObjectNameForTest(t), namespace))
@@ -178,15 +178,15 @@ spec:
   taskSpec:
     steps:
     - name: no-timeout
-      image: docker.io/library/busybox
+      image: mirror.gcr.io/busybox
       script: sleep 1
       timeout: 2s
     - name: timeout
-      image: docker.io/library/busybox
+      image: mirror.gcr.io/busybox
       script: sleep 1
       timeout: 1ms
     - name: canceled
-      image: docker.io/library/busybox
+      image: mirror.gcr.io/busybox
       script: sleep 1
 `, helpers.ObjectNameForTest(t), namespace))
 	t.Logf("Creating TaskRun %s in namespace %s", taskRun.Name, namespace)
@@ -242,7 +242,7 @@ spec:
       - name: test
     steps:
       - name: timeout
-        image: docker.io/library/busybox
+        image: mirror.gcr.io/busybox
         script: sleep 1
         timeout: 1ms`)
 
@@ -277,7 +277,7 @@ metadata:
   namespace: %s
 spec:
   steps:
-  - image: docker.io/library/busybox:1.36
+  - image: mirror.gcr.io/busybox
     command: ['/bin/sh']
     args: ['-c', 'sleep 3000']
 `, helpers.ObjectNameForTest(t), namespace))
@@ -333,7 +333,7 @@ metadata:
   namespace: %s
 spec:
   steps:
-  - image: docker.io/library/busybox:1.36
+  - image: mirror.gcr.io/busybox
     command: ['/bin/sh']
     args: ['-c', 'sleep 1s']
 `, helpers.ObjectNameForTest(t), namespace))
@@ -343,7 +343,7 @@ metadata:
   namespace: %s
 spec:
   steps:
-  - image: docker.io/library/busybox:1.36
+  - image: mirror.gcr.io/busybox
     command: ['/bin/sh']
     args: ['-c', 'sleep 10s']
 `, helpers.ObjectNameForTest(t), namespace))
@@ -454,7 +454,7 @@ metadata:
   namespace: %s
 spec:
   steps:
-  - image: docker.io/library/busybox:1.36
+  - image: mirror.gcr.io/busybox
     command: ['/bin/sh']
     args: ['-c', 'sleep 30']
 `, helpers.ObjectNameForTest(t), namespace))
@@ -469,7 +469,7 @@ metadata:
   namespace: %s
 spec:
   steps:
-  - image: docker.io/library/busybox:1.36
+  - image: mirror.gcr.io/busybox
     command: ['/bin/sh']
     args: ['-c', 'sleep 1']
 `, helpers.ObjectNameForTest(t), namespace))

--- a/test/upgrade/simpleResources.yaml
+++ b/test/upgrade/simpleResources.yaml
@@ -10,18 +10,18 @@ spec:
       default: "response"
   steps:
   - name: echo-param
-    image: docker.io/library/alpine:3.20.1
+    image: mirror.gcr.io/alpine
     script: |
       echo "$(params.rsp)"
   - name: check-workspace
-    image: docker.io/library/alpine:3.20.1
+    image: mirror.gcr.io/alpine
     script: |
       if [ "$(workspaces.workspace.bound)" == "true" ]; then
         echo "Workspace provided"
       fi
   sidecars:
   - name: server
-    image: docker.io/library/alpine:3.20.1
+    image: mirror.gcr.io/alpine
     command: ['/bin/bash']
     workingDir: /foo
     script: echo server
@@ -44,7 +44,7 @@ spec:
           type: string
           default: "1"
       steps:
-        - image: docker.io/library/alpine:3.20.1
+        - image: mirror.gcr.io/alpine
           name: check-workspace
           script: |
             if [ "$(workspaces.workspace.bound)" == "true" ]; then
@@ -63,5 +63,5 @@ spec:
           default: "Succeeded"
       steps:
         - name: verify-status
-          image: docker.io/library/ubuntu
+          image: mirror.gcr.io/ubuntu
           script: echo $(params.echoStatus)

--- a/test/upgrade_test.go
+++ b/test/upgrade_test.go
@@ -52,11 +52,11 @@ spec:
     default: "response"
   steps:
   - name: echo-param
-    image: docker.io/library/alpine:3.20.1
+    image: mirror.gcr.io/alpine
     script: |
       echo "$(params.rsp)"
   - name: check-workspace
-    image: docker.io/library/alpine:3.20.1
+    image: mirror.gcr.io/alpine
     script: |
       if [ "$(workspaces.taskWorkspace.bound)" == "true" ]; then
         echo "Workspace provided"
@@ -128,12 +128,12 @@ status:
     status: "True"
   taskSpec:
     steps:
-    - image: docker.io/library/alpine:3.20.1
+    - image: mirror.gcr.io/alpine
       name: echo-param
       script: |
        echo "response"
     - name: check-workspace
-      image: docker.io/library/alpine:3.20.1
+      image: mirror.gcr.io/alpine
       script: |
         if [ "true" == "true" ]; then
           echo "Workspace provided"

--- a/test/workingdir_test.go
+++ b/test/workingdir_test.go
@@ -51,7 +51,7 @@ metadata:
   namespace: %s
 spec:
   steps:
-  - image: docker.io/library/ubuntu:24.04
+  - image: mirror.gcr.io/ubuntu
     workingDir: /workspace/HELLOMOTO
     args: ['-c', 'echo YES']
 `, wdTaskName, namespace))
@@ -124,7 +124,7 @@ metadata:
   namespace: %s
 spec:
   steps:
-  - image: docker.io/library/ubuntu:24.04
+  - image: mirror.gcr.io/ubuntu
     workingDir: /HELLOMOTO
     args: ['-c', 'echo YES']
 `, wdTaskName, namespace))

--- a/test/workspace_test.go
+++ b/test/workspace_test.go
@@ -51,7 +51,7 @@ metadata:
   namespace: %s
 spec:
   steps:
-  - image: docker.io/library/alpine:3.20.1
+  - image: mirror.gcr.io/alpine
     script: 'echo foo > /workspace/test/file'
   workspaces:
   - name: test
@@ -129,7 +129,7 @@ metadata:
   namespace: %s
 spec:
   steps:
-  - image: docker.io/library/alpine:3.20.1
+  - image: mirror.gcr.io/alpine
     script: 'cat /workspace/test/file'
   workspaces:
   - name: test
@@ -199,7 +199,7 @@ metadata:
   namespace: %s
 spec:
   steps:
-  - image: docker.io/library/alpine:3.20.1
+  - image: mirror.gcr.io/alpine
     script: 'cat /workspace/test/file'
   workspaces:
   - name: test
@@ -268,7 +268,7 @@ metadata:
   namespace: %s
 spec:
   steps:
-  - image: docker.io/library/alpine:3.20.1
+  - image: mirror.gcr.io/alpine
     name: foo
     command: ['echo']
     args: ['$(workspaces.test.volume)']


### PR DESCRIPTION
Docker hub reduced its rate limit to a 100 container pulls per hour. This is very small and making our tests flaky. As a stop gap, we think that changing to `mirror.gcr.io` will get us past the rate limit since the image will be pushed from the artifact registry cache instead of docker hub.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
