### PR TITLE
Refine check if the result is from a matrix task

### DIFF
--- a/pkg/reconciler/pipelinerun/resources/resultrefresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/resultrefresolution.go
@@ -132,7 +132,7 @@ func convertToResultRefs(pipelineRunState PipelineRunState, target *ResolvedPipe
 			resolvedResultRefs = append(resolvedResultRefs, resolved)
 		default:
 			// Matrixed referenced Pipeline Task
-			if len(referencedPipelineTask.TaskRuns) > 1 {
+			if referencedPipelineTask.PipelineTask.IsMatrixed() {
 				arrayValues, err := findResultValuesForMatrix(referencedPipelineTask, resultRef)
 				if err != nil {
 					return nil, resultRef.PipelineTask, err


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Given a matrix run of a TaskRun with cardinality of 1, the result from it will not be converted to an array but kept as a string, i.e. as if the TaskRun was not configured to run with matrix.

This causes issues for consumers of the TaskRun's results as they will be configured to consume array results. As a result making the passed value equal to expression value instead.

Resolves: #8157

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [X] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [X] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [X] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [X] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [X] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Fixed variable substitution of results from matrix TaskRuns with cardinality of 1.
```
