### PR TITLE
Add UID label to PipelineRun and TaskRun

### DIFF
--- a/pkg/apis/pipeline/register.go
+++ b/pkg/apis/pipeline/register.go
@@ -34,11 +34,17 @@ const (
 	// TaskRunLabelKey is used as the label identifier for a TaskRun
 	TaskRunLabelKey = GroupName + "/taskRun"
 
+	// TaskRunLabelKey is used as the label identifier for a TaskRun
+	TaskRunUIDLabelKey = GroupName + "/taskRunUID"
+
 	// PipelineLabelKey is used as the label identifier for a Pipeline
 	PipelineLabelKey = GroupName + "/pipeline"
 
 	// PipelineRunLabelKey is used as the label identifier for a PipelineRun
 	PipelineRunLabelKey = GroupName + "/pipelineRun"
+
+	// PipelineRunLabelKey is used as the label identifier for a PipelineRun
+	PipelineRunUIDLabelKey = GroupName + "/pipelineRunUID"
 
 	// PipelineTaskLabelKey is used as the label identifier for a PipelineTask
 	PipelineTaskLabelKey = GroupName + "/pipelineTask"

--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -658,6 +658,7 @@ func makeLabels(s *v1.TaskRun) map[string]string {
 	// NB: Set this *after* passing through TaskRun Labels. If the TaskRun
 	// specifies this label, it should be overridden by this value.
 	labels[pipeline.TaskRunLabelKey] = s.Name
+	labels[pipeline.TaskRunUIDLabelKey] = string(s.UID)
 	return labels
 }
 

--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -37,6 +37,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/version"
 	fakediscovery "k8s.io/client-go/discovery/fake"
 	fakek8s "k8s.io/client-go/kubernetes/fake"
@@ -3250,14 +3251,17 @@ func verifyTaskLevelComputeResources(expectedComputeResources []ExpectedComputeR
 
 func TestMakeLabels(t *testing.T) {
 	taskRunName := "task-run-name"
+	taskRunUID := types.UID("taskrunuid")
 	want := map[string]string{
-		pipeline.TaskRunLabelKey: taskRunName,
-		"foo":                    "bar",
-		"hello":                  "world",
+		pipeline.TaskRunLabelKey:    taskRunName,
+		"foo":                       "bar",
+		"hello":                     "world",
+		pipeline.TaskRunUIDLabelKey: string(taskRunUID),
 	}
 	got := makeLabels(&v1.TaskRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: taskRunName,
+			UID:  taskRunUID,
 			Labels: map[string]string{
 				"foo":   "bar",
 				"hello": "world",

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -1359,6 +1359,7 @@ func getTaskrunLabels(pr *v1.PipelineRun, pipelineTaskName string, includePipeli
 		}
 	}
 	labels[pipeline.PipelineRunLabelKey] = pr.Name
+	labels[pipeline.PipelineRunUIDLabelKey] = string(pr.UID)
 	if pipelineTaskName != "" {
 		labels[pipeline.PipelineTaskLabelKey] = pipelineTaskName
 	}

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -430,6 +430,7 @@ func TestReconcile_ExplicitDefaultSA(t *testing.T) {
 metadata:
   name: test-taskrun-run-success
   namespace: foo
+  uid: bar
 spec:
   taskRef:
     apiVersion: v1
@@ -439,6 +440,7 @@ spec:
 metadata:
   name: test-taskrun-with-sa-run-success
   namespace: foo
+  uid: bar
 spec:
   serviceAccountName: test-sa
   taskRef:
@@ -468,7 +470,7 @@ spec:
 	}{{
 		name:    "success",
 		taskRun: taskRunSuccess,
-		wantPod: expectedPod("test-taskrun-run-success-pod", "test-task", "test-taskrun-run-success", "foo", defaultSAName, false, nil, []stepForExpectedPod{{
+		wantPod: expectedPod("test-taskrun-run-success-pod", "test-task", "test-taskrun-run-success", "bar", "foo", defaultSAName, false, nil, []stepForExpectedPod{{
 			image: "foo",
 			name:  "simple-step",
 			cmd:   "/mycmd",
@@ -476,7 +478,7 @@ spec:
 	}, {
 		name:    "serviceaccount",
 		taskRun: taskRunWithSaSuccess,
-		wantPod: expectedPod("test-taskrun-with-sa-run-success-pod", "test-with-sa", "test-taskrun-with-sa-run-success", "foo", "test-sa", false, nil, []stepForExpectedPod{{
+		wantPod: expectedPod("test-taskrun-with-sa-run-success-pod", "test-with-sa", "test-taskrun-with-sa-run-success", "bar", "foo", "test-sa", false, nil, []stepForExpectedPod{{
 			image: "foo",
 			name:  "sa-step",
 			cmd:   "/mycmd",
@@ -642,6 +644,7 @@ func TestReconcile(t *testing.T) {
 metadata:
   name: test-taskrun-run-success
   namespace: foo
+  uid: bar
 spec:
   taskRef:
     apiVersion: v1
@@ -651,6 +654,7 @@ spec:
 metadata:
   name: test-taskrun-with-sa-run-success
   namespace: foo
+  uid: bar
 spec:
   serviceAccountName: test-sa
   taskRef:
@@ -661,6 +665,7 @@ spec:
 metadata:
   name: test-taskrun-substitution
   namespace: foo
+  uid: bar
 spec:
   params:
   - name: myarg
@@ -677,6 +682,7 @@ spec:
 metadata:
   name: test-taskrun-with-taskspec
   namespace: foo
+  uid: bar
 spec:
   params:
   - name: myarg
@@ -698,6 +704,7 @@ spec:
 metadata:
   name: test-taskrun-with-cluster-task
   namespace: foo
+  uid: bar
 spec:
   taskRef:
     kind: ClusterTask
@@ -711,6 +718,7 @@ metadata:
     tekton.dev/taskRun: WillNotBeUsed
   name: test-taskrun-with-labels
   namespace: foo
+  uid: bar
 spec:
   taskRef:
     name: test-task
@@ -722,6 +730,7 @@ metadata:
     TaskRunAnnotation: TaskRunValue
   name: test-taskrun-with-annotations
   namespace: foo
+  uid: bar
 spec:
   taskRef:
     name: test-task
@@ -731,6 +740,7 @@ spec:
 metadata:
   name: test-taskrun-with-pod
   namespace: foo
+  uid: bar
 spec:
   taskRef:
     name: test-task
@@ -742,6 +752,7 @@ status:
 metadata:
   name: test-taskrun-with-credentials-variable
   namespace: foo
+  uid: bar
 spec:
   taskSpec:
     steps:
@@ -769,6 +780,7 @@ spec:
 metadata:
   name: test-taskrun-bundle
   namespace: foo
+  uid: bar
 spec:
   taskRef:
     bundle: %s
@@ -799,7 +811,7 @@ spec:
 			"Normal Started ",
 			"Normal Running Not all Steps",
 		},
-		wantPod: expectedPod("test-taskrun-run-success-pod", "test-task", "test-taskrun-run-success", "foo", config.DefaultServiceAccountValue, false, nil, []stepForExpectedPod{{
+		wantPod: expectedPod("test-taskrun-run-success-pod", "test-task", "test-taskrun-run-success", "bar", "foo", config.DefaultServiceAccountValue, false, nil, []stepForExpectedPod{{
 			image: "foo",
 			name:  "simple-step",
 			cmd:   "/mycmd",
@@ -811,7 +823,7 @@ spec:
 			"Normal Started ",
 			"Normal Running Not all Steps",
 		},
-		wantPod: expectedPod("test-taskrun-with-sa-run-success-pod", "test-with-sa", "test-taskrun-with-sa-run-success", "foo", "test-sa", false, nil, []stepForExpectedPod{{
+		wantPod: expectedPod("test-taskrun-with-sa-run-success-pod", "test-with-sa", "test-taskrun-with-sa-run-success", "bar", "foo", "test-sa", false, nil, []stepForExpectedPod{{
 			image: "foo",
 			name:  "sa-step",
 			cmd:   "/mycmd",
@@ -823,7 +835,7 @@ spec:
 			"Normal Started ",
 			"Normal Running Not all Steps",
 		},
-		wantPod: expectedPod("test-taskrun-substitution-pod", "test-task-with-substitution", "test-taskrun-substitution", "foo", config.DefaultServiceAccountValue, false, []corev1.Volume{{
+		wantPod: expectedPod("test-taskrun-substitution-pod", "test-task-with-substitution", "test-taskrun-substitution", "bar", "foo", config.DefaultServiceAccountValue, false, []corev1.Volume{{
 			Name: "volume-configmap",
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
@@ -859,7 +871,7 @@ spec:
 			"Normal Started ",
 			"Normal Running Not all Steps",
 		},
-		wantPod: expectedPod("test-taskrun-with-taskspec-pod", "", "test-taskrun-with-taskspec", "foo", config.DefaultServiceAccountValue, false, nil, []stepForExpectedPod{
+		wantPod: expectedPod("test-taskrun-with-taskspec-pod", "", "test-taskrun-with-taskspec", "bar", "foo", config.DefaultServiceAccountValue, false, nil, []stepForExpectedPod{
 			{
 				name:  "mycontainer",
 				image: "myimage",
@@ -873,7 +885,7 @@ spec:
 			"Normal Started ",
 			"Normal Running Not all Steps",
 		},
-		wantPod: expectedPod("test-taskrun-with-cluster-task-pod", "test-cluster-task", "test-taskrun-with-cluster-task", "foo", config.DefaultServiceAccountValue, true, nil, []stepForExpectedPod{{
+		wantPod: expectedPod("test-taskrun-with-cluster-task-pod", "test-cluster-task", "test-taskrun-with-cluster-task", "bar", "foo", config.DefaultServiceAccountValue, true, nil, []stepForExpectedPod{{
 			name:  "simple-step",
 			image: "foo",
 			cmd:   "/mycmd",
@@ -885,7 +897,7 @@ spec:
 			"Normal Started ",
 			"Normal Running Not all Steps",
 		},
-		wantPod: expectedPod("test-taskrun-with-pod-pod", "test-task", "test-taskrun-with-pod", "foo", config.DefaultServiceAccountValue, false, nil, []stepForExpectedPod{{
+		wantPod: expectedPod("test-taskrun-with-pod-pod", "test-task", "test-taskrun-with-pod", "bar", "foo", config.DefaultServiceAccountValue, false, nil, []stepForExpectedPod{{
 			name:  "simple-step",
 			image: "foo",
 			cmd:   "/mycmd",
@@ -897,7 +909,7 @@ spec:
 			"Normal Started ",
 			"Normal Running Not all Steps",
 		},
-		wantPod: expectedPod("test-taskrun-with-credentials-variable-pod", "", "test-taskrun-with-credentials-variable", "foo", config.DefaultServiceAccountValue, false, nil, []stepForExpectedPod{{
+		wantPod: expectedPod("test-taskrun-with-credentials-variable-pod", "", "test-taskrun-with-credentials-variable", "bar", "foo", config.DefaultServiceAccountValue, false, nil, []stepForExpectedPod{{
 			name:  "mycontainer",
 			image: "myimage",
 			cmd:   "/mycmd /tekton/creds",
@@ -909,7 +921,7 @@ spec:
 			"Normal Started ",
 			"Normal Running Not all Steps",
 		},
-		wantPod: expectedPod("test-taskrun-bundle-pod", "test-task", "test-taskrun-bundle", "foo", config.DefaultServiceAccountValue, false, nil, []stepForExpectedPod{{
+		wantPod: expectedPod("test-taskrun-bundle-pod", "test-task", "test-taskrun-bundle", "bar", "foo", config.DefaultServiceAccountValue, false, nil, []stepForExpectedPod{{
 			name:  "simple-step",
 			image: "foo",
 			cmd:   "/mycmd",
@@ -979,6 +991,7 @@ func TestAlphaReconcile(t *testing.T) {
 metadata:
   name: test-taskrun-with-output-config
   namespace: foo
+  uid: bar
 spec:
   taskSpec:
     steps:
@@ -994,6 +1007,7 @@ spec:
 metadata:
   name: test-taskrun-with-output-config-ws
   namespace: foo
+  uid: bar
 spec:
   workspaces:
     - name: data
@@ -1038,7 +1052,7 @@ spec:
 			"Normal Started ",
 			"Normal Running Not all Steps",
 		},
-		wantPod: expectedPod("test-taskrun-with-output-config-pod", "", "test-taskrun-with-output-config", "foo", config.DefaultServiceAccountValue, false, nil, []stepForExpectedPod{{
+		wantPod: expectedPod("test-taskrun-with-output-config-pod", "", "test-taskrun-with-output-config", "bar", "foo", config.DefaultServiceAccountValue, false, nil, []stepForExpectedPod{{
 			name:       "mycontainer",
 			image:      "myimage",
 			stdoutPath: "stdout.txt",
@@ -1051,7 +1065,7 @@ spec:
 			"Normal Started ",
 			"Normal Running Not all Steps",
 		},
-		wantPod: addVolumeMounts(expectedPod("test-taskrun-with-output-config-ws-pod", "", "test-taskrun-with-output-config-ws", "foo", config.DefaultServiceAccountValue, false,
+		wantPod: addVolumeMounts(expectedPod("test-taskrun-with-output-config-ws-pod", "", "test-taskrun-with-output-config-ws", "bar", "foo", config.DefaultServiceAccountValue, false,
 			[]corev1.Volume{{
 				Name: "ws-d872e",
 				VolumeSource: corev1.VolumeSource{
@@ -5941,7 +5955,7 @@ func podArgs(cmd string, stdoutPath string, stderrPath string, additionalArgs []
 	return args
 }
 
-func podObjectMeta(name, taskName, taskRunName, ns string, isClusterTask bool) metav1.ObjectMeta {
+func podObjectMeta(name, taskName, taskRunName, taskRunUID, ns string, isClusterTask bool) metav1.ObjectMeta {
 	trueB := true
 	om := metav1.ObjectMeta{
 		Name:      name,
@@ -5951,6 +5965,7 @@ func podObjectMeta(name, taskName, taskRunName, ns string, isClusterTask bool) m
 		},
 		Labels: map[string]string{
 			pipeline.TaskRunLabelKey:       taskRunName,
+			pipeline.TaskRunUIDLabelKey:    taskRunUID,
 			"app.kubernetes.io/managed-by": "tekton-pipelines",
 		},
 		OwnerReferences: []metav1.OwnerReference{{
@@ -5959,6 +5974,7 @@ func podObjectMeta(name, taskName, taskRunName, ns string, isClusterTask bool) m
 			Controller:         &trueB,
 			BlockOwnerDeletion: &trueB,
 			APIVersion:         currentAPIVersion,
+			UID:                types.UID(taskRunUID),
 		}},
 	}
 
@@ -5985,13 +6001,13 @@ type stepForExpectedPod struct {
 	stderrPath      string
 }
 
-func expectedPod(podName, taskName, taskRunName, ns, saName string, isClusterTask bool, extraVolumes []corev1.Volume, steps []stepForExpectedPod) *corev1.Pod {
+func expectedPod(podName, taskName, taskRunName, taskRunUID, ns, saName string, isClusterTask bool, extraVolumes []corev1.Volume, steps []stepForExpectedPod) *corev1.Pod {
 	stepNames := make([]string, 0, len(steps))
 	for _, s := range steps {
 		stepNames = append(stepNames, "step-"+s.name)
 	}
 	p := &corev1.Pod{
-		ObjectMeta: podObjectMeta(podName, taskName, taskRunName, ns, isClusterTask),
+		ObjectMeta: podObjectMeta(podName, taskName, taskRunName, taskRunUID, ns, isClusterTask),
 		Spec: corev1.PodSpec{
 			Volumes: []corev1.Volume{
 				workspaceVolume,


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Fixes #8165 
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
TaskRun pods have tekton.dev/taskRunUID and tekton.dev/pipelineRunUID labels
```
