### PR TITLE
fix(e2e): stabilize TestTaskRunFailure test

### DIFF
--- a/test/taskrun_test.go
+++ b/test/taskrun_test.go
@@ -127,10 +127,33 @@ spec:
 		Name:              "unnamed-2",
 		Container:         "step-unnamed-2",
 	}}
+	expectedStepNumber := len(expectedStepState)
+	if len(taskrun.Status.Steps) < expectedStepNumber {
+		t.Fatalf("expected at least %d steps, got %d", expectedStepNumber, len(taskrun.Status.Steps))
+	}
 	ignoreTerminatedFields := cmpopts.IgnoreFields(corev1.ContainerStateTerminated{}, "StartedAt", "FinishedAt", "ContainerID")
-	ignoreStepFields := cmpopts.IgnoreFields(v1.StepState{}, "ImageID")
-	if d := cmp.Diff(taskrun.Status.Steps, expectedStepState, ignoreTerminatedFields, ignoreStepFields); d != "" {
-		t.Fatalf("-got, +want: %v", d)
+	ignoreStepFields := cmpopts.IgnoreFields(v1.StepState{}, "ImageID", "Running")
+	lastStepIndex := len(expectedStepState) - 1
+	for i := range lastStepIndex {
+		if d := cmp.Diff(taskrun.Status.Steps[i], expectedStepState[i], ignoreTerminatedFields, ignoreStepFields); d != "" {
+			t.Fatalf("taskrun.Status.Steps[%d]:\n-got, +want: %v", i, d)
+		}
+	}
+
+	// Sometimes, the state of the last container in the Pod is still running,
+	// and the state content of the final step is not skipped.
+	// In this case, we should compare the state of the last step with the normal state.
+	otherLatestExpectedStepState := v1.StepState{
+		Name:      "unnamed-2",
+		Container: "step-unnamed-2",
+	}
+
+	if d := cmp.Diff(taskrun.Status.Steps[lastStepIndex], expectedStepState[lastStepIndex], ignoreTerminatedFields, ignoreStepFields); d != "" {
+		t.Logf("taskrun.Status.Steps[%d]:\n-got, +want: %v", lastStepIndex, d)
+		// try to compare the state of the last step with the other state
+		if d := cmp.Diff(taskrun.Status.Steps[lastStepIndex], otherLatestExpectedStepState, ignoreTerminatedFields, ignoreStepFields); d != "" {
+			t.Fatalf("taskrun.Status.Steps[%d]:\n-got, +want: %v", lastStepIndex, d)
+		}
 	}
 
 	releaseAnnotation, ok := taskrun.Annotations[pod.ReleaseAnnotation]


### PR DESCRIPTION
Most of the time, if a middle step fails, the subsequent steps are immediately marked as skipped. However, in rare cases, the subsequent steps may not be marked as skipped in time.

To ensure the stability of e2e, we adapted to this scenario.

## Failed cases:
- https://prow.tekton.dev/view/gs/tekton-prow/pr-logs/pull/tektoncd_pipeline/8171/pull-tekton-pipeline-beta-integration-tests/1819553517078056960
- https://prow.tekton.dev/view/gs/tekton-prow/pr-logs/pull/tektoncd_pipeline/8171/pull-tekton-pipeline-alpha-integration-tests/1819553517015142400

Fatal log

```yaml
    taskrun_test.go:133: -got, +want:   []v1.StepState{
          	{ContainerState: {Terminated: &{Reason: "Completed"}}, Name: "unnamed-0", Container: "step-unnamed-0", TerminationReason: "Completed", ...},
          	{ContainerState: {Terminated: &{ExitCode: 1, Reason: "Error"}}, Name: "unnamed-1", Container: "step-unnamed-1", TerminationReason: "Error", ...},
          	{
          		ContainerState: v1.ContainerState{
          			Waiting:    nil,
        - 			Running:    s"&ContainerStateRunning{StartedAt:2024-08-03 02:18:01 +0000 UTC,}",
        + 			Running:    nil,
        - 			Terminated: nil,
        + 			Terminated: s"&ContainerStateTerminated{ExitCode:1,Signal:0,Reason:Error,Message:,StartedAt:0001-01-01 00:00:00 +0000 UTC,FinishedAt:0001-01-01 00:00:00 +0000 UTC,ContainerID:,}",
          		},
          		Name:      "unnamed-2",
          		Container: "step-unnamed-2",
          		... // 1 ignored field
          		Results:           nil,
          		Provenance:        nil,
        - 		TerminationReason: "",
        + 		TerminationReason: "Skipped",
          		Inputs:            nil,
          		Outputs:           nil,
          	},
          }
```

Code:

https://github.com/tektoncd/pipeline/blob/dd36119baf9247382675cece422157480ee8d404/test/taskrun_test.go#L99-L134

## Debug stepStatuses

https://github.com/tektoncd/pipeline/blob/95fbf318460a2f73ac505bbdb13786a788d1c092/pkg/reconciler/taskrun/taskrun.go#L677-L678

https://github.com/tektoncd/pipeline/blob/95fbf318460a2f73ac505bbdb13786a788d1c092/pkg/pod/status.go#L144-L162

https://github.com/tektoncd/pipeline/blob/95fbf318460a2f73ac505bbdb13786a788d1c092/pkg/pod/status.go#L267-L309

### Normal e2e is successful
```
stepStatuses:
  - name: "step-unnamed-0"
    state:
      terminated:
        exitCode: 0
        reason: "Completed"
        message: '[{"key":"StartedAt","value":"2024-08-03T08:32:01.924Z","type":3}]'
        startedAt: "2024-08-03T08:31:58Z"
        finishedAt: "2024-08-03T08:32:01Z"
        containerID: "containerd://0626499f8e35d6179dcb67c2b7bbba2f78cc14d9430106125eb3f4be5a435fc4"
    lastState: {}
    ready: false
    restartCount: 0
    image: "docker.io/library/busybox:latest"
    imageID: "docker.io/library/busybox@sha256:9ae97d36d26566ff84e8893c64a6dc4fe8ca6d1144bf5b87b2b85a32def253c7"
    containerID: "containerd://0626499f8e35d6179dcb67c2b7bbba2f78cc14d9430106125eb3f4be5a435fc4"
    started: false
  - name: "step-unnamed-1"
    state:
      terminated:
        exitCode: 1
        reason: "Error"
        message: '[{"key":"StartedAt","value":"2024-08-03T08:32:02.781Z","type":3}]'
        startedAt: "2024-08-03T08:31:59Z"
        finishedAt: "2024-08-03T08:32:02Z"
        containerID: "containerd://a04c5360b640cbb82ffc2f04d12bc7b38b1851add06a19df5c603659eee36262"
    lastState: {}
    ready: false
    restartCount: 0
    image: "docker.io/library/busybox:latest"
    imageID: "docker.io/library/busybox@sha256:9ae97d36d26566ff84e8893c64a6dc4fe8ca6d1144bf5b87b2b85a32def253c7"
    containerID: "containerd://a04c5360b640cbb82ffc2f04d12bc7b38b1851add06a19df5c603659eee36262"
    started: false
  - name: "step-unnamed-2"
    state:
      terminated:
        exitCode: 1
        reason: "Error"
        message: '[{"key":"StartedAt","value":"2024-08-03T08:32:03.705Z","type":3},{"key":"Reason","value":"Skipped","type":3}]'
        startedAt: "2024-08-03T08:32:00Z"
        finishedAt: "2024-08-03T08:32:03Z"
        containerID: "containerd://8e14be369ce0f62b95ccdf785ced891c5979ce901f887a68bede87dd8b2538d3"
    lastState: {}
    ready: false
    restartCount: 0
    image: "docker.io/library/busybox:latest"
    imageID: "docker.io/library/busybox@sha256:9ae97d36d26566ff84e8893c64a6dc4fe8ca6d1144bf5b87b2b85a32def253c7"
    containerID: "containerd://8e14be369ce0f62b95ccdf785ced891c5979ce901f887a68bede87dd8b2538d3"
    started: false
```

### Accidental failure
```
stepStatuses:
  - name: "step-unnamed-0"
    state:
      terminated:
        exitCode: 0
        reason: "Completed"
        message: '[{"key":"StartedAt","value":"2024-08-03T08:32:01.924Z","type":3}]'
        startedAt: "2024-08-03T08:31:58Z"
        finishedAt: "2024-08-03T08:32:01Z"
        containerID: "containerd://0626499f8e35d6179dcb67c2b7bbba2f78cc14d9430106125eb3f4be5a435fc4"
    lastState: {}
    ready: false
    restartCount: 0
    image: "docker.io/library/busybox:latest"
    imageID: "docker.io/library/busybox@sha256:9ae97d36d26566ff84e8893c64a6dc4fe8ca6d1144bf5b87b2b85a32def253c7"
    containerID: "containerd://0626499f8e35d6179dcb67c2b7bbba2f78cc14d9430106125eb3f4be5a435fc4"
    started: false
  - name: "step-unnamed-1"
    state:
      terminated:
        exitCode: 1
        reason: "Error"
        message: '[{"key":"StartedAt","value":"2024-08-03T08:32:02.781Z","type":3}]'
        startedAt: "2024-08-03T08:31:59Z"
        finishedAt: "2024-08-03T08:32:02Z"
        containerID: "containerd://a04c5360b640cbb82ffc2f04d12bc7b38b1851add06a19df5c603659eee36262"
    lastState: {}
    ready: false
    restartCount: 0
    image: "docker.io/library/busybox:latest"
    imageID: "docker.io/library/busybox@sha256:9ae97d36d26566ff84e8893c64a6dc4fe8ca6d1144bf5b87b2b85a32def253c7"
    containerID: "containerd://a04c5360b640cbb82ffc2f04d12bc7b38b1851add06a19df5c603659eee36262"
    started: false
  - name: "step-unnamed-2"
    state:
      running:
        startedAt: "2024-08-03T08:32:00Z"
    lastState: {}
    ready: true
    restartCount: 0
    image: "docker.io/library/busybox:latest"
    imageID: "docker.io/library/busybox@sha256:9ae97d36d26566ff84e8893c64a6dc4fe8ca6d1144bf5b87b2b85a32def253c7"
    containerID: "containerd://8e14be369ce0f62b95ccdf785ced891c5979ce901f887a68bede87dd8b2538d3"
    started: true
```


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

/kind bug

# Release Notes

```release-note
NONE
```
