### PR TITLE
Implement set-security-context feature for affinity assistant containers

### DIFF
--- a/docs/additional-configs.md
+++ b/docs/additional-configs.md
@@ -461,7 +461,8 @@ Out-of-the-box, Tekton Pipelines Controller is configured for relatively small-s
 
 To allow TaskRuns and PipelineRuns to run in namespaces with [restricted pod security standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/),
 set the "set-security-context" feature flag to "true" in the [feature-flags configMap](#customizing-the-pipelines-controller-behavior). This configuration option applies a [SecurityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
-to any containers injected into TaskRuns by the Pipelines controller. This SecurityContext may not be supported in all Kubernetes implementations (for example, OpenShift).
+to any containers injected into TaskRuns by the Pipelines controller. If the [Affinity Assistants](affinityassistants.md) feature is enabled, the SecurityContext is also applied to those containers.
+This SecurityContext may not be supported in all Kubernetes implementations (for example, OpenShift).
 
 **Note**: running TaskRuns and PipelineRuns in the "tekton-pipelines" namespace is discouraged.
 

--- a/pkg/internal/affinityassistant/affinityassistant_types.go
+++ b/pkg/internal/affinityassistant/affinityassistant_types.go
@@ -54,3 +54,9 @@ func GetAffinityAssistantBehavior(ctx context.Context) (AffinityAssistantBehavio
 
 	return "", fmt.Errorf("unknown combination of disable-affinity-assistant: %v and coschedule: %v", disableAA, coschedule)
 }
+
+// ContainerConfig defines AffinityAssistant container configuration
+type ContainerConfig struct {
+	Image              string
+	SetSecurityContext bool
+}

--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -60,8 +60,8 @@ const (
 	// SpiffeCsiDriver is the CSI storage plugin needed for injection of SPIFFE workload api.
 	SpiffeCsiDriver = "csi.spiffe.io"
 
-	// osSelectorLabel is the label Kubernetes uses for OS-specific workloads (https://kubernetes.io/docs/reference/labels-annotations-taints/#kubernetes-io-os)
-	osSelectorLabel = "kubernetes.io/os"
+	// OsSelectorLabel is the label Kubernetes uses for OS-specific workloads (https://kubernetes.io/docs/reference/labels-annotations-taints/#kubernetes-io-os)
+	OsSelectorLabel = "kubernetes.io/os"
 
 	// TerminationReasonTimeoutExceeded indicates a step execution timed out.
 	TerminationReasonTimeoutExceeded = "TimeoutExceeded"
@@ -132,10 +132,10 @@ var (
 	allowPrivilegeEscalation = false
 	runAsNonRoot             = true
 
-	// The following security contexts allow init containers to run in namespaces
+	// LinuxSecurityContext allow init containers to run in namespaces
 	// with "restricted" pod security admission
 	// See https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
-	linuxSecurityContext = &corev1.SecurityContext{
+	LinuxSecurityContext = &corev1.SecurityContext{
 		AllowPrivilegeEscalation: &allowPrivilegeEscalation,
 		Capabilities: &corev1.Capabilities{
 			Drop: []corev1.Capability{"ALL"},
@@ -145,7 +145,7 @@ var (
 			Type: corev1.SeccompProfileTypeRuntimeDefault,
 		},
 	}
-	windowsSecurityContext = &corev1.SecurityContext{
+	WindowsSecurityContext = &corev1.SecurityContext{
 		RunAsNonRoot: &runAsNonRoot,
 	}
 )
@@ -607,9 +607,9 @@ func entrypointInitContainer(image string, steps []v1.Step, setSecurityContext, 
 		command = append(command, StepName(s.Name, i))
 	}
 	volumeMounts := []corev1.VolumeMount{binMount, internalStepsMount}
-	securityContext := linuxSecurityContext
+	securityContext := LinuxSecurityContext
 	if windows {
-		securityContext = windowsSecurityContext
+		securityContext = WindowsSecurityContext
 	}
 
 	// Rewrite steps with entrypoint binary. Append the entrypoint init
@@ -679,9 +679,9 @@ func createResultsSidecar(taskSpec v1.TaskSpec, image string, setSecurityContext
 		Image:   image,
 		Command: command,
 	}
-	securityContext := linuxSecurityContext
+	securityContext := LinuxSecurityContext
 	if windows {
-		securityContext = windowsSecurityContext
+		securityContext = WindowsSecurityContext
 	}
 	if setSecurityContext {
 		sidecar.SecurityContext = securityContext
@@ -696,7 +696,7 @@ func usesWindows(tr *v1.TaskRun) bool {
 	if tr.Spec.PodTemplate == nil || tr.Spec.PodTemplate.NodeSelector == nil {
 		return false
 	}
-	osSelector := tr.Spec.PodTemplate.NodeSelector[osSelectorLabel]
+	osSelector := tr.Spec.PodTemplate.NodeSelector[OsSelectorLabel]
 	return osSelector == "windows"
 }
 

--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -2162,7 +2162,7 @@ _EOF_
 						{Name: "tekton-internal-bin", ReadOnly: true, MountPath: "/tekton/bin"},
 						{Name: "tekton-internal-run-0", ReadOnly: true, MountPath: "/tekton/run/0"},
 					}, implicitVolumeMounts...),
-					SecurityContext: linuxSecurityContext,
+					SecurityContext: LinuxSecurityContext,
 				}},
 				Volumes: append(implicitVolumes, binVolume, runVolume(0), downwardVolume, corev1.Volume{
 					Name:         "tekton-creds-init-home-0",
@@ -2403,7 +2403,7 @@ _EOF_
 						{Name: "tekton-internal-bin", ReadOnly: true, MountPath: "/tekton/bin"},
 						{Name: "tekton-internal-run-0", ReadOnly: true, MountPath: "/tekton/run/0"},
 					}, implicitVolumeMounts...),
-					SecurityContext: linuxSecurityContext,
+					SecurityContext: LinuxSecurityContext,
 				}},
 				Volumes: append(implicitVolumes, binVolume, runVolume(0), downwardVolume, corev1.Volume{
 					Name:         "tekton-creds-init-home-0",
@@ -3424,7 +3424,7 @@ func TestPrepareInitContainers(t *testing.T) {
 			WorkingDir:      "/",
 			Command:         []string{"/ko-app/entrypoint", "init", "/ko-app/entrypoint", entrypointBinary, "step-foo", "step-bar"},
 			VolumeMounts:    []corev1.VolumeMount{binMount, internalStepsMount},
-			SecurityContext: linuxSecurityContext,
+			SecurityContext: LinuxSecurityContext,
 		},
 	}, {
 		name: "nothing-special-two-steps-windows",
@@ -3456,7 +3456,7 @@ func TestPrepareInitContainers(t *testing.T) {
 			WorkingDir:      "/",
 			Command:         []string{"/ko-app/entrypoint", "init", "/ko-app/entrypoint", entrypointBinary, "step-foo", "step-bar"},
 			VolumeMounts:    []corev1.VolumeMount{binMount, internalStepsMount},
-			SecurityContext: windowsSecurityContext,
+			SecurityContext: WindowsSecurityContext,
 		},
 	}}
 	for _, tc := range tcs {
@@ -3485,13 +3485,13 @@ func TestUsesWindows(t *testing.T) {
 	}, {
 		name: "uses linux",
 		taskRun: &v1.TaskRun{Spec: v1.TaskRunSpec{PodTemplate: &pod.Template{NodeSelector: map[string]string{
-			osSelectorLabel: "linux",
+			OsSelectorLabel: "linux",
 		}}}},
 		want: false,
 	}, {
 		name: "uses windows",
 		taskRun: &v1.TaskRun{Spec: v1.TaskRunSpec{PodTemplate: &pod.Template{NodeSelector: map[string]string{
-			osSelectorLabel: "windows",
+			OsSelectorLabel: "windows",
 		}}}},
 		want: true,
 	}}

--- a/pkg/pod/script.go
+++ b/pkg/pod/script.go
@@ -87,13 +87,13 @@ func convertScripts(shellImageLinux string, shellImageWin string, steps []v1.Ste
 	shellImage := shellImageLinux
 	shellCommand := "sh"
 	shellArg := "-c"
-	securityContext := linuxSecurityContext
+	securityContext := LinuxSecurityContext
 	// Set windows variants for Image, Command and Args
 	if requiresWindows {
 		shellImage = shellImageWin
 		shellCommand = "pwsh"
 		shellArg = "-Command"
-		securityContext = windowsSecurityContext
+		securityContext = WindowsSecurityContext
 	}
 
 	placeScriptsInit := corev1.Container{

--- a/pkg/pod/script_test.go
+++ b/pkg/pod/script_test.go
@@ -159,7 +159,7 @@ _EOF_
 /tekton/bin/entrypoint decode-script "${scriptfile}"
 `},
 		VolumeMounts:    []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
-		SecurityContext: linuxSecurityContext,
+		SecurityContext: LinuxSecurityContext,
 	}
 	want := []corev1.Container{{
 		Image:        "step-1",
@@ -465,7 +465,7 @@ fi
 debug-fail-continue-heredoc-randomly-generated-6nl7g
 `},
 				VolumeMounts:    []corev1.VolumeMount{writeScriptsVolumeMount, binMount, debugScriptsVolumeMount},
-				SecurityContext: linuxSecurityContext,
+				SecurityContext: LinuxSecurityContext,
 			},
 			wantSteps: []corev1.Container{{
 				Image:   "step-1",
@@ -608,7 +608,7 @@ fi
 debug-beforestep-fail-continue-heredoc-randomly-generated-6nl7g
 `},
 				VolumeMounts:    []corev1.VolumeMount{writeScriptsVolumeMount, binMount, debugScriptsVolumeMount},
-				SecurityContext: linuxSecurityContext},
+				SecurityContext: LinuxSecurityContext},
 			wantSteps: []corev1.Container{{
 				Name:    "step-1",
 				Image:   "step-1",
@@ -690,7 +690,7 @@ _EOF_
 /tekton/bin/entrypoint decode-script "${scriptfile}"
 `},
 		VolumeMounts:    []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
-		SecurityContext: linuxSecurityContext,
+		SecurityContext: LinuxSecurityContext,
 	}
 	want := []corev1.Container{{
 		Image:        "step-1",
@@ -777,7 +777,7 @@ no-shebang
 "@ | Out-File -FilePath /tekton/scripts/script-3-mssqb.cmd
 `},
 		VolumeMounts:    []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
-		SecurityContext: windowsSecurityContext,
+		SecurityContext: WindowsSecurityContext,
 	}
 	want := []corev1.Container{{
 		Image:        "step-1",
@@ -860,7 +860,7 @@ sidecar-1
 "@ | Out-File -FilePath /tekton/scripts/sidecar-script-0-mssqb
 `},
 		VolumeMounts:    []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
-		SecurityContext: windowsSecurityContext,
+		SecurityContext: WindowsSecurityContext,
 	}
 	want := []corev1.Container{{
 		Image:        "step-1",
@@ -922,7 +922,7 @@ sidecar-1
 "@ | Out-File -FilePath /tekton/scripts/sidecar-script-0-9l9zj
 `},
 		VolumeMounts:    []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
-		SecurityContext: windowsSecurityContext,
+		SecurityContext: WindowsSecurityContext,
 	}
 	want := []corev1.Container{{
 		Image: "step-1",

--- a/pkg/pod/workingdir_init.go
+++ b/pkg/pod/workingdir_init.go
@@ -60,9 +60,9 @@ func workingDirInit(workingdirinitImage string, stepContainers []corev1.Containe
 		// There are no workingDirs to initialize.
 		return nil
 	}
-	securityContext := linuxSecurityContext
+	securityContext := LinuxSecurityContext
 	if windows {
-		securityContext = windowsSecurityContext
+		securityContext = WindowsSecurityContext
 	}
 
 	c := &corev1.Container{

--- a/pkg/pod/workingdir_init_test.go
+++ b/pkg/pod/workingdir_init_test.go
@@ -90,7 +90,7 @@ func TestWorkingDirInit(t *testing.T) {
 			Args:            []string{"/workspace/bbb", "aaa", "zzz"},
 			WorkingDir:      pipeline.WorkspaceDir,
 			VolumeMounts:    implicitVolumeMounts,
-			SecurityContext: linuxSecurityContext,
+			SecurityContext: LinuxSecurityContext,
 		},
 	}, {
 		desc: "workingDirs are unique and sorted, absolute dirs are ignored, uses windows",
@@ -144,7 +144,7 @@ func TestWorkingDirInit(t *testing.T) {
 			Args:            []string{"/workspace/bbb", "aaa", "zzz"},
 			WorkingDir:      pipeline.WorkspaceDir,
 			VolumeMounts:    implicitVolumeMounts,
-			SecurityContext: windowsSecurityContext,
+			SecurityContext: WindowsSecurityContext,
 		},
 	}} {
 		t.Run(c.desc, func(t *testing.T) {


### PR DESCRIPTION
Solves https://github.com/tektoncd/pipeline/issues/8181

Needed for this issue: https://github.com/tektoncd/pipeline/issues/8183

# Changes

Added container securityContext for affinity assistant when feature flag `set-security-context` is set to true. 
Implemented for both windows and linux OS. )

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Affinity Assistant containers will now have a securityContext when feature flag `set-security-context` is enabled in ConfigMap `feature-flags`.
```
