### PR TITLE
cluster-reslover: add support for StepAction

### DIFF
--- a/pkg/resolution/resolver/cluster/resolver.go
+++ b/pkg/resolution/resolver/cluster/resolver.go
@@ -25,6 +25,7 @@ import (
 
 	resolverconfig "github.com/tektoncd/pipeline/pkg/apis/config/resolver"
 	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	pipelinev1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	clientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	pipelineclient "github.com/tektoncd/pipeline/pkg/client/injection/client"
 	common "github.com/tektoncd/pipeline/pkg/resolution/common"
@@ -109,6 +110,16 @@ func ResolveFromParams(ctx context.Context, origParams []pipelinev1.Param, pipel
 	groupVersion := pipelinev1.SchemeGroupVersion.String()
 
 	switch params[KindParam] {
+	case "stepaction":
+		stepaction, err := pipelineClientSet.TektonV1beta1().StepActions(params[NamespaceParam]).Get(ctx, params[NameParam], metav1.GetOptions{})
+		if err != nil {
+			logger.Infof("failed to load stepaction %s from namespace %s: %v", params[NameParam], params[NamespaceParam], err)
+			return nil, err
+		}
+		uid, data, sha256Checksum, spec, err = fetchStepaction(ctx, pipelinev1beta1.SchemeGroupVersion.String(), stepaction, params)
+		if err != nil {
+			return nil, err
+		}
 	case "task":
 		task, err := pipelineClientSet.TektonV1().Tasks(params[NamespaceParam]).Get(ctx, params[NameParam], metav1.GetOptions{})
 		if err != nil {
@@ -269,6 +280,7 @@ func isInCommaSeparatedList(checkVal string, commaList string) bool {
 	}
 	return false
 }
+
 func isDisabled(ctx context.Context) bool {
 	cfg := resolverconfig.FromContextOrDefaults(ctx)
 	return !cfg.FeatureFlags.EnableClusterResolver
@@ -281,6 +293,29 @@ func ValidateParams(ctx context.Context, params []pipelinev1.Param) error {
 
 	_, err := populateParamsWithDefaults(ctx, params)
 	return err
+}
+
+func fetchStepaction(ctx context.Context, groupVersion string, stepaction *pipelinev1beta1.StepAction, params map[string]string) (string, []byte, []byte, []byte, error) {
+	logger := logging.FromContext(ctx)
+	uid := string(stepaction.UID)
+	stepaction.Kind = "StepAction"
+	stepaction.APIVersion = groupVersion
+	data, err := yaml.Marshal(stepaction)
+	if err != nil {
+		logger.Infof("failed to marshal stepaction %s from namespace %s: %v", params[NameParam], params[NamespaceParam], err)
+		return "", nil, nil, nil, err
+	}
+	sha256Checksum, err := stepaction.Checksum()
+	if err != nil {
+		return "", nil, nil, nil, err
+	}
+
+	spec, err := yaml.Marshal(stepaction.Spec)
+	if err != nil {
+		logger.Infof("failed to marshal the spec of the task %s from namespace %s: %v", params[NameParam], params[NamespaceParam], err)
+		return "", nil, nil, nil, err
+	}
+	return uid, data, sha256Checksum, spec, nil
 }
 
 func fetchTask(ctx context.Context, groupVersion string, task *pipelinev1.Task, params map[string]string) (string, []byte, []byte, []byte, error) {
@@ -305,6 +340,7 @@ func fetchTask(ctx context.Context, groupVersion string, task *pipelinev1.Task, 
 	}
 	return uid, data, sha256Checksum, spec, nil
 }
+
 func fetchPipeline(ctx context.Context, groupVersion string, pipeline *pipelinev1.Pipeline, params map[string]string) (string, []byte, []byte, []byte, error) {
 	logger := logging.FromContext(ctx)
 	uid := string(pipeline.UID)


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This adds support for `StepAction` in the cluster resolver.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/kind feature
/wip

- [ ] Needs updated docs
- [ ] Needs some unit tests

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
StepAction are now supported to a refered via the cluster resolver.
```
