### PR TITLE
check namespace config for node throttle metric

### DIFF
--- a/pkg/taskrunmetrics/metrics.go
+++ b/pkg/taskrunmetrics/metrics.go
@@ -528,7 +528,11 @@ func (r *Recorder) RunningTaskRuns(ctx context.Context, lister listers.TaskRunLi
 		metrics.Record(ctx, runningTRsThrottledByQuota.M(float64(cnt)))
 	}
 	for ns, cnt := range trsThrottledByNode {
-		ctx, err := tag.New(ctx, []tag.Mutator{tag.Insert(namespaceTag, ns)}...)
+		var mutators []tag.Mutator
+		if addNamespaceLabelToQuotaThrottleMetric {
+			mutators = []tag.Mutator{tag.Insert(namespaceTag, ns)}
+		}
+		ctx, err := tag.New(ctx, mutators...)
 		if err != nil {
 			return err
 		}

--- a/pkg/taskrunmetrics/metrics_test.go
+++ b/pkg/taskrunmetrics/metrics_test.go
@@ -584,6 +584,18 @@ func TestRecordRunningTaskRunsThrottledCounts(t *testing.T) {
 			nodeCount: 3,
 		},
 		{
+			status:     corev1.ConditionUnknown,
+			reason:     pod.ReasonExceededResourceQuota,
+			quotaCount: 3,
+			addNS:      true,
+		},
+		{
+			status:    corev1.ConditionUnknown,
+			reason:    pod.ReasonExceededNodeResources,
+			nodeCount: 3,
+			addNS:     true,
+		},
+		{
 			status:    corev1.ConditionUnknown,
 			reason:    v1.TaskRunReasonResolvingTaskRef,
 			waitCount: 3,


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Now that @vdemeester 's fix so that the background metric polling goroutines for pipelinerunmetrics and taskrunmetrics can access config.observability, we can properly address issue around verifiying non-default config around adding the namespace label for the node and quota throttle metrics that @divyansh42 @khrm and myself discovered last week.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [Y ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [Y ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ Y] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [Y ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [/ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [n/a ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [n/a ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
With this fix the 'config-observabilitiy' configmap setting 'metrics.taskrun.throttle.enable-namespace' is now checked before incrementing the 'tekton_pipelines_controller_running_taskruns_throttled_by_node', where previously that config value was not being checked for the metric.
```
