### PR TITLE
Fix Artifact type to a pointer

### DIFF
--- a/pkg/apis/pipeline/v1/artifact_types_test.go
+++ b/pkg/apis/pipeline/v1/artifact_types_test.go
@@ -182,7 +182,7 @@ func TestArtifactsMerge(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			tc.a1.Merge(tc.a2)
+			tc.a1.Merge(&tc.a2)
 			got := tc.a1
 			if d := cmp.Diff(tc.expected, got, cmpopts.SortSlices(func(a, b Artifact) bool { return a.Name > b.Name })); d != "" {
 				t.Errorf("TestArtifactsMerge() did not produce expected artifacts for test %s: %s", tc.name, diff.PrintWantGot(d))

--- a/pkg/apis/pipeline/v1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1/openapi_generated.go
@@ -4239,7 +4239,6 @@ func schema_pkg_apis_pipeline_v1_TaskRunStatus(ref common.ReferenceCallback) com
 						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Artifacts are the list of artifacts written out by the task's containers",
-							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Artifacts"),
 						},
 					},
@@ -4391,7 +4390,6 @@ func schema_pkg_apis_pipeline_v1_TaskRunStatusFields(ref common.ReferenceCallbac
 						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Artifacts are the list of artifacts written out by the task's containers",
-							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Artifacts"),
 						},
 					},

--- a/pkg/apis/pipeline/v1/swagger.json
+++ b/pkg/apis/pipeline/v1/swagger.json
@@ -2137,7 +2137,6 @@
         },
         "artifacts": {
           "description": "Artifacts are the list of artifacts written out by the task's containers",
-          "default": {},
           "$ref": "#/definitions/v1.Artifacts",
           "x-kubernetes-list-type": "atomic"
         },
@@ -2232,7 +2231,6 @@
       "properties": {
         "artifacts": {
           "description": "Artifacts are the list of artifacts written out by the task's containers",
-          "default": {},
           "$ref": "#/definitions/v1.Artifacts",
           "x-kubernetes-list-type": "atomic"
         },

--- a/pkg/apis/pipeline/v1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1/taskrun_types.go
@@ -300,7 +300,7 @@ type TaskRunStatusFields struct {
 	// Artifacts are the list of artifacts written out by the task's containers
 	// +optional
 	// +listType=atomic
-	Artifacts Artifacts `json:"artifacts,omitempty"`
+	Artifacts *Artifacts `json:"artifacts,omitempty"`
 
 	// The list has one entry per sidecar in the manifest. Each entry is
 	// represents the imageid of the corresponding sidecar.

--- a/pkg/apis/pipeline/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/pipeline/v1/zz_generated.deepcopy.go
@@ -1939,7 +1939,11 @@ func (in *TaskRunStatusFields) DeepCopyInto(out *TaskRunStatusFields) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	in.Artifacts.DeepCopyInto(&out.Artifacts)
+	if in.Artifacts != nil {
+		in, out := &in.Artifacts, &out.Artifacts
+		*out = new(Artifacts)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Sidecars != nil {
 		in, out := &in.Sidecars, &out.Sidecars
 		*out = make([]SidecarState, len(*in))

--- a/pkg/pod/status.go
+++ b/pkg/pod/status.go
@@ -260,7 +260,7 @@ func setTaskRunStatusBasedOnStepStatus(ctx context.Context, logger *zap.SugaredL
 			logger.Errorf("Failed to set artifacts value from sidecar logs: %v", err)
 			merr = multierror.Append(merr, err)
 		} else {
-			trs.Artifacts = tras
+			trs.Artifacts = &tras
 		}
 	}
 
@@ -343,8 +343,8 @@ func setTaskRunStatusBasedOnStepStatus(ctx context.Context, logger *zap.SugaredL
 						logger.Errorf("error setting step artifacts in taskrun %q: %v", tr.Name, err)
 						merr = multierror.Append(merr, err)
 					}
-					trs.Artifacts.Merge(tras)
-					trs.Artifacts.Merge(sas)
+					trs.Artifacts.Merge(&tras)
+					trs.Artifacts.Merge(&sas)
 				}
 				msg, err = createMessageFromResults(filteredResults)
 				if err != nil {

--- a/pkg/pod/status_test.go
+++ b/pkg/pod/status_test.go
@@ -311,7 +311,8 @@ func TestMakeTaskRunStatus_StepResults(t *testing.T) {
 						Value: *v1.NewStructuredValues("https://foo.bar\n"),
 					}},
 				}},
-				Sidecars: []v1.SidecarState{},
+				Sidecars:  []v1.SidecarState{},
+				Artifacts: &v1.Artifacts{},
 				Results: []v1.TaskRunResult{{
 					Name:  "task-result",
 					Type:  v1.ResultsTypeString,
@@ -376,7 +377,8 @@ func TestMakeTaskRunStatus_StepResults(t *testing.T) {
 						Value: *v1.NewStructuredValues("hello", "world"),
 					}},
 				}},
-				Sidecars: []v1.SidecarState{},
+				Sidecars:  []v1.SidecarState{},
+				Artifacts: &v1.Artifacts{},
 				Results: []v1.TaskRunResult{{
 					Name:  "resultName",
 					Type:  v1.ResultsTypeArray,
@@ -448,7 +450,8 @@ func TestMakeTaskRunStatus_StepResults(t *testing.T) {
 						Value: *v1.NewStructuredValues("resultValue"),
 					}},
 				}},
-				Sidecars: []v1.SidecarState{},
+				Sidecars:  []v1.SidecarState{},
+				Artifacts: &v1.Artifacts{},
 				Results: []v1.TaskRunResult{{
 					Name:  "resultDigest",
 					Type:  v1.ResultsTypeString,
@@ -553,7 +556,8 @@ func TestMakeTaskRunStatus_StepProvenance(t *testing.T) {
 						Digest: map[string]string{"sha256": "digest"},
 					}},
 				}},
-				Sidecars: []v1.SidecarState{},
+				Sidecars:  []v1.SidecarState{},
+				Artifacts: &v1.Artifacts{},
 				// We don't actually care about the time, just that it's not nil
 				CompletionTime: &metav1.Time{Time: time.Now()},
 			},
@@ -624,7 +628,8 @@ func TestMakeTaskRunStatus_StepProvenance(t *testing.T) {
 					Container: "step-two",
 					Results:   []v1.TaskRunResult{},
 				}},
-				Sidecars: []v1.SidecarState{},
+				Sidecars:  []v1.SidecarState{},
+				Artifacts: &v1.Artifacts{},
 				// We don't actually care about the time, just that it's not nil
 				CompletionTime: &metav1.Time{Time: time.Now()},
 			},
@@ -738,7 +743,7 @@ func TestMakeTaskRunStatus_StepArtifacts(t *testing.T) {
 						},
 						Results: []v1.TaskRunResult{},
 					}},
-					Artifacts: v1.Artifacts{
+					Artifacts: &v1.Artifacts{
 						Inputs: []v1.Artifact{
 							{
 								Name: "input-artifacts",
@@ -853,7 +858,8 @@ func TestMakeTaskRunStatus(t *testing.T) {
 					Name:      "state-name",
 					Container: "step-state-name",
 				}},
-				Sidecars: []v1.SidecarState{},
+				Sidecars:  []v1.SidecarState{},
+				Artifacts: &v1.Artifacts{},
 				// We don't actually care about the time, just that it's not nil
 				CompletionTime: &metav1.Time{Time: time.Now()},
 			},
@@ -891,7 +897,8 @@ func TestMakeTaskRunStatus(t *testing.T) {
 					Container: "step-state-name",
 					ImageID:   "image-id",
 				}},
-				Sidecars: []v1.SidecarState{},
+				Sidecars:  []v1.SidecarState{},
+				Artifacts: &v1.Artifacts{},
 				// We don't actually care about the time, just that it's not nil
 				CompletionTime: &metav1.Time{Time: time.Now()},
 			},
@@ -923,7 +930,8 @@ func TestMakeTaskRunStatus(t *testing.T) {
 					Container: "step-step-push",
 					ImageID:   "image-id",
 				}},
-				Sidecars: []v1.SidecarState{},
+				Sidecars:  []v1.SidecarState{},
+				Artifacts: &v1.Artifacts{},
 				// We don't actually care about the time, just that it's not nil
 				CompletionTime: &metav1.Time{Time: time.Now()},
 			},
@@ -984,7 +992,8 @@ func TestMakeTaskRunStatus(t *testing.T) {
 					Container: "step-failure",
 					ImageID:   "image-id",
 				}},
-				Sidecars: []v1.SidecarState{},
+				Sidecars:  []v1.SidecarState{},
+				Artifacts: &v1.Artifacts{},
 				// We don't actually care about the time, just that it's not nil
 				CompletionTime: &metav1.Time{Time: time.Now()},
 			},
@@ -998,7 +1007,8 @@ func TestMakeTaskRunStatus(t *testing.T) {
 		want: v1.TaskRunStatus{
 			Status: statusFailure(v1.TaskRunReasonFailed.String(), "boom"),
 			TaskRunStatusFields: v1.TaskRunStatusFields{
-				Sidecars: []v1.SidecarState{},
+				Sidecars:  []v1.SidecarState{},
+				Artifacts: &v1.Artifacts{},
 				// We don't actually care about the time, just that it's not nil
 				CompletionTime: &metav1.Time{Time: time.Now()},
 			},
@@ -1032,7 +1042,8 @@ func TestMakeTaskRunStatus(t *testing.T) {
 					Container: "step-step-push",
 					ImageID:   "image-id",
 				}},
-				Sidecars: []v1.SidecarState{},
+				Sidecars:  []v1.SidecarState{},
+				Artifacts: &v1.Artifacts{},
 				// We don't actually care about the time, just that it's not nil
 				CompletionTime: &metav1.Time{Time: time.Now()},
 			},
@@ -1043,7 +1054,8 @@ func TestMakeTaskRunStatus(t *testing.T) {
 		want: v1.TaskRunStatus{
 			Status: statusFailure(v1.TaskRunReasonFailed.String(), "build failed for unspecified reasons."),
 			TaskRunStatusFields: v1.TaskRunStatusFields{
-				Sidecars: []v1.SidecarState{},
+				Sidecars:  []v1.SidecarState{},
+				Artifacts: &v1.Artifacts{},
 				// We don't actually care about the time, just that it's not nil
 				CompletionTime: &metav1.Time{Time: time.Now()},
 			},
@@ -1146,7 +1158,8 @@ func TestMakeTaskRunStatus(t *testing.T) {
 		want: v1.TaskRunStatus{
 			Status: statusFailure(ReasonCreateContainerConfigError, "Failed to create pod due to config error"),
 			TaskRunStatusFields: v1.TaskRunStatusFields{
-				Sidecars: []v1.SidecarState{},
+				Sidecars:  []v1.SidecarState{},
+				Artifacts: &v1.Artifacts{},
 			},
 		},
 	}, {
@@ -1308,7 +1321,8 @@ func TestMakeTaskRunStatus(t *testing.T) {
 					Name:      "foo",
 					Container: "step-foo",
 				}},
-				Sidecars: []v1.SidecarState{},
+				Sidecars:  []v1.SidecarState{},
+				Artifacts: &v1.Artifacts{},
 				// We don't actually care about the time, just that it's not nil
 				CompletionTime: &metav1.Time{Time: time.Now()},
 			},
@@ -1338,7 +1352,8 @@ func TestMakeTaskRunStatus(t *testing.T) {
 					Name:      "bar",
 					Container: "step-bar",
 				}},
-				Sidecars: []v1.SidecarState{},
+				Sidecars:  []v1.SidecarState{},
+				Artifacts: &v1.Artifacts{},
 				Results: []v1.TaskRunResult{{
 					Name:  "resultName",
 					Type:  v1.ResultsTypeString,
@@ -1373,7 +1388,8 @@ func TestMakeTaskRunStatus(t *testing.T) {
 					Name:      "banana",
 					Container: "step-banana",
 				}},
-				Sidecars: []v1.SidecarState{},
+				Sidecars:  []v1.SidecarState{},
+				Artifacts: &v1.Artifacts{},
 				Results: []v1.TaskRunResult{{
 					Name:  "resultName",
 					Type:  v1.ResultsTypeString,
@@ -1423,7 +1439,8 @@ func TestMakeTaskRunStatus(t *testing.T) {
 					Name:      "two",
 					Container: "step-two",
 				}},
-				Sidecars: []v1.SidecarState{},
+				Sidecars:  []v1.SidecarState{},
+				Artifacts: &v1.Artifacts{},
 				Results: []v1.TaskRunResult{{
 					Name:  "resultNameOne",
 					Type:  v1.ResultsTypeString,
@@ -1463,6 +1480,7 @@ func TestMakeTaskRunStatus(t *testing.T) {
 					Container: "step-task-result",
 				}},
 				Sidecars:       []v1.SidecarState{},
+				Artifacts:      &v1.Artifacts{},
 				CompletionTime: &metav1.Time{Time: time.Now()},
 				Results: []v1.TaskRunResult{{
 					Name:  "resultName",
@@ -1492,7 +1510,8 @@ func TestMakeTaskRunStatus(t *testing.T) {
 					Name:      "mango",
 					Container: "step-mango",
 				}},
-				Sidecars: []v1.SidecarState{},
+				Sidecars:  []v1.SidecarState{},
+				Artifacts: &v1.Artifacts{},
 				// We don't actually care about the time, just that it's not nil
 				CompletionTime: &metav1.Time{Time: time.Now()},
 			},
@@ -1520,7 +1539,8 @@ func TestMakeTaskRunStatus(t *testing.T) {
 					Name:      "pineapple",
 					Container: "step-pineapple",
 				}},
-				Sidecars: []v1.SidecarState{},
+				Sidecars:  []v1.SidecarState{},
+				Artifacts: &v1.Artifacts{},
 				// We don't actually care about the time, just that it's not nil
 				CompletionTime: &metav1.Time{Time: time.Now()},
 			},
@@ -1550,7 +1570,8 @@ func TestMakeTaskRunStatus(t *testing.T) {
 					Name:      "pear",
 					Container: "step-pear",
 				}},
-				Sidecars: []v1.SidecarState{},
+				Sidecars:  []v1.SidecarState{},
+				Artifacts: &v1.Artifacts{},
 				Results: []v1.TaskRunResult{{
 					Name:  "resultNameThree",
 					Type:  v1.ResultsTypeString,
@@ -1585,7 +1606,8 @@ func TestMakeTaskRunStatus(t *testing.T) {
 					Name:      "pear",
 					Container: "step-pear",
 				}},
-				Sidecars: []v1.SidecarState{},
+				Sidecars:  []v1.SidecarState{},
+				Artifacts: &v1.Artifacts{},
 				Results: []v1.TaskRunResult{{
 					Name:  "resultNameThree",
 					Type:  v1.ResultsTypeString,
@@ -1678,7 +1700,8 @@ func TestMakeTaskRunStatus(t *testing.T) {
 					Name:      "fourth",
 					Container: "step-fourth",
 				}},
-				Sidecars: []v1.SidecarState{},
+				Sidecars:  []v1.SidecarState{},
+				Artifacts: &v1.Artifacts{},
 				// We don't actually care about the time, just that it's not nil
 				CompletionTime: &metav1.Time{Time: time.Now()},
 			},
@@ -1734,7 +1757,8 @@ func TestMakeTaskRunStatus(t *testing.T) {
 					Name:      "second",
 					Container: "step-second",
 				}},
-				Sidecars: []v1.SidecarState{},
+				Sidecars:  []v1.SidecarState{},
+				Artifacts: &v1.Artifacts{},
 				// We don't actually care about the time, just that it's not nil
 				CompletionTime: &metav1.Time{Time: time.Now()},
 			},
@@ -1830,6 +1854,7 @@ func TestMakeTaskRunStatus(t *testing.T) {
 					ImageID:   "image-id-A",
 				}},
 				Sidecars:       []v1.SidecarState{},
+				Artifacts:      &v1.Artifacts{},
 				CompletionTime: &metav1.Time{Time: time.Now()},
 			},
 		},
@@ -1877,6 +1902,7 @@ func TestMakeTaskRunStatus(t *testing.T) {
 					Container: "step-A",
 				}},
 				Sidecars:       []v1.SidecarState{},
+				Artifacts:      &v1.Artifacts{},
 				CompletionTime: &metav1.Time{Time: time.Now()},
 			},
 		},
@@ -2173,7 +2199,8 @@ func TestMakeTaskRunStatusAlpha(t *testing.T) {
 					Name:      "bar",
 					Container: "step-bar",
 				}},
-				Sidecars: []v1.SidecarState{},
+				Sidecars:  []v1.SidecarState{},
+				Artifacts: &v1.Artifacts{},
 				Results: []v1.TaskRunResult{{
 					Name:  "resultName",
 					Type:  v1.ResultsTypeString,
@@ -2216,7 +2243,8 @@ func TestMakeTaskRunStatusAlpha(t *testing.T) {
 					Name:      "bar",
 					Container: "step-bar",
 				}},
-				Sidecars: []v1.SidecarState{},
+				Sidecars:  []v1.SidecarState{},
+				Artifacts: &v1.Artifacts{},
 				Results: []v1.TaskRunResult{{
 					Name:  "resultName",
 					Type:  v1.ResultsTypeString,
@@ -2259,7 +2287,8 @@ func TestMakeTaskRunStatusAlpha(t *testing.T) {
 					Name:      "bar",
 					Container: "step-bar",
 				}},
-				Sidecars: []v1.SidecarState{},
+				Sidecars:  []v1.SidecarState{},
+				Artifacts: &v1.Artifacts{},
 				Results: []v1.TaskRunResult{{
 					Name:  "resultName",
 					Type:  v1.ResultsTypeArray,
@@ -2302,7 +2331,8 @@ func TestMakeTaskRunStatusAlpha(t *testing.T) {
 					Name:      "bar",
 					Container: "step-bar",
 				}},
-				Sidecars: []v1.SidecarState{},
+				Sidecars:  []v1.SidecarState{},
+				Artifacts: &v1.Artifacts{},
 				Results: []v1.TaskRunResult{{
 					Name:  "resultName",
 					Type:  v1.ResultsTypeObject,
@@ -2349,7 +2379,8 @@ func TestMakeTaskRunStatusAlpha(t *testing.T) {
 					Name:      "bar",
 					Container: "step-bar",
 				}},
-				Sidecars: []v1.SidecarState{},
+				Sidecars:  []v1.SidecarState{},
+				Artifacts: &v1.Artifacts{},
 				Results: []v1.TaskRunResult{{
 					Name:  "resultName",
 					Type:  v1.ResultsTypeString,
@@ -2510,7 +2541,8 @@ func TestMakeRunStatusJSONError(t *testing.T) {
 				Results:   []v1.TaskRunResult{},
 				ImageID:   "image",
 			}},
-			Sidecars: []v1.SidecarState{},
+			Sidecars:  []v1.SidecarState{},
+			Artifacts: &v1.Artifacts{},
 			// We don't actually care about the time, just that it's not nil
 			CompletionTime: &metav1.Time{Time: time.Now()},
 		},

--- a/pkg/reconciler/pipelinerun/resources/apply.go
+++ b/pkg/reconciler/pipelinerun/resources/apply.go
@@ -450,24 +450,26 @@ func PropagateArtifacts(rpt *ResolvedPipelineTask, runStates PipelineRunState) e
 	}
 	stringReplacements := map[string]string{}
 	for taskName, artifacts := range runStates.GetTaskRunsArtifacts() {
-		for i, input := range artifacts.Inputs {
-			ib, err := json.Marshal(input.Values)
-			if err != nil {
-				return err
+		if artifacts != nil {
+			for i, input := range artifacts.Inputs {
+				ib, err := json.Marshal(input.Values)
+				if err != nil {
+					return err
+				}
+				stringReplacements[fmt.Sprintf("tasks.%s.inputs.%s", taskName, input.Name)] = string(ib)
+				if i == 0 {
+					stringReplacements[fmt.Sprintf("tasks.%s.inputs", taskName)] = string(ib)
+				}
 			}
-			stringReplacements[fmt.Sprintf("tasks.%s.inputs.%s", taskName, input.Name)] = string(ib)
-			if i == 0 {
-				stringReplacements[fmt.Sprintf("tasks.%s.inputs", taskName)] = string(ib)
-			}
-		}
-		for i, output := range artifacts.Outputs {
-			ob, err := json.Marshal(output.Values)
-			if err != nil {
-				return err
-			}
-			stringReplacements[fmt.Sprintf("tasks.%s.outputs.%s", taskName, output.Name)] = string(ob)
-			if i == 0 {
-				stringReplacements[fmt.Sprintf("tasks.%s.outputs", taskName)] = string(ob)
+			for i, output := range artifacts.Outputs {
+				ob, err := json.Marshal(output.Values)
+				if err != nil {
+					return err
+				}
+				stringReplacements[fmt.Sprintf("tasks.%s.outputs.%s", taskName, output.Name)] = string(ob)
+				if i == 0 {
+					stringReplacements[fmt.Sprintf("tasks.%s.outputs", taskName)] = string(ob)
+				}
 			}
 		}
 	}

--- a/pkg/reconciler/pipelinerun/resources/apply_test.go
+++ b/pkg/reconciler/pipelinerun/resources/apply_test.go
@@ -4814,7 +4814,7 @@ func TestPropagateArtifacts(t *testing.T) {
 									},
 								},
 								TaskRunStatusFields: v1.TaskRunStatusFields{
-									Artifacts: v1.Artifacts{
+									Artifacts: &v1.Artifacts{
 										Inputs:  []v1.Artifact{{Name: "source", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}},
 										Outputs: nil,
 									},
@@ -4870,7 +4870,7 @@ func TestPropagateArtifacts(t *testing.T) {
 									},
 								},
 								TaskRunStatusFields: v1.TaskRunStatusFields{
-									Artifacts: v1.Artifacts{
+									Artifacts: &v1.Artifacts{
 										Inputs:  []v1.Artifact{{Name: "source", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}},
 										Outputs: []v1.Artifact{{Name: "image", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}},
 									},

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
@@ -176,8 +176,8 @@ func (state PipelineRunState) GetTaskRunsResults() map[string][]v1.TaskRunResult
 
 // GetTaskRunsArtifacts returns a map of all successfully completed TaskRuns in the state, with the pipeline task name as
 // the key and the artifacts from the corresponding TaskRun as the value. It only includes tasks which have completed successfully.
-func (state PipelineRunState) GetTaskRunsArtifacts() map[string]v1.Artifacts {
-	results := make(map[string]v1.Artifacts)
+func (state PipelineRunState) GetTaskRunsArtifacts() map[string]*v1.Artifacts {
+	results := make(map[string]*v1.Artifacts)
 	for _, rpt := range state {
 		if rpt.IsCustomTask() {
 			continue
@@ -190,7 +190,7 @@ func (state PipelineRunState) GetTaskRunsArtifacts() map[string]v1.Artifacts {
 			for _, tr := range rpt.TaskRuns {
 				ars.Merge(tr.Status.Artifacts)
 			}
-			results[rpt.PipelineTask.Name] = ars
+			results[rpt.PipelineTask.Name] = &ars
 		} else {
 			results[rpt.PipelineTask.Name] = rpt.TaskRuns[0].Status.Artifacts
 		}

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
@@ -3167,7 +3167,7 @@ func TestPipelineRunState_GetTaskRunsArtifacts(t *testing.T) {
 	testCases := []struct {
 		name              string
 		state             PipelineRunState
-		expectedArtifacts map[string]v1.Artifacts
+		expectedArtifacts map[string]*v1.Artifacts
 	}{
 		{
 			name: "successful-task-with-artifacts",
@@ -3183,14 +3183,14 @@ func TestPipelineRunState_GetTaskRunsArtifacts(t *testing.T) {
 							Status: corev1.ConditionTrue,
 						}}},
 						TaskRunStatusFields: v1.TaskRunStatusFields{
-							Artifacts: v1.Artifacts{
+							Artifacts: &v1.Artifacts{
 								Inputs:  []v1.Artifact{{Name: "source", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}},
 								Outputs: []v1.Artifact{{Name: "image", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}},
 							},
 						}},
 				}},
 			}},
-			expectedArtifacts: map[string]v1.Artifacts{"successful-task-with-artifacts-1": {
+			expectedArtifacts: map[string]*v1.Artifacts{"successful-task-with-artifacts-1": {
 				Inputs:  []v1.Artifact{{Name: "source", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}},
 				Outputs: []v1.Artifact{{Name: "image", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}},
 			}},
@@ -3209,7 +3209,7 @@ func TestPipelineRunState_GetTaskRunsArtifacts(t *testing.T) {
 							Status: corev1.ConditionTrue,
 						}}},
 						TaskRunStatusFields: v1.TaskRunStatusFields{
-							Artifacts: v1.Artifacts{
+							Artifacts: &v1.Artifacts{
 								Inputs:  []v1.Artifact{{Name: "source", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}},
 								Outputs: []v1.Artifact{{Name: "image", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}},
 							},
@@ -3227,14 +3227,14 @@ func TestPipelineRunState_GetTaskRunsArtifacts(t *testing.T) {
 							Status: corev1.ConditionTrue,
 						}}},
 						TaskRunStatusFields: v1.TaskRunStatusFields{
-							Artifacts: v1.Artifacts{
+							Artifacts: &v1.Artifacts{
 								Inputs:  []v1.Artifact{{Name: "source2", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}},
 								Outputs: []v1.Artifact{{Name: "image2", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}},
 							},
 						}},
 				}},
 			}},
-			expectedArtifacts: map[string]v1.Artifacts{"successful-task-with-artifacts-1": {
+			expectedArtifacts: map[string]*v1.Artifacts{"successful-task-with-artifacts-1": {
 				Inputs:  []v1.Artifact{{Name: "source", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}},
 				Outputs: []v1.Artifact{{Name: "image", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}},
 			}, "successful-task-with-artifacts-2": {
@@ -3256,14 +3256,14 @@ func TestPipelineRunState_GetTaskRunsArtifacts(t *testing.T) {
 							Status: corev1.ConditionFalse,
 						}}},
 						TaskRunStatusFields: v1.TaskRunStatusFields{
-							Artifacts: v1.Artifacts{
+							Artifacts: &v1.Artifacts{
 								Inputs:  []v1.Artifact{{Name: "source", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}},
 								Outputs: []v1.Artifact{{Name: "image", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}},
 							},
 						}},
 				}},
 			}},
-			expectedArtifacts: map[string]v1.Artifacts{},
+			expectedArtifacts: map[string]*v1.Artifacts{},
 		},
 		{
 			name: "One successful task and one failed task, only retrieving artifacts from the successful one",
@@ -3280,7 +3280,7 @@ func TestPipelineRunState_GetTaskRunsArtifacts(t *testing.T) {
 								Status: corev1.ConditionTrue,
 							}}},
 							TaskRunStatusFields: v1.TaskRunStatusFields{
-								Artifacts: v1.Artifacts{
+								Artifacts: &v1.Artifacts{
 									Inputs:  []v1.Artifact{{Name: "source", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}},
 									Outputs: []v1.Artifact{{Name: "image", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}},
 								},
@@ -3299,14 +3299,14 @@ func TestPipelineRunState_GetTaskRunsArtifacts(t *testing.T) {
 								Status: corev1.ConditionFalse,
 							}}},
 							TaskRunStatusFields: v1.TaskRunStatusFields{
-								Artifacts: v1.Artifacts{
+								Artifacts: &v1.Artifacts{
 									Inputs:  []v1.Artifact{{Name: "source0", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}},
 									Outputs: []v1.Artifact{{Name: "image0", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}},
 								},
 							}},
 					}},
 				}},
-			expectedArtifacts: map[string]v1.Artifacts{"successful-task-with-artifacts-1": {
+			expectedArtifacts: map[string]*v1.Artifacts{"successful-task-with-artifacts-1": {
 				Inputs:  []v1.Artifact{{Name: "source", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}},
 				Outputs: []v1.Artifact{{Name: "image", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}},
 			}},
@@ -3342,7 +3342,7 @@ func TestPipelineRunState_GetTaskRunsArtifacts(t *testing.T) {
 								Status: corev1.ConditionTrue,
 							}}},
 							TaskRunStatusFields: v1.TaskRunStatusFields{
-								Artifacts: v1.Artifacts{
+								Artifacts: &v1.Artifacts{
 									Inputs:  []v1.Artifact{{Name: "source", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}},
 									Outputs: []v1.Artifact{{Name: "image", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}},
 								},
@@ -3350,7 +3350,7 @@ func TestPipelineRunState_GetTaskRunsArtifacts(t *testing.T) {
 					}},
 				},
 			},
-			expectedArtifacts: map[string]v1.Artifacts{"successful-task-with-artifacts-1": {
+			expectedArtifacts: map[string]*v1.Artifacts{"successful-task-with-artifacts-1": {
 				Inputs:  []v1.Artifact{{Name: "source", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}},
 				Outputs: []v1.Artifact{{Name: "image", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}},
 			}},
@@ -3390,7 +3390,7 @@ func TestPipelineRunState_GetTaskRunsArtifacts(t *testing.T) {
 							Reason: v1.TaskRunReasonSuccessful.String(),
 						}}},
 						TaskRunStatusFields: v1.TaskRunStatusFields{
-							Artifacts: v1.Artifacts{
+							Artifacts: &v1.Artifacts{
 								Inputs:  []v1.Artifact{{Name: "source1", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}},
 								Outputs: []v1.Artifact{{Name: "image1", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}},
 							},
@@ -3405,7 +3405,7 @@ func TestPipelineRunState_GetTaskRunsArtifacts(t *testing.T) {
 							Reason: v1.TaskRunReasonSuccessful.String(),
 						}}},
 						TaskRunStatusFields: v1.TaskRunStatusFields{
-							Artifacts: v1.Artifacts{
+							Artifacts: &v1.Artifacts{
 								Inputs:  []v1.Artifact{{Name: "source2", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}},
 								Outputs: []v1.Artifact{{Name: "image2", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}},
 							},
@@ -3420,7 +3420,7 @@ func TestPipelineRunState_GetTaskRunsArtifacts(t *testing.T) {
 							Reason: v1.TaskRunReasonSuccessful.String(),
 						}}},
 						TaskRunStatusFields: v1.TaskRunStatusFields{
-							Artifacts: v1.Artifacts{
+							Artifacts: &v1.Artifacts{
 								Inputs:  []v1.Artifact{{Name: "source3", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}},
 								Outputs: []v1.Artifact{{Name: "image3", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}},
 							},
@@ -3435,14 +3435,14 @@ func TestPipelineRunState_GetTaskRunsArtifacts(t *testing.T) {
 							Reason: v1.TaskRunReasonSuccessful.String(),
 						}}},
 						TaskRunStatusFields: v1.TaskRunStatusFields{
-							Artifacts: v1.Artifacts{
+							Artifacts: &v1.Artifacts{
 								Inputs:  []v1.Artifact{{Name: "source4", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}},
 								Outputs: []v1.Artifact{{Name: "image4", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}},
 							},
 						}},
 				}},
 			}},
-			expectedArtifacts: map[string]v1.Artifacts{"matrixed-task-with-artifacts": {
+			expectedArtifacts: map[string]*v1.Artifacts{"matrixed-task-with-artifacts": {
 				Inputs:  []v1.Artifact{{Name: "source1", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}, {Name: "source2", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}, {Name: "source3", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}, {Name: "source4", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}},
 				Outputs: []v1.Artifact{{Name: "image1", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}, {Name: "image2", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}, {Name: "image3", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}, {Name: "image4", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}},
 			}},

--- a/test/conversion_test.go
+++ b/test/conversion_test.go
@@ -35,7 +35,7 @@ import (
 var (
 	filterLabels                   = cmpopts.IgnoreFields(metav1.ObjectMeta{}, "Labels")
 	filterAnnotations              = cmpopts.IgnoreFields(metav1.ObjectMeta{}, "Annotations")
-	filterV1TaskRunStatus          = cmpopts.IgnoreFields(v1.TaskRunStatusFields{}, "StartTime", "CompletionTime")
+	filterV1TaskRunStatus          = cmpopts.IgnoreFields(v1.TaskRunStatusFields{}, "StartTime", "CompletionTime", "Artifacts")
 	filterV1PipelineRunStatus      = cmpopts.IgnoreFields(v1.PipelineRunStatusFields{}, "StartTime", "CompletionTime")
 	filterV1beta1TaskRunStatus     = cmpopts.IgnoreFields(v1beta1.TaskRunStatusFields{}, "StartTime", "CompletionTime")
 	filterV1beta1PipelineRunStatus = cmpopts.IgnoreFields(v1beta1.PipelineRunStatusFields{}, "StartTime", "CompletionTime")

--- a/test/larger_results_sidecar_logs_test.go
+++ b/test/larger_results_sidecar_logs_test.go
@@ -437,6 +437,7 @@ status:
   sidecars:
     - name: tekton-log-results
       container: sidecar-tekton-log-results
+  artifacts: {}
 `, namespace, strings.Repeat("a", 2000), strings.Repeat("b", 2000), strings.Repeat("a", 2000), strings.Repeat("b", 2000), strings.Repeat("a", 2000), strings.Repeat("b", 2000)))
 	taskRun2 := parse.MustParseV1TaskRun(t, fmt.Sprintf(`
 metadata:
@@ -490,6 +491,7 @@ status:
   sidecars:
     - name: tekton-log-results
       container: sidecar-tekton-log-results
+  artifacts: {}
 `, namespace, strings.Repeat("d", 2000), strings.Repeat("c", 2000), strings.Repeat("d", 2000), strings.Repeat("c", 2000), strings.Repeat("d", 2000)))
 	taskRun3 := parse.MustParseV1TaskRun(t, fmt.Sprintf(`
 metadata:
@@ -552,6 +554,7 @@ status:
   sidecars:
     - name: tekton-log-results
       container: sidecar-tekton-log-results
+  artifacts: {}
 `, namespace, strings.Repeat("a", 2000), strings.Repeat("d", 2000), strings.Repeat("a", 2000), strings.Repeat("d", 2000), strings.Repeat("a", 2000), strings.Repeat("d", 2000)))
 	taskRun4 := parse.MustParseV1TaskRun(t, fmt.Sprintf(`
 metadata:
@@ -604,6 +607,7 @@ status:
   sidecars:
     - name: tekton-log-results
       container: sidecar-tekton-log-results
+  artifacts: {}
 `, namespace, strings.Repeat("e", 2000), strings.Repeat("f", 2000), strings.Repeat("e", 2000), strings.Repeat("f", 2000), strings.Repeat("e", 2000), strings.Repeat("f", 2000)))
 	return pipelineRun, expectedPipelineRun, []*v1.TaskRun{taskRun1, taskRun2, taskRun3, taskRun4}
 }

--- a/test/matrix_test.go
+++ b/test/matrix_test.go
@@ -206,6 +206,9 @@ spec:
 				Reason:  "Succeeded",
 				Message: "All Steps have completed executing",
 			}}},
+			TaskRunStatusFields: v1.TaskRunStatusFields{
+				Artifacts: &v1.Artifacts{},
+			},
 		},
 	}, {
 		ObjectMeta: metav1.ObjectMeta{
@@ -235,6 +238,9 @@ spec:
 				Reason:  "Succeeded",
 				Message: "All Steps have completed executing",
 			}}},
+			TaskRunStatusFields: v1.TaskRunStatusFields{
+				Artifacts: &v1.Artifacts{},
+			},
 		},
 	}, {
 		ObjectMeta: metav1.ObjectMeta{
@@ -261,6 +267,9 @@ spec:
 				Reason:  "Succeeded",
 				Message: "All Steps have completed executing",
 			}}},
+			TaskRunStatusFields: v1.TaskRunStatusFields{
+				Artifacts: &v1.Artifacts{},
+			},
 		},
 	}, {
 		ObjectMeta: metav1.ObjectMeta{
@@ -287,6 +296,9 @@ spec:
 				Reason:  "Succeeded",
 				Message: "All Steps have completed executing",
 			}}},
+			TaskRunStatusFields: v1.TaskRunStatusFields{
+				Artifacts: &v1.Artifacts{},
+			},
 		},
 	}, {
 		ObjectMeta: metav1.ObjectMeta{
@@ -307,6 +319,9 @@ spec:
 				Reason:  "Succeeded",
 				Message: "All Steps have completed executing",
 			}}},
+			TaskRunStatusFields: v1.TaskRunStatusFields{
+				Artifacts: &v1.Artifacts{},
+			},
 		},
 	}, {
 		ObjectMeta: metav1.ObjectMeta{
@@ -323,6 +338,7 @@ spec:
 					Type:  "array",
 					Value: v1.ParamValue{Type: v1.ParamTypeArray, ArrayVal: []string{"linux/amd64", "linux/ppc64le"}},
 				}},
+				Artifacts: &v1.Artifacts{},
 			},
 			Status: duckv1.Status{Conditions: []apis.Condition{{
 				Type:    apis.ConditionSucceeded,
@@ -346,6 +362,7 @@ spec:
 					Type:  "array",
 					Value: v1.ParamValue{Type: v1.ParamTypeArray, ArrayVal: []string{"go1.17", "go1.18.1"}},
 				}},
+				Artifacts: &v1.Artifacts{},
 			},
 			Status: duckv1.Status{Conditions: []apis.Condition{{
 				Type:    apis.ConditionSucceeded,

--- a/test/propagated_params_test.go
+++ b/test/propagated_params_test.go
@@ -215,6 +215,7 @@ spec:
         script: echo Hello World!
 status:
    podName: propagated-parameters-fully-echo-hello-pod
+   artifacts: {}
    steps:
      - name: echo
        container: step-echo
@@ -236,6 +237,7 @@ spec:
         image: mirror.gcr.io/ubuntu
         script: echo Hello World!
 status:
+   artifacts: {}
    podName: propagated-parameters-fully-echo-hello-finally-pod
    steps:
      - name: echo
@@ -320,6 +322,7 @@ spec:
         image: mirror.gcr.io/ubuntu
         script: echo Hello World!
 status:
+  artifacts: {}
   podName: propagated-parameters-task-level-echo-hello-pod
   steps:
     - name: echo
@@ -408,6 +411,7 @@ spec:
         image: mirror.gcr.io/ubuntu
         script: echo Hello World!
 status:
+  artifacts: {}
   podName: propagated-parameters-default-task-level-echo-hello-pod
   steps:
     - name: echo

--- a/test/propagated_results_test.go
+++ b/test/propagated_results_test.go
@@ -362,6 +362,7 @@ spec:
       name: add-map-uid
   timeout: 1h0m0s
 status:
+  artifacts: {}
   podName: propagated-all-type-results-make-uid-pod
   results:
   - name: strUid
@@ -453,6 +454,7 @@ spec:
       name: show-map-uid
   timeout: 1h0m0s
 status:
+  artifacts: {}
   podName: propagated-all-type-results-show-uid-pod
   steps:
   - container: step-show-str-uid

--- a/test/stepaction_results_test.go
+++ b/test/stepaction_results_test.go
@@ -189,6 +189,7 @@ status:
       status: "True"
       reason: "Succeeded"
   podName: step-results-task-run-pod
+  artifacts: {}
   taskSpec:
     steps:
       - name: step1

--- a/test/upgrade_test.go
+++ b/test/upgrade_test.go
@@ -155,6 +155,7 @@ status:
     terminationReason: Completed
     terminated:
       reason: Completed
+  artifacts: {}
 `
 
 	expectedSimplePipelineRunYaml = `


### PR DESCRIPTION
Prior to this, the Artifacts in TaskRunStatusFields was not set to a pointer of the underlying struct. As a result, it was incompatible with `tkn`. Here we fix that issue by updating it to a `pointer`.

Fixes https://github.com/tektoncd/pipeline/issues/8225

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Fix Artifact type to a pointer.
```
