### PR TITLE
[release-v0.62.x] Fix Artifact type to a pointer

### DIFF
--- a/pkg/apis/pipeline/v1/artifact_types_test.go
+++ b/pkg/apis/pipeline/v1/artifact_types_test.go
@@ -182,7 +182,7 @@ func TestArtifactsMerge(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			tc.a1.Merge(tc.a2)
+			tc.a1.Merge(&tc.a2)
 			got := tc.a1
 			if d := cmp.Diff(tc.expected, got, cmpopts.SortSlices(func(a, b Artifact) bool { return a.Name > b.Name })); d != "" {
 				t.Errorf("TestArtifactsMerge() did not produce expected artifacts for test %s: %s", tc.name, diff.PrintWantGot(d))

--- a/pkg/apis/pipeline/v1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1/openapi_generated.go
@@ -4214,7 +4214,6 @@ func schema_pkg_apis_pipeline_v1_TaskRunStatus(ref common.ReferenceCallback) com
 						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Artifacts are the list of artifacts written out by the task's containers",
-							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Artifacts"),
 						},
 					},
@@ -4366,7 +4365,6 @@ func schema_pkg_apis_pipeline_v1_TaskRunStatusFields(ref common.ReferenceCallbac
 						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Artifacts are the list of artifacts written out by the task's containers",
-							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Artifacts"),
 						},
 					},

--- a/pkg/apis/pipeline/v1/swagger.json
+++ b/pkg/apis/pipeline/v1/swagger.json
@@ -2125,7 +2125,6 @@
         },
         "artifacts": {
           "description": "Artifacts are the list of artifacts written out by the task's containers",
-          "default": {},
           "$ref": "#/definitions/v1.Artifacts",
           "x-kubernetes-list-type": "atomic"
         },
@@ -2220,7 +2219,6 @@
       "properties": {
         "artifacts": {
           "description": "Artifacts are the list of artifacts written out by the task's containers",
-          "default": {},
           "$ref": "#/definitions/v1.Artifacts",
           "x-kubernetes-list-type": "atomic"
         },

--- a/pkg/apis/pipeline/v1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1/taskrun_types.go
@@ -282,7 +282,7 @@ type TaskRunStatusFields struct {
 	// Artifacts are the list of artifacts written out by the task's containers
 	// +optional
 	// +listType=atomic
-	Artifacts Artifacts `json:"artifacts,omitempty"`
+	Artifacts *Artifacts `json:"artifacts,omitempty"`
 
 	// The list has one entry per sidecar in the manifest. Each entry is
 	// represents the imageid of the corresponding sidecar.

--- a/pkg/apis/pipeline/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/pipeline/v1/zz_generated.deepcopy.go
@@ -1934,7 +1934,11 @@ func (in *TaskRunStatusFields) DeepCopyInto(out *TaskRunStatusFields) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	in.Artifacts.DeepCopyInto(&out.Artifacts)
+	if in.Artifacts != nil {
+		in, out := &in.Artifacts, &out.Artifacts
+		*out = new(Artifacts)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Sidecars != nil {
 		in, out := &in.Sidecars, &out.Sidecars
 		*out = make([]SidecarState, len(*in))

--- a/pkg/pod/status.go
+++ b/pkg/pod/status.go
@@ -260,7 +260,7 @@ func setTaskRunStatusBasedOnStepStatus(ctx context.Context, logger *zap.SugaredL
 			logger.Errorf("Failed to set artifacts value from sidecar logs: %v", err)
 			merr = multierror.Append(merr, err)
 		} else {
-			trs.Artifacts = tras
+			trs.Artifacts = &tras
 		}
 	}
 
@@ -343,8 +343,8 @@ func setTaskRunStatusBasedOnStepStatus(ctx context.Context, logger *zap.SugaredL
 						logger.Errorf("error setting step artifacts in taskrun %q: %v", tr.Name, err)
 						merr = multierror.Append(merr, err)
 					}
-					trs.Artifacts.Merge(tras)
-					trs.Artifacts.Merge(sas)
+					trs.Artifacts.Merge(&tras)
+					trs.Artifacts.Merge(&sas)
 				}
 				msg, err = createMessageFromResults(filteredResults)
 				if err != nil {

--- a/pkg/pod/status_test.go
+++ b/pkg/pod/status_test.go
@@ -47,14 +47,15 @@ func TestSetTaskRunStatusBasedOnStepStatus(t *testing.T) {
 		ContainerStatuses []corev1.ContainerStatus
 	}{{
 		desc: "test result with large pipeline result",
-		ContainerStatuses: []corev1.ContainerStatus{{
-			Name: "step-bar-0",
-			State: corev1.ContainerState{
-				Terminated: &corev1.ContainerStateTerminated{
-					Message: `[{"key":"resultName","value":"resultValue", "type":1}, {"key":"digest","value":"sha256:1234","resourceName":"source-image"}]`,
+		ContainerStatuses: []corev1.ContainerStatus{
+			{
+				Name: "step-bar-0",
+				State: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{
+						Message: `[{"key":"resultName","value":"resultValue", "type":1}, {"key":"digest","value":"sha256:1234","resourceName":"source-image"}]`,
+					},
 				},
 			},
-		},
 			{
 				Name: "step-bar1",
 				State: corev1.ContainerState{
@@ -70,7 +71,8 @@ func TestSetTaskRunStatusBasedOnStepStatus(t *testing.T) {
 						Message: `[{"key":"resultName","value":"resultValue", "type":1}, {"key":"digest","value":"sha256:1234` + strings.Repeat("a", 3072) + `","resourceName":"source-image"}]`,
 					},
 				},
-			}},
+			},
+		},
 	}, {
 		desc: "The ExitCode in the result cannot modify the original ExitCode",
 		ContainerStatuses: []corev1.ContainerStatus{{
@@ -299,7 +301,8 @@ func TestMakeTaskRunStatus_StepResults(t *testing.T) {
 					ContainerState: corev1.ContainerState{
 						Terminated: &corev1.ContainerStateTerminated{
 							Message: `[{"key":"uri","value":"https://foo.bar\n","type":4}]`,
-						}},
+						},
+					},
 					Name:      "one",
 					Container: "step-one",
 					Results: []v1.TaskRunStepResult{{
@@ -308,7 +311,8 @@ func TestMakeTaskRunStatus_StepResults(t *testing.T) {
 						Value: *v1.NewStructuredValues("https://foo.bar\n"),
 					}},
 				}},
-				Sidecars: []v1.SidecarState{},
+				Sidecars:  []v1.SidecarState{},
+				Artifacts: &v1.Artifacts{},
 				Results: []v1.TaskRunResult{{
 					Name:  "task-result",
 					Type:  v1.ResultsTypeString,
@@ -363,7 +367,8 @@ func TestMakeTaskRunStatus_StepResults(t *testing.T) {
 					ContainerState: corev1.ContainerState{
 						Terminated: &corev1.ContainerStateTerminated{
 							Message: `[{"key":"array","value":"[\"hello\",\"world\"]","type":4}]`,
-						}},
+						},
+					},
 					Name:      "one",
 					Container: "step-one",
 					Results: []v1.TaskRunStepResult{{
@@ -372,7 +377,8 @@ func TestMakeTaskRunStatus_StepResults(t *testing.T) {
 						Value: *v1.NewStructuredValues("hello", "world"),
 					}},
 				}},
-				Sidecars: []v1.SidecarState{},
+				Sidecars:  []v1.SidecarState{},
+				Artifacts: &v1.Artifacts{},
 				Results: []v1.TaskRunResult{{
 					Name:  "resultName",
 					Type:  v1.ResultsTypeArray,
@@ -430,7 +436,8 @@ func TestMakeTaskRunStatus_StepResults(t *testing.T) {
 					ContainerState: corev1.ContainerState{
 						Terminated: &corev1.ContainerStateTerminated{
 							Message: `[{"key":"digest","value":"sha256:1234","type":4},{"key":"resultName","value":"resultValue","type":4}]`,
-						}},
+						},
+					},
 					Name:      "one",
 					Container: "step-one",
 					Results: []v1.TaskRunStepResult{{
@@ -443,7 +450,8 @@ func TestMakeTaskRunStatus_StepResults(t *testing.T) {
 						Value: *v1.NewStructuredValues("resultValue"),
 					}},
 				}},
-				Sidecars: []v1.SidecarState{},
+				Sidecars:  []v1.SidecarState{},
+				Artifacts: &v1.Artifacts{},
 				Results: []v1.TaskRunResult{{
 					Name:  "resultDigest",
 					Type:  v1.ResultsTypeString,
@@ -548,7 +556,8 @@ func TestMakeTaskRunStatus_StepProvenance(t *testing.T) {
 						Digest: map[string]string{"sha256": "digest"},
 					}},
 				}},
-				Sidecars: []v1.SidecarState{},
+				Sidecars:  []v1.SidecarState{},
+				Artifacts: &v1.Artifacts{},
 				// We don't actually care about the time, just that it's not nil
 				CompletionTime: &metav1.Time{Time: time.Now()},
 			},
@@ -619,7 +628,8 @@ func TestMakeTaskRunStatus_StepProvenance(t *testing.T) {
 					Container: "step-two",
 					Results:   []v1.TaskRunResult{},
 				}},
-				Sidecars: []v1.SidecarState{},
+				Sidecars:  []v1.SidecarState{},
+				Artifacts: &v1.Artifacts{},
 				// We don't actually care about the time, just that it's not nil
 				CompletionTime: &metav1.Time{Time: time.Now()},
 			},
@@ -702,55 +712,60 @@ func TestMakeTaskRunStatus_StepArtifacts(t *testing.T) {
 						ContainerState: corev1.ContainerState{
 							Terminated: &corev1.ContainerStateTerminated{
 								Message: `[{"key":"/tekton/run/0/status/artifacts/provenance.json","value":"{\n  \"inputs\":[\n    {\n      \"name\":\"input-artifacts\",\n      \"values\":[\n        {\n          \"uri\":\"git:jjjsss\",\n          \"digest\":{\n            \"sha256\":\"b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0\"\n          }\n        }\n      ]\n    }\n  ],\n  \"outputs\":[\n    {\n      \"name\":\"build-results\",\n      \"values\":[\n        {\n          \"uri\":\"pkg:balba\",\n          \"digest\":{\n            \"sha256\":\"df85b9e3983fe2ce20ef76ad675ecf435cc99fc9350adc54fa230bae8c32ce48\",\n            \"sha1\":\"95588b8f34c31eb7d62c92aaa4e6506639b06ef2\"\n          }\n        }\n      ]\n    }\n  ]\n}\n","type":5}]`,
-							}},
+							},
+						},
 						Name:      "one",
 						Container: "step-one",
 						Inputs: []v1.Artifact{
 							{
 								Name: "input-artifacts",
-								Values: []v1.ArtifactValue{{
-									Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"},
-									Uri:    "git:jjjsss",
-								},
+								Values: []v1.ArtifactValue{
+									{
+										Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"},
+										Uri:    "git:jjjsss",
+									},
 								},
 							},
 						},
 						Outputs: []v1.Artifact{
 							{
 								Name: "build-results",
-								Values: []v1.ArtifactValue{{
-									Digest: map[v1.Algorithm]string{
-										"sha1":   "95588b8f34c31eb7d62c92aaa4e6506639b06ef2",
-										"sha256": "df85b9e3983fe2ce20ef76ad675ecf435cc99fc9350adc54fa230bae8c32ce48",
+								Values: []v1.ArtifactValue{
+									{
+										Digest: map[v1.Algorithm]string{
+											"sha1":   "95588b8f34c31eb7d62c92aaa4e6506639b06ef2",
+											"sha256": "df85b9e3983fe2ce20ef76ad675ecf435cc99fc9350adc54fa230bae8c32ce48",
+										},
+										Uri: "pkg:balba",
 									},
-									Uri: "pkg:balba",
-								},
 								},
 							},
 						},
 						Results: []v1.TaskRunResult{},
 					}},
-					Artifacts: v1.Artifacts{
+					Artifacts: &v1.Artifacts{
 						Inputs: []v1.Artifact{
 							{
 								Name: "input-artifacts",
-								Values: []v1.ArtifactValue{{
-									Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"},
-									Uri:    "git:jjjsss",
-								},
+								Values: []v1.ArtifactValue{
+									{
+										Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"},
+										Uri:    "git:jjjsss",
+									},
 								},
 							},
 						},
 						Outputs: []v1.Artifact{
 							{
 								Name: "build-results",
-								Values: []v1.ArtifactValue{{
-									Digest: map[v1.Algorithm]string{
-										"sha1":   "95588b8f34c31eb7d62c92aaa4e6506639b06ef2",
-										"sha256": "df85b9e3983fe2ce20ef76ad675ecf435cc99fc9350adc54fa230bae8c32ce48",
+								Values: []v1.ArtifactValue{
+									{
+										Digest: map[v1.Algorithm]string{
+											"sha1":   "95588b8f34c31eb7d62c92aaa4e6506639b06ef2",
+											"sha256": "df85b9e3983fe2ce20ef76ad675ecf435cc99fc9350adc54fa230bae8c32ce48",
+										},
+										Uri: "pkg:balba",
 									},
-									Uri: "pkg:balba",
-								},
 								},
 							},
 						},
@@ -838,11 +853,13 @@ func TestMakeTaskRunStatus(t *testing.T) {
 					ContainerState: corev1.ContainerState{
 						Terminated: &corev1.ContainerStateTerminated{
 							ExitCode: 123,
-						}},
+						},
+					},
 					Name:      "state-name",
 					Container: "step-state-name",
 				}},
-				Sidecars: []v1.SidecarState{},
+				Sidecars:  []v1.SidecarState{},
+				Artifacts: nil,
 			},
 		},
 	}, {
@@ -872,12 +889,14 @@ func TestMakeTaskRunStatus(t *testing.T) {
 					ContainerState: corev1.ContainerState{
 						Terminated: &corev1.ContainerStateTerminated{
 							ExitCode: 123,
-						}},
+						},
+					},
 					Name:      "state-name",
 					Container: "step-state-name",
 					ImageID:   "image-id",
 				}},
-				Sidecars: []v1.SidecarState{},
+				Sidecars:  []v1.SidecarState{},
+				Artifacts: nil,
 			},
 		},
 	}, {
@@ -901,12 +920,14 @@ func TestMakeTaskRunStatus(t *testing.T) {
 					ContainerState: corev1.ContainerState{
 						Terminated: &corev1.ContainerStateTerminated{
 							ExitCode: 0,
-						}},
+						},
+					},
 					Name:      "step-push",
 					Container: "step-step-push",
 					ImageID:   "image-id",
 				}},
-				Sidecars: []v1.SidecarState{},
+				Sidecars:  []v1.SidecarState{},
+				Artifacts: &v1.Artifacts{},
 				// We don't actually care about the time, just that it's not nil
 				CompletionTime: &metav1.Time{Time: time.Now()},
 			},
@@ -960,13 +981,15 @@ func TestMakeTaskRunStatus(t *testing.T) {
 					ContainerState: corev1.ContainerState{
 						Terminated: &corev1.ContainerStateTerminated{
 							ExitCode: 123,
-						}},
+						},
+					},
 
 					Name:      "failure",
 					Container: "step-failure",
 					ImageID:   "image-id",
 				}},
-				Sidecars: []v1.SidecarState{},
+				Sidecars:  []v1.SidecarState{},
+				Artifacts: &v1.Artifacts{},
 				// We don't actually care about the time, just that it's not nil
 				CompletionTime: &metav1.Time{Time: time.Now()},
 			},
@@ -980,7 +1003,8 @@ func TestMakeTaskRunStatus(t *testing.T) {
 		want: v1.TaskRunStatus{
 			Status: statusFailure(v1.TaskRunReasonFailed.String(), "boom"),
 			TaskRunStatusFields: v1.TaskRunStatusFields{
-				Sidecars: []v1.SidecarState{},
+				Sidecars:  []v1.SidecarState{},
+				Artifacts: &v1.Artifacts{},
 				// We don't actually care about the time, just that it's not nil
 				CompletionTime: &metav1.Time{Time: time.Now()},
 			},
@@ -1008,12 +1032,14 @@ func TestMakeTaskRunStatus(t *testing.T) {
 						Terminated: &corev1.ContainerStateTerminated{
 							Reason:   "OOMKilled",
 							ExitCode: 0,
-						}},
+						},
+					},
 					Name:      "step-push",
 					Container: "step-step-push",
 					ImageID:   "image-id",
 				}},
-				Sidecars: []v1.SidecarState{},
+				Sidecars:  []v1.SidecarState{},
+				Artifacts: &v1.Artifacts{},
 				// We don't actually care about the time, just that it's not nil
 				CompletionTime: &metav1.Time{Time: time.Now()},
 			},
@@ -1024,7 +1050,8 @@ func TestMakeTaskRunStatus(t *testing.T) {
 		want: v1.TaskRunStatus{
 			Status: statusFailure(v1.TaskRunReasonFailed.String(), "build failed for unspecified reasons."),
 			TaskRunStatusFields: v1.TaskRunStatusFields{
-				Sidecars: []v1.SidecarState{},
+				Sidecars:  []v1.SidecarState{},
+				Artifacts: &v1.Artifacts{},
 				// We don't actually care about the time, just that it's not nil
 				CompletionTime: &metav1.Time{Time: time.Now()},
 			},
@@ -1127,7 +1154,8 @@ func TestMakeTaskRunStatus(t *testing.T) {
 		want: v1.TaskRunStatus{
 			Status: statusFailure(ReasonCreateContainerConfigError, "Failed to create pod due to config error"),
 			TaskRunStatusFields: v1.TaskRunStatusFields{
-				Sidecars: []v1.SidecarState{},
+				Sidecars:  []v1.SidecarState{},
+				Artifacts: &v1.Artifacts{},
 			},
 		},
 	}, {
@@ -1284,11 +1312,13 @@ func TestMakeTaskRunStatus(t *testing.T) {
 					ContainerState: corev1.ContainerState{
 						Terminated: &corev1.ContainerStateTerminated{
 							Message: `[{"key":"digest","value":"sha256:12345","resourceName":"source-image"}]`,
-						}},
+						},
+					},
 					Name:      "foo",
 					Container: "step-foo",
 				}},
-				Sidecars: []v1.SidecarState{},
+				Sidecars:  []v1.SidecarState{},
+				Artifacts: &v1.Artifacts{},
 				// We don't actually care about the time, just that it's not nil
 				CompletionTime: &metav1.Time{Time: time.Now()},
 			},
@@ -1313,11 +1343,13 @@ func TestMakeTaskRunStatus(t *testing.T) {
 					ContainerState: corev1.ContainerState{
 						Terminated: &corev1.ContainerStateTerminated{
 							Message: `[{"key":"digest","value":"sha256:1234","resourceName":"source-image"},{"key":"resultName","value":"resultValue","type":1}]`,
-						}},
+						},
+					},
 					Name:      "bar",
 					Container: "step-bar",
 				}},
-				Sidecars: []v1.SidecarState{},
+				Sidecars:  []v1.SidecarState{},
+				Artifacts: &v1.Artifacts{},
 				Results: []v1.TaskRunResult{{
 					Name:  "resultName",
 					Type:  v1.ResultsTypeString,
@@ -1347,11 +1379,13 @@ func TestMakeTaskRunStatus(t *testing.T) {
 					ContainerState: corev1.ContainerState{
 						Terminated: &corev1.ContainerStateTerminated{
 							Message: `[{"key":"digest","value":"sha256:1234","resourceName":"source-image"},{"key":"resultName","value":"resultValue","type":1}]`,
-						}},
+						},
+					},
 					Name:      "banana",
 					Container: "step-banana",
 				}},
-				Sidecars: []v1.SidecarState{},
+				Sidecars:  []v1.SidecarState{},
+				Artifacts: &v1.Artifacts{},
 				Results: []v1.TaskRunResult{{
 					Name:  "resultName",
 					Type:  v1.ResultsTypeString,
@@ -1388,18 +1422,21 @@ func TestMakeTaskRunStatus(t *testing.T) {
 					ContainerState: corev1.ContainerState{
 						Terminated: &corev1.ContainerStateTerminated{
 							Message: `[{"key":"resultNameOne","value":"resultValueOne","type":1},{"key":"resultNameTwo","value":"resultValueTwo","type":1}]`,
-						}},
+						},
+					},
 					Name:      "one",
 					Container: "step-one",
 				}, {
 					ContainerState: corev1.ContainerState{
 						Terminated: &corev1.ContainerStateTerminated{
 							Message: `[{"key":"resultNameOne","value":"resultValueThree","type":1},{"key":"resultNameTwo","value":"resultValueTwo","type":1}]`,
-						}},
+						},
+					},
 					Name:      "two",
 					Container: "step-two",
 				}},
-				Sidecars: []v1.SidecarState{},
+				Sidecars:  []v1.SidecarState{},
+				Artifacts: &v1.Artifacts{},
 				Results: []v1.TaskRunResult{{
 					Name:  "resultNameOne",
 					Type:  v1.ResultsTypeString,
@@ -1439,6 +1476,7 @@ func TestMakeTaskRunStatus(t *testing.T) {
 					Container: "step-task-result",
 				}},
 				Sidecars:       []v1.SidecarState{},
+				Artifacts:      &v1.Artifacts{},
 				CompletionTime: &metav1.Time{Time: time.Now()},
 				Results: []v1.TaskRunResult{{
 					Name:  "resultName",
@@ -1463,11 +1501,13 @@ func TestMakeTaskRunStatus(t *testing.T) {
 			TaskRunStatusFields: v1.TaskRunStatusFields{
 				Steps: []v1.StepState{{
 					ContainerState: corev1.ContainerState{
-						Terminated: &corev1.ContainerStateTerminated{}},
+						Terminated: &corev1.ContainerStateTerminated{},
+					},
 					Name:      "mango",
 					Container: "step-mango",
 				}},
-				Sidecars: []v1.SidecarState{},
+				Sidecars:  []v1.SidecarState{},
+				Artifacts: &v1.Artifacts{},
 				// We don't actually care about the time, just that it's not nil
 				CompletionTime: &metav1.Time{Time: time.Now()},
 			},
@@ -1490,11 +1530,13 @@ func TestMakeTaskRunStatus(t *testing.T) {
 			TaskRunStatusFields: v1.TaskRunStatusFields{
 				Steps: []v1.StepState{{
 					ContainerState: corev1.ContainerState{
-						Terminated: &corev1.ContainerStateTerminated{}},
+						Terminated: &corev1.ContainerStateTerminated{},
+					},
 					Name:      "pineapple",
 					Container: "step-pineapple",
 				}},
-				Sidecars: []v1.SidecarState{},
+				Sidecars:  []v1.SidecarState{},
+				Artifacts: &v1.Artifacts{},
 				// We don't actually care about the time, just that it's not nil
 				CompletionTime: &metav1.Time{Time: time.Now()},
 			},
@@ -1507,7 +1549,8 @@ func TestMakeTaskRunStatus(t *testing.T) {
 				Name: "step-pear",
 				State: corev1.ContainerState{
 					Terminated: &corev1.ContainerStateTerminated{
-						Message: `[{"key":"resultNameOne","value":"","type":3}, {"key":"resultNameThree","value":"","type":1}]`},
+						Message: `[{"key":"resultNameOne","value":"","type":3}, {"key":"resultNameThree","value":"","type":1}]`,
+					},
 				},
 			}},
 		},
@@ -1518,11 +1561,13 @@ func TestMakeTaskRunStatus(t *testing.T) {
 					ContainerState: corev1.ContainerState{
 						Terminated: &corev1.ContainerStateTerminated{
 							Message: `[{"key":"resultNameThree","value":"","type":1}]`,
-						}},
+						},
+					},
 					Name:      "pear",
 					Container: "step-pear",
 				}},
-				Sidecars: []v1.SidecarState{},
+				Sidecars:  []v1.SidecarState{},
+				Artifacts: &v1.Artifacts{},
 				Results: []v1.TaskRunResult{{
 					Name:  "resultNameThree",
 					Type:  v1.ResultsTypeString,
@@ -1552,11 +1597,13 @@ func TestMakeTaskRunStatus(t *testing.T) {
 					ContainerState: corev1.ContainerState{
 						Terminated: &corev1.ContainerStateTerminated{
 							Message: `[{"key":"resultNameThree","value":"","type":1}]`,
-						}},
+						},
+					},
 					Name:      "pear",
 					Container: "step-pear",
 				}},
-				Sidecars: []v1.SidecarState{},
+				Sidecars:  []v1.SidecarState{},
+				Artifacts: &v1.Artifacts{},
 				Results: []v1.TaskRunResult{{
 					Name:  "resultNameThree",
 					Type:  v1.ResultsTypeString,
@@ -1626,26 +1673,31 @@ func TestMakeTaskRunStatus(t *testing.T) {
 					Container: "step-first",
 				}, {
 					ContainerState: corev1.ContainerState{
-						Terminated: &corev1.ContainerStateTerminated{}},
+						Terminated: &corev1.ContainerStateTerminated{},
+					},
 					Name:      "second",
 					Container: "step-second",
 				}, {
 					ContainerState: corev1.ContainerState{
-						Terminated: &corev1.ContainerStateTerminated{}},
+						Terminated: &corev1.ContainerStateTerminated{},
+					},
 					Name:      "third",
 					Container: "step-third",
 				}, {
 					ContainerState: corev1.ContainerState{
-						Terminated: &corev1.ContainerStateTerminated{}},
+						Terminated: &corev1.ContainerStateTerminated{},
+					},
 					Name:      "",
 					Container: "step-",
 				}, {
 					ContainerState: corev1.ContainerState{
-						Terminated: &corev1.ContainerStateTerminated{}},
+						Terminated: &corev1.ContainerStateTerminated{},
+					},
 					Name:      "fourth",
 					Container: "step-fourth",
 				}},
-				Sidecars: []v1.SidecarState{},
+				Sidecars:  []v1.SidecarState{},
+				Artifacts: &v1.Artifacts{},
 				// We don't actually care about the time, just that it's not nil
 				CompletionTime: &metav1.Time{Time: time.Now()},
 			},
@@ -1696,11 +1748,13 @@ func TestMakeTaskRunStatus(t *testing.T) {
 					ContainerState: corev1.ContainerState{
 						Terminated: &corev1.ContainerStateTerminated{
 							ExitCode: 0,
-						}},
+						},
+					},
 					Name:      "second",
 					Container: "step-second",
 				}},
-				Sidecars: []v1.SidecarState{},
+				Sidecars:  []v1.SidecarState{},
+				Artifacts: &v1.Artifacts{},
 				// We don't actually care about the time, just that it's not nil
 				CompletionTime: &metav1.Time{Time: time.Now()},
 			},
@@ -1768,7 +1822,8 @@ func TestMakeTaskRunStatus(t *testing.T) {
 					State: corev1.ContainerState{
 						Terminated: &corev1.ContainerStateTerminated{
 							ExitCode: 1,
-						}},
+						},
+					},
 				}},
 				ContainerStatuses: []corev1.ContainerStatus{{
 					Name:    "step-A",
@@ -1795,6 +1850,7 @@ func TestMakeTaskRunStatus(t *testing.T) {
 					ImageID:   "image-id-A",
 				}},
 				Sidecars:       []v1.SidecarState{},
+				Artifacts:      &v1.Artifacts{},
 				CompletionTime: &metav1.Time{Time: time.Now()},
 			},
 		},
@@ -1817,15 +1873,17 @@ func TestMakeTaskRunStatus(t *testing.T) {
 				Phase:   corev1.PodFailed,
 				Reason:  "Evicted",
 				Message: `Usage of EmptyDir volume "ws-b6dfk" exceeds the limit "10Gi".`,
-				ContainerStatuses: []corev1.ContainerStatus{{
-					Name: "step-A",
-					State: corev1.ContainerState{
-						Terminated: &corev1.ContainerStateTerminated{
-							ExitCode: 137,
+				ContainerStatuses: []corev1.ContainerStatus{
+					{
+						Name: "step-A",
+						State: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{
+								ExitCode: 137,
+							},
 						},
 					},
 				},
-				}},
+			},
 		},
 		want: v1.TaskRunStatus{
 			Status: statusFailure(v1.TaskRunReasonFailed.String(), "Usage of EmptyDir volume \"ws-b6dfk\" exceeds the limit \"10Gi\"."),
@@ -1834,11 +1892,13 @@ func TestMakeTaskRunStatus(t *testing.T) {
 					ContainerState: corev1.ContainerState{
 						Terminated: &corev1.ContainerStateTerminated{
 							ExitCode: 137,
-						}},
+						},
+					},
 					Name:      "A",
 					Container: "step-A",
 				}},
 				Sidecars:       []v1.SidecarState{},
+				Artifacts:      &v1.Artifacts{},
 				CompletionTime: &metav1.Time{Time: time.Now()},
 			},
 		},
@@ -2130,11 +2190,13 @@ func TestMakeTaskRunStatusAlpha(t *testing.T) {
 					ContainerState: corev1.ContainerState{
 						Terminated: &corev1.ContainerStateTerminated{
 							Message: `[{"key":"digest","value":"sha256:1234","resourceName":"source-image"},{"key":"resultName","value":"","type":1}]`,
-						}},
+						},
+					},
 					Name:      "bar",
 					Container: "step-bar",
 				}},
-				Sidecars: []v1.SidecarState{},
+				Sidecars:  []v1.SidecarState{},
+				Artifacts: &v1.Artifacts{},
 				Results: []v1.TaskRunResult{{
 					Name:  "resultName",
 					Type:  v1.ResultsTypeString,
@@ -2172,11 +2234,13 @@ func TestMakeTaskRunStatusAlpha(t *testing.T) {
 					ContainerState: corev1.ContainerState{
 						Terminated: &corev1.ContainerStateTerminated{
 							Message: `[{"key":"digest","value":"sha256:1234","resourceName":"source-image"},{"key":"resultName","value":"hello","type":1}]`,
-						}},
+						},
+					},
 					Name:      "bar",
 					Container: "step-bar",
 				}},
-				Sidecars: []v1.SidecarState{},
+				Sidecars:  []v1.SidecarState{},
+				Artifacts: &v1.Artifacts{},
 				Results: []v1.TaskRunResult{{
 					Name:  "resultName",
 					Type:  v1.ResultsTypeString,
@@ -2214,11 +2278,13 @@ func TestMakeTaskRunStatusAlpha(t *testing.T) {
 					ContainerState: corev1.ContainerState{
 						Terminated: &corev1.ContainerStateTerminated{
 							Message: `[{"key":"digest","value":"sha256:1234","resourceName":"source-image"},{"key":"resultName","value":"[\"hello\",\"world\"]","type":1}]`,
-						}},
+						},
+					},
 					Name:      "bar",
 					Container: "step-bar",
 				}},
-				Sidecars: []v1.SidecarState{},
+				Sidecars:  []v1.SidecarState{},
+				Artifacts: &v1.Artifacts{},
 				Results: []v1.TaskRunResult{{
 					Name:  "resultName",
 					Type:  v1.ResultsTypeArray,
@@ -2256,11 +2322,13 @@ func TestMakeTaskRunStatusAlpha(t *testing.T) {
 					ContainerState: corev1.ContainerState{
 						Terminated: &corev1.ContainerStateTerminated{
 							Message: `[{"key":"digest","value":"sha256:1234","resourceName":"source-image"},{"key":"resultName","value":"{\"hello\":\"world\"}","type":1}]`,
-						}},
+						},
+					},
 					Name:      "bar",
 					Container: "step-bar",
 				}},
-				Sidecars: []v1.SidecarState{},
+				Sidecars:  []v1.SidecarState{},
+				Artifacts: &v1.Artifacts{},
 				Results: []v1.TaskRunResult{{
 					Name:  "resultName",
 					Type:  v1.ResultsTypeObject,
@@ -2302,11 +2370,13 @@ func TestMakeTaskRunStatusAlpha(t *testing.T) {
 					ContainerState: corev1.ContainerState{
 						Terminated: &corev1.ContainerStateTerminated{
 							Message: `[{"key":"resultName","value":"{\"hello\":\"world\"}","type":1},{"key":"resultName2","value":"[\"hello\",\"world\"]","type":1}]`,
-						}},
+						},
+					},
 					Name:      "bar",
 					Container: "step-bar",
 				}},
-				Sidecars: []v1.SidecarState{},
+				Sidecars:  []v1.SidecarState{},
+				Artifacts: &v1.Artifacts{},
 				Results: []v1.TaskRunResult{{
 					Name:  "resultName",
 					Type:  v1.ResultsTypeString,
@@ -2436,34 +2506,39 @@ func TestMakeRunStatusJSONError(t *testing.T) {
 					Terminated: &corev1.ContainerStateTerminated{
 						ExitCode: 1,
 						Message:  "this is a non-json termination message. dont panic!",
-					}},
+					},
+				},
 				Name:      "non-json",
 				Container: "step-non-json",
 				Results:   []v1.TaskRunResult{},
 				ImageID:   "image",
 			}, {
 				ContainerState: corev1.ContainerState{
-					Terminated: &corev1.ContainerStateTerminated{}},
+					Terminated: &corev1.ContainerStateTerminated{},
+				},
 				Name:      "after-non-json",
 				Container: "step-after-non-json",
 				Results:   []v1.TaskRunResult{},
 				ImageID:   "image",
 			}, {
 				ContainerState: corev1.ContainerState{
-					Terminated: &corev1.ContainerStateTerminated{}},
+					Terminated: &corev1.ContainerStateTerminated{},
+				},
 				Name:      "this-step-might-panic",
 				Container: "step-this-step-might-panic",
 				Results:   []v1.TaskRunResult{},
 				ImageID:   "image",
 			}, {
 				ContainerState: corev1.ContainerState{
-					Terminated: &corev1.ContainerStateTerminated{}},
+					Terminated: &corev1.ContainerStateTerminated{},
+				},
 				Name:      "foo",
 				Container: "step-foo",
 				Results:   []v1.TaskRunResult{},
 				ImageID:   "image",
 			}},
-			Sidecars: []v1.SidecarState{},
+			Sidecars:  []v1.SidecarState{},
+			Artifacts: &v1.Artifacts{},
 			// We don't actually care about the time, just that it's not nil
 			CompletionTime: &metav1.Time{Time: time.Now()},
 		},
@@ -2654,10 +2729,12 @@ func TestIsPodArchived(t *testing.T) {
 	}, {
 		name:    "Pod is in the retriesStatus",
 		podName: "pod",
-		retriesStatus: []v1.TaskRunStatus{{
-			TaskRunStatusFields: v1.TaskRunStatusFields{
-				PodName: "pod",
-			}},
+		retriesStatus: []v1.TaskRunStatus{
+			{
+				TaskRunStatusFields: v1.TaskRunStatusFields{
+					PodName: "pod",
+				},
+			},
 		},
 		want: true,
 	}} {

--- a/pkg/reconciler/pipelinerun/resources/apply.go
+++ b/pkg/reconciler/pipelinerun/resources/apply.go
@@ -450,24 +450,26 @@ func PropagateArtifacts(rpt *ResolvedPipelineTask, runStates PipelineRunState) e
 	}
 	stringReplacements := map[string]string{}
 	for taskName, artifacts := range runStates.GetTaskRunsArtifacts() {
-		for i, input := range artifacts.Inputs {
-			ib, err := json.Marshal(input.Values)
-			if err != nil {
-				return err
+		if artifacts != nil {
+			for i, input := range artifacts.Inputs {
+				ib, err := json.Marshal(input.Values)
+				if err != nil {
+					return err
+				}
+				stringReplacements[fmt.Sprintf("tasks.%s.inputs.%s", taskName, input.Name)] = string(ib)
+				if i == 0 {
+					stringReplacements[fmt.Sprintf("tasks.%s.inputs", taskName)] = string(ib)
+				}
 			}
-			stringReplacements[fmt.Sprintf("tasks.%s.inputs.%s", taskName, input.Name)] = string(ib)
-			if i == 0 {
-				stringReplacements[fmt.Sprintf("tasks.%s.inputs", taskName)] = string(ib)
-			}
-		}
-		for i, output := range artifacts.Outputs {
-			ob, err := json.Marshal(output.Values)
-			if err != nil {
-				return err
-			}
-			stringReplacements[fmt.Sprintf("tasks.%s.outputs.%s", taskName, output.Name)] = string(ob)
-			if i == 0 {
-				stringReplacements[fmt.Sprintf("tasks.%s.outputs", taskName)] = string(ob)
+			for i, output := range artifacts.Outputs {
+				ob, err := json.Marshal(output.Values)
+				if err != nil {
+					return err
+				}
+				stringReplacements[fmt.Sprintf("tasks.%s.outputs.%s", taskName, output.Name)] = string(ob)
+				if i == 0 {
+					stringReplacements[fmt.Sprintf("tasks.%s.outputs", taskName)] = string(ob)
+				}
 			}
 		}
 	}

--- a/pkg/reconciler/pipelinerun/resources/apply_test.go
+++ b/pkg/reconciler/pipelinerun/resources/apply_test.go
@@ -4813,7 +4813,7 @@ func TestPropagateArtifacts(t *testing.T) {
 									},
 								},
 								TaskRunStatusFields: v1.TaskRunStatusFields{
-									Artifacts: v1.Artifacts{
+									Artifacts: &v1.Artifacts{
 										Inputs:  []v1.Artifact{{Name: "source", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}},
 										Outputs: nil,
 									},
@@ -4869,7 +4869,7 @@ func TestPropagateArtifacts(t *testing.T) {
 									},
 								},
 								TaskRunStatusFields: v1.TaskRunStatusFields{
-									Artifacts: v1.Artifacts{
+									Artifacts: &v1.Artifacts{
 										Inputs:  []v1.Artifact{{Name: "source", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}},
 										Outputs: []v1.Artifact{{Name: "image", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}},
 									},

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
@@ -176,8 +176,8 @@ func (state PipelineRunState) GetTaskRunsResults() map[string][]v1.TaskRunResult
 
 // GetTaskRunsArtifacts returns a map of all successfully completed TaskRuns in the state, with the pipeline task name as
 // the key and the artifacts from the corresponding TaskRun as the value. It only includes tasks which have completed successfully.
-func (state PipelineRunState) GetTaskRunsArtifacts() map[string]v1.Artifacts {
-	results := make(map[string]v1.Artifacts)
+func (state PipelineRunState) GetTaskRunsArtifacts() map[string]*v1.Artifacts {
+	results := make(map[string]*v1.Artifacts)
 	for _, rpt := range state {
 		if rpt.IsCustomTask() {
 			continue
@@ -190,7 +190,7 @@ func (state PipelineRunState) GetTaskRunsArtifacts() map[string]v1.Artifacts {
 			for _, tr := range rpt.TaskRuns {
 				ars.Merge(tr.Status.Artifacts)
 			}
-			results[rpt.PipelineTask.Name] = ars
+			results[rpt.PipelineTask.Name] = &ars
 		} else {
 			results[rpt.PipelineTask.Name] = rpt.TaskRuns[0].Status.Artifacts
 		}

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
@@ -3167,7 +3167,7 @@ func TestPipelineRunState_GetTaskRunsArtifacts(t *testing.T) {
 	testCases := []struct {
 		name              string
 		state             PipelineRunState
-		expectedArtifacts map[string]v1.Artifacts
+		expectedArtifacts map[string]*v1.Artifacts
 	}{
 		{
 			name: "successful-task-with-artifacts",
@@ -3183,14 +3183,14 @@ func TestPipelineRunState_GetTaskRunsArtifacts(t *testing.T) {
 							Status: corev1.ConditionTrue,
 						}}},
 						TaskRunStatusFields: v1.TaskRunStatusFields{
-							Artifacts: v1.Artifacts{
+							Artifacts: &v1.Artifacts{
 								Inputs:  []v1.Artifact{{Name: "source", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}},
 								Outputs: []v1.Artifact{{Name: "image", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}},
 							},
 						}},
 				}},
 			}},
-			expectedArtifacts: map[string]v1.Artifacts{"successful-task-with-artifacts-1": {
+			expectedArtifacts: map[string]*v1.Artifacts{"successful-task-with-artifacts-1": {
 				Inputs:  []v1.Artifact{{Name: "source", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}},
 				Outputs: []v1.Artifact{{Name: "image", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}},
 			}},
@@ -3209,7 +3209,7 @@ func TestPipelineRunState_GetTaskRunsArtifacts(t *testing.T) {
 							Status: corev1.ConditionTrue,
 						}}},
 						TaskRunStatusFields: v1.TaskRunStatusFields{
-							Artifacts: v1.Artifacts{
+							Artifacts: &v1.Artifacts{
 								Inputs:  []v1.Artifact{{Name: "source", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}},
 								Outputs: []v1.Artifact{{Name: "image", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}},
 							},
@@ -3227,14 +3227,14 @@ func TestPipelineRunState_GetTaskRunsArtifacts(t *testing.T) {
 							Status: corev1.ConditionTrue,
 						}}},
 						TaskRunStatusFields: v1.TaskRunStatusFields{
-							Artifacts: v1.Artifacts{
+							Artifacts: &v1.Artifacts{
 								Inputs:  []v1.Artifact{{Name: "source2", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}},
 								Outputs: []v1.Artifact{{Name: "image2", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}},
 							},
 						}},
 				}},
 			}},
-			expectedArtifacts: map[string]v1.Artifacts{"successful-task-with-artifacts-1": {
+			expectedArtifacts: map[string]*v1.Artifacts{"successful-task-with-artifacts-1": {
 				Inputs:  []v1.Artifact{{Name: "source", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}},
 				Outputs: []v1.Artifact{{Name: "image", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}},
 			}, "successful-task-with-artifacts-2": {
@@ -3256,14 +3256,14 @@ func TestPipelineRunState_GetTaskRunsArtifacts(t *testing.T) {
 							Status: corev1.ConditionFalse,
 						}}},
 						TaskRunStatusFields: v1.TaskRunStatusFields{
-							Artifacts: v1.Artifacts{
+							Artifacts: &v1.Artifacts{
 								Inputs:  []v1.Artifact{{Name: "source", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}},
 								Outputs: []v1.Artifact{{Name: "image", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}},
 							},
 						}},
 				}},
 			}},
-			expectedArtifacts: map[string]v1.Artifacts{},
+			expectedArtifacts: map[string]*v1.Artifacts{},
 		},
 		{
 			name: "One successful task and one failed task, only retrieving artifacts from the successful one",
@@ -3280,7 +3280,7 @@ func TestPipelineRunState_GetTaskRunsArtifacts(t *testing.T) {
 								Status: corev1.ConditionTrue,
 							}}},
 							TaskRunStatusFields: v1.TaskRunStatusFields{
-								Artifacts: v1.Artifacts{
+								Artifacts: &v1.Artifacts{
 									Inputs:  []v1.Artifact{{Name: "source", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}},
 									Outputs: []v1.Artifact{{Name: "image", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}},
 								},
@@ -3299,14 +3299,14 @@ func TestPipelineRunState_GetTaskRunsArtifacts(t *testing.T) {
 								Status: corev1.ConditionFalse,
 							}}},
 							TaskRunStatusFields: v1.TaskRunStatusFields{
-								Artifacts: v1.Artifacts{
+								Artifacts: &v1.Artifacts{
 									Inputs:  []v1.Artifact{{Name: "source0", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}},
 									Outputs: []v1.Artifact{{Name: "image0", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}},
 								},
 							}},
 					}},
 				}},
-			expectedArtifacts: map[string]v1.Artifacts{"successful-task-with-artifacts-1": {
+			expectedArtifacts: map[string]*v1.Artifacts{"successful-task-with-artifacts-1": {
 				Inputs:  []v1.Artifact{{Name: "source", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}},
 				Outputs: []v1.Artifact{{Name: "image", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}},
 			}},
@@ -3342,7 +3342,7 @@ func TestPipelineRunState_GetTaskRunsArtifacts(t *testing.T) {
 								Status: corev1.ConditionTrue,
 							}}},
 							TaskRunStatusFields: v1.TaskRunStatusFields{
-								Artifacts: v1.Artifacts{
+								Artifacts: &v1.Artifacts{
 									Inputs:  []v1.Artifact{{Name: "source", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}},
 									Outputs: []v1.Artifact{{Name: "image", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}},
 								},
@@ -3350,7 +3350,7 @@ func TestPipelineRunState_GetTaskRunsArtifacts(t *testing.T) {
 					}},
 				},
 			},
-			expectedArtifacts: map[string]v1.Artifacts{"successful-task-with-artifacts-1": {
+			expectedArtifacts: map[string]*v1.Artifacts{"successful-task-with-artifacts-1": {
 				Inputs:  []v1.Artifact{{Name: "source", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}},
 				Outputs: []v1.Artifact{{Name: "image", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}},
 			}},
@@ -3390,7 +3390,7 @@ func TestPipelineRunState_GetTaskRunsArtifacts(t *testing.T) {
 							Reason: v1.TaskRunReasonSuccessful.String(),
 						}}},
 						TaskRunStatusFields: v1.TaskRunStatusFields{
-							Artifacts: v1.Artifacts{
+							Artifacts: &v1.Artifacts{
 								Inputs:  []v1.Artifact{{Name: "source1", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}},
 								Outputs: []v1.Artifact{{Name: "image1", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}},
 							},
@@ -3405,7 +3405,7 @@ func TestPipelineRunState_GetTaskRunsArtifacts(t *testing.T) {
 							Reason: v1.TaskRunReasonSuccessful.String(),
 						}}},
 						TaskRunStatusFields: v1.TaskRunStatusFields{
-							Artifacts: v1.Artifacts{
+							Artifacts: &v1.Artifacts{
 								Inputs:  []v1.Artifact{{Name: "source2", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}},
 								Outputs: []v1.Artifact{{Name: "image2", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}},
 							},
@@ -3420,7 +3420,7 @@ func TestPipelineRunState_GetTaskRunsArtifacts(t *testing.T) {
 							Reason: v1.TaskRunReasonSuccessful.String(),
 						}}},
 						TaskRunStatusFields: v1.TaskRunStatusFields{
-							Artifacts: v1.Artifacts{
+							Artifacts: &v1.Artifacts{
 								Inputs:  []v1.Artifact{{Name: "source3", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}},
 								Outputs: []v1.Artifact{{Name: "image3", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}},
 							},
@@ -3435,14 +3435,14 @@ func TestPipelineRunState_GetTaskRunsArtifacts(t *testing.T) {
 							Reason: v1.TaskRunReasonSuccessful.String(),
 						}}},
 						TaskRunStatusFields: v1.TaskRunStatusFields{
-							Artifacts: v1.Artifacts{
+							Artifacts: &v1.Artifacts{
 								Inputs:  []v1.Artifact{{Name: "source4", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}},
 								Outputs: []v1.Artifact{{Name: "image4", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}},
 							},
 						}},
 				}},
 			}},
-			expectedArtifacts: map[string]v1.Artifacts{"matrixed-task-with-artifacts": {
+			expectedArtifacts: map[string]*v1.Artifacts{"matrixed-task-with-artifacts": {
 				Inputs:  []v1.Artifact{{Name: "source1", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}, {Name: "source2", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}, {Name: "source3", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}, {Name: "source4", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha256": "b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"}, Uri: "pkg:example.github.com/inputs"}}}},
 				Outputs: []v1.Artifact{{Name: "image1", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}, {Name: "image2", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}, {Name: "image3", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}, {Name: "image4", Values: []v1.ArtifactValue{{Digest: map[v1.Algorithm]string{"sha1": "95588b8f34c31eb7d62c92aaa4e6506639b06ef2"}, Uri: "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c"}}}},
 			}},

--- a/test/conversion_test.go
+++ b/test/conversion_test.go
@@ -35,7 +35,7 @@ import (
 var (
 	filterLabels                   = cmpopts.IgnoreFields(metav1.ObjectMeta{}, "Labels")
 	filterAnnotations              = cmpopts.IgnoreFields(metav1.ObjectMeta{}, "Annotations")
-	filterV1TaskRunStatus          = cmpopts.IgnoreFields(v1.TaskRunStatusFields{}, "StartTime", "CompletionTime")
+	filterV1TaskRunStatus          = cmpopts.IgnoreFields(v1.TaskRunStatusFields{}, "StartTime", "CompletionTime", "Artifacts")
 	filterV1PipelineRunStatus      = cmpopts.IgnoreFields(v1.PipelineRunStatusFields{}, "StartTime", "CompletionTime")
 	filterV1beta1TaskRunStatus     = cmpopts.IgnoreFields(v1beta1.TaskRunStatusFields{}, "StartTime", "CompletionTime")
 	filterV1beta1PipelineRunStatus = cmpopts.IgnoreFields(v1beta1.PipelineRunStatusFields{}, "StartTime", "CompletionTime")

--- a/test/larger_results_sidecar_logs_test.go
+++ b/test/larger_results_sidecar_logs_test.go
@@ -437,6 +437,7 @@ status:
   sidecars:
     - name: tekton-log-results
       container: sidecar-tekton-log-results
+  artifacts: {}
 `, namespace, strings.Repeat("a", 2000), strings.Repeat("b", 2000), strings.Repeat("a", 2000), strings.Repeat("b", 2000), strings.Repeat("a", 2000), strings.Repeat("b", 2000)))
 	taskRun2 := parse.MustParseV1TaskRun(t, fmt.Sprintf(`
 metadata:
@@ -490,6 +491,7 @@ status:
   sidecars:
     - name: tekton-log-results
       container: sidecar-tekton-log-results
+  artifacts: {}
 `, namespace, strings.Repeat("d", 2000), strings.Repeat("c", 2000), strings.Repeat("d", 2000), strings.Repeat("c", 2000), strings.Repeat("d", 2000)))
 	taskRun3 := parse.MustParseV1TaskRun(t, fmt.Sprintf(`
 metadata:
@@ -552,6 +554,7 @@ status:
   sidecars:
     - name: tekton-log-results
       container: sidecar-tekton-log-results
+  artifacts: {}
 `, namespace, strings.Repeat("a", 2000), strings.Repeat("d", 2000), strings.Repeat("a", 2000), strings.Repeat("d", 2000), strings.Repeat("a", 2000), strings.Repeat("d", 2000)))
 	taskRun4 := parse.MustParseV1TaskRun(t, fmt.Sprintf(`
 metadata:
@@ -604,6 +607,7 @@ status:
   sidecars:
     - name: tekton-log-results
       container: sidecar-tekton-log-results
+  artifacts: {}
 `, namespace, strings.Repeat("e", 2000), strings.Repeat("f", 2000), strings.Repeat("e", 2000), strings.Repeat("f", 2000), strings.Repeat("e", 2000), strings.Repeat("f", 2000)))
 	return pipelineRun, expectedPipelineRun, []*v1.TaskRun{taskRun1, taskRun2, taskRun3, taskRun4}
 }

--- a/test/matrix_test.go
+++ b/test/matrix_test.go
@@ -206,6 +206,9 @@ spec:
 				Reason:  "Succeeded",
 				Message: "All Steps have completed executing",
 			}}},
+			TaskRunStatusFields: v1.TaskRunStatusFields{
+				Artifacts: &v1.Artifacts{},
+			},
 		},
 	}, {
 		ObjectMeta: metav1.ObjectMeta{
@@ -235,6 +238,9 @@ spec:
 				Reason:  "Succeeded",
 				Message: "All Steps have completed executing",
 			}}},
+			TaskRunStatusFields: v1.TaskRunStatusFields{
+				Artifacts: &v1.Artifacts{},
+			},
 		},
 	}, {
 		ObjectMeta: metav1.ObjectMeta{
@@ -261,6 +267,9 @@ spec:
 				Reason:  "Succeeded",
 				Message: "All Steps have completed executing",
 			}}},
+			TaskRunStatusFields: v1.TaskRunStatusFields{
+				Artifacts: &v1.Artifacts{},
+			},
 		},
 	}, {
 		ObjectMeta: metav1.ObjectMeta{
@@ -287,6 +296,9 @@ spec:
 				Reason:  "Succeeded",
 				Message: "All Steps have completed executing",
 			}}},
+			TaskRunStatusFields: v1.TaskRunStatusFields{
+				Artifacts: &v1.Artifacts{},
+			},
 		},
 	}, {
 		ObjectMeta: metav1.ObjectMeta{
@@ -307,6 +319,9 @@ spec:
 				Reason:  "Succeeded",
 				Message: "All Steps have completed executing",
 			}}},
+			TaskRunStatusFields: v1.TaskRunStatusFields{
+				Artifacts: &v1.Artifacts{},
+			},
 		},
 	}, {
 		ObjectMeta: metav1.ObjectMeta{
@@ -323,6 +338,7 @@ spec:
 					Type:  "array",
 					Value: v1.ParamValue{Type: v1.ParamTypeArray, ArrayVal: []string{"linux/amd64", "linux/ppc64le"}},
 				}},
+				Artifacts: &v1.Artifacts{},
 			},
 			Status: duckv1.Status{Conditions: []apis.Condition{{
 				Type:    apis.ConditionSucceeded,
@@ -346,6 +362,7 @@ spec:
 					Type:  "array",
 					Value: v1.ParamValue{Type: v1.ParamTypeArray, ArrayVal: []string{"go1.17", "go1.18.1"}},
 				}},
+				Artifacts: &v1.Artifacts{},
 			},
 			Status: duckv1.Status{Conditions: []apis.Condition{{
 				Type:    apis.ConditionSucceeded,

--- a/test/propagated_params_test.go
+++ b/test/propagated_params_test.go
@@ -215,6 +215,7 @@ spec:
         script: echo Hello World!
 status:
    podName: propagated-parameters-fully-echo-hello-pod
+   artifacts: {}
    steps:
      - name: echo
        container: step-echo
@@ -236,6 +237,7 @@ spec:
         image: mirror.gcr.io/ubuntu
         script: echo Hello World!
 status:
+   artifacts: {}
    podName: propagated-parameters-fully-echo-hello-finally-pod
    steps:
      - name: echo
@@ -320,6 +322,7 @@ spec:
         image: mirror.gcr.io/ubuntu
         script: echo Hello World!
 status:
+  artifacts: {}
   podName: propagated-parameters-task-level-echo-hello-pod
   steps:
     - name: echo
@@ -408,6 +411,7 @@ spec:
         image: mirror.gcr.io/ubuntu
         script: echo Hello World!
 status:
+  artifacts: {}
   podName: propagated-parameters-default-task-level-echo-hello-pod
   steps:
     - name: echo

--- a/test/propagated_results_test.go
+++ b/test/propagated_results_test.go
@@ -362,6 +362,7 @@ spec:
       name: add-map-uid
   timeout: 1h0m0s
 status:
+  artifacts: {}
   podName: propagated-all-type-results-make-uid-pod
   results:
   - name: strUid
@@ -453,6 +454,7 @@ spec:
       name: show-map-uid
   timeout: 1h0m0s
 status:
+  artifacts: {}
   podName: propagated-all-type-results-show-uid-pod
   steps:
   - container: step-show-str-uid

--- a/test/stepaction_results_test.go
+++ b/test/stepaction_results_test.go
@@ -189,6 +189,7 @@ status:
       status: "True"
       reason: "Succeeded"
   podName: step-results-task-run-pod
+  artifacts: {}
   taskSpec:
     steps:
       - name: step1

--- a/test/upgrade_test.go
+++ b/test/upgrade_test.go
@@ -155,6 +155,7 @@ status:
     terminationReason: Completed
     terminated:
       reason: Completed
+  artifacts: {}
 `
 
 	expectedSimplePipelineRunYaml = `


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Prior to this, the Artifacts in TaskRunStatusFields was not set to
a pointer of the underlying struct. As a result, it was incompatible
with `tkn`. Here we fix that issue by updating it to a `pointer`.

(cherry picked from commit c9105944929841916450b9e32b3b7c818ed9b7d1)

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Fix Artifact type to a pointer.
```
