### PR TITLE
fix(pipelinerun): resolve issue with PipelineRun not timing out successfully

### DIFF
--- a/pkg/apis/pipeline/errors/errors.go
+++ b/pkg/apis/pipeline/errors/errors.go
@@ -13,7 +13,12 @@ limitations under the License.
 
 package errors
 
-import "errors"
+import (
+	"errors"
+	"strings"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
 
 const UserErrorLabel = "[User error] "
 
@@ -70,4 +75,11 @@ func GetErrorMessage(err error) string {
 		return ue.Reason + err.Error()
 	}
 	return err.Error()
+}
+
+// IsImmutableTaskRunSpecError returns true if the error is the taskrun spec is immutable
+func IsImmutableTaskRunSpecError(err error) bool {
+	// The TaskRun may have completed and the spec field is immutable.
+	// validation code: https://github.com/tektoncd/pipeline/blob/v0.62.0/pkg/apis/pipeline/v1/taskrun_validation.go#L136-L138
+	return apierrors.IsBadRequest(err) && strings.Contains(err.Error(), "no updates are allowed")
 }

--- a/pkg/reconciler/pipelinerun/cancel.go
+++ b/pkg/reconciler/pipelinerun/cancel.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	pipelineErrors "github.com/tektoncd/pipeline/pkg/apis/pipeline/errors"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	clientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
@@ -88,9 +89,8 @@ func cancelTaskRun(ctx context.Context, taskRunName string, namespace string, cl
 		// still be able to cancel the PipelineRun
 		return nil
 	}
-	if errors.IsBadRequest(err) && strings.Contains(err.Error(), "no updates are allowed") {
+	if pipelineErrors.IsImmutableTaskRunSpecError(err) {
 		// The TaskRun may have completed and the spec field is immutable, we should ignore this error.
-		// validation code: https://github.com/tektoncd/pipeline/blob/v0.62.0/pkg/apis/pipeline/v1/taskrun_validation.go#L136-L138
 		return nil
 	}
 	return err


### PR DESCRIPTION
fix #8230

When the PipelineRun timeout, validation errors returned when patch a completed TaskRun should be ignored.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
fix(pipelinerun): resolve issue with PipelineRun not timing out successfully
```

/kind bug