### PR TITLE
[WIP] Re-register metrics only during real updation

### DIFF
--- a/pkg/pipelinerunmetrics/metrics.go
+++ b/pkg/pipelinerunmetrics/metrics.go
@@ -23,17 +23,25 @@ import (
 	"sync"
 	"time"
 
+	"encoding/hex"
+
+	"golang.org/x/crypto/blake2b"
+
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	listers "github.com/tektoncd/pipeline/pkg/client/listers/pipeline/v1"
+
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
+
 	"go.uber.org/zap"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/labels"
+
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/metrics"
@@ -111,6 +119,8 @@ type Recorder struct {
 		pipelinerun string) []tag.Mutator
 
 	ReportingPeriod time.Duration
+
+	hash string
 }
 
 // We cannot register the view multiple times, so NewRecorder lazily
@@ -272,7 +282,10 @@ func OnStore(logger *zap.SugaredLogger, r *Recorder) func(name string,
 				logger.Error("Failed to do type insertion for extracting metrics config")
 				return
 			}
-			r.updateConfig(cfg)
+			updated := r.updateConfig(cfg)
+			if !updated {
+				return
+			}
 			// Update metrics according to configuration
 			viewUnregister()
 			err := viewRegister(cfg)
@@ -317,11 +330,23 @@ func getPipelineTagName(pr *v1.PipelineRun) string {
 	return pipelineName
 }
 
-func (r *Recorder) updateConfig(cfg *config.Metrics) {
+func (r *Recorder) updateConfig(cfg *config.Metrics) bool {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
+	var hash string
+	if cfg != nil {
+		s := fmt.Sprintf("%v", *cfg)
+		sum := blake2b.Sum256([]byte(s))
+		hash = hex.EncodeToString(sum[:])
+	}
+
+	if r.hash == hash {
+		return false
+	}
 
 	r.cfg = cfg
+
+	return true
 }
 
 // DurationAndCount logs the duration of PipelineRun execution and

--- a/pkg/taskrunmetrics/metrics.go
+++ b/pkg/taskrunmetrics/metrics.go
@@ -22,20 +22,29 @@ import (
 	"sync"
 	"time"
 
+	"encoding/hex"
+
+	"golang.org/x/crypto/blake2b"
+
 	"github.com/pkg/errors"
+
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	listers "github.com/tektoncd/pipeline/pkg/client/listers/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/pod"
+
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
+
 	"go.uber.org/zap"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/metrics"
@@ -130,6 +139,8 @@ type Recorder struct {
 
 	insertPipelineTag func(pipeline,
 		pipelinerun string) []tag.Mutator
+
+	hash string
 }
 
 // We cannot register the view multiple times, so NewRecorder lazily
@@ -335,7 +346,10 @@ func OnStore(logger *zap.SugaredLogger, r *Recorder) func(name string, value int
 				logger.Error("Failed to do type insertion for extracting metrics config")
 				return
 			}
-			r.updateConfig(cfg)
+			updated := r.updateConfig(cfg)
+			if !updated {
+				return
+			}
 			// Update metrics according to the configuration
 			viewUnregister()
 			err := viewRegister(cfg)
@@ -400,11 +414,24 @@ func getTaskTagName(tr *v1.TaskRun) string {
 	return taskName
 }
 
-func (r *Recorder) updateConfig(cfg *config.Metrics) {
+func (r *Recorder) updateConfig(cfg *config.Metrics) bool {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 
+	var hash string
+	if cfg != nil {
+		s := fmt.Sprintf("%v", *cfg)
+		sum := blake2b.Sum256([]byte(s))
+		hash = hex.EncodeToString(sum[:])
+	}
+
+	if r.hash == hash {
+		return false
+	}
+
 	r.cfg = cfg
+
+	return true
 }
 
 // DurationAndCount logs the duration of TaskRun execution and


### PR DESCRIPTION
Before this, metrics were beign registered and unregisterd even when anything in configMap used to change including revision, etc.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
