### PR TITLE
Make image registry regions configurable

### DIFF
--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -197,8 +197,6 @@ spec:
       mkdir -p ${DOCKER_CONFIG}
       cp /workspace/docker-config.json ${DOCKER_CONFIG}/config.json
 
-      REGIONS="us eu asia"
-
       # Tag the images and put them in all the regions
       for IMAGE in $(cat /workspace/built_images)
       do

--- a/tekton/release-pipeline.yaml
+++ b/tekton/release-pipeline.yaml
@@ -16,6 +16,9 @@ spec:
   - name: imageRegistryPath
     description: The path (project) in the image registry
     default: tekton-releases
+  - name: imageRegistryRegions
+    description: The target image registry regions
+    default: "us eu asia"
   - name: versionTag
     description: The X.Y.Z version that the artifacts should be tagged with
   - name: releaseBucket
@@ -154,6 +157,8 @@ spec:
           value: $(params.imageRegistry)
         - name: imageRegistryPath
           value: $(params.imageRegistryPath)
+        - name: imageRegistryRegions
+          value: $(params.imageRegistryRegions)
         - name: releaseAsLatest
           value: $(params.releaseAsLatest)
         - name: serviceAccountPath


### PR DESCRIPTION
# Changes

Regions are already configurable in the publish task, although one of the steps ignored the config, which is fixed in this PR.

Expose the imageRegistryRegions parameter in the pipeline too, so that it may be controlled via the pipeline run.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```

/kind misc