### PR TITLE
Improve how gosec G115 findings are addressed

### DIFF
--- a/pkg/pod/status.go
+++ b/pkg/pod/status.go
@@ -567,12 +567,11 @@ func extractExitCodeFromResults(results []result.RunResult) (*int32, error) {
 	for _, result := range results {
 		if result.Key == "ExitCode" {
 			// We could just pass the string through but this provides extra validation
-			i, err := strconv.ParseUint(result.Value, 10, 32)
+			i, err := strconv.ParseInt(result.Value, 10, 32)
 			if err != nil {
 				return nil, fmt.Errorf("could not parse int value %q in ExitCode field: %w", result.Value, err)
 			}
-			//nolint: gosec
-			exitCode := int32(i)
+			exitCode := int32(i) // #nosec G115: ParseInt was called with bit size 32, so this is safe
 			return &exitCode, nil
 		}
 	}

--- a/pkg/spire/controller.go
+++ b/pkg/spire/controller.go
@@ -231,10 +231,15 @@ func (sc *spireControllerAPIClient) CreateEntries(ctx context.Context, tr *v1bet
 	var errCodes []int32
 
 	for _, r := range resp.GetResults() {
-		if codes.Code(r.GetStatus().GetCode()) != codes.AlreadyExists &&
-			codes.Code(r.GetStatus().GetCode()) != codes.OK {
+		statusCode := r.GetStatus().GetCode()
+		if statusCode < 0 {
+			return fmt.Errorf("statusCode overflows uint32: %d", statusCode)
+		}
+		code := codes.Code(statusCode)
+
+		if code != codes.AlreadyExists && code != codes.OK {
 			errPaths = append(errPaths, r.GetEntry().GetSpiffeId().GetPath())
-			errCodes = append(errCodes, r.GetStatus().GetCode())
+			errCodes = append(errCodes, statusCode)
 		}
 	}
 
@@ -296,10 +301,15 @@ func (sc *spireControllerAPIClient) DeleteEntry(ctx context.Context, tr *v1beta1
 	var errCodes []int32
 
 	for _, r := range resp.GetResults() {
-		if codes.Code(r.GetStatus().GetCode()) != codes.NotFound &&
-			codes.Code(r.GetStatus().GetCode()) != codes.OK {
+		statusCode := r.GetStatus().GetCode()
+		if statusCode < 0 {
+			return fmt.Errorf("statusCode overflows uint32: %d", statusCode)
+		}
+		code := codes.Code(statusCode)
+
+		if code != codes.NotFound && code != codes.OK {
 			errIds = append(errIds, r.GetId())
-			errCodes = append(errCodes, r.GetStatus().GetCode())
+			errCodes = append(errCodes, statusCode)
 		}
 	}
 


### PR DESCRIPTION
# Changes

Gosec recently introduced the G115 rule for integer overflows. Making related changes:

- in pkg/pod/status.go, [this commit](https://github.com/tektoncd/pipeline/pull/8219/commits/4d87e61534388c9c701797416559d7aa67fb7b3a) simply added an exclusion where I think changing the type conversion is more reasonable. `nosec` is still required due to the lacking intelligence of gosec to recognize that this conversion is fine (or Go lacking parse functions for each bit size instead of one that at the end still always returns int64 ;-) ).
- in pkg/spire/controller.go, I am still getting findings. We have to run gosec directly while Tekton runs it through golangcilint. I was not able to figure out where in Tekton's golangcilint config they would be exluded, so I fixed them

/cc vdemeester
/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
