### PR TITLE
Support separate bucket and image reg creds

### DIFF
--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -30,6 +30,9 @@ spec:
       default: linux/amd64,linux/arm,linux/arm64,linux/s390x,linux/ppc64le,windows/amd64
     - name: serviceAccountPath
       description: The name of the service account path within the release-secret workspace
+    - name: registryUser
+      description: Username to be used to login to the container registry
+      default: "_json_key"
   workspaces:
     - name: source
       description: >-
@@ -50,6 +53,8 @@ spec:
         value: "$(workspaces.release-secret.path)/$(params.serviceAccountPath)"
       - name: CONTAINER_REGISTRY
         value: "$(params.imageRegistry)/$(params.imageRegistryPath)"
+      - name: CONTAINER_REGISTRY_USER
+        value: "$(params.registryUser)"
       - name: REGIONS
         value: "$(params.imageRegistryRegions)"
       - name: OUTPUT_RELEASE_DIR
@@ -68,7 +73,7 @@ spec:
 
       # Login to the container registry
       DOCKER_CONFIG=$(cat ${CONTAINER_REGISTRY_CREDENTIALS} | \
-        crane auth login -u _json_key --password-stdin $(params.imageRegistry) 2>&1 | \
+        crane auth login -u ${CONTAINER_REGISTRY_USER} --password-stdin $(params.imageRegistry) 2>&1 | \
         sed 's,^.*logged in via \(.*\)$,\1,g')
 
       # Auth with account credentials for all regions.

--- a/tekton/release-cheat-sheet.md
+++ b/tekton/release-cheat-sheet.md
@@ -62,9 +62,11 @@ the pipelines repo, a terminal window and a text editor.
       --serviceaccount=release-right-meow \
       --param=gitRevision="${TEKTON_RELEASE_GIT_SHA}" \
       --param=serviceAccountPath=release.json \
+      --param=serviceAccountImagesPath=release.json \
       --param=versionTag="${TEKTON_VERSION}" \
       --param=releaseBucket=gs://tekton-releases/pipeline \
       --workspace name=release-secret,secret=release-secret \
+      --workspace name=release-images-secret,secret=release-secret \
       --workspace name=workarea,volumeClaimTemplateFile=workspace-template.yaml \
       --tasks-timeout 2h \
       --pipeline-timeout 3h

--- a/tekton/release-pipeline.yaml
+++ b/tekton/release-pipeline.yaml
@@ -19,6 +19,9 @@ spec:
   - name: imageRegistryRegions
     description: The target image registry regions
     default: "us eu asia"
+  - name: imageRegistryUser
+    description: The user for the image registry credentials
+    default: _json_key
   - name: versionTag
     description: The X.Y.Z version that the artifacts should be tagged with
   - name: releaseBucket
@@ -38,11 +41,15 @@ spec:
     default: linux/amd64,linux/arm,linux/arm64,linux/s390x,linux/ppc64le,windows/amd64
   - name: serviceAccountPath
     description: The path to the service account file within the release-secret workspace
+  - name: serviceAccountImagesPath
+    description: The path to the service account file or credentials within the release-images-secret workspace
   workspaces:
     - name: workarea
       description: The workspace where the repo will be cloned.
     - name: release-secret
-      description: The secret that contains a service account authorized to push to the imageRegistry and to the output bucket
+      description: The secret that contains a service account authorized to push to the output bucket
+    - name: release-images-secret
+      description: The secret that contains a service account authorized to push to the imageRegistry
   results:
     - name: commit-sha
       description: the sha of the commit that was released
@@ -157,12 +164,12 @@ spec:
           value: $(params.imageRegistry)
         - name: imageRegistryPath
           value: $(params.imageRegistryPath)
-        - name: imageRegistryRegions
-          value: $(params.imageRegistryRegions)
+        - name: imageRegistryUser
+          value: $(params.registryUser)
         - name: releaseAsLatest
           value: $(params.releaseAsLatest)
         - name: serviceAccountPath
-          value: $(params.serviceAccountPath)
+          value: $(params.serviceAccountImagesPath)
         - name: platforms
           value: $(params.publishPlatforms)
       workspaces:
@@ -173,7 +180,7 @@ spec:
           workspace: workarea
           subpath: bucket
         - name: release-secret
-          workspace: release-secret
+          workspace: release-images-secret
       timeout: 2h
     - name: publish-to-bucket
       runAfter: [publish-images]


### PR DESCRIPTION
# Changes

The current release pipeline assumes that the same credentials are used to authenticate to the cloud storage service as well as to the container registry.

This enables having independent credentials. It also enables using PAT based auth for the container registry by making the user configurable (instead of _json_key which works with gcr).

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```

/kind misc