### PR TITLE
fix(TaskRun): fixed the issue where some step statuses might not be correctly updated in failed TaskRun

### DIFF
--- a/pkg/pod/status.go
+++ b/pkg/pod/status.go
@@ -125,7 +125,7 @@ func MakeTaskRunStatus(ctx context.Context, logger *zap.SugaredLogger, tr v1.Tas
 
 	sortPodContainerStatuses(pod.Status.ContainerStatuses, pod.Spec.Containers)
 
-	complete := areContainersCompleted(ctx, pod) || pod.Status.Phase == corev1.PodSucceeded || DidTaskRunFail(pod)
+	complete := areContainersCompleted(ctx, pod) || isPodCompleted(pod)
 
 	if complete {
 		onError, ok := tr.Annotations[v1.PipelineTaskOnErrorAnnotation]
@@ -634,6 +634,30 @@ func updateIncompleteTaskRunStatus(trs *v1.TaskRunStatus, pod *corev1.Pod) {
 	case corev1.PodSucceeded, corev1.PodFailed, corev1.PodUnknown:
 		// Do nothing; pod has completed or is in an unknown state.
 	}
+}
+
+// isPodCompleted checks if the given pod is completed.
+// A pod is considered completed if its phase is either "Succeeded" or "Failed".
+//
+// If it is foreseeable that the pod will eventually be in a failed state,
+// but it remains in a Running status for a visible period of time, it should be considered completed in advance.
+//
+// For example, when certain steps encounter OOM, only the pods that have timed out will change to a failed state,
+// we should consider them completed in advance.
+func isPodCompleted(pod *corev1.Pod) bool {
+	if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {
+		return true
+	}
+	for _, s := range pod.Status.ContainerStatuses {
+		if IsContainerStep(s.Name) {
+			if s.State.Terminated != nil {
+				if isOOMKilled(s) {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }
 
 // DidTaskRunFail check the status of pod to decide if related taskrun is failed


### PR DESCRIPTION
Previously, if the Pod cache is not updated in time, a `TaskRun` would be immediately marked as failed after a certain step fails. When the pod status changes to failed, the TaskRun at that time still has a completed status and will not enter the reconcile logic to update the status of each step.

Currently, TaskRun will only fail prematurely in the event of an OOM. If a specific step exits abnormally, it will wait for the Pod status to ultimately change to failed before synchronizing the status of each step.

<hr>
At the same time, it also resolved the previous issue of unstable integration tests.

https://github.com/tektoncd/pipeline/pull/8236#issuecomment-2348256242
The instability in this integration test is related to another PR https://github.com/tektoncd/pipeline/pull/8171.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
fix: fixed the issue where some step statuses might not be correctly updated in failed TaskRun
```

/kind bug