### PR TITLE
[release-v0.59.x] Fix isolated workspaces ignored when using StepTemplate

### DIFF
--- a/pkg/apis/pipeline/v1/merge.go
+++ b/pkg/apis/pipeline/v1/merge.go
@@ -60,7 +60,17 @@ func MergeStepsWithStepTemplate(template *StepTemplate, steps []Step) ([]Step, e
 		amendConflictingContainerFields(&merged, s)
 
 		// Pass through original step Script, for later conversion.
-		newStep := Step{Script: s.Script, OnError: s.OnError, Timeout: s.Timeout, StdoutConfig: s.StdoutConfig, StderrConfig: s.StderrConfig, Results: s.Results, Params: s.Params, Ref: s.Ref}
+		newStep := Step{
+			Script:       s.Script,
+			OnError:      s.OnError,
+			Timeout:      s.Timeout,
+			StdoutConfig: s.StdoutConfig,
+			StderrConfig: s.StderrConfig,
+			Results:      s.Results,
+			Params:       s.Params,
+			Ref:          s.Ref,
+			Workspaces:   s.Workspaces,
+		}
 		newStep.SetContainerFields(merged)
 		steps[i] = newStep
 	}

--- a/pkg/apis/pipeline/v1/merge_test.go
+++ b/pkg/apis/pipeline/v1/merge_test.go
@@ -240,6 +240,48 @@ func TestMergeStepsWithStepTemplate(t *testing.T) {
 				},
 			}},
 		}},
+	}, {
+		name: "isolated workspaces",
+		template: &v1.StepTemplate{
+			Env: []corev1.EnvVar{{
+				Name:  "KEEP_THIS",
+				Value: "A_VALUE",
+			}},
+		},
+		steps: []v1.Step{{
+			Image: "some-image",
+			Workspaces: []v1.WorkspaceUsage{{
+				Name:      "foo",
+				MountPath: "/foo/bar",
+			}},
+		}, {
+			Image: "some-image",
+			Workspaces: []v1.WorkspaceUsage{{
+				Name:      "bar",
+				MountPath: "/bar/baz",
+			}},
+		}},
+		expected: []v1.Step{{
+			Image: "some-image",
+			Env: []corev1.EnvVar{{
+				Name:  "KEEP_THIS",
+				Value: "A_VALUE",
+			}},
+			Workspaces: []v1.WorkspaceUsage{{
+				Name:      "foo",
+				MountPath: "/foo/bar",
+			}},
+		}, {
+			Image: "some-image",
+			Env: []corev1.EnvVar{{
+				Name:  "KEEP_THIS",
+				Value: "A_VALUE",
+			}},
+			Workspaces: []v1.WorkspaceUsage{{
+				Name:      "bar",
+				MountPath: "/bar/baz",
+			}},
+		}},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := v1.MergeStepsWithStepTemplate(tc.template, tc.steps)


### PR DESCRIPTION
This is an manual cherry-pick of #8272

/assign @afrittoli @chitrangpatel 

```release-note
Isolated workspaces are now correctly set when using in conjuction with StepTemplate
```