### PR TITLE
Add Metrics for Running PipelinesRuns at Pipeline and Namespace level

### DIFF
--- a/config/config-observability.yaml
+++ b/config/config-observability.yaml
@@ -59,3 +59,4 @@ data:
     metrics.pipelinerun.level: "pipeline"
     metrics.pipelinerun.duration-type: "histogram"
     metrics.count.enable-reason: "false"
+    metrics.running-pipelinerun.level: ""

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -41,26 +41,31 @@ A sample config-map has been provided as [config-observability](./../config/conf
     metrics.taskrun.level: "task"
     metrics.taskrun.duration-type: "histogram"
     metrics.pipelinerun.level: "pipeline"
+    metrics.running-pipelinerun.level: ""
     metrics.pipelinerun.duration-type: "histogram"
     metrics.count.enable-reason: "false"
 ```
 
 Following values are available in the configmap:
 
-| configmap data | value | description |
-| -- | ----------- | ----------- |
-| metrics.taskrun.level | `taskrun` | Level of metrics is taskrun |
-| metrics.taskrun.level | `task` | Level of metrics is task and taskrun label isn't present in the metrics |
-| metrics.taskrun.level | `namespace` | Level of metrics is namespace, and task and taskrun label isn't present in the metrics
-| metrics.pipelinerun.level | `pipelinerun` | Level of metrics is pipelinerun |
-| metrics.pipelinerun.level | `pipeline` | Level of metrics is pipeline and pipelinerun label isn't present in the metrics |
-| metrics.pipelinerun.level | `namespace` | Level of metrics is namespace, pipeline and pipelinerun label isn't present in the metrics |
-| metrics.taskrun.duration-type | `histogram` | `tekton_pipelines_controller_pipelinerun_taskrun_duration_seconds` and `tekton_pipelines_controller_taskrun_duration_seconds` is of type histogram |
+| configmap data | value | description                                                                                                                                                  |
+| -- | ----------- |--------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| metrics.taskrun.level | `taskrun` | Level of metrics is taskrun                                                                                                                                  |
+| metrics.taskrun.level | `task` | Level of metrics is task and taskrun label isn't present in the metrics                                                                                      |
+| metrics.taskrun.level | `namespace` | Level of metrics is namespace, and task and taskrun label isn't present in the metrics                                                                       
+| metrics.pipelinerun.level | `pipelinerun` | Level of metrics is pipelinerun                                                                                                                              |
+| metrics.pipelinerun.level | `pipeline` | Level of metrics is pipeline and pipelinerun label isn't present in the metrics                                                                              |
+| metrics.pipelinerun.level | `namespace` | Level of metrics is namespace, pipeline and pipelinerun label isn't present in the metrics                                                                   |
+| metrics.running-pipelinerun.level | `pipelinerun` | Level of running-pipelinerun metrics is pipelinerun                                                                                                          |
+| metrics.running-pipelinerun.level | `pipeline` | Level of running-pipelinerun metrics is pipeline and pipelinerun label isn't present in the metrics                                                          |
+| metrics.running-pipelinerun.level | `namespace` | Level of running-pipelinerun metrics is namespace, pipeline and pipelinerun label isn't present in the metrics                                               |
+| metrics.running-pipelinerun.level | `` | Level of running-pipelinerun metrics is cluster, namespace, pipeline and pipelinerun label isn't present in the metrics.                                     |
+| metrics.taskrun.duration-type | `histogram` | `tekton_pipelines_controller_pipelinerun_taskrun_duration_seconds` and `tekton_pipelines_controller_taskrun_duration_seconds` is of type histogram           |
 | metrics.taskrun.duration-type | `lastvalue` | `tekton_pipelines_controller_pipelinerun_taskrun_duration_seconds` and  `tekton_pipelines_controller_taskrun_duration_seconds` is of type gauge or lastvalue |
-| metrics.pipelinerun.duration-type | `histogram` | `tekton_pipelines_controller_pipelinerun_duration_seconds` is of type histogram |
-| metrics.pipelinerun.duration-type | `lastvalue` | `tekton_pipelines_controller_pipelinerun_duration_seconds` is of type gauge or lastvalue |
-| metrics.count.enable-reason | `false` | Sets if the `reason` label should be included on count metrics |
-| metrics.taskrun.throttle.enable-namespace | `false` | Sets if the `namespace` label should be included on the `tekton_pipelines_controller_running_taskruns_throttled_by_quota` metric |
+| metrics.pipelinerun.duration-type | `histogram` | `tekton_pipelines_controller_pipelinerun_duration_seconds` is of type histogram                                                                              |
+| metrics.pipelinerun.duration-type | `lastvalue` | `tekton_pipelines_controller_pipelinerun_duration_seconds` is of type gauge or lastvalue                                                                     |
+| metrics.count.enable-reason | `false` | Sets if the `reason` label should be included on count metrics                                                                                               |
+| metrics.taskrun.throttle.enable-namespace | `false` | Sets if the `namespace` label should be included on the `tekton_pipelines_controller_running_taskruns_throttled_by_quota` metric                             |
 
 Histogram value isn't available when pipelinerun or taskrun labels are selected. The Lastvalue or Gauge will be provided. Histogram would serve no purpose because it would generate a single bar. TaskRun and PipelineRun level metrics aren't recommended because they lead to an unbounded cardinality which degrades the observability database.
 

--- a/pkg/apis/config/metrics.go
+++ b/pkg/apis/config/metrics.go
@@ -29,6 +29,9 @@ const (
 	// metricsPipelinerunLevel determines to what level to aggregate metrics
 	// for pipelinerun
 	metricsPipelinerunLevelKey = "metrics.pipelinerun.level"
+	// metricsRunningPipelinerunLevelKey determines to what level to aggregate metrics
+	// for running pipelineruns
+	metricsRunningPipelinerunLevelKey = "metrics.running-pipelinerun.level"
 	// metricsDurationTaskrunType determines what type of
 	// metrics to use for aggregating duration for taskrun
 	metricsDurationTaskrunType = "metrics.taskrun.duration-type"
@@ -55,6 +58,9 @@ const (
 	// DefaultPipelinerunLevel determines to what level to aggregate metrics
 	// when it isn't specified in configmap
 	DefaultPipelinerunLevel = PipelinerunLevelAtPipeline
+	// DefaultRunningPipelinerunLevel determines to what level to aggregate metrics
+	// when it isn't specified in configmap
+	DefaultRunningPipelinerunLevel = ""
 	// PipelinerunLevelAtPipelinerun specify that aggregation will be done at
 	// pipelinerun level
 	PipelinerunLevelAtPipelinerun = "pipelinerun"
@@ -96,6 +102,7 @@ var DefaultMetrics, _ = newMetricsFromMap(map[string]string{})
 type Metrics struct {
 	TaskrunLevel            string
 	PipelinerunLevel        string
+	RunningPipelinerunLevel string
 	DurationTaskrunType     string
 	DurationPipelinerunType string
 	CountWithReason         bool
@@ -130,6 +137,7 @@ func newMetricsFromMap(cfgMap map[string]string) (*Metrics, error) {
 	tc := Metrics{
 		TaskrunLevel:            DefaultTaskrunLevel,
 		PipelinerunLevel:        DefaultPipelinerunLevel,
+		RunningPipelinerunLevel: DefaultRunningPipelinerunLevel,
 		DurationTaskrunType:     DefaultDurationTaskrunType,
 		DurationPipelinerunType: DefaultDurationPipelinerunType,
 		CountWithReason:         false,
@@ -142,6 +150,9 @@ func newMetricsFromMap(cfgMap map[string]string) (*Metrics, error) {
 
 	if pipelinerunLevel, ok := cfgMap[metricsPipelinerunLevelKey]; ok {
 		tc.PipelinerunLevel = pipelinerunLevel
+	}
+	if runningPipelinerunLevel, ok := cfgMap[metricsRunningPipelinerunLevelKey]; ok {
+		tc.RunningPipelinerunLevel = runningPipelinerunLevel
 	}
 	if durationTaskrun, ok := cfgMap[metricsDurationTaskrunType]; ok {
 		tc.DurationTaskrunType = durationTaskrun

--- a/pkg/apis/config/metrics_test.go
+++ b/pkg/apis/config/metrics_test.go
@@ -36,6 +36,7 @@ func TestNewMetricsFromConfigMap(t *testing.T) {
 			expectedConfig: &config.Metrics{
 				TaskrunLevel:            config.TaskrunLevelAtTaskrun,
 				PipelinerunLevel:        config.PipelinerunLevelAtPipelinerun,
+				RunningPipelinerunLevel: config.DefaultRunningPipelinerunLevel,
 				DurationTaskrunType:     config.DurationPipelinerunTypeHistogram,
 				DurationPipelinerunType: config.DurationPipelinerunTypeHistogram,
 				CountWithReason:         false,
@@ -47,6 +48,7 @@ func TestNewMetricsFromConfigMap(t *testing.T) {
 			expectedConfig: &config.Metrics{
 				TaskrunLevel:            config.TaskrunLevelAtNS,
 				PipelinerunLevel:        config.PipelinerunLevelAtNS,
+				RunningPipelinerunLevel: config.PipelinerunLevelAtNS,
 				DurationTaskrunType:     config.DurationTaskrunTypeHistogram,
 				DurationPipelinerunType: config.DurationPipelinerunTypeLastValue,
 				CountWithReason:         false,
@@ -58,6 +60,7 @@ func TestNewMetricsFromConfigMap(t *testing.T) {
 			expectedConfig: &config.Metrics{
 				TaskrunLevel:            config.TaskrunLevelAtNS,
 				PipelinerunLevel:        config.PipelinerunLevelAtNS,
+				RunningPipelinerunLevel: config.DefaultRunningPipelinerunLevel,
 				DurationTaskrunType:     config.DurationTaskrunTypeHistogram,
 				DurationPipelinerunType: config.DurationPipelinerunTypeLastValue,
 				CountWithReason:         true,
@@ -69,6 +72,7 @@ func TestNewMetricsFromConfigMap(t *testing.T) {
 			expectedConfig: &config.Metrics{
 				TaskrunLevel:            config.TaskrunLevelAtNS,
 				PipelinerunLevel:        config.PipelinerunLevelAtNS,
+				RunningPipelinerunLevel: config.PipelinerunLevelAtPipeline,
 				DurationTaskrunType:     config.DurationTaskrunTypeHistogram,
 				DurationPipelinerunType: config.DurationPipelinerunTypeLastValue,
 				CountWithReason:         true,
@@ -88,6 +92,7 @@ func TestNewMetricsFromEmptyConfigMap(t *testing.T) {
 	expectedConfig := &config.Metrics{
 		TaskrunLevel:            config.TaskrunLevelAtTask,
 		PipelinerunLevel:        config.PipelinerunLevelAtPipeline,
+		RunningPipelinerunLevel: config.DefaultRunningPipelinerunLevel,
 		DurationTaskrunType:     config.DurationPipelinerunTypeHistogram,
 		DurationPipelinerunType: config.DurationPipelinerunTypeHistogram,
 		CountWithReason:         false,

--- a/pkg/apis/config/testdata/config-observability-namespacelevel.yaml
+++ b/pkg/apis/config/testdata/config-observability-namespacelevel.yaml
@@ -27,4 +27,5 @@ data:
   metrics.taskrun.level: "namespace"
   metrics.taskrun.duration-type: "histogram"
   metrics.pipelinerun.level: "namespace"
+  metrics.running-pipelinerun.level: "namespace"
   metrics.pipelinerun.duration-type: "lastvalue"

--- a/pkg/apis/config/testdata/config-observability-throttle.yaml
+++ b/pkg/apis/config/testdata/config-observability-throttle.yaml
@@ -27,6 +27,7 @@ data:
   metrics.taskrun.level: "namespace"
   metrics.taskrun.duration-type: "histogram"
   metrics.pipelinerun.level: "namespace"
+  metrics.running-pipelinerun.level: "pipeline"
   metrics.pipelinerun.duration-type: "lastvalue"
   metrics.count.enable-reason: "true"
   metrics.taskrun.throttle.enable-namespace: "true"

--- a/pkg/pipelinerunmetrics/metrics_test.go
+++ b/pkg/pipelinerunmetrics/metrics_test.go
@@ -23,6 +23,9 @@ import (
 	"testing"
 	"time"
 
+	"go.opencensus.io/metric/metricproducer"
+	"go.opencensus.io/stats/view"
+
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 
 	"github.com/tektoncd/pipeline/pkg/apis/config"
@@ -50,9 +53,25 @@ func getConfigContext(countWithReason bool) context.Context {
 		Metrics: &config.Metrics{
 			TaskrunLevel:            config.TaskrunLevelAtTaskrun,
 			PipelinerunLevel:        config.PipelinerunLevelAtPipelinerun,
+			RunningPipelinerunLevel: config.DefaultRunningPipelinerunLevel,
 			DurationTaskrunType:     config.DefaultDurationTaskrunType,
 			DurationPipelinerunType: config.DefaultDurationPipelinerunType,
 			CountWithReason:         countWithReason,
+		},
+	}
+	return config.ToContext(ctx, cfg)
+}
+
+func getConfigContextRunningPRLevel(runningPipelinerunLevel string) context.Context {
+	ctx := context.Background()
+	cfg := &config.Config{
+		Metrics: &config.Metrics{
+			TaskrunLevel:            config.TaskrunLevelAtTaskrun,
+			PipelinerunLevel:        config.PipelinerunLevelAtPipelinerun,
+			DurationTaskrunType:     config.DefaultDurationTaskrunType,
+			DurationPipelinerunType: config.DefaultDurationPipelinerunType,
+			CountWithReason:         false,
+			RunningPipelinerunLevel: runningPipelinerunLevel,
 		},
 	}
 	return config.ToContext(ctx, cfg)
@@ -504,6 +523,204 @@ func TestRecordRunningPipelineRunsCount(t *testing.T) {
 	metricstest.CheckLastValueData(t, "running_pipelineruns", map[string]string{}, 1)
 }
 
+func TestRecordRunningPipelineRunsCountAtPipelineRunLevel(t *testing.T) {
+	unregisterMetrics()
+
+	newPipelineRun := func(status corev1.ConditionStatus, pipelineRun, namespace string) *v1.PipelineRun {
+		return &v1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{Name: pipelineRun, Namespace: namespace},
+			Status: v1.PipelineRunStatus{
+				Status: duckv1.Status{
+					Conditions: duckv1.Conditions{{
+						Type:   apis.ConditionSucceeded,
+						Status: status,
+					}},
+				},
+			},
+		}
+	}
+
+	ctx, _ := ttesting.SetupFakeContext(t)
+	informer := fakepipelineruninformer.Get(ctx)
+	// Add N randomly-named PipelineRuns with differently-succeeded statuses.
+	for _, pipelineRun := range []*v1.PipelineRun{
+		newPipelineRun(corev1.ConditionUnknown, "testpr1", "testns1"),
+		newPipelineRun(corev1.ConditionUnknown, "testpr1", "testns2"),
+		newPipelineRun(corev1.ConditionUnknown, "testpr2", "testns2"),
+		newPipelineRun(corev1.ConditionUnknown, "testpr1", "testns3"),
+		newPipelineRun(corev1.ConditionUnknown, "testpr2", "testns3"),
+		newPipelineRun(corev1.ConditionUnknown, "testpr3", "testns3"),
+		newPipelineRun(corev1.ConditionUnknown, "testpr4", "testns3"),
+	} {
+		if err := informer.Informer().GetIndexer().Add(pipelineRun); err != nil {
+			t.Fatalf("Adding TaskRun to informer: %v", err)
+		}
+	}
+
+	ctx = getConfigContextRunningPRLevel("pipelinerun")
+	recorder, err := NewRecorder(ctx)
+	if err != nil {
+		t.Fatalf("NewRecorder: %v", err)
+	}
+
+	if err := recorder.RunningPipelineRuns(informer.Lister()); err != nil {
+		t.Errorf("RunningPipelineRuns: %v", err)
+	}
+
+	checkLastValueDataForTags(t, "running_pipelineruns", map[string]string{"namespace": "testns1", "pipeline": "anonymous", "pipelinerun": "testpr1"}, 1)
+	checkLastValueDataForTags(t, "running_pipelineruns", map[string]string{"namespace": "testns2", "pipeline": "anonymous", "pipelinerun": "testpr1"}, 1)
+	checkLastValueDataForTags(t, "running_pipelineruns", map[string]string{"namespace": "testns2", "pipeline": "anonymous", "pipelinerun": "testpr2"}, 1)
+	checkLastValueDataForTags(t, "running_pipelineruns", map[string]string{"namespace": "testns3", "pipeline": "anonymous", "pipelinerun": "testpr1"}, 1)
+	checkLastValueDataForTags(t, "running_pipelineruns", map[string]string{"namespace": "testns3", "pipeline": "anonymous", "pipelinerun": "testpr2"}, 1)
+	checkLastValueDataForTags(t, "running_pipelineruns", map[string]string{"namespace": "testns3", "pipeline": "anonymous", "pipelinerun": "testpr3"}, 1)
+	checkLastValueDataForTags(t, "running_pipelineruns", map[string]string{"namespace": "testns3", "pipeline": "anonymous", "pipelinerun": "testpr4"}, 1)
+}
+
+func TestRecordRunningPipelineRunsCountAtPipelineLevel(t *testing.T) {
+	unregisterMetrics()
+
+	newPipelineRun := func(status corev1.ConditionStatus, namespace string) *v1.PipelineRun {
+		return &v1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{Name: names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pipelinerun-"), Namespace: namespace},
+			Status: v1.PipelineRunStatus{
+				Status: duckv1.Status{
+					Conditions: duckv1.Conditions{{
+						Type:   apis.ConditionSucceeded,
+						Status: status,
+					}},
+				},
+			},
+		}
+	}
+
+	ctx, _ := ttesting.SetupFakeContext(t)
+	informer := fakepipelineruninformer.Get(ctx)
+	// Add N randomly-named PipelineRuns with differently-succeeded statuses.
+	for _, pipelineRun := range []*v1.PipelineRun{
+		newPipelineRun(corev1.ConditionUnknown, "testns1"),
+		newPipelineRun(corev1.ConditionUnknown, "testns2"),
+		newPipelineRun(corev1.ConditionUnknown, "testns2"),
+		newPipelineRun(corev1.ConditionUnknown, "testns3"),
+		newPipelineRun(corev1.ConditionUnknown, "testns3"),
+		newPipelineRun(corev1.ConditionUnknown, "testns3"),
+		newPipelineRun(corev1.ConditionUnknown, "testns3"),
+	} {
+		if err := informer.Informer().GetIndexer().Add(pipelineRun); err != nil {
+			t.Fatalf("Adding TaskRun to informer: %v", err)
+		}
+	}
+
+	ctx = getConfigContextRunningPRLevel("pipeline")
+	recorder, err := NewRecorder(ctx)
+	if err != nil {
+		t.Fatalf("NewRecorder: %v", err)
+	}
+
+	if err := recorder.RunningPipelineRuns(informer.Lister()); err != nil {
+		t.Errorf("RunningPipelineRuns: %v", err)
+	}
+
+	checkLastValueDataForTags(t, "running_pipelineruns", map[string]string{"namespace": "testns1", "pipeline": "anonymous"}, 1)
+	checkLastValueDataForTags(t, "running_pipelineruns", map[string]string{"namespace": "testns2", "pipeline": "anonymous"}, 2)
+	checkLastValueDataForTags(t, "running_pipelineruns", map[string]string{"namespace": "testns3", "pipeline": "anonymous"}, 4)
+}
+
+func TestRecordRunningPipelineRunsCountAtNamespaceLevel(t *testing.T) {
+	unregisterMetrics()
+
+	newPipelineRun := func(status corev1.ConditionStatus, namespace string) *v1.PipelineRun {
+		return &v1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{Name: names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pipelinerun-"), Namespace: namespace},
+			Status: v1.PipelineRunStatus{
+				Status: duckv1.Status{
+					Conditions: duckv1.Conditions{{
+						Type:   apis.ConditionSucceeded,
+						Status: status,
+					}},
+				},
+			},
+		}
+	}
+
+	ctx, _ := ttesting.SetupFakeContext(t)
+	informer := fakepipelineruninformer.Get(ctx)
+	// Add N randomly-named PipelineRuns with differently-succeeded statuses.
+	for _, pipelineRun := range []*v1.PipelineRun{
+		newPipelineRun(corev1.ConditionUnknown, "testns1"),
+		newPipelineRun(corev1.ConditionUnknown, "testns2"),
+		newPipelineRun(corev1.ConditionUnknown, "testns2"),
+		newPipelineRun(corev1.ConditionUnknown, "testns3"),
+		newPipelineRun(corev1.ConditionUnknown, "testns3"),
+		newPipelineRun(corev1.ConditionUnknown, "testns3"),
+		newPipelineRun(corev1.ConditionUnknown, "testns3"),
+	} {
+		if err := informer.Informer().GetIndexer().Add(pipelineRun); err != nil {
+			t.Fatalf("Adding TaskRun to informer: %v", err)
+		}
+	}
+
+	ctx = getConfigContextRunningPRLevel("namespace")
+	recorder, err := NewRecorder(ctx)
+	if err != nil {
+		t.Fatalf("NewRecorder: %v", err)
+	}
+
+	if err := recorder.RunningPipelineRuns(informer.Lister()); err != nil {
+		t.Errorf("RunningPipelineRuns: %v", err)
+	}
+
+	checkLastValueDataForTags(t, "running_pipelineruns", map[string]string{"namespace": "testns1"}, 1)
+	checkLastValueDataForTags(t, "running_pipelineruns", map[string]string{"namespace": "testns2"}, 2)
+	checkLastValueDataForTags(t, "running_pipelineruns", map[string]string{"namespace": "testns3"}, 4)
+}
+
+func TestRecordRunningPipelineRunsCountAtClusterLevel(t *testing.T) {
+	unregisterMetrics()
+
+	newPipelineRun := func(status corev1.ConditionStatus, namespace string) *v1.PipelineRun {
+		return &v1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{Name: names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pipelinerun-"), Namespace: namespace},
+			Status: v1.PipelineRunStatus{
+				Status: duckv1.Status{
+					Conditions: duckv1.Conditions{{
+						Type:   apis.ConditionSucceeded,
+						Status: status,
+					}},
+				},
+			},
+		}
+	}
+
+	ctx, _ := ttesting.SetupFakeContext(t)
+	informer := fakepipelineruninformer.Get(ctx)
+	// Add N randomly-named PipelineRuns with differently-succeeded statuses.
+	for _, pipelineRun := range []*v1.PipelineRun{
+		newPipelineRun(corev1.ConditionUnknown, "testns1"),
+		newPipelineRun(corev1.ConditionUnknown, "testns2"),
+		newPipelineRun(corev1.ConditionUnknown, "testns2"),
+		newPipelineRun(corev1.ConditionUnknown, "testns3"),
+		newPipelineRun(corev1.ConditionUnknown, "testns3"),
+		newPipelineRun(corev1.ConditionUnknown, "testns3"),
+		newPipelineRun(corev1.ConditionUnknown, "testns3"),
+	} {
+		if err := informer.Informer().GetIndexer().Add(pipelineRun); err != nil {
+			t.Fatalf("Adding TaskRun to informer: %v", err)
+		}
+	}
+
+	ctx = getConfigContextRunningPRLevel("")
+	recorder, err := NewRecorder(ctx)
+	if err != nil {
+		t.Fatalf("NewRecorder: %v", err)
+	}
+
+	if err := recorder.RunningPipelineRuns(informer.Lister()); err != nil {
+		t.Errorf("RunningPipelineRuns: %v", err)
+	}
+
+	checkLastValueDataForTags(t, "running_pipelineruns", map[string]string{}, 7)
+}
+
 func TestRecordRunningPipelineRunsResolutionWaitCounts(t *testing.T) {
 	multiplier := 3
 	for _, tc := range []struct {
@@ -595,4 +812,41 @@ func unregisterMetrics() {
 	once = sync.Once{}
 	r = nil
 	errRegistering = nil
+}
+
+// We have to write this function as knative package does not provide the feature to validate multiple records for same metric.
+func checkLastValueDataForTags(t *testing.T, name string, wantTags map[string]string, expected float64) {
+	t.Helper()
+	for _, producer := range metricproducer.GlobalManager().GetAll() {
+		meter := producer.(view.Meter)
+		data, err := meter.RetrieveData(name)
+		if err != nil || len(data) == 0 {
+			continue
+		}
+		val := getLastValueData(data, wantTags)
+		if expected != val.Value {
+			t.Error("Value did not match for ", name, wantTags, ", expected", expected, "got", val.Value)
+		}
+	}
+}
+
+// Returns the LastValueData from the matching row. If no row is matched then returns nil
+func getLastValueData(rows []*view.Row, wantTags map[string]string) *view.LastValueData {
+	for _, row := range rows {
+		if len(wantTags) != len(row.Tags) {
+			continue
+		}
+		matched := true
+		for _, got := range row.Tags {
+			n := got.Key.Name()
+			if wantTags[n] != got.Value {
+				matched = false
+				break
+			}
+		}
+		if matched {
+			return row.Data.(*view.LastValueData)
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
# Changes

- Currently metrics shown for Running Pipeline Count is at cluster level. 
- There is no way we can get that metric at namespace or pipeline level.
- We have added the PipelineRun metric at pipeline and namespace level.
- Level of PipelineRun Can be configured via ConfigMap. Default is  `""` . but it can be set to `namespace` or `Pipelinerun`.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
