### PR TITLE
WIP: Remove Deprecated Metrics

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -15,17 +15,11 @@ We expose several kinds of exporters, including Prometheus, Google Stackdriver, 
 |-----------------------------------------------------------------------------------------| ----------- |-------------------------------------------------| ----------- |
 | `tekton_pipelines_controller_pipelinerun_duration_seconds_[bucket, sum, count]`         | Histogram/LastValue(Gauge) | `*pipeline`=&lt;pipeline_name&gt; <br> `*pipelinerun`=&lt;pipelinerun_name&gt; <br> `status`=&lt;status&gt; <br> `namespace`=&lt;pipelinerun-namespace&gt; | experimental |
 | `tekton_pipelines_controller_pipelinerun_taskrun_duration_seconds_[bucket, sum, count]` | Histogram/LastValue(Gauge) | `*pipeline`=&lt;pipeline_name&gt; <br> `*pipelinerun`=&lt;pipelinerun_name&gt; <br> `status`=&lt;status&gt; <br> `*task`=&lt;task_name&gt; <br> `*taskrun`=&lt;taskrun_name&gt;<br> `namespace`=&lt;pipelineruns-taskruns-namespace&gt;  <br> `*reason`=&lt;reason&gt; | experimental |
-| `tekton_pipelines_controller_pipelinerun_count` | Counter | `status`=&lt;status&gt;  <br> `*reason`=&lt;reason&gt; | deprecate |
 | `tekton_pipelines_controller_pipelinerun_total` | Counter | `status`=&lt;status&gt;                         | experimental |
-| `tekton_pipelines_controller_running_pipelineruns_count` | Gauge |                                                 | deprecate |
 | `tekton_pipelines_controller_running_pipelineruns` | Gauge |                                                 | experimental |
 | `tekton_pipelines_controller_taskrun_duration_seconds_[bucket, sum, count]` | Histogram/LastValue(Gauge) | `status`=&lt;status&gt; <br> `*task`=&lt;task_name&gt; <br> `*taskrun`=&lt;taskrun_name&gt;<br> `namespace`=&lt;pipelineruns-taskruns-namespace&gt; <br> `*reason`=&lt;reason&gt; | experimental |
-| `tekton_pipelines_controller_taskrun_count` | Counter | `status`=&lt;status&gt; <br> `*reason`=&lt;reason&gt; | deprecate |
 | `tekton_pipelines_controller_taskrun_total` | Counter | `status`=&lt;status&gt;                         | experimental |
-| `tekton_pipelines_controller_running_taskruns_count` | Gauge |                                                 | deprecate |
 | `tekton_pipelines_controller_running_taskruns` | Gauge |                                                 | experimental |
-| `tekton_pipelines_controller_running_taskruns_throttled_by_quota_count` | Gauge | <br> `namespace`=&lt;pipelinerun-namespace&gt;  | deprecate |
-| `tekton_pipelines_controller_running_taskruns_throttled_by_node_count`  | Gauge | <br> `namespace`=&lt;pipelinerun-namespace&gt;  | deprecate |
 | `tekton_pipelines_controller_running_taskruns_throttled_by_quota` | Gauge | <br> `namespace`=&lt;pipelinerun-namespace&gt; | experimental |
 | `tekton_pipelines_controller_running_taskruns_throttled_by_node`  | Gauge | <br> `namespace`=&lt;pipelinerun-namespace&gt; | experimental |
 | `tekton_pipelines_controller_client_latency_[bucket, sum, count]` | Histogram |                                                 | experimental |

--- a/pkg/pipelinerunmetrics/metrics.go
+++ b/pkg/pipelinerunmetrics/metrics.go
@@ -52,20 +52,10 @@ var (
 		stats.UnitDimensionless)
 	prDurationView *view.View
 
-	prCount = stats.Float64("pipelinerun_count",
-		"number of pipelineruns",
-		stats.UnitDimensionless)
-	prCountView *view.View
-
 	prTotal = stats.Float64("pipelinerun_total",
 		"Number of pipelineruns",
 		stats.UnitDimensionless)
 	prTotalView *view.View
-
-	runningPRsCount = stats.Float64("running_pipelineruns_count",
-		"Number of pipelineruns executing currently",
-		stats.UnitDimensionless)
-	runningPRsCountView *view.View
 
 	runningPRs = stats.Float64("running_pipelineruns",
 		"Number of pipelineruns executing currently",
@@ -82,10 +72,6 @@ var (
 		stats.UnitDimensionless)
 	runningPRsWaitingOnPipelineResolutionView *view.View
 
-	runningPRsWaitingOnTaskResolutionCount = stats.Float64("running_pipelineruns_waiting_on_task_resolution_count",
-		"Number of pipelineruns executing currently that are waiting on resolution requests for the task references of their taskrun children.",
-		stats.UnitDimensionless)
-	runningPRsWaitingOnTaskResolutionCountView *view.View
 
 	runningPRsWaitingOnTaskResolution = stats.Float64("running_pipelineruns_waiting_on_task_resolution",
 		"Number of pipelineruns executing currently that are waiting on resolution requests for the task references of their taskrun children.",
@@ -178,9 +164,7 @@ func viewRegister(cfg *config.Metrics) error {
 		}
 	}
 
-	prCountViewTags := []tag.Key{statusTag}
 	if cfg.CountWithReason {
-		prCountViewTags = append(prCountViewTags, reasonTag)
 		prunTag = append(prunTag, reasonTag)
 	}
 
@@ -191,12 +175,6 @@ func viewRegister(cfg *config.Metrics) error {
 		TagKeys:     append([]tag.Key{statusTag, namespaceTag}, prunTag...),
 	}
 
-	prCountView = &view.View{
-		Description: prCount.Description(),
-		Measure:     prCount,
-		Aggregation: view.Count(),
-		TagKeys:     prCountViewTags,
-	}
 	prTotalView = &view.View{
 		Description: prTotal.Description(),
 		Measure:     prTotal,
@@ -215,22 +193,12 @@ func viewRegister(cfg *config.Metrics) error {
 		Aggregation: view.LastValue(),
 	}
 
-	runningPRsWaitingOnPipelineResolutionCountView = &view.View{
-		Description: runningPRsWaitingOnPipelineResolutionCount.Description(),
-		Measure:     runningPRsWaitingOnPipelineResolutionCount,
-		Aggregation: view.LastValue(),
-	}
 	runningPRsWaitingOnPipelineResolutionView = &view.View{
 		Description: runningPRsWaitingOnPipelineResolution.Description(),
 		Measure:     runningPRsWaitingOnPipelineResolution,
 		Aggregation: view.LastValue(),
 	}
 
-	runningPRsWaitingOnTaskResolutionCountView = &view.View{
-		Description: runningPRsWaitingOnTaskResolutionCount.Description(),
-		Measure:     runningPRsWaitingOnTaskResolutionCount,
-		Aggregation: view.LastValue(),
-	}
 	runningPRsWaitingOnTaskResolutionView = &view.View{
 		Description: runningPRsWaitingOnTaskResolution.Description(),
 		Measure:     runningPRsWaitingOnTaskResolution,
@@ -239,26 +207,18 @@ func viewRegister(cfg *config.Metrics) error {
 
 	return view.Register(
 		prDurationView,
-		prCountView,
 		prTotalView,
-		runningPRsCountView,
 		runningPRsView,
-		runningPRsWaitingOnPipelineResolutionCountView,
 		runningPRsWaitingOnPipelineResolutionView,
-		runningPRsWaitingOnTaskResolutionCountView,
 		runningPRsWaitingOnTaskResolutionView,
 	)
 }
 
 func viewUnregister() {
 	view.Unregister(prDurationView,
-		prCountView,
 		prTotalView,
-		runningPRsCountView,
 		runningPRsView,
-		runningPRsWaitingOnPipelineResolutionCountView,
 		runningPRsWaitingOnPipelineResolutionView,
-		runningPRsWaitingOnTaskResolutionCountView,
 		runningPRsWaitingOnTaskResolutionView)
 }
 
@@ -372,7 +332,6 @@ func (r *Recorder) DurationAndCount(pr *v1.PipelineRun, beforeCondition *apis.Co
 	}
 
 	metrics.Record(ctx, prDuration.M(duration.Seconds()))
-	metrics.Record(ctx, prCount.M(1))
 	metrics.Record(ctx, prTotal.M(1))
 
 	return nil
@@ -416,11 +375,8 @@ func (r *Recorder) RunningPipelineRuns(lister listers.PipelineRunLister) error {
 	if err != nil {
 		return err
 	}
-	metrics.Record(ctx, runningPRsWaitingOnPipelineResolutionCount.M(float64(prsWaitResolvingPipelineRef)))
 	metrics.Record(ctx, runningPRsWaitingOnPipelineResolution.M(float64(prsWaitResolvingPipelineRef)))
-	metrics.Record(ctx, runningPRsWaitingOnTaskResolutionCount.M(float64(trsWaitResolvingTaskRef)))
 	metrics.Record(ctx, runningPRsWaitingOnTaskResolution.M(float64(trsWaitResolvingTaskRef)))
-	metrics.Record(ctx, runningPRsCount.M(float64(runningPipelineRuns)))
 	metrics.Record(ctx, runningPRs.M(float64(runningPipelineRuns)))
 
 	return nil


### PR DESCRIPTION
We have given sufficient time to the users to migrate to newer metrics. This PR removes the deprecated metrics. Metrics already exist with Prometheus recommended names.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
