### PR TITLE
Introducing Tekton Pipelines Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)
 [![Go Report Card](https://goreportcard.com/badge/tektoncd/pipeline)](https://goreportcard.com/report/tektoncd/pipeline)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/4020/badge)](https://bestpractices.coreinfrastructure.org/projects/4020)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Tekton%20Pipelines%20Guru-006BFF)](https://gurubase.io/g/tekton-pipelines)
 
 The Tekton Pipelines project provides k8s-style resources for declaring
 CI/CD-style pipelines.


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Tekton Pipelines Guru](https://gurubase.io/g/tekton-pipelines) to Gurubase. Tekton Pipelines Guru uses the data from this repo and data from the [docs](https://tekton.dev/docs) to answer questions by leveraging the LLM.

In this PR, I showcased the "Tekton Pipelines Guru", which highlights that Tekton Pipelines now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Tekton Pipelines Guru in Gurubase, just let me know that's totally fine.
