### PR TITLE
Use io.ReadFull to read the bundle content

### DIFF
--- a/pkg/resolution/resolver/bundle/bundle.go
+++ b/pkg/resolution/resolver/bundle/bundle.go
@@ -194,7 +194,7 @@ func readTarLayer(layer v1.Layer) ([]byte, error) {
 	}
 
 	contents := make([]byte, header.Size)
-	if _, err := treader.Read(contents); err != nil && !errors.Is(err, io.EOF) {
+	if _, err := io.ReadFull(treader, contents); err != nil && err != io.EOF {
 		// We only allow 1 resource per layer so this tar bundle should have one and only one file.
 		return nil, fmt.Errorf("failed to read tar bundle: %w", err)
 	}


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The io.Reader documentation says:

> Read reads up to len(p) bytes into p. It returns the number of bytes
> read (0 <= n <= len(p)) and any error encountered. ... If some data is
> available but not len(p) bytes, Read conventionally returns what is
> available instead of waiting for more.

Read is not guaranteed to fill the data argument. Use io.ReadFull to
fill the buffer.

In some cases (a relatively big bundle), the bundle content was not
completely read and it would fail to parse. Using `io.ReadFull` fixes
the issue.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/kind bug

Closes #8388

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [X] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [X] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [X] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [X] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Fix an issue on `bundle list` command with relatively big bundles that couldn't be parsed (truncated data)
```
