### PR TITLE
fix: add missing stepaction RBAC permission for resolver

### DIFF
--- a/config/resolvers/200-clusterrole.yaml
+++ b/config/resolvers/200-clusterrole.yaml
@@ -26,7 +26,7 @@ rules:
     resources: ["resolutionrequests", "resolutionrequests/status"]
     verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: ["tekton.dev"]
-    resources: ["tasks", "pipelines"]
+    resources: ["tasks", "pipelines", "stepactions"]
     verbs: ["get", "list"]
   # Read-only access to these.
   - apiGroups: [""]


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Added the missing RBAC permission needed for the cluster resolver to be able to resolve step actions

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
fix: include missing RBAC permission to allow cluster resolver to get and list StepActions
```
