### PR TITLE
Fixes git-resolver configuration for serverUrl and scmType

### DIFF
--- a/pkg/remoteresolution/resolver/git/resolver_test.go
+++ b/pkg/remoteresolution/resolver/git/resolver_test.go
@@ -645,9 +645,9 @@ func TestResolve(t *testing.T) {
 			gitresolution.APISecretKeyKey:       "token",
 			gitresolution.APISecretNamespaceKey: system.Namespace(),
 		},
-		apiToken:       "some-token",
-		expectedStatus: resolution.CreateResolutionRequestFailureStatus(),
-		expectedErr:    createError("missing or empty scm-type value in configmap"),
+		apiToken:          "some-token",
+		expectedCommitSHA: commitSHAsInSCMRepo[0],
+		expectedStatus:    resolution.CreateResolutionRequestStatusWithData(mainPipelineYAML),
 	}}
 
 	for _, tc := range testCases {

--- a/pkg/resolution/resolver/git/resolver.go
+++ b/pkg/resolution/resolver/git/resolver.go
@@ -530,18 +530,12 @@ func getSCMTypeAndServerURL(ctx context.Context, params map[string]string) (stri
 	}
 	if scmType == "" {
 		scmType = conf.SCMType
-		if scmType == "" {
-			return "", "", fmt.Errorf("missing or empty %s value in configmap", SCMTypeKey)
-		}
 	}
 	if key, ok := params[ServerURLParam]; ok {
 		serverURL = key
 	}
 	if serverURL == "" {
 		serverURL = conf.ServerURL
-		if serverURL == "" {
-			return "", "", fmt.Errorf("missing or empty %s value in configmap", ServerURLKey)
-		}
 	}
 	return scmType, serverURL, nil
 }

--- a/pkg/resolution/resolver/git/resolver_test.go
+++ b/pkg/resolution/resolver/git/resolver_test.go
@@ -642,9 +642,9 @@ func TestResolve(t *testing.T) {
 			APISecretKeyKey:       "token",
 			APISecretNamespaceKey: system.Namespace(),
 		},
-		apiToken:       "some-token",
-		expectedStatus: resolution.CreateResolutionRequestFailureStatus(),
-		expectedErr:    createError("missing or empty scm-type value in configmap"),
+		apiToken:          "some-token",
+		expectedCommitSHA: commitSHAsInSCMRepo[0],
+		expectedStatus:    resolution.CreateResolutionRequestStatusWithData(mainPipelineYAML),
 	}}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
* With the latest support for multiple git providers in git-resolvers, it was having a regression issue where if value serverUrl was not given then it used to return an error

* Hence this patch fixes the issue to avoid regression

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
