### PR TITLE
Add /retest chatops command

### DIFF
--- a/.github/workflows/chatops_retest.yaml
+++ b/.github/workflows/chatops_retest.yaml
@@ -1,0 +1,68 @@
+# The _chatops_retest workflow reruns failed GHA for a PR
+#
+# This workflow is triggered by leaving a "/retest" comment on
+# a pull request. If the required preconditions are met, it will
+# rerun failed GitHub actions checks on that PR
+#
+# Condition for the "/retest" command are:
+# - either the issuer is a maintainer
+# - or the issuer is the owner the PR
+
+name: Rerun Failed Actions
+on:
+  repository_dispatch:
+    types: [retest-command]
+
+jobs:
+  retest:
+    name: Rerun Failed Actions
+    runs-on: ubuntu-latest
+    steps:
+    - name: Show Environment Variables
+      run: env
+    - name: Show Github Object
+      run: |
+        cat <<'EOF'
+        ${{ toJson(github) }}
+        EOF
+    - name: Show Github Event Path Json
+      run: 'cat $GITHUB_EVENT_PATH || true'
+    - name: Rerun Failed Actions
+      run: |
+        # Get a list of run IDs
+        RUN_IDS=$(gh api repos/${GITHUB_REPO}/commits/${GITHUB_COMMIT_SHA}/check-runs | \
+            jq -r '.check_runs[] | select(.name != "Rerun Failed Actions") | .html_url | capture("/runs/(?<number>[0-9]+)/job") | .number' | \
+            sort -u)
+
+        # For each run, retrigger faild jobs
+        for runid in ${RUN_IDS}; do
+            gh run \
+                --repo ${GITHUB_REPO} \
+                rerun ${runid} \
+                --failed
+        done
+      env:
+        GITHUB_TOKEN: ${{ secrets.CHATOPS_TOKEN }}
+        GITHUB_REPO: ${{ github.event.client_payload.github.payload.repository.full_name }}
+        GITHUB_COMMIT_SHA: ${{ github.event.client_payload.github.payload.commit.sha }}
+
+    - name: Create comment
+      if: ${{ failure() && steps.landStack.outcome == 'failure' }}
+      uses: peter-evans/create-or-update-comment@v4
+      with:
+        token: ${{ secrets.CHATOPS_TOKEN }}
+        repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+        issue-number: ${{ github.event.client_payload.github.payload.issue.number }}
+        body: |
+          Something went wrong with your `/${{ github.event.client_payload.slash_command.command }}` command: [please check the logs][1].
+
+          [1]: ${{ steps.vars.outputs.run-url }}
+
+    - name: Add reaction
+      if: ${{ success() }}
+      uses: peter-evans/create-or-update-comment@v4
+      with:
+        token: ${{ secrets.CHATOPS_TOKEN }}
+        repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+        comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+        reaction-type: hooray

--- a/.github/workflows/slash.yml
+++ b/.github/workflows/slash.yml
@@ -1,0 +1,41 @@
+# The slash workflow handles slash commands
+#
+# Slash commands are given through comments on pull requests
+# and may be used only by individuals with "write" access to
+# the repository (i.e. maintainers).
+#
+# Slash commands must be placed at the very beginning of the
+# first line of a comment. More details are available in the
+# action docs: https://github.com/peter-evans/slash-command-dispatch/tree/main?tab=readme-ov-file#how-comments-are-parsed-for-slash-commands
+#
+# The workflow looks for and dispatches to another workflow
+# named <command>-command which must exist in the repository.
+#
+# Supported commands:
+# - /land: invokes the land-command workflow, to land (merge) PRs
+#          stacked through ghstack
+#
+# When a command is recognised, the rocket and eyes emojis are added
+
+name: Slash Command Routing
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  check_comments:
+    runs-on: ubuntu-latest
+    steps:
+    - name: route-land
+      uses: peter-evans/slash-command-dispatch@v4
+      with:
+        token: ${{ secrets.CHATOPS_TOKEN }}
+        config: >
+          [
+            {
+              "command": "retest",
+              "permission": "write",
+              "issue_type": "pull-request",
+              "repository": "tektoncd/pipeline"
+            }
+          ]


### PR DESCRIPTION
# Changes

Add a /retest chatops command that reruns failed GitHub actions. This uses github.com/peter-evans/slash-command-dispatch which intercepts the comment on the PR, filters based on the role of the commenter and dispatches an event with the original payload to run the command.

The chatops_retest workflow receives the event, extracts the details about the run_ids from the GitHub API and runs failed jobs, thanks for the gh CLI.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

/kind misc

# Release Notes

```release-note
NONE
```
