### PR TITLE
Fix getting the commit sha from comment event

### DIFF
--- a/.github/workflows/chatops_retest.yaml
+++ b/.github/workflows/chatops_retest.yaml
@@ -29,11 +29,20 @@ jobs:
       run: 'cat $GITHUB_EVENT_PATH || true'
     - name: Rerun Failed Actions
       run: |
+        echo '::group:: Get the PT commit sha'
+        # Get the sha of the HEAD commit in the PR
+        GITHUB_COMMIT_SHA=$(gh api $(echo ${GITHUB_PULL_URL#https://api.github.com/}) | \
+          | jq -r .head.sha)
+        echo '::endgroup::'
+
+        echo '::group:: Get the list of run IDs'
         # Get a list of run IDs
         RUN_IDS=$(gh api repos/${GITHUB_REPO}/commits/${GITHUB_COMMIT_SHA}/check-runs | \
             jq -r '.check_runs[] | select(.name != "Rerun Failed Actions") | .html_url | capture("/runs/(?<number>[0-9]+)/job") | .number' | \
             sort -u)
+        echo '::endgroup::'
 
+        echo '::group:: Rerun failed runs'
         # For each run, retrigger faild jobs
         for runid in ${RUN_IDS}; do
             gh run \
@@ -41,10 +50,11 @@ jobs:
                 rerun ${runid} \
                 --failed
         done
+        echo '::endgroup::'
       env:
         GITHUB_TOKEN: ${{ secrets.CHATOPS_TOKEN }}
         GITHUB_REPO: ${{ github.event.client_payload.github.payload.repository.full_name }}
-        GITHUB_COMMIT_SHA: ${{ github.event.client_payload.github.payload.commit.sha }}
+        GITHUB_PULL_URL: ${{ github.event.client_payload.github.payload.issue.pull_request.url }}
 
     - name: Create comment
       if: ${{ failure() && steps.landStack.outcome == 'failure' }}


### PR DESCRIPTION
# Changes

The comment event does not include the commit sha directly. Extract the pull_url, query that and get the head sha.

This is for the "/retest" chatops command.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
