### PR TITLE
Ignore failures when rerunning jobs

### DIFF
--- a/.github/workflows/chatops_retest.yaml
+++ b/.github/workflows/chatops_retest.yaml
@@ -29,10 +29,11 @@ jobs:
       run: 'cat $GITHUB_EVENT_PATH || true'
     - name: Rerun Failed Actions
       run: |
-        echo '::group:: Get the PT commit sha'
+        echo '::group:: Get the PR commit sha'
         # Get the sha of the HEAD commit in the PR
         GITHUB_COMMIT_SHA=$(gh api $(echo ${GITHUB_PULL_URL#https://api.github.com/}) | \
             jq -r .head.sha)
+        echo GITHUB_COMMIT_SHA=${GITHUB_COMMIT_SHA}
         echo '::endgroup::'
 
         echo '::group:: Get the list of run IDs'
@@ -40,15 +41,17 @@ jobs:
         RUN_IDS=$(gh api repos/${GITHUB_REPO}/commits/${GITHUB_COMMIT_SHA}/check-runs | \
             jq -r '.check_runs[] | select(.name != "Rerun Failed Actions") | .html_url | capture("/runs/(?<number>[0-9]+)/job") | .number' | \
             sort -u)
+        echo RUN_IDS=${RUN_IDS}
         echo '::endgroup::'
 
         echo '::group:: Rerun failed runs'
         # For each run, retrigger faild jobs
         for runid in ${RUN_IDS}; do
+            echo Restarting run ${runid} for commit ${GITHUB_COMMIT_SHA}
             gh run \
                 --repo ${GITHUB_REPO} \
                 rerun ${runid} \
-                --failed
+                --failed || true
         done
         echo '::endgroup::'
       env:


### PR DESCRIPTION
# Changes

The CodeQL Actions gives a strange error when re-running. Just ignore failures when attempting to re-run and add some more verbose logs.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
