### PR TITLE
Improve gha k8s e2e tests names

### DIFF
--- a/.github/workflows/chatops_retest.yaml
+++ b/.github/workflows/chatops_retest.yaml
@@ -78,4 +78,4 @@ jobs:
         token: ${{ secrets.CHATOPS_TOKEN }}
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
-        reaction-type: hooray
+        reactions: hooray

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -16,16 +16,27 @@ jobs:
     strategy:
       fail-fast: false # Keep running if one leg fails.
       matrix:
-        k8s-version:
-        - v1.28.x
-        - v1.29.x
+        k8s-name:
+        - k8s-oldest
+        - k8s-plus-one
 
         feature-flags:
-        - prow
-        - prow-beta
-        - prow-alpha
+        - stable
+        - beta
+        - alpha
         # - prow-feature-flags  - this is tested today as a periodic job, but we could integrate it here
 
+        include:
+        - k8s-name: k8s-oldest
+          k8s-version: v1.28.x
+        - k8s-name: k8s-plus-one
+          k8s-version: v1.29.x
+        - feature-flags: stable
+          env-file: prow
+        - feature-flags: alpha
+          env-file: prow-alpha
+        - feature-flags: beta
+          env-file: prow-beta
     env:
       GOPATH: ${{ github.workspace }}
       GO111MODULE: on
@@ -73,7 +84,7 @@ jobs:
           --nodes 3 \
           --k8s-version ${{ matrix.k8s-version }} \
           --e2e-script ./test/e2e-tests.sh \
-          --e2e-env ./test/e2e-tests-kind-${{ matrix.feature-flags }}.env
+          --e2e-env ./test/e2e-tests-kind-${{ matrix.env-file }}.env
 
     - name: Upload test results
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
# Changes

Change the job names so that the names do not need to changes when things like k8s versions change. This helps with keeping the prow/tide configuration of required jobs fixed.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
