### PR TITLE
fix: minor version check for sidecar logic

### DIFF
--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -446,8 +446,9 @@ func (b *Builder) Build(ctx context.Context, taskRun *v1.TaskRun, taskSpec v1.Ta
 		if err != nil {
 			return nil, err
 		}
-		svMinorInt, _ := strconv.Atoi(sv.Minor)
+		svMinor := strings.TrimSuffix(sv.Minor, "+") // Remove '+' if present
 		svMajorInt, _ := strconv.Atoi(sv.Major)
+		svMinorInt, _ := strconv.Atoi(svMinor)
 		if svMajorInt >= 1 && svMinorInt >= SidecarK8sMinorVersionCheck {
 			// Add RestartPolicy and Merge into initContainer
 			useTektonSidecar = false

--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -37,6 +37,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/strings/slices"
 	"knative.dev/pkg/changeset"
@@ -433,10 +434,6 @@ func (b *Builder) Build(ctx context.Context, taskRun *v1.TaskRun, taskSpec v1.Ta
 	mergedPodContainers := stepContainers
 	mergedPodInitContainers := initContainers
 
-	// Check if current k8s version is less than 1.29
-	// Since Kubernetes Major version cannot be 0 and if it's 2 then sidecar will be in
-	// we are only concerned about major version 1 and if the minor is less than 29 then
-	// we need to do the current logic
 	useTektonSidecar := true
 	if config.FromContextOrDefaults(ctx).FeatureFlags.EnableKubernetesSidecar {
 		// Go through the logic for enable-kubernetes feature flag
@@ -446,10 +443,7 @@ func (b *Builder) Build(ctx context.Context, taskRun *v1.TaskRun, taskSpec v1.Ta
 		if err != nil {
 			return nil, err
 		}
-		svMinor := strings.TrimSuffix(sv.Minor, "+") // Remove '+' if present
-		svMajorInt, _ := strconv.Atoi(sv.Major)
-		svMinorInt, _ := strconv.Atoi(svMinor)
-		if svMajorInt >= 1 && svMinorInt >= SidecarK8sMinorVersionCheck {
+		if IsNativeSidecarSupport(sv) {
 			// Add RestartPolicy and Merge into initContainer
 			useTektonSidecar = false
 			for i := range sidecarContainers {
@@ -733,6 +727,19 @@ func artifactPathReferencedInStep(step v1.Step) bool {
 		if strings.Contains(e.Value, path) || strings.Contains(e.Value, unresolvedPath) {
 			return true
 		}
+	}
+	return false
+}
+
+// isNativeSidecarSupport returns true if k8s api has native sidecar support
+// based on the k8s version (1.29+).
+// See https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/ for more info.
+func IsNativeSidecarSupport(serverVersion *version.Info) bool {
+	minor := strings.TrimSuffix(serverVersion.Minor, "+") // Remove '+' if present
+	majorInt, _ := strconv.Atoi(serverVersion.Major)
+	minorInt, _ := strconv.Atoi(minor)
+	if (majorInt == 1 && minorInt >= SidecarK8sMinorVersionCheck) || majorInt > 1 {
+		return true
 	}
 	return false
 }

--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -3767,3 +3767,75 @@ func TestPodBuildWithK8s129(t *testing.T) {
 		t.Errorf("Sidecar does not have RestartPolicy Always: %s", diff.PrintWantGot(d))
 	}
 }
+func TestIsNativeSidecarSupport(t *testing.T) {
+	tests := []struct {
+		name          string
+		serverVersion *version.Info
+		want          bool
+	}{
+		{
+			name: "Kubernetes version 1.29",
+			serverVersion: &version.Info{
+				Major: "1",
+				Minor: "29",
+			},
+			want: true,
+		},
+		{
+			name: "Kubernetes version 1.30",
+			serverVersion: &version.Info{
+				Major: "1",
+				Minor: "30",
+			},
+			want: true,
+		},
+		{
+			name: "Kubernetes version 2.0",
+			serverVersion: &version.Info{
+				Major: "2",
+				Minor: "0",
+			},
+			want: true,
+		},
+		{
+			name: "Kubernetes version 1.28",
+			serverVersion: &version.Info{
+				Major: "1",
+				Minor: "28",
+			},
+			want: false,
+		},
+		{
+			name: "Kubernetes version 1.29+",
+			serverVersion: &version.Info{
+				Major: "1",
+				Minor: "29+",
+			},
+			want: true,
+		},
+		{
+			name: "Kubernetes version 1.28+",
+			serverVersion: &version.Info{
+				Major: "1",
+				Minor: "28+",
+			},
+			want: false,
+		},
+		{
+			name: "Kubernetes version 0.29",
+			serverVersion: &version.Info{
+				Major: "0",
+				Minor: "29",
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsNativeSidecarSupport(tt.serverVersion); got != tt.want {
+				t.Errorf("IsNativeSidecarSupport() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -164,9 +164,10 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, tr *v1.TaskRun) pkgrecon
 			if err != nil {
 				return err
 			}
+			svMinor := strings.TrimSuffix(sv.Minor, "+") // Remove '+' if present
 			svMajorInt, _ := strconv.Atoi(sv.Major)
-			svMinorInt, _ := strconv.Atoi(sv.Minor)
-			if svMajorInt >= 1 && svMinorInt >= 29 {
+			svMinorInt, _ := strconv.Atoi(svMinor)
+			if svMajorInt >= 1 && svMinorInt >= podconvert.SidecarK8sMinorVersionCheck {
 				useTektonSidecar = false
 				logger.Infof("Using Kubernetes Native Sidecars \n")
 			}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Fix https://github.com/tektoncd/pipeline/issues/8446 
Currently minor version check may not work when `sv.Minor` has `+` suffix.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
