### PR TITLE
Migrate golangci-lint to a github workflow

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -1,0 +1,25 @@
+name: golangci-lint
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - main
+  pull_request:  # yamllint disable-line rule:empty-values
+
+permissions:
+  contents: read
+  checks: write  # Used to annotate code in the PR
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a  # v5.2.0
+        with:
+          go-version: stable
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8  # v6.1.1
+        with:
+          version: v1.62.2
+          args: --timeout=10m

--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -29,20 +29,6 @@ export DISABLE_YAML_LINTING=1
 
 source $(git rev-parse --show-toplevel)/vendor/github.com/tektoncd/plumbing/scripts/presubmit-tests.sh
 
-function check_go_lint() {
-    header "Testing if golint has been done"
-
-    # deadline of 5m, and show all the issues
-    GOFLAGS="-mod=mod" make golangci-lint-check
-
-    if [[ $? != 0 ]]; then
-        results_banner "Go Lint" 1
-        exit 1
-    fi
-
-    results_banner "Go Lint" 0
-}
-
 function check_yaml_lint() {
     header "Testing if yamllint has been done"
 
@@ -77,7 +63,6 @@ EOF
 }
 
 function post_build_tests() {
-  check_go_lint
   check_yaml_lint
   ko_resolve
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Similar to what was done in `tektoncd/operator`. Let's move
golangci-lint to its own github workflow.

/kind misc

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
