### PR TITLE
fix: avoid fan out matrix task failed due to result ref

### DIFF
--- a/pkg/apis/pipeline/v1/matrix_types.go
+++ b/pkg/apis/pipeline/v1/matrix_types.go
@@ -237,7 +237,9 @@ func (m *Matrix) countGeneratedCombinationsFromParams() int {
 	}
 	count := 1
 	for _, param := range m.Params {
-		count *= len(param.Value.ArrayVal)
+		if len(param.Value.ArrayVal) > 0 {
+			count *= len(param.Value.ArrayVal)
+		}
 	}
 	return count
 }

--- a/pkg/apis/pipeline/v1/matrix_types_test.go
+++ b/pkg/apis/pipeline/v1/matrix_types_test.go
@@ -782,7 +782,8 @@ func TestPipelineTask_CountCombinations(t *testing.T) {
 	}{{
 		name: "combinations count is zero",
 		matrix: &v1.Matrix{
-			Params: v1.Params{{}}},
+			Params: v1.Params{},
+		},
 		want: 0,
 	}, {
 		name: "combinations count is one from one parameter",
@@ -915,11 +916,20 @@ func TestPipelineTask_CountCombinations(t *testing.T) {
 				}},
 			}},
 		want: 7,
+	}, {
+		name: "matrix params with string value containing variable reference",
+		matrix: &v1.Matrix{
+			Params: v1.Params{{
+				Name: "GOARCH", Value: v1.ParamValue{ArrayVal: []string{"linux/amd64", "linux/ppc64le", "linux/s390x"}},
+			}, {
+				Name: "version", Value: v1.ParamValue{StringVal: "$(tasks.platforms.results.str[*])"}},
+			}},
+		want: 3,
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if d := cmp.Diff(tt.want, tt.matrix.CountCombinations()); d != "" {
-				t.Errorf("Matrix.CountCombinations() errors diff %s", diff.PrintWantGot(d))
+				t.Errorf("%s Matrix.CountCombinations() errors diff %s", tt.name, diff.PrintWantGot(d))
 			}
 		})
 	}

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -8939,8 +8939,14 @@ spec:
            script: |
              echo "$(params.platform)"
     - name: b-task
-      taskRef:
-        name: mytask
+      taskSpec:
+        params:
+          - name: platform
+        steps:
+         - name: echo
+           image: alpine
+           script: |
+             echo "$(params.platform)"
       matrix:
         params:
           - name: platform

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -8858,6 +8858,10 @@ func TestReconcile_DependencyValidationsImmediatelyFailPipelineRun(t *testing.T)
 	cfg := config.NewStore(logtesting.TestLogger(t))
 	ctx = cfg.ToContext(ctx)
 
+	ts := []*v1.Task{
+		simpleSomeTask,
+	}
+
 	prs := []*v1.PipelineRun{
 		parse.MustParseV1PipelineRun(t, `
 metadata:
@@ -8939,14 +8943,8 @@ spec:
            script: |
              echo "$(params.platform)"
     - name: b-task
-      taskSpec:
-        params:
-          - name: platform
-        steps:
-         - name: echo
-           image: alpine
-           script: |
-             echo "$(params.platform)"
+      taskRef:
+        name: some-task
       matrix:
         params:
           - name: platform
@@ -8976,6 +8974,7 @@ spec:
 	d := test.Data{
 		ConfigMaps:   cms,
 		PipelineRuns: prs,
+		Tasks:        ts,
 		ServiceAccounts: []*corev1.ServiceAccount{{
 			ObjectMeta: metav1.ObjectMeta{Name: prs[0].Spec.TaskRunTemplate.ServiceAccountName, Namespace: "foo"},
 		}},

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
@@ -3800,10 +3800,10 @@ func TestResolvePipelineRunTask_WithMatrix(t *testing.T) {
 		name: "task with matrix - whole array results",
 		pt:   pts[2],
 		want: &ResolvedPipelineTask{
-			TaskRunNames: nil,
+			TaskRunNames: []string{"pipelinerun-pipelinetask-with-whole-array-results"},
 			TaskRuns:     nil,
 			PipelineTask: &pts[2],
-			ResolvedTask: nil,
+			ResolvedTask: rtr,
 		},
 		pst: pipelineRunState,
 	}} {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

fix #8324
Continuing development based on this PR: https://github.com/tektoncd/pipeline/pull/8327

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
fix: avoid fan out matrix task failed due to result ref
```

/kind bug

### 1. Reproducible steps
```shell
$ kubectl version

Client Version: v1.32.0
Kustomize Version: v5.5.0
Server Version: v1.28.8

$ tkn version

Client version: 0.39.0
Pipeline version: v0.66.0
```

```shell
cat <<'EOF' | kubectl replace -f -
apiVersion: tekton.dev/v1
kind: Task
metadata:
  name: array-emitter
spec:
  results:
  - name: array
    type: array
  steps:
    - name: echo
      image: mirror.gcr.io/alpine
      script: |
        echo -n "[\"linux\",\"max\",\"windows\"]" > $(results.array.path)

---
apiVersion: tekton.dev/v1
kind: Task
metadata:
  name: platform-browsers
spec:
  params:
    - name: platform
  results:
  - name: str
    type: string
  steps:
    - name: echo
      image: mirror.gcr.io/alpine
      script: |
        echo -n "$(params.platform)" | tee $(results.str.path)

---
apiVersion: tekton.dev/v1
kind: Task
metadata:
  name: printer
spec:
  params:
    - name: platform
      default: "default-platform"
    - name: platforms
      default: []
  steps:
    - name: echo
      image: mirror.gcr.io/alpine
      args:
        - "$(params.platforms)"
      script: |
        if [ -z "$(params.platform)" ]; then
          echo "platform: $(params.platform)"
        fi
        if [ $# -gt 0 ]; then
          echo "platforms: $@"
        fi

---
apiVersion: tekton.dev/v1
kind: PipelineRun
metadata:
  name: matrixed-pr
spec:
  taskRunTemplate:
    serviceAccountName: "default"
  pipelineSpec:
    tasks:

    - name: array-emitter
      taskRef:
        name: array-emitter

    - name: platforms
      params:
        - name: test
          value: test
      matrix:
        params:
          - name: platform
            value: $(tasks.array-emitter.results.array[*])
      taskRef:
        name: platform-browsers

    - name: printer-matrix
      taskRef:
        name: printer
      matrix:
        params:
          - name: platform
            value: $(tasks.platforms.results.str[*])

    - name: printer-all-platforms
      taskRef:
        name: printer
      params:
        - name: platforms
          value: $(tasks.platforms.results.str[*])
EOF
```

### 2. Error message

`invalid result reference in pipeline task "printer-matrix": unable to validate result referencing pipeline task "platforms": task spec not found`

```yaml
apiVersion: tekton.dev/v1
kind: PipelineRun
metadata:
  creationTimestamp: "2025-01-14T07:40:10Z"
  generation: 1
  name: matrixed-pr
  namespace: default
  resourceVersion: "26861"
  uid: feba93ac-759d-4817-8512-700eb8eef059
spec:
  pipelineSpec:
    tasks:
    - name: array-emitter
      taskRef:
        kind: Task
        name: array-emitter
    - matrix:
        params:
        - name: platform
          value: $(tasks.array-emitter.results.array[*])
      name: platforms
      params:
      - name: test
        value: test
      taskRef:
        kind: Task
        name: platform-browsers
    - matrix:
        params:
        - name: platform
          value: $(tasks.platforms.results.str[*])
      name: printer-matrix
      taskRef:
        kind: Task
        name: printer
    - name: printer-all-platforms
      params:
      - name: platforms
        value: $(tasks.platforms.results.str[*])
      taskRef:
        kind: Task
        name: printer
  taskRunTemplate:
    serviceAccountName: default
  timeouts:
    pipeline: 1h0m0s
status:
  completionTime: "2025-01-14T07:40:12Z"
  conditions:
  - lastTransitionTime: "2025-01-14T07:40:12Z"
    message: 'invalid result reference in pipeline task "printer-matrix": unable to
      validate result referencing pipeline task "platforms": task spec not found'
    reason: InvalidTaskResultReference
    status: "False"
    type: Succeeded
  pipelineSpec:
    tasks:
    - name: array-emitter
      taskRef:
        kind: Task
        name: array-emitter
    - matrix:
        params:
        - name: platform
          value: $(tasks.array-emitter.results.array[*])
      name: platforms
      params:
      - name: test
        value: test
      taskRef:
        kind: Task
        name: platform-browsers
    - matrix:
        params:
        - name: platform
          value: $(tasks.platforms.results.str[*])
      name: printer-matrix
      taskRef:
        kind: Task
        name: printer
    - name: printer-all-platforms
      params:
      - name: platforms
        value: $(tasks.platforms.results.str[*])
      taskRef:
        kind: Task
        name: printer
  provenance:
    featureFlags:
      AwaitSidecarReadiness: true
      Coschedule: workspaces
      DisableAffinityAssistant: false
      DisableCredsInit: false
      DisableInlineSpec: ""
      EnableAPIFields: beta
      EnableArtifacts: false
      EnableCELInWhenExpression: false
      EnableConciseResolverSyntax: false
      EnableKeepPodOnCancel: false
      EnableKubernetesSidecar: false
      EnableParamEnum: false
      EnableProvenanceInStatus: true
      EnableStepActions: false
      EnforceNonfalsifiability: none
      MaxResultSize: 4096
      RequireGitSSHSecretKnownHosts: false
      ResultExtractionMethod: termination-message
      RunningInEnvWithInjectedSidecars: true
      SendCloudEventsForRuns: false
      SetSecurityContext: false
      VerificationNoMatchPolicy: ignore
  startTime: "2025-01-14T07:40:12Z"
```

### 3. Analysis

##### a. `validateResultRef`: `unable to validate result referencing pipeline task`

`if ptMap[ref.PipelineTask].ResolvedTask == nil || ptMap[ref.PipelineTask].ResolvedTask.TaskSpec == nil {`

https://github.com/tektoncd/pipeline/blob/1dd488eda738a124e9dfe8874dbb192f8bc30839/pkg/reconciler/pipelinerun/resources/validate_dependencies.go#L75-L77

##### b. `ValidatePipelineTaskResults`: `invalid result reference in pipeline task`

https://github.com/tektoncd/pipeline/blob/1dd488eda738a124e9dfe8874dbb192f8bc30839/pkg/reconciler/pipelinerun/resources/validate_dependencies.go#L31-L36

##### c. `PipelineRun-Reconcile`: call `ValidatePipelineTaskResults`

https://github.com/tektoncd/pipeline/blob/1dd488eda738a124e9dfe8874dbb192f8bc30839/pkg/reconciler/pipelinerun/pipelinerun.go#L697-L702

##### d. `pipelineRunFacts.State`: come from `resolvePipelineState`

https://github.com/tektoncd/pipeline/blob/1dd488eda738a124e9dfe8874dbb192f8bc30839/pkg/reconciler/pipelinerun/pipelinerun.go#L612-L627

##### e. `resolvePipelineState`: resolvedTask - `ResolvePipelineTask`

https://github.com/tektoncd/pipeline/blob/1dd488eda738a124e9dfe8874dbb192f8bc30839/pkg/reconciler/pipelinerun/pipelinerun.go#L368-L377

##### f. **`ResolvePipelineTask`**: call `CountCombinations`

https://github.com/tektoncd/pipeline/blob/1dd488eda738a124e9dfe8874dbb192f8bc30839/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go#L602-L630

##### h1. `CountCombinations`: Calculate the number of TaskRuns

https://github.com/tektoncd/pipeline/blob/1dd488eda738a124e9dfe8874dbb192f8bc30839/pkg/apis/pipeline/v1/matrix_types.go#L220-L242

##### h2. **Error**: The calculated count is 0.

https://github.com/tektoncd/pipeline/blob/1dd488eda738a124e9dfe8874dbb192f8bc30839/pkg/apis/pipeline/v1/matrix_types.go#L233-L239

Because the `param.Value.StringVale` is `$(tasks.platforms.results.str[*])` and `param.Value.ArrayVal` is empty.

##### j1. `ResolvePipelineTask`: call `GetNamesOfTaskRuns`

https://github.com/tektoncd/pipeline/blob/1dd488eda738a124e9dfe8874dbb192f8bc30839/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go#L628-L630

##### j2. `GetNamesOfTaskRuns`: call `getNewRunNames` the `numberOfRuns` is 0, the result `taskRunNames` is empty

https://github.com/tektoncd/pipeline/blob/1dd488eda738a124e9dfe8874dbb192f8bc30839/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go#L749-L771

##### k. `ResolvePipelineTask`: `setTaskRunsAndResolvedTask` has not been called.

https://github.com/tektoncd/pipeline/blob/1dd488eda738a124e9dfe8874dbb192f8bc30839/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go#L628-L632

##### l. `setTaskRunsAndResolvedTask`: `ResolvedTask` has not been set.

https://github.com/tektoncd/pipeline/blob/1dd488eda738a124e9dfe8874dbb192f8bc30839/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go#L641-L662

##### m. **So it led to the error seen at the top.**
