### PR TITLE
Add PipelineRun pipeline-timeout note to pipeline docs

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -1202,6 +1202,10 @@ format. For example, valid values are `1h30m`, `1h`, `1m`, and `60s`.
 
 **Note:** If you do not specify a `Timeout` value, Tekton instead honors the timeout for the [`PipelineRun`](pipelineruns.md#configuring-a-pipelinerun).
 
+**Note:** If the specified `Task` timeout is greater than the Pipeline timeout as configured in the [`PipelineRun`](pipelineruns.md#configuring-a-failure-timeout), the Pipeline will time-out first causing the `Task` to timeout before its configured timeout.
+For example, if the `PipelineRun` sets `timeouts.pipeline = 1h` and the `Pipeline` sets `tasks[0].timeout = 3h`, the task will still timeout after `1h`.
+See [`PipelineRun - Configuring a failure timeout`](pipelineruns.md#configuring-a-failure-timeout) for details.
+
 In the example below, the `build-the-image` `Task` is configured to time out after 90 seconds:
 
 ```yaml


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The Pipelines docs' timeout section did not mention that the Pipeline itself had its timeout configured by the PipelineRun, causing some confusion in #8114. Without adding a whole section, linking to the PipelineRun timeout docs in a note about Task vs Pipeline timeout precedence both documents where the pipeline timeout is configured while also clarifying the misconception of timeout precedence.


# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
