### PR TITLE
SSH Auth docs improvement

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -236,7 +236,11 @@ This section describes how to configure an `ssh-auth` type `Secret` for use with
 before executing any `Steps` in the `Run`, Tekton creates a `~/.ssh/config` file containing the SSH key
 specified in the `Secret`.
 
-1. In `secret.yaml`, define a `Secret` that specifies your SSH private key:
+1. Generate a new SSH key with `ssh-keygen` command (optionally specify the file path in which the key will be saved, default is ~/.ssh/<key-name>)
+
+2. View public key with `cat ~/.ssh/<key-name>.pub` and add it to GitHub (under Settings > SSH and GPG Keys > New SSH key)
+
+3. In `secret.yaml`, define a `Secret` containing your SSH private key:
 
    ```yaml
    apiVersion: v1
@@ -247,23 +251,25 @@ specified in the `Secret`.
        tekton.dev/git-0: github.com # Described below
    type: kubernetes.io/ssh-auth
    stringData:
-     ssh-privatekey: <private-key>
-     # This is non-standard, but its use is encouraged to make this more secure.
+     ssh-privatekey: |
+       -----BEGIN OPENSSH PRIVATE KEY-----
+       b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAA...
+       ...
+       -----END OPENSSH PRIVATE KEY-----
+     # known-hosts is not mandatory, but its use is strongly encouraged for security reasons.
      # If it is not provided then the git server's public key will be requested
      # when the repo is first fetched.
-     known_hosts: <known-hosts>
+     known_hosts: |
+       github.com ssh-rsa AAAAB3NzaC1yc2EA...
+       github.com ecdsa-sha2-nistp256 AAAAE2VjZHNh...
+       github.com ssh-ed25519 AAAAC3NzaC1l...
    ```
 
    In the above example, the value for `tekton.dev/git-0` specifies the URL for which Tekton will use this `Secret`,
    as described in [Understanding credential selection](#understanding-credential-selection).
+   You can view your private key with `cat ~/.ssh/<key-name>` and get GitHub's public key with `ssh-keyscan github.com`
 
-1. Generate the `ssh-privatekey` value. For example:
-
-   `cat ~/.ssh/id_rsa`
-
-1. Set the value of the `known_hosts` field to the generated `ssh-privatekey` value from the previous step.
-
-1. In `serviceaccount.yaml`, associate the `Secret` with the desired `ServiceAccount`:
+4. In `serviceaccount.yaml`, associate the `Secret` with the desired `ServiceAccount`:
 
    ```yaml
    apiVersion: v1
@@ -274,7 +280,7 @@ specified in the `Secret`.
      - name: ssh-key
    ```
 
-1. In `run.yaml`, associate the `ServiceAccount` with your `Run` by doing one of the following:
+5. In `run.yaml`, associate the `ServiceAccount` with your `Run` by doing one of the following:
 
    - Associate the `ServiceAccount` with your `TaskRun`:
 
@@ -303,7 +309,7 @@ specified in the `Secret`.
        name: demo-pipeline
    ```
 
-1. Execute the `Run`:
+6. Execute the `Run`:
 
    ```shell
    kubectl apply --filename secret.yaml,serviceaccount.yaml,run.yaml

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -267,9 +267,10 @@ specified in the `Secret`.
 
    In the above example, the value for `tekton.dev/git-0` specifies the URL for which Tekton will use this `Secret`,
    as described in [Understanding credential selection](#understanding-credential-selection).
+   
    You can view your private key with `cat ~/.ssh/<key-name>` and get GitHub's public key with `ssh-keyscan github.com`
 
-4. In `serviceaccount.yaml`, associate the `Secret` with the desired `ServiceAccount`:
+5. In `serviceaccount.yaml`, associate the `Secret` with the desired `ServiceAccount`:
 
    ```yaml
    apiVersion: v1
@@ -280,7 +281,7 @@ specified in the `Secret`.
      - name: ssh-key
    ```
 
-5. In `run.yaml`, associate the `ServiceAccount` with your `Run` by doing one of the following:
+6. In `run.yaml`, associate the `ServiceAccount` with your `Run` by doing one of the following:
 
    - Associate the `ServiceAccount` with your `TaskRun`:
 
@@ -309,7 +310,7 @@ specified in the `Secret`.
        name: demo-pipeline
    ```
 
-6. Execute the `Run`:
+7. Execute the `Run`:
 
    ```shell
    kubectl apply --filename secret.yaml,serviceaccount.yaml,run.yaml

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -236,7 +236,7 @@ This section describes how to configure an `ssh-auth` type `Secret` for use with
 before executing any `Steps` in the `Run`, Tekton creates a `~/.ssh/config` file containing the SSH key
 specified in the `Secret`.
 
-1. Generate a new SSH key with `ssh-keygen` command (optionally specify the file path in which the key will be saved, default is ~/.ssh/<key-name>)
+1. Generate a new SSH key with `ssh-keygen` command (optionally specify the file path in which the key will be saved, default is `~/.ssh/<key-name>`)
 
 2. View public key with `cat ~/.ssh/<key-name>.pub` and add it to GitHub (under Settings > SSH and GPG Keys > New SSH key)
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -238,9 +238,9 @@ specified in the `Secret`.
 
 1. Generate a new SSH key with `ssh-keygen` command (optionally specify the file path in which the key will be saved, default is `~/.ssh/<key-name>`)
 
-2. View public key with `cat ~/.ssh/<key-name>.pub` and add it to GitHub (under Settings > SSH and GPG Keys > New SSH key)
+1. View public key with `cat ~/.ssh/<key-name>.pub` and add it to GitHub (under Settings > SSH and GPG Keys > New SSH key)
 
-3. In `secret.yaml`, define a `Secret` containing your SSH private key:
+1. In `secret.yaml`, define a `Secret` containing your SSH private key:
 
    ```yaml
    apiVersion: v1
@@ -267,10 +267,10 @@ specified in the `Secret`.
 
    In the above example, the value for `tekton.dev/git-0` specifies the URL for which Tekton will use this `Secret`,
    as described in [Understanding credential selection](#understanding-credential-selection).
-   
+
    You can view your private key with `cat ~/.ssh/<key-name>` and get GitHub's public key with `ssh-keyscan github.com`
 
-5. In `serviceaccount.yaml`, associate the `Secret` with the desired `ServiceAccount`:
+1. In `serviceaccount.yaml`, associate the `Secret` with the desired `ServiceAccount`:
 
    ```yaml
    apiVersion: v1
@@ -281,7 +281,7 @@ specified in the `Secret`.
      - name: ssh-key
    ```
 
-6. In `run.yaml`, associate the `ServiceAccount` with your `Run` by doing one of the following:
+1. In `run.yaml`, associate the `ServiceAccount` with your `Run` by doing one of the following:
 
    - Associate the `ServiceAccount` with your `TaskRun`:
 
@@ -310,7 +310,7 @@ specified in the `Secret`.
        name: demo-pipeline
    ```
 
-7. Execute the `Run`:
+1. Execute the `Run`:
 
    ```shell
    kubectl apply --filename secret.yaml,serviceaccount.yaml,run.yaml

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -256,7 +256,7 @@ specified in the `Secret`.
        b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAA...
        ...
        -----END OPENSSH PRIVATE KEY-----
-     # known-hosts is not mandatory, but its use is strongly encouraged for security reasons.
+     # known_hosts is not mandatory, but its use is strongly encouraged for security reasons.
      # If it is not provided then the git server's public key will be requested
      # when the repo is first fetched.
      known_hosts: |


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Some small changes in the ssh auth part of the docs:
- Some commands concerning generating ssh keys were misleading (cat is used for viewing files and not generating ssh keys)
- Added formatting for ssh-privatekey and known-hosts keys
- Added instructions on how to get known-hosts value for GitHub

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
