### PR TITLE
better step result referencing and docs for step param substitution order and 

### DIFF
--- a/docs/stepactions.md
+++ b/docs/stepactions.md
@@ -136,6 +136,21 @@ spec:
 
 **Note:** If a `Step` declares `params` for an `inlined Step`, it will also lead to a validation error. This is because an `inlined Step` gets its `params` from the `TaskRun`.
 
+#### Parameter Substitution Precedence
+
+When applying parameters to a StepAction, the substitutions are applied in the following order:
+
+1. TaskRun parameter values in step parameters
+2. Parameters from StepAction defaults
+3. Parameters from the step (overwriting any defaults)
+4. Step result replacements
+
+This order ensures that:
+- Step parameters can reference TaskRun parameters
+- StepAction defaults provide fallback values
+- Step-specific parameters take precedence over defaults
+- Step result references are resolved last to allow referencing results from previous steps
+
 ### Emitting Results
 
 A `StepAction` also declares the results that it will emit.

--- a/pkg/reconciler/taskrun/resources/apply.go
+++ b/pkg/reconciler/taskrun/resources/apply.go
@@ -99,7 +99,10 @@ func applyStepActionParameters(step *v1.Step, spec *v1.TaskSpec, tr *v1.TaskRun,
 	}
 
 	// 4. set step result replacements last
-	stepResultReplacements, _ := replacementsFromStepResults(step, stepParams, defaults)
+	stepResultReplacements, err := replacementsFromStepResults(step, stepParams, defaults)
+	if err != nil {
+		return nil, err
+	}
 	for k, v := range stepResultReplacements {
 		stringReplacements[k] = v
 	}

--- a/pkg/reconciler/taskrun/resources/apply.go
+++ b/pkg/reconciler/taskrun/resources/apply.go
@@ -90,14 +90,6 @@ func applyStepActionParameters(step *v1.Step, spec *v1.TaskSpec, tr *v1.TaskRun,
 		arrayReplacements[k] = v
 	}
 
-	// check if there are duplicate keys in the replacements
-	// if the same key is present in both stringReplacements and arrayReplacements, it means
-	// that the default value and the passed value have different types.
-	err := checkForDuplicateKeys(stringReplacements, arrayReplacements)
-	if err != nil {
-		return nil, err
-	}
-
 	// 4. set step result replacements last
 	stepResultReplacements, err := replacementsFromStepResults(step, stepParams, defaults)
 	if err != nil {
@@ -105,6 +97,14 @@ func applyStepActionParameters(step *v1.Step, spec *v1.TaskSpec, tr *v1.TaskRun,
 	}
 	for k, v := range stepResultReplacements {
 		stringReplacements[k] = v
+	}
+
+	// check if there are duplicate keys in the replacements
+	// if the same key is present in both stringReplacements and arrayReplacements, it means
+	// that the default value and the passed value have different types.
+	err = checkForDuplicateKeys(stringReplacements, arrayReplacements)
+	if err != nil {
+		return nil, err
 	}
 
 	container.ApplyStepReplacements(step, stringReplacements, arrayReplacements)

--- a/pkg/reconciler/taskrun/resources/apply.go
+++ b/pkg/reconciler/taskrun/resources/apply.go
@@ -91,19 +91,18 @@ func applyStepActionParameters(step *v1.Step, spec *v1.TaskSpec, tr *v1.TaskRun,
 	}
 
 	// 4. set step result replacements last
-	stepResultReplacements, err := replacementsFromStepResults(step, stepParams, defaults)
-	if err != nil {
+	if stepResultReplacements, err := replacementsFromStepResults(step, stepParams, defaults); err != nil {
 		return nil, err
-	}
-	for k, v := range stepResultReplacements {
-		stringReplacements[k] = v
+	} else {
+		for k, v := range stepResultReplacements {
+			stringReplacements[k] = v
+		}
 	}
 
 	// check if there are duplicate keys in the replacements
 	// if the same key is present in both stringReplacements and arrayReplacements, it means
 	// that the default value and the passed value have different types.
-	err = checkForDuplicateKeys(stringReplacements, arrayReplacements)
-	if err != nil {
+	if err := checkForDuplicateKeys(stringReplacements, arrayReplacements); err != nil {
 		return nil, err
 	}
 

--- a/pkg/reconciler/taskrun/resources/taskspec_test.go
+++ b/pkg/reconciler/taskrun/resources/taskspec_test.go
@@ -1665,10 +1665,10 @@ func TestGetStepActionsData_InvalidStepResultReference(t *testing.T) {
 		},
 	}
 
+	expectedError := `must be one of the form 1). "steps.<stepName>.results.<resultName>"; 2). "steps.<stepName>.results.<objectResultName>.<individualAttribute>"`
 	ctx := context.Background()
 	tektonclient := fake.NewSimpleClientset(stepAction)
-	_, err := resources.GetStepActionsData(ctx, *tr.Spec.TaskSpec, tr, tektonclient, nil, nil)
-	if err == nil {
-		t.Error("Expected error due to invalid step result reference, but got nil")
+	if _, err := resources.GetStepActionsData(ctx, *tr.Spec.TaskSpec, tr, tektonclient, nil, nil); err.Error() != expectedError {
+		t.Errorf("Expected error message %s but got %s", expectedError, err.Error())
 	}
 }


### PR DESCRIPTION
# Changes

after making the necessary changes for fixing  https://github.com/tektoncd/pipeline/issues/7935, I came across this issue 

- ensure all parameters are hydrated with their respective values before parsing results from steps
- add check in replacementsFromStepResults to only parse the paramter if it starts with `$(steps.` else it throws the error 
```
must be one of the form 1).steps.<stepName>.results.<resultName> 2).steps.<stepName>.results.<objectResultName>.<individualAttribute>
```
- verbose comments

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
