### PR TITLE
fix: reference params in default values, allow chained references in stepactions

### DIFF
--- a/docs/stepactions.md
+++ b/docs/stepactions.md
@@ -141,14 +141,15 @@ spec:
 When applying parameters to a StepAction, the substitutions are applied in the following order:
 
 1. TaskRun parameter values in step parameters
-2. Parameters from StepAction defaults
-3. Parameters from the step (overwriting any defaults)
-4. Step result replacements
+2. Step-provided parameter values 
+3. Default values that reference other parameters
+4. Simple default values
+5. Step result references
 
 This order ensures that:
-- Step parameters can reference TaskRun parameters
-- StepAction defaults provide fallback values
-- Step-specific parameters take precedence over defaults
+- TaskRun parameters are available for step parameter substitution
+- Step-provided values take precedence over defaults
+- Parameter references in defaults are resolved before simple defaults
 - Step result references are resolved last to allow referencing results from previous steps
 
 ### Emitting Results

--- a/pkg/apis/pipeline/v1alpha1/stepaction_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/stepaction_validation_test.go
@@ -81,6 +81,38 @@ func TestStepActionSpecValidate(t *testing.T) {
 			Args:    []string{"-lh"},
 		},
 	}, {
+		name: "valid param default value references defined param",
+		fields: fields{
+			Image: "myimage",
+			Params: []v1.ParamSpec{{
+				Name:    "param1",
+				Type:    v1.ParamTypeString,
+				Default: v1.NewStructuredValues("hello"),
+			}, {
+				Name:    "param2",
+				Type:    v1.ParamTypeString,
+				Default: v1.NewStructuredValues("$(params.param1) world"),
+			}},
+		},
+	}, {
+		name: "multiple param references in default value",
+		fields: fields{
+			Image: "myimage",
+			Params: []v1.ParamSpec{{
+				Name:    "param1",
+				Type:    v1.ParamTypeString,
+				Default: v1.NewStructuredValues("hello"),
+			}, {
+				Name:    "param2",
+				Type:    v1.ParamTypeString,
+				Default: v1.NewStructuredValues("hi"),
+			}, {
+				Name:    "param3",
+				Type:    v1.ParamTypeString,
+				Default: v1.NewStructuredValues("$(params.param1) $(params.param2)"),
+			}},
+		},
+	}, {
 		name: "step action with script",
 		fields: fields{
 			Image:  "myimage",
@@ -591,6 +623,20 @@ func TestStepActionSpecValidateError(t *testing.T) {
 		expectedError: apis.FieldError{
 			Message: `missing field(s)`,
 			Paths:   []string{"Image"},
+		},
+	}, {
+		name: "param default value references undefined param",
+		fields: fields{
+			Image: "myimage",
+			Params: []v1.ParamSpec{{
+				Name:    "param2",
+				Type:    v1.ParamTypeString,
+				Default: v1.NewStructuredValues("$(params.param1)"),
+			}},
+		},
+		expectedError: apis.FieldError{
+			Message: `param "param2" default value references param "param1" which is not defined`,
+			Paths:   []string{"params"},
 		},
 	}, {
 		name: "command and script both used.",

--- a/pkg/reconciler/taskrun/resources/taskspec_test.go
+++ b/pkg/reconciler/taskrun/resources/taskspec_test.go
@@ -1470,7 +1470,110 @@ func TestGetStepActionsData(t *testing.T) {
 			Image: "myimage",
 			Args:  []string{"$(steps.step1.results.config.key1)", "$(steps.step1.results.config.key2)"},
 		}},
+	}, {
+		name: "chained parameter references in defaults",
+		tr: &v1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "mytaskrun",
+				Namespace: "default",
+			},
+			Spec: v1.TaskRunSpec{
+				TaskSpec: &v1.TaskSpec{
+					Steps: []v1.Step{{
+						Ref: &v1.Ref{
+							Name: "stepAction",
+						},
+					}},
+				},
+			},
+		},
+		stepAction: &v1beta1.StepAction{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "stepAction",
+				Namespace: "default",
+			},
+			Spec: v1beta1.StepActionSpec{
+				Image: "myimage",
+				Args:  []string{"$(params.param1)", "$(params.param2)", "$(params.param3)"},
+				Params: v1.ParamSpecs{{
+					Name: "param1",
+					Type: v1.ParamTypeString,
+					Default: &v1.ParamValue{
+						Type:      v1.ParamTypeString,
+						StringVal: "hello",
+					},
+				}, {
+					Name: "param2",
+					Type: v1.ParamTypeString,
+					Default: &v1.ParamValue{
+						Type:      v1.ParamTypeString,
+						StringVal: "$(params.param1) world",
+					},
+				}, {
+					Name: "param3",
+					Type: v1.ParamTypeString,
+					Default: &v1.ParamValue{
+						Type:      v1.ParamTypeString,
+						StringVal: "$(params.param2)!",
+					},
+				}},
+			},
+		},
+		want: []v1.Step{{
+			Image: "myimage",
+			Args:  []string{"hello", "hello world", "hello world!"},
+		}},
+	}, {
+		name: "parameter substitution with task param reference",
+		tr: &v1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "mytaskrun",
+				Namespace: "default",
+			},
+			Spec: v1.TaskRunSpec{
+				Params: v1.Params{{
+					Name:  "task-param",
+					Value: *v1.NewStructuredValues("task-override"),
+				}},
+				TaskSpec: &v1.TaskSpec{
+					Params: []v1.ParamSpec{{
+						Name:    "task-param",
+						Type:    v1.ParamTypeString,
+						Default: v1.NewStructuredValues("task-default"),
+					}},
+					Steps: []v1.Step{{
+						Ref: &v1.Ref{
+							Name: "stepAction",
+						},
+						Params: v1.Params{{
+							Name:  "message",
+							Value: *v1.NewStructuredValues("override"),
+						}},
+					}},
+				},
+			},
+		},
+		stepAction: &v1beta1.StepAction{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "stepAction",
+				Namespace: "default",
+			},
+			Spec: v1beta1.StepActionSpec{
+				Image: "myimage",
+				Args:  []string{"$(params.message)"},
+				Params: v1.ParamSpecs{{
+					Name:    "message",
+					Type:    v1.ParamTypeString,
+					Default: v1.NewStructuredValues("$(params.task-param)"),
+				}},
+			},
+		},
+		want: []v1.Step{{
+			Image: "myimage",
+			Args:  []string{"override"},
+		}},
 	}}
+
 	for _, tt := range tests {
 		ctx := context.Background()
 		tektonclient := fake.NewSimpleClientset(tt.stepAction)
@@ -1492,6 +1595,92 @@ func TestGetStepActionsData_Error(t *testing.T) {
 		stepAction    *v1beta1.StepAction
 		expectedError error
 	}{{
+		name: "unresolvable parameter reference",
+		tr: &v1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "mytaskrun",
+				Namespace: "default",
+			},
+			Spec: v1.TaskRunSpec{
+				TaskSpec: &v1.TaskSpec{
+					Steps: []v1.Step{{
+						Ref: &v1.Ref{
+							Name: "stepAction",
+						},
+					}},
+				},
+			},
+		},
+		stepAction: &v1beta1.StepAction{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "stepAction",
+				Namespace: "default",
+			},
+			Spec: v1beta1.StepActionSpec{
+				Image: "myimage",
+				Args:  []string{"$(params.param1)"},
+				Params: v1.ParamSpecs{{
+					Name: "param1",
+					Type: v1.ParamTypeString,
+					Default: &v1.ParamValue{
+						Type:      v1.ParamTypeString,
+						StringVal: "$(params.nonexistent)",
+					},
+				}},
+			},
+		},
+		expectedError: errors.New(`parameter "param1" references non-existent parameter "nonexistent"`),
+	}, {
+		name: "circular dependency in params",
+		tr: &v1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "mytaskrun",
+				Namespace: "default",
+			},
+			Spec: v1.TaskRunSpec{
+				TaskSpec: &v1.TaskSpec{
+					Steps: []v1.Step{{
+						Ref: &v1.Ref{
+							Name: "stepAction",
+						},
+					}},
+				},
+			},
+		},
+		stepAction: &v1beta1.StepAction{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "stepAction",
+				Namespace: "default",
+			},
+			Spec: v1beta1.StepActionSpec{
+				Image: "myimage",
+				Args:  []string{"$(params.param1)", "$(params.param2)", "$(params.param3)"},
+				Params: v1.ParamSpecs{{
+					Name: "param1",
+					Type: v1.ParamTypeString,
+					Default: &v1.ParamValue{
+						Type:      v1.ParamTypeString,
+						StringVal: "$(params.param3)",
+					},
+				}, {
+					Name: "param2",
+					Type: v1.ParamTypeString,
+					Default: &v1.ParamValue{
+						Type:      v1.ParamTypeString,
+						StringVal: "$(params.param1)",
+					},
+				}, {
+					Name: "param3",
+					Type: v1.ParamTypeString,
+					Default: &v1.ParamValue{
+						Type:      v1.ParamTypeString,
+						StringVal: "$(params.param2)",
+					},
+				}},
+			},
+		},
+		expectedError: errors.New("circular dependency detected in parameter references"),
+	}, {
 		name: "namespace missing error",
 		tr: &v1.TaskRun{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

- parameter defaults can now reference other parameters in chain
    - validate if the default parameter references are correct
    - ensure that no referenced parameter goes unresolved, including the chains
    - ensure that there are no circular dependencies with param referencing
    - multipass replacement from default params to ensure both referenced and non reference default values are processed
    - add tests

fixes https://github.com/tektoncd/pipeline/issues/7935

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

/kind bug

# Release Notes

```release-note
fixes https://github.com/tektoncd/pipeline/issues/7935 allowing users to reference other parameters in default values
```
