### PR TITLE
feat: add support for authenticated git clone

### DIFF
--- a/pkg/remoteresolution/resolver/git/resolver.go
+++ b/pkg/remoteresolution/resolver/git/resolver.go
@@ -119,11 +119,19 @@ func (r *Resolver) Resolve(ctx context.Context, req *v1beta1.ResolutionRequestSp
 			return nil, err
 		}
 
-		if params[git.UrlParam] != "" {
-			return git.ResolveAnonymousGit(ctx, params)
+		g := &git.GitResolver{
+			KubeClient: r.kubeClient,
+			Logger:     r.logger,
+			Cache:      r.cache,
+			TTL:        r.ttl,
+			Params:     params,
 		}
 
-		return git.ResolveAPIGit(ctx, params, r.kubeClient, r.logger, r.cache, r.ttl, r.clientFunc)
+		if params[git.UrlParam] != "" {
+			return g.ResolveGitClone(ctx)
+		}
+
+		return g.ResolveAPIGit(ctx, r.clientFunc)
 	}
 	// Remove this error once resolution of url has been implemented.
 	return nil, errors.New("the Resolve method has not been implemented.")

--- a/pkg/resolution/resolver/git/config.go
+++ b/pkg/resolution/resolver/git/config.go
@@ -62,6 +62,7 @@ type ScmConfig struct {
 	Org                string `json:"default-org"`
 	ServerURL          string `json:"server-url"`
 	SCMType            string `json:"scm-type"`
+	GitToken           string `json:"git-token"`
 	APISecretName      string `json:"api-token-secret-name"`
 	APISecretKey       string `json:"api-token-secret-key"`
 	APISecretNamespace string `json:"api-token-secret-namespace"`

--- a/pkg/resolution/resolver/git/params.go
+++ b/pkg/resolution/resolver/git/params.go
@@ -33,6 +33,10 @@ const (
 	TokenParam string = "token"
 	// TokenKeyParam is an optional reference to a key in the TokenParam secret for SCM API authentication
 	TokenKeyParam string = "tokenKey"
+	// GitTokenParam is an optional reference to a secret name when using go-git for git authentication
+	GitTokenParam string = "gitToken"
+	// GitTokenParam is an optional reference to a secret name when using go-git for git authentication
+	GitTokenKeyParam string = "gitTokenKey"
 	// DefaultTokenKeyParam is the default key in the TokenParam secret for SCM API authentication
 	DefaultTokenKeyParam string = "token"
 	// scmTypeParam is an optional string overriding the scm-type configuration (ie: github, gitea, gitlab etc..)


### PR DESCRIPTION
# Changes

Added support for authenticated git cloning using `gitToken` and `gitTokenKey`
parameters. Updated documentation to reflect the new parameters and their
usage. Modified resolver functions to handle authentication when cloning
repositories. Added tests to verify the functionality of authenticated git
cloning.

The differences between the two modes are:

- The `git clone` method support anonymous cloning and authenticated cloning.
- Depending of the Git provider `git clone` has a lower rate limit (if none)
  than the authenticated API.
- The authenticated API supports private repositories and fetches only the file
  at the specified path rather than doing a full clone.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
An optional token can now be passed to the git clone method (using go-git library) to
bypass token limit when using the API.
```

/kind feature
