### PR TITLE
cleanup: breakup the pkg/credentials into writer and matcher + ensure non corev1 usage in entrypoint for FIPs compliance

### DIFF
--- a/cmd/entrypoint/main.go
+++ b/cmd/entrypoint/main.go
@@ -30,11 +30,10 @@ import (
 
 	"github.com/tektoncd/pipeline/cmd/entrypoint/subcommands"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1/types"
-	"github.com/tektoncd/pipeline/pkg/credentials"
 	"github.com/tektoncd/pipeline/pkg/credentials/dockercreds"
 	"github.com/tektoncd/pipeline/pkg/credentials/gitcreds"
+	credwriter "github.com/tektoncd/pipeline/pkg/credentials/writer"
 	"github.com/tektoncd/pipeline/pkg/entrypoint"
-	"github.com/tektoncd/pipeline/pkg/entrypoint/pipeline"
 	"github.com/tektoncd/pipeline/pkg/platforms"
 	"github.com/tektoncd/pipeline/pkg/termination"
 )
@@ -92,9 +91,9 @@ func main() {
 	// from secret volume mounts to /tekton/creds. This is done to support the expansion
 	// of a variable, $(credentials.path), that resolves to a single place with all the
 	// stored credentials.
-	builders := []credentials.Builder{dockercreds.NewBuilder(), gitcreds.NewBuilder()}
+	builders := []credwriter.Writer{dockercreds.NewBuilder(), gitcreds.NewBuilder()}
 	for _, c := range builders {
-		if err := c.Write(pipeline.CredsDir); err != nil {
+		if err := c.Write(entrypoint.CredsDir); err != nil {
 			log.Printf("Error initializing credentials: %s", err)
 		}
 	}
@@ -154,7 +153,7 @@ func main() {
 
 	// Copy any creds injected by the controller into the $HOME directory of the current
 	// user so that they're discoverable by git / ssh.
-	if err := credentials.CopyCredsToHome(credentials.CredsInitCredentials); err != nil {
+	if err := credwriter.CopyCredsToHome(credwriter.CredsInitCredentials); err != nil {
 		log.Printf("non-fatal error copying credentials: %q", err)
 	}
 

--- a/pkg/credentials/common/constants.go
+++ b/pkg/credentials/common/constants.go
@@ -1,0 +1,21 @@
+package common
+
+// Secret key constants used in credential files,
+// so as to avoid reliance on corev1.Secret.
+//
+//nolint:gosec // for known Kubernetes secret-type constants, not real credentials
+const (
+	BasicAuthUsernameKey          = "username"
+	BasicAuthPasswordKey          = "password"
+	SSHAuthPrivateKey             = "ssh-privatekey"
+	DockerConfigKey               = ".dockercfg"
+	DockerConfigJsonKey           = ".dockerconfigjson"
+	SecretTypeBasicAuth           = "kubernetes.io/basic-auth"
+	SecretTypeSSHAuth             = "kubernetes.io/ssh-auth"
+	SecretTypeDockerConfigJson    = "kubernetes.io/dockerconfigjson"
+	SecretTypeDockercfg           = "kubernetes.io/dockercfg"
+	SecretTypeServiceAccountToken = "kubernetes.io/service-account-token"
+	SecretTypeOpaque              = "kubernetes.io/opaque"
+	SecretTypeTLS                 = "kubernetes.io/tls"
+	SecretTypeBootstrapToken      = "kubernetes.io/bootstrap-token"
+)

--- a/pkg/credentials/dockercreds/creds_test.go
+++ b/pkg/credentials/dockercreds/creds_test.go
@@ -23,14 +23,14 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/tektoncd/pipeline/pkg/credentials"
+	credmatcher "github.com/tektoncd/pipeline/pkg/credentials/matcher"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestFlagHandling(t *testing.T) {
-	credentials.VolumePath = t.TempDir()
-	dir := credentials.VolumeName("foo")
+	credmatcher.VolumePath = t.TempDir()
+	dir := credmatcher.VolumeName("foo")
 	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
 		t.Fatalf("os.MkdirAll(%s) = %v", dir, err)
 	}
@@ -50,12 +50,12 @@ func TestFlagHandling(t *testing.T) {
 		t.Fatalf("flag.CommandLine.Parse() = %v", err)
 	}
 
-	t.Setenv("HOME", credentials.VolumePath)
-	if err := NewBuilder().Write(credentials.VolumePath); err != nil {
+	t.Setenv("HOME", credmatcher.VolumePath)
+	if err := NewBuilder().Write(credmatcher.VolumePath); err != nil {
 		t.Fatalf("Write() = %v", err)
 	}
 
-	b, err := os.ReadFile(filepath.Join(credentials.VolumePath, ".docker", "config.json"))
+	b, err := os.ReadFile(filepath.Join(credmatcher.VolumePath, ".docker", "config.json"))
 	if err != nil {
 		t.Fatalf("os.ReadFile(.docker/config.json) = %v", err)
 	}
@@ -68,8 +68,8 @@ func TestFlagHandling(t *testing.T) {
 }
 
 func TestFlagHandlingTwice(t *testing.T) {
-	credentials.VolumePath = t.TempDir()
-	fooDir := credentials.VolumeName("foo")
+	credmatcher.VolumePath = t.TempDir()
+	fooDir := credmatcher.VolumeName("foo")
 	if err := os.MkdirAll(fooDir, os.ModePerm); err != nil {
 		t.Fatalf("os.MkdirAll(%s) = %v", fooDir, err)
 	}
@@ -79,7 +79,7 @@ func TestFlagHandlingTwice(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(fooDir, corev1.BasicAuthPasswordKey), []byte("blah"), 0o777); err != nil {
 		t.Fatalf("os.WriteFile(password) = %v", err)
 	}
-	barDir := credentials.VolumeName("bar")
+	barDir := credmatcher.VolumeName("bar")
 	if err := os.MkdirAll(barDir, os.ModePerm); err != nil {
 		t.Fatalf("os.MkdirAll(%s) = %v", barDir, err)
 	}
@@ -100,12 +100,12 @@ func TestFlagHandlingTwice(t *testing.T) {
 		t.Fatalf("flag.CommandLine.Parse() = %v", err)
 	}
 
-	t.Setenv("HOME", credentials.VolumePath)
-	if err := NewBuilder().Write(credentials.VolumePath); err != nil {
+	t.Setenv("HOME", credmatcher.VolumePath)
+	if err := NewBuilder().Write(credmatcher.VolumePath); err != nil {
 		t.Fatalf("Write() = %v", err)
 	}
 
-	b, err := os.ReadFile(filepath.Join(credentials.VolumePath, ".docker", "config.json"))
+	b, err := os.ReadFile(filepath.Join(credmatcher.VolumePath, ".docker", "config.json"))
 	if err != nil {
 		t.Fatalf("os.ReadFile(.docker/config.json) = %v", err)
 	}
@@ -118,8 +118,8 @@ func TestFlagHandlingTwice(t *testing.T) {
 }
 
 func TestFlagHandlingMissingFiles(t *testing.T) {
-	credentials.VolumePath = t.TempDir()
-	dir := credentials.VolumeName("not-found")
+	credmatcher.VolumePath = t.TempDir()
+	dir := credmatcher.VolumeName("not-found")
 	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
 		t.Fatalf("os.MkdirAll(%s) = %v", dir, err)
 	}
@@ -132,8 +132,8 @@ func TestFlagHandlingMissingFiles(t *testing.T) {
 }
 
 func TestFlagHandlingURLCollision(t *testing.T) {
-	credentials.VolumePath = t.TempDir()
-	dir := credentials.VolumeName("foo")
+	credmatcher.VolumePath = t.TempDir()
+	dir := credmatcher.VolumeName("foo")
 	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
 		t.Fatalf("os.MkdirAll(%s) = %v", dir, err)
 	}
@@ -244,8 +244,8 @@ func TestMatchingAnnotations(t *testing.T) {
 }
 
 func TestMultipleFlagHandling(t *testing.T) {
-	credentials.VolumePath = t.TempDir()
-	fooDir := credentials.VolumeName("foo")
+	credmatcher.VolumePath = t.TempDir()
+	fooDir := credmatcher.VolumeName("foo")
 	if err := os.MkdirAll(fooDir, os.ModePerm); err != nil {
 		t.Fatalf("os.MkdirAll(%s) = %v", fooDir, err)
 	}
@@ -256,7 +256,7 @@ func TestMultipleFlagHandling(t *testing.T) {
 		t.Fatalf("os.WriteFile(password) = %v", err)
 	}
 
-	barDir := credentials.VolumeName("bar")
+	barDir := credmatcher.VolumeName("bar")
 	if err := os.MkdirAll(barDir, os.ModePerm); err != nil {
 		t.Fatalf("os.MkdirAll(%s) = %v", barDir, err)
 	}
@@ -264,7 +264,7 @@ func TestMultipleFlagHandling(t *testing.T) {
 		t.Fatalf("os.WriteFile(username) = %v", err)
 	}
 
-	blubbDir := credentials.VolumeName("blubb")
+	blubbDir := credmatcher.VolumeName("blubb")
 	if err := os.MkdirAll(blubbDir, os.ModePerm); err != nil {
 		t.Fatalf("os.MkdirAll(%s) = %v", blubbDir, err)
 	}
@@ -272,7 +272,7 @@ func TestMultipleFlagHandling(t *testing.T) {
 		t.Fatalf("os.WriteFile(username) = %v", err)
 	}
 
-	bazDir := credentials.VolumeName("baz")
+	bazDir := credmatcher.VolumeName("baz")
 	if err := os.MkdirAll(bazDir, os.ModePerm); err != nil {
 		t.Fatalf("os.MkdirAll(%s) = %v", bazDir, err)
 	}
@@ -280,7 +280,7 @@ func TestMultipleFlagHandling(t *testing.T) {
 		t.Fatalf("os.WriteFile(username) = %v", err)
 	}
 
-	blaDir := credentials.VolumeName("bla")
+	blaDir := credmatcher.VolumeName("bla")
 	if err := os.MkdirAll(blaDir, os.ModePerm); err != nil {
 		t.Fatalf("os.MkdirAll(%s) = %v", blaDir, err)
 	}
@@ -301,12 +301,12 @@ func TestMultipleFlagHandling(t *testing.T) {
 		t.Fatalf("flag.CommandLine.Parse() = %v", err)
 	}
 
-	t.Setenv("HOME", credentials.VolumePath)
-	if err := NewBuilder().Write(credentials.VolumePath); err != nil {
+	t.Setenv("HOME", credmatcher.VolumePath)
+	if err := NewBuilder().Write(credmatcher.VolumePath); err != nil {
 		t.Fatalf("Write() = %v", err)
 	}
 
-	b, err := os.ReadFile(filepath.Join(credentials.VolumePath, ".docker", "config.json"))
+	b, err := os.ReadFile(filepath.Join(credmatcher.VolumePath, ".docker", "config.json"))
 	if err != nil {
 		t.Fatalf("os.ReadFile(.docker/config.json) = %v", err)
 	}
@@ -321,8 +321,8 @@ func TestMultipleFlagHandling(t *testing.T) {
 // TestNoAuthProvided confirms that providing zero secrets results in no docker
 // credential file being written to disk.
 func TestNoAuthProvided(t *testing.T) {
-	credentials.VolumePath = t.TempDir()
-	fooDir := credentials.VolumeName("foo")
+	credmatcher.VolumePath = t.TempDir()
+	fooDir := credmatcher.VolumeName("foo")
 	if err := os.MkdirAll(fooDir, os.ModePerm); err != nil {
 		t.Fatalf("os.MkdirAll(%s) = %v", fooDir, err)
 	}
@@ -333,11 +333,11 @@ func TestNoAuthProvided(t *testing.T) {
 	if err != nil {
 		t.Fatalf("flag.CommandLine.Parse() = %v", err)
 	}
-	t.Setenv("HOME", credentials.VolumePath)
-	if err := NewBuilder().Write(credentials.VolumePath); err != nil {
+	t.Setenv("HOME", credmatcher.VolumePath)
+	if err := NewBuilder().Write(credmatcher.VolumePath); err != nil {
 		t.Fatalf("Write() = %v", err)
 	}
-	_, err = os.ReadFile(filepath.Join(credentials.VolumePath, ".docker", "config.json"))
+	_, err = os.ReadFile(filepath.Join(credmatcher.VolumePath, ".docker", "config.json"))
 	if err == nil || !os.IsNotExist(err) {
 		t.Errorf("expected does not exist error but received: %v", err)
 	}

--- a/pkg/credentials/gitcreds/basic.go
+++ b/pkg/credentials/gitcreds/basic.go
@@ -23,8 +23,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/tektoncd/pipeline/pkg/credentials"
-	corev1 "k8s.io/api/core/v1"
+	"github.com/tektoncd/pipeline/pkg/credentials/common"
+	credmatcher "github.com/tektoncd/pipeline/pkg/credentials/matcher"
 )
 
 // As the flag is read, this status is populated.
@@ -121,15 +121,15 @@ func (be *basicEntry) escapedUsername() string {
 }
 
 func newBasicEntry(u, secret string) (*basicEntry, error) {
-	secretPath := credentials.VolumeName(secret)
+	secretPath := credmatcher.VolumeName(secret)
 
-	ub, err := os.ReadFile(filepath.Join(secretPath, corev1.BasicAuthUsernameKey))
+	ub, err := os.ReadFile(filepath.Join(secretPath, common.BasicAuthUsernameKey))
 	if err != nil {
 		return nil, err
 	}
 	username := string(ub)
 
-	pb, err := os.ReadFile(filepath.Join(secretPath, corev1.BasicAuthPasswordKey))
+	pb, err := os.ReadFile(filepath.Join(secretPath, common.BasicAuthPasswordKey))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/credentials/gitcreds/creds_test.go
+++ b/pkg/credentials/gitcreds/creds_test.go
@@ -24,15 +24,15 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/tektoncd/pipeline/pkg/credentials"
+	credmatcher "github.com/tektoncd/pipeline/pkg/credentials/matcher"
 	"github.com/tektoncd/pipeline/test/diff"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestBasicFlagHandling(t *testing.T) {
-	credentials.VolumePath = t.TempDir()
-	dir := credentials.VolumeName("foo")
+	credmatcher.VolumePath = t.TempDir()
+	dir := credmatcher.VolumeName("foo")
 	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
 		t.Fatalf("os.MkdirAll(%s) = %v", dir, err)
 	}
@@ -52,12 +52,12 @@ func TestBasicFlagHandling(t *testing.T) {
 		t.Fatalf("flag.CommandLine.Parse() = %v", err)
 	}
 
-	t.Setenv("HOME", credentials.VolumePath)
-	if err := NewBuilder().Write(credentials.VolumePath); err != nil {
+	t.Setenv("HOME", credmatcher.VolumePath)
+	if err := NewBuilder().Write(credmatcher.VolumePath); err != nil {
 		t.Fatalf("Write() = %v", err)
 	}
 
-	b, err := os.ReadFile(filepath.Join(credentials.VolumePath, ".gitconfig"))
+	b, err := os.ReadFile(filepath.Join(credmatcher.VolumePath, ".gitconfig"))
 	if err != nil {
 		t.Fatalf("os.ReadFile(.gitconfig) = %v", err)
 	}
@@ -71,7 +71,7 @@ func TestBasicFlagHandling(t *testing.T) {
 		t.Errorf("got: %v, wanted: %v", string(b), expectedGitConfig)
 	}
 
-	b, err = os.ReadFile(filepath.Join(credentials.VolumePath, ".git-credentials"))
+	b, err = os.ReadFile(filepath.Join(credmatcher.VolumePath, ".git-credentials"))
 	if err != nil {
 		t.Fatalf("os.ReadFile(.git-credentials) = %v", err)
 	}
@@ -84,8 +84,8 @@ func TestBasicFlagHandling(t *testing.T) {
 }
 
 func TestBasicFlagHandlingTwice(t *testing.T) {
-	credentials.VolumePath = t.TempDir()
-	fooDir := credentials.VolumeName("foo")
+	credmatcher.VolumePath = t.TempDir()
+	fooDir := credmatcher.VolumeName("foo")
 	if err := os.MkdirAll(fooDir, os.ModePerm); err != nil {
 		t.Fatalf("os.MkdirAll(%s) = %v", fooDir, err)
 	}
@@ -95,7 +95,7 @@ func TestBasicFlagHandlingTwice(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(fooDir, corev1.BasicAuthPasswordKey), []byte("blah"), 0o777); err != nil {
 		t.Fatalf("os.WriteFile(password) = %v", err)
 	}
-	barDir := credentials.VolumeName("bar")
+	barDir := credmatcher.VolumeName("bar")
 	if err := os.MkdirAll(barDir, os.ModePerm); err != nil {
 		t.Fatalf("os.MkdirAll(%s) = %v", barDir, err)
 	}
@@ -116,12 +116,12 @@ func TestBasicFlagHandlingTwice(t *testing.T) {
 		t.Fatalf("flag.CommandLine.Parse() = %v", err)
 	}
 
-	t.Setenv("HOME", credentials.VolumePath)
-	if err := NewBuilder().Write(credentials.VolumePath); err != nil {
+	t.Setenv("HOME", credmatcher.VolumePath)
+	if err := NewBuilder().Write(credmatcher.VolumePath); err != nil {
 		t.Fatalf("Write() = %v", err)
 	}
 
-	b, err := os.ReadFile(filepath.Join(credentials.VolumePath, ".gitconfig"))
+	b, err := os.ReadFile(filepath.Join(credmatcher.VolumePath, ".gitconfig"))
 	if err != nil {
 		t.Fatalf("os.ReadFile(.gitconfig) = %v", err)
 	}
@@ -137,7 +137,7 @@ func TestBasicFlagHandlingTwice(t *testing.T) {
 		t.Errorf("got: %v, wanted: %v", string(b), expectedGitConfig)
 	}
 
-	b, err = os.ReadFile(filepath.Join(credentials.VolumePath, ".git-credentials"))
+	b, err = os.ReadFile(filepath.Join(credmatcher.VolumePath, ".git-credentials"))
 	if err != nil {
 		t.Fatalf("os.ReadFile(.git-credentials) = %v", err)
 	}
@@ -151,8 +151,8 @@ https://bleh:belch@gitlab.com
 }
 
 func TestBasicFlagHandlingMissingFiles(t *testing.T) {
-	credentials.VolumePath = t.TempDir()
-	dir := credentials.VolumeName("not-found")
+	credmatcher.VolumePath = t.TempDir()
+	dir := credmatcher.VolumeName("not-found")
 	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
 		t.Fatalf("os.MkdirAll(%s) = %v", dir, err)
 	}
@@ -165,8 +165,8 @@ func TestBasicFlagHandlingMissingFiles(t *testing.T) {
 }
 
 func TestBasicFlagHandlingURLCollision(t *testing.T) {
-	credentials.VolumePath = t.TempDir()
-	dir := credentials.VolumeName("foo")
+	credmatcher.VolumePath = t.TempDir()
+	dir := credmatcher.VolumeName("foo")
 	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
 		t.Fatalf("os.MkdirAll(%s) = %v", dir, err)
 	}
@@ -187,8 +187,8 @@ func TestBasicFlagHandlingURLCollision(t *testing.T) {
 }
 
 func TestSSHFlagHandling(t *testing.T) {
-	credentials.VolumePath = t.TempDir()
-	dir := credentials.VolumeName("foo")
+	credmatcher.VolumePath = t.TempDir()
+	dir := credmatcher.VolumeName("foo")
 	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
 		t.Fatalf("os.MkdirAll(%s) = %v", dir, err)
 	}
@@ -208,12 +208,12 @@ func TestSSHFlagHandling(t *testing.T) {
 		t.Fatalf("flag.CommandLine.Parse() = %v", err)
 	}
 
-	t.Setenv("HOME", credentials.VolumePath)
-	if err := NewBuilder().Write(credentials.VolumePath); err != nil {
+	t.Setenv("HOME", credmatcher.VolumePath)
+	if err := NewBuilder().Write(credmatcher.VolumePath); err != nil {
 		t.Fatalf("Write() = %v", err)
 	}
 
-	b, err := os.ReadFile(filepath.Join(credentials.VolumePath, ".ssh", "config"))
+	b, err := os.ReadFile(filepath.Join(credmatcher.VolumePath, ".ssh", "config"))
 	if err != nil {
 		t.Fatalf("os.ReadFile(.ssh/config) = %v", err)
 	}
@@ -222,12 +222,12 @@ func TestSSHFlagHandling(t *testing.T) {
     HostName github.com
     Port 22
     IdentityFile %s/.ssh/id_foo
-`, credentials.VolumePath)
+`, credmatcher.VolumePath)
 	if d := cmp.Diff(expectedSSHConfig, string(b)); d != "" {
 		t.Errorf("ssh_config diff %s", diff.PrintWantGot(d))
 	}
 
-	b, err = os.ReadFile(filepath.Join(credentials.VolumePath, ".ssh", "known_hosts"))
+	b, err = os.ReadFile(filepath.Join(credmatcher.VolumePath, ".ssh", "known_hosts"))
 	if err != nil {
 		t.Fatalf("os.ReadFile(.ssh/known_hosts) = %v", err)
 	}
@@ -236,7 +236,7 @@ func TestSSHFlagHandling(t *testing.T) {
 		t.Errorf("got: %v, wanted: %v", string(b), expectedSSHKnownHosts)
 	}
 
-	b, err = os.ReadFile(filepath.Join(credentials.VolumePath, ".ssh", "id_foo"))
+	b, err = os.ReadFile(filepath.Join(credmatcher.VolumePath, ".ssh", "id_foo"))
 	if err != nil {
 		t.Fatalf("os.ReadFile(.ssh/id_foo) = %v", err)
 	}
@@ -248,8 +248,8 @@ func TestSSHFlagHandling(t *testing.T) {
 }
 
 func TestSSHFlagHandlingThrice(t *testing.T) {
-	credentials.VolumePath = t.TempDir()
-	fooDir := credentials.VolumeName("foo")
+	credmatcher.VolumePath = t.TempDir()
+	fooDir := credmatcher.VolumeName("foo")
 	if err := os.MkdirAll(fooDir, os.ModePerm); err != nil {
 		t.Fatalf("os.MkdirAll(%s) = %v", fooDir, err)
 	}
@@ -259,7 +259,7 @@ func TestSSHFlagHandlingThrice(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(fooDir, "known_hosts"), []byte("ssh-rsa aaaa"), 0o777); err != nil {
 		t.Fatalf("os.WriteFile(known_hosts) = %v", err)
 	}
-	barDir := credentials.VolumeName("bar")
+	barDir := credmatcher.VolumeName("bar")
 	if err := os.MkdirAll(barDir, os.ModePerm); err != nil {
 		t.Fatalf("os.MkdirAll(%s) = %v", barDir, err)
 	}
@@ -269,7 +269,7 @@ func TestSSHFlagHandlingThrice(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(barDir, "known_hosts"), []byte("ssh-rsa bbbb"), 0o777); err != nil {
 		t.Fatalf("os.WriteFile(known_hosts) = %v", err)
 	}
-	bazDir := credentials.VolumeName("baz")
+	bazDir := credmatcher.VolumeName("baz")
 	if err := os.MkdirAll(bazDir, os.ModePerm); err != nil {
 		t.Fatalf("os.MkdirAll(%s) = %v", bazDir, err)
 	}
@@ -293,12 +293,12 @@ func TestSSHFlagHandlingThrice(t *testing.T) {
 		t.Fatalf("flag.CommandLine.Parse() = %v", err)
 	}
 
-	t.Setenv("HOME", credentials.VolumePath)
-	if err := NewBuilder().Write(credentials.VolumePath); err != nil {
+	t.Setenv("HOME", credmatcher.VolumePath)
+	if err := NewBuilder().Write(credmatcher.VolumePath); err != nil {
 		t.Fatalf("Write() = %v", err)
 	}
 
-	b, err := os.ReadFile(filepath.Join(credentials.VolumePath, ".ssh", "config"))
+	b, err := os.ReadFile(filepath.Join(credmatcher.VolumePath, ".ssh", "config"))
 	if err != nil {
 		t.Fatalf("os.ReadFile(.ssh/config) = %v", err)
 	}
@@ -312,12 +312,12 @@ Host gitlab.example.com
     HostName gitlab.example.com
     Port 2222
     IdentityFile %s/.ssh/id_baz
-`, credentials.VolumePath, credentials.VolumePath, credentials.VolumePath)
+`, credmatcher.VolumePath, credmatcher.VolumePath, credmatcher.VolumePath)
 	if d := cmp.Diff(expectedSSHConfig, string(b)); d != "" {
 		t.Errorf("ssh_config diff %s", diff.PrintWantGot(d))
 	}
 
-	b, err = os.ReadFile(filepath.Join(credentials.VolumePath, ".ssh", "known_hosts"))
+	b, err = os.ReadFile(filepath.Join(credmatcher.VolumePath, ".ssh", "known_hosts"))
 	if err != nil {
 		t.Fatalf("os.ReadFile(.ssh/known_hosts) = %v", err)
 	}
@@ -328,7 +328,7 @@ ssh-rsa cccc`
 		t.Errorf("known_hosts diff %s", diff.PrintWantGot(d))
 	}
 
-	b, err = os.ReadFile(filepath.Join(credentials.VolumePath, ".ssh", "id_foo"))
+	b, err = os.ReadFile(filepath.Join(credmatcher.VolumePath, ".ssh", "id_foo"))
 	if err != nil {
 		t.Fatalf("os.ReadFile(.ssh/id_foo) = %v", err)
 	}
@@ -338,7 +338,7 @@ ssh-rsa cccc`
 		t.Errorf("got: %v, wanted: %v", string(b), expectedIDFoo)
 	}
 
-	b, err = os.ReadFile(filepath.Join(credentials.VolumePath, ".ssh", "id_bar"))
+	b, err = os.ReadFile(filepath.Join(credmatcher.VolumePath, ".ssh", "id_bar"))
 	if err != nil {
 		t.Fatalf("os.ReadFile(.ssh/id_bar) = %v", err)
 	}
@@ -348,7 +348,7 @@ ssh-rsa cccc`
 		t.Errorf("got: %v, wanted: %v", string(b), expectedIDBar)
 	}
 
-	b, err = os.ReadFile(filepath.Join(credentials.VolumePath, ".ssh", "id_baz"))
+	b, err = os.ReadFile(filepath.Join(credmatcher.VolumePath, ".ssh", "id_baz"))
 	if err != nil {
 		t.Fatalf("os.ReadFile(.ssh/id_baz) = %v", err)
 	}
@@ -360,8 +360,8 @@ ssh-rsa cccc`
 }
 
 func TestSSHFlagHandlingMissingFiles(t *testing.T) {
-	credentials.VolumePath = t.TempDir()
-	dir := credentials.VolumeName("not-found")
+	credmatcher.VolumePath = t.TempDir()
+	dir := credmatcher.VolumeName("not-found")
 	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
 		t.Fatalf("os.MkdirAll(%s) = %v", dir, err)
 	}
@@ -464,8 +464,8 @@ func TestMatchingAnnotations(t *testing.T) {
 }
 
 func TestBasicBackslashInUsername(t *testing.T) {
-	credentials.VolumePath = t.TempDir()
-	dir := credentials.VolumeName("foo")
+	credmatcher.VolumePath = t.TempDir()
+	dir := credmatcher.VolumeName("foo")
 	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
 		t.Fatalf("os.MkdirAll(%s) = %v", dir, err)
 	}
@@ -485,12 +485,12 @@ func TestBasicBackslashInUsername(t *testing.T) {
 		t.Fatalf("flag.CommandLine.Parse() = %v", err)
 	}
 
-	t.Setenv("HOME", credentials.VolumePath)
-	if err := NewBuilder().Write(credentials.VolumePath); err != nil {
+	t.Setenv("HOME", credmatcher.VolumePath)
+	if err := NewBuilder().Write(credmatcher.VolumePath); err != nil {
 		t.Fatalf("Write() = %v", err)
 	}
 
-	b, err := os.ReadFile(filepath.Join(credentials.VolumePath, ".gitconfig"))
+	b, err := os.ReadFile(filepath.Join(credmatcher.VolumePath, ".gitconfig"))
 	if err != nil {
 		t.Fatalf("os.ReadFile(.gitconfig) = %v", err)
 	}
@@ -504,7 +504,7 @@ func TestBasicBackslashInUsername(t *testing.T) {
 		t.Errorf("got: %v, wanted: %v", string(b), expectedGitConfig)
 	}
 
-	b, err = os.ReadFile(filepath.Join(credentials.VolumePath, ".git-credentials"))
+	b, err = os.ReadFile(filepath.Join(credmatcher.VolumePath, ".git-credentials"))
 	if err != nil {
 		t.Fatalf("os.ReadFile(.git-credentials) = %v", err)
 	}

--- a/pkg/credentials/gitcreds/ssh.go
+++ b/pkg/credentials/gitcreds/ssh.go
@@ -23,8 +23,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/tektoncd/pipeline/pkg/credentials"
-	corev1 "k8s.io/api/core/v1"
+	"github.com/tektoncd/pipeline/pkg/credentials/common"
+	credmatcher "github.com/tektoncd/pipeline/pkg/credentials/matcher"
 )
 
 const sshKnownHosts = "known_hosts"
@@ -140,9 +140,9 @@ func (be *sshEntry) Write(sshDir string) error {
 }
 
 func newSSHEntry(url, secretName string) (*sshEntry, error) {
-	secretPath := credentials.VolumeName(secretName)
+	secretPath := credmatcher.VolumeName(secretName)
 
-	pk, err := os.ReadFile(filepath.Join(secretPath, corev1.SSHAuthPrivateKey))
+	pk, err := os.ReadFile(filepath.Join(secretPath, common.SSHAuthPrivateKey))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/credentials/matcher/matcher.go
+++ b/pkg/credentials/matcher/matcher.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2025 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package matcher
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// VolumePath is the path where build secrets are written.
+// It is mutable and exported for testing.
+var VolumePath = "/tekton/creds-secrets"
+
+// Secret is the minimal interface needed for credential matching
+type Secret interface {
+	GetName() string
+	GetAnnotations() map[string]string
+}
+
+// Matcher is the interface for a credential initializer of any type.
+type Matcher interface {
+	// MatchingAnnotations extracts flags for the credential
+	// helper from the supplied secret and returns a slice (of length 0 or greater)
+	MatchingAnnotations(secret Secret) []string
+}
+
+// VolumeName returns the full path to the secret, inside the VolumePath.
+func VolumeName(secretName string) string {
+	return fmt.Sprintf("%s/%s", VolumePath, secretName)
+}
+
+// GetSecretType returns secret type from secret interface using reflection
+func GetSecretType(secret Secret) string {
+	if secret == nil {
+		return ""
+	}
+	v := reflect.ValueOf(secret)
+	// If a pointer, check if it's nil before dereferencing
+	if v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			return ""
+		}
+		v = v.Elem()
+	}
+	// access the Type field for Kubernetes secrets
+	f := v.FieldByName("Type")
+	if !f.IsValid() || !f.CanInterface() {
+		return ""
+	}
+	return fmt.Sprintf("%v", f.Interface())
+}

--- a/pkg/credentials/matcher/matcher_test.go
+++ b/pkg/credentials/matcher/matcher_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2025 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package matcher_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/tektoncd/pipeline/pkg/credentials/common"
+	"github.com/tektoncd/pipeline/pkg/credentials/matcher"
+	"github.com/tektoncd/pipeline/test/diff"
+)
+
+func TestGetSecretType(t *testing.T) {
+	tests := []struct {
+		name   string
+		secret *corev1.Secret
+		want   string
+	}{{
+		name: "basic auth secret",
+		secret: &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-secret",
+				Annotations: map[string]string{
+					"tekton.dev/git-0": "https://github.com",
+				},
+			},
+			Type: corev1.SecretType(common.SecretTypeBasicAuth),
+		},
+		want: common.SecretTypeBasicAuth,
+	}, {
+		name: "docker config json secret",
+		secret: &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-secret",
+				Annotations: map[string]string{
+					"tekton.dev/docker-0": "https://gcr.io",
+				},
+			},
+			Type: corev1.SecretType(common.SecretTypeDockerConfigJson),
+		},
+		want: common.SecretTypeDockerConfigJson,
+	}, {
+		name: "ssh auth secret",
+		secret: &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-secret",
+				Annotations: map[string]string{
+					"tekton.dev/git-0": "https://github.com",
+				},
+			},
+			Type: corev1.SecretType(common.SecretTypeSSHAuth),
+		},
+		want: common.SecretTypeSSHAuth,
+	}, {
+		name: "opaque secret",
+		secret: &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-secret",
+				Annotations: map[string]string{
+					"tekton.dev/git-0": "https://github.com",
+				},
+			},
+			Type: corev1.SecretType(common.SecretTypeOpaque),
+		},
+		want: common.SecretTypeOpaque,
+	}, {
+		name:   "nil secret",
+		secret: nil,
+		want:   "",
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := matcher.GetSecretType(tc.secret)
+			if d := cmp.Diff(tc.want, got); d != "" {
+				t.Error(diff.PrintWantGot(d))
+			}
+		})
+	}
+}

--- a/pkg/credentials/writer/writer.go
+++ b/pkg/credentials/writer/writer.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2024 The Tekton Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package credentials
+package writer
 
 import (
 	"fmt"
@@ -27,7 +27,6 @@ import (
 
 	"github.com/mitchellh/go-homedir"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
-	corev1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -44,24 +43,10 @@ const (
 // helper (aka "creds-init") can write to /tekton/creds.
 var CredsInitCredentials = []string{".docker", ".gitconfig", ".git-credentials", ".ssh"}
 
-// VolumePath is the path where build secrets are written.
-// It is mutable and exported for testing.
-var VolumePath = "/tekton/creds-secrets"
-
-// Builder is the interface for a credential initializer of any type.
-type Builder interface {
-	// MatchingAnnotations extracts flags for the credential
-	// helper from the supplied secret and returns a slice (of
-	// length 0 or greater) of applicable domains.
-	MatchingAnnotations(secret *corev1.Secret) []string
-
+// Writer is the interface for a credential initializer of any type.
+type Writer interface {
 	// Write writes the credentials to the provided directory.
 	Write(folder string) error
-}
-
-// VolumeName returns the full path to the secret, inside the VolumePath.
-func VolumeName(secretName string) string {
-	return fmt.Sprintf("%s/%s", VolumePath, secretName)
 }
 
 // SortAnnotations return sorted array of strings which has annotationPrefix

--- a/pkg/credentials/writer/writer_test.go
+++ b/pkg/credentials/writer/writer_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Tekton Authors
+Copyright 2025 The Tekton Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package credentials
+package writer
 
 import (
 	"os"
@@ -23,6 +23,19 @@ import (
 )
 
 const credContents string = "hello, world!"
+
+func writeFakeCred(t *testing.T, dir, name, contents string) string {
+	t.Helper()
+	flags := os.O_RDWR | os.O_CREATE | os.O_TRUNC
+	path := filepath.Join(dir, name)
+	cred, err := os.OpenFile(path, flags, 0o600)
+	if err != nil {
+		t.Fatalf("unexpected error writing fake credential: %v", err)
+	}
+	_, _ = cred.WriteString(contents)
+	_ = cred.Close()
+	return path
+}
 
 func TestTryCopyCredDir(t *testing.T) {
 	dir := t.TempDir()
@@ -87,17 +100,4 @@ func TestTryCopyCredFileMissing(t *testing.T) {
 	if !os.IsNotExist(err) {
 		t.Fatalf("destination file exists but should not have been copied: %v", err)
 	}
-}
-
-func writeFakeCred(t *testing.T, dir, name, contents string) string {
-	t.Helper()
-	flags := os.O_RDWR | os.O_CREATE | os.O_TRUNC
-	path := filepath.Join(dir, name)
-	cred, err := os.OpenFile(path, flags, 0o600)
-	if err != nil {
-		t.Fatalf("unexpected error writing fake credential: %v", err)
-	}
-	_, _ = cred.WriteString(contents)
-	_ = cred.Close()
-	return path
 }

--- a/pkg/entrypoint/entrypointer.go
+++ b/pkg/entrypoint/entrypointer.go
@@ -61,6 +61,11 @@ const (
 	downwardMountCancelFile = "cancel"
 	stepPrefix              = "step-"
 )
+const (
+	// CredsDir is the directory where credentials are placed to meet the legacy credentials
+	// helpers image (aka "creds-init") contract
+	CredsDir = "/tekton/creds" // #nosec
+)
 
 var DownwardMountCancelFile string
 


### PR DESCRIPTION
# Changes

The credentials package contains the a matcher and a writer which out of which only the writer is used in cmd/entrypoint. In an effort to isolate usage and not indirectly import the corev1 api which the matcher uses for MatchingAnnotations, we are breaking up the credentials builder interface into two builders for writer and matcher.

This ensures that the entrypoint only uses the writer and not the matcher, and we are only using either the writer or the matcher functionality as necessary and not importing unnecessary deps.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

/kind cleanup

# Release Notes

```release-note
import only the writer part of the credentials package in the entrypoint so that we do not pull core v1 API indirectly into the package
```
