### PR TITLE
FIPS Compliance: Refactor Entrypoint, Remove zap Dependency & Update Build Checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,18 @@ jobs:
     - name: build
       run: |
         go build -v ./...
+  buildFips:
+    name: buildFips
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+    - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34  # v5.3.0
+      with:
+        go-version-file: "go.mod"
+    - name: build
+      run: |
+        go build -v -tags "disable_spire,disable_tls" ./cmd/entrypoint
+        echo "Build finished with exit code: $?"
   linting:
     needs: [build]
     name: lint

--- a/cmd/entrypoint/main.go
+++ b/cmd/entrypoint/main.go
@@ -29,12 +29,12 @@ import (
 	"time"
 
 	"github.com/tektoncd/pipeline/cmd/entrypoint/subcommands"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
-	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1/types"
 	"github.com/tektoncd/pipeline/pkg/credentials"
 	"github.com/tektoncd/pipeline/pkg/credentials/dockercreds"
 	"github.com/tektoncd/pipeline/pkg/credentials/gitcreds"
 	"github.com/tektoncd/pipeline/pkg/entrypoint"
+	"github.com/tektoncd/pipeline/pkg/entrypoint/pipeline"
 	"github.com/tektoncd/pipeline/pkg/platforms"
 	"github.com/tektoncd/pipeline/pkg/termination"
 )

--- a/cmd/entrypoint/runner.go
+++ b/cmd/entrypoint/runner.go
@@ -31,7 +31,10 @@ import (
 	"syscall"
 
 	"github.com/tektoncd/pipeline/pkg/entrypoint"
-	"github.com/tektoncd/pipeline/pkg/pod"
+)
+
+const (
+	TektonHermeticEnvVar = "TEKTON_HERMETIC"
 )
 
 // TODO(jasonhall): Test that original exit code is propagated and that
@@ -111,7 +114,7 @@ func (rr *realRunner) Run(ctx context.Context, args ...string) error {
 	// main process and all children
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
-	if os.Getenv("TEKTON_RESOURCE_NAME") == "" && os.Getenv(pod.TektonHermeticEnvVar) == "1" {
+	if os.Getenv("TEKTON_RESOURCE_NAME") == "" && os.Getenv(TektonHermeticEnvVar) == "1" {
 		dropNetworking(cmd)
 	}
 

--- a/pkg/apis/config/feature_flags.go
+++ b/pkg/apis/config/feature_flags.go
@@ -17,13 +17,10 @@ limitations under the License.
 package config
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"strconv"
 	"strings"
-
-	corev1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -448,21 +445,6 @@ func setVerificationNoMatchPolicy(cfgMap map[string]string, defaultValue string,
 		return fmt.Errorf("invalid value for feature flag %q: %q", verificationNoMatchPolicy, value)
 	}
 	return nil
-}
-
-// NewFeatureFlagsFromConfigMap returns a Config for the given configmap
-func NewFeatureFlagsFromConfigMap(config *corev1.ConfigMap) (*FeatureFlags, error) {
-	return NewFeatureFlagsFromMap(config.Data)
-}
-
-// GetVerificationNoMatchPolicy returns the "trusted-resources-verification-no-match-policy" value
-func GetVerificationNoMatchPolicy(ctx context.Context) string {
-	return FromContextOrDefaults(ctx).FeatureFlags.VerificationNoMatchPolicy
-}
-
-// IsSpireEnabled checks if non-falsifiable provenance is enforced through SPIRE
-func IsSpireEnabled(ctx context.Context) bool {
-	return FromContextOrDefaults(ctx).FeatureFlags.EnforceNonfalsifiability == EnforceNonfalsifiabilityWithSpire
 }
 
 type PerFeatureFlag struct {

--- a/pkg/apis/config/featureflags_validation.go
+++ b/pkg/apis/config/featureflags_validation.go
@@ -1,3 +1,5 @@
+//go:build !disable_tls
+
 /*
 Copyright 2021 The Tekton Authors
 

--- a/pkg/apis/config/metrics.go
+++ b/pkg/apis/config/metrics.go
@@ -18,7 +18,6 @@ package config
 
 import (
 	corev1 "k8s.io/api/core/v1"
-	"knative.dev/pkg/metrics"
 )
 
 const (
@@ -107,12 +106,6 @@ type Metrics struct {
 	DurationPipelinerunType string
 	CountWithReason         bool
 	ThrottleWithNamespace   bool
-}
-
-// GetMetricsConfigName returns the name of the configmap containing all
-// customizations for the storage bucket.
-func GetMetricsConfigName() string {
-	return metrics.ConfigMapName()
 }
 
 // Equals returns true if two Configs are identical

--- a/pkg/apis/config/metrics_notls.go
+++ b/pkg/apis/config/metrics_notls.go
@@ -1,0 +1,7 @@
+//go:build disable_tls
+
+package config
+
+// GetMetricsConfigName returns the name of the configmap containing all
+// customizations for the storage bucket.
+func GetMetricsConfigName() string { panic("not supported when tls is disabled") }

--- a/pkg/apis/config/metrics_tls.go
+++ b/pkg/apis/config/metrics_tls.go
@@ -1,0 +1,31 @@
+//go:build !disable_tls
+
+package config
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"knative.dev/pkg/metrics"
+)
+
+// GetMetricsConfigName returns the name of the configmap containing all
+// customizations for the storage bucket.
+func GetMetricsConfigName() string {
+	return metrics.ConfigMapName()
+}
+
+// NewFeatureFlagsFromConfigMap returns a Config for the given configmap
+func NewFeatureFlagsFromConfigMap(config *corev1.ConfigMap) (*FeatureFlags, error) {
+	return NewFeatureFlagsFromMap(config.Data)
+}
+
+// GetVerificationNoMatchPolicy returns the "trusted-resources-verification-no-match-policy" value
+func GetVerificationNoMatchPolicy(ctx context.Context) string {
+	return FromContextOrDefaults(ctx).FeatureFlags.VerificationNoMatchPolicy
+}
+
+// IsSpireEnabled checks if non-falsifiable provenance is enforced through SPIRE
+func IsSpireEnabled(ctx context.Context) bool {
+	return FromContextOrDefaults(ctx).FeatureFlags.EnforceNonfalsifiability == EnforceNonfalsifiabilityWithSpire
+}

--- a/pkg/apis/config/resolver/store.go
+++ b/pkg/apis/config/resolver/store.go
@@ -1,3 +1,5 @@
+//go:build !disable_tls
+
 /*
 Copyright 2022 The Tekton Authors
 

--- a/pkg/apis/config/spire_config.go
+++ b/pkg/apis/config/spire_config.go
@@ -1,3 +1,5 @@
+//go:build !disable_tls
+
 /*
 Copyright 2022 The Tekton Authors
 

--- a/pkg/apis/config/store.go
+++ b/pkg/apis/config/store.go
@@ -1,3 +1,5 @@
+//go:build !disable_tls
+
 /*
 Copyright 2019 The Tekton Authors
 

--- a/pkg/apis/pipeline/v1/types/artifacts_types.go
+++ b/pkg/apis/pipeline/v1/types/artifacts_types.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2025 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"github.com/google/go-cmp/cmp"
+)
+
+// Algorithm Standard cryptographic hash algorithm
+type Algorithm string
+
+// Artifact represents an artifact within a system, potentially containing multiple values
+// associated with it.
+type Artifact struct {
+	// The artifact's identifying category name
+	Name string `json:"name,omitempty"`
+	// A collection of values related to the artifact
+	Values []ArtifactValue `json:"values,omitempty"`
+	// Indicate if the artifact is a build output or a by-product
+	BuildOutput bool `json:"buildOutput,omitempty"`
+}
+
+// ArtifactValue represents a specific value or data element within an Artifact.
+type ArtifactValue struct {
+	Digest map[Algorithm]string `json:"digest,omitempty"` // Algorithm-specific digests for verifying the content (e.g., SHA256)
+	Uri    string               `json:"uri,omitempty"`    // Location where the artifact value can be retrieved
+}
+
+// TaskRunStepArtifact represents an artifact produced or used by a step within a task run.
+// It directly uses the Artifact type for its structure.
+type TaskRunStepArtifact = Artifact
+
+// Artifacts represents the collection of input and output artifacts associated with
+// a task run or a similar process. Artifacts in this context are units of data or resources
+// that the process either consumes as input or produces as output.
+type Artifacts struct {
+	Inputs  []Artifact `json:"inputs,omitempty"`
+	Outputs []Artifact `json:"outputs,omitempty"`
+}
+
+func (a *Artifacts) Merge(another *Artifacts) {
+	inputMap := make(map[string][]ArtifactValue)
+	var newInputs []Artifact
+
+	for _, v := range a.Inputs {
+		inputMap[v.Name] = v.Values
+	}
+	if another != nil {
+		for _, v := range another.Inputs {
+			_, ok := inputMap[v.Name]
+			if !ok {
+				inputMap[v.Name] = []ArtifactValue{}
+			}
+			for _, vv := range v.Values {
+				exists := false
+				for _, av := range inputMap[v.Name] {
+					if cmp.Equal(vv, av) {
+						exists = true
+						break
+					}
+				}
+				if !exists {
+					inputMap[v.Name] = append(inputMap[v.Name], vv)
+				}
+			}
+		}
+	}
+
+	for k, v := range inputMap {
+		newInputs = append(newInputs, Artifact{
+			Name:   k,
+			Values: v,
+		})
+	}
+
+	outputMap := make(map[string]Artifact)
+	var newOutputs []Artifact
+	for _, v := range a.Outputs {
+		outputMap[v.Name] = v
+	}
+
+	if another != nil {
+		for _, v := range another.Outputs {
+			_, ok := outputMap[v.Name]
+			if !ok {
+				outputMap[v.Name] = Artifact{Name: v.Name, Values: []ArtifactValue{}, BuildOutput: v.BuildOutput}
+			}
+			// only update buildOutput to true.
+			// Do not convert to false if it was true before.
+			if v.BuildOutput {
+				art := outputMap[v.Name]
+				art.BuildOutput = v.BuildOutput
+				outputMap[v.Name] = art
+			}
+			for _, vv := range v.Values {
+				exists := false
+				for _, av := range outputMap[v.Name].Values {
+					if cmp.Equal(vv, av) {
+						exists = true
+						break
+					}
+				}
+				if !exists {
+					art := outputMap[v.Name]
+					art.Values = append(art.Values, vv)
+					outputMap[v.Name] = art
+				}
+			}
+		}
+	}
+
+	for _, v := range outputMap {
+		newOutputs = append(newOutputs, Artifact{
+			Name:        v.Name,
+			Values:      v.Values,
+			BuildOutput: v.BuildOutput,
+		})
+	}
+	a.Inputs = newInputs
+	a.Outputs = newOutputs
+}

--- a/pkg/apis/pipeline/v1/types/param_types.go
+++ b/pkg/apis/pipeline/v1/types/param_types.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2025 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// ParamType indicates the type of an input parameter;
+// Used to distinguish between a single string and an array of strings.
+type ParamType string
+
+// Valid ParamTypes:
+const (
+	ParamTypeString ParamType = "string"
+	ParamTypeArray  ParamType = "array"
+	ParamTypeObject ParamType = "object"
+)
+
+// AllParamTypes can be used for ParamType validation.
+var AllParamTypes = []ParamType{ParamTypeString, ParamTypeArray, ParamTypeObject}
+
+// ParamValues is modeled after IntOrString in kubernetes/apimachinery:
+
+// ParamValue is a type that can hold a single string, string array, or string map.
+// Used in JSON unmarshalling so that a single JSON field can accept
+// either an individual string or an array of strings.
+type ParamValue struct {
+	Type      ParamType // Represents the stored type of ParamValues.
+	StringVal string
+	// +listType=atomic
+	ArrayVal  []string
+	ObjectVal map[string]string
+}
+
+// PropertySpec defines the struct for object keys
+type PropertySpec struct {
+	Type ParamType `json:"type,omitempty"`
+}
+
+// ParamsPrefix is the prefix used in $(...) expressions referring to parameters
+const ParamsPrefix = "params"
+
+// ArrayReference returns the name of the parameter from array parameter reference
+// returns arrayParam from $(params.arrayParam[*])
+func ArrayReference(a string) string {
+	return strings.TrimSuffix(strings.TrimPrefix(a, "$("+ParamsPrefix+"."), "[*])")
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface.
+func (paramValues *ParamValue) UnmarshalJSON(value []byte) error {
+	// ParamValues is used for Results Value as well, the results can be any kind of
+	// data so we need to check if it is empty.
+	if len(value) == 0 {
+		paramValues.Type = ParamTypeString
+		return nil
+	}
+	if value[0] == '[' {
+		// We're trying to Unmarshal to []string, but for cases like []int or other types
+		// of nested array which we don't support yet, we should continue and Unmarshal
+		// it to String. If the Type being set doesn't match what it actually should be,
+		// it will be captured by validation in reconciler.
+		// if failed to unmarshal to array, we will convert the value to string and marshal it to string
+		var a []string
+		if err := json.Unmarshal(value, &a); err == nil {
+			paramValues.Type = ParamTypeArray
+			paramValues.ArrayVal = a
+			return nil
+		}
+	}
+	if value[0] == '{' {
+		// if failed to unmarshal to map, we will convert the value to string and marshal it to string
+		var m map[string]string
+		if err := json.Unmarshal(value, &m); err == nil {
+			paramValues.Type = ParamTypeObject
+			paramValues.ObjectVal = m
+			return nil
+		}
+	}
+
+	// By default we unmarshal to string
+	paramValues.Type = ParamTypeString
+	if err := json.Unmarshal(value, &paramValues.StringVal); err == nil {
+		return nil
+	}
+	paramValues.StringVal = string(value)
+
+	return nil
+}

--- a/pkg/apis/pipeline/v1/types/result_types.go
+++ b/pkg/apis/pipeline/v1/types/result_types.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2025 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import "strings"
+
+// TaskResult used to describe the results of a task
+type TaskResult struct {
+	// Name the given name
+	Name string `json:"name"`
+
+	// Type is the user-specified type of the result. The possible type
+	// is currently "string" and will support "array" in following work.
+	// +optional
+	Type ResultsType `json:"type,omitempty"`
+
+	// Properties is the JSON Schema properties to support key-value pairs results.
+	// +optional
+	Properties map[string]PropertySpec `json:"properties,omitempty"`
+
+	// Description is a human-readable description of the result
+	// +optional
+	Description string `json:"description,omitempty"`
+
+	// Value the expression used to retrieve the value of the result from an underlying Step.
+	// +optional
+	Value *ResultValue `json:"value,omitempty"`
+}
+
+// StepResult used to describe the Results of a Step.
+//
+// This is field is at an BETA stability level and gated by "enable-step-actions" feature flag.
+type StepResult struct {
+	// Name the given name
+	Name string `json:"name"`
+
+	// The possible types are 'string', 'array', and 'object', with 'string' as the default.
+	// +optional
+	Type ResultsType `json:"type,omitempty"`
+
+	// Properties is the JSON Schema properties to support key-value pairs results.
+	// +optional
+	Properties map[string]PropertySpec `json:"properties,omitempty"`
+
+	// Description is a human-readable description of the result
+	// +optional
+	Description string `json:"description,omitempty"`
+}
+
+// TaskRunResult used to describe the results of a task
+type TaskRunResult struct {
+	// Name the given name
+	Name string `json:"name"`
+
+	// Type is the user-specified type of the result. The possible type
+	// is currently "string" and will support "array" in following work.
+	// +optional
+	Type ResultsType `json:"type,omitempty"`
+
+	// Value the given value of the result
+	Value ResultValue `json:"value"`
+}
+
+// TaskRunStepResult is a type alias of TaskRunResult
+type TaskRunStepResult = TaskRunResult
+
+// ResultValue is a type alias of ParamValue
+type ResultValue = ParamValue
+
+// ResultsType indicates the type of a result;
+// Used to distinguish between a single string and an array of strings.
+// Note that there is ResultType used to find out whether a
+// RunResult is from a task result or not, which is different from
+// this ResultsType.
+type ResultsType string
+
+// Valid ResultsType:
+const (
+	ResultsTypeString ResultsType = "string"
+	ResultsTypeArray  ResultsType = "array"
+	ResultsTypeObject ResultsType = "object"
+)
+
+// AllResultsTypes can be used for ResultsTypes validation.
+var AllResultsTypes = []ResultsType{ResultsTypeString, ResultsTypeArray, ResultsTypeObject}
+
+// ResultsArrayReference returns the reference of the result. e.g. results.resultname from $(results.resultname[*])
+func ResultsArrayReference(a string) string {
+	return strings.TrimSuffix(strings.TrimSuffix(strings.TrimPrefix(a, "$("), ")"), "[*]")
+}

--- a/pkg/apis/pipeline/v1/types/resultsref.go
+++ b/pkg/apis/pipeline/v1/types/resultsref.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2025 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"regexp"
+	"strings"
+)
+
+const (
+	// TODO(#2462) use one regex across all substitutions
+	// variableSubstitutionFormat matches format like $result.resultname, $result.resultname[int] and $result.resultname[*]
+	variableSubstitutionFormat = `\$\([_a-zA-Z0-9.-]+(\.[_a-zA-Z0-9.-]+)*(\[([0-9]+|\*)\])?\)`
+)
+
+// VariableSubstitutionRegex is a regex to find all result matching substitutions
+var VariableSubstitutionRegex = regexp.MustCompile(variableSubstitutionFormat)
+
+func stripVarSubExpression(expression string) string {
+	return strings.TrimSuffix(strings.TrimPrefix(expression, "$("), ")")
+}
+
+func validateString(value string) []string {
+	expressions := VariableSubstitutionRegex.FindAllString(value, -1)
+	if expressions == nil {
+		return nil
+	}
+	var result []string
+	for _, expression := range expressions {
+		result = append(result, stripVarSubExpression(expression))
+	}
+	return result
+}

--- a/pkg/apis/pipeline/v1/types/when_types.go
+++ b/pkg/apis/pipeline/v1/types/when_types.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2025 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"fmt"
+
+	"github.com/tektoncd/pipeline/pkg/substitution"
+	"k8s.io/apimachinery/pkg/selection"
+)
+
+// WhenExpression allows a PipelineTask to declare expressions to be evaluated before the Task is run
+// to determine whether the Task should be executed or skipped
+type WhenExpression struct {
+	// Input is the string for guard checking which can be a static input or an output from a parent Task
+	Input string `json:"input,omitempty"`
+
+	// Operator that represents an Input's relationship to the values
+	Operator selection.Operator `json:"operator,omitempty"`
+
+	// Values is an array of strings, which is compared against the input, for guard checking
+	// It must be non-empty
+	// +listType=atomic
+	Values []string `json:"values,omitempty"`
+
+	// CEL is a string of Common Language Expression, which can be used to conditionally execute
+	// the task based on the result of the expression evaluation
+	// More info about CEL syntax: https://github.com/google/cel-spec/blob/master/doc/langdef.md
+	// +optional
+	CEL string `json:"cel,omitempty"`
+}
+
+func (we *WhenExpression) isInputInValues() bool {
+	for i := range we.Values {
+		if we.Values[i] == we.Input {
+			return true
+		}
+	}
+	return false
+}
+
+func (we *WhenExpression) isTrue() bool {
+	if we.Operator == selection.In {
+		return we.isInputInValues()
+	}
+	// selection.NotIn
+	return !we.isInputInValues()
+}
+
+func (we *WhenExpression) applyReplacements(replacements map[string]string, arrayReplacements map[string][]string) WhenExpression {
+	replacedInput := substitution.ApplyReplacements(we.Input, replacements)
+	replacedCEL := substitution.ApplyReplacements(we.CEL, replacements)
+
+	var replacedValues []string
+	for _, val := range we.Values {
+		// arrayReplacements holds a list of array parameters with a pattern - params.arrayParam1
+		// array params are referenced using $(params.arrayParam1[*])
+		// array results are referenced using $(results.resultname[*])
+		// check if the param exist in the arrayReplacements to replace it with a list of values
+		if _, ok := arrayReplacements[fmt.Sprintf("%s.%s", ParamsPrefix, ArrayReference(val))]; ok {
+			replacedValues = append(replacedValues, substitution.ApplyArrayReplacements(val, replacements, arrayReplacements)...)
+		} else if _, ok := arrayReplacements[ResultsArrayReference(val)]; ok {
+			replacedValues = append(replacedValues, substitution.ApplyArrayReplacements(val, replacements, arrayReplacements)...)
+		} else {
+			replacedValues = append(replacedValues, substitution.ApplyReplacements(val, replacements))
+		}
+	}
+
+	return WhenExpression{Input: replacedInput, Operator: we.Operator, Values: replacedValues, CEL: replacedCEL}
+}
+
+// GetVarSubstitutionExpressions extracts all the values between "$(" and ")" in a When Expression
+func (we *WhenExpression) GetVarSubstitutionExpressions() ([]string, bool) {
+	var allExpressions []string
+	allExpressions = append(allExpressions, validateString(we.Input)...)
+	allExpressions = append(allExpressions, validateString(we.CEL)...)
+	for _, value := range we.Values {
+		allExpressions = append(allExpressions, validateString(value)...)
+	}
+	return allExpressions, len(allExpressions) != 0
+}
+
+// WhenExpressions are used to specify whether a Task should be executed or skipped
+// All of them need to evaluate to True for a guarded Task to be executed.
+type WhenExpressions []WhenExpression
+
+type StepWhenExpressions = WhenExpressions
+
+// AllowsExecution evaluates an Input's relationship to an array of Values, based on the Operator,
+// to determine whether all the When Expressions are True. If they are all True, the guarded Task is
+// executed, otherwise it is skipped.
+// If CEL expression exists, AllowsExecution will get the evaluated results from evaluatedCEL and determine
+// if the Task should be skipped.
+func (wes WhenExpressions) AllowsExecution(evaluatedCEL map[string]bool) bool {
+	for _, we := range wes {
+		if !we.isTrue() || (we.CEL != "" && !evaluatedCEL[we.CEL]) {
+			return false
+		}
+	}
+	return true
+}
+
+// ReplaceVariables interpolates variables, such as Parameters and Results, in
+// the Input and Values.
+func (wes WhenExpressions) ReplaceVariables(replacements map[string]string, arrayReplacements map[string][]string) WhenExpressions {
+	replaced := wes
+	for i := range wes {
+		replaced[i] = wes[i].applyReplacements(replacements, arrayReplacements)
+	}
+	return replaced
+}

--- a/pkg/entrypoint/entrypointer.go
+++ b/pkg/entrypoint/entrypointer.go
@@ -35,8 +35,8 @@ import (
 
 	"github.com/google/cel-go/cel"
 	"github.com/tektoncd/pipeline/internal/artifactref"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
-	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1/types"
+	"github.com/tektoncd/pipeline/pkg/entrypoint/pipeline"
 	"github.com/tektoncd/pipeline/pkg/internal/resultref"
 	"github.com/tektoncd/pipeline/pkg/result"
 	"github.com/tektoncd/pipeline/pkg/termination"

--- a/pkg/entrypoint/entrypointer_test.go
+++ b/pkg/entrypoint/entrypointer_test.go
@@ -33,7 +33,7 @@ import (
 	"time"
 
 	"github.com/tektoncd/pipeline/pkg/apis/config"
-	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1/types"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/pod"
 	"github.com/tektoncd/pipeline/pkg/result"

--- a/pkg/entrypoint/pipeline/paths.go
+++ b/pkg/entrypoint/pipeline/paths.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2025 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pipeline
+
+const (
+	// WorkspaceDir is the root directory used for PipelineResources and (by default) Workspaces
+	WorkspaceDir = "/workspace"
+	// DefaultResultPath is the path for a task result to create the result file
+	DefaultResultPath = "/tekton/results"
+	// HomeDir is the HOME directory of PipelineResources
+	HomeDir = "/tekton/home"
+	// CredsDir is the directory where credentials are placed to meet the legacy credentials
+	// helpers image (aka "creds-init") contract
+	CredsDir = "/tekton/creds" // #nosec
+	// StepsDir is the directory used for a step to store any metadata related to the step
+	StepsDir = "/tekton/steps"
+
+	ScriptDir = "/tekton/scripts"
+
+	ArtifactsDir = "/tekton/artifacts"
+)

--- a/pkg/substitution/replacements.go
+++ b/pkg/substitution/replacements.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2025 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package substitution
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ApplyReplacements returns a string with references to parameters replaced,
+// based on the mapping provided in replacements.
+// For example, if the input string is "foo: $(params.foo)", and replacements maps "params.foo" to "bar",
+// the output would be "foo: bar".
+func ApplyReplacements(in string, replacements map[string]string) string {
+	replacementsList := []string{}
+	for k, v := range replacements {
+		replacementsList = append(replacementsList, fmt.Sprintf("$(%s)", k), v)
+	}
+	// strings.Replacer does all replacements in one pass, preventing multiple replacements
+	// See #2093 for an explanation on why we need to do this.
+	replacer := strings.NewReplacer(replacementsList...)
+	return replacer.Replace(in)
+}
+
+// ApplyArrayReplacements takes an input string, and output an array of strings related to possible arrayReplacements. If there aren't any
+// areas where the input can be split up via arrayReplacements, then just return an array with a single element,
+// which is ApplyReplacements(in, replacements).
+func ApplyArrayReplacements(in string, stringReplacements map[string]string, arrayReplacements map[string][]string) []string {
+	for k, v := range arrayReplacements {
+		stringToReplace := fmt.Sprintf("$(%s)", k)
+
+		// If the input string matches a replacement's key (without padding characters), return the corresponding array.
+		// Note that the webhook should prevent all instances where this could evaluate to false.
+		if (strings.Count(in, stringToReplace) == 1) && len(in) == len(stringToReplace) {
+			return v
+		}
+
+		// same replace logic for star array expressions
+		starStringtoReplace := fmt.Sprintf("$(%s[*])", k)
+		if (strings.Count(in, starStringtoReplace) == 1) && len(in) == len(starStringtoReplace) {
+			return v
+		}
+	}
+
+	// Otherwise return a size-1 array containing the input string with standard stringReplacements applied.
+	return []string{ApplyReplacements(in, stringReplacements)}
+}

--- a/pkg/substitution/substitution.go
+++ b/pkg/substitution/substitution.go
@@ -1,3 +1,5 @@
+//go:build !disable_tls
+
 /*
 Copyright 2019 The Tekton Authors
 
@@ -304,45 +306,6 @@ func matchGroups(matches []string, pattern *regexp.Regexp) map[string]string {
 		groups[name] = matches[i+1]
 	}
 	return groups
-}
-
-// ApplyReplacements returns a string with references to parameters replaced,
-// based on the mapping provided in replacements.
-// For example, if the input string is "foo: $(params.foo)", and replacements maps "params.foo" to "bar",
-// the output would be "foo: bar".
-func ApplyReplacements(in string, replacements map[string]string) string {
-	replacementsList := []string{}
-	for k, v := range replacements {
-		replacementsList = append(replacementsList, fmt.Sprintf("$(%s)", k), v)
-	}
-	// strings.Replacer does all replacements in one pass, preventing multiple replacements
-	// See #2093 for an explanation on why we need to do this.
-	replacer := strings.NewReplacer(replacementsList...)
-	return replacer.Replace(in)
-}
-
-// ApplyArrayReplacements takes an input string, and output an array of strings related to possible arrayReplacements. If there aren't any
-// areas where the input can be split up via arrayReplacements, then just return an array with a single element,
-// which is ApplyReplacements(in, replacements).
-func ApplyArrayReplacements(in string, stringReplacements map[string]string, arrayReplacements map[string][]string) []string {
-	for k, v := range arrayReplacements {
-		stringToReplace := fmt.Sprintf("$(%s)", k)
-
-		// If the input string matches a replacement's key (without padding characters), return the corresponding array.
-		// Note that the webhook should prevent all instances where this could evaluate to false.
-		if (strings.Count(in, stringToReplace) == 1) && len(in) == len(stringToReplace) {
-			return v
-		}
-
-		// same replace logic for star array expressions
-		starStringtoReplace := fmt.Sprintf("$(%s[*])", k)
-		if (strings.Count(in, starStringtoReplace) == 1) && len(in) == len(starStringtoReplace) {
-			return v
-		}
-	}
-
-	// Otherwise return a size-1 array containing the input string with standard stringReplacements applied.
-	return []string{ApplyReplacements(in, stringReplacements)}
 }
 
 // TrimArrayIndex replaces all `[i]` and `[*]` to "".

--- a/pkg/termination/parse.go
+++ b/pkg/termination/parse.go
@@ -1,3 +1,5 @@
+//go:build !disable_tls
+
 /*
 Copyright 2019 The Tekton Authors
 


### PR DESCRIPTION
- The Pipelines entrypoint is the only remaining component of Pipelines that is not yet FIPS compliant. It needs to be compiled statically, but currently, it includes crypto symbols
- Hence, to make Tekton Pipelines FIPS compliant, the entrypoint command is a key step in this effort. Since it is statically compiled, we must ensure that cryptographic symbols are removed from the entrypoint binary.
- The patch includes following changes 
  -  Removes zap and dependency where k8s API are included
  - Moves pipelines types to `apis/pipeline/v1/types` 
  - Refactor and split metrics and adds `disable_tls` flag
  - Adds a build check in Github Actions CI Workflow

Fixes: https://github.com/tektoncd/pipeline/issues/8531 (one part of the issue)

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

- This patch uses logging with the standard library instead of using zap to ensure that we are not pulling in too many indirect dependencies into the entrypoint through the uber-go/zap module
- The `corev1` API package is now split because it imports crypto-related functions
- Add a build tag `disable_tls` to conditionally exclude crypto related dependencies

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
