### PR TITLE
fix: resolve panic issue in pipeline controller caused by CustomRun

### DIFF
--- a/pkg/reconciler/pipelinerun/resources/validate_dependencies.go
+++ b/pkg/reconciler/pipelinerun/resources/validate_dependencies.go
@@ -101,12 +101,10 @@ func ValidateOptionalWorkspaces(pipelineWorkspaces []v1.PipelineWorkspaceDeclara
 
 	for _, rpt := range state {
 		for _, pws := range rpt.PipelineTask.Workspaces {
-			if optionalWorkspaces.Has(pws.Workspace) {
+			if rpt.ResolvedTask != nil && rpt.ResolvedTask.TaskSpec != nil && optionalWorkspaces.Has(pws.Workspace) {
 				for _, tws := range rpt.ResolvedTask.TaskSpec.Workspaces {
-					if tws.Name == pws.Name {
-						if !tws.Optional {
-							return fmt.Errorf("pipeline workspace %q is marked optional but pipeline task %q requires it be provided", pws.Workspace, rpt.PipelineTask.Name)
-						}
+					if tws.Name == pws.Name && !tws.Optional {
+						return fmt.Errorf("pipeline workspace %q is marked optional but pipeline task %q requires it be provided", pws.Workspace, rpt.PipelineTask.Name)
 					}
 				}
 			}

--- a/pkg/reconciler/pipelinerun/resources/validate_dependencies_test.go
+++ b/pkg/reconciler/pipelinerun/resources/validate_dependencies_test.go
@@ -422,6 +422,23 @@ func TestValidateOptionalWorkspaces_ValidStates(t *testing.T) {
 				},
 			},
 		}},
+	}, {
+		desc: "pipeline with optional workspace combined with customrun",
+		workspaces: []v1.PipelineWorkspaceDeclaration{{
+			Name:     "ws1",
+			Optional: true,
+		}},
+		state: prresources.PipelineRunState{{
+			PipelineTask: &v1.PipelineTask{
+				Name: "pt1",
+				Workspaces: []v1.WorkspacePipelineTaskBinding{{
+					Name:      "foo",
+					Workspace: "ws1",
+				}},
+			},
+			ResolvedTask: nil,
+			CustomTask:   true,
+		}},
 	}} {
 		t.Run(tc.desc, func(t *testing.T) {
 			if err := prresources.ValidateOptionalWorkspaces(tc.workspaces, tc.state); err != nil {


### PR DESCRIPTION
fix #8561

When validating the optional workspace of the pipeline, encountering a CustomRun should not cause a panic, as this configuration will be validated again during the creation of the CustomRun.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
fix: resolve panic issue in pipeline controller caused by CustomRun
```

/kind bug