### PR TITLE
fix: Move when condition to higher priority

### DIFF
--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -357,12 +357,12 @@ func (t *ResolvedPipelineTask) skip(facts *PipelineRunFacts) TaskSkipStatus {
 		skippingReason = v1.GracefullyCancelledSkip
 	case facts.IsGracefullyStopped():
 		skippingReason = v1.GracefullyStoppedSkip
+	case t.skipBecauseWhenExpressionsEvaluatedToFalse(facts):
+		skippingReason = v1.WhenExpressionsSkip
 	case t.skipBecauseParentTaskWasSkipped(facts):
 		skippingReason = v1.ParentTasksSkip
 	case t.skipBecauseResultReferencesAreMissing(facts):
 		skippingReason = v1.MissingResultsSkip
-	case t.skipBecauseWhenExpressionsEvaluatedToFalse(facts):
-		skippingReason = v1.WhenExpressionsSkip
 	case t.skipBecausePipelineRunPipelineTimeoutReached(facts):
 		skippingReason = v1.PipelineTimedOutSkip
 	case t.skipBecausePipelineRunTasksTimeoutReached(facts):

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
@@ -1079,8 +1079,7 @@ func TestIsSkipped(t *testing.T) {
 				TaskSpec: &task.Spec,
 			},
 		}, {
-			// skipped because of parent task mytask22 was skipping because of missing result from grandparent task
-			// mytask11 which was skipped
+			// not skipped because of parent task mytask22 was skipping because when condition
 			PipelineTask: &v1.PipelineTask{
 				Name:     "mytask23",
 				TaskRef:  &v1.TaskRef{Name: "task"},
@@ -1099,7 +1098,7 @@ func TestIsSkipped(t *testing.T) {
 			"mytask20": true,
 			"mytask21": true,
 			"mytask22": true,
-			"mytask23": true,
+			"mytask23": false,
 		},
 	}, {
 		name:         "pipeline-tasks-timeout-not-reached",


### PR DESCRIPTION
When using "when" condition in pipelinerun definition we can sometime get into a situation when a task would be skipped due to "when" condition but instead it is skipped either by parent is skipped or result reference is missing. This behaviour has a negative impact on the rest of the tasks in the pipeline.

A good example of this issue is represented by this pipeline:

A -> B -> C

In case B depends on A's result and both A and B uses when condition that both evaluates to false the C is automatically skipped with "Parent Tasks were skipped" even-though C doesn't depend on any previous results.

With this change both A and B are skipped by evaluating the "when" condition and C is executed as expected.

This commit address the bug #7680.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
fix: Move when condition to higher priority
```

/kind bug