### PR TITLE
Include envFrom in "how to use a `Secret` as an environment source"

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -1462,9 +1462,9 @@ spec:
         name: "$(params.CFGNAME)"
 ```
 
-#### Using a `Secret` as an environment source
+#### Using a `Secret` or `ConfigMap` as an environment source
 
-The example below illustrates how to use a `Secret` as an environment source:
+The example below illustrates how to use a `Secret` (or a `ConfigMap`) as an environment source. Using the `envFrom`-type works well for e.g. secrets with a specified format, like a `kubernetes.io/basic-auth` secret which will allways contain a `username` and `password` variable which you can then use in your script. For a 'free form' `Secret` (or `ConfigMap`), use the `env` style as it allows you to have a param-reference for the `key` which you can then 'remap' to a well-known environment variable in your script:
 
 ```yaml
 apiVersion: tekton.dev/v1 # or tekton.dev/v1beta1
@@ -1490,6 +1490,14 @@ spec:
         - goreleaser
       args:
         - release
+      # All variables from the referenced secret / configmap will be injected.
+      envFrom:
+        - secretRef:
+            name: $(params.my-basic-auth-ssh-or-docker-type-secret-name}
+        # Using configMapRef works, but as al ConfigMaps are freeform this is not recommended  
+        - configMapRef:
+            name: $(params.my-configmap-name}
+      # using env allows to 'remap' values to fixed environment variables via the ${params}
       env:
         - name: GOPATH
           value: /workspace
@@ -1497,7 +1505,7 @@ spec:
           valueFrom:
             secretKeyRef:
               name: $(params.github-token-secret)
-              key: bot-token
+              key: $(params.github-token-secret-key)
 ```
 
 #### Using a `Sidecar` in a `Task`


### PR DESCRIPTION
I suggest that using envFrom for well known secrets types is recommended (or at least documented as an option),

https://kubernetes.io/docs/concepts/configuration/secret/#basic-authentication-secret

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

I suggest that using envFrom for well known secrets types is recommended (or at least documented as an option) as it makes use of the existing 'typing'  in kubernetes, and many times in practice secrets will be some form of (well known) authentication secret like https://kubernetes.io/docs/concepts/configuration/secret/#basic-authentication-secret.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

n.a., only documentation
