### PR TITLE
fix: add stepaction as a valid kind in the hub resolver

### DIFF
--- a/pkg/remoteresolution/resolver/hub/resolver_test.go
+++ b/pkg/remoteresolution/resolver/hub/resolver_test.go
@@ -60,7 +60,16 @@ func TestValidate(t *testing.T) {
 			version:      "bar",
 			catalog:      "baz",
 			hubType:      ArtifactHubType,
-		}, {
+		},
+		{
+			testName:     "stepaction validation",
+			kind:         "stepaction",
+			resourceName: "foo",
+			version:      "bar",
+			catalog:      "baz",
+			hubType:      ArtifactHubType,
+		},
+		{
 			testName:     "tekton type validation",
 			kind:         "task",
 			resourceName: "foo",
@@ -134,7 +143,7 @@ func TestValidateConflictingKindName(t *testing.T) {
 		hubType string
 	}{
 		{
-			kind:    "not-taskpipeline",
+			kind:    "not-taskpipelineorstepaction",
 			name:    "foo",
 			version: "bar",
 			catalog: "baz",

--- a/pkg/resolution/resolver/hub/resolver.go
+++ b/pkg/resolution/resolver/hub/resolver.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
 	"strings"
 
 	goversion "github.com/hashicorp/go-version"
@@ -44,6 +45,8 @@ const (
 
 	disabledError = "cannot handle resolution request, enable-hub-resolver feature flag not true"
 )
+
+var supportedKinds = []string{"task", "pipeline", "stepaction"}
 
 // Resolver implements a framework.Resolver that can fetch files from OCI bundles.
 //
@@ -359,8 +362,8 @@ func validateParams(ctx context.Context, paramsMap map[string]string, tektonHubU
 		missingParams = append(missingParams, ParamVersion)
 	}
 	if kind, ok := paramsMap[ParamKind]; ok {
-		if kind != "task" && kind != "pipeline" {
-			return errors.New("kind param must be task or pipeline")
+		if !isSupportedKind(kind) {
+			return fmt.Errorf("kind param must be one of: %s", strings.Join(supportedKinds, ", "))
 		}
 	}
 	if hubType, ok := paramsMap[ParamType]; ok {
@@ -438,4 +441,8 @@ func resolveVersionConstraint(ctx context.Context, paramsMap map[string]string, 
 		return nil, fmt.Errorf("no version found for constraint %s", paramsMap[ParamVersion])
 	}
 	return ret, nil
+}
+
+func isSupportedKind(kindValue string) bool {
+	return slices.Contains[[]string, string](supportedKinds, kindValue)
 }

--- a/pkg/resolution/resolver/hub/resolver_test.go
+++ b/pkg/resolution/resolver/hub/resolver_test.go
@@ -62,7 +62,16 @@ func TestValidateParams(t *testing.T) {
 			version:      "bar",
 			catalog:      "baz",
 			hubType:      ArtifactHubType,
-		}, {
+		},
+		{
+			testName:     "stepaction validation",
+			kind:         "stepaction",
+			resourceName: "foo",
+			version:      "bar",
+			catalog:      "baz",
+			hubType:      ArtifactHubType,
+		},
+		{
 			testName:     "tekton type validation",
 			kind:         "task",
 			resourceName: "foo",
@@ -148,7 +157,7 @@ func TestValidateParamsConflictingKindName(t *testing.T) {
 		hubType string
 	}{
 		{
-			kind:    "not-taskpipeline",
+			kind:    "not-taskpipelineorstepaction",
 			name:    "foo",
 			version: "bar",
 			catalog: "baz",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

fixes https://github.com/tektoncd/pipeline/issues/8634

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
the hub resolver now validates StepActions as a valid kind
```
