### PR TITLE
fix: Fix remote task params default-value substitution

### DIFF
--- a/examples/v1/taskruns/default_task_params.yaml
+++ b/examples/v1/taskruns/default_task_params.yaml
@@ -1,0 +1,27 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  # This has to be explicit instead of `generateName`, since it will be referenced
+  # by the TaskRun
+  name: example-default-task-param
+spec:
+  params:
+    - name: input
+      default: "No input provided, but that's okay!"
+  steps:
+    - name: echo-input
+      image: mirror.gcr.io/ubuntu
+      script: |
+        echo "$(params.input)"
+---
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  generateName: default-task-params-run-
+spec:
+  taskRef:
+    name: example-default-task-param
+    # # Uncomment this block to override the default param value!
+    # params:
+    #   - name: input
+    #     value: "You can supply the param from the TaskRun if the default not what you want"

--- a/pkg/reconciler/taskrun/resources/taskspec.go
+++ b/pkg/reconciler/taskrun/resources/taskspec.go
@@ -107,7 +107,7 @@ func GetStepActionsData(ctx context.Context, taskSpec v1.TaskSpec, taskRun *v1.T
 	for i, step := range taskSpec.Steps {
 		s := step.DeepCopy()
 		if step.Ref != nil {
-			getStepAction := GetStepActionFunc(tekton, k8s, requester, taskRun, s)
+			getStepAction := GetStepActionFunc(tekton, k8s, requester, taskRun, taskSpec, s)
 			stepAction, source, err := getStepAction(ctx, s.Ref.Name)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
Fixes #8637

When substituting Params in a StepAction was initially implemented, the defaults were taken from the `TaskRun.Spec.TaskSpec.Params`. This works when the Task is defined in place, however if the TaskRun does not define the Task inline and instead references a remote Task from `TaskRun.Spec.TaskRef`, then any param defaults failed to be applied.

When `GetStepActionFunc` is called from the TaskRun reconciler, it's passed a TaskSpec which comes from either the `TaskRun.Spec.TaskSpec` or a remotely-resolved TaskRef. By checking this TaskSpec for the Param defaults, instead of `TaskRun.Spec.TaskSpec`, we can ensure the defaults will always be applied when they're specified

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Task Param defaults will now be correctly substituted in Steps when the Task is referenced by a TaskRun
```
