### PR TITLE
feat: support passing clock during RunStatus initialization

### DIFF
--- a/pkg/apis/pipeline/v1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1/taskrun_types.go
@@ -356,10 +356,10 @@ func (trs *TaskRunStatus) GetCondition(t apis.ConditionType) *apis.Condition {
 
 // InitializeConditions will set all conditions in taskRunCondSet to unknown for the TaskRun
 // and set the started time to the current time
-func (trs *TaskRunStatus) InitializeConditions() {
+func (trs *TaskRunStatus) InitializeConditions(c clock.PassiveClock) {
 	started := false
 	if trs.StartTime.IsZero() {
-		trs.StartTime = &metav1.Time{Time: time.Now()}
+		trs.StartTime = &metav1.Time{Time: c.Now()}
 		started = true
 	}
 	conditionManager := taskRunCondSet.Manage(trs)

--- a/pkg/apis/pipeline/v1/taskrun_types_test.go
+++ b/pkg/apis/pipeline/v1/taskrun_types_test.go
@@ -381,7 +381,7 @@ func TestInitializeTaskRunConditions(t *testing.T) {
 			Namespace: "test-ns",
 		},
 	}
-	tr.Status.InitializeConditions()
+	tr.Status.InitializeConditions(testClock)
 
 	if tr.Status.StartTime.IsZero() {
 		t.Fatalf("TaskRun StartTime not initialized correctly")
@@ -400,7 +400,7 @@ func TestInitializeTaskRunConditions(t *testing.T) {
 		Message: "hello",
 	})
 
-	tr.Status.InitializeConditions()
+	tr.Status.InitializeConditions(testClock)
 
 	newCondition := tr.Status.GetCondition(apis.ConditionSucceeded)
 	if newCondition.Reason != "not just started" {

--- a/pkg/apis/pipeline/v1beta1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_types.go
@@ -369,10 +369,10 @@ func (trs *TaskRunStatus) GetCondition(t apis.ConditionType) *apis.Condition {
 
 // InitializeConditions will set all conditions in taskRunCondSet to unknown for the TaskRun
 // and set the started time to the current time
-func (trs *TaskRunStatus) InitializeConditions() {
+func (trs *TaskRunStatus) InitializeConditions(c clock.PassiveClock) {
 	started := false
 	if trs.StartTime.IsZero() {
-		trs.StartTime = &metav1.Time{Time: time.Now()}
+		trs.StartTime = &metav1.Time{Time: c.Now()}
 		started = true
 	}
 	conditionManager := taskRunCondSet.Manage(trs)

--- a/pkg/apis/pipeline/v1beta1/taskrun_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_types_test.go
@@ -439,7 +439,7 @@ func TestInitializeTaskRunConditions(t *testing.T) {
 			Namespace: "test-ns",
 		},
 	}
-	tr.Status.InitializeConditions()
+	tr.Status.InitializeConditions(testClock)
 
 	if tr.Status.StartTime.IsZero() {
 		t.Fatalf("TaskRun StartTime not initialized correctly")
@@ -458,7 +458,7 @@ func TestInitializeTaskRunConditions(t *testing.T) {
 		Message: "hello",
 	})
 
-	tr.Status.InitializeConditions()
+	tr.Status.InitializeConditions(testClock)
 
 	newCondition := tr.Status.GetCondition(apis.ConditionSucceeded)
 	if newCondition.Reason != "not just started" {

--- a/pkg/apis/run/v1beta1/customrunstatus_types.go
+++ b/pkg/apis/run/v1beta1/customrunstatus_types.go
@@ -18,11 +18,11 @@ package v1beta1
 
 import (
 	"encoding/json"
-	"time"
 
 	"github.com/tektoncd/pipeline/pkg/apis/run/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/clock"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
@@ -89,10 +89,10 @@ func (r *CustomRunStatus) GetCondition(t apis.ConditionType) *apis.Condition {
 
 // InitializeConditions will set all conditions in customRunCondSet to unknown
 // and set the started time to the current time
-func (r *CustomRunStatus) InitializeConditions() {
+func (r *CustomRunStatus) InitializeConditions(c clock.PassiveClock) {
 	started := false
 	if r.StartTime.IsZero() {
-		r.StartTime = &metav1.Time{Time: time.Now()}
+		r.StartTime = &metav1.Time{Time: c.Now()}
 		started = true
 	}
 	conditionManager := customRunCondSet.Manage(r)

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -130,7 +130,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, tr *v1.TaskRun) pkgrecon
 	// If the TaskRun is just starting, this will also set the starttime,
 	// from which the timeout will immediately begin counting down.
 	if !tr.HasStarted() {
-		tr.Status.InitializeConditions()
+		tr.Status.InitializeConditions(c.Clock)
 		// In case node time was not synchronized, when controller has been scheduled to other nodes.
 		if tr.Status.StartTime.Sub(tr.CreationTimestamp.Time) < 0 {
 			logger.Warnf("TaskRun %s createTimestamp %s is after the taskRun started %s", tr.GetNamespacedName().String(), tr.CreationTimestamp, tr.Status.StartTime)


### PR DESCRIPTION
# Changes

Currently, the TaskRunStatus/CustomRunStatus implementation did not allow passing a clock when initializing conditions, making it difficult to test and set arbitrary time values.

This commit updates the InitializeConditions method of TaskRunStatus/CustomRunStatus to accept a clock as an argument, allowing the start time to be set using the provided clock.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
action required: The `InitializeConditions` method for `CustomRun` and `TaskRun` conditions now requires a `clock.PassiveClock` as an argument. If you are implementing a `CustomTask` controller, ensure that you pass a `clock` when invoking `InitializeConditions` for `CustomRun`.
```
