### PR TITLE
Remove linux/arm from platform we publish

### DIFF
--- a/docs/additional-configs.md
+++ b/docs/additional-configs.md
@@ -481,7 +481,6 @@ The controller and webhook components are currently built for:
 
 - linux/amd64
 - linux/arm64
-- linux/arm (Arm v7)
 - linux/ppc64le (PowerPC)
 - linux/s390x (IBM Z)
 

--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -33,7 +33,7 @@ spec:
       default: "true"
     - name: platforms
       description: Platforms to publish for the images (e.g. linux/amd64,linux/arm64)
-      default: linux/amd64,linux/arm,linux/arm64,linux/s390x,linux/ppc64le,windows/amd64
+      default: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le,windows/amd64
     - name: serviceAccountPath
       description: The name of the service account path within the release-secret workspace
   workspaces:

--- a/tekton/release-pipeline.yaml
+++ b/tekton/release-pipeline.yaml
@@ -32,13 +32,13 @@ spec:
     default: "true"
   - name: buildPlatforms
     description: Platforms to build images for (e.g. linux/amd64,linux/arm64)
-    default: linux/amd64,linux/arm,linux/arm64,linux/s390x,linux/ppc64le
+    default: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
   - name: publishPlatforms
     description: |
       Platforms to publish images for (e.g. linux/amd64,linux/arm64,windows/amd64). This
       can differ from buildPlatforms due to the fact that a windows-compatible base image
       is constructed for the publishing phase.
-    default: linux/amd64,linux/arm,linux/arm64,linux/s390x,linux/ppc64le,windows/amd64
+    default: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le,windows/amd64
   - name: koExtraArgs
     description: Extra args to be passed to ko
     default: "--preserve-import-paths"
@@ -195,7 +195,7 @@ spec:
           subpath: bucket
         - name: release-secret
           workspace: release-images-secret
-      timeout: 2h
+      timeout: 3h
     - name: publish-to-bucket
       runAfter: [publish-images]
       taskRef:


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

There is likely *no* kubernetes cluster running linux/arm (v5, v6 or
v7), so removing it to reduce build and release time.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/kind cleanup
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
linux/arm images are not published anymore as part of the release. This means armv5, armv6 and armv7 are not supported anymore.
```
