### PR TITLE
Fix wrong entry in development documentation and other minor documentation corrections.

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -96,6 +96,12 @@ You must install these tools:
 1. [`go-licenses`](https://github.com/google/go-licenses) is used in e2e tests.
 
 1. (Optional)
+   [`yamllint`](https://github.com/adrienverge/yamllint?tab=readme-ov-file#installation)
+   is run against every PR as part of `pre-commit`. You may want to install this tool
+   so that `pre-commit` can use it, otherwise it will show a `failed` message for
+   when linting yaml files.
+
+1. (Optional)
    [`golangci-lint`](https://golangci-lint.run/welcome/install/#local-installation)
    is run against every PR. You may want to install and [run this tool
    locally](https://golangci-lint.run/welcome/quick-start) to iterate quickly on
@@ -303,7 +309,7 @@ The recommended minimum development configuration is:
 4. Configure [ko](https://kind.sigs.k8s.io/):
 
    ```sh
-   $ export KO_DOCKER_REPO="kind.local"
+   $ export KO_DOCKER_REPO="localhost:5000"
    $ export KIND_CLUSTER_NAME="kind"  # only needed if you used a custom name in the previous step
    ```
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ TESTPKGS = $(shell env GO111MODULE=on $(GO) list -f \
 BIN      = $(CURDIR)/.bin
 WOKE 	?= go run -modfile go.mod github.com/get-woke/woke
 
-# Get golangci_version from tools/go.mod
 GOLANGCI_VERSION := $(shell yq '.jobs.linting.steps[] | select(.name == "golangci-lint") | .with.version' .github/workflows/ci.yaml)
 WOKE_VERSION     = v0.19.0
 

--- a/test/README.md
+++ b/test/README.md
@@ -410,7 +410,7 @@ via the sections for `tektoncd/pipeline`.
 
 The presubmit integration tests entrypoint will run:
 
-- [The integration tests](#integration-tests)
+- [The integration tests](#end-to-end-tests)
 - A test of [our example CRDs](../examples/README.md#testing-the-examples)
 
 When run using Prow, integration tests will try to get a new cluster using


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Change the docker registry entry for `KO_DOCKER_REPO` to `localhost:5000`. The former entry `kind.local` ([here](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#using-kind)) lead to an error when deploying the local pipeline build.

Fix a broken link in the testing documentation and remove a leftover comment from the makefile which was targeted to a non existing configuration.

Add optional installation recommendation for `yamllint` so that it can be used when running `pre-commit` locally otherwise it will show a `Failed` message when linting yaml files.

![Screenshot from 2025-03-24 12-29-16](https://github.com/user-attachments/assets/e283dc3c-f158-4f9d-9549-c246c6c9c332)

Closes #8660
Closes #8486

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
