### PR TITLE
Document `ko` settings for kind clusters with and without a local registry.

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -145,7 +145,7 @@ For example:
 
         ```shell
         # format: ${localhost:port}/{}
-        export KO_DOCKER_REPO=`localhost:5000/mypipelineimages`
+        export KO_DOCKER_REPO='localhost:5000/mypipelineimages'
         ```
 
 1. Optionally, add `$HOME/go/bin` to your system `PATH` so that any tooling installed via `go get` will work properly. For example:
@@ -303,17 +303,24 @@ The recommended minimum development configuration is:
 3. Create cluster:
 
    ```sh
-   $ kind create cluster
+   kind create cluster
    ```
 
 4. Configure [ko](https://kind.sigs.k8s.io/):
 
    ```sh
-   $ export KO_DOCKER_REPO="localhost:5000"
-   $ export KIND_CLUSTER_NAME="kind"  # only needed if you used a custom name in the previous step
+   export KO_DOCKER_REPO="kind.local"
+   export KIND_CLUSTER_NAME="kind"  # only needed if you used a custom name in the previous step
    ```
 
 optional: As a convenience, the [Tekton plumbing project](https://github.com/tektoncd/plumbing) provides a script named ['tekton_in_kind.sh'](https://github.com/tektoncd/plumbing/tree/main/hack#tekton_in_kindsh) that leverages `kind` to create a cluster and install Tekton Pipeline, [Tekton Triggers](https://github.com/tektoncd/triggers) and [Tekton Dashboard](https://github.com/tektoncd/dashboard) components into it.
+
+If you used the ['tekton_in_kind.sh'](https://github.com/tektoncd/plumbing/tree/main/hack#tekton_in_kindsh) plumbing script to deploy your `kind` cluster, you need to tell `ko` to use the local registry as mentioned [here](#configure-environment).
+
+
+```sh
+export KO_DOCKER_REPO="localhost:5000"
+```
 
 #### Using MiniKube
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The previous removed entry `kind.local` can be used if the started kind cluster is not using a local registry. If the developer starts a kind cluster with the [tekton_in_kind.sh](https://github.com/tektoncd/plumbing/tree/main/hack#tekton_in_kindsh) plumbing script `ko` must be configured to use the local registry which is `localhost:5000`. The documentation was updated.

/kind documentation

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
