### PR TITLE
fix: resolve Git Anonymous Resolver excessive memory usage

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,0 +1,2 @@
+baseImageOverrides:
+  github.com/tektoncd/pipeline/cmd/resolvers: cgr.dev/chainguard/git@sha256:566235a8ef752f37d285042ee05fc37dbb04293e50f116a231984080fb835693

--- a/config/resolvers/resolvers-deployment.yaml
+++ b/config/resolvers/resolvers-deployment.yaml
@@ -106,6 +106,9 @@ spec:
           value: "https://artifacthub.io/"
         - name: TEKTON_HUB_API
           value: "https://api.hub.tekton.dev/"
+        volumeMounts:
+          - name: tmp-clone-volume
+            mountPath: "/tmp"
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
@@ -115,3 +118,7 @@ spec:
             - "ALL"
           seccompProfile:
             type: RuntimeDefault
+      volumes:
+        - name: tmp-clone-volume
+          emptyDir:
+            sizeLimit: 4Gi

--- a/docs/git-resolver.md
+++ b/docs/git-resolver.md
@@ -59,7 +59,7 @@ The `git` resolver has two modes: cloning a repository anonymously, or fetching 
 
 ### Anonymous Cloning
 
-Anonymous cloning is supported only for public repositories. This mode clones the full git repo.
+Anonymous cloning is supported only for public repositories. This mode shallow-clones the git repo before shallow-fetching and checking out the provided revision.
 
 #### Task Resolution
 

--- a/pkg/remoteresolution/resolver/git/resolver_test.go
+++ b/pkg/remoteresolution/resolver/git/resolver_test.go
@@ -429,7 +429,7 @@ func TestResolve(t *testing.T) {
 			pathInRepo: "foo/new",
 			url:        anonFakeRepoURL,
 		},
-		expectedErr: createError("revision error: reference not found"),
+		expectedErr: createError("error resolving repository: git fetch error: fatal: couldn't find remote ref non-existent-revision: exit status 128"),
 	}, {
 		name: "api: successful task from params api information",
 		args: &params{

--- a/pkg/resolution/resolver/git/git.go
+++ b/pkg/resolution/resolver/git/git.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2022 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package git
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+type repository struct {
+	url       string
+	directory string
+	revision  string
+}
+
+func resolveRepository(ctx context.Context, url, revision string) (*repository, func(), error) {
+	urlParts := strings.Split(url, "/")
+	repoName := urlParts[len(urlParts)-1]
+	tmpDir, err := os.MkdirTemp("", repoName+"-*")
+	if err != nil {
+		return nil, func() {}, err
+	}
+	cleanupFunc := func() {
+		os.RemoveAll(tmpDir)
+	}
+
+	repo := repository{
+		url:       url,
+		directory: tmpDir,
+		revision:  revision,
+	}
+
+	_, err = repo.execGit(ctx, "clone", repo.url, tmpDir, "--depth=1", "--no-checkout")
+	if err != nil {
+		return nil, cleanupFunc, err
+	}
+
+	_, err = repo.execGit(ctx, "fetch", "origin", repo.revision, "--depth=1")
+	if err != nil {
+		return nil, cleanupFunc, err
+	}
+
+	_, err = repo.execGit(ctx, "checkout", "FETCH_HEAD")
+	if err != nil {
+		return nil, cleanupFunc, err
+	}
+
+	revisionSha, err := repo.execGit(ctx, "rev-list", "-n1", "HEAD")
+	if err != nil {
+		return nil, cleanupFunc, err
+	}
+	repo.revision = strings.TrimSpace(string(revisionSha))
+
+	return &repo, cleanupFunc, nil
+}
+
+func (repo repository) execGit(ctx context.Context, args ...string) ([]byte, error) {
+	gitCommangStr := ""
+	if len(args) > 0 && args[0] != "clone" {
+		// Just used for error message
+		gitCommangStr = args[0]
+		// If we're not cloning the repository, then we need to configure
+		// which directory contains the cloned repository since  `cd`ing
+		// into the repository directory is not concurrency-safe
+		args = append([]string{"-C", repo.directory}, args...)
+	}
+	cmd := exec.CommandContext(ctx, "git", args...)
+	out, err := cmd.Output()
+	if err != nil {
+		msg := string(out)
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			msg = string(exitErr.Stderr)
+		}
+		err = fmt.Errorf("git %s error: %s: %w", gitCommangStr, strings.TrimSpace(msg), err)
+	}
+	return out, err
+}
+
+func (repo repository) getFileContent(path string) ([]byte, error) {
+	if _, err := os.Stat(repo.directory); errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("repository clone no longer exists, used after cleaned? %w", err)
+	}
+	fileContents, err := os.ReadFile(filepath.Join(repo.directory, path))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, errors.New("file does not exist")
+		}
+		return nil, err
+	}
+	return fileContents, nil
+}

--- a/pkg/resolution/resolver/git/resolver.go
+++ b/pkg/resolution/resolver/git/resolver.go
@@ -17,21 +17,14 @@ limitations under the License.
 package git
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"regexp"
 	"strings"
 	"time"
 
-	"github.com/go-git/go-billy/v5/memfs"
-	"github.com/go-git/go-git/v5"
-	gitcfg "github.com/go-git/go-git/v5/config"
-	"github.com/go-git/go-git/v5/plumbing"
-	"github.com/go-git/go-git/v5/storage/memory"
 	"github.com/jenkins-x/go-scm/scm"
 	"github.com/jenkins-x/go-scm/scm/factory"
 	resolverconfig "github.com/tektoncd/pipeline/pkg/apis/config/resolver"
@@ -162,8 +155,8 @@ func ResolveAnonymousGit(ctx context.Context, params map[string]string) (framewo
 	if err != nil {
 		return nil, err
 	}
-	repo := params[UrlParam]
-	if repo == "" {
+	repoURL := params[UrlParam]
+	if repoURL == "" {
 		urlString := conf.URL
 		if urlString == "" {
 			return nil, errors.New("default Git Repo Url was not set during installation of the git resolver")
@@ -176,63 +169,24 @@ func ResolveAnonymousGit(ctx context.Context, params map[string]string) (framewo
 			return nil, errors.New("default Git Revision was not set during installation of the git resolver")
 		}
 	}
-
-	cloneOpts := &git.CloneOptions{
-		URL: repo,
-	}
-	filesystem := memfs.New()
-	repository, err := git.Clone(memory.NewStorage(), filesystem, cloneOpts)
-	if err != nil {
-		return nil, fmt.Errorf("clone error: %w", err)
-	}
-
-	// try fetch the branch when the given revision refers to a branch name
-	refSpec := gitcfg.RefSpec(fmt.Sprintf("+refs/heads/%s:refs/remotes/%s", revision, revision))
-	err = repository.Fetch(&git.FetchOptions{
-		RefSpecs: []gitcfg.RefSpec{refSpec},
-	})
-	if err != nil {
-		var fetchErr git.NoMatchingRefSpecError
-		if !errors.As(err, &fetchErr) {
-			return nil, fmt.Errorf("unexpected fetch error: %w", err)
-		}
-	}
-
-	w, err := repository.Worktree()
-	if err != nil {
-		return nil, fmt.Errorf("worktree error: %w", err)
-	}
-
-	h, err := repository.ResolveRevision(plumbing.Revision(revision))
-	if err != nil {
-		return nil, fmt.Errorf("revision error: %w", err)
-	}
-
-	err = w.Checkout(&git.CheckoutOptions{
-		Hash: *h,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("checkout error: %w", err)
-	}
-
 	path := params[PathParam]
 
-	f, err := filesystem.Open(path)
+	repo, cleanupFunc, err := resolveRepository(ctx, repoURL, revision)
+	defer cleanupFunc()
+	if err != nil {
+		return nil, fmt.Errorf("error resolving repository: %w", err)
+	}
+
+	fileContents, err := repo.getFileContent(path)
 	if err != nil {
 		return nil, fmt.Errorf("error opening file %q: %w", path, err)
 	}
 
-	buf := &bytes.Buffer{}
-	_, err = io.Copy(buf, f)
-	if err != nil {
-		return nil, fmt.Errorf("error reading file %q: %w", path, err)
-	}
-
 	return &resolvedGitResource{
-		Revision: h.String(),
-		Content:  buf.Bytes(),
-		URL:      params[UrlParam],
-		Path:     params[PathParam],
+		Revision: repo.revision,
+		Content:  fileContents,
+		URL:      repo.url,
+		Path:     path,
 	}, nil
 }
 

--- a/pkg/resolution/resolver/git/resolver_test.go
+++ b/pkg/resolution/resolver/git/resolver_test.go
@@ -426,7 +426,7 @@ func TestResolve(t *testing.T) {
 			pathInRepo: "foo/new",
 			url:        anonFakeRepoURL,
 		},
-		expectedErr: createError("revision error: reference not found"),
+		expectedErr: createError("error resolving repository: git fetch error: fatal: couldn't find remote ref non-existent-revision: exit status 128"),
 	}, {
 		name: "api: successful task from params api information",
 		args: &params{

--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -29,7 +29,7 @@ spec:
       description: Username to be used to login to the container registry
       default: "_json_key"
     - name: releaseAsLatest
-      description: Whether to tag and publish this release as Pipelines' latest
+      description: Whether to tag and publish this release as Pipelines latest
       default: "true"
     - name: platforms
       description: Platforms to publish for the images (e.g. linux/amd64,linux/arm64)
@@ -130,6 +130,7 @@ spec:
         $(params.package)/cmd/entrypoint: ${COMBINED_BASE_IMAGE}
         $(params.package)/cmd/nop: ${COMBINED_BASE_IMAGE}
         $(params.package)/cmd/workingdirinit: ${COMBINED_BASE_IMAGE}
+        $(params.package)/cmd/resolvers: cgr.dev/chainguard/git@sha256:566235a8ef752f37d285042ee05fc37dbb04293e50f116a231984080fb835693
       EOF
 
       cat /workspace/.ko.yaml

--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -55,7 +55,7 @@ function ko_resolve() {
       github.com/tektoncd/pipeline/cmd/nop: ghcr.io/tektoncd/pipeline/github.com/tektoncd/pipeline/combined-base-image:latest
       github.com/tektoncd/pipeline/cmd/workingdirinit: ghcr.io/tektoncd/pipeline/github.com/tektoncd/pipeline/combined-base-image:latest
 
-      github.com/tektoncd/pipeline/cmd/git-init: cgr.dev/chainguard/git
+      github.com/tektoncd/pipeline/cmd/resolvers: cgr.dev/chainguard/git@sha256:566235a8ef752f37d285042ee05fc37dbb04293e50f116a231984080fb835693
 EOF
 
   KO_DOCKER_REPO=example.com ko resolve -l 'app.kubernetes.io/component!=resolvers' --platform=all --push=false -R -f config 1>/dev/null


### PR DESCRIPTION
Switch git resolver from go-git library to use git binary.

The go-git library does not resolve deltas efficiently, and as a result is not recommended to be used to clone repositories with full-depth. In one example RemoteResolutionRequest targeting a repository which summed 145Mb, configuring the resolution timeout to 10 minutes and giving the resolver to have 25Gb of memory, the resolver pod was OOM killed after ~6 minutes. Additionally, since go-git's delta resolution does not accept any contexts, the time required and memory used during resolving a large repository will not be cutoff when the context is canceled, impacting the resolver's performance for other concurrent remote resolutions.

Since the git resolver can be provided a revision which is not tracked at any ref in the repository, and because go-git only supports fetching fully-qualified refs, go-git does not support fetching arbitrary revisions. Therefore, in order to guarantee the requested revision is fetched, if we continue to use the go-git library we must fetch all revisions.

Switching to the git binary enables the git resolver to take advantage of the git-fetch's support for fetching arbitrary revisions. Note that if the revision is not at any ref head, fetching the revision does depend on the git server enabling uploadpack.allowReachableSHA1InWant. This feature is enabled and supported in Github and Gitlab but
not Gitea: https://github.com/go-gitea/gitea/issues/11958

Resolves https://github.com/tektoncd/pipeline/issues/8652

See also: https://git-scm.com/docs/protocol-capabilities#_allow_reachable_sha1_in_want


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
