### PR TITLE
fix: handle subPath directory creation errors gracefully

### DIFF
--- a/pkg/pod/status.go
+++ b/pkg/pod/status.go
@@ -623,6 +623,9 @@ func updateIncompleteTaskRunStatus(trs *v1.TaskRunStatus, pod *corev1.Pod) {
 		switch {
 		case IsPodExceedingNodeResources(pod):
 			markStatusRunning(trs, ReasonExceededNodeResources, "TaskRun Pod exceeded available resources")
+		case isSubPathDirectoryError(pod):
+			// if subPath directory creation errors, mark as running and wait for recovery
+			markStatusRunning(trs, ReasonPodPending, "Waiting for subPath directory creation to complete")
 		case isPodHitConfigError(pod):
 			markStatusFailure(trs, ReasonCreateContainerConfigError, "Failed to create pod due to config error")
 		case isPullImageError(pod):
@@ -803,6 +806,10 @@ func IsPodExceedingNodeResources(pod *corev1.Pod) bool {
 func isPodHitConfigError(pod *corev1.Pod) bool {
 	for _, containerStatus := range pod.Status.ContainerStatuses {
 		if containerStatus.State.Waiting != nil && containerStatus.State.Waiting.Reason == ReasonCreateContainerConfigError {
+			// for subPath directory creation errors, we want to allow recovery
+			if strings.Contains(containerStatus.State.Waiting.Message, "failed to create subPath directory") {
+				return false
+			}
 			return true
 		}
 	}
@@ -911,4 +918,15 @@ func sortPodContainerStatuses(podContainerStatuses []corev1.ContainerStatus, pod
 
 func isOOMKilled(s corev1.ContainerStatus) bool {
 	return s.State.Terminated.Reason == oomKilled
+}
+
+func isSubPathDirectoryError(pod *corev1.Pod) bool {
+	for _, containerStatus := range pod.Status.ContainerStatuses {
+		if containerStatus.State.Waiting != nil &&
+			containerStatus.State.Waiting.Reason == ReasonCreateContainerConfigError &&
+			strings.Contains(containerStatus.State.Waiting.Message, "failed to create subPath directory") {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
handle transient subPath directory creation failures by keeping the TaskRun in running state instead of immediate failure.
fixes https://github.com/tektoncd/pipeline/issues/6960

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
