### PR TITLE
Move Steps and Sidecars validation to `container_validation.go`.

### DIFF
--- a/pkg/apis/pipeline/v1/container_validation_test.go
+++ b/pkg/apis/pipeline/v1/container_validation_test.go
@@ -48,7 +48,7 @@ func TestRef_Valid(t *testing.T) {
 		name: "simple ref",
 		ref:  &v1.Ref{Name: "refname"},
 	}, {
-		name: "ref name - consice syntax",
+		name: "ref name - concise syntax",
 		ref:  &v1.Ref{Name: "foo://baz:ver", ResolverRef: v1.ResolverRef{Resolver: "git"}},
 		wc:   enableConciseResolverSyntax,
 	}, {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Move step and sidecar validation functions with their call chain to `container_validation.go` and fix small typos.

Create [ `validateSidecar`](https://github.com/tektoncd/pipeline/pull/8685/files#diff-b41c2729625c811236fb6518d146e398c9732a46a6df67651fa0013ae59e56e0R405) and move to `container_validation.go` to be consistent with the `validateStep` function location. Inline [`validateSidecarName` ](https://github.com/tektoncd/pipeline/pull/8685/files#diff-64fca3cc648dd33daa918b8fbffaac0748b6cb35ca666069cacd4dcc7d68acb8L150)function into [`validateSidecar`](https://github.com/tektoncd/pipeline/pull/8685/files#diff-b41c2729625c811236fb6518d146e398c9732a46a6df67651fa0013ae59e56e0R406) to keep consistency because the fields `sc.Image` and `sc.Script` are validated in the caller.

Keep `validationSteps` and  `validateSidecars` in `task_validation.go`.

Closes #7442.

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
