### PR TITLE
docs: clarify container contract documentation to avoid ambiguity

### DIFF
--- a/docs/container-contract.md
+++ b/docs/container-contract.md
@@ -30,7 +30,7 @@ If you do not specify a `command` value, the Pipelines controller performs a loo
 the `entrypoint` value in the associated remote container registry. If the image is in
 a private registry, you must include an [`ImagePullSecret`](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account)
 value in the service account definition used by the `Task`.
-The Pipelines controller uses this value unless the service account is not 
+The Pipelines controller uses this value unless the service account is not
 defined, at which point it assumes the value of `default`.
 
 The final fallback occurs to the Docker config specified in the `$HOME/.docker/config.json` file.
@@ -39,16 +39,16 @@ controller performs an anonymous lookup of the image.
 
 For example, consider the following `Task`, which uses two images named
 `gcr.io/cloud-builders/gcloud` and `gcr.io/cloud-builders/docker`. In this example, the
-Pipelines controller retrieves the `entrypoint` value from the registry, which allows
-the `Task` to execute the `gcloud` and `docker` commands, respectively.
+Pipelines controller retrieves the `entrypoint` value from the registry, which means
+the container will execute using the default `entrypoint` defined in the image.
 
 ```yaml
 spec:
   steps:
     - image: gcr.io/cloud-builders/gcloud
-      command: [gcloud]
+      # No command specified, so the default entrypoint from the image will be used
     - image: gcr.io/cloud-builders/docker
-      command: [docker]
+      # No command specified, so the default entrypoint from the image will be used
 ```
 
 However, if you specify a custom `command` value, the controller uses that value instead:


### PR DESCRIPTION
fix #8647

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
docs: clarify container contract documentation to avoid ambiguity
```

/kind documentation