### PR TITLE
Add oomkilled reason

### DIFF
--- a/pkg/pod/status.go
+++ b/pkg/pod/status.go
@@ -784,6 +784,10 @@ func extractContainerFailureMessage(logger *zap.SugaredLogger, status corev1.Con
 			}
 		}
 		if term.ExitCode != 0 {
+			// Include the termination reason, if available to add clarity for causes such as external signals, e.g. OOM
+			if term.Reason != "" {
+				return fmt.Sprintf("%q exited with code %d: %s", status.Name, term.ExitCode, term.Reason)
+			}
 			return fmt.Sprintf("%q exited with code %d", status.Name, term.ExitCode)
 		}
 	}

--- a/pkg/pod/status_test.go
+++ b/pkg/pod/status_test.go
@@ -1468,7 +1468,7 @@ func TestMakeTaskRunStatus(t *testing.T) {
 			}},
 		},
 		want: v1.TaskRunStatus{
-			Status: statusFailure(v1.TaskRunReasonFailed.String(), "\"step-one\" exited with code 137"),
+			Status: statusFailure(v1.TaskRunReasonFailed.String(), "\"step-one\" exited with code 137: OOMKilled"),
 			TaskRunStatusFields: v1.TaskRunStatusFields{
 				Steps: []v1.StepState{{
 					ContainerState: corev1.ContainerState{


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR improves the error reporting for TaskRuns that fail due to Out of Memory (OOM) conditions. The changes modify the extractContainerFailureMessage function in pkg/pod/status.go to include the termination reason in the failure message when a container is OOMKilled.
Fix jira #SRVKP-7343

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind bug`.
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).

# Release Notes

```release-note
TaskRuns that fail due to Out of Memory (OOM) conditions will now show the termination reason in their failure message.
```
