### PR TITLE
Raise test coverage in `task_validation.go` and `container_validation.go`.

### DIFF
--- a/pkg/apis/pipeline/v1/container_validation.go
+++ b/pkg/apis/pipeline/v1/container_validation.go
@@ -182,7 +182,7 @@ func validateStep(ctx context.Context, s Step, names sets.String) (errs *apis.Fi
 
 	if s.Name != "" {
 		if names.Has(s.Name) {
-			errs = errs.Also(apis.ErrInvalidValue(s.Name, "name"))
+			errs = errs.Also(apis.ErrMultipleOneOf("name"))
 		}
 		if e := validation.IsDNS1123Label(s.Name); len(e) > 0 {
 			errs = errs.Also(&apis.FieldError{

--- a/pkg/apis/pipeline/v1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1/task_validation_test.go
@@ -1048,7 +1048,19 @@ func TestTaskSpecValidateError(t *testing.T) {
 			Details: "Task step name must be a valid DNS Label, For more info refer to https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
 		},
 	}, {
-		name: "array used in unaccepted field",
+		name: "duplicate step name",
+		fields: fields{
+			Steps: []v1.Step{
+				{Name: "mystep", Image: "myimage"},
+				{Name: "mystep", Image: "myimage"},
+			},
+		},
+		expectedError: apis.FieldError{
+			Message: `expected exactly one, got both`,
+			Paths:   []string{"steps[1].name"},
+		},
+	}, {
+		name: "array used in a string field",
 		fields: fields{
 			Params: []v1.ParamSpec{{
 				Name: "baz",
@@ -1070,7 +1082,7 @@ func TestTaskSpecValidateError(t *testing.T) {
 			Paths:   []string{"steps[0].image"},
 		},
 	}, {
-		name: "array star used in unaccepted field",
+		name: "array star used in a string field",
 		fields: fields{
 			Params: []v1.ParamSpec{{
 				Name: "baz",
@@ -1092,7 +1104,7 @@ func TestTaskSpecValidateError(t *testing.T) {
 			Paths:   []string{"steps[0].image"},
 		},
 	}, {
-		name: "array star used illegaly in script field",
+		name: "array star used illegally in script field",
 		fields: fields{
 			Params: []v1.ParamSpec{{
 				Name: "baz",
@@ -1113,6 +1125,23 @@ func TestTaskSpecValidateError(t *testing.T) {
 		expectedError: apis.FieldError{
 			Message: `variable type invalid in "$(params.baz[*])"`,
 			Paths:   []string{"steps[0].script"},
+		},
+	}, {
+		name: "array param used in step env value field that can accept string type",
+		fields: fields{
+			Params: []v1.ParamSpec{{
+				Name: "baz",
+				Type: v1.ParamTypeArray,
+			}},
+			Steps: []v1.Step{{
+				Name:  "mystep",
+				Image: "my-image",
+				Env:   []corev1.EnvVar{{Name: "URL", Value: "$(params.baz)"}},
+			}},
+		},
+		expectedError: apis.FieldError{
+			Message: `variable type invalid in "$(params.baz)"`,
+			Paths:   []string{"steps[0].env[URL]"},
 		},
 	}, {
 		name: "array not properly isolated",
@@ -1774,6 +1803,38 @@ func TestTaskSpecValidateSuccessWithArtifactsRefFlagEnabled(t *testing.T) {
 		})
 	}
 }
+
+func TestTaskSpecValidateSuccessWithArtifactsRefFlagNotEnabled(t *testing.T) {
+	tests := []struct {
+		name  string
+		Steps []v1.Step
+	}{
+		{
+			name: "script without reference to a step artifact",
+			Steps: []v1.Step{{
+				Image:  "busybox",
+				Script: "echo 123",
+			}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := v1.TaskSpec{
+				Steps: tt.Steps,
+			}
+			ctx := config.ToContext(context.Background(), &config.Config{
+				FeatureFlags: nil,
+			})
+			ctx = apis.WithinCreate(ctx)
+			ts.SetDefaults(ctx)
+			err := ts.Validate(ctx)
+			if err != nil {
+				t.Fatalf("Expected no errors, got err for %v", err)
+			}
+		})
+	}
+}
+
 func TestTaskSpecValidateErrorWithArtifactsRefFlagNotEnabled(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -2365,6 +2426,25 @@ func TestTaskSpecValidateUsageOfDeclaredParams(t *testing.T) {
 			Paths:   []string{"steps[0].args[0]"},
 		},
 	}, {
+		name: "object param used in step env value field that can accept string type",
+		Params: []v1.ParamSpec{{
+			Name: "gitrepo",
+			Type: v1.ParamTypeObject,
+			Properties: map[string]v1.PropertySpec{
+				"url":    {},
+				"commit": {},
+			},
+		}},
+		Steps: []v1.Step{{
+			Name:  "do-the-clone",
+			Image: "some-git-image",
+			Env:   []corev1.EnvVar{{Name: "URL", Value: "$(params.gitrepo)"}},
+		}},
+		expectedError: apis.FieldError{
+			Message: `variable type invalid in "$(params.gitrepo)"`,
+			Paths:   []string{"steps[0].env[URL]"},
+		},
+	}, {
 		name: "non-existent individual key of an object param is used in task step",
 		Params: []v1.ParamSpec{{
 			Name: "gitrepo",
@@ -2385,7 +2465,7 @@ func TestTaskSpecValidateUsageOfDeclaredParams(t *testing.T) {
 			Paths:   []string{"steps[0].args[0]"},
 		},
 	}, {
-		name: "Inexistent param variable in volumeMount with existing",
+		name: "inexistent param variable in volumeMount with existing",
 		Params: []v1.ParamSpec{
 			{
 				Name:        "foo",
@@ -2405,7 +2485,7 @@ func TestTaskSpecValidateUsageOfDeclaredParams(t *testing.T) {
 			Paths:   []string{"steps[0].volumeMount[0].name"},
 		},
 	}, {
-		name: "Inexistent param variable with existing",
+		name: "inexistent param variable with existing",
 		Params: []v1.ParamSpec{{
 			Name:        "foo",
 			Description: "param",
@@ -2419,6 +2499,17 @@ func TestTaskSpecValidateUsageOfDeclaredParams(t *testing.T) {
 		expectedError: apis.FieldError{
 			Message: `non-existent variable in "$(params.foo) && $(params.inexistent)"`,
 			Paths:   []string{"steps[0].args[0]"},
+		},
+	}, {
+		name: "object param variable with non-existent properties",
+		Params: []v1.ParamSpec{{
+			Name: "foo",
+			Type: v1.ParamTypeObject,
+		}},
+		Steps: validSteps,
+		expectedError: apis.FieldError{
+			Message: "missing field(s)",
+			Paths:   []string{"foo.properties"},
 		},
 	}}
 	for _, tt := range tests {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Add test for checking duplicate names of steps and a success test when the `enable-artifacts` feature flag is not enabled. This raises the test coverage of `container_validation.go` to **100%**. Replace `ErrInvalidValue` with `ErrMultipleOneOf` like in the pipeline validation tests for duplicate tasks.

Add a test for checking of object params without properties and using an object param in step environment variable value where it is forbidden which raises the coverage of `task_validation.go` to **99.1%**.

Issue #8700.

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
