### PR TITLE
fix(docs): correct documentation link errors related to sidecar-logs

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -1022,12 +1022,12 @@ As a general rule-of-thumb, if a result needs to be larger than a kilobyte, you 
 #### Larger `Results` using sidecar logs
 
 This is a beta feature which is guarded behind its own feature flag.  The `results-from` feature flag must be set to
-[`"sidecar-logs"`](./install.md#enabling-larger-results-using-sidecar-logs) to enable larger results using sidecar logs.
+[`"sidecar-logs"`](additional-configs.md#enabling-larger-results-using-sidecar-logs) to enable larger results using sidecar logs.
 
 Instead of using termination messages to store results, the taskrun controller injects a sidecar container which monitors
 the results of all the steps. The sidecar mounts the volume where results of all the steps are stored. As soon as it
 finds a new result, it logs it to std out. The controller has access to the logs of the sidecar container.
-**CAUTION**: we need you to enable access to [kubernetes pod/logs](./install.md#enabling-larger-results-using-sidecar-logs).
+**CAUTION**: we need you to enable access to [kubernetes pod/logs](additional-configs.md#enabling-larger-results-using-sidecar-logs).
 
 This feature allows users to store up to 4 KB per result by default. Because we are not limited by the size of the
 termination messages, users can have as many results as they require (or until the CRD reaches its limit). If the size
@@ -1035,7 +1035,7 @@ of a result exceeds this limit, then the TaskRun will be placed into a failed st
 exceeded the maximum allowed limit.`
 
 **Note**: If you require even larger results, you can specify a different upper limit per result by setting
-`max-result-size` feature flag to your desired size in bytes ([see instructions](./install.md#enabling-larger-results-using-sidecar-logs)).
+`max-result-size` feature flag to your desired size in bytes ([see instructions](additional-configs.md#enabling-larger-results-using-sidecar-logs)).
 **CAUTION**: the larger you make the size, more likely will the CRD reach its max limit enforced by the `etcd` server
 leading to bad user experience.
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```

/kind documentation