### PR TITLE
fix: Ensure retryable errors during validation do not fail Runs

### DIFF
--- a/docs/resolver-reference.md
+++ b/docs/resolver-reference.md
@@ -31,7 +31,7 @@ configuration for the framework to get a resolver running.
 | GetName | Use this method to return a name to refer to your Resolver by. e.g. `"Git"` |
 | GetSelector | Use this method to specify the labels that a resolution request must have to be routed to your resolver. |
 | Validate | Use this method to validate the resolution Spec given to your resolver. |
-| Resolve | Use this method to perform get the resource based on the ResolutionRequestSpec as input and return it, along with any metadata about it in annotations |
+| Resolve | Use this method to perform get the resource based on the ResolutionRequestSpec as input and return it, along with any metadata about it in annotations. Errors returned by this method mark the ResolutionRequest as Failed, unless the error type is considered transient (e.g. a Kubernetes request timeout or etcd leader changes). |
 
 {{% /tab %}}
 

--- a/pkg/reconciler/apiserver/apiserver.go
+++ b/pkg/reconciler/apiserver/apiserver.go
@@ -104,5 +104,5 @@ func handleDryRunCreateErr(err error, objectName string) error {
 		// Additional errors can be added to the switch statements as needed
 		errType = ErrCouldntValidateObjectRetryable
 	}
-	return fmt.Errorf("%w %s: %s", errType, objectName, err.Error())
+	return fmt.Errorf("%w %s: %w", errType, objectName, err)
 }

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -31,6 +31,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/reconciler/taskrun/resources"
 	"github.com/tektoncd/pipeline/pkg/remote"
+	resolutioncommon "github.com/tektoncd/pipeline/pkg/resolution/common"
 	"github.com/tektoncd/pipeline/pkg/resolution/resource"
 	"github.com/tektoncd/pipeline/pkg/substitution"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -684,7 +685,7 @@ func resolveTask(
 			// Instead, the child TaskRun's status will be the place recording the RefSource of individual task.
 			t, _, vr, err := getTask(ctx, pipelineTask.TaskRef.Name)
 			switch {
-			case errors.Is(err, remote.ErrRequestInProgress):
+			case errors.Is(err, remote.ErrRequestInProgress) || (err != nil && resolutioncommon.IsErrTransient(err)):
 				return rt, err
 			case err != nil:
 				// some of the resolvers obtain the name from the parameters instead of from the TaskRef.Name field,

--- a/pkg/remoteresolution/resolver/framework/interface.go
+++ b/pkg/remoteresolution/resolver/framework/interface.go
@@ -48,6 +48,10 @@ type Resolver interface {
 	// to include in the response. If resolution fails then an error
 	// should be returned instead. If a resolution.Error
 	// is returned then its Reason and Message are used as part of the
-	// response to the request.
+	// response to the request. If an error is returned which is transient,
+	// such as a kubernetes timeout or too many requests error, the
+	// ResolutionRequest will not be updated with a failed status.
+	// See github.com/tektoncd/pipeline/pkg/resolution/common/errors.go for
+	// the definition of a transient error.
 	Resolve(ctx context.Context, req *v1beta1.ResolutionRequestSpec) (framework.ResolvedResource, error)
 }

--- a/pkg/resolution/common/errors.go
+++ b/pkg/resolution/common/errors.go
@@ -153,11 +153,7 @@ func ReasonError(err error) (string, error) {
 // IsErrTransient returns true if an error returned by GetTask/GetStepAction is retryable.
 func IsErrTransient(err error) bool {
 	switch {
-	case apierrors.IsConflict(err):
-		return true
-	case apierrors.IsServerTimeout(err):
-		return true
-	case apierrors.IsTimeout(err):
+	case apierrors.IsConflict(err), apierrors.IsServerTimeout(err), apierrors.IsTimeout(err), apierrors.IsTooManyRequests(err):
 		return true
 	default:
 		return slices.ContainsFunc([]string{errEtcdLeaderChange, context.DeadlineExceeded.Error()}, func(s string) bool {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

During resource creation/validation, retryale errors such as a k8s timeout should not result in the resource being marked as failed. To ensure this is the case, these errors must either be bubbled up or wrapped and cannot be un-wrapped into a new error using `retryableErr.Error()`.

Additionally, IsTooManyRequests is now considered Transient (retryable).

/kind bug


# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Retryable errors during dry-run Task validation will no longer cause a PipelineRun to be failed.
```
