### PR TITLE
Update kubernetes version of the CI

### DIFF
--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -18,8 +18,11 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-name:
-        - k8s-oldest
-        - k8s-plus-one
+        - k8s-oldest             # 1.28
+        - k8s-latest-minus-three # 1.29
+        - k8s-latest-minus-two   # 1.30
+        - k8s-latest-minus-one   # 1.31
+        - k8s-latest             # 1.32
 
         feature-flags:
         - stable
@@ -30,8 +33,14 @@ jobs:
         include:
         - k8s-name: k8s-oldest
           k8s-version: v1.28.x
-        - k8s-name: k8s-plus-one
+        - k8s-name: k8s-latest-minus-three
           k8s-version: v1.29.x
+        - k8s-name: k8s-latest-minus-two
+          k8s-version: v1.30.x
+        - k8s-name: k8s-latest-minus-one
+          k8s-version: v1.31.x
+        - k8s-name: k8s-latest
+          k8s-version: v1.32.x
         - feature-flags: stable
           env-file: prow
         - feature-flags: alpha

--- a/hack/setup-kind.sh
+++ b/hack/setup-kind.sh
@@ -30,7 +30,7 @@ function abort() {
 }
 
 # Defaults
-K8S_VERSION="v1.28.x"
+K8S_VERSION="v1.30.x"
 REGISTRY_NAME="registry.local"
 REGISTRY_PORT="5000"
 CLUSTER_SUFFIX="cluster.local"
@@ -84,34 +84,29 @@ fi
 
 # The version map correlated with this version of KinD
 case ${K8S_VERSION} in
-  v1.25.x)
-    K8S_VERSION="1.25.16"
-    KIND_IMAGE_SHA="sha256:5da57dfc290ac3599e775e63b8b6c49c0c85d3fec771cd7d55b45fae14b38d3b"
-    KIND_IMAGE="kindest/node:${K8S_VERSION}@${KIND_IMAGE_SHA}"
-    ;;
-  v1.26.x)
-    K8S_VERSION="1.26.15"
-    KIND_IMAGE_SHA="sha256:84333e26cae1d70361bb7339efb568df1871419f2019c80f9a12b7e2d485fe19"
-    KIND_IMAGE="kindest/node:${K8S_VERSION}@${KIND_IMAGE_SHA}"
-    ;;
-  v1.27.x)
-    K8S_VERSION="1.27.13"
-    KIND_IMAGE_SHA="sha256:17439fa5b32290e3ead39ead1250dca1d822d94a10d26f1981756cd51b24b9d8"
-    KIND_IMAGE="kindest/node:${K8S_VERSION}@${KIND_IMAGE_SHA}"
-    ;;
   v1.28.x)
     K8S_VERSION="1.28.9"
     KIND_IMAGE_SHA="sha256:dca54bc6a6079dd34699d53d7d4ffa2e853e46a20cd12d619a09207e35300bd0"
     KIND_IMAGE="kindest/node:${K8S_VERSION}@${KIND_IMAGE_SHA}"
     ;;
   v1.29.x)
-    K8S_VERSION="1.29.4"
-    KIND_IMAGE_SHA="sha256:3abb816a5b1061fb15c6e9e60856ec40d56b7b52bcea5f5f1350bc6e2320b6f8"
+    K8S_VERSION="1.29.14"
+    KIND_IMAGE_SHA="sha256:8703bd94ee24e51b778d5556ae310c6c0fa67d761fae6379c8e0bb480e6fea29"
     KIND_IMAGE="kindest/node:${K8S_VERSION}@${KIND_IMAGE_SHA}"
     ;;
   v1.30.x)
-    K8S_VERSION="1.30.0"
-    KIND_IMAGE_SHA="sha256:047357ac0cfea04663786a612ba1eaba9702bef25227a794b52890dd8bcd692e"
+    K8S_VERSION="1.30.10"
+    KIND_IMAGE_SHA="sha256:4de75d0e82481ea846c0ed1de86328d821c1e6a6a91ac37bf804e5313670e507"
+    KIND_IMAGE="kindest/node:${K8S_VERSION}@${KIND_IMAGE_SHA}"
+    ;;
+  v1.31.x)
+    K8S_VERSION="1.31.6"
+    KIND_IMAGE_SHA="sha256:28b7cbb993dfe093c76641a0c95807637213c9109b761f1d422c2400e22b8e87"
+    KIND_IMAGE="kindest/node:${K8S_VERSION}@${KIND_IMAGE_SHA}"
+    ;;
+  v1.32.x)
+    K8S_VERSION="1.32.2"
+    KIND_IMAGE_SHA="sha256:f226345927d7e348497136874b6d207e0b32cc52154ad8323129352923a3142f"
     KIND_IMAGE="kindest/node:${K8S_VERSION}@${KIND_IMAGE_SHA}"
     ;;
   *) abort "Unsupported version: ${K8S_VERSION}" ;;


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

We are lagging a bit behind in terms of kubernetes version we test
against. This updates to run on more "recent" versions of k8s.

@tektoncd/core-maintainers  I am not sure what version we should use there, but… right
now we test 1.28.x and 1.29.x, but most recent version of kubernetes
is 1.33.x. We should definitely keep the version we specify in
`MIN_KUBERNETES_VERSION` in our tests, but I wonder if we should run
all version from it to the latest (which would be 6 k8s version,
making 18 e2e runs).

/kind misc

Signed-off-by: Vincent Demeester <vincent@sbr.pm>

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
