### PR TITLE
docs: add more explicit language in the Pipelines in Pipelines docs

### DIFF
--- a/docs/pipelines-in-pipelines.md
+++ b/docs/pipelines-in-pipelines.md
@@ -16,9 +16,9 @@ weight: 406
 
 A mechanism to define and execute Pipelines in Pipelines, alongside Tasks and Custom Tasks, for a more in-depth background and inspiration, refer to the proposal [TEP-0056](https://github.com/tektoncd/community/blob/main/teps/0056-pipelines-in-pipelines.md "Proposal").
 
-> :seedling: **Pipelines in Pipelines is an  [alpha](additional-configs.md#alpha-features) feature.**
-> The `enable-api-fields` feature flag must be set to `"alpha"` to specify `pipelineRef` or `pipelineSpec` in a `pipelineTask`.
-> This feature is in Preview Only mode and not yet supported/implemented.
+> :seedling: **Pipelines in Pipelines not yet [alpha](additional-configs.md#alpha-features) feature.**
+> If the `enable-api-fields` feature flag is set to `"alpha"` users may specify `pipelineRef` or `pipelineSpec` in a `pipelineTask`, however this feature is not yet supported/implemented.
+> **Specifying a `pipelineRef` or `pipelineSpec` in a `pipelineTask` will not cause the Pipeline to run at this time.**
 
 ## Specifying `pipelineRef` in `pipelineTasks`
 


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Add more explicit language in the Pipelines in Pipelines docs to make it clear that the feature does not currently work, even with the alpha api fields enabled. 

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
