### PR TITLE
Move `Step` step action reference test to `container_validation_test.go`.

### DIFF
--- a/pkg/apis/pipeline/v1/container_validation_test.go
+++ b/pkg/apis/pipeline/v1/container_validation_test.go
@@ -985,6 +985,43 @@ func TestStepValidateErrorWithArtifactsRef(t *testing.T) {
 	}
 }
 
+func TestStepWithStepActionReferenceValidate(t *testing.T) {
+	tests := []struct {
+		name string
+		Step v1.Step
+	}{{
+		name: "valid stepAction ref",
+		Step: v1.Step{
+			Name: "mystep",
+			Ref: &v1.Ref{
+				Name: "stepAction",
+			},
+		},
+	}, {
+		name: "valid use of params with Ref",
+		Step: v1.Step{
+			Ref: &v1.Ref{
+				Name: "stepAction",
+			},
+			Params: v1.Params{{
+				Name: "param",
+			}},
+		},
+	}}
+	for _, st := range tests {
+		t.Run(st.name, func(t *testing.T) {
+			ctx := config.ToContext(t.Context(), &config.Config{
+				FeatureFlags: &config.FeatureFlags{
+					EnableStepActions: true,
+				},
+			})
+			if err := st.Step.Validate(ctx); err != nil {
+				t.Errorf("Step.Validate() = %v", err)
+			}
+		})
+	}
+}
+
 func TestSidecarValidate(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
# Changes

Now that `Step` implements the `Validatable` interface the tests for the `Step` validation are moved from `task_validation_test.go` to `container_validation_test.go`.

The following tests is moved and renamed:
- `TestTaskSpecStepActionReferenceValidate`
  - to `TestStepWithStepActionReferenceValidate`

This PR is one of a series to migrate the tests in small batches so that they are easier to review.

More details are in issue #8700. Closes #8700.

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
