### PR TITLE
fix: stepaction resolution should respect task's namespace

### DIFF
--- a/config/300-crds/300-taskrun.yaml
+++ b/config/300-crds/300-taskrun.yaml
@@ -4098,6 +4098,11 @@ spec:
                             URI indicates the identity of the source of the build definition.
                             Example: "https://github.com/tektoncd/catalog"
                           type: string
+                resolvedTaskNamespace:
+                  description: |-
+                    ResolvedTaskNamespace is the namespace of the resolved Task, used for
+                    cross-namespace StepAction resolution. Set by the controller, not user-modifiable.
+                  type: string
                 results:
                   description: Results are the list of results written out by the task's containers
                   type: array

--- a/docs/pipeline-api.md
+++ b/docs/pipeline-api.md
@@ -6,4344 +6,17141 @@ weight: 404
 ---
 -->
 
-# API Reference
-
-## Packages
-- [resolution.tekton.dev/v1alpha1](#resolutiontektondevv1alpha1)
-- [resolution.tekton.dev/v1beta1](#resolutiontektondevv1beta1)
-- [tekton.dev/unversioned](#tektondevunversioned)
-- [tekton.dev/v1](#tektondevv1)
-- [tekton.dev/v1alpha1](#tektondevv1alpha1)
-- [tekton.dev/v1beta1](#tektondevv1beta1)
-
-
-## resolution.tekton.dev/v1alpha1
-
-
-### Resource Types
-- [ResolutionRequest](#resolutionrequest)
-
-
-
-#### ResolutionRequest
-
-
-
-ResolutionRequest is an object for requesting the content of
-a Tekton resource like a pipeline.yaml.
-
-
-
-
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `resolution.tekton.dev/v1alpha1` | | |
-| `kind` _string_ | `ResolutionRequest` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  | Optional: \{\} <br /> |
-| `spec` _[ResolutionRequestSpec](#resolutionrequestspec)_ | Spec holds the information for the request part of the resource request. |  | Optional: \{\} <br /> |
-| `status` _[ResolutionRequestStatus](#resolutionrequeststatus)_ | Status communicates the state of the request and, ultimately,<br />the content of the resolved resource. |  | Optional: \{\} <br /> |
-
-
-#### ResolutionRequestSpec
-
-
-
-ResolutionRequestSpec are all the fields in the spec of the
-ResolutionRequest CRD.
-
-
-
-_Appears in:_
-- [ResolutionRequest](#resolutionrequest)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `params` _object (keys:string, values:string)_ | Parameters are the runtime attributes passed to<br />the resolver to help it figure out how to resolve the<br />resource being requested. For example: repo URL, commit SHA,<br />path to file, the kind of authentication to leverage, etc. |  | Optional: \{\} <br /> |
-
-
-#### ResolutionRequestStatus
-
-
-
-ResolutionRequestStatus are all the fields in a ResolutionRequest's
-status subresource.
-
-
-
-_Appears in:_
-- [ResolutionRequest](#resolutionrequest)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `observedGeneration` _integer_ | ObservedGeneration is the 'Generation' of the Service that<br />was last processed by the controller. |  | Optional: \{\} <br /> |
-| `conditions` _[Conditions](#conditions)_ | Conditions the latest available observations of a resource's current state. |  | Optional: \{\} <br /> |
-| `annotations` _object (keys:string, values:string)_ | Annotations is additional Status fields for the Resource to save some<br />additional State as well as convey more information to the user. This is<br />roughly akin to Annotations on any k8s resource, just the reconciler conveying<br />richer information outwards. |  |  |
-| `data` _string_ | Data is a string representation of the resolved content<br />of the requested resource in-lined into the ResolutionRequest<br />object. |  |  |
-| `refSource` _[RefSource](#refsource)_ | RefSource is the source reference of the remote data that records where the remote<br />file came from including the url, digest and the entrypoint. |  | Schemaless: \{\} <br /> |
-
-
-#### ResolutionRequestStatusFields
-
-
-
-ResolutionRequestStatusFields are the ResolutionRequest-specific fields
-for the status subresource.
-
-
-
-_Appears in:_
-- [ResolutionRequestStatus](#resolutionrequeststatus)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `data` _string_ | Data is a string representation of the resolved content<br />of the requested resource in-lined into the ResolutionRequest<br />object. |  |  |
-| `refSource` _[RefSource](#refsource)_ | RefSource is the source reference of the remote data that records where the remote<br />file came from including the url, digest and the entrypoint. |  | Schemaless: \{\} <br /> |
-
-
-
-## resolution.tekton.dev/v1beta1
-
-
-### Resource Types
-- [ResolutionRequest](#resolutionrequest)
-
-
-
-#### ResolutionRequest
-
-
-
-ResolutionRequest is an object for requesting the content of
-a Tekton resource like a pipeline.yaml.
-
-
-
-
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `resolution.tekton.dev/v1beta1` | | |
-| `kind` _string_ | `ResolutionRequest` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  | Optional: \{\} <br /> |
-| `spec` _[ResolutionRequestSpec](#resolutionrequestspec)_ | Spec holds the information for the request part of the resource request. |  | Optional: \{\} <br /> |
-| `status` _[ResolutionRequestStatus](#resolutionrequeststatus)_ | Status communicates the state of the request and, ultimately,<br />the content of the resolved resource. |  | Optional: \{\} <br /> |
-
-
-#### ResolutionRequestSpec
-
-
-
-ResolutionRequestSpec are all the fields in the spec of the
-ResolutionRequest CRD.
-
-
-
-_Appears in:_
-- [ResolutionRequest](#resolutionrequest)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `params` _[Param](#param) array_ | Parameters are the runtime attributes passed to<br />the resolver to help it figure out how to resolve the<br />resource being requested. For example: repo URL, commit SHA,<br />path to file, the kind of authentication to leverage, etc. |  | Optional: \{\} <br /> |
-| `url` _string_ | URL is the runtime url passed to the resolver<br />to help it figure out how to resolver the resource being<br />requested.<br />This is currently at an ALPHA stability level and subject to<br />alpha API compatibility policies. |  | Optional: \{\} <br /> |
-
-
-#### ResolutionRequestStatus
-
-
-
-ResolutionRequestStatus are all the fields in a ResolutionRequest's
-status subresource.
-
-
-
-_Appears in:_
-- [ResolutionRequest](#resolutionrequest)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `observedGeneration` _integer_ | ObservedGeneration is the 'Generation' of the Service that<br />was last processed by the controller. |  | Optional: \{\} <br /> |
-| `conditions` _[Conditions](#conditions)_ | Conditions the latest available observations of a resource's current state. |  | Optional: \{\} <br /> |
-| `annotations` _object (keys:string, values:string)_ | Annotations is additional Status fields for the Resource to save some<br />additional State as well as convey more information to the user. This is<br />roughly akin to Annotations on any k8s resource, just the reconciler conveying<br />richer information outwards. |  |  |
-| `data` _string_ | Data is a string representation of the resolved content<br />of the requested resource in-lined into the ResolutionRequest<br />object. |  |  |
-| `source` _[RefSource](#refsource)_ | Deprecated: Use RefSource instead |  | Schemaless: \{\} <br /> |
-| `refSource` _[RefSource](#refsource)_ | RefSource is the source reference of the remote data that records the url, digest<br />and the entrypoint. |  | Schemaless: \{\} <br /> |
-
-
-#### ResolutionRequestStatusFields
-
-
-
-ResolutionRequestStatusFields are the ResolutionRequest-specific fields
-for the status subresource.
-
-
-
-_Appears in:_
-- [ResolutionRequestStatus](#resolutionrequeststatus)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `data` _string_ | Data is a string representation of the resolved content<br />of the requested resource in-lined into the ResolutionRequest<br />object. |  |  |
-| `source` _[RefSource](#refsource)_ | Deprecated: Use RefSource instead |  | Schemaless: \{\} <br /> |
-| `refSource` _[RefSource](#refsource)_ | RefSource is the source reference of the remote data that records the url, digest<br />and the entrypoint. |  | Schemaless: \{\} <br /> |
-
-
-
-## tekton.dev/unversioned
-
-Package pod contains non-versioned pod configuration
-
-
-
-
-
-
-
-
-
-
-
-#### Volumes
-
-_Underlying type:_ _[Volume](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#volume-v1-core)_
-
-
-
-
-
-_Appears in:_
-- [Template](#template)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `name` _string_ | name of the volume.<br />Must be a DNS_LABEL and unique within the pod.<br />More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names |  |  |
-| `hostPath` _[HostPathVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#hostpathvolumesource-v1-core)_ | hostPath represents a pre-existing file or directory on the host<br />machine that is directly exposed to the container. This is generally<br />used for system agents or other privileged things that are allowed<br />to see the host machine. Most containers will NOT need this.<br />More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath |  | Optional: \{\} <br /> |
-| `emptyDir` _[EmptyDirVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#emptydirvolumesource-v1-core)_ | emptyDir represents a temporary directory that shares a pod's lifetime.<br />More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir |  | Optional: \{\} <br /> |
-| `gcePersistentDisk` _[GCEPersistentDiskVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#gcepersistentdiskvolumesource-v1-core)_ | gcePersistentDisk represents a GCE Disk resource that is attached to a<br />kubelet's host machine and then exposed to the pod.<br />Deprecated: GCEPersistentDisk is deprecated. All operations for the in-tree<br />gcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.<br />More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk |  | Optional: \{\} <br /> |
-| `awsElasticBlockStore` _[AWSElasticBlockStoreVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#awselasticblockstorevolumesource-v1-core)_ | awsElasticBlockStore represents an AWS Disk resource that is attached to a<br />kubelet's host machine and then exposed to the pod.<br />Deprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree<br />awsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.<br />More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore |  | Optional: \{\} <br /> |
-| `gitRepo` _[GitRepoVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#gitrepovolumesource-v1-core)_ | gitRepo represents a git repository at a particular revision.<br />Deprecated: GitRepo is deprecated. To provision a container with a git repo, mount an<br />EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir<br />into the Pod's container. |  | Optional: \{\} <br /> |
-| `secret` _[SecretVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#secretvolumesource-v1-core)_ | secret represents a secret that should populate this volume.<br />More info: https://kubernetes.io/docs/concepts/storage/volumes#secret |  | Optional: \{\} <br /> |
-| `nfs` _[NFSVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#nfsvolumesource-v1-core)_ | nfs represents an NFS mount on the host that shares a pod's lifetime<br />More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs |  | Optional: \{\} <br /> |
-| `iscsi` _[ISCSIVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#iscsivolumesource-v1-core)_ | iscsi represents an ISCSI Disk resource that is attached to a<br />kubelet's host machine and then exposed to the pod.<br />More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi |  | Optional: \{\} <br /> |
-| `glusterfs` _[GlusterfsVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#glusterfsvolumesource-v1-core)_ | glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.<br />Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported. |  | Optional: \{\} <br /> |
-| `persistentVolumeClaim` _[PersistentVolumeClaimVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#persistentvolumeclaimvolumesource-v1-core)_ | persistentVolumeClaimVolumeSource represents a reference to a<br />PersistentVolumeClaim in the same namespace.<br />More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims |  | Optional: \{\} <br /> |
-| `rbd` _[RBDVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#rbdvolumesource-v1-core)_ | rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.<br />Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported. |  | Optional: \{\} <br /> |
-| `flexVolume` _[FlexVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#flexvolumesource-v1-core)_ | flexVolume represents a generic volume resource that is<br />provisioned/attached using an exec based plugin.<br />Deprecated: FlexVolume is deprecated. Consider using a CSIDriver instead. |  | Optional: \{\} <br /> |
-| `cinder` _[CinderVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#cindervolumesource-v1-core)_ | cinder represents a cinder volume attached and mounted on kubelets host machine.<br />Deprecated: Cinder is deprecated. All operations for the in-tree cinder type<br />are redirected to the cinder.csi.openstack.org CSI driver.<br />More info: https://examples.k8s.io/mysql-cinder-pd/README.md |  | Optional: \{\} <br /> |
-| `cephfs` _[CephFSVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#cephfsvolumesource-v1-core)_ | cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.<br />Deprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported. |  | Optional: \{\} <br /> |
-| `flocker` _[FlockerVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#flockervolumesource-v1-core)_ | flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.<br />Deprecated: Flocker is deprecated and the in-tree flocker type is no longer supported. |  | Optional: \{\} <br /> |
-| `downwardAPI` _[DownwardAPIVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#downwardapivolumesource-v1-core)_ | downwardAPI represents downward API about the pod that should populate this volume |  | Optional: \{\} <br /> |
-| `fc` _[FCVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#fcvolumesource-v1-core)_ | fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod. |  | Optional: \{\} <br /> |
-| `azureFile` _[AzureFileVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#azurefilevolumesource-v1-core)_ | azureFile represents an Azure File Service mount on the host and bind mount to the pod.<br />Deprecated: AzureFile is deprecated. All operations for the in-tree azureFile type<br />are redirected to the file.csi.azure.com CSI driver. |  | Optional: \{\} <br /> |
-| `configMap` _[ConfigMapVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#configmapvolumesource-v1-core)_ | configMap represents a configMap that should populate this volume |  | Optional: \{\} <br /> |
-| `vsphereVolume` _[VsphereVirtualDiskVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#vspherevirtualdiskvolumesource-v1-core)_ | vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.<br />Deprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type<br />are redirected to the csi.vsphere.vmware.com CSI driver. |  | Optional: \{\} <br /> |
-| `quobyte` _[QuobyteVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#quobytevolumesource-v1-core)_ | quobyte represents a Quobyte mount on the host that shares a pod's lifetime.<br />Deprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported. |  | Optional: \{\} <br /> |
-| `azureDisk` _[AzureDiskVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#azurediskvolumesource-v1-core)_ | azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.<br />Deprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type<br />are redirected to the disk.csi.azure.com CSI driver. |  | Optional: \{\} <br /> |
-| `photonPersistentDisk` _[PhotonPersistentDiskVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#photonpersistentdiskvolumesource-v1-core)_ | photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.<br />Deprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported. |  |  |
-| `projected` _[ProjectedVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#projectedvolumesource-v1-core)_ | projected items for all in one resources secrets, configmaps, and downward API |  |  |
-| `portworxVolume` _[PortworxVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#portworxvolumesource-v1-core)_ | portworxVolume represents a portworx volume attached and mounted on kubelets host machine.<br />Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type<br />are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate<br />is on. |  | Optional: \{\} <br /> |
-| `scaleIO` _[ScaleIOVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#scaleiovolumesource-v1-core)_ | scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.<br />Deprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported. |  | Optional: \{\} <br /> |
-| `storageos` _[StorageOSVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#storageosvolumesource-v1-core)_ | storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.<br />Deprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported. |  | Optional: \{\} <br /> |
-| `csi` _[CSIVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#csivolumesource-v1-core)_ | csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers. |  | Optional: \{\} <br /> |
-| `ephemeral` _[EphemeralVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#ephemeralvolumesource-v1-core)_ | ephemeral represents a volume that is handled by a cluster storage driver.<br />The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,<br />and deleted when the pod is removed.<br />Use this if:<br />a) the volume is only needed while the pod runs,<br />b) features of normal volumes like restoring from snapshot or capacity<br />   tracking are needed,<br />c) the storage driver is specified through a storage class, and<br />d) the storage driver supports dynamic volume provisioning through<br />   a PersistentVolumeClaim (see EphemeralVolumeSource for more<br />   information on the connection between this volume type<br />   and PersistentVolumeClaim).<br />Use PersistentVolumeClaim or one of the vendor-specific<br />APIs for volumes that persist for longer than the lifecycle<br />of an individual pod.<br />Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to<br />be used that way - see the documentation of the driver for<br />more information.<br />A pod can use both types of ephemeral volumes and<br />persistent volumes at the same time. |  | Optional: \{\} <br /> |
-| `image` _[ImageVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#imagevolumesource-v1-core)_ | image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.<br />The volume is resolved at pod startup depending on which PullPolicy value is provided:<br />- Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.<br />- Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.<br />- IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.<br />The volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.<br />A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.<br />The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.<br />The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.<br />The volume will be mounted read-only (ro) and non-executable files (noexec).<br />Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.<br />The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type. |  | Optional: \{\} <br /> |
-
-
-
-## tekton.dev/v1
-
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-	http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-Package v1 contains API Schema definitions for the pipeline v1 API group
-
-### Resource Types
-- [Pipeline](#pipeline)
-- [PipelineRun](#pipelinerun)
-- [Task](#task)
-- [TaskRun](#taskrun)
-
-
-
-#### Algorithm
-
-_Underlying type:_ _string_
-
-Algorithm Standard cryptographic hash algorithm
-
-
-
-_Appears in:_
-- [ArtifactValue](#artifactvalue)
-
-
-
-#### Artifact
-
-
-
-Artifact represents an artifact within a system, potentially containing multiple values
-associated with it.
-
-
-
-_Appears in:_
-- [Artifacts](#artifacts)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `name` _string_ | The artifact's identifying category name |  |  |
-| `values` _[ArtifactValue](#artifactvalue) array_ | A collection of values related to the artifact |  |  |
-| `buildOutput` _boolean_ | Indicate if the artifact is a build output or a by-product |  |  |
-
-
-#### ArtifactValue
-
-
-
-ArtifactValue represents a specific value or data element within an Artifact.
-
-
-
-_Appears in:_
-- [Artifact](#artifact)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `digest` _object (keys:[Algorithm](#algorithm), values:string)_ |  |  |  |
-| `uri` _string_ |  |  |  |
-
-
-#### Artifacts
-
-
-
-Artifacts represents the collection of input and output artifacts associated with
-a task run or a similar process. Artifacts in this context are units of data or resources
-that the process either consumes as input or produces as output.
-
-
-
-_Appears in:_
-- [TaskRunStatus](#taskrunstatus)
-- [TaskRunStatusFields](#taskrunstatusfields)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `inputs` _[Artifact](#artifact) array_ |  |  |  |
-| `outputs` _[Artifact](#artifact) array_ |  |  |  |
-
-
-#### ChildStatusReference
-
-
-
-ChildStatusReference is used to point to the statuses of individual TaskRuns and Runs within this PipelineRun.
-
-
-
-_Appears in:_
-- [PipelineRunStatus](#pipelinerunstatus)
-- [PipelineRunStatusFields](#pipelinerunstatusfields)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `name` _string_ | Name is the name of the TaskRun or Run this is referencing. |  |  |
-| `displayName` _string_ | DisplayName is a user-facing name of the pipelineTask that may be<br />used to populate a UI. |  |  |
-| `pipelineTaskName` _string_ | PipelineTaskName is the name of the PipelineTask this is referencing. |  |  |
-| `whenExpressions` _[WhenExpression](#whenexpression) array_ | WhenExpressions is the list of checks guarding the execution of the PipelineTask |  | Optional: \{\} <br /> |
-
-
-#### Combination
-
-_Underlying type:_ _object_
-
-Combination is a map, mainly defined to hold a single combination from a Matrix with key as param.Name and value as param.Value
-
-
-
-_Appears in:_
-- [Combinations](#combinations)
-
-
-
-
-
-#### EmbeddedTask
-
-
-
-EmbeddedTask is used to define a Task inline within a Pipeline's PipelineTasks.
-
-
-
-_Appears in:_
-- [PipelineTask](#pipelinetask)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `spec` _[RawExtension](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#rawextension-runtime-pkg)_ | Spec is a specification of a custom task |  | Optional: \{\} <br /> |
-| `metadata` _[PipelineTaskMetadata](#pipelinetaskmetadata)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  | Optional: \{\} <br /> |
-| `params` _[ParamSpecs](#paramspecs)_ | Params is a list of input parameters required to run the task. Params<br />must be supplied as inputs in TaskRuns unless they declare a default<br />value. |  | Optional: \{\} <br /> |
-| `displayName` _string_ | DisplayName is a user-facing name of the task that may be<br />used to populate a UI. |  | Optional: \{\} <br /> |
-| `description` _string_ | Description is a user-facing description of the task that may be<br />used to populate a UI. |  | Optional: \{\} <br /> |
-| `steps` _[Step](#step) array_ | Steps are the steps of the build; each step is run sequentially with the<br />source mounted into /workspace. |  |  |
-| `volumes` _[Volumes](#volumes)_ | Volumes is a collection of volumes that are available to mount into the<br />steps of the build.<br />See Pod.spec.volumes (API version: v1) |  | Schemaless: \{\} <br /> |
-| `stepTemplate` _[StepTemplate](#steptemplate)_ | StepTemplate can be used as the basis for all step containers within the<br />Task, so that the steps inherit settings on the base container. |  |  |
-| `sidecars` _[Sidecar](#sidecar) array_ | Sidecars are run alongside the Task's step containers. They begin before<br />the steps start and end after the steps complete. |  |  |
-| `workspaces` _[WorkspaceDeclaration](#workspacedeclaration) array_ | Workspaces are the volumes that this Task requires. |  |  |
-| `results` _[TaskResult](#taskresult) array_ | Results are values that this Task can output |  |  |
-
-
-
-
-#### Matrix
-
-
-
-Matrix is used to fan out Tasks in a Pipeline
-
-
-
-_Appears in:_
-- [PipelineTask](#pipelinetask)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `params` _[Params](#params)_ | Params is a list of parameters used to fan out the pipelineTask<br />Params takes only `Parameters` of type `"array"`<br />Each array element is supplied to the `PipelineTask` by substituting `params` of type `"string"` in the underlying `Task`.<br />The names of the `params` in the `Matrix` must match the names of the `params` in the underlying `Task` that they will be substituting. |  |  |
-
-
-#### OnErrorType
-
-_Underlying type:_ _string_
-
-OnErrorType defines a list of supported exiting behavior of a container on error
-
-
-
-_Appears in:_
-- [Step](#step)
-
-| Field | Description |
-| --- | --- |
-| `stopAndFail` | StopAndFail indicates exit the taskRun if the container exits with non-zero exit code<br /> |
-| `continue` | Continue indicates continue executing the rest of the steps irrespective of the container exit code<br /> |
-
-
-#### Param
-
-
-
-Param declares an ParamValues to use for the parameter called name.
-
-
-
-_Appears in:_
-- [Params](#params)
-- [ResolutionRequestSpec](#resolutionrequestspec)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `name` _string_ |  |  |  |
-| `value` _[ParamValue](#paramvalue)_ |  |  | Schemaless: \{\} <br /> |
-
-
-#### ParamSpec
-
-
-
-ParamSpec defines arbitrary parameters needed beyond typed inputs (such as
-resources). Parameter values are provided by users as inputs on a TaskRun
-or PipelineRun.
-
-
-
-_Appears in:_
-- [ParamSpecs](#paramspecs)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `name` _string_ | Name declares the name by which a parameter is referenced. |  |  |
-| `type` _[ParamType](#paramtype)_ | Type is the user-specified type of the parameter. The possible types<br />are currently "string", "array" and "object", and "string" is the default. |  | Optional: \{\} <br /> |
-| `description` _string_ | Description is a user-facing description of the parameter that may be<br />used to populate a UI. |  | Optional: \{\} <br /> |
-| `properties` _object (keys:string, values:[PropertySpec](#propertyspec))_ | Properties is the JSON Schema properties to support key-value pairs parameter. |  | Optional: \{\} <br /> |
-| `default` _[ParamValue](#paramvalue)_ | Default is the value a parameter takes if no input value is supplied. If<br />default is set, a Task may be executed without a supplied value for the<br />parameter. |  | Schemaless: \{\} <br />Optional: \{\} <br /> |
-| `enum` _string array_ | Enum declares a set of allowed param input values for tasks/pipelines that can be validated.<br />If Enum is not set, no input validation is performed for the param. |  | Optional: \{\} <br /> |
-
-
-#### ParamSpecs
-
-_Underlying type:_ _[ParamSpec](#paramspec)_
-
-ParamSpecs is a list of ParamSpec
-
-
-
-_Appears in:_
-- [EmbeddedTask](#embeddedtask)
-- [PipelineSpec](#pipelinespec)
-- [StepActionSpec](#stepactionspec)
-- [StepActionSpec](#stepactionspec)
-- [TaskSpec](#taskspec)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `name` _string_ | Name declares the name by which a parameter is referenced. |  |  |
-| `type` _[ParamType](#paramtype)_ | Type is the user-specified type of the parameter. The possible types<br />are currently "string", "array" and "object", and "string" is the default. |  | Optional: \{\} <br /> |
-| `description` _string_ | Description is a user-facing description of the parameter that may be<br />used to populate a UI. |  | Optional: \{\} <br /> |
-| `properties` _object (keys:string, values:[PropertySpec](#propertyspec))_ | Properties is the JSON Schema properties to support key-value pairs parameter. |  | Optional: \{\} <br /> |
-| `default` _[ParamValue](#paramvalue)_ | Default is the value a parameter takes if no input value is supplied. If<br />default is set, a Task may be executed without a supplied value for the<br />parameter. |  | Schemaless: \{\} <br />Optional: \{\} <br /> |
-| `enum` _string array_ | Enum declares a set of allowed param input values for tasks/pipelines that can be validated.<br />If Enum is not set, no input validation is performed for the param. |  | Optional: \{\} <br /> |
-
-
-#### ParamType
-
-_Underlying type:_ _string_
-
-ParamType indicates the type of an input parameter;
-Used to distinguish between a single string and an array of strings.
-
-
-
-_Appears in:_
-- [ParamSpec](#paramspec)
-- [ParamValue](#paramvalue)
-- [PropertySpec](#propertyspec)
-
-| Field | Description |
-| --- | --- |
-| `string` |  |
-| `array` |  |
-| `object` |  |
-
-
-#### ParamValue
-
-
-
-ParamValue is a type that can hold a single string, string array, or string map.
-Used in JSON unmarshalling so that a single JSON field can accept
-either an individual string or an array of strings.
-
-
-
-_Appears in:_
-- [Param](#param)
-- [ParamSpec](#paramspec)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `Type` _[ParamType](#paramtype)_ |  |  |  |
-| `StringVal` _string_ |  |  |  |
-| `ArrayVal` _string array_ |  |  |  |
-| `ObjectVal` _object (keys:string, values:string)_ |  |  |  |
-
-
-#### Params
-
-_Underlying type:_ _[Param](#param)_
-
-Params is a list of Param
-
-
-
-_Appears in:_
-- [IncludeParams](#includeparams)
-- [Matrix](#matrix)
-- [PipelineRunSpec](#pipelinerunspec)
-- [PipelineTask](#pipelinetask)
-- [ResolverRef](#resolverref)
-- [Step](#step)
-- [TaskRunInputs](#taskruninputs)
-- [TaskRunSpec](#taskrunspec)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `name` _string_ |  |  |  |
-| `value` _[ParamValue](#paramvalue)_ |  |  | Schemaless: \{\} <br /> |
-
-
-#### Pipeline
-
-
-
-Pipeline describes a list of Tasks to execute. It expresses how outputs
-of tasks feed into inputs of subsequent tasks.
-
-
-
-
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `tekton.dev/v1` | | |
-| `kind` _string_ | `Pipeline` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  | Optional: \{\} <br /> |
-| `spec` _[PipelineSpec](#pipelinespec)_ | Spec holds the desired state of the Pipeline from the client |  | Optional: \{\} <br /> |
-
-
-#### PipelineRef
-
-
-
-PipelineRef can be used to refer to a specific instance of a Pipeline.
-
-
-
-_Appears in:_
-- [PipelineRunSpec](#pipelinerunspec)
-- [PipelineTask](#pipelinetask)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `name` _string_ | Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names |  |  |
-| `apiVersion` _string_ | API version of the referent |  | Optional: \{\} <br /> |
-| `ResolverRef` _[ResolverRef](#resolverref)_ | ResolverRef allows referencing a Pipeline in a remote location<br />like a git repo. This field is only supported when the alpha<br />feature gate is enabled. |  | Optional: \{\} <br /> |
-
-
-#### PipelineResult
-
-_Underlying type:_ _[struct{Name string "json:\"name\""; Type ResultsType "json:\"type,omitempty\""; Description string "json:\"description\""; Value ResultValue "json:\"value\""}](#struct{name-string-"json:\"name\"";-type-resultstype-"json:\"type,omitempty\"";-description-string-"json:\"description\"";-value-resultvalue-"json:\"value\""})_
-
-PipelineResult used to describe the results of a pipeline
-
-
-
-_Appears in:_
-- [PipelineSpec](#pipelinespec)
-
-
-
-#### PipelineRun
-
-
-
-PipelineRun represents a single execution of a Pipeline. PipelineRuns are how
+<p>Packages:</p>
+<ul>
+<li>
+<a href="#resolution.tekton.dev%2fv1alpha1">resolution.tekton.dev/v1alpha1</a>
+</li>
+<li>
+<a href="#resolution.tekton.dev%2fv1beta1">resolution.tekton.dev/v1beta1</a>
+</li>
+<li>
+<a href="#tekton.dev%2fv1">tekton.dev/v1</a>
+</li>
+<li>
+<a href="#tekton.dev%2fv1alpha1">tekton.dev/v1alpha1</a>
+</li>
+<li>
+<a href="#tekton.dev%2fv1beta1">tekton.dev/v1beta1</a>
+</li>
+</ul>
+<h2 id="resolution.tekton.dev/v1alpha1">resolution.tekton.dev/v1alpha1</h2>
+<div>
+</div>
+Resource Types:
+<ul></ul>
+<h3 id="resolution.tekton.dev/v1alpha1.ResolutionRequest">ResolutionRequest
+</h3>
+<div>
+<p>ResolutionRequest is an object for requesting the content of
+a Tekton resource like a pipeline.yaml.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#resolution.tekton.dev/v1alpha1.ResolutionRequestSpec">
+ResolutionRequestSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec holds the information for the request part of the resource request.</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>params</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Parameters are the runtime attributes passed to
+the resolver to help it figure out how to resolve the
+resource being requested. For example: repo URL, commit SHA,
+path to file, the kind of authentication to leverage, etc.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code><br/>
+<em>
+<a href="#resolution.tekton.dev/v1alpha1.ResolutionRequestStatus">
+ResolutionRequestStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Status communicates the state of the request and, ultimately,
+the content of the resolved resource.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="resolution.tekton.dev/v1alpha1.ResolutionRequestSpec">ResolutionRequestSpec
+</h3>
+<p>
+(<em>Appears on:</em><a href="#resolution.tekton.dev/v1alpha1.ResolutionRequest">ResolutionRequest</a>)
+</p>
+<div>
+<p>ResolutionRequestSpec are all the fields in the spec of the
+ResolutionRequest CRD.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>params</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Parameters are the runtime attributes passed to
+the resolver to help it figure out how to resolve the
+resource being requested. For example: repo URL, commit SHA,
+path to file, the kind of authentication to leverage, etc.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="resolution.tekton.dev/v1alpha1.ResolutionRequestStatus">ResolutionRequestStatus
+</h3>
+<p>
+(<em>Appears on:</em><a href="#resolution.tekton.dev/v1alpha1.ResolutionRequest">ResolutionRequest</a>)
+</p>
+<div>
+<p>ResolutionRequestStatus are all the fields in a ResolutionRequest&rsquo;s
+status subresource.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>Status</code><br/>
+<em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Status">
+knative.dev/pkg/apis/duck/v1.Status
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>Status</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ResolutionRequestStatusFields</code><br/>
+<em>
+<a href="#resolution.tekton.dev/v1alpha1.ResolutionRequestStatusFields">
+ResolutionRequestStatusFields
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>ResolutionRequestStatusFields</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="resolution.tekton.dev/v1alpha1.ResolutionRequestStatusFields">ResolutionRequestStatusFields
+</h3>
+<p>
+(<em>Appears on:</em><a href="#resolution.tekton.dev/v1alpha1.ResolutionRequestStatus">ResolutionRequestStatus</a>)
+</p>
+<div>
+<p>ResolutionRequestStatusFields are the ResolutionRequest-specific fields
+for the status subresource.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>data</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Data is a string representation of the resolved content
+of the requested resource in-lined into the ResolutionRequest
+object.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>refSource</code><br/>
+<em>
+<a href="#tekton.dev/v1.RefSource">
+RefSource
+</a>
+</em>
+</td>
+<td>
+<p>RefSource is the source reference of the remote data that records where the remote
+file came from including the url, digest and the entrypoint.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<hr/>
+<h2 id="resolution.tekton.dev/v1beta1">resolution.tekton.dev/v1beta1</h2>
+<div>
+</div>
+Resource Types:
+<ul></ul>
+<h3 id="resolution.tekton.dev/v1beta1.ResolutionRequest">ResolutionRequest
+</h3>
+<div>
+<p>ResolutionRequest is an object for requesting the content of
+a Tekton resource like a pipeline.yaml.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#resolution.tekton.dev/v1beta1.ResolutionRequestSpec">
+ResolutionRequestSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec holds the information for the request part of the resource request.</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>params</code><br/>
+<em>
+<a href="#tekton.dev/v1.Param">
+[]Param
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Parameters are the runtime attributes passed to
+the resolver to help it figure out how to resolve the
+resource being requested. For example: repo URL, commit SHA,
+path to file, the kind of authentication to leverage, etc.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>url</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>URL is the runtime url passed to the resolver
+to help it figure out how to resolver the resource being
+requested.
+This is currently at an ALPHA stability level and subject to
+alpha API compatibility policies.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code><br/>
+<em>
+<a href="#resolution.tekton.dev/v1beta1.ResolutionRequestStatus">
+ResolutionRequestStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Status communicates the state of the request and, ultimately,
+the content of the resolved resource.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="resolution.tekton.dev/v1beta1.ResolutionRequestSpec">ResolutionRequestSpec
+</h3>
+<p>
+(<em>Appears on:</em><a href="#resolution.tekton.dev/v1beta1.ResolutionRequest">ResolutionRequest</a>)
+</p>
+<div>
+<p>ResolutionRequestSpec are all the fields in the spec of the
+ResolutionRequest CRD.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>params</code><br/>
+<em>
+<a href="#tekton.dev/v1.Param">
+[]Param
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Parameters are the runtime attributes passed to
+the resolver to help it figure out how to resolve the
+resource being requested. For example: repo URL, commit SHA,
+path to file, the kind of authentication to leverage, etc.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>url</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>URL is the runtime url passed to the resolver
+to help it figure out how to resolver the resource being
+requested.
+This is currently at an ALPHA stability level and subject to
+alpha API compatibility policies.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="resolution.tekton.dev/v1beta1.ResolutionRequestStatus">ResolutionRequestStatus
+</h3>
+<p>
+(<em>Appears on:</em><a href="#resolution.tekton.dev/v1beta1.ResolutionRequest">ResolutionRequest</a>)
+</p>
+<div>
+<p>ResolutionRequestStatus are all the fields in a ResolutionRequest&rsquo;s
+status subresource.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>Status</code><br/>
+<em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Status">
+knative.dev/pkg/apis/duck/v1.Status
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>Status</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ResolutionRequestStatusFields</code><br/>
+<em>
+<a href="#resolution.tekton.dev/v1beta1.ResolutionRequestStatusFields">
+ResolutionRequestStatusFields
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>ResolutionRequestStatusFields</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="resolution.tekton.dev/v1beta1.ResolutionRequestStatusFields">ResolutionRequestStatusFields
+</h3>
+<p>
+(<em>Appears on:</em><a href="#resolution.tekton.dev/v1beta1.ResolutionRequestStatus">ResolutionRequestStatus</a>)
+</p>
+<div>
+<p>ResolutionRequestStatusFields are the ResolutionRequest-specific fields
+for the status subresource.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>data</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Data is a string representation of the resolved content
+of the requested resource in-lined into the ResolutionRequest
+object.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>source</code><br/>
+<em>
+<a href="#tekton.dev/v1.RefSource">
+RefSource
+</a>
+</em>
+</td>
+<td>
+<p>Deprecated: Use RefSource instead</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>refSource</code><br/>
+<em>
+<a href="#tekton.dev/v1.RefSource">
+RefSource
+</a>
+</em>
+</td>
+<td>
+<p>RefSource is the source reference of the remote data that records the url, digest
+and the entrypoint.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<hr/>
+<h2 id="tekton.dev/v1">tekton.dev/v1</h2>
+<div>
+<p>Package v1 contains API Schema definitions for the pipeline v1 API group</p>
+</div>
+Resource Types:
+<ul><li>
+<a href="#tekton.dev/v1.Pipeline">Pipeline</a>
+</li><li>
+<a href="#tekton.dev/v1.PipelineRun">PipelineRun</a>
+</li><li>
+<a href="#tekton.dev/v1.Task">Task</a>
+</li><li>
+<a href="#tekton.dev/v1.TaskRun">TaskRun</a>
+</li></ul>
+<h3 id="tekton.dev/v1.Pipeline">Pipeline
+</h3>
+<div>
+<p>Pipeline describes a list of Tasks to execute. It expresses how outputs
+of tasks feed into inputs of subsequent tasks.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code><br/>
+string</td>
+<td>
+<code>
+tekton.dev/v1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code><br/>
+string
+</td>
+<td><code>Pipeline</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#tekton.dev/v1.PipelineSpec">
+PipelineSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec holds the desired state of the Pipeline from the client</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>displayName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DisplayName is a user-facing name of the pipeline that may be
+used to populate a UI.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>description</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Description is a user-facing description of the pipeline that may be
+used to populate a UI.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>tasks</code><br/>
+<em>
+<a href="#tekton.dev/v1.PipelineTask">
+[]PipelineTask
+</a>
+</em>
+</td>
+<td>
+<p>Tasks declares the graph of Tasks that execute when this Pipeline is run.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>params</code><br/>
+<em>
+<a href="#tekton.dev/v1.ParamSpecs">
+ParamSpecs
+</a>
+</em>
+</td>
+<td>
+<p>Params declares a list of input parameters that must be supplied when
+this Pipeline is run.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>workspaces</code><br/>
+<em>
+<a href="#tekton.dev/v1.PipelineWorkspaceDeclaration">
+[]PipelineWorkspaceDeclaration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Workspaces declares a set of named workspaces that are expected to be
+provided by a PipelineRun.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>results</code><br/>
+<em>
+<a href="#tekton.dev/v1.PipelineResult">
+[]PipelineResult
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Results are values that this pipeline can output once run</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>finally</code><br/>
+<em>
+<a href="#tekton.dev/v1.PipelineTask">
+[]PipelineTask
+</a>
+</em>
+</td>
+<td>
+<p>Finally declares the list of Tasks that execute just before leaving the Pipeline
+i.e. either after all Tasks are finished executing successfully
+or after a failure which would result in ending the Pipeline</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.PipelineRun">PipelineRun
+</h3>
+<div>
+<p>PipelineRun represents a single execution of a Pipeline. PipelineRuns are how
 the graph of Tasks declared in a Pipeline are executed; they specify inputs
 to Pipelines such as parameter values and capture operational aspects of the
 Tasks execution such as service account and tolerations. Creating a
-PipelineRun creates TaskRuns for Tasks in the referenced Pipeline.
-
-
-
-
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `tekton.dev/v1` | | |
-| `kind` _string_ | `PipelineRun` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  | Optional: \{\} <br /> |
-| `spec` _[PipelineRunSpec](#pipelinerunspec)_ |  |  | Optional: \{\} <br /> |
-| `status` _[PipelineRunStatus](#pipelinerunstatus)_ |  |  | Optional: \{\} <br /> |
-
-
-
-
-#### PipelineRunResult
-
-
-
-PipelineRunResult used to describe the results of a pipeline
-
-
-
-_Appears in:_
-- [PipelineRunStatus](#pipelinerunstatus)
-- [PipelineRunStatusFields](#pipelinerunstatusfields)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `name` _string_ | Name is the result's name as declared by the Pipeline |  |  |
-| `value` _[ResultValue](#resultvalue)_ | Value is the result returned from the execution of this PipelineRun |  | Schemaless: \{\} <br /> |
-
-
-
-
-#### PipelineRunSpec
-
-
-
-PipelineRunSpec defines the desired state of PipelineRun
-
-
-
-_Appears in:_
-- [PipelineRun](#pipelinerun)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `pipelineRef` _[PipelineRef](#pipelineref)_ |  |  | Optional: \{\} <br /> |
-| `pipelineSpec` _[PipelineSpec](#pipelinespec)_ | Specifying PipelineSpec can be disabled by setting<br />`disable-inline-spec` feature flag.<br />See Pipeline.spec (API version: tekton.dev/v1) |  | Schemaless: \{\} <br />Optional: \{\} <br /> |
-| `params` _[Params](#params)_ | Params is a list of parameter names and values. |  |  |
-| `status` _[PipelineRunSpecStatus](#pipelinerunspecstatus)_ | Used for cancelling a pipelinerun (and maybe more later on) |  | Optional: \{\} <br /> |
-| `timeouts` _[TimeoutFields](#timeoutfields)_ | Time after which the Pipeline times out.<br />Currently three keys are accepted in the map<br />pipeline, tasks and finally<br />with Timeouts.pipeline >= Timeouts.tasks + Timeouts.finally |  | Optional: \{\} <br /> |
-| `taskRunTemplate` _[PipelineTaskRunTemplate](#pipelinetaskruntemplate)_ | TaskRunTemplate represent template of taskrun |  | Optional: \{\} <br /> |
-| `workspaces` _[WorkspaceBinding](#workspacebinding) array_ | Workspaces holds a set of workspace bindings that must match names<br />with those declared in the pipeline. |  | Optional: \{\} <br /> |
-| `taskRunSpecs` _[PipelineTaskRunSpec](#pipelinetaskrunspec) array_ | TaskRunSpecs holds a set of runtime specs |  | Optional: \{\} <br /> |
-| `managedBy` _string_ | ManagedBy indicates which controller is responsible for reconciling<br />this resource. If unset or set to "tekton.dev/pipeline", the default<br />Tekton controller will manage this resource.<br />This field is immutable. |  | Optional: \{\} <br /> |
-
-
-#### PipelineRunSpecStatus
-
-_Underlying type:_ _string_
-
-PipelineRunSpecStatus defines the pipelinerun spec status the user can provide
-
-
-
-_Appears in:_
-- [PipelineRunSpec](#pipelinerunspec)
-
-
-
-#### PipelineRunStatus
-
-
-
-PipelineRunStatus defines the observed state of PipelineRun
-
-
-
-_Appears in:_
-- [PipelineRun](#pipelinerun)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `observedGeneration` _integer_ | ObservedGeneration is the 'Generation' of the Service that<br />was last processed by the controller. |  | Optional: \{\} <br /> |
-| `conditions` _[Conditions](#conditions)_ | Conditions the latest available observations of a resource's current state. |  | Optional: \{\} <br /> |
-| `annotations` _object (keys:string, values:string)_ | Annotations is additional Status fields for the Resource to save some<br />additional State as well as convey more information to the user. This is<br />roughly akin to Annotations on any k8s resource, just the reconciler conveying<br />richer information outwards. |  |  |
-| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | StartTime is the time the PipelineRun is actually started. |  |  |
-| `completionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | CompletionTime is the time the PipelineRun completed. |  |  |
-| `results` _[PipelineRunResult](#pipelinerunresult) array_ | Results are the list of results written out by the pipeline task's containers |  | Optional: \{\} <br /> |
-| `pipelineSpec` _[PipelineSpec](#pipelinespec)_ | PipelineSpec contains the exact spec used to instantiate the run.<br />See Pipeline.spec (API version: tekton.dev/v1) |  | Schemaless: \{\} <br /> |
-| `skippedTasks` _[SkippedTask](#skippedtask) array_ | list of tasks that were skipped due to when expressions evaluating to false |  | Optional: \{\} <br /> |
-| `childReferences` _[ChildStatusReference](#childstatusreference) array_ | list of TaskRun and Run names, PipelineTask names, and API versions/kinds for children of this PipelineRun. |  | Optional: \{\} <br /> |
-| `finallyStartTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | FinallyStartTime is when all non-finally tasks have been completed and only finally tasks are being executed. |  | Optional: \{\} <br /> |
-| `provenance` _[Provenance](#provenance)_ | Provenance contains some key authenticated metadata about how a software artifact was built (what sources, what inputs/outputs, etc.). |  | Optional: \{\} <br /> |
-| `spanContext` _object (keys:string, values:string)_ | SpanContext contains tracing span context fields |  |  |
-
-
-#### PipelineRunStatusFields
-
-
-
-PipelineRunStatusFields holds the fields of PipelineRunStatus' status.
-This is defined separately and inlined so that other types can readily
-consume these fields via duck typing.
-
-
-
-_Appears in:_
-- [PipelineRunStatus](#pipelinerunstatus)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | StartTime is the time the PipelineRun is actually started. |  |  |
-| `completionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | CompletionTime is the time the PipelineRun completed. |  |  |
-| `results` _[PipelineRunResult](#pipelinerunresult) array_ | Results are the list of results written out by the pipeline task's containers |  | Optional: \{\} <br /> |
-| `pipelineSpec` _[PipelineSpec](#pipelinespec)_ | PipelineSpec contains the exact spec used to instantiate the run.<br />See Pipeline.spec (API version: tekton.dev/v1) |  | Schemaless: \{\} <br /> |
-| `skippedTasks` _[SkippedTask](#skippedtask) array_ | list of tasks that were skipped due to when expressions evaluating to false |  | Optional: \{\} <br /> |
-| `childReferences` _[ChildStatusReference](#childstatusreference) array_ | list of TaskRun and Run names, PipelineTask names, and API versions/kinds for children of this PipelineRun. |  | Optional: \{\} <br /> |
-| `finallyStartTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | FinallyStartTime is when all non-finally tasks have been completed and only finally tasks are being executed. |  | Optional: \{\} <br /> |
-| `provenance` _[Provenance](#provenance)_ | Provenance contains some key authenticated metadata about how a software artifact was built (what sources, what inputs/outputs, etc.). |  | Optional: \{\} <br /> |
-| `spanContext` _object (keys:string, values:string)_ | SpanContext contains tracing span context fields |  |  |
-
-
-
-
-#### PipelineSpec
-
-
-
-PipelineSpec defines the desired state of Pipeline.
-
-
-
-_Appears in:_
-- [Pipeline](#pipeline)
-- [PipelineRunSpec](#pipelinerunspec)
-- [PipelineRunStatus](#pipelinerunstatus)
-- [PipelineRunStatusFields](#pipelinerunstatusfields)
-- [PipelineTask](#pipelinetask)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `displayName` _string_ | DisplayName is a user-facing name of the pipeline that may be<br />used to populate a UI. |  | Optional: \{\} <br /> |
-| `description` _string_ | Description is a user-facing description of the pipeline that may be<br />used to populate a UI. |  | Optional: \{\} <br /> |
-| `tasks` _[PipelineTask](#pipelinetask) array_ | Tasks declares the graph of Tasks that execute when this Pipeline is run. |  |  |
-| `params` _[ParamSpecs](#paramspecs)_ | Params declares a list of input parameters that must be supplied when<br />this Pipeline is run. |  |  |
-| `workspaces` _[PipelineWorkspaceDeclaration](#pipelineworkspacedeclaration) array_ | Workspaces declares a set of named workspaces that are expected to be<br />provided by a PipelineRun. |  | Optional: \{\} <br /> |
-| `results` _[PipelineResult](#pipelineresult) array_ | Results are values that this pipeline can output once run |  | Optional: \{\} <br /> |
-| `finally` _[PipelineTask](#pipelinetask) array_ | Finally declares the list of Tasks that execute just before leaving the Pipeline<br />i.e. either after all Tasks are finished executing successfully<br />or after a failure which would result in ending the Pipeline |  |  |
-
-
-#### PipelineTask
-
-
-
-PipelineTask defines a task in a Pipeline, passing inputs from both
-Params and from the output of previous tasks.
-
-
-
-_Appears in:_
-- [PipelineSpec](#pipelinespec)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `name` _string_ | Name is the name of this task within the context of a Pipeline. Name is<br />used as a coordinate with the `from` and `runAfter` fields to establish<br />the execution order of tasks relative to one another. |  |  |
-| `displayName` _string_ | DisplayName is the display name of this task within the context of a Pipeline.<br />This display name may be used to populate a UI. |  | Optional: \{\} <br /> |
-| `description` _string_ | Description is the description of this task within the context of a Pipeline.<br />This description may be used to populate a UI. |  | Optional: \{\} <br /> |
-| `taskRef` _[TaskRef](#taskref)_ | TaskRef is a reference to a task definition. |  | Optional: \{\} <br /> |
-| `taskSpec` _[EmbeddedTask](#embeddedtask)_ | TaskSpec is a specification of a task<br />Specifying TaskSpec can be disabled by setting<br />`disable-inline-spec` feature flag.<br />See Task.spec (API version: tekton.dev/v1) |  | Schemaless: \{\} <br />Optional: \{\} <br /> |
-| `when` _[WhenExpressions](#whenexpressions)_ | When is a list of when expressions that need to be true for the task to run |  | Optional: \{\} <br /> |
-| `retries` _integer_ | Retries represents how many times this task should be retried in case of task failure: ConditionSucceeded set to False |  | Optional: \{\} <br /> |
-| `runAfter` _string array_ | RunAfter is the list of PipelineTask names that should be executed before<br />this Task executes. (Used to force a specific ordering in graph execution.) |  | Optional: \{\} <br /> |
-| `params` _[Params](#params)_ | Parameters declares parameters passed to this task. |  | Optional: \{\} <br /> |
-| `matrix` _[Matrix](#matrix)_ | Matrix declares parameters used to fan out this task. |  | Optional: \{\} <br /> |
-| `workspaces` _[WorkspacePipelineTaskBinding](#workspacepipelinetaskbinding) array_ | Workspaces maps workspaces from the pipeline spec to the workspaces<br />declared in the Task. |  | Optional: \{\} <br /> |
-| `timeout` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ | Duration after which the TaskRun times out. Defaults to 1 hour.<br />Refer Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration |  | Optional: \{\} <br /> |
-| `pipelineRef` _[PipelineRef](#pipelineref)_ | PipelineRef is a reference to a pipeline definition.<br />This is an alpha field. You must set the "enable-api-fields" feature flag<br />to "alpha" for this field to be supported. When enabled, the referenced<br />Pipeline is executed as a child PipelineRun owned by the parent PipelineRun. |  | Optional: \{\} <br /> |
-| `pipelineSpec` _[PipelineSpec](#pipelinespec)_ | PipelineSpec is a specification of a pipeline.<br />This is an alpha field. You must set the "enable-api-fields" feature flag<br />to "alpha" for this field to be supported. When enabled, the embedded<br />Pipeline is executed as a child PipelineRun owned by the parent PipelineRun.<br />Specifying PipelineSpec can be disabled by setting<br />`disable-inline-spec` feature flag.<br />See Pipeline.spec (API version: tekton.dev/v1) |  | Schemaless: \{\} <br />Optional: \{\} <br /> |
-| `onError` _[PipelineTaskOnErrorType](#pipelinetaskonerrortype)_ | OnError defines the exiting behavior of a PipelineRun on error<br />can be set to [ continue \| stopAndFail ] |  | Optional: \{\} <br /> |
-
-
-#### PipelineTaskMetadata
-
-
-
-PipelineTaskMetadata contains the labels or annotations for an EmbeddedTask
-
-
-
-_Appears in:_
-- [EmbeddedTask](#embeddedtask)
-- [PipelineTaskRunSpec](#pipelinetaskrunspec)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `labels` _object (keys:string, values:string)_ |  |  | Optional: \{\} <br /> |
-| `annotations` _object (keys:string, values:string)_ |  |  | Optional: \{\} <br /> |
-
-
-#### PipelineTaskOnErrorType
-
-_Underlying type:_ _string_
-
-PipelineTaskOnErrorType defines a list of supported failure handling behaviors of a PipelineTask on error
-
-
-
-_Appears in:_
-- [PipelineTask](#pipelinetask)
-
-| Field | Description |
-| --- | --- |
-| `stopAndFail` | PipelineTaskStopAndFail indicates to stop and fail the PipelineRun if the PipelineTask fails<br /> |
-| `continue` | PipelineTaskContinue indicates to continue executing the rest of the DAG when the PipelineTask fails<br /> |
-
-
-
-
-
-
-#### PipelineTaskRunSpec
-
-
-
-PipelineTaskRunSpec  can be used to configure specific
-specs for a concrete Task
-
-
-
-_Appears in:_
-- [PipelineRunSpec](#pipelinerunspec)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `pipelineTaskName` _string_ |  |  |  |
-| `serviceAccountName` _string_ |  |  |  |
-| `podTemplate` _[PodTemplate](#podtemplate)_ |  |  |  |
-| `stepSpecs` _[TaskRunStepSpec](#taskrunstepspec) array_ |  |  |  |
-| `sidecarSpecs` _[TaskRunSidecarSpec](#taskrunsidecarspec) array_ |  |  |  |
-| `metadata` _[PipelineTaskMetadata](#pipelinetaskmetadata)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  | Optional: \{\} <br /> |
-| `computeResources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcerequirements-v1-core)_ | Compute resources to use for this TaskRun |  |  |
-| `timeout` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ | Duration after which the TaskRun times out. Overrides the timeout specified<br />on the Task's spec if specified. Takes lower precedence to PipelineRun's<br />`spec.timeouts.tasks`<br />Refer Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration |  | Optional: \{\} <br /> |
-
-
-#### PipelineTaskRunTemplate
-
-
-
-PipelineTaskRunTemplate is used to specify run specifications for all Task in pipelinerun.
-
-
-
-_Appears in:_
-- [PipelineRunSpec](#pipelinerunspec)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `podTemplate` _[PodTemplate](#podtemplate)_ |  |  | Optional: \{\} <br /> |
-| `serviceAccountName` _string_ |  |  | Optional: \{\} <br /> |
-
-
-#### PipelineWorkspaceDeclaration
-
-_Underlying type:_ _[struct{Name string "json:\"name\""; Description string "json:\"description,omitempty\""; Optional bool "json:\"optional,omitempty\""}](#struct{name-string-"json:\"name\"";-description-string-"json:\"description,omitempty\"";-optional-bool-"json:\"optional,omitempty\""})_
-
-PipelineWorkspaceDeclaration creates a named slot in a Pipeline that a PipelineRun
-is expected to populate with a workspace binding.
-
-
-
-_Appears in:_
-- [PipelineSpec](#pipelinespec)
-
-
-
-#### PropertySpec
-
-
-
-PropertySpec defines the struct for object keys
-
-
-
-_Appears in:_
-- [ParamSpec](#paramspec)
-- [StepResult](#stepresult)
-- [TaskResult](#taskresult)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `type` _[ParamType](#paramtype)_ |  |  |  |
-
-
-#### Provenance
-
-
-
-Provenance contains metadata about resources used in the TaskRun/PipelineRun
-such as the source from where a remote build definition was fetched.
-This field aims to carry minimum amoumt of metadata in *Run status so that
-Tekton Chains can capture them in the provenance.
-
-
-
-_Appears in:_
-- [PipelineRunStatus](#pipelinerunstatus)
-- [PipelineRunStatusFields](#pipelinerunstatusfields)
-- [StepState](#stepstate)
-- [TaskRunStatus](#taskrunstatus)
-- [TaskRunStatusFields](#taskrunstatusfields)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `refSource` _[RefSource](#refsource)_ | RefSource identifies the source where a remote task/pipeline came from. |  |  |
-| `featureFlags` _[FeatureFlags](#featureflags)_ | FeatureFlags identifies the feature flags that were used during the task/pipeline run |  |  |
-
-
-#### Ref
-
-
-
-Ref can be used to refer to a specific instance of a StepAction.
-
-
-
-_Appears in:_
-- [Step](#step)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `name` _string_ | Name of the referenced step |  |  |
-| `ResolverRef` _[ResolverRef](#resolverref)_ | ResolverRef allows referencing a StepAction in a remote location<br />like a git repo. |  | Optional: \{\} <br /> |
-
-
-#### RefSource
-
-
-
-RefSource contains the information that can uniquely identify where a remote
-built definition came from i.e. Git repositories, Tekton Bundles in OCI registry
-and hub.
-
-
-
-_Appears in:_
-- [Provenance](#provenance)
-- [ResolutionRequestStatus](#resolutionrequeststatus)
-- [ResolutionRequestStatus](#resolutionrequeststatus)
-- [ResolutionRequestStatusFields](#resolutionrequeststatusfields)
-- [ResolutionRequestStatusFields](#resolutionrequeststatusfields)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `uri` _string_ | URI indicates the identity of the source of the build definition.<br />Example: "https://github.com/tektoncd/catalog" |  |  |
-| `digest` _object (keys:string, values:string)_ | Digest is a collection of cryptographic digests for the contents of the artifact specified by URI.<br />Example: \{"sha1": "f99d13e554ffcb696dee719fa85b695cb5b0f428"\} |  |  |
-| `entryPoint` _string_ | EntryPoint identifies the entry point into the build. This is often a path to a<br />build definition file and/or a target label within that file.<br />Example: "task/git-clone/0.10/git-clone.yaml" |  |  |
-
-
-#### ResolverName
-
-_Underlying type:_ _string_
-
-ResolverName is the name of a resolver from which a resource can be
-requested.
-
-
-
-_Appears in:_
-- [ResolverRef](#resolverref)
-
-
-
-#### ResolverRef
-
-
-
-ResolverRef can be used to refer to a Pipeline or Task in a remote
-location like a git repo. This feature is in beta and these fields
-are only available when the beta feature gate is enabled.
-
-
-
-_Appears in:_
-- [PipelineRef](#pipelineref)
-- [Ref](#ref)
-- [TaskRef](#taskref)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `resolver` _[ResolverName](#resolvername)_ | Resolver is the name of the resolver that should perform<br />resolution of the referenced Tekton resource, such as "git". |  | Optional: \{\} <br /> |
-| `params` _[Params](#params)_ | Params contains the parameters used to identify the<br />referenced Tekton resource. Example entries might include<br />"repo" or "path" but the set of params ultimately depends on<br />the chosen resolver. |  | Optional: \{\} <br /> |
-
-
-
-
-
-
-#### ResultsType
-
-_Underlying type:_ _string_
-
-ResultsType indicates the type of a result;
-Used to distinguish between a single string and an array of strings.
-Note that there is ResultType used to find out whether a
-RunResult is from a task result or not, which is different from
-this ResultsType.
-
-
-
-_Appears in:_
-- [StepResult](#stepresult)
-- [TaskResult](#taskresult)
-- [TaskRunResult](#taskrunresult)
-
-| Field | Description |
-| --- | --- |
-| `string` |  |
-| `array` |  |
-| `object` |  |
-
-
-#### RetriesStatus
-
-_Underlying type:_ _[TaskRunStatus](#taskrunstatus)_
-
-
-
-
-
-_Appears in:_
-- [TaskRunStatus](#taskrunstatus)
-- [TaskRunStatusFields](#taskrunstatusfields)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `Status` _[Status](https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Status)_ |  |  |  |
-| `TaskRunStatusFields` _[TaskRunStatusFields](#taskrunstatusfields)_ | TaskRunStatusFields inlines the status fields. |  |  |
-
-
-#### Sidecar
-
-
-
-Sidecar has nearly the same data structure as Step but does not have the ability to timeout.
-
-
-
-_Appears in:_
-- [EmbeddedTask](#embeddedtask)
-- [TaskSpec](#taskspec)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `name` _string_ | Name of the Sidecar specified as a DNS_LABEL.<br />Each Sidecar in a Task must have a unique name (DNS_LABEL).<br />Cannot be updated. |  |  |
-| `image` _string_ | Image reference name.<br />More info: https://kubernetes.io/docs/concepts/containers/images |  | Optional: \{\} <br /> |
-| `command` _string array_ | Entrypoint array. Not executed within a shell.<br />The image's ENTRYPOINT is used if this is not provided.<br />Variable references $(VAR_NAME) are expanded using the Sidecar's environment. If a variable<br />cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced<br />to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will<br />produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless<br />of whether the variable exists or not. Cannot be updated.<br />More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell |  | Optional: \{\} <br /> |
-| `args` _string array_ | Arguments to the entrypoint.<br />The image's CMD is used if this is not provided.<br />Variable references $(VAR_NAME) are expanded using the Sidecar's environment. If a variable<br />cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced<br />to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will<br />produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless<br />of whether the variable exists or not. Cannot be updated.<br />More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell |  | Optional: \{\} <br /> |
-| `workingDir` _string_ | Sidecar's working directory.<br />If not specified, the container runtime's default will be used, which<br />might be configured in the container image.<br />Cannot be updated. |  | Optional: \{\} <br /> |
-| `ports` _[ContainerPort](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#containerport-v1-core) array_ | List of ports to expose from the Sidecar. Exposing a port here gives<br />the system additional information about the network connections a<br />container uses, but is primarily informational. Not specifying a port here<br />DOES NOT prevent that port from being exposed. Any port which is<br />listening on the default "0.0.0.0" address inside a container will be<br />accessible from the network.<br />Cannot be updated. |  | Optional: \{\} <br /> |
-| `envFrom` _[EnvFromSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#envfromsource-v1-core) array_ | List of sources to populate environment variables in the Sidecar.<br />The keys defined within a source must be a C_IDENTIFIER. All invalid keys<br />will be reported as an event when the container is starting. When a key exists in multiple<br />sources, the value associated with the last source will take precedence.<br />Values defined by an Env with a duplicate key will take precedence.<br />Cannot be updated. |  | Optional: \{\} <br /> |
-| `env` _[EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#envvar-v1-core) array_ | List of environment variables to set in the Sidecar.<br />Cannot be updated. |  | Optional: \{\} <br /> |
-| `computeResources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcerequirements-v1-core)_ | ComputeResources required by this Sidecar.<br />Cannot be updated.<br />More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |  | Optional: \{\} <br /> |
-| `volumeMounts` _[VolumeMount](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#volumemount-v1-core) array_ | Volumes to mount into the Sidecar's filesystem.<br />Cannot be updated. |  | Optional: \{\} <br /> |
-| `volumeDevices` _[VolumeDevice](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#volumedevice-v1-core) array_ | volumeDevices is the list of block devices to be used by the Sidecar. |  | Optional: \{\} <br /> |
-| `livenessProbe` _[Probe](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#probe-v1-core)_ | Periodic probe of Sidecar liveness.<br />Container will be restarted if the probe fails.<br />Cannot be updated.<br />More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes |  | Optional: \{\} <br /> |
-| `readinessProbe` _[Probe](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#probe-v1-core)_ | Periodic probe of Sidecar service readiness.<br />Container will be removed from service endpoints if the probe fails.<br />Cannot be updated.<br />More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes |  | Optional: \{\} <br /> |
-| `startupProbe` _[Probe](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#probe-v1-core)_ | StartupProbe indicates that the Pod the Sidecar is running in has successfully initialized.<br />If specified, no other probes are executed until this completes successfully.<br />If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.<br />This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,<br />when it might take a long time to load data or warm a cache, than during steady-state operation.<br />This cannot be updated.<br />More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes |  | Optional: \{\} <br /> |
-| `lifecycle` _[Lifecycle](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#lifecycle-v1-core)_ | Actions that the management system should take in response to Sidecar lifecycle events.<br />Cannot be updated. |  | Optional: \{\} <br /> |
-| `terminationMessagePath` _string_ | Optional: Path at which the file to which the Sidecar's termination message<br />will be written is mounted into the Sidecar's filesystem.<br />Message written is intended to be brief final status, such as an assertion failure message.<br />Will be truncated by the node if greater than 4096 bytes. The total message length across<br />all containers will be limited to 12kb.<br />Defaults to /dev/termination-log.<br />Cannot be updated. |  | Optional: \{\} <br /> |
-| `terminationMessagePolicy` _[TerminationMessagePolicy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#terminationmessagepolicy-v1-core)_ | Indicate how the termination message should be populated. File will use the contents of<br />terminationMessagePath to populate the Sidecar status message on both success and failure.<br />FallbackToLogsOnError will use the last chunk of Sidecar log output if the termination<br />message file is empty and the Sidecar exited with an error.<br />The log output is limited to 2048 bytes or 80 lines, whichever is smaller.<br />Defaults to File.<br />Cannot be updated. |  | Optional: \{\} <br /> |
-| `imagePullPolicy` _[PullPolicy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#pullpolicy-v1-core)_ | Image pull policy.<br />One of Always, Never, IfNotPresent.<br />Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.<br />Cannot be updated.<br />More info: https://kubernetes.io/docs/concepts/containers/images#updating-images |  | Optional: \{\} <br /> |
-| `securityContext` _[SecurityContext](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#securitycontext-v1-core)_ | SecurityContext defines the security options the Sidecar should be run with.<br />If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.<br />More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ |  | Optional: \{\} <br /> |
-| `stdin` _boolean_ | Whether this Sidecar should allocate a buffer for stdin in the container runtime. If this<br />is not set, reads from stdin in the Sidecar will always result in EOF.<br />Default is false. |  | Optional: \{\} <br /> |
-| `stdinOnce` _boolean_ | Whether the container runtime should close the stdin channel after it has been opened by<br />a single attach. When stdin is true the stdin stream will remain open across multiple attach<br />sessions. If stdinOnce is set to true, stdin is opened on Sidecar start, is empty until the<br />first client attaches to stdin, and then remains open and accepts data until the client disconnects,<br />at which time stdin is closed and remains closed until the Sidecar is restarted. If this<br />flag is false, a container processes that reads from stdin will never receive an EOF.<br />Default is false |  | Optional: \{\} <br /> |
-| `tty` _boolean_ | Whether this Sidecar should allocate a TTY for itself, also requires 'stdin' to be true.<br />Default is false. |  | Optional: \{\} <br /> |
-| `script` _string_ | Script is the contents of an executable file to execute.<br />If Script is not empty, the Step cannot have an Command or Args. |  | Optional: \{\} <br /> |
-| `workspaces` _[WorkspaceUsage](#workspaceusage) array_ | This is an alpha field. You must set the "enable-api-fields" feature flag to "alpha"<br />for this field to be supported.<br />Workspaces is a list of workspaces from the Task that this Sidecar wants<br />exclusive access to. Adding a workspace to this list means that any<br />other Step or Sidecar that does not also request this Workspace will<br />not have access to it. |  | Optional: \{\} <br /> |
-| `restartPolicy` _[ContainerRestartPolicy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#containerrestartpolicy-v1-core)_ | RestartPolicy refers to kubernetes RestartPolicy. It can only be set for an<br />initContainer and must have it's policy set to "Always". It is currently<br />left optional to help support Kubernetes versions prior to 1.29 when this feature<br />was introduced. |  | Optional: \{\} <br /> |
-
-
-#### SidecarState
-
-
-
-SidecarState reports the results of running a sidecar in a Task.
-
-
-
-_Appears in:_
-- [TaskRunStatus](#taskrunstatus)
-- [TaskRunStatusFields](#taskrunstatusfields)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `waiting` _[ContainerStateWaiting](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#containerstatewaiting-v1-core)_ | Details about a waiting container |  | Optional: \{\} <br /> |
-| `running` _[ContainerStateRunning](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#containerstaterunning-v1-core)_ | Details about a running container |  | Optional: \{\} <br /> |
-| `terminated` _[ContainerStateTerminated](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#containerstateterminated-v1-core)_ | Details about a terminated container |  | Optional: \{\} <br /> |
-| `name` _string_ |  |  |  |
-| `container` _string_ |  |  |  |
-| `imageID` _string_ |  |  |  |
-
-
-#### SkippedTask
-
-
-
-SkippedTask is used to describe the Tasks that were skipped due to their When Expressions
-evaluating to False. This is a struct because we are looking into including more details
-about the When Expressions that caused this Task to be skipped.
-
-
-
-_Appears in:_
-- [PipelineRunStatus](#pipelinerunstatus)
-- [PipelineRunStatusFields](#pipelinerunstatusfields)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `name` _string_ | Name is the Pipeline Task name |  |  |
-| `reason` _[SkippingReason](#skippingreason)_ | Reason is the cause of the PipelineTask being skipped. |  |  |
-| `whenExpressions` _[WhenExpression](#whenexpression) array_ | WhenExpressions is the list of checks guarding the execution of the PipelineTask |  | Optional: \{\} <br /> |
-
-
-#### SkippingReason
-
-_Underlying type:_ _string_
-
-SkippingReason explains why a PipelineTask was skipped.
-
-
-
-_Appears in:_
-- [SkippedTask](#skippedtask)
-
-| Field | Description |
-| --- | --- |
-| `When Expressions evaluated to false` | WhenExpressionsSkip means the task was skipped due to at least one of its when expressions evaluating to false<br /> |
-| `Parent Tasks were skipped` | ParentTasksSkip means the task was skipped because its parent was skipped<br /> |
-| `PipelineRun was stopping` | StoppingSkip means the task was skipped because the pipeline run is stopping<br /> |
-| `PipelineRun was gracefully cancelled` | GracefullyCancelledSkip means the task was skipped because the pipeline run has been gracefully cancelled<br /> |
-| `PipelineRun was gracefully stopped` | GracefullyStoppedSkip means the task was skipped because the pipeline run has been gracefully stopped<br /> |
-| `Results were missing` | MissingResultsSkip means the task was skipped because it's missing necessary results<br /> |
-| `PipelineRun timeout has been reached` | PipelineTimedOutSkip means the task was skipped because the PipelineRun has passed its overall timeout.<br /> |
-| `PipelineRun Tasks timeout has been reached` | TasksTimedOutSkip means the task was skipped because the PipelineRun has passed its Timeouts.Tasks.<br /> |
-| `PipelineRun Finally timeout has been reached` | FinallyTimedOutSkip means the task was skipped because the PipelineRun has passed its Timeouts.Finally.<br /> |
-| `Matrix Parameters have an empty array` | EmptyArrayInMatrixParams means the task was skipped because Matrix parameters contain empty array.<br /> |
-| `None` | None means the task was not skipped<br /> |
-
-
-#### Step
-
-
-
-Step runs a subcomponent of a Task
-
-
-
-_Appears in:_
-- [EmbeddedTask](#embeddedtask)
-- [TaskSpec](#taskspec)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `name` _string_ | Name of the Step specified as a DNS_LABEL.<br />Each Step in a Task must have a unique name. |  |  |
-| `displayName` _string_ | DisplayName is a user-facing name of the step that may be<br />used to populate a UI. |  | Optional: \{\} <br /> |
-| `image` _string_ | Docker image name.<br />More info: https://kubernetes.io/docs/concepts/containers/images |  | Optional: \{\} <br /> |
-| `command` _string array_ | Entrypoint array. Not executed within a shell.<br />The image's ENTRYPOINT is used if this is not provided.<br />Variable references $(VAR_NAME) are expanded using the container's environment. If a variable<br />cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced<br />to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will<br />produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless<br />of whether the variable exists or not. Cannot be updated.<br />More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell |  | Optional: \{\} <br /> |
-| `args` _string array_ | Arguments to the entrypoint.<br />The image's CMD is used if this is not provided.<br />Variable references $(VAR_NAME) are expanded using the container's environment. If a variable<br />cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced<br />to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will<br />produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless<br />of whether the variable exists or not. Cannot be updated.<br />More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell |  | Optional: \{\} <br /> |
-| `workingDir` _string_ | Step's working directory.<br />If not specified, the container runtime's default will be used, which<br />might be configured in the container image.<br />Cannot be updated. |  | Optional: \{\} <br /> |
-| `envFrom` _[EnvFromSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#envfromsource-v1-core) array_ | List of sources to populate environment variables in the Step.<br />The keys defined within a source must be a C_IDENTIFIER. All invalid keys<br />will be reported as an event when the Step is starting. When a key exists in multiple<br />sources, the value associated with the last source will take precedence.<br />Values defined by an Env with a duplicate key will take precedence.<br />Cannot be updated. |  | Optional: \{\} <br /> |
-| `env` _[EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#envvar-v1-core) array_ | List of environment variables to set in the Step.<br />Cannot be updated. |  | Optional: \{\} <br /> |
-| `computeResources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcerequirements-v1-core)_ | ComputeResources required by this Step.<br />Cannot be updated.<br />More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |  | Optional: \{\} <br /> |
-| `volumeMounts` _[VolumeMount](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#volumemount-v1-core) array_ | Volumes to mount into the Step's filesystem.<br />Cannot be updated. |  | Optional: \{\} <br /> |
-| `volumeDevices` _[VolumeDevice](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#volumedevice-v1-core) array_ | volumeDevices is the list of block devices to be used by the Step. |  | Optional: \{\} <br /> |
-| `imagePullPolicy` _[PullPolicy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#pullpolicy-v1-core)_ | Image pull policy.<br />One of Always, Never, IfNotPresent.<br />Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.<br />Cannot be updated.<br />More info: https://kubernetes.io/docs/concepts/containers/images#updating-images |  | Optional: \{\} <br /> |
-| `securityContext` _[SecurityContext](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#securitycontext-v1-core)_ | SecurityContext defines the security options the Step should be run with.<br />If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.<br />More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ |  | Optional: \{\} <br /> |
-| `script` _string_ | Script is the contents of an executable file to execute.<br />If Script is not empty, the Step cannot have an Command and the Args will be passed to the Script. |  | Optional: \{\} <br /> |
-| `timeout` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ | Timeout is the time after which the step times out. Defaults to never.<br />Refer to Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration |  | Optional: \{\} <br /> |
-| `workspaces` _[WorkspaceUsage](#workspaceusage) array_ | This is an alpha field. You must set the "enable-api-fields" feature flag to "alpha"<br />for this field to be supported.<br />Workspaces is a list of workspaces from the Task that this Step wants<br />exclusive access to. Adding a workspace to this list means that any<br />other Step or Sidecar that does not also request this Workspace will<br />not have access to it. |  | Optional: \{\} <br /> |
-| `onError` _[OnErrorType](#onerrortype)_ | OnError defines the exiting behavior of a container on error<br />can be set to [ continue \| stopAndFail ] |  |  |
-| `stdoutConfig` _[StepOutputConfig](#stepoutputconfig)_ | Stores configuration for the stdout stream of the step. |  | Optional: \{\} <br /> |
-| `stderrConfig` _[StepOutputConfig](#stepoutputconfig)_ | Stores configuration for the stderr stream of the step. |  | Optional: \{\} <br /> |
-| `ref` _[Ref](#ref)_ | Contains the reference to an existing StepAction. |  | Optional: \{\} <br /> |
-| `params` _[Params](#params)_ | Params declares parameters passed to this step action. |  | Optional: \{\} <br /> |
-| `results` _[StepResult](#stepresult) array_ | Results declares StepResults produced by the Step.<br />It can be used in an inlined Step when used to store Results to $(step.results.resultName.path).<br />It cannot be used when referencing StepActions using [v1.Step.Ref].<br />The Results declared by the StepActions will be stored here instead. |  | Optional: \{\} <br /> |
-| `when` _[StepWhenExpressions](#stepwhenexpressions)_ | When is a list of when expressions that need to be true for the task to run |  | Optional: \{\} <br /> |
-
-
-#### StepOutputConfig
-
-
-
-StepOutputConfig stores configuration for a step output stream.
-
-
-
-_Appears in:_
-- [Step](#step)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `path` _string_ | Path to duplicate stdout stream to on container's local filesystem. |  | Optional: \{\} <br /> |
-
-
-#### StepResult
-
-
-
-StepResult used to describe the Results of a Step.
-
-
-
-_Appears in:_
-- [Step](#step)
-- [Step](#step)
-- [StepActionSpec](#stepactionspec)
-- [StepActionSpec](#stepactionspec)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `name` _string_ | Name the given name |  |  |
-| `type` _[ResultsType](#resultstype)_ | The possible types are 'string', 'array', and 'object', with 'string' as the default. |  | Optional: \{\} <br /> |
-| `properties` _object (keys:string, values:[PropertySpec](#propertyspec))_ | Properties is the JSON Schema properties to support key-value pairs results. |  | Optional: \{\} <br /> |
-| `description` _string_ | Description is a human-readable description of the result |  | Optional: \{\} <br /> |
-
-
-#### StepState
-
-
-
-StepState reports the results of running a step in a Task.
-
-
-
-_Appears in:_
-- [TaskRunStatus](#taskrunstatus)
-- [TaskRunStatusFields](#taskrunstatusfields)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `waiting` _[ContainerStateWaiting](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#containerstatewaiting-v1-core)_ | Details about a waiting container |  | Optional: \{\} <br /> |
-| `running` _[ContainerStateRunning](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#containerstaterunning-v1-core)_ | Details about a running container |  | Optional: \{\} <br /> |
-| `terminated` _[ContainerStateTerminated](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#containerstateterminated-v1-core)_ | Details about a terminated container |  | Optional: \{\} <br /> |
-| `name` _string_ |  |  |  |
-| `container` _string_ |  |  |  |
-| `imageID` _string_ |  |  |  |
-| `results` _[TaskRunStepResult](#taskrunstepresult) array_ |  |  |  |
-| `provenance` _[Provenance](#provenance)_ |  |  |  |
-| `terminationReason` _string_ |  |  |  |
-| `inputs` _[TaskRunStepArtifact](#taskrunstepartifact) array_ |  |  |  |
-| `outputs` _[TaskRunStepArtifact](#taskrunstepartifact) array_ |  |  |  |
-
-
-#### StepTemplate
-
-
-
-StepTemplate is a template for a Step
-
-
-
-_Appears in:_
-- [EmbeddedTask](#embeddedtask)
-- [TaskSpec](#taskspec)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `image` _string_ | Image reference name.<br />More info: https://kubernetes.io/docs/concepts/containers/images |  | Optional: \{\} <br /> |
-| `command` _string array_ | Entrypoint array. Not executed within a shell.<br />The image's ENTRYPOINT is used if this is not provided.<br />Variable references $(VAR_NAME) are expanded using the Step's environment. If a variable<br />cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced<br />to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will<br />produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless<br />of whether the variable exists or not. Cannot be updated.<br />More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell |  | Optional: \{\} <br /> |
-| `args` _string array_ | Arguments to the entrypoint.<br />The image's CMD is used if this is not provided.<br />Variable references $(VAR_NAME) are expanded using the Step's environment. If a variable<br />cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced<br />to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will<br />produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless<br />of whether the variable exists or not. Cannot be updated.<br />More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell |  | Optional: \{\} <br /> |
-| `workingDir` _string_ | Step's working directory.<br />If not specified, the container runtime's default will be used, which<br />might be configured in the container image.<br />Cannot be updated. |  | Optional: \{\} <br /> |
-| `envFrom` _[EnvFromSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#envfromsource-v1-core) array_ | List of sources to populate environment variables in the Step.<br />The keys defined within a source must be a C_IDENTIFIER. All invalid keys<br />will be reported as an event when the Step is starting. When a key exists in multiple<br />sources, the value associated with the last source will take precedence.<br />Values defined by an Env with a duplicate key will take precedence.<br />Cannot be updated. |  | Optional: \{\} <br /> |
-| `env` _[EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#envvar-v1-core) array_ | List of environment variables to set in the Step.<br />Cannot be updated. |  | Optional: \{\} <br /> |
-| `computeResources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcerequirements-v1-core)_ | ComputeResources required by this Step.<br />Cannot be updated.<br />More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |  | Optional: \{\} <br /> |
-| `volumeMounts` _[VolumeMount](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#volumemount-v1-core) array_ | Volumes to mount into the Step's filesystem.<br />Cannot be updated. |  | Optional: \{\} <br /> |
-| `volumeDevices` _[VolumeDevice](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#volumedevice-v1-core) array_ | volumeDevices is the list of block devices to be used by the Step. |  | Optional: \{\} <br /> |
-| `imagePullPolicy` _[PullPolicy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#pullpolicy-v1-core)_ | Image pull policy.<br />One of Always, Never, IfNotPresent.<br />Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.<br />Cannot be updated.<br />More info: https://kubernetes.io/docs/concepts/containers/images#updating-images |  | Optional: \{\} <br /> |
-| `securityContext` _[SecurityContext](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#securitycontext-v1-core)_ | SecurityContext defines the security options the Step should be run with.<br />If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.<br />More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ |  | Optional: \{\} <br /> |
-
-
-
-
-#### Task
-
-
-
-Task represents a collection of sequential steps that are run as part of a
+PipelineRun creates TaskRuns for Tasks in the referenced Pipeline.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code><br/>
+string</td>
+<td>
+<code>
+tekton.dev/v1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code><br/>
+string
+</td>
+<td><code>PipelineRun</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#tekton.dev/v1.PipelineRunSpec">
+PipelineRunSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>pipelineRef</code><br/>
+<em>
+<a href="#tekton.dev/v1.PipelineRef">
+PipelineRef
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>pipelineSpec</code><br/>
+<em>
+<a href="#tekton.dev/v1.PipelineSpec">
+PipelineSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Specifying PipelineSpec can be disabled by setting
+<code>disable-inline-spec</code> feature flag.
+See Pipeline.spec (API version: tekton.dev/v1)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>params</code><br/>
+<em>
+<a href="#tekton.dev/v1.Params">
+Params
+</a>
+</em>
+</td>
+<td>
+<p>Params is a list of parameter names and values.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code><br/>
+<em>
+<a href="#tekton.dev/v1.PipelineRunSpecStatus">
+PipelineRunSpecStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Used for cancelling a pipelinerun (and maybe more later on)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>timeouts</code><br/>
+<em>
+<a href="#tekton.dev/v1.TimeoutFields">
+TimeoutFields
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Time after which the Pipeline times out.
+Currently three keys are accepted in the map
+pipeline, tasks and finally
+with Timeouts.pipeline &gt;= Timeouts.tasks + Timeouts.finally</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>taskRunTemplate</code><br/>
+<em>
+<a href="#tekton.dev/v1.PipelineTaskRunTemplate">
+PipelineTaskRunTemplate
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TaskRunTemplate represent template of taskrun</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>workspaces</code><br/>
+<em>
+<a href="#tekton.dev/v1.WorkspaceBinding">
+[]WorkspaceBinding
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Workspaces holds a set of workspace bindings that must match names
+with those declared in the pipeline.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>taskRunSpecs</code><br/>
+<em>
+<a href="#tekton.dev/v1.PipelineTaskRunSpec">
+[]PipelineTaskRunSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TaskRunSpecs holds a set of runtime specs</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>managedBy</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ManagedBy indicates which controller is responsible for reconciling
+this resource. If unset or set to &ldquo;tekton.dev/pipeline&rdquo;, the default
+Tekton controller will manage this resource.
+This field is immutable.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code><br/>
+<em>
+<a href="#tekton.dev/v1.PipelineRunStatus">
+PipelineRunStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.Task">Task
+</h3>
+<div>
+<p>Task represents a collection of sequential steps that are run as part of a
 Pipeline using a set of inputs and producing a set of outputs. Tasks execute
 when TaskRuns are created that provide the input parameters and resources and
-output resources the Task requires.
-
-
-
-
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `tekton.dev/v1` | | |
-| `kind` _string_ | `Task` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  | Optional: \{\} <br /> |
-| `spec` _[TaskSpec](#taskspec)_ | Spec holds the desired state of the Task from the client |  | Optional: \{\} <br /> |
-
-
-#### TaskBreakpoints
-
-
-
-TaskBreakpoints defines the breakpoint config for a particular Task
-
-
-
-_Appears in:_
-- [TaskRunDebug](#taskrundebug)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `onFailure` _string_ | if enabled, pause TaskRun on failure of a step<br />failed step will not exit |  | Optional: \{\} <br /> |
-| `beforeSteps` _string array_ |  |  | Optional: \{\} <br /> |
-
-
-#### TaskKind
-
-_Underlying type:_ _string_
-
-TaskKind defines the type of Task used by the pipeline.
-
-
-
-_Appears in:_
-- [TaskRef](#taskref)
-
-| Field | Description |
-| --- | --- |
-| `Task` | NamespacedTaskKind indicates that the task type has a namespaced scope.<br /> |
-
-
-#### TaskRef
-
-
-
-TaskRef can be used to refer to a specific instance of a task.
-
-
-
-_Appears in:_
-- [PipelineTask](#pipelinetask)
-- [TaskRunSpec](#taskrunspec)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `name` _string_ | Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names |  |  |
-| `kind` _[TaskKind](#taskkind)_ | TaskKind indicates the Kind of the Task:<br />1. Namespaced Task when Kind is set to "Task". If Kind is "", it defaults to "Task".<br />2. Custom Task when Kind is non-empty and APIVersion is non-empty |  |  |
-| `apiVersion` _string_ | API version of the referent<br />Note: A Task with non-empty APIVersion and Kind is considered a Custom Task |  | Optional: \{\} <br /> |
-| `ResolverRef` _[ResolverRef](#resolverref)_ | ResolverRef allows referencing a Task in a remote location<br />like a git repo. This field is only supported when the alpha<br />feature gate is enabled. |  | Optional: \{\} <br /> |
-
-
-#### TaskResult
-
-
-
-TaskResult used to describe the results of a task
-
-
-
-_Appears in:_
-- [EmbeddedTask](#embeddedtask)
-- [TaskSpec](#taskspec)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `name` _string_ | Name the given name |  |  |
-| `type` _[ResultsType](#resultstype)_ | Type is the user-specified type of the result. The possible type<br />is currently "string" and will support "array" in following work. |  | Optional: \{\} <br /> |
-| `properties` _object (keys:string, values:[PropertySpec](#propertyspec))_ | Properties is the JSON Schema properties to support key-value pairs results. |  | Optional: \{\} <br /> |
-| `description` _string_ | Description is a human-readable description of the result |  | Optional: \{\} <br /> |
-| `value` _[ResultValue](#resultvalue)_ | Value the expression used to retrieve the value of the result from an underlying Step. |  | Schemaless: \{\} <br />Optional: \{\} <br /> |
-
-
-#### TaskRun
-
-
-
-TaskRun represents a single execution of a Task. TaskRuns are how the steps
+output resources the Task requires.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code><br/>
+string</td>
+<td>
+<code>
+tekton.dev/v1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code><br/>
+string
+</td>
+<td><code>Task</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#tekton.dev/v1.TaskSpec">
+TaskSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec holds the desired state of the Task from the client</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>params</code><br/>
+<em>
+<a href="#tekton.dev/v1.ParamSpecs">
+ParamSpecs
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Params is a list of input parameters required to run the task. Params
+must be supplied as inputs in TaskRuns unless they declare a default
+value.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>displayName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DisplayName is a user-facing name of the task that may be
+used to populate a UI.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>description</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Description is a user-facing description of the task that may be
+used to populate a UI.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>steps</code><br/>
+<em>
+<a href="#tekton.dev/v1.Step">
+[]Step
+</a>
+</em>
+</td>
+<td>
+<p>Steps are the steps of the build; each step is run sequentially with the
+source mounted into /workspace.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>volumes</code><br/>
+<em>
+<a href="#tekton.dev/v1.Volumes">
+Volumes
+</a>
+</em>
+</td>
+<td>
+<p>Volumes is a collection of volumes that are available to mount into the
+steps of the build.
+See Pod.spec.volumes (API version: v1)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>stepTemplate</code><br/>
+<em>
+<a href="#tekton.dev/v1.StepTemplate">
+StepTemplate
+</a>
+</em>
+</td>
+<td>
+<p>StepTemplate can be used as the basis for all step containers within the
+Task, so that the steps inherit settings on the base container.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sidecars</code><br/>
+<em>
+<a href="#tekton.dev/v1.Sidecar">
+[]Sidecar
+</a>
+</em>
+</td>
+<td>
+<p>Sidecars are run alongside the Task&rsquo;s step containers. They begin before
+the steps start and end after the steps complete.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>workspaces</code><br/>
+<em>
+<a href="#tekton.dev/v1.WorkspaceDeclaration">
+[]WorkspaceDeclaration
+</a>
+</em>
+</td>
+<td>
+<p>Workspaces are the volumes that this Task requires.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>results</code><br/>
+<em>
+<a href="#tekton.dev/v1.TaskResult">
+[]TaskResult
+</a>
+</em>
+</td>
+<td>
+<p>Results are values that this Task can output</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.TaskRun">TaskRun
+</h3>
+<div>
+<p>TaskRun represents a single execution of a Task. TaskRuns are how the steps
 specified in a Task are executed; they specify the parameters and resources
-used to run the steps in a Task.
-
-
-
-
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `tekton.dev/v1` | | |
-| `kind` _string_ | `TaskRun` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  | Optional: \{\} <br /> |
-| `spec` _[TaskRunSpec](#taskrunspec)_ |  |  | Optional: \{\} <br /> |
-| `status` _[TaskRunStatus](#taskrunstatus)_ |  |  | Optional: \{\} <br /> |
-
-
-#### TaskRunDebug
-
-
-
-TaskRunDebug defines the breakpoint config for a particular TaskRun
-
-
-
-_Appears in:_
-- [TaskRunSpec](#taskrunspec)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `breakpoints` _[TaskBreakpoints](#taskbreakpoints)_ |  |  | Optional: \{\} <br /> |
-
-
-
-
-
-
-#### TaskRunResult
-
-
-
-TaskRunResult used to describe the results of a task
-
-
-
-_Appears in:_
-- [TaskRunStatus](#taskrunstatus)
-- [TaskRunStatusFields](#taskrunstatusfields)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `name` _string_ | Name the given name |  |  |
-| `type` _[ResultsType](#resultstype)_ | Type is the user-specified type of the result. The possible type<br />is currently "string" and will support "array" in following work. |  | Optional: \{\} <br /> |
-| `value` _[ResultValue](#resultvalue)_ | Value the given value of the result |  | Schemaless: \{\} <br /> |
-
-
-#### TaskRunSidecarSpec
-
-
-
-TaskRunSidecarSpec is used to override the values of a Sidecar in the corresponding Task.
-
-
-
-_Appears in:_
-- [PipelineTaskRunSpec](#pipelinetaskrunspec)
-- [TaskRunSpec](#taskrunspec)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `name` _string_ | The name of the Sidecar to override. |  |  |
-| `computeResources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcerequirements-v1-core)_ | The resource requirements to apply to the Sidecar. |  |  |
-
-
-#### TaskRunSpec
-
-
-
-TaskRunSpec defines the desired state of TaskRun
-
-
-
-_Appears in:_
-- [TaskRun](#taskrun)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `debug` _[TaskRunDebug](#taskrundebug)_ |  |  | Optional: \{\} <br /> |
-| `params` _[Params](#params)_ |  |  | Optional: \{\} <br /> |
-| `serviceAccountName` _string_ |  |  | Optional: \{\} <br /> |
-| `taskRef` _[TaskRef](#taskref)_ | no more than one of the TaskRef and TaskSpec may be specified. |  | Optional: \{\} <br /> |
-| `taskSpec` _[TaskSpec](#taskspec)_ | Specifying TaskSpec can be disabled by setting<br />`disable-inline-spec` feature flag.<br />See Task.spec (API version: tekton.dev/v1) |  | Schemaless: \{\} <br />Optional: \{\} <br /> |
-| `status` _[TaskRunSpecStatus](#taskrunspecstatus)_ | Used for cancelling a TaskRun (and maybe more later on) |  | Optional: \{\} <br /> |
-| `statusMessage` _[TaskRunSpecStatusMessage](#taskrunspecstatusmessage)_ | Status message for cancellation. |  | Optional: \{\} <br /> |
-| `retries` _integer_ | Retries represents how many times this TaskRun should be retried in the event of task failure. |  | Optional: \{\} <br /> |
-| `timeout` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ | Time after which one retry attempt times out. Defaults to 1 hour.<br />Refer Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration |  | Optional: \{\} <br /> |
-| `podTemplate` _[PodTemplate](#podtemplate)_ | PodTemplate holds pod specific configuration |  |  |
-| `workspaces` _[WorkspaceBinding](#workspacebinding) array_ | Workspaces is a list of WorkspaceBindings from volumes to workspaces. |  | Optional: \{\} <br /> |
-| `stepSpecs` _[TaskRunStepSpec](#taskrunstepspec) array_ | Specs to apply to Steps in this TaskRun.<br />If a field is specified in both a Step and a StepSpec,<br />the value from the StepSpec will be used.<br />This field is only supported when the alpha feature gate is enabled. |  | Optional: \{\} <br /> |
-| `sidecarSpecs` _[TaskRunSidecarSpec](#taskrunsidecarspec) array_ | Specs to apply to Sidecars in this TaskRun.<br />If a field is specified in both a Sidecar and a SidecarSpec,<br />the value from the SidecarSpec will be used.<br />This field is only supported when the alpha feature gate is enabled. |  | Optional: \{\} <br /> |
-| `computeResources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcerequirements-v1-core)_ | Compute resources to use for this TaskRun |  |  |
-| `managedBy` _string_ | ManagedBy indicates which controller is responsible for reconciling<br />this resource. If unset or set to "tekton.dev/pipeline", the default<br />Tekton controller will manage this resource.<br />This field is immutable. |  | Optional: \{\} <br /> |
-
-
-#### TaskRunSpecStatus
-
-_Underlying type:_ _string_
-
-TaskRunSpecStatus defines the TaskRun spec status the user can provide
-
-
-
-_Appears in:_
-- [TaskRunSpec](#taskrunspec)
-
-
-
-#### TaskRunSpecStatusMessage
-
-_Underlying type:_ _string_
-
-TaskRunSpecStatusMessage defines human readable status messages for the TaskRun.
-
-
-
-_Appears in:_
-- [TaskRunSpec](#taskrunspec)
-
-| Field | Description |
-| --- | --- |
-| `TaskRun cancelled as the PipelineRun it belongs to has been cancelled.` | TaskRunCancelledByPipelineMsg indicates that the PipelineRun of which this<br />TaskRun was a part of has been cancelled.<br /> |
-| `TaskRun cancelled as the PipelineRun it belongs to has timed out.` | TaskRunCancelledByPipelineTimeoutMsg indicates that the TaskRun was cancelled because the PipelineRun running it timed out.<br /> |
-
-
-#### TaskRunStatus
-
-
-
-TaskRunStatus defines the observed state of TaskRun
-
-
-
-_Appears in:_
-- [PipelineRunTaskRunStatus](#pipelineruntaskrunstatus)
-- [RetriesStatus](#retriesstatus)
-- [TaskRun](#taskrun)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `observedGeneration` _integer_ | ObservedGeneration is the 'Generation' of the Service that<br />was last processed by the controller. |  | Optional: \{\} <br /> |
-| `conditions` _[Conditions](#conditions)_ | Conditions the latest available observations of a resource's current state. |  | Optional: \{\} <br /> |
-| `annotations` _object (keys:string, values:string)_ | Annotations is additional Status fields for the Resource to save some<br />additional State as well as convey more information to the user. This is<br />roughly akin to Annotations on any k8s resource, just the reconciler conveying<br />richer information outwards. |  |  |
-| `podName` _string_ | PodName is the name of the pod responsible for executing this task's steps. |  |  |
-| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | StartTime is the time the build is actually started. |  |  |
-| `completionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | CompletionTime is the time the build completed. |  |  |
-| `steps` _[StepState](#stepstate) array_ | Steps describes the state of each build step container. |  | Optional: \{\} <br /> |
-| `retriesStatus` _[RetriesStatus](#retriesstatus)_ | RetriesStatus contains the history of TaskRunStatus in case of a retry in order to keep record of failures.<br />All TaskRunStatus stored in RetriesStatus will have no date within the RetriesStatus as is redundant. |  | Schemaless: \{\} <br />Optional: \{\} <br /> |
-| `results` _[TaskRunResult](#taskrunresult) array_ | Results are the list of results written out by the task's containers |  | Optional: \{\} <br /> |
-| `artifacts` _[Artifacts](#artifacts)_ | Artifacts are the list of artifacts written out by the task's containers |  | Optional: \{\} <br /> |
-| `sidecars` _[SidecarState](#sidecarstate) array_ | The list has one entry per sidecar in the manifest. Each entry is<br />represents the imageid of the corresponding sidecar. |  |  |
-| `taskSpec` _[TaskSpec](#taskspec)_ | TaskSpec contains the Spec from the dereferenced Task definition used to instantiate this TaskRun. |  |  |
-| `provenance` _[Provenance](#provenance)_ | Provenance contains some key authenticated metadata about how a software artifact was built (what sources, what inputs/outputs, etc.). |  | Optional: \{\} <br /> |
-| `spanContext` _object (keys:string, values:string)_ | SpanContext contains tracing span context fields |  |  |
-
-
-#### TaskRunStatusFields
-
-
-
-TaskRunStatusFields holds the fields of TaskRun's status.  This is defined
-separately and inlined so that other types can readily consume these fields
-via duck typing.
-
-
-
-_Appears in:_
-- [TaskRunStatus](#taskrunstatus)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `podName` _string_ | PodName is the name of the pod responsible for executing this task's steps. |  |  |
-| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | StartTime is the time the build is actually started. |  |  |
-| `completionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | CompletionTime is the time the build completed. |  |  |
-| `steps` _[StepState](#stepstate) array_ | Steps describes the state of each build step container. |  | Optional: \{\} <br /> |
-| `retriesStatus` _[RetriesStatus](#retriesstatus)_ | RetriesStatus contains the history of TaskRunStatus in case of a retry in order to keep record of failures.<br />All TaskRunStatus stored in RetriesStatus will have no date within the RetriesStatus as is redundant. |  | Schemaless: \{\} <br />Optional: \{\} <br /> |
-| `results` _[TaskRunResult](#taskrunresult) array_ | Results are the list of results written out by the task's containers |  | Optional: \{\} <br /> |
-| `artifacts` _[Artifacts](#artifacts)_ | Artifacts are the list of artifacts written out by the task's containers |  | Optional: \{\} <br /> |
-| `sidecars` _[SidecarState](#sidecarstate) array_ | The list has one entry per sidecar in the manifest. Each entry is<br />represents the imageid of the corresponding sidecar. |  |  |
-| `taskSpec` _[TaskSpec](#taskspec)_ | TaskSpec contains the Spec from the dereferenced Task definition used to instantiate this TaskRun. |  |  |
-| `provenance` _[Provenance](#provenance)_ | Provenance contains some key authenticated metadata about how a software artifact was built (what sources, what inputs/outputs, etc.). |  | Optional: \{\} <br /> |
-| `spanContext` _object (keys:string, values:string)_ | SpanContext contains tracing span context fields |  |  |
-
-
-
-
-
-
-#### TaskRunStepSpec
-
-
-
-TaskRunStepSpec is used to override the values of a Step in the corresponding Task.
-
-
-
-_Appears in:_
-- [PipelineTaskRunSpec](#pipelinetaskrunspec)
-- [TaskRunSpec](#taskrunspec)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `name` _string_ | The name of the Step to override. |  |  |
-| `computeResources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcerequirements-v1-core)_ | The resource requirements to apply to the Step. |  |  |
-
-
-#### TaskSpec
-
-
-
-TaskSpec defines the desired state of Task.
-
-
-
-_Appears in:_
-- [EmbeddedTask](#embeddedtask)
-- [Task](#task)
-- [TaskRunSpec](#taskrunspec)
-- [TaskRunStatus](#taskrunstatus)
-- [TaskRunStatusFields](#taskrunstatusfields)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `params` _[ParamSpecs](#paramspecs)_ | Params is a list of input parameters required to run the task. Params<br />must be supplied as inputs in TaskRuns unless they declare a default<br />value. |  | Optional: \{\} <br /> |
-| `displayName` _string_ | DisplayName is a user-facing name of the task that may be<br />used to populate a UI. |  | Optional: \{\} <br /> |
-| `description` _string_ | Description is a user-facing description of the task that may be<br />used to populate a UI. |  | Optional: \{\} <br /> |
-| `steps` _[Step](#step) array_ | Steps are the steps of the build; each step is run sequentially with the<br />source mounted into /workspace. |  |  |
-| `volumes` _[Volumes](#volumes)_ | Volumes is a collection of volumes that are available to mount into the<br />steps of the build.<br />See Pod.spec.volumes (API version: v1) |  | Schemaless: \{\} <br /> |
-| `stepTemplate` _[StepTemplate](#steptemplate)_ | StepTemplate can be used as the basis for all step containers within the<br />Task, so that the steps inherit settings on the base container. |  |  |
-| `sidecars` _[Sidecar](#sidecar) array_ | Sidecars are run alongside the Task's step containers. They begin before<br />the steps start and end after the steps complete. |  |  |
-| `workspaces` _[WorkspaceDeclaration](#workspacedeclaration) array_ | Workspaces are the volumes that this Task requires. |  |  |
-| `results` _[TaskResult](#taskresult) array_ | Results are values that this Task can output |  |  |
-
-
-#### TimeoutFields
-
-
-
-TimeoutFields allows granular specification of pipeline, task, and finally timeouts
-
-
-
-_Appears in:_
-- [PipelineRunSpec](#pipelinerunspec)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `pipeline` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ | Pipeline sets the maximum allowed duration for execution of the entire pipeline. The sum of individual timeouts for tasks and finally must not exceed this value. |  |  |
-| `tasks` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ | Tasks sets the maximum allowed duration of this pipeline's tasks |  |  |
-| `finally` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ | Finally sets the maximum allowed duration of this pipeline's finally |  |  |
-
-
-#### Volumes
-
-_Underlying type:_ _[Volume](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#volume-v1-core)_
-
-
-
-
-
-_Appears in:_
-- [EmbeddedTask](#embeddedtask)
-- [TaskSpec](#taskspec)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `name` _string_ | name of the volume.<br />Must be a DNS_LABEL and unique within the pod.<br />More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names |  |  |
-| `hostPath` _[HostPathVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#hostpathvolumesource-v1-core)_ | hostPath represents a pre-existing file or directory on the host<br />machine that is directly exposed to the container. This is generally<br />used for system agents or other privileged things that are allowed<br />to see the host machine. Most containers will NOT need this.<br />More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath |  | Optional: \{\} <br /> |
-| `emptyDir` _[EmptyDirVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#emptydirvolumesource-v1-core)_ | emptyDir represents a temporary directory that shares a pod's lifetime.<br />More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir |  | Optional: \{\} <br /> |
-| `gcePersistentDisk` _[GCEPersistentDiskVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#gcepersistentdiskvolumesource-v1-core)_ | gcePersistentDisk represents a GCE Disk resource that is attached to a<br />kubelet's host machine and then exposed to the pod.<br />Deprecated: GCEPersistentDisk is deprecated. All operations for the in-tree<br />gcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.<br />More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk |  | Optional: \{\} <br /> |
-| `awsElasticBlockStore` _[AWSElasticBlockStoreVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#awselasticblockstorevolumesource-v1-core)_ | awsElasticBlockStore represents an AWS Disk resource that is attached to a<br />kubelet's host machine and then exposed to the pod.<br />Deprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree<br />awsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.<br />More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore |  | Optional: \{\} <br /> |
-| `gitRepo` _[GitRepoVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#gitrepovolumesource-v1-core)_ | gitRepo represents a git repository at a particular revision.<br />Deprecated: GitRepo is deprecated. To provision a container with a git repo, mount an<br />EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir<br />into the Pod's container. |  | Optional: \{\} <br /> |
-| `secret` _[SecretVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#secretvolumesource-v1-core)_ | secret represents a secret that should populate this volume.<br />More info: https://kubernetes.io/docs/concepts/storage/volumes#secret |  | Optional: \{\} <br /> |
-| `nfs` _[NFSVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#nfsvolumesource-v1-core)_ | nfs represents an NFS mount on the host that shares a pod's lifetime<br />More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs |  | Optional: \{\} <br /> |
-| `iscsi` _[ISCSIVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#iscsivolumesource-v1-core)_ | iscsi represents an ISCSI Disk resource that is attached to a<br />kubelet's host machine and then exposed to the pod.<br />More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi |  | Optional: \{\} <br /> |
-| `glusterfs` _[GlusterfsVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#glusterfsvolumesource-v1-core)_ | glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.<br />Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported. |  | Optional: \{\} <br /> |
-| `persistentVolumeClaim` _[PersistentVolumeClaimVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#persistentvolumeclaimvolumesource-v1-core)_ | persistentVolumeClaimVolumeSource represents a reference to a<br />PersistentVolumeClaim in the same namespace.<br />More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims |  | Optional: \{\} <br /> |
-| `rbd` _[RBDVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#rbdvolumesource-v1-core)_ | rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.<br />Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported. |  | Optional: \{\} <br /> |
-| `flexVolume` _[FlexVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#flexvolumesource-v1-core)_ | flexVolume represents a generic volume resource that is<br />provisioned/attached using an exec based plugin.<br />Deprecated: FlexVolume is deprecated. Consider using a CSIDriver instead. |  | Optional: \{\} <br /> |
-| `cinder` _[CinderVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#cindervolumesource-v1-core)_ | cinder represents a cinder volume attached and mounted on kubelets host machine.<br />Deprecated: Cinder is deprecated. All operations for the in-tree cinder type<br />are redirected to the cinder.csi.openstack.org CSI driver.<br />More info: https://examples.k8s.io/mysql-cinder-pd/README.md |  | Optional: \{\} <br /> |
-| `cephfs` _[CephFSVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#cephfsvolumesource-v1-core)_ | cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.<br />Deprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported. |  | Optional: \{\} <br /> |
-| `flocker` _[FlockerVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#flockervolumesource-v1-core)_ | flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.<br />Deprecated: Flocker is deprecated and the in-tree flocker type is no longer supported. |  | Optional: \{\} <br /> |
-| `downwardAPI` _[DownwardAPIVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#downwardapivolumesource-v1-core)_ | downwardAPI represents downward API about the pod that should populate this volume |  | Optional: \{\} <br /> |
-| `fc` _[FCVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#fcvolumesource-v1-core)_ | fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod. |  | Optional: \{\} <br /> |
-| `azureFile` _[AzureFileVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#azurefilevolumesource-v1-core)_ | azureFile represents an Azure File Service mount on the host and bind mount to the pod.<br />Deprecated: AzureFile is deprecated. All operations for the in-tree azureFile type<br />are redirected to the file.csi.azure.com CSI driver. |  | Optional: \{\} <br /> |
-| `configMap` _[ConfigMapVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#configmapvolumesource-v1-core)_ | configMap represents a configMap that should populate this volume |  | Optional: \{\} <br /> |
-| `vsphereVolume` _[VsphereVirtualDiskVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#vspherevirtualdiskvolumesource-v1-core)_ | vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.<br />Deprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type<br />are redirected to the csi.vsphere.vmware.com CSI driver. |  | Optional: \{\} <br /> |
-| `quobyte` _[QuobyteVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#quobytevolumesource-v1-core)_ | quobyte represents a Quobyte mount on the host that shares a pod's lifetime.<br />Deprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported. |  | Optional: \{\} <br /> |
-| `azureDisk` _[AzureDiskVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#azurediskvolumesource-v1-core)_ | azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.<br />Deprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type<br />are redirected to the disk.csi.azure.com CSI driver. |  | Optional: \{\} <br /> |
-| `photonPersistentDisk` _[PhotonPersistentDiskVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#photonpersistentdiskvolumesource-v1-core)_ | photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.<br />Deprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported. |  |  |
-| `projected` _[ProjectedVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#projectedvolumesource-v1-core)_ | projected items for all in one resources secrets, configmaps, and downward API |  |  |
-| `portworxVolume` _[PortworxVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#portworxvolumesource-v1-core)_ | portworxVolume represents a portworx volume attached and mounted on kubelets host machine.<br />Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type<br />are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate<br />is on. |  | Optional: \{\} <br /> |
-| `scaleIO` _[ScaleIOVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#scaleiovolumesource-v1-core)_ | scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.<br />Deprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported. |  | Optional: \{\} <br /> |
-| `storageos` _[StorageOSVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#storageosvolumesource-v1-core)_ | storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.<br />Deprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported. |  | Optional: \{\} <br /> |
-| `csi` _[CSIVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#csivolumesource-v1-core)_ | csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers. |  | Optional: \{\} <br /> |
-| `ephemeral` _[EphemeralVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#ephemeralvolumesource-v1-core)_ | ephemeral represents a volume that is handled by a cluster storage driver.<br />The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,<br />and deleted when the pod is removed.<br />Use this if:<br />a) the volume is only needed while the pod runs,<br />b) features of normal volumes like restoring from snapshot or capacity<br />   tracking are needed,<br />c) the storage driver is specified through a storage class, and<br />d) the storage driver supports dynamic volume provisioning through<br />   a PersistentVolumeClaim (see EphemeralVolumeSource for more<br />   information on the connection between this volume type<br />   and PersistentVolumeClaim).<br />Use PersistentVolumeClaim or one of the vendor-specific<br />APIs for volumes that persist for longer than the lifecycle<br />of an individual pod.<br />Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to<br />be used that way - see the documentation of the driver for<br />more information.<br />A pod can use both types of ephemeral volumes and<br />persistent volumes at the same time. |  | Optional: \{\} <br /> |
-| `image` _[ImageVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#imagevolumesource-v1-core)_ | image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.<br />The volume is resolved at pod startup depending on which PullPolicy value is provided:<br />- Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.<br />- Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.<br />- IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.<br />The volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.<br />A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.<br />The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.<br />The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.<br />The volume will be mounted read-only (ro) and non-executable files (noexec).<br />Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.<br />The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type. |  | Optional: \{\} <br /> |
-
-
-#### WhenExpression
-
-
-
-WhenExpression allows a PipelineTask to declare expressions to be evaluated before the Task is run
-to determine whether the Task should be executed or skipped
-
-
-
-_Appears in:_
-- [ChildStatusReference](#childstatusreference)
-- [PipelineRunRunStatus](#pipelinerunrunstatus)
-- [PipelineRunTaskRunStatus](#pipelineruntaskrunstatus)
-- [SkippedTask](#skippedtask)
-- [WhenExpressions](#whenexpressions)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `input` _string_ | Input is the string for guard checking which can be a static input or an output from a parent Task |  |  |
-| `operator` _[Operator](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#operator-selection-pkg)_ | Operator that represents an Input's relationship to the values |  |  |
-| `values` _string array_ | Values is an array of strings, which is compared against the input, for guard checking<br />It must be non-empty |  |  |
-| `cel` _string_ | CEL is a string of Common Language Expression, which can be used to conditionally execute<br />the task based on the result of the expression evaluation<br />More info about CEL syntax: https://github.com/google/cel-spec/blob/master/doc/langdef.md |  | Optional: \{\} <br /> |
-
-
-#### WhenExpressions
-
-_Underlying type:_ _[WhenExpression](#whenexpression)_
-
-WhenExpressions are used to specify whether a Task should be executed or skipped
-All of them need to evaluate to True for a guarded Task to be executed.
-
-
-
-_Appears in:_
-- [PipelineTask](#pipelinetask)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `input` _string_ | Input is the string for guard checking which can be a static input or an output from a parent Task |  |  |
-| `operator` _[Operator](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#operator-selection-pkg)_ | Operator that represents an Input's relationship to the values |  |  |
-| `values` _string array_ | Values is an array of strings, which is compared against the input, for guard checking<br />It must be non-empty |  |  |
-| `cel` _string_ | CEL is a string of Common Language Expression, which can be used to conditionally execute<br />the task based on the result of the expression evaluation<br />More info about CEL syntax: https://github.com/google/cel-spec/blob/master/doc/langdef.md |  | Optional: \{\} <br /> |
-
-
-#### WorkspaceBinding
-
-
-
-WorkspaceBinding maps a Task's declared workspace to a Volume.
-
-
-
-_Appears in:_
-- [PipelineRunSpec](#pipelinerunspec)
-- [TaskRunSpec](#taskrunspec)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `name` _string_ | Name is the name of the workspace populated by the volume. |  |  |
-| `subPath` _string_ | SubPath is optionally a directory on the volume which should be used<br />for this binding (i.e. the volume will be mounted at this sub directory). |  | Optional: \{\} <br /> |
-| `volumeClaimTemplate` _[PersistentVolumeClaim](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#persistentvolumeclaim-v1-core)_ | VolumeClaimTemplate is a template for a claim that will be created in the same namespace.<br />The PipelineRun controller is responsible for creating a unique claim for each instance of PipelineRun.<br />See PersistentVolumeClaim (API version: v1) |  | Schemaless: \{\} <br />Optional: \{\} <br /> |
-| `persistentVolumeClaim` _[PersistentVolumeClaimVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#persistentvolumeclaimvolumesource-v1-core)_ | PersistentVolumeClaimVolumeSource represents a reference to a<br />PersistentVolumeClaim in the same namespace. Either this OR EmptyDir can be used. |  | Optional: \{\} <br /> |
-| `emptyDir` _[EmptyDirVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#emptydirvolumesource-v1-core)_ | EmptyDir represents a temporary directory that shares a Task's lifetime.<br />More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir<br />Either this OR PersistentVolumeClaim can be used. |  | Optional: \{\} <br /> |
-| `configMap` _[ConfigMapVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#configmapvolumesource-v1-core)_ | ConfigMap represents a configMap that should populate this workspace. |  | Optional: \{\} <br /> |
-| `secret` _[SecretVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#secretvolumesource-v1-core)_ | Secret represents a secret that should populate this workspace. |  | Optional: \{\} <br /> |
-| `projected` _[ProjectedVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#projectedvolumesource-v1-core)_ | Projected represents a projected volume that should populate this workspace. |  | Optional: \{\} <br /> |
-| `csi` _[CSIVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#csivolumesource-v1-core)_ | CSI (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers. |  | Optional: \{\} <br /> |
-
-
-#### WorkspaceDeclaration
-
-
-
-WorkspaceDeclaration is a declaration of a volume that a Task requires.
-
-
-
-_Appears in:_
-- [EmbeddedTask](#embeddedtask)
-- [TaskSpec](#taskspec)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `name` _string_ | Name is the name by which you can bind the volume at runtime. |  |  |
-| `description` _string_ | Description is an optional human readable description of this volume. |  | Optional: \{\} <br /> |
-| `mountPath` _string_ | MountPath overrides the directory that the volume will be made available at. |  | Optional: \{\} <br /> |
-| `readOnly` _boolean_ | ReadOnly dictates whether a mounted volume is writable. By default this<br />field is false and so mounted volumes are writable. |  |  |
-| `optional` _boolean_ | Optional marks a Workspace as not being required in TaskRuns. By default<br />this field is false and so declared workspaces are required. |  |  |
-
-
-
-
-#### WorkspacePipelineTaskBinding
-
-
-
-WorkspacePipelineTaskBinding describes how a workspace passed into the pipeline should be
-mapped to a task's declared workspace.
-
-
-
-_Appears in:_
-- [PipelineTask](#pipelinetask)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `name` _string_ | Name is the name of the workspace as declared by the task |  |  |
-| `workspace` _string_ | Workspace is the name of the workspace declared by the pipeline |  | Optional: \{\} <br /> |
-| `subPath` _string_ | SubPath is optionally a directory on the volume which should be used<br />for this binding (i.e. the volume will be mounted at this sub directory). |  | Optional: \{\} <br /> |
-
-
-#### WorkspaceUsage
-
-
-
-WorkspaceUsage is used by a Step or Sidecar to declare that it wants isolated access
-to a Workspace defined in a Task.
-
-
-
-_Appears in:_
-- [Sidecar](#sidecar)
-- [Step](#step)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `name` _string_ | Name is the name of the workspace this Step or Sidecar wants access to. |  |  |
-| `mountPath` _string_ | MountPath is the path that the workspace should be mounted to inside the Step or Sidecar,<br />overriding any MountPath specified in the Task's WorkspaceDeclaration. |  |  |
-
-
-
-## tekton.dev/v1alpha1
-
-Package v1alpha1 contains API Schema definitions for the run v1alpha1 API group
-
-### Resource Types
-- [PipelineResource](#pipelineresource)
-- [Run](#run)
-- [StepAction](#stepaction)
-- [VerificationPolicy](#verificationpolicy)
-
-
-
-#### Authority
-
-
-
-The Authority block defines the keys for validating signatures.
-
-
-
-_Appears in:_
-- [VerificationPolicySpec](#verificationpolicyspec)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `name` _string_ | Name is the name for this authority. |  |  |
-| `key` _[KeyRef](#keyref)_ | Key contains the public key to validate the resource. |  |  |
-
-
-#### EmbeddedRunSpec
-
-
-
-EmbeddedRunSpec allows custom task definitions to be embedded
-
-
-
-_Appears in:_
-- [RunSpec](#runspec)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `metadata` _[PipelineTaskMetadata](#pipelinetaskmetadata)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  | Optional: \{\} <br /> |
-| `spec` _[RawExtension](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#rawextension-runtime-pkg)_ | Spec is a specification of a custom task |  | Optional: \{\} <br /> |
-
-
-#### HashAlgorithm
-
-_Underlying type:_ _string_
-
-HashAlgorithm defines the hash algorithm used for the public key
-
-
-
-_Appears in:_
-- [KeyRef](#keyref)
-
-| Field | Description |
-| --- | --- |
-| `sha224` |  |
-| `sha256` |  |
-| `sha384` |  |
-| `sha512` |  |
-| `` |  |
-
-
-#### KeyRef
-
-
-
-KeyRef defines the reference to a public key
-
-
-
-_Appears in:_
-- [Authority](#authority)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `secretRef` _[SecretReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#secretreference-v1-core)_ | SecretRef sets a reference to a secret with the key. |  | Optional: \{\} <br /> |
-| `data` _string_ | Data contains the inline public key. |  | Optional: \{\} <br /> |
-| `kms` _string_ | KMS contains the KMS url of the public key<br />Supported formats differ based on the KMS system used.<br />One example of a KMS url could be:<br />gcpkms://projects/[PROJECT]/locations/[LOCATION]>/keyRings/[KEYRING]/cryptoKeys/[KEY]/cryptoKeyVersions/[KEY_VERSION]<br />For more examples please refer https://docs.sigstore.dev/cosign/kms_support.<br />Note that the KMS is not supported yet. |  | Optional: \{\} <br /> |
-| `hashAlgorithm` _[HashAlgorithm](#hashalgorithm)_ | HashAlgorithm always defaults to sha256 if the algorithm hasn't been explicitly set |  | Optional: \{\} <br /> |
-
-
-#### ModeType
-
-_Underlying type:_ _string_
-
-ModeType indicates the type of a mode for VerificationPolicy
-
-
-
-_Appears in:_
-- [VerificationPolicySpec](#verificationpolicyspec)
-
-| Field | Description |
-| --- | --- |
-| `warn` |  |
-| `enforce` |  |
-
-
-#### PipelineResource
-
-
-
-PipelineResource describes a resource that is an input to or output from a
-Task.
-
-Deprecated: Unused, preserved only for backwards compatibility
-
-
-
-
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `tekton.dev/v1alpha1` | | |
-| `kind` _string_ | `PipelineResource` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  | Optional: \{\} <br /> |
-| `spec` _[PipelineResourceSpec](#pipelineresourcespec)_ | Spec holds the desired state of the PipelineResource from the client |  |  |
-| `status` _[PipelineResourceStatus](#pipelineresourcestatus)_ | Status is used to communicate the observed state of the PipelineResource from<br />the controller, but was unused as there is no controller for PipelineResource. |  | Optional: \{\} <br /> |
-
-
-#### PipelineResourceSpec
-
-
-
-PipelineResourceSpec defines an individual resources used in the pipeline.
-
-Deprecated: Unused, preserved only for backwards compatibility
-
-
-
-_Appears in:_
-- [PipelineResource](#pipelineresource)
-- [PipelineResourceBinding](#pipelineresourcebinding)
-- [TaskResourceBinding](#taskresourcebinding)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `description` _string_ | Description is a user-facing description of the resource that may be<br />used to populate a UI. |  | Optional: \{\} <br /> |
-| `type` _[PipelineResourceType](#pipelineresourcetype)_ |  |  |  |
-| `params` _[ResourceParam](#resourceparam) array_ |  |  |  |
-| `secrets` _[SecretParam](#secretparam) array_ | Secrets to fetch to populate some of resource fields |  | Optional: \{\} <br /> |
-
-
-#### PipelineResourceStatus
-
-
-
-PipelineResourceStatus does not contain anything because PipelineResources on their own
-do not have a status
-
-Deprecated: Unused, preserved only for backwards compatibility
-
-
-
-_Appears in:_
-- [PipelineResource](#pipelineresource)
-
-
-
-
-
-
-
-#### ResourceParam
-
-
-
-ResourceParam declares a string value to use for the parameter called Name, and is used in
-the specific context of PipelineResources.
-
-Deprecated: Unused, preserved only for backwards compatibility
-
-
-
-_Appears in:_
-- [PipelineResourceSpec](#pipelineresourcespec)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `name` _string_ |  |  |  |
-| `value` _string_ |  |  |  |
-
-
-#### ResourcePattern
-
-
-
-ResourcePattern defines the pattern of the resource source
-
-
-
-_Appears in:_
-- [VerificationPolicySpec](#verificationpolicyspec)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `pattern` _string_ | Pattern defines a resource pattern. Regex is created to filter resources based on `Pattern`<br />Example patterns:<br />GitHub resource: https://github.com/tektoncd/catalog.git, https://github.com/tektoncd/*<br />Bundle resource: gcr.io/tekton-releases/catalog/upstream/git-clone, gcr.io/tekton-releases/catalog/upstream/*<br />Hub resource: https://artifacthub.io/*, |  |  |
-
-
-#### Run
-
-
-
-Run represents a single execution of a Custom Task.
-
-
-
-
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `tekton.dev/v1alpha1` | | |
-| `kind` _string_ | `Run` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  | Optional: \{\} <br /> |
-| `spec` _[RunSpec](#runspec)_ |  |  | Optional: \{\} <br /> |
-| `status` _[RunStatus](#runstatus)_ |  |  | Optional: \{\} <br /> |
-
-
-
-
-
-
-#### RunSpec
-
-
-
-RunSpec defines the desired state of Run
-
-
-
-_Appears in:_
-- [Run](#run)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `ref` _[TaskRef](#taskref)_ |  |  | Optional: \{\} <br /> |
-| `spec` _[EmbeddedRunSpec](#embeddedrunspec)_ | Spec is a specification of a custom task |  | Optional: \{\} <br /> |
-| `params` _[Params](#params)_ |  |  | Optional: \{\} <br /> |
-| `status` _[RunSpecStatus](#runspecstatus)_ | Used for cancelling a run (and maybe more later on) |  | Optional: \{\} <br /> |
-| `statusMessage` _[RunSpecStatusMessage](#runspecstatusmessage)_ | Status message for cancellation. |  | Optional: \{\} <br /> |
-| `retries` _integer_ | Used for propagating retries count to custom tasks |  | Optional: \{\} <br /> |
-| `serviceAccountName` _string_ |  |  | Optional: \{\} <br /> |
-| `podTemplate` _[PodTemplate](#podtemplate)_ | PodTemplate holds pod specific configuration |  | Optional: \{\} <br /> |
-| `timeout` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ | Time after which the custom-task times out.<br />Refer Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration |  | Optional: \{\} <br /> |
-| `workspaces` _[WorkspaceBinding](#workspacebinding) array_ | Workspaces is a list of WorkspaceBindings from volumes to workspaces. |  | Optional: \{\} <br /> |
-
-
-#### RunSpecStatus
-
-_Underlying type:_ _string_
-
-RunSpecStatus defines the taskrun spec status the user can provide
-
-
-
-_Appears in:_
-- [RunSpec](#runspec)
-
-| Field | Description |
-| --- | --- |
-| `RunCancelled` | RunSpecStatusCancelled indicates that the user wants to cancel the run,<br />if not already cancelled or terminated<br /> |
-
-
-#### RunSpecStatusMessage
-
-_Underlying type:_ _string_
-
-RunSpecStatusMessage defines human readable status messages for the TaskRun.
-
-
-
-_Appears in:_
-- [RunSpec](#runspec)
-
-| Field | Description |
-| --- | --- |
-| `Run cancelled as the PipelineRun it belongs to has been cancelled.` | RunCancelledByPipelineMsg indicates that the PipelineRun of which part this Run was<br />has been cancelled.<br /> |
-| `Run cancelled as the PipelineRun it belongs to has timed out.` | RunCancelledByPipelineTimeoutMsg indicates that the Run was cancelled because the PipelineRun running it timed out.<br /> |
-
-
-
-
-
-
-#### SecretParam
-
-
-
-SecretParam indicates which secret can be used to populate a field of the resource
-
-Deprecated: Unused, preserved only for backwards compatibility
-
-
-
-_Appears in:_
-- [PipelineResourceSpec](#pipelineresourcespec)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `fieldName` _string_ |  |  |  |
-| `secretKey` _string_ |  |  |  |
-| `secretName` _string_ |  |  |  |
-
-
-#### StepAction
-
-
-
-StepAction represents the actionable components of Step.
-The Step can only reference it from the cluster or using remote resolution.
-
-
-
-
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `tekton.dev/v1alpha1` | | |
-| `kind` _string_ | `StepAction` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  | Optional: \{\} <br /> |
-| `spec` _[StepActionSpec](#stepactionspec)_ | Spec holds the desired state of the Step from the client |  | Optional: \{\} <br /> |
-
-
-
-
-#### StepActionSpec
-
-
-
-StepActionSpec contains the actionable components of a step.
-
-
-
-_Appears in:_
-- [StepAction](#stepaction)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `description` _string_ | Description is a user-facing description of the stepaction that may be<br />used to populate a UI. |  | Optional: \{\} <br /> |
-| `image` _string_ | Image reference name to run for this StepAction.<br />More info: https://kubernetes.io/docs/concepts/containers/images |  | Optional: \{\} <br /> |
-| `command` _string array_ | Entrypoint array. Not executed within a shell.<br />The image's ENTRYPOINT is used if this is not provided.<br />Variable references $(VAR_NAME) are expanded using the container's environment. If a variable<br />cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced<br />to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will<br />produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless<br />of whether the variable exists or not. Cannot be updated.<br />More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell |  | Optional: \{\} <br /> |
-| `args` _string array_ | Arguments to the entrypoint.<br />The image's CMD is used if this is not provided.<br />Variable references $(VAR_NAME) are expanded using the container's environment. If a variable<br />cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced<br />to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will<br />produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless<br />of whether the variable exists or not. Cannot be updated.<br />More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell |  | Optional: \{\} <br /> |
-| `env` _[EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#envvar-v1-core) array_ | List of environment variables to set in the container.<br />Cannot be updated. |  | Optional: \{\} <br /> |
-| `script` _string_ | Script is the contents of an executable file to execute.<br />If Script is not empty, the Step cannot have an Command and the Args will be passed to the Script. |  | Optional: \{\} <br /> |
-| `workingDir` _string_ | Step's working directory.<br />If not specified, the container runtime's default will be used, which<br />might be configured in the container image.<br />Cannot be updated. |  | Optional: \{\} <br /> |
-| `params` _[ParamSpecs](#paramspecs)_ | Params is a list of input parameters required to run the stepAction.<br />Params must be supplied as inputs in Steps unless they declare a defaultvalue. |  | Optional: \{\} <br /> |
-| `results` _[StepResult](#stepresult) array_ | Results are values that this StepAction can output |  | Optional: \{\} <br /> |
-| `securityContext` _[SecurityContext](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#securitycontext-v1-core)_ | SecurityContext defines the security options the Step should be run with.<br />If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.<br />More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/<br />The value set in StepAction will take precedence over the value from Task. |  | Optional: \{\} <br /> |
-| `volumeMounts` _[VolumeMount](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#volumemount-v1-core) array_ | Volumes to mount into the Step's filesystem.<br />Cannot be updated. |  | Optional: \{\} <br /> |
-
-
-#### VerificationPolicy
-
-
-
-VerificationPolicy defines the rules to verify Tekton resources.
-VerificationPolicy can config the mapping from resources to a list of public
-keys, so when verifying the resources we can use the corresponding public keys.
-
-
-
-
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `tekton.dev/v1alpha1` | | |
-| `kind` _string_ | `VerificationPolicy` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  | Optional: \{\} <br /> |
-| `spec` _[VerificationPolicySpec](#verificationpolicyspec)_ | Spec holds the desired state of the VerificationPolicy. |  |  |
-
-
-#### VerificationPolicySpec
-
-
-
-VerificationPolicySpec defines the patterns and authorities.
-
-
-
-_Appears in:_
-- [VerificationPolicy](#verificationpolicy)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `resources` _[ResourcePattern](#resourcepattern) array_ | Resources defines the patterns of resources sources that should be subject to this policy.<br />For example, we may want to apply this Policy from a certain GitHub repo.<br />Then the ResourcesPattern should be valid regex. E.g. If using gitresolver, and we want to config keys from a certain git repo.<br />`ResourcesPattern` can be `https://github.com/tektoncd/catalog.git`, we will use regex to filter out those resources. |  |  |
-| `authorities` _[Authority](#authority) array_ | Authorities defines the rules for validating signatures. |  |  |
-| `mode` _[ModeType](#modetype)_ | Mode controls whether a failing policy will fail the taskrun/pipelinerun, or only log the warnings<br />enforce - fail the taskrun/pipelinerun if verification fails (default)<br />warn - don't fail the taskrun/pipelinerun if verification fails but log warnings |  | Optional: \{\} <br /> |
-
-
-
-## tekton.dev/v1beta1
-
-Package v1beta1 contains API Schema definitions for the customrun v1beta1 API group
-
-### Resource Types
-- [CustomRun](#customrun)
-- [Pipeline](#pipeline)
-- [PipelineRun](#pipelinerun)
-- [StepAction](#stepaction)
-- [Task](#task)
-- [TaskRun](#taskrun)
-
-
-
-#### Algorithm
-
-_Underlying type:_ _string_
-
-Algorithm Standard cryptographic hash algorithm
-
-
-
-_Appears in:_
-- [ArtifactValue](#artifactvalue)
-
-
-
-#### Args
-
-_Underlying type:_ _string array_
-
-
-
-
-
-_Appears in:_
-- [StepActionSpec](#stepactionspec)
-
-
-
-
-
-#### Artifact
-
-
-
-Artifact represents an artifact within a system, potentially containing multiple values
-associated with it.
-
-
-
-_Appears in:_
-- [Artifacts](#artifacts)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `name` _string_ | The artifact's identifying category name |  |  |
-| `values` _[ArtifactValue](#artifactvalue) array_ | A collection of values related to the artifact |  |  |
-| `buildOutput` _boolean_ | Indicate if the artifact is a build output or a by-product |  |  |
-
-
-#### ArtifactValue
-
-
-
-ArtifactValue represents a specific value or data element within an Artifact.
-
-
-
-_Appears in:_
-- [Artifact](#artifact)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `digest` _object (keys:[Algorithm](#algorithm), values:string)_ |  |  |  |
-| `uri` _string_ |  |  |  |
-
-
-
-
-#### ChildStatusReference
-
-
-
-ChildStatusReference is used to point to the statuses of individual TaskRuns and Runs within this PipelineRun.
-
-
-
-_Appears in:_
-- [PipelineRunStatus](#pipelinerunstatus)
-- [PipelineRunStatusFields](#pipelinerunstatusfields)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `name` _string_ | Name is the name of the TaskRun or Run this is referencing. |  |  |
-| `displayName` _string_ | DisplayName is a user-facing name of the pipelineTask that may be<br />used to populate a UI. |  |  |
-| `pipelineTaskName` _string_ | PipelineTaskName is the name of the PipelineTask this is referencing. |  |  |
-| `whenExpressions` _[WhenExpression](#whenexpression) array_ | WhenExpressions is the list of checks guarding the execution of the PipelineTask |  | Optional: \{\} <br /> |
-
-
-#### CloudEventCondition
-
-_Underlying type:_ _string_
-
-CloudEventCondition is a string that represents the condition of the event.
-
-
-
-_Appears in:_
-- [CloudEventDeliveryState](#cloudeventdeliverystate)
-
-| Field | Description |
-| --- | --- |
-| `Unknown` | CloudEventConditionUnknown means that the condition for the event to be<br />triggered was not met yet, or we don't know the state yet.<br /> |
-| `Sent` | CloudEventConditionSent means that the event was sent successfully<br /> |
-| `Failed` | CloudEventConditionFailed means that there was one or more attempts to<br />send the event, and none was successful so far.<br /> |
-
-
-#### CloudEventDelivery
-
-
-
-CloudEventDelivery is the target of a cloud event along with the state of
-delivery.
-
-
-
-_Appears in:_
-- [TaskRunStatus](#taskrunstatus)
-- [TaskRunStatusFields](#taskrunstatusfields)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `target` _string_ | Target points to an addressable |  |  |
-| `status` _[CloudEventDeliveryState](#cloudeventdeliverystate)_ |  |  |  |
-
-
-#### CloudEventDeliveryState
-
-
-
-CloudEventDeliveryState reports the state of a cloud event to be sent.
-
-
-
-_Appears in:_
-- [CloudEventDelivery](#cloudeventdelivery)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `condition` _[CloudEventCondition](#cloudeventcondition)_ | Current status |  |  |
-| `sentAt` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | SentAt is the time at which the last attempt to send the event was made |  | Optional: \{\} <br /> |
-| `message` _string_ | Error is the text of error (if any) |  |  |
-| `retryCount` _integer_ | RetryCount is the number of attempts of sending the cloud event |  |  |
-
-
-#### Combination
-
-_Underlying type:_ _object_
-
-Combination is a map, mainly defined to hold a single combination from a Matrix with key as param.Name and value as param.Value
-
-
-
-_Appears in:_
-- [Combinations](#combinations)
-
-
-
-
-
-#### ConfigSource
-
-
-
-ConfigSource contains the information that can uniquely identify where a remote
-built definition came from i.e. Git repositories, Tekton Bundles in OCI registry
-and hub.
-
-
-
-_Appears in:_
-- [Provenance](#provenance)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `uri` _string_ | URI indicates the identity of the source of the build definition.<br />Example: "https://github.com/tektoncd/catalog" |  |  |
-| `digest` _object (keys:string, values:string)_ | Digest is a collection of cryptographic digests for the contents of the artifact specified by URI.<br />Example: \{"sha1": "f99d13e554ffcb696dee719fa85b695cb5b0f428"\} |  |  |
-| `entryPoint` _string_ | EntryPoint identifies the entry point into the build. This is often a path to a<br />build definition file and/or a target label within that file.<br />Example: "task/git-clone/0.10/git-clone.yaml" |  |  |
-
-
-#### CustomRun
-
-
-
-CustomRun represents a single execution of a Custom Task.
-
-
-
-
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `tekton.dev/v1beta1` | | |
-| `kind` _string_ | `CustomRun` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  | Optional: \{\} <br /> |
-| `spec` _[CustomRunSpec](#customrunspec)_ |  |  | Optional: \{\} <br /> |
-| `status` _[CustomRunStatus](#customrunstatus)_ |  |  | Optional: \{\} <br /> |
-
-
-
-
-
-
-#### CustomRunSpec
-
-
-
-CustomRunSpec defines the desired state of CustomRun
-
-
-
-_Appears in:_
-- [CustomRun](#customrun)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `customRef` _[TaskRef](#taskref)_ |  |  | Optional: \{\} <br /> |
-| `customSpec` _[EmbeddedCustomRunSpec](#embeddedcustomrunspec)_ | Spec is a specification of a custom task |  | Optional: \{\} <br /> |
-| `params` _[Params](#params)_ |  |  | Optional: \{\} <br /> |
-| `status` _[CustomRunSpecStatus](#customrunspecstatus)_ | Used for cancelling a customrun (and maybe more later on) |  | Optional: \{\} <br /> |
-| `statusMessage` _[CustomRunSpecStatusMessage](#customrunspecstatusmessage)_ | Status message for cancellation. |  | Optional: \{\} <br /> |
-| `retries` _integer_ | Used for propagating retries count to custom tasks |  | Optional: \{\} <br /> |
-| `serviceAccountName` _string_ |  |  | Optional: \{\} <br /> |
-| `timeout` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ | Time after which the custom-task times out.<br />Refer Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration |  | Optional: \{\} <br /> |
-| `workspaces` _[WorkspaceBinding](#workspacebinding) array_ | Workspaces is a list of WorkspaceBindings from volumes to workspaces. |  | Optional: \{\} <br /> |
-
-
-#### CustomRunSpecStatus
-
-_Underlying type:_ _string_
-
-CustomRunSpecStatus defines the taskrun spec status the user can provide
-
-
-
-_Appears in:_
-- [CustomRunSpec](#customrunspec)
-
-| Field | Description |
-| --- | --- |
-| `RunCancelled` | CustomRunSpecStatusCancelled indicates that the user wants to cancel the run,<br />if not already cancelled or terminated<br /> |
-
-
-#### CustomRunSpecStatusMessage
-
-_Underlying type:_ _string_
-
-CustomRunSpecStatusMessage defines human readable status messages for the TaskRun.
-
-
-
-_Appears in:_
-- [CustomRunSpec](#customrunspec)
-
-| Field | Description |
-| --- | --- |
-| `CustomRun cancelled as the PipelineRun it belongs to has been cancelled.` | CustomRunCancelledByPipelineMsg indicates that the PipelineRun of which part this CustomRun was<br />has been cancelled.<br /> |
-| `CustomRun cancelled as the PipelineRun it belongs to has timed out.` | CustomRunCancelledByPipelineTimeoutMsg indicates that the Run was cancelled because the PipelineRun running it timed out.<br /> |
-
-
-
-
-
-
-#### EmbeddedCustomRunSpec
-
-
-
-EmbeddedCustomRunSpec allows custom task definitions to be embedded
-
-
-
-_Appears in:_
-- [CustomRunSpec](#customrunspec)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `metadata` _[PipelineTaskMetadata](#pipelinetaskmetadata)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  | Optional: \{\} <br /> |
-| `spec` _[RawExtension](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#rawextension-runtime-pkg)_ | Spec is a specification of a custom task |  | Optional: \{\} <br /> |
-
-
-#### EmbeddedTask
-
-
-
-EmbeddedTask is used to define a Task inline within a Pipeline's PipelineTasks.
-
-
-
-_Appears in:_
-- [PipelineTask](#pipelinetask)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `spec` _[RawExtension](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#rawextension-runtime-pkg)_ | Spec is a specification of a custom task |  | Optional: \{\} <br /> |
-| `metadata` _[PipelineTaskMetadata](#pipelinetaskmetadata)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  | Optional: \{\} <br /> |
-| `resources` _[TaskResources](#taskresources)_ | Resources is a list input and output resource to run the task<br />Resources are represented in TaskRuns as bindings to instances of<br />PipelineResources.<br />Deprecated: Unused, preserved only for backwards compatibility |  | Optional: \{\} <br /> |
-| `params` _[ParamSpecs](#paramspecs)_ | Params is a list of input parameters required to run the task. Params<br />must be supplied as inputs in TaskRuns unless they declare a default<br />value. |  | Optional: \{\} <br /> |
-| `displayName` _string_ | DisplayName is a user-facing name of the task that may be<br />used to populate a UI. |  | Optional: \{\} <br /> |
-| `description` _string_ | Description is a user-facing description of the task that may be<br />used to populate a UI. |  | Optional: \{\} <br /> |
-| `steps` _[Step](#step) array_ | Steps are the steps of the build; each step is run sequentially with the<br />source mounted into /workspace. |  |  |
-| `volumes` _[Volumes](#volumes)_ | Volumes is a collection of volumes that are available to mount into the<br />steps of the build.<br />See Pod.spec.volumes (API version: v1) |  | Schemaless: \{\} <br /> |
-| `stepTemplate` _[StepTemplate](#steptemplate)_ | StepTemplate can be used as the basis for all step containers within the<br />Task, so that the steps inherit settings on the base container. |  |  |
-| `sidecars` _[Sidecar](#sidecar) array_ | Sidecars are run alongside the Task's step containers. They begin before<br />the steps start and end after the steps complete. |  |  |
-| `workspaces` _[WorkspaceDeclaration](#workspacedeclaration) array_ | Workspaces are the volumes that this Task requires. |  |  |
-| `results` _[TaskResult](#taskresult) array_ | Results are values that this Task can output |  |  |
-
-
-
-
-
-
-#### Matrix
-
-
-
-Matrix is used to fan out Tasks in a Pipeline
-
-
-
-_Appears in:_
-- [PipelineTask](#pipelinetask)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `params` _[Params](#params)_ | Params is a list of parameters used to fan out the pipelineTask<br />Params takes only `Parameters` of type `"array"`<br />Each array element is supplied to the `PipelineTask` by substituting `params` of type `"string"` in the underlying `Task`.<br />The names of the `params` in the `Matrix` must match the names of the `params` in the underlying `Task` that they will be substituting. |  |  |
-
-
-#### OnErrorType
-
-_Underlying type:_ _string_
-
-OnErrorType defines a list of supported exiting behavior of a container on error
-
-
-
-_Appears in:_
-- [Step](#step)
-
-| Field | Description |
-| --- | --- |
-| `stopAndFail` | StopAndFail indicates exit the taskRun if the container exits with non-zero exit code<br /> |
-| `continue` | Continue indicates continue executing the rest of the steps irrespective of the container exit code<br /> |
-
-
-#### Param
-
-
-
-Param declares an ParamValues to use for the parameter called name.
-
-
-
-_Appears in:_
-- [Params](#params)
-- [TaskRunInputs](#taskruninputs)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `name` _string_ |  |  |  |
-| `value` _[ParamValue](#paramvalue)_ |  |  | Schemaless: \{\} <br /> |
-
-
-#### ParamSpec
-
-
-
-ParamSpec defines arbitrary parameters needed beyond typed inputs (such as
+used to run the steps in a Task.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code><br/>
+string</td>
+<td>
+<code>
+tekton.dev/v1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code><br/>
+string
+</td>
+<td><code>TaskRun</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#tekton.dev/v1.TaskRunSpec">
+TaskRunSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>debug</code><br/>
+<em>
+<a href="#tekton.dev/v1.TaskRunDebug">
+TaskRunDebug
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>params</code><br/>
+<em>
+<a href="#tekton.dev/v1.Params">
+Params
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceAccountName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>taskRef</code><br/>
+<em>
+<a href="#tekton.dev/v1.TaskRef">
+TaskRef
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>no more than one of the TaskRef and TaskSpec may be specified.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>taskSpec</code><br/>
+<em>
+<a href="#tekton.dev/v1.TaskSpec">
+TaskSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Specifying TaskSpec can be disabled by setting
+<code>disable-inline-spec</code> feature flag.
+See Task.spec (API version: tekton.dev/v1)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code><br/>
+<em>
+<a href="#tekton.dev/v1.TaskRunSpecStatus">
+TaskRunSpecStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Used for cancelling a TaskRun (and maybe more later on)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>statusMessage</code><br/>
+<em>
+<a href="#tekton.dev/v1.TaskRunSpecStatusMessage">
+TaskRunSpecStatusMessage
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Status message for cancellation.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>retries</code><br/>
+<em>
+int
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Retries represents how many times this TaskRun should be retried in the event of task failure.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>timeout</code><br/>
+<em>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+Kubernetes meta/v1.Duration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Time after which one retry attempt times out. Defaults to 1 hour.
+Refer Go&rsquo;s ParseDuration documentation for expected format: <a href="https://golang.org/pkg/time/#ParseDuration">https://golang.org/pkg/time/#ParseDuration</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>podTemplate</code><br/>
+<em>
+<a href="#tekton.dev/unversioned.PodTemplate">
+PodTemplate
+</a>
+</em>
+</td>
+<td>
+<p>PodTemplate holds pod specific configuration</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>workspaces</code><br/>
+<em>
+<a href="#tekton.dev/v1.WorkspaceBinding">
+[]WorkspaceBinding
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Workspaces is a list of WorkspaceBindings from volumes to workspaces.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>stepSpecs</code><br/>
+<em>
+<a href="#tekton.dev/v1.TaskRunStepSpec">
+[]TaskRunStepSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Specs to apply to Steps in this TaskRun.
+If a field is specified in both a Step and a StepSpec,
+the value from the StepSpec will be used.
+This field is only supported when the alpha feature gate is enabled.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sidecarSpecs</code><br/>
+<em>
+<a href="#tekton.dev/v1.TaskRunSidecarSpec">
+[]TaskRunSidecarSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Specs to apply to Sidecars in this TaskRun.
+If a field is specified in both a Sidecar and a SidecarSpec,
+the value from the SidecarSpec will be used.
+This field is only supported when the alpha feature gate is enabled.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>computeResources</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#resourcerequirements-v1-core">
+Kubernetes core/v1.ResourceRequirements
+</a>
+</em>
+</td>
+<td>
+<p>Compute resources to use for this TaskRun</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>managedBy</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ManagedBy indicates which controller is responsible for reconciling
+this resource. If unset or set to &ldquo;tekton.dev/pipeline&rdquo;, the default
+Tekton controller will manage this resource.
+This field is immutable.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code><br/>
+<em>
+<a href="#tekton.dev/v1.TaskRunStatus">
+TaskRunStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.Algorithm">Algorithm
+(<code>string</code> alias)</h3>
+<div>
+<p>Algorithm Standard cryptographic hash algorithm</p>
+</div>
+<h3 id="tekton.dev/v1.Artifact">Artifact
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.Artifacts">Artifacts</a>)
+</p>
+<div>
+<p>Artifact represents an artifact within a system, potentially containing multiple values
+associated with it.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>The artifact&rsquo;s identifying category name</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>values</code><br/>
+<em>
+<a href="#tekton.dev/v1.ArtifactValue">
+[]ArtifactValue
+</a>
+</em>
+</td>
+<td>
+<p>A collection of values related to the artifact</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>buildOutput</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>Indicate if the artifact is a build output or a by-product</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.ArtifactValue">ArtifactValue
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.Artifact">Artifact</a>)
+</p>
+<div>
+<p>ArtifactValue represents a specific value or data element within an Artifact.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>digest</code><br/>
+<em>
+map[github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Algorithm]string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>uri</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Algorithm-specific digests for verifying the content (e.g., SHA256)</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.Artifacts">Artifacts
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.TaskRunStatusFields">TaskRunStatusFields</a>)
+</p>
+<div>
+<p>Artifacts represents the collection of input and output artifacts associated with
+a task run or a similar process. Artifacts in this context are units of data or resources
+that the process either consumes as input or produces as output.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>inputs</code><br/>
+<em>
+<a href="#tekton.dev/v1.Artifact">
+[]Artifact
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>outputs</code><br/>
+<em>
+<a href="#tekton.dev/v1.Artifact">
+[]Artifact
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.ChildStatusReference">ChildStatusReference
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineRunStatusFields">PipelineRunStatusFields</a>)
+</p>
+<div>
+<p>ChildStatusReference is used to point to the statuses of individual TaskRuns and Runs within this PipelineRun.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is the name of the TaskRun or Run this is referencing.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>displayName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>DisplayName is a user-facing name of the pipelineTask that may be
+used to populate a UI.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>pipelineTaskName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>PipelineTaskName is the name of the PipelineTask this is referencing.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>whenExpressions</code><br/>
+<em>
+<a href="#tekton.dev/v1.WhenExpression">
+[]WhenExpression
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>WhenExpressions is the list of checks guarding the execution of the PipelineTask</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.Combination">Combination
+(<code>map[string]string</code> alias)</h3>
+<div>
+<p>Combination is a map, mainly defined to hold a single combination from a Matrix with key as param.Name and value as param.Value</p>
+</div>
+<h3 id="tekton.dev/v1.Combinations">Combinations
+(<code>[]github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Combination</code> alias)</h3>
+<div>
+<p>Combinations is a Combination list</p>
+</div>
+<h3 id="tekton.dev/v1.EmbeddedTask">EmbeddedTask
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineTask">PipelineTask</a>)
+</p>
+<div>
+<p>EmbeddedTask is used to define a Task inline within a Pipeline&rsquo;s PipelineTasks.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime#RawExtension">
+k8s.io/apimachinery/pkg/runtime.RawExtension
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec is a specification of a custom task</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>-</code><br/>
+<em>
+[]byte
+</em>
+</td>
+<td>
+<p>Raw is the underlying serialization of this object.</p>
+<p>TODO: Determine how to detect ContentType and ContentEncoding of &lsquo;Raw&rsquo; data.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>-</code><br/>
+<em>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime#Object">
+k8s.io/apimachinery/pkg/runtime.Object
+</a>
+</em>
+</td>
+<td>
+<p>Object can hold a representation of this extension - useful for working with versioned
+structs.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="#tekton.dev/v1.PipelineTaskMetadata">
+PipelineTaskMetadata
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>TaskSpec</code><br/>
+<em>
+<a href="#tekton.dev/v1.TaskSpec">
+TaskSpec
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>TaskSpec</code> are embedded into this type.)
+</p>
+<em>(Optional)</em>
+<p>TaskSpec is a specification of a task</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.IncludeParams">IncludeParams
+</h3>
+<div>
+<p>IncludeParams allows passing in a specific combinations of Parameters into the Matrix.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name the specified combination</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>params</code><br/>
+<em>
+<a href="#tekton.dev/v1.Params">
+Params
+</a>
+</em>
+</td>
+<td>
+<p>Params takes only <code>Parameters</code> of type <code>&quot;string&quot;</code>
+The names of the <code>params</code> must match the names of the <code>params</code> in the underlying <code>Task</code></p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.Matrix">Matrix
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineTask">PipelineTask</a>)
+</p>
+<div>
+<p>Matrix is used to fan out Tasks in a Pipeline</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>params</code><br/>
+<em>
+<a href="#tekton.dev/v1.Params">
+Params
+</a>
+</em>
+</td>
+<td>
+<p>Params is a list of parameters used to fan out the pipelineTask
+Params takes only <code>Parameters</code> of type <code>&quot;array&quot;</code>
+Each array element is supplied to the <code>PipelineTask</code> by substituting <code>params</code> of type <code>&quot;string&quot;</code> in the underlying <code>Task</code>.
+The names of the <code>params</code> in the <code>Matrix</code> must match the names of the <code>params</code> in the underlying <code>Task</code> that they will be substituting.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>include</code><br/>
+<em>
+<a href="#tekton.dev/v1.IncludeParamsList">
+IncludeParamsList
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Include is a list of IncludeParams which allows passing in specific combinations of Parameters into the Matrix.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.OnErrorType">OnErrorType
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.Step">Step</a>)
+</p>
+<div>
+<p>OnErrorType defines a list of supported exiting behavior of a container on error</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;continue&#34;</p></td>
+<td><p>Continue indicates continue executing the rest of the steps irrespective of the container exit code</p>
+</td>
+</tr><tr><td><p>&#34;stopAndFail&#34;</p></td>
+<td><p>StopAndFail indicates exit the taskRun if the container exits with non-zero exit code</p>
+</td>
+</tr></tbody>
+</table>
+<h3 id="tekton.dev/v1.Param">Param
+</h3>
+<p>
+(<em>Appears on:</em><a href="#resolution.tekton.dev/v1beta1.ResolutionRequestSpec">ResolutionRequestSpec</a>)
+</p>
+<div>
+<p>Param declares an ParamValues to use for the parameter called name.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>value</code><br/>
+<em>
+<a href="#tekton.dev/v1.ParamValue">
+ParamValue
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.ParamSpec">ParamSpec
+</h3>
+<div>
+<p>ParamSpec defines arbitrary parameters needed beyond typed inputs (such as
 resources). Parameter values are provided by users as inputs on a TaskRun
-or PipelineRun.
-
-
-
-_Appears in:_
-- [ParamSpecs](#paramspecs)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `name` _string_ | Name declares the name by which a parameter is referenced. |  |  |
-| `type` _[ParamType](#paramtype)_ | Type is the user-specified type of the parameter. The possible types<br />are currently "string", "array" and "object", and "string" is the default. |  | Optional: \{\} <br /> |
-| `description` _string_ | Description is a user-facing description of the parameter that may be<br />used to populate a UI. |  | Optional: \{\} <br /> |
-| `properties` _object (keys:string, values:[PropertySpec](#propertyspec))_ | Properties is the JSON Schema properties to support key-value pairs parameter. |  | Optional: \{\} <br /> |
-| `default` _[ParamValue](#paramvalue)_ | Default is the value a parameter takes if no input value is supplied. If<br />default is set, a Task may be executed without a supplied value for the<br />parameter. |  | Schemaless: \{\} <br />Optional: \{\} <br /> |
-| `enum` _string array_ | Enum declares a set of allowed param input values for tasks/pipelines that can be validated.<br />If Enum is not set, no input validation is performed for the param. |  | Optional: \{\} <br /> |
-
-
-#### ParamSpecs
-
-_Underlying type:_ _[ParamSpec](#paramspec)_
-
-ParamSpecs is a list of ParamSpec
-
-
-
-_Appears in:_
-- [EmbeddedTask](#embeddedtask)
-- [PipelineSpec](#pipelinespec)
-- [TaskSpec](#taskspec)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `name` _string_ | Name declares the name by which a parameter is referenced. |  |  |
-| `type` _[ParamType](#paramtype)_ | Type is the user-specified type of the parameter. The possible types<br />are currently "string", "array" and "object", and "string" is the default. |  | Optional: \{\} <br /> |
-| `description` _string_ | Description is a user-facing description of the parameter that may be<br />used to populate a UI. |  | Optional: \{\} <br /> |
-| `properties` _object (keys:string, values:[PropertySpec](#propertyspec))_ | Properties is the JSON Schema properties to support key-value pairs parameter. |  | Optional: \{\} <br /> |
-| `default` _[ParamValue](#paramvalue)_ | Default is the value a parameter takes if no input value is supplied. If<br />default is set, a Task may be executed without a supplied value for the<br />parameter. |  | Schemaless: \{\} <br />Optional: \{\} <br /> |
-| `enum` _string array_ | Enum declares a set of allowed param input values for tasks/pipelines that can be validated.<br />If Enum is not set, no input validation is performed for the param. |  | Optional: \{\} <br /> |
-
-
-#### ParamType
-
-_Underlying type:_ _string_
-
-ParamType indicates the type of an input parameter;
-Used to distinguish between a single string and an array of strings.
-
-
-
-_Appears in:_
-- [ParamSpec](#paramspec)
-- [ParamValue](#paramvalue)
-- [PropertySpec](#propertyspec)
-
-| Field | Description |
-| --- | --- |
-| `string` |  |
-| `array` |  |
-| `object` |  |
-
-
-#### ParamValue
-
-
-
-ParamValue is a type that can hold a single string or string array.
+or PipelineRun.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name declares the name by which a parameter is referenced.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>type</code><br/>
+<em>
+<a href="#tekton.dev/v1.ParamType">
+ParamType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Type is the user-specified type of the parameter. The possible types
+are currently &ldquo;string&rdquo;, &ldquo;array&rdquo; and &ldquo;object&rdquo;, and &ldquo;string&rdquo; is the default.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>description</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Description is a user-facing description of the parameter that may be
+used to populate a UI.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>properties</code><br/>
+<em>
+<a href="#tekton.dev/v1.PropertySpec">
+map[string]github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PropertySpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Properties is the JSON Schema properties to support key-value pairs parameter.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>default</code><br/>
+<em>
+<a href="#tekton.dev/v1.ParamValue">
+ParamValue
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Default is the value a parameter takes if no input value is supplied. If
+default is set, a Task may be executed without a supplied value for the
+parameter.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>enum</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Enum declares a set of allowed param input values for tasks/pipelines that can be validated.
+If Enum is not set, no input validation is performed for the param.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.ParamSpecs">ParamSpecs
+(<code>[]github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.ParamSpec</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineSpec">PipelineSpec</a>, <a href="#tekton.dev/v1.TaskSpec">TaskSpec</a>, <a href="#tekton.dev/v1alpha1.StepActionSpec">StepActionSpec</a>, <a href="#tekton.dev/v1beta1.StepActionSpec">StepActionSpec</a>)
+</p>
+<div>
+<p>ParamSpecs is a list of ParamSpec</p>
+</div>
+<h3 id="tekton.dev/v1.ParamType">ParamType
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.ParamSpec">ParamSpec</a>, <a href="#tekton.dev/v1.ParamValue">ParamValue</a>, <a href="#tekton.dev/v1.PropertySpec">PropertySpec</a>)
+</p>
+<div>
+<p>ParamType indicates the type of an input parameter;
+Used to distinguish between a single string and an array of strings.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;array&#34;</p></td>
+<td></td>
+</tr><tr><td><p>&#34;object&#34;</p></td>
+<td></td>
+</tr><tr><td><p>&#34;string&#34;</p></td>
+<td></td>
+</tr></tbody>
+</table>
+<h3 id="tekton.dev/v1.ParamValue">ParamValue
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.Param">Param</a>, <a href="#tekton.dev/v1.ParamSpec">ParamSpec</a>)
+</p>
+<div>
+<p>ParamValue is a type that can hold a single string, string array, or string map.
 Used in JSON unmarshalling so that a single JSON field can accept
-either an individual string or an array of strings.
-
-
-
-_Appears in:_
-- [Param](#param)
-- [ParamSpec](#paramspec)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `Type` _[ParamType](#paramtype)_ |  |  |  |
-| `StringVal` _string_ |  |  |  |
-| `ArrayVal` _string array_ |  |  |  |
-| `ObjectVal` _object (keys:string, values:string)_ |  |  |  |
-
-
-#### Params
-
-_Underlying type:_ _[Param](#param)_
-
-Params is a list of Param
-
-
-
-_Appears in:_
-- [CustomRunSpec](#customrunspec)
-- [IncludeParams](#includeparams)
-- [Matrix](#matrix)
-- [PipelineRunSpec](#pipelinerunspec)
-- [PipelineTask](#pipelinetask)
-- [ResolverRef](#resolverref)
-- [RunSpec](#runspec)
-- [Step](#step)
-- [TaskRunSpec](#taskrunspec)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `name` _string_ |  |  |  |
-| `value` _[ParamValue](#paramvalue)_ |  |  | Schemaless: \{\} <br /> |
-
-
-#### Pipeline
-
-
-
-Pipeline describes a list of Tasks to execute. It expresses how outputs
-of tasks feed into inputs of subsequent tasks.
-
-Deprecated: Please use v1.Pipeline instead.
-
-
-
-
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `tekton.dev/v1beta1` | | |
-| `kind` _string_ | `Pipeline` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  | Optional: \{\} <br /> |
-| `spec` _[PipelineSpec](#pipelinespec)_ | Spec holds the desired state of the Pipeline from the client |  | Optional: \{\} <br /> |
-
-
-#### PipelineDeclaredResource
-
-
-
-PipelineDeclaredResource is used by a Pipeline to declare the types of the
-PipelineResources that it will required to run and names which can be used to
-refer to these PipelineResources in PipelineTaskResourceBindings.
-
-Deprecated: Unused, preserved only for backwards compatibility
-
-
-
-_Appears in:_
-- [PipelineSpec](#pipelinespec)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `name` _string_ | Name is the name that will be used by the Pipeline to refer to this resource.<br />It does not directly correspond to the name of any PipelineResources Task<br />inputs or outputs, and it does not correspond to the actual names of the<br />PipelineResources that will be bound in the PipelineRun. |  |  |
-| `type` _[PipelineResourceType](#pipelineresourcetype)_ | Type is the type of the PipelineResource. |  |  |
-| `optional` _boolean_ | Optional declares the resource as optional.<br />optional: true - the resource is considered optional<br />optional: false - the resource is considered required (default/equivalent of not specifying it) |  |  |
-
-
-
-
-#### PipelineRef
-
-
-
-PipelineRef can be used to refer to a specific instance of a Pipeline.
-
-
-
-_Appears in:_
-- [PipelineRunSpec](#pipelinerunspec)
-- [PipelineTask](#pipelinetask)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `name` _string_ | Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names |  |  |
-| `apiVersion` _string_ | API version of the referent |  | Optional: \{\} <br /> |
-| `bundle` _string_ | Bundle url reference to a Tekton Bundle.<br />Deprecated: Please use ResolverRef with the bundles resolver instead.<br />The field is staying there for go client backward compatibility, but is not used/allowed anymore. |  | Optional: \{\} <br /> |
-| `ResolverRef` _[ResolverRef](#resolverref)_ | ResolverRef allows referencing a Pipeline in a remote location<br />like a git repo. This field is only supported when the alpha<br />feature gate is enabled. |  | Optional: \{\} <br /> |
-
-
-#### PipelineResourceBinding
-
-
-
-PipelineResourceBinding connects a reference to an instance of a PipelineResource
-with a PipelineResource dependency that the Pipeline has declared
-
-Deprecated: Unused, preserved only for backwards compatibility
-
-
-
-_Appears in:_
-- [PipelineRunSpec](#pipelinerunspec)
-- [TaskResourceBinding](#taskresourcebinding)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `name` _string_ | Name is the name of the PipelineResource in the Pipeline's declaration |  |  |
-| `resourceRef` _[PipelineResourceRef](#pipelineresourceref)_ | ResourceRef is a reference to the instance of the actual PipelineResource<br />that should be used |  | Optional: \{\} <br /> |
-| `resourceSpec` _[PipelineResourceSpec](#pipelineresourcespec)_ | ResourceSpec is specification of a resource that should be created and<br />consumed by the task |  | Optional: \{\} <br /> |
-
-
-
-
-#### PipelineResourceRef
-
-
-
-PipelineResourceRef can be used to refer to a specific instance of a Resource
-
-Deprecated: Unused, preserved only for backwards compatibility
-
-
-
-_Appears in:_
-- [PipelineResourceBinding](#pipelineresourcebinding)
-- [TaskResourceBinding](#taskresourcebinding)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `name` _string_ | Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names |  |  |
-| `apiVersion` _string_ | API version of the referent |  | Optional: \{\} <br /> |
-
-
-
-
-
-
-#### PipelineResult
-
-_Underlying type:_ _[struct{Name string "json:\"name\""; Type ResultsType "json:\"type,omitempty\""; Description string "json:\"description\""; Value ResultValue "json:\"value\""}](#struct{name-string-"json:\"name\"";-type-resultstype-"json:\"type,omitempty\"";-description-string-"json:\"description\"";-value-resultvalue-"json:\"value\""})_
-
-PipelineResult used to describe the results of a pipeline
-
-
-
-_Appears in:_
-- [PipelineSpec](#pipelinespec)
-
-
-
-#### PipelineRun
-
-
-
-PipelineRun represents a single execution of a Pipeline. PipelineRuns are how
-the graph of Tasks declared in a Pipeline are executed; they specify inputs
-to Pipelines such as parameter values and capture operational aspects of the
-Tasks execution such as service account and tolerations. Creating a
-PipelineRun creates TaskRuns for Tasks in the referenced Pipeline.
-
-Deprecated: Please use v1.PipelineRun instead.
-
-
-
-
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `tekton.dev/v1beta1` | | |
-| `kind` _string_ | `PipelineRun` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  | Optional: \{\} <br /> |
-| `spec` _[PipelineRunSpec](#pipelinerunspec)_ |  |  | Optional: \{\} <br /> |
-| `status` _[PipelineRunStatus](#pipelinerunstatus)_ |  |  | Optional: \{\} <br /> |
-
-
-
-
-#### PipelineRunResult
-
-
-
-PipelineRunResult used to describe the results of a pipeline
-
-
-
-_Appears in:_
-- [PipelineRunStatus](#pipelinerunstatus)
-- [PipelineRunStatusFields](#pipelinerunstatusfields)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `name` _string_ | Name is the result's name as declared by the Pipeline |  |  |
-| `value` _[ResultValue](#resultvalue)_ | Value is the result returned from the execution of this PipelineRun |  | Schemaless: \{\} <br /> |
-
-
-#### PipelineRunRunStatus
-
-
-
-PipelineRunRunStatus contains the name of the PipelineTask for this CustomRun or Run and the CustomRun or Run's Status
-
-
-
-_Appears in:_
-- [PipelineRunStatus](#pipelinerunstatus)
-- [PipelineRunStatusFields](#pipelinerunstatusfields)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `pipelineTaskName` _string_ | PipelineTaskName is the name of the PipelineTask. |  |  |
-| `status` _[CustomRunStatus](#customrunstatus)_ | Status is the CustomRunStatus for the corresponding CustomRun or Run |  | Optional: \{\} <br /> |
-| `whenExpressions` _[WhenExpression](#whenexpression) array_ | WhenExpressions is the list of checks guarding the execution of the PipelineTask |  | Optional: \{\} <br /> |
-
-
-#### PipelineRunSpec
-
-
-
-PipelineRunSpec defines the desired state of PipelineRun
-
-
-
-_Appears in:_
-- [PipelineRun](#pipelinerun)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `pipelineRef` _[PipelineRef](#pipelineref)_ |  |  | Optional: \{\} <br /> |
-| `pipelineSpec` _[PipelineSpec](#pipelinespec)_ | Specifying PipelineSpec can be disabled by setting<br />`disable-inline-spec` feature flag.<br />See Pipeline.spec (API version: tekton.dev/v1beta1) |  | Schemaless: \{\} <br />Optional: \{\} <br /> |
-| `resources` _[PipelineResourceBinding](#pipelineresourcebinding) array_ | Resources is a list of bindings specifying which actual instances of<br />PipelineResources to use for the resources the Pipeline has declared<br />it needs.<br />Deprecated: Unused, preserved only for backwards compatibility |  |  |
-| `params` _[Params](#params)_ | Params is a list of parameter names and values. |  |  |
-| `serviceAccountName` _string_ |  |  | Optional: \{\} <br /> |
-| `status` _[PipelineRunSpecStatus](#pipelinerunspecstatus)_ | Used for cancelling a pipelinerun (and maybe more later on) |  | Optional: \{\} <br /> |
-| `timeouts` _[TimeoutFields](#timeoutfields)_ | Time after which the Pipeline times out.<br />Currently three keys are accepted in the map<br />pipeline, tasks and finally<br />with Timeouts.pipeline >= Timeouts.tasks + Timeouts.finally |  | Optional: \{\} <br /> |
-| `timeout` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ | Timeout is the Time after which the Pipeline times out.<br />Defaults to never.<br />Refer to Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration<br />Deprecated: use pipelineRunSpec.Timeouts.Pipeline instead |  | Optional: \{\} <br /> |
-| `podTemplate` _[PodTemplate](#podtemplate)_ | PodTemplate holds pod specific configuration |  |  |
-| `workspaces` _[WorkspaceBinding](#workspacebinding) array_ | Workspaces holds a set of workspace bindings that must match names<br />with those declared in the pipeline. |  | Optional: \{\} <br /> |
-| `taskRunSpecs` _[PipelineTaskRunSpec](#pipelinetaskrunspec) array_ | TaskRunSpecs holds a set of runtime specs |  | Optional: \{\} <br /> |
-| `managedBy` _string_ | ManagedBy indicates which controller is responsible for reconciling<br />this resource. If unset or set to "tekton.dev/pipeline", the default<br />Tekton controller will manage this resource.<br />This field is immutable. |  | Optional: \{\} <br /> |
-
-
-#### PipelineRunSpecStatus
-
-_Underlying type:_ _string_
-
-PipelineRunSpecStatus defines the pipelinerun spec status the user can provide
-
-
-
-_Appears in:_
-- [PipelineRunSpec](#pipelinerunspec)
-
-
-
-#### PipelineRunStatus
-
-
-
-PipelineRunStatus defines the observed state of PipelineRun
-
-
-
-_Appears in:_
-- [PipelineRun](#pipelinerun)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `observedGeneration` _integer_ | ObservedGeneration is the 'Generation' of the Service that<br />was last processed by the controller. |  | Optional: \{\} <br /> |
-| `conditions` _[Conditions](#conditions)_ | Conditions the latest available observations of a resource's current state. |  | Optional: \{\} <br /> |
-| `annotations` _object (keys:string, values:string)_ | Annotations is additional Status fields for the Resource to save some<br />additional State as well as convey more information to the user. This is<br />roughly akin to Annotations on any k8s resource, just the reconciler conveying<br />richer information outwards. |  |  |
-| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | StartTime is the time the PipelineRun is actually started. |  |  |
-| `completionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | CompletionTime is the time the PipelineRun completed. |  |  |
-| `taskRuns` _object (keys:string, values:[PipelineRunTaskRunStatus](#pipelineruntaskrunstatus))_ | TaskRuns is a map of PipelineRunTaskRunStatus with the taskRun name as the key.<br />Deprecated: use ChildReferences instead. As of v0.45.0, this field is no<br />longer populated and is only included for backwards compatibility with<br />older server versions. |  | Optional: \{\} <br /> |
-| `runs` _object (keys:string, values:[PipelineRunRunStatus](#pipelinerunrunstatus))_ | Runs is a map of PipelineRunRunStatus with the run name as the key<br />Deprecated: use ChildReferences instead. As of v0.45.0, this field is no<br />longer populated and is only included for backwards compatibility with<br />older server versions. |  | Optional: \{\} <br /> |
-| `pipelineResults` _[PipelineRunResult](#pipelinerunresult) array_ | PipelineResults are the list of results written out by the pipeline task's containers |  | Optional: \{\} <br /> |
-| `pipelineSpec` _[PipelineSpec](#pipelinespec)_ | PipelineSpec contains the exact spec used to instantiate the run.<br />See Pipeline.spec (API version: tekton.dev/v1beta1) |  | Schemaless: \{\} <br /> |
-| `skippedTasks` _[SkippedTask](#skippedtask) array_ | list of tasks that were skipped due to when expressions evaluating to false |  | Optional: \{\} <br /> |
-| `childReferences` _[ChildStatusReference](#childstatusreference) array_ | list of TaskRun and Run names, PipelineTask names, and API versions/kinds for children of this PipelineRun. |  | Optional: \{\} <br /> |
-| `finallyStartTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | FinallyStartTime is when all non-finally tasks have been completed and only finally tasks are being executed. |  | Optional: \{\} <br /> |
-| `provenance` _[Provenance](#provenance)_ | Provenance contains some key authenticated metadata about how a software artifact was built (what sources, what inputs/outputs, etc.). |  | Optional: \{\} <br /> |
-| `spanContext` _object (keys:string, values:string)_ | SpanContext contains tracing span context fields |  |  |
-
-
-#### PipelineRunStatusFields
-
-
-
-PipelineRunStatusFields holds the fields of PipelineRunStatus' status.
+either an individual string or an array of strings.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>Type</code><br/>
+<em>
+<a href="#tekton.dev/v1.ParamType">
+ParamType
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>StringVal</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Represents the stored type of ParamValues.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ArrayVal</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>ObjectVal</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.Params">Params
+(<code>[]github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Param</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.IncludeParams">IncludeParams</a>, <a href="#tekton.dev/v1.Matrix">Matrix</a>, <a href="#tekton.dev/v1.PipelineRunSpec">PipelineRunSpec</a>, <a href="#tekton.dev/v1.PipelineTask">PipelineTask</a>, <a href="#tekton.dev/v1.ResolverRef">ResolverRef</a>, <a href="#tekton.dev/v1.Step">Step</a>, <a href="#tekton.dev/v1.TaskRunInputs">TaskRunInputs</a>, <a href="#tekton.dev/v1.TaskRunSpec">TaskRunSpec</a>)
+</p>
+<div>
+<p>Params is a list of Param</p>
+</div>
+<h3 id="tekton.dev/v1.PipelineRef">PipelineRef
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineRunSpec">PipelineRunSpec</a>, <a href="#tekton.dev/v1.PipelineTask">PipelineTask</a>)
+</p>
+<div>
+<p>PipelineRef can be used to refer to a specific instance of a Pipeline.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name of the referent; More info: <a href="http://kubernetes.io/docs/user-guide/identifiers#names">http://kubernetes.io/docs/user-guide/identifiers#names</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>apiVersion</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>API version of the referent</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ResolverRef</code><br/>
+<em>
+<a href="#tekton.dev/v1.ResolverRef">
+ResolverRef
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ResolverRef allows referencing a Pipeline in a remote location
+like a git repo. This field is only supported when the alpha
+feature gate is enabled.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.PipelineResult">PipelineResult
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineSpec">PipelineSpec</a>)
+</p>
+<div>
+<p>PipelineResult used to describe the results of a pipeline</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name the given name</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>type</code><br/>
+<em>
+<a href="#tekton.dev/v1.ResultsType">
+ResultsType
+</a>
+</em>
+</td>
+<td>
+<p>Type is the user-specified type of the result.
+The possible types are &lsquo;string&rsquo;, &lsquo;array&rsquo;, and &lsquo;object&rsquo;, with &lsquo;string&rsquo; as the default.
+&lsquo;array&rsquo; and &lsquo;object&rsquo; types are alpha features.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>description</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Description is a human-readable description of the result</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>value</code><br/>
+<em>
+<a href="#tekton.dev/v1.ResultValue">
+ResultValue
+</a>
+</em>
+</td>
+<td>
+<p>Value the expression used to retrieve the value</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.PipelineRunReason">PipelineRunReason
+(<code>string</code> alias)</h3>
+<div>
+<p>PipelineRunReason represents a reason for the pipeline run &ldquo;Succeeded&rdquo; condition</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;CELEvaluationFailed&#34;</p></td>
+<td><p>ReasonCELEvaluationFailed indicates the pipeline fails the CEL evaluation</p>
+</td>
+</tr><tr><td><p>&#34;Cancelled&#34;</p></td>
+<td><p>PipelineRunReasonCancelled is the reason set when the PipelineRun cancelled by the user
+This reason may be found with a corev1.ConditionFalse status, if the cancellation was processed successfully
+This reason may be found with a corev1.ConditionUnknown status, if the cancellation is being processed or failed</p>
+</td>
+</tr><tr><td><p>&#34;CancelledRunningFinally&#34;</p></td>
+<td><p>PipelineRunReasonCancelledRunningFinally indicates that pipeline has been gracefully cancelled
+and no new Tasks will be scheduled by the controller, but final tasks are now running</p>
+</td>
+</tr><tr><td><p>&#34;Completed&#34;</p></td>
+<td><p>PipelineRunReasonCompleted is the reason set when the PipelineRun completed successfully with one or more skipped Tasks</p>
+</td>
+</tr><tr><td><p>&#34;PipelineRunCouldntCancel&#34;</p></td>
+<td><p>ReasonCouldntCancel indicates that a PipelineRun was cancelled but attempting to update
+all of the running TaskRuns as cancelled failed.</p>
+</td>
+</tr><tr><td><p>&#34;CouldntGetPipeline&#34;</p></td>
+<td><p>ReasonCouldntGetPipeline indicates that the reason for the failure status is that the
+associated Pipeline couldn&rsquo;t be retrieved</p>
+</td>
+</tr><tr><td><p>&#34;CouldntGetPipelineResult&#34;</p></td>
+<td><p>PipelineRunReasonCouldntGetPipelineResult indicates that the pipeline fails to retrieve the
+referenced result. This could be due to failed TaskRuns or Runs that were supposed to produce
+the results</p>
+</td>
+</tr><tr><td><p>&#34;CouldntGetTask&#34;</p></td>
+<td><p>ReasonCouldntGetTask indicates that the reason for the failure status is that the
+associated Pipeline&rsquo;s Tasks couldn&rsquo;t all be retrieved</p>
+</td>
+</tr><tr><td><p>&#34;PipelineRunCouldntTimeOut&#34;</p></td>
+<td><p>ReasonCouldntTimeOut indicates that a PipelineRun was timed out but attempting to update
+all of the running TaskRuns as timed out failed.</p>
+</td>
+</tr><tr><td><p>&#34;CreateRunFailed&#34;</p></td>
+<td><p>ReasonCreateRunFailed indicates that the pipeline fails to create the taskrun or other run resources</p>
+</td>
+</tr><tr><td><p>&#34;Failed&#34;</p></td>
+<td><p>PipelineRunReasonFailed is the reason set when the PipelineRun completed with a failure</p>
+</td>
+</tr><tr><td><p>&#34;PipelineValidationFailed&#34;</p></td>
+<td><p>ReasonFailedValidation indicates that the reason for failure status is
+that pipelinerun failed runtime validation</p>
+</td>
+</tr><tr><td><p>&#34;InvalidPipelineResourceBindings&#34;</p></td>
+<td><p>ReasonInvalidBindings indicates that the reason for the failure status is that the
+PipelineResources bound in the PipelineRun didn&rsquo;t match those declared in the Pipeline</p>
+</td>
+</tr><tr><td><p>&#34;PipelineInvalidGraph&#34;</p></td>
+<td><p>ReasonInvalidGraph indicates that the reason for the failure status is that the
+associated Pipeline is an invalid graph (a.k.a wrong order, cycle, …)</p>
+</td>
+</tr><tr><td><p>&#34;InvalidMatrixParameterTypes&#34;</p></td>
+<td><p>ReasonInvalidMatrixParameterTypes indicates a matrix contains invalid parameter types</p>
+</td>
+</tr><tr><td><p>&#34;InvalidParamValue&#34;</p></td>
+<td><p>PipelineRunReasonInvalidParamValue indicates that the PipelineRun Param input value is not allowed.</p>
+</td>
+</tr><tr><td><p>&#34;InvalidPipelineResultReference&#34;</p></td>
+<td><p>PipelineRunReasonInvalidPipelineResultReference indicates a pipeline result was declared
+by the pipeline but not initialized in the pipelineTask</p>
+</td>
+</tr><tr><td><p>&#34;InvalidTaskResultReference&#34;</p></td>
+<td><p>ReasonInvalidTaskResultReference indicates a task result was declared
+but was not initialized by that task</p>
+</td>
+</tr><tr><td><p>&#34;InvalidTaskRunSpecs&#34;</p></td>
+<td><p>ReasonInvalidTaskRunSpec indicates that PipelineRun.Spec.TaskRunSpecs[].PipelineTaskName is defined with
+a not exist taskName in pipelineSpec.</p>
+</td>
+</tr><tr><td><p>&#34;InvalidWorkspaceBindings&#34;</p></td>
+<td><p>ReasonInvalidWorkspaceBinding indicates that a Pipeline expects a workspace but a
+PipelineRun has provided an invalid binding.</p>
+</td>
+</tr><tr><td><p>&#34;ObjectParameterMissKeys&#34;</p></td>
+<td><p>ReasonObjectParameterMissKeys indicates that the object param value provided from PipelineRun spec
+misses some keys required for the object param declared in Pipeline spec.</p>
+</td>
+</tr><tr><td><p>&#34;ParamArrayIndexingInvalid&#34;</p></td>
+<td><p>ReasonParamArrayIndexingInvalid indicates that the use of param array indexing is out of bound.</p>
+</td>
+</tr><tr><td><p>&#34;ParameterMissing&#34;</p></td>
+<td><p>ReasonParameterMissing indicates that the reason for the failure status is that the
+associated PipelineRun didn&rsquo;t provide all the required parameters</p>
+</td>
+</tr><tr><td><p>&#34;ParameterTypeMismatch&#34;</p></td>
+<td><p>ReasonParameterTypeMismatch indicates that the reason for the failure status is that
+parameter(s) declared in the PipelineRun do not have the some declared type as the
+parameters(s) declared in the Pipeline that they are supposed to override.</p>
+</td>
+</tr><tr><td><p>&#34;PipelineRunPending&#34;</p></td>
+<td><p>PipelineRunReasonPending is the reason set when the PipelineRun is in the pending state</p>
+</td>
+</tr><tr><td><p>&#34;RequiredWorkspaceMarkedOptional&#34;</p></td>
+<td><p>ReasonRequiredWorkspaceMarkedOptional indicates an optional workspace
+has been passed to a Task that is expecting a non-optional workspace</p>
+</td>
+</tr><tr><td><p>&#34;ResolvingPipelineRef&#34;</p></td>
+<td><p>ReasonResolvingPipelineRef indicates that the PipelineRun is waiting for
+its pipelineRef to be asynchronously resolved.</p>
+</td>
+</tr><tr><td><p>&#34;ResourceVerificationFailed&#34;</p></td>
+<td><p>ReasonResourceVerificationFailed indicates that the pipeline fails the trusted resource verification,
+it could be the content has changed, signature is invalid or public key is invalid</p>
+</td>
+</tr><tr><td><p>&#34;Running&#34;</p></td>
+<td><p>PipelineRunReasonRunning is the reason set when the PipelineRun is running</p>
+</td>
+</tr><tr><td><p>&#34;Started&#34;</p></td>
+<td><p>PipelineRunReasonStarted is the reason set when the PipelineRun has just started</p>
+</td>
+</tr><tr><td><p>&#34;StoppedRunningFinally&#34;</p></td>
+<td><p>PipelineRunReasonStoppedRunningFinally indicates that pipeline has been gracefully stopped
+and no new Tasks will be scheduled by the controller, but final tasks are now running</p>
+</td>
+</tr><tr><td><p>&#34;PipelineRunStopping&#34;</p></td>
+<td><p>PipelineRunReasonStopping indicates that no new Tasks will be scheduled by the controller, and the
+pipeline will stop once all running tasks complete their work</p>
+</td>
+</tr><tr><td><p>&#34;Succeeded&#34;</p></td>
+<td><p>PipelineRunReasonSuccessful is the reason set when the PipelineRun completed successfully</p>
+</td>
+</tr><tr><td><p>&#34;PipelineRunTimeout&#34;</p></td>
+<td><p>PipelineRunReasonTimedOut is the reason set when the PipelineRun has timed out</p>
+</td>
+</tr></tbody>
+</table>
+<h3 id="tekton.dev/v1.PipelineRunResult">PipelineRunResult
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineRunStatusFields">PipelineRunStatusFields</a>)
+</p>
+<div>
+<p>PipelineRunResult used to describe the results of a pipeline</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is the result&rsquo;s name as declared by the Pipeline</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>value</code><br/>
+<em>
+<a href="#tekton.dev/v1.ResultValue">
+ResultValue
+</a>
+</em>
+</td>
+<td>
+<p>Value is the result returned from the execution of this PipelineRun</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.PipelineRunRunStatus">PipelineRunRunStatus
+</h3>
+<div>
+<p>PipelineRunRunStatus contains the name of the PipelineTask for this Run and the Run&rsquo;s Status</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>pipelineTaskName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>PipelineTaskName is the name of the PipelineTask.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.CustomRunStatus">
+CustomRunStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Status is the RunStatus for the corresponding Run</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>whenExpressions</code><br/>
+<em>
+<a href="#tekton.dev/v1.WhenExpression">
+[]WhenExpression
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>WhenExpressions is the list of checks guarding the execution of the PipelineTask</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.PipelineRunSpec">PipelineRunSpec
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineRun">PipelineRun</a>)
+</p>
+<div>
+<p>PipelineRunSpec defines the desired state of PipelineRun</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>pipelineRef</code><br/>
+<em>
+<a href="#tekton.dev/v1.PipelineRef">
+PipelineRef
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>pipelineSpec</code><br/>
+<em>
+<a href="#tekton.dev/v1.PipelineSpec">
+PipelineSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Specifying PipelineSpec can be disabled by setting
+<code>disable-inline-spec</code> feature flag.
+See Pipeline.spec (API version: tekton.dev/v1)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>params</code><br/>
+<em>
+<a href="#tekton.dev/v1.Params">
+Params
+</a>
+</em>
+</td>
+<td>
+<p>Params is a list of parameter names and values.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code><br/>
+<em>
+<a href="#tekton.dev/v1.PipelineRunSpecStatus">
+PipelineRunSpecStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Used for cancelling a pipelinerun (and maybe more later on)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>timeouts</code><br/>
+<em>
+<a href="#tekton.dev/v1.TimeoutFields">
+TimeoutFields
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Time after which the Pipeline times out.
+Currently three keys are accepted in the map
+pipeline, tasks and finally
+with Timeouts.pipeline &gt;= Timeouts.tasks + Timeouts.finally</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>taskRunTemplate</code><br/>
+<em>
+<a href="#tekton.dev/v1.PipelineTaskRunTemplate">
+PipelineTaskRunTemplate
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TaskRunTemplate represent template of taskrun</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>workspaces</code><br/>
+<em>
+<a href="#tekton.dev/v1.WorkspaceBinding">
+[]WorkspaceBinding
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Workspaces holds a set of workspace bindings that must match names
+with those declared in the pipeline.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>taskRunSpecs</code><br/>
+<em>
+<a href="#tekton.dev/v1.PipelineTaskRunSpec">
+[]PipelineTaskRunSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TaskRunSpecs holds a set of runtime specs</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>managedBy</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ManagedBy indicates which controller is responsible for reconciling
+this resource. If unset or set to &ldquo;tekton.dev/pipeline&rdquo;, the default
+Tekton controller will manage this resource.
+This field is immutable.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.PipelineRunSpecStatus">PipelineRunSpecStatus
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineRunSpec">PipelineRunSpec</a>)
+</p>
+<div>
+<p>PipelineRunSpecStatus defines the pipelinerun spec status the user can provide</p>
+</div>
+<h3 id="tekton.dev/v1.PipelineRunStatus">PipelineRunStatus
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineRun">PipelineRun</a>)
+</p>
+<div>
+<p>PipelineRunStatus defines the observed state of PipelineRun</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>Status</code><br/>
+<em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Status">
+knative.dev/pkg/apis/duck/v1.Status
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>Status</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>PipelineRunStatusFields</code><br/>
+<em>
+<a href="#tekton.dev/v1.PipelineRunStatusFields">
+PipelineRunStatusFields
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>PipelineRunStatusFields</code> are embedded into this type.)
+</p>
+<p>PipelineRunStatusFields inlines the status fields.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.PipelineRunStatusFields">PipelineRunStatusFields
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineRunStatus">PipelineRunStatus</a>)
+</p>
+<div>
+<p>PipelineRunStatusFields holds the fields of PipelineRunStatus&rsquo; status.
 This is defined separately and inlined so that other types can readily
-consume these fields via duck typing.
-
-
-
-_Appears in:_
-- [PipelineRunStatus](#pipelinerunstatus)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | StartTime is the time the PipelineRun is actually started. |  |  |
-| `completionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | CompletionTime is the time the PipelineRun completed. |  |  |
-| `taskRuns` _object (keys:string, values:[PipelineRunTaskRunStatus](#pipelineruntaskrunstatus))_ | TaskRuns is a map of PipelineRunTaskRunStatus with the taskRun name as the key.<br />Deprecated: use ChildReferences instead. As of v0.45.0, this field is no<br />longer populated and is only included for backwards compatibility with<br />older server versions. |  | Optional: \{\} <br /> |
-| `runs` _object (keys:string, values:[PipelineRunRunStatus](#pipelinerunrunstatus))_ | Runs is a map of PipelineRunRunStatus with the run name as the key<br />Deprecated: use ChildReferences instead. As of v0.45.0, this field is no<br />longer populated and is only included for backwards compatibility with<br />older server versions. |  | Optional: \{\} <br /> |
-| `pipelineResults` _[PipelineRunResult](#pipelinerunresult) array_ | PipelineResults are the list of results written out by the pipeline task's containers |  | Optional: \{\} <br /> |
-| `pipelineSpec` _[PipelineSpec](#pipelinespec)_ | PipelineSpec contains the exact spec used to instantiate the run.<br />See Pipeline.spec (API version: tekton.dev/v1beta1) |  | Schemaless: \{\} <br /> |
-| `skippedTasks` _[SkippedTask](#skippedtask) array_ | list of tasks that were skipped due to when expressions evaluating to false |  | Optional: \{\} <br /> |
-| `childReferences` _[ChildStatusReference](#childstatusreference) array_ | list of TaskRun and Run names, PipelineTask names, and API versions/kinds for children of this PipelineRun. |  | Optional: \{\} <br /> |
-| `finallyStartTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | FinallyStartTime is when all non-finally tasks have been completed and only finally tasks are being executed. |  | Optional: \{\} <br /> |
-| `provenance` _[Provenance](#provenance)_ | Provenance contains some key authenticated metadata about how a software artifact was built (what sources, what inputs/outputs, etc.). |  | Optional: \{\} <br /> |
-| `spanContext` _object (keys:string, values:string)_ | SpanContext contains tracing span context fields |  |  |
-
-
-#### PipelineRunTaskRunStatus
-
-
-
-PipelineRunTaskRunStatus contains the name of the PipelineTask for this TaskRun and the TaskRun's Status
-
-
-
-_Appears in:_
-- [PipelineRunStatus](#pipelinerunstatus)
-- [PipelineRunStatusFields](#pipelinerunstatusfields)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `pipelineTaskName` _string_ | PipelineTaskName is the name of the PipelineTask. |  |  |
-| `status` _[TaskRunStatus](#taskrunstatus)_ | Status is the TaskRunStatus for the corresponding TaskRun |  | Optional: \{\} <br /> |
-| `whenExpressions` _[WhenExpression](#whenexpression) array_ | WhenExpressions is the list of checks guarding the execution of the PipelineTask |  | Optional: \{\} <br /> |
-
-
-#### PipelineSpec
-
-
-
-PipelineSpec defines the desired state of Pipeline.
-
-
-
-_Appears in:_
-- [Pipeline](#pipeline)
-- [PipelineRunSpec](#pipelinerunspec)
-- [PipelineRunStatus](#pipelinerunstatus)
-- [PipelineRunStatusFields](#pipelinerunstatusfields)
-- [PipelineTask](#pipelinetask)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `displayName` _string_ | DisplayName is a user-facing name of the pipeline that may be<br />used to populate a UI. |  | Optional: \{\} <br /> |
-| `description` _string_ | Description is a user-facing description of the pipeline that may be<br />used to populate a UI. |  | Optional: \{\} <br /> |
-| `resources` _[PipelineDeclaredResource](#pipelinedeclaredresource) array_ | Deprecated: Unused, preserved only for backwards compatibility |  |  |
-| `tasks` _[PipelineTask](#pipelinetask) array_ | Tasks declares the graph of Tasks that execute when this Pipeline is run. |  |  |
-| `params` _[ParamSpecs](#paramspecs)_ | Params declares a list of input parameters that must be supplied when<br />this Pipeline is run. |  |  |
-| `workspaces` _[PipelineWorkspaceDeclaration](#pipelineworkspacedeclaration) array_ | Workspaces declares a set of named workspaces that are expected to be<br />provided by a PipelineRun. |  | Optional: \{\} <br /> |
-| `results` _[PipelineResult](#pipelineresult) array_ | Results are values that this pipeline can output once run |  | Optional: \{\} <br /> |
-| `finally` _[PipelineTask](#pipelinetask) array_ | Finally declares the list of Tasks that execute just before leaving the Pipeline<br />i.e. either after all Tasks are finished executing successfully<br />or after a failure which would result in ending the Pipeline |  |  |
-
-
-#### PipelineTask
-
-
-
-PipelineTask defines a task in a Pipeline, passing inputs from both
-Params and from the output of previous tasks.
-
-
-
-_Appears in:_
-- [PipelineSpec](#pipelinespec)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `name` _string_ | Name is the name of this task within the context of a Pipeline. Name is<br />used as a coordinate with the `from` and `runAfter` fields to establish<br />the execution order of tasks relative to one another. |  |  |
-| `displayName` _string_ | DisplayName is the display name of this task within the context of a Pipeline.<br />This display name may be used to populate a UI. |  | Optional: \{\} <br /> |
-| `description` _string_ | Description is the description of this task within the context of a Pipeline.<br />This description may be used to populate a UI. |  | Optional: \{\} <br /> |
-| `taskRef` _[TaskRef](#taskref)_ | TaskRef is a reference to a task definition. |  | Optional: \{\} <br /> |
-| `taskSpec` _[EmbeddedTask](#embeddedtask)_ | TaskSpec is a specification of a task<br />Specifying TaskSpec can be disabled by setting<br />`disable-inline-spec` feature flag.<br />See Task.spec (API version: tekton.dev/v1beta1) |  | Schemaless: \{\} <br />Optional: \{\} <br /> |
-| `when` _[WhenExpressions](#whenexpressions)_ | WhenExpressions is a list of when expressions that need to be true for the task to run |  | Optional: \{\} <br /> |
-| `retries` _integer_ | Retries represents how many times this task should be retried in case of task failure: ConditionSucceeded set to False |  | Optional: \{\} <br /> |
-| `runAfter` _string array_ | RunAfter is the list of PipelineTask names that should be executed before<br />this Task executes. (Used to force a specific ordering in graph execution.) |  | Optional: \{\} <br /> |
-| `resources` _[PipelineTaskResources](#pipelinetaskresources)_ | Deprecated: Unused, preserved only for backwards compatibility |  | Optional: \{\} <br /> |
-| `params` _[Params](#params)_ | Parameters declares parameters passed to this task. |  | Optional: \{\} <br /> |
-| `matrix` _[Matrix](#matrix)_ | Matrix declares parameters used to fan out this task. |  | Optional: \{\} <br /> |
-| `workspaces` _[WorkspacePipelineTaskBinding](#workspacepipelinetaskbinding) array_ | Workspaces maps workspaces from the pipeline spec to the workspaces<br />declared in the Task. |  | Optional: \{\} <br /> |
-| `timeout` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ | Duration after which the TaskRun times out. Defaults to 1 hour.<br />Refer Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration |  | Optional: \{\} <br /> |
-| `pipelineRef` _[PipelineRef](#pipelineref)_ | PipelineRef is a reference to a pipeline definition.<br />This is an alpha field. You must set the "enable-api-fields" feature flag<br />to "alpha" for this field to be supported. When enabled, the referenced<br />Pipeline is executed as a child PipelineRun owned by the parent PipelineRun. |  | Optional: \{\} <br /> |
-| `pipelineSpec` _[PipelineSpec](#pipelinespec)_ | PipelineSpec is a specification of a pipeline.<br />This is an alpha field. You must set the "enable-api-fields" feature flag<br />to "alpha" for this field to be supported. When enabled, the embedded<br />Pipeline is executed as a child PipelineRun owned by the parent PipelineRun.<br />Specifying PipelineSpec can be disabled by setting<br />`disable-inline-spec` feature flag.<br />See Pipeline.spec (API version: tekton.dev/v1beta1) |  | Schemaless: \{\} <br />Optional: \{\} <br /> |
-| `onError` _[PipelineTaskOnErrorType](#pipelinetaskonerrortype)_ | OnError defines the exiting behavior of a PipelineRun on error<br />can be set to [ continue \| stopAndFail ] |  | Optional: \{\} <br /> |
-
-
-#### PipelineTaskInputResource
-
-
-
-PipelineTaskInputResource maps the name of a declared PipelineResource input
-dependency in a Task to the resource in the Pipeline's DeclaredPipelineResources
-that should be used. This input may come from a previous task.
-
-Deprecated: Unused, preserved only for backwards compatibility
-
-
-
-_Appears in:_
-- [PipelineTaskResources](#pipelinetaskresources)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `name` _string_ | Name is the name of the PipelineResource as declared by the Task. |  |  |
-| `resource` _string_ | Resource is the name of the DeclaredPipelineResource to use. |  |  |
-| `from` _string array_ | From is the list of PipelineTask names that the resource has to come from.<br />(Implies an ordering in the execution graph.) |  | Optional: \{\} <br /> |
-
-
-#### PipelineTaskMetadata
-
-
-
-PipelineTaskMetadata contains the labels or annotations for an EmbeddedTask
-
-
-
-_Appears in:_
-- [EmbeddedCustomRunSpec](#embeddedcustomrunspec)
-- [EmbeddedRunSpec](#embeddedrunspec)
-- [EmbeddedTask](#embeddedtask)
-- [PipelineTaskRunSpec](#pipelinetaskrunspec)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `labels` _object (keys:string, values:string)_ |  |  | Optional: \{\} <br /> |
-| `annotations` _object (keys:string, values:string)_ |  |  | Optional: \{\} <br /> |
-
-
-#### PipelineTaskOnErrorType
-
-_Underlying type:_ _string_
-
-PipelineTaskOnErrorType defines a list of supported failure handling behaviors of a PipelineTask on error
-
-
-
-_Appears in:_
-- [PipelineTask](#pipelinetask)
-
-| Field | Description |
-| --- | --- |
-| `stopAndFail` | PipelineTaskStopAndFail indicates to stop and fail the PipelineRun if the PipelineTask fails<br /> |
-| `continue` | PipelineTaskContinue indicates to continue executing the rest of the DAG when the PipelineTask fails<br /> |
-
-
-#### PipelineTaskOutputResource
-
-
-
-PipelineTaskOutputResource maps the name of a declared PipelineResource output
-dependency in a Task to the resource in the Pipeline's DeclaredPipelineResources
-that should be used.
-
-Deprecated: Unused, preserved only for backwards compatibility
-
-
-
-_Appears in:_
-- [PipelineTaskResources](#pipelinetaskresources)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `name` _string_ | Name is the name of the PipelineResource as declared by the Task. |  |  |
-| `resource` _string_ | Resource is the name of the DeclaredPipelineResource to use. |  |  |
-
-
-
-
-#### PipelineTaskResources
-
-
-
-PipelineTaskResources allows a Pipeline to declare how its DeclaredPipelineResources
-should be provided to a Task as its inputs and outputs.
-
-Deprecated: Unused, preserved only for backwards compatibility
-
-
-
-_Appears in:_
-- [PipelineTask](#pipelinetask)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `inputs` _[PipelineTaskInputResource](#pipelinetaskinputresource) array_ | Inputs holds the mapping from the PipelineResources declared in<br />DeclaredPipelineResources to the input PipelineResources required by the Task. |  |  |
-| `outputs` _[PipelineTaskOutputResource](#pipelinetaskoutputresource) array_ | Outputs holds the mapping from the PipelineResources declared in<br />DeclaredPipelineResources to the input PipelineResources required by the Task. |  |  |
-
-
-
-
-#### PipelineTaskRunSpec
-
-
-
-PipelineTaskRunSpec  can be used to configure specific
-specs for a concrete Task
-
-
-
-_Appears in:_
-- [PipelineRunSpec](#pipelinerunspec)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `pipelineTaskName` _string_ |  |  |  |
-| `taskServiceAccountName` _string_ |  |  |  |
-| `taskPodTemplate` _[PodTemplate](#podtemplate)_ |  |  |  |
-| `stepOverrides` _[TaskRunStepOverride](#taskrunstepoverride) array_ |  |  |  |
-| `sidecarOverrides` _[TaskRunSidecarOverride](#taskrunsidecaroverride) array_ |  |  |  |
-| `metadata` _[PipelineTaskMetadata](#pipelinetaskmetadata)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  | Optional: \{\} <br /> |
-| `computeResources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcerequirements-v1-core)_ | Compute resources to use for this TaskRun |  |  |
-| `timeout` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ | Duration after which the TaskRun times out.<br />Refer Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration |  | Optional: \{\} <br /> |
-
-
-#### PipelineWorkspaceDeclaration
-
-_Underlying type:_ _[struct{Name string "json:\"name\""; Description string "json:\"description,omitempty\""; Optional bool "json:\"optional,omitempty\""}](#struct{name-string-"json:\"name\"";-description-string-"json:\"description,omitempty\"";-optional-bool-"json:\"optional,omitempty\""})_
-
-PipelineWorkspaceDeclaration creates a named slot in a Pipeline that a PipelineRun
-is expected to populate with a workspace binding.
-
-
-
-_Appears in:_
-- [PipelineSpec](#pipelinespec)
-
-
-
-#### PropertySpec
-
-
-
-PropertySpec defines the struct for object keys
-
-
-
-_Appears in:_
-- [ParamSpec](#paramspec)
-- [TaskResult](#taskresult)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `type` _[ParamType](#paramtype)_ |  |  |  |
-
-
-#### Provenance
-
-
-
-Provenance contains metadata about resources used in the TaskRun/PipelineRun
+consume these fields via duck typing.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>startTime</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+<p>StartTime is the time the PipelineRun is actually started.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>completionTime</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+<p>CompletionTime is the time the PipelineRun completed.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>results</code><br/>
+<em>
+<a href="#tekton.dev/v1.PipelineRunResult">
+[]PipelineRunResult
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Results are the list of results written out by the pipeline task&rsquo;s containers</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>pipelineSpec</code><br/>
+<em>
+<a href="#tekton.dev/v1.PipelineSpec">
+PipelineSpec
+</a>
+</em>
+</td>
+<td>
+<p>PipelineSpec contains the exact spec used to instantiate the run.
+See Pipeline.spec (API version: tekton.dev/v1)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>skippedTasks</code><br/>
+<em>
+<a href="#tekton.dev/v1.SkippedTask">
+[]SkippedTask
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>list of tasks that were skipped due to when expressions evaluating to false</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>childReferences</code><br/>
+<em>
+<a href="#tekton.dev/v1.ChildStatusReference">
+[]ChildStatusReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>list of TaskRun and Run names, PipelineTask names, and API versions/kinds for children of this PipelineRun.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>finallyStartTime</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>FinallyStartTime is when all non-finally tasks have been completed and only finally tasks are being executed.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>provenance</code><br/>
+<em>
+<a href="#tekton.dev/v1.Provenance">
+Provenance
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Provenance contains some key authenticated metadata about how a software artifact was built (what sources, what inputs/outputs, etc.).</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>spanContext</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<p>SpanContext contains tracing span context fields</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.PipelineRunTaskRunStatus">PipelineRunTaskRunStatus
+</h3>
+<div>
+<p>PipelineRunTaskRunStatus contains the name of the PipelineTask for this TaskRun and the TaskRun&rsquo;s Status</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>pipelineTaskName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>PipelineTaskName is the name of the PipelineTask.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code><br/>
+<em>
+<a href="#tekton.dev/v1.TaskRunStatus">
+TaskRunStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Status is the TaskRunStatus for the corresponding TaskRun</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>whenExpressions</code><br/>
+<em>
+<a href="#tekton.dev/v1.WhenExpression">
+[]WhenExpression
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>WhenExpressions is the list of checks guarding the execution of the PipelineTask</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.PipelineSpec">PipelineSpec
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.Pipeline">Pipeline</a>, <a href="#tekton.dev/v1.PipelineRunSpec">PipelineRunSpec</a>, <a href="#tekton.dev/v1.PipelineRunStatusFields">PipelineRunStatusFields</a>, <a href="#tekton.dev/v1.PipelineTask">PipelineTask</a>)
+</p>
+<div>
+<p>PipelineSpec defines the desired state of Pipeline.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>displayName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DisplayName is a user-facing name of the pipeline that may be
+used to populate a UI.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>description</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Description is a user-facing description of the pipeline that may be
+used to populate a UI.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>tasks</code><br/>
+<em>
+<a href="#tekton.dev/v1.PipelineTask">
+[]PipelineTask
+</a>
+</em>
+</td>
+<td>
+<p>Tasks declares the graph of Tasks that execute when this Pipeline is run.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>params</code><br/>
+<em>
+<a href="#tekton.dev/v1.ParamSpecs">
+ParamSpecs
+</a>
+</em>
+</td>
+<td>
+<p>Params declares a list of input parameters that must be supplied when
+this Pipeline is run.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>workspaces</code><br/>
+<em>
+<a href="#tekton.dev/v1.PipelineWorkspaceDeclaration">
+[]PipelineWorkspaceDeclaration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Workspaces declares a set of named workspaces that are expected to be
+provided by a PipelineRun.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>results</code><br/>
+<em>
+<a href="#tekton.dev/v1.PipelineResult">
+[]PipelineResult
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Results are values that this pipeline can output once run</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>finally</code><br/>
+<em>
+<a href="#tekton.dev/v1.PipelineTask">
+[]PipelineTask
+</a>
+</em>
+</td>
+<td>
+<p>Finally declares the list of Tasks that execute just before leaving the Pipeline
+i.e. either after all Tasks are finished executing successfully
+or after a failure which would result in ending the Pipeline</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.PipelineTask">PipelineTask
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineSpec">PipelineSpec</a>)
+</p>
+<div>
+<p>PipelineTask defines a task in a Pipeline, passing inputs from both
+Params and from the output of previous tasks.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is the name of this task within the context of a Pipeline. Name is
+used as a coordinate with the <code>from</code> and <code>runAfter</code> fields to establish
+the execution order of tasks relative to one another.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>displayName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DisplayName is the display name of this task within the context of a Pipeline.
+This display name may be used to populate a UI.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>description</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Description is the description of this task within the context of a Pipeline.
+This description may be used to populate a UI.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>taskRef</code><br/>
+<em>
+<a href="#tekton.dev/v1.TaskRef">
+TaskRef
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TaskRef is a reference to a task definition.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>taskSpec</code><br/>
+<em>
+<a href="#tekton.dev/v1.EmbeddedTask">
+EmbeddedTask
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TaskSpec is a specification of a task
+Specifying TaskSpec can be disabled by setting
+<code>disable-inline-spec</code> feature flag.
+See Task.spec (API version: tekton.dev/v1)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>when</code><br/>
+<em>
+<a href="#tekton.dev/v1.WhenExpressions">
+WhenExpressions
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>When is a list of when expressions that need to be true for the task to run</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>retries</code><br/>
+<em>
+int
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Retries represents how many times this task should be retried in case of task failure: ConditionSucceeded set to False</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>runAfter</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>RunAfter is the list of PipelineTask names that should be executed before
+this Task executes. (Used to force a specific ordering in graph execution.)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>params</code><br/>
+<em>
+<a href="#tekton.dev/v1.Params">
+Params
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Parameters declares parameters passed to this task.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>matrix</code><br/>
+<em>
+<a href="#tekton.dev/v1.Matrix">
+Matrix
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Matrix declares parameters used to fan out this task.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>workspaces</code><br/>
+<em>
+<a href="#tekton.dev/v1.WorkspacePipelineTaskBinding">
+[]WorkspacePipelineTaskBinding
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Workspaces maps workspaces from the pipeline spec to the workspaces
+declared in the Task.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>timeout</code><br/>
+<em>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+Kubernetes meta/v1.Duration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Duration after which the TaskRun times out. Defaults to 1 hour.
+Refer Go&rsquo;s ParseDuration documentation for expected format: <a href="https://golang.org/pkg/time/#ParseDuration">https://golang.org/pkg/time/#ParseDuration</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>pipelineRef</code><br/>
+<em>
+<a href="#tekton.dev/v1.PipelineRef">
+PipelineRef
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>PipelineRef is a reference to a pipeline definition
+Note: PipelineRef is in preview mode and not yet supported</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>pipelineSpec</code><br/>
+<em>
+<a href="#tekton.dev/v1.PipelineSpec">
+PipelineSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>PipelineSpec is a specification of a pipeline
+Note: PipelineSpec is in preview mode and not yet supported
+Specifying PipelineSpec can be disabled by setting
+<code>disable-inline-spec</code> feature flag.
+See Pipeline.spec (API version: tekton.dev/v1)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>onError</code><br/>
+<em>
+<a href="#tekton.dev/v1.PipelineTaskOnErrorType">
+PipelineTaskOnErrorType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>OnError defines the exiting behavior of a PipelineRun on error
+can be set to [ continue | stopAndFail ]</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.PipelineTaskMetadata">PipelineTaskMetadata
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.EmbeddedTask">EmbeddedTask</a>, <a href="#tekton.dev/v1.PipelineTaskRunSpec">PipelineTaskRunSpec</a>)
+</p>
+<div>
+<p>PipelineTaskMetadata contains the labels or annotations for an EmbeddedTask</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>labels</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>annotations</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.PipelineTaskOnErrorType">PipelineTaskOnErrorType
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineTask">PipelineTask</a>)
+</p>
+<div>
+<p>PipelineTaskOnErrorType defines a list of supported failure handling behaviors of a PipelineTask on error</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;continue&#34;</p></td>
+<td><p>PipelineTaskContinue indicates to continue executing the rest of the DAG when the PipelineTask fails</p>
+</td>
+</tr><tr><td><p>&#34;stopAndFail&#34;</p></td>
+<td><p>PipelineTaskStopAndFail indicates to stop and fail the PipelineRun if the PipelineTask fails</p>
+</td>
+</tr></tbody>
+</table>
+<h3 id="tekton.dev/v1.PipelineTaskParam">PipelineTaskParam
+</h3>
+<div>
+<p>PipelineTaskParam is used to provide arbitrary string parameters to a Task.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>value</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.PipelineTaskRun">PipelineTaskRun
+</h3>
+<div>
+<p>PipelineTaskRun reports the results of running a step in the Task. Each
+task has the potential to succeed or fail (based on the exit code)
+and produces logs.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.PipelineTaskRunSpec">PipelineTaskRunSpec
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineRunSpec">PipelineRunSpec</a>)
+</p>
+<div>
+<p>PipelineTaskRunSpec  can be used to configure specific
+specs for a concrete Task</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>pipelineTaskName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceAccountName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>podTemplate</code><br/>
+<em>
+<a href="#tekton.dev/unversioned.PodTemplate">
+PodTemplate
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>stepSpecs</code><br/>
+<em>
+<a href="#tekton.dev/v1.TaskRunStepSpec">
+[]TaskRunStepSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>sidecarSpecs</code><br/>
+<em>
+<a href="#tekton.dev/v1.TaskRunSidecarSpec">
+[]TaskRunSidecarSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="#tekton.dev/v1.PipelineTaskMetadata">
+PipelineTaskMetadata
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>computeResources</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#resourcerequirements-v1-core">
+Kubernetes core/v1.ResourceRequirements
+</a>
+</em>
+</td>
+<td>
+<p>Compute resources to use for this TaskRun</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>timeout</code><br/>
+<em>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+Kubernetes meta/v1.Duration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Duration after which the TaskRun times out. Overrides the timeout specified
+on the Task&rsquo;s spec if specified. Takes lower precedence to PipelineRun&rsquo;s
+<code>spec.timeouts.tasks</code>
+Refer Go&rsquo;s ParseDuration documentation for expected format: <a href="https://golang.org/pkg/time/#ParseDuration">https://golang.org/pkg/time/#ParseDuration</a></p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.PipelineTaskRunTemplate">PipelineTaskRunTemplate
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineRunSpec">PipelineRunSpec</a>)
+</p>
+<div>
+<p>PipelineTaskRunTemplate is used to specify run specifications for all Task in pipelinerun.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>podTemplate</code><br/>
+<em>
+<a href="#tekton.dev/unversioned.PodTemplate">
+PodTemplate
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceAccountName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.PipelineWorkspaceDeclaration">PipelineWorkspaceDeclaration
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineSpec">PipelineSpec</a>)
+</p>
+<div>
+<p>PipelineWorkspaceDeclaration creates a named slot in a Pipeline that a PipelineRun
+is expected to populate with a workspace binding.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is the name of a workspace to be provided by a PipelineRun.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>description</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Description is a human readable string describing how the workspace will be
+used in the Pipeline. It can be useful to include a bit of detail about which
+tasks are intended to have access to the data on the workspace.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>optional</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>Optional marks a Workspace as not being required in PipelineRuns. By default
+this field is false and so declared workspaces are required.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.PropertySpec">PropertySpec
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.ParamSpec">ParamSpec</a>, <a href="#tekton.dev/v1.StepResult">StepResult</a>, <a href="#tekton.dev/v1.TaskResult">TaskResult</a>)
+</p>
+<div>
+<p>PropertySpec defines the struct for object keys</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>type</code><br/>
+<em>
+<a href="#tekton.dev/v1.ParamType">
+ParamType
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.Provenance">Provenance
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineRunStatusFields">PipelineRunStatusFields</a>, <a href="#tekton.dev/v1.StepState">StepState</a>, <a href="#tekton.dev/v1.TaskRunStatusFields">TaskRunStatusFields</a>)
+</p>
+<div>
+<p>Provenance contains metadata about resources used in the TaskRun/PipelineRun
 such as the source from where a remote build definition was fetched.
 This field aims to carry minimum amoumt of metadata in *Run status so that
-Tekton Chains can capture them in the provenance.
-
-
-
-_Appears in:_
-- [PipelineRunStatus](#pipelinerunstatus)
-- [PipelineRunStatusFields](#pipelinerunstatusfields)
-- [StepState](#stepstate)
-- [TaskRunStatus](#taskrunstatus)
-- [TaskRunStatusFields](#taskrunstatusfields)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `configSource` _[ConfigSource](#configsource)_ | Deprecated: Use RefSource instead |  |  |
-| `refSource` _[RefSource](#refsource)_ | RefSource identifies the source where a remote task/pipeline came from. |  |  |
-| `featureFlags` _[FeatureFlags](#featureflags)_ | FeatureFlags identifies the feature flags that were used during the task/pipeline run |  |  |
-
-
-#### Ref
-
-
-
-Ref can be used to refer to a specific instance of a StepAction.
-
-
-
-_Appears in:_
-- [Step](#step)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `name` _string_ | Name of the referenced step |  |  |
-| `ResolverRef` _[ResolverRef](#resolverref)_ | ResolverRef allows referencing a StepAction in a remote location<br />like a git repo. |  | Optional: \{\} <br /> |
-
-
-#### RefSource
-
-
-
-RefSource contains the information that can uniquely identify where a remote
+Tekton Chains can capture them in the provenance.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>refSource</code><br/>
+<em>
+<a href="#tekton.dev/v1.RefSource">
+RefSource
+</a>
+</em>
+</td>
+<td>
+<p>RefSource identifies the source where a remote task/pipeline came from.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>featureFlags</code><br/>
+<em>
+github.com/tektoncd/pipeline/pkg/apis/config.FeatureFlags
+</em>
+</td>
+<td>
+<p>FeatureFlags identifies the feature flags that were used during the task/pipeline run</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.Ref">Ref
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.Step">Step</a>)
+</p>
+<div>
+<p>Ref can be used to refer to a specific instance of a StepAction.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name of the referenced step</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ResolverRef</code><br/>
+<em>
+<a href="#tekton.dev/v1.ResolverRef">
+ResolverRef
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ResolverRef allows referencing a StepAction in a remote location
+like a git repo.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.RefSource">RefSource
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.Provenance">Provenance</a>, <a href="#resolution.tekton.dev/v1alpha1.ResolutionRequestStatusFields">ResolutionRequestStatusFields</a>, <a href="#resolution.tekton.dev/v1beta1.ResolutionRequestStatusFields">ResolutionRequestStatusFields</a>)
+</p>
+<div>
+<p>RefSource contains the information that can uniquely identify where a remote
 built definition came from i.e. Git repositories, Tekton Bundles in OCI registry
-and hub.
-
-
-
-_Appears in:_
-- [Provenance](#provenance)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `uri` _string_ | URI indicates the identity of the source of the build definition.<br />Example: "https://github.com/tektoncd/catalog" |  |  |
-| `digest` _object (keys:string, values:string)_ | Digest is a collection of cryptographic digests for the contents of the artifact specified by URI.<br />Example: \{"sha1": "f99d13e554ffcb696dee719fa85b695cb5b0f428"\} |  |  |
-| `entryPoint` _string_ | EntryPoint identifies the entry point into the build. This is often a path to a<br />build definition file and/or a target label within that file.<br />Example: "task/git-clone/0.10/git-clone.yaml" |  |  |
-
-
-#### ResolverName
-
-_Underlying type:_ _string_
-
-ResolverName is the name of a resolver from which a resource can be
-requested.
-
-
-
-_Appears in:_
-- [ResolverRef](#resolverref)
-
-
-
-#### ResolverRef
-
-
-
-ResolverRef can be used to refer to a Pipeline or Task in a remote
-location like a git repo.
-
-
-
-_Appears in:_
-- [PipelineRef](#pipelineref)
-- [Ref](#ref)
-- [TaskRef](#taskref)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `resolver` _[ResolverName](#resolvername)_ | Resolver is the name of the resolver that should perform<br />resolution of the referenced Tekton resource, such as "git". |  | Optional: \{\} <br /> |
-| `params` _[Params](#params)_ | Params contains the parameters used to identify the<br />referenced Tekton resource. Example entries might include<br />"repo" or "path" but the set of params ultimately depends on<br />the chosen resolver. |  | Optional: \{\} <br /> |
-
-
-
-
-
-
-
-
-
-
-
-
-#### ResultsType
-
-_Underlying type:_ _string_
-
-ResultsType indicates the type of a result;
+and hub.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>uri</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>URI indicates the identity of the source of the build definition.
+Example: &ldquo;<a href="https://github.com/tektoncd/catalog&quot;">https://github.com/tektoncd/catalog&rdquo;</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>digest</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<p>Digest is a collection of cryptographic digests for the contents of the artifact specified by URI.
+Example: {&ldquo;sha1&rdquo;: &ldquo;f99d13e554ffcb696dee719fa85b695cb5b0f428&rdquo;}</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>entryPoint</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>EntryPoint identifies the entry point into the build. This is often a path to a
+build definition file and/or a target label within that file.
+Example: &ldquo;task/git-clone/0.10/git-clone.yaml&rdquo;</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.ResolverName">ResolverName
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.ResolverRef">ResolverRef</a>)
+</p>
+<div>
+<p>ResolverName is the name of a resolver from which a resource can be
+requested.</p>
+</div>
+<h3 id="tekton.dev/v1.ResolverRef">ResolverRef
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineRef">PipelineRef</a>, <a href="#tekton.dev/v1.Ref">Ref</a>, <a href="#tekton.dev/v1.TaskRef">TaskRef</a>)
+</p>
+<div>
+<p>ResolverRef can be used to refer to a Pipeline or Task in a remote
+location like a git repo. This feature is in beta and these fields
+are only available when the beta feature gate is enabled.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>resolver</code><br/>
+<em>
+<a href="#tekton.dev/v1.ResolverName">
+ResolverName
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Resolver is the name of the resolver that should perform
+resolution of the referenced Tekton resource, such as &ldquo;git&rdquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>params</code><br/>
+<em>
+<a href="#tekton.dev/v1.Params">
+Params
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Params contains the parameters used to identify the
+referenced Tekton resource. Example entries might include
+&ldquo;repo&rdquo; or &ldquo;path&rdquo; but the set of params ultimately depends on
+the chosen resolver.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.ResultRef">ResultRef
+</h3>
+<div>
+<p>ResultRef is a type that represents a reference to a task run result</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>pipelineTask</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>result</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>resultsIndex</code><br/>
+<em>
+int
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>property</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.ResultValue">ResultValue
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineResult">PipelineResult</a>, <a href="#tekton.dev/v1.PipelineRunResult">PipelineRunResult</a>, <a href="#tekton.dev/v1.TaskResult">TaskResult</a>, <a href="#tekton.dev/v1.TaskRunResult">TaskRunResult</a>)
+</p>
+<div>
+<p>ResultValue is a type alias of ParamValue</p>
+</div>
+<h3 id="tekton.dev/v1.ResultsType">ResultsType
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineResult">PipelineResult</a>, <a href="#tekton.dev/v1.StepResult">StepResult</a>, <a href="#tekton.dev/v1.TaskResult">TaskResult</a>, <a href="#tekton.dev/v1.TaskRunResult">TaskRunResult</a>)
+</p>
+<div>
+<p>ResultsType indicates the type of a result;
 Used to distinguish between a single string and an array of strings.
 Note that there is ResultType used to find out whether a
 RunResult is from a task result or not, which is different from
-this ResultsType.
-
-
-
-_Appears in:_
-- [TaskResult](#taskresult)
-- [TaskRunResult](#taskrunresult)
-
-| Field | Description |
-| --- | --- |
-| `string` |  |
-| `array` |  |
-| `object` |  |
-
-
-#### RetriesStatus
-
-_Underlying type:_ _[TaskRunStatus](#taskrunstatus)_
-
-
-
-
-
-_Appears in:_
-- [TaskRunStatus](#taskrunstatus)
-- [TaskRunStatusFields](#taskrunstatusfields)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `Status` _[Status](https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Status)_ |  |  |  |
-| `TaskRunStatusFields` _[TaskRunStatusFields](#taskrunstatusfields)_ | TaskRunStatusFields inlines the status fields. |  |  |
-
-
-
-
-
-
-
-
-#### Sidecar
-
-
-
-Sidecar has nearly the same data structure as Step but does not have the ability to timeout.
-
-
-
-_Appears in:_
-- [EmbeddedTask](#embeddedtask)
-- [TaskSpec](#taskspec)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `name` _string_ | Name of the Sidecar specified as a DNS_LABEL.<br />Each Sidecar in a Task must have a unique name (DNS_LABEL).<br />Cannot be updated. |  |  |
-| `image` _string_ | Image name to be used by the Sidecar.<br />More info: https://kubernetes.io/docs/concepts/containers/images |  | Optional: \{\} <br /> |
-| `command` _string array_ | Entrypoint array. Not executed within a shell.<br />The image's ENTRYPOINT is used if this is not provided.<br />Variable references $(VAR_NAME) are expanded using the Sidecar's environment. If a variable<br />cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced<br />to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will<br />produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless<br />of whether the variable exists or not. Cannot be updated.<br />More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell |  | Optional: \{\} <br /> |
-| `args` _string array_ | Arguments to the entrypoint.<br />The image's CMD is used if this is not provided.<br />Variable references $(VAR_NAME) are expanded using the container's environment. If a variable<br />cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced<br />to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will<br />produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless<br />of whether the variable exists or not. Cannot be updated.<br />More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell |  | Optional: \{\} <br /> |
-| `workingDir` _string_ | Sidecar's working directory.<br />If not specified, the container runtime's default will be used, which<br />might be configured in the container image.<br />Cannot be updated. |  | Optional: \{\} <br /> |
-| `ports` _[ContainerPort](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#containerport-v1-core) array_ | List of ports to expose from the Sidecar. Exposing a port here gives<br />the system additional information about the network connections a<br />container uses, but is primarily informational. Not specifying a port here<br />DOES NOT prevent that port from being exposed. Any port which is<br />listening on the default "0.0.0.0" address inside a container will be<br />accessible from the network.<br />Cannot be updated. |  | Optional: \{\} <br /> |
-| `envFrom` _[EnvFromSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#envfromsource-v1-core) array_ | List of sources to populate environment variables in the Sidecar.<br />The keys defined within a source must be a C_IDENTIFIER. All invalid keys<br />will be reported as an event when the Sidecar is starting. When a key exists in multiple<br />sources, the value associated with the last source will take precedence.<br />Values defined by an Env with a duplicate key will take precedence.<br />Cannot be updated. |  | Optional: \{\} <br /> |
-| `env` _[EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#envvar-v1-core) array_ | List of environment variables to set in the Sidecar.<br />Cannot be updated. |  | Optional: \{\} <br /> |
-| `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcerequirements-v1-core)_ | Compute Resources required by this Sidecar.<br />Cannot be updated.<br />More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |  | Optional: \{\} <br /> |
-| `volumeMounts` _[VolumeMount](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#volumemount-v1-core) array_ | Volumes to mount into the Sidecar's filesystem.<br />Cannot be updated. |  | Optional: \{\} <br /> |
-| `volumeDevices` _[VolumeDevice](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#volumedevice-v1-core) array_ | volumeDevices is the list of block devices to be used by the Sidecar. |  | Optional: \{\} <br /> |
-| `livenessProbe` _[Probe](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#probe-v1-core)_ | Periodic probe of Sidecar liveness.<br />Container will be restarted if the probe fails.<br />Cannot be updated.<br />More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes |  | Optional: \{\} <br /> |
-| `readinessProbe` _[Probe](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#probe-v1-core)_ | Periodic probe of Sidecar service readiness.<br />Container will be removed from service endpoints if the probe fails.<br />Cannot be updated.<br />More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes |  | Optional: \{\} <br /> |
-| `startupProbe` _[Probe](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#probe-v1-core)_ | StartupProbe indicates that the Pod the Sidecar is running in has successfully initialized.<br />If specified, no other probes are executed until this completes successfully.<br />If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.<br />This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,<br />when it might take a long time to load data or warm a cache, than during steady-state operation.<br />This cannot be updated.<br />More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes |  | Optional: \{\} <br /> |
-| `lifecycle` _[Lifecycle](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#lifecycle-v1-core)_ | Actions that the management system should take in response to Sidecar lifecycle events.<br />Cannot be updated. |  | Optional: \{\} <br /> |
-| `terminationMessagePath` _string_ | Optional: Path at which the file to which the Sidecar's termination message<br />will be written is mounted into the Sidecar's filesystem.<br />Message written is intended to be brief final status, such as an assertion failure message.<br />Will be truncated by the node if greater than 4096 bytes. The total message length across<br />all containers will be limited to 12kb.<br />Defaults to /dev/termination-log.<br />Cannot be updated. |  | Optional: \{\} <br /> |
-| `terminationMessagePolicy` _[TerminationMessagePolicy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#terminationmessagepolicy-v1-core)_ | Indicate how the termination message should be populated. File will use the contents of<br />terminationMessagePath to populate the Sidecar status message on both success and failure.<br />FallbackToLogsOnError will use the last chunk of Sidecar log output if the termination<br />message file is empty and the Sidecar exited with an error.<br />The log output is limited to 2048 bytes or 80 lines, whichever is smaller.<br />Defaults to File.<br />Cannot be updated. |  | Optional: \{\} <br /> |
-| `imagePullPolicy` _[PullPolicy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#pullpolicy-v1-core)_ | Image pull policy.<br />One of Always, Never, IfNotPresent.<br />Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.<br />Cannot be updated.<br />More info: https://kubernetes.io/docs/concepts/containers/images#updating-images |  | Optional: \{\} <br /> |
-| `securityContext` _[SecurityContext](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#securitycontext-v1-core)_ | SecurityContext defines the security options the Sidecar should be run with.<br />If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.<br />More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ |  | Optional: \{\} <br /> |
-| `stdin` _boolean_ | Whether this Sidecar should allocate a buffer for stdin in the container runtime. If this<br />is not set, reads from stdin in the Sidecar will always result in EOF.<br />Default is false. |  | Optional: \{\} <br /> |
-| `stdinOnce` _boolean_ | Whether the container runtime should close the stdin channel after it has been opened by<br />a single attach. When stdin is true the stdin stream will remain open across multiple attach<br />sessions. If stdinOnce is set to true, stdin is opened on Sidecar start, is empty until the<br />first client attaches to stdin, and then remains open and accepts data until the client disconnects,<br />at which time stdin is closed and remains closed until the Sidecar is restarted. If this<br />flag is false, a container processes that reads from stdin will never receive an EOF.<br />Default is false |  | Optional: \{\} <br /> |
-| `tty` _boolean_ | Whether this Sidecar should allocate a TTY for itself, also requires 'stdin' to be true.<br />Default is false. |  | Optional: \{\} <br /> |
-| `script` _string_ | Script is the contents of an executable file to execute.<br />If Script is not empty, the Step cannot have an Command or Args. |  | Optional: \{\} <br /> |
-| `workspaces` _[WorkspaceUsage](#workspaceusage) array_ | This is an alpha field. You must set the "enable-api-fields" feature flag to "alpha"<br />for this field to be supported.<br />Workspaces is a list of workspaces from the Task that this Sidecar wants<br />exclusive access to. Adding a workspace to this list means that any<br />other Step or Sidecar that does not also request this Workspace will<br />not have access to it. |  | Optional: \{\} <br /> |
-| `restartPolicy` _[ContainerRestartPolicy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#containerrestartpolicy-v1-core)_ | RestartPolicy refers to kubernetes RestartPolicy. It can only be set for an<br />initContainer and must have it's policy set to "Always". It is currently<br />left optional to help support Kubernetes versions prior to 1.29 when this feature<br />was introduced. |  | Optional: \{\} <br /> |
-
-
-#### SidecarState
-
-
-
-SidecarState reports the results of running a sidecar in a Task.
-
-
-
-_Appears in:_
-- [TaskRunStatus](#taskrunstatus)
-- [TaskRunStatusFields](#taskrunstatusfields)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `waiting` _[ContainerStateWaiting](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#containerstatewaiting-v1-core)_ | Details about a waiting container |  | Optional: \{\} <br /> |
-| `running` _[ContainerStateRunning](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#containerstaterunning-v1-core)_ | Details about a running container |  | Optional: \{\} <br /> |
-| `terminated` _[ContainerStateTerminated](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#containerstateterminated-v1-core)_ | Details about a terminated container |  | Optional: \{\} <br /> |
-| `name` _string_ |  |  |  |
-| `container` _string_ |  |  |  |
-| `imageID` _string_ |  |  |  |
-
-
-#### SkippedTask
-
-
-
-SkippedTask is used to describe the Tasks that were skipped due to their When Expressions
+this ResultsType.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;array&#34;</p></td>
+<td></td>
+</tr><tr><td><p>&#34;object&#34;</p></td>
+<td></td>
+</tr><tr><td><p>&#34;string&#34;</p></td>
+<td></td>
+</tr></tbody>
+</table>
+<h3 id="tekton.dev/v1.RetriesStatus">RetriesStatus
+(<code>[]github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskRunStatus</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.TaskRunStatusFields">TaskRunStatusFields</a>)
+</p>
+<div>
+</div>
+<h3 id="tekton.dev/v1.Sidecar">Sidecar
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.TaskSpec">TaskSpec</a>)
+</p>
+<div>
+<p>Sidecar has nearly the same data structure as Step but does not have the ability to timeout.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name of the Sidecar specified as a DNS_LABEL.
+Each Sidecar in a Task must have a unique name (DNS_LABEL).
+Cannot be updated.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>image</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Image reference name.
+More info: <a href="https://kubernetes.io/docs/concepts/containers/images">https://kubernetes.io/docs/concepts/containers/images</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>command</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Entrypoint array. Not executed within a shell.
+The image&rsquo;s ENTRYPOINT is used if this is not provided.
+Variable references $(VAR_NAME) are expanded using the Sidecar&rsquo;s environment. If a variable
+cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. &ldquo;$$(VAR_NAME)&rdquo; will
+produce the string literal &ldquo;$(VAR_NAME)&rdquo;. Escaped references will never be expanded, regardless
+of whether the variable exists or not. Cannot be updated.
+More info: <a href="https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell">https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>args</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Arguments to the entrypoint.
+The image&rsquo;s CMD is used if this is not provided.
+Variable references $(VAR_NAME) are expanded using the Sidecar&rsquo;s environment. If a variable
+cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. &ldquo;$$(VAR_NAME)&rdquo; will
+produce the string literal &ldquo;$(VAR_NAME)&rdquo;. Escaped references will never be expanded, regardless
+of whether the variable exists or not. Cannot be updated.
+More info: <a href="https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell">https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>workingDir</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Sidecar&rsquo;s working directory.
+If not specified, the container runtime&rsquo;s default will be used, which
+might be configured in the container image.
+Cannot be updated.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ports</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#containerport-v1-core">
+[]Kubernetes core/v1.ContainerPort
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>List of ports to expose from the Sidecar. Exposing a port here gives
+the system additional information about the network connections a
+container uses, but is primarily informational. Not specifying a port here
+DOES NOT prevent that port from being exposed. Any port which is
+listening on the default &ldquo;0.0.0.0&rdquo; address inside a container will be
+accessible from the network.
+Cannot be updated.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>envFrom</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#envfromsource-v1-core">
+[]Kubernetes core/v1.EnvFromSource
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>List of sources to populate environment variables in the Sidecar.
+The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+will be reported as an event when the container is starting. When a key exists in multiple
+sources, the value associated with the last source will take precedence.
+Values defined by an Env with a duplicate key will take precedence.
+Cannot be updated.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>env</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#envvar-v1-core">
+[]Kubernetes core/v1.EnvVar
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>List of environment variables to set in the Sidecar.
+Cannot be updated.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>computeResources</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#resourcerequirements-v1-core">
+Kubernetes core/v1.ResourceRequirements
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ComputeResources required by this Sidecar.
+Cannot be updated.
+More info: <a href="https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/">https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>volumeMounts</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#volumemount-v1-core">
+[]Kubernetes core/v1.VolumeMount
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Volumes to mount into the Sidecar&rsquo;s filesystem.
+Cannot be updated.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>volumeDevices</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#volumedevice-v1-core">
+[]Kubernetes core/v1.VolumeDevice
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>volumeDevices is the list of block devices to be used by the Sidecar.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>livenessProbe</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#probe-v1-core">
+Kubernetes core/v1.Probe
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Periodic probe of Sidecar liveness.
+Container will be restarted if the probe fails.
+Cannot be updated.
+More info: <a href="https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes">https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>readinessProbe</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#probe-v1-core">
+Kubernetes core/v1.Probe
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Periodic probe of Sidecar service readiness.
+Container will be removed from service endpoints if the probe fails.
+Cannot be updated.
+More info: <a href="https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes">https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>startupProbe</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#probe-v1-core">
+Kubernetes core/v1.Probe
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>StartupProbe indicates that the Pod the Sidecar is running in has successfully initialized.
+If specified, no other probes are executed until this completes successfully.
+If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+This can be used to provide different probe parameters at the beginning of a Pod&rsquo;s lifecycle,
+when it might take a long time to load data or warm a cache, than during steady-state operation.
+This cannot be updated.
+More info: <a href="https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes">https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>lifecycle</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#lifecycle-v1-core">
+Kubernetes core/v1.Lifecycle
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Actions that the management system should take in response to Sidecar lifecycle events.
+Cannot be updated.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>terminationMessagePath</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Optional: Path at which the file to which the Sidecar&rsquo;s termination message
+will be written is mounted into the Sidecar&rsquo;s filesystem.
+Message written is intended to be brief final status, such as an assertion failure message.
+Will be truncated by the node if greater than 4096 bytes. The total message length across
+all containers will be limited to 12kb.
+Defaults to /dev/termination-log.
+Cannot be updated.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>terminationMessagePolicy</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#terminationmessagepolicy-v1-core">
+Kubernetes core/v1.TerminationMessagePolicy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Indicate how the termination message should be populated. File will use the contents of
+terminationMessagePath to populate the Sidecar status message on both success and failure.
+FallbackToLogsOnError will use the last chunk of Sidecar log output if the termination
+message file is empty and the Sidecar exited with an error.
+The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+Defaults to File.
+Cannot be updated.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>imagePullPolicy</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#pullpolicy-v1-core">
+Kubernetes core/v1.PullPolicy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Image pull policy.
+One of Always, Never, IfNotPresent.
+Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+Cannot be updated.
+More info: <a href="https://kubernetes.io/docs/concepts/containers/images#updating-images">https://kubernetes.io/docs/concepts/containers/images#updating-images</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>securityContext</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#securitycontext-v1-core">
+Kubernetes core/v1.SecurityContext
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>SecurityContext defines the security options the Sidecar should be run with.
+If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+More info: <a href="https://kubernetes.io/docs/tasks/configure-pod-container/security-context/">https://kubernetes.io/docs/tasks/configure-pod-container/security-context/</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>stdin</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Whether this Sidecar should allocate a buffer for stdin in the container runtime. If this
+is not set, reads from stdin in the Sidecar will always result in EOF.
+Default is false.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>stdinOnce</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Whether the container runtime should close the stdin channel after it has been opened by
+a single attach. When stdin is true the stdin stream will remain open across multiple attach
+sessions. If stdinOnce is set to true, stdin is opened on Sidecar start, is empty until the
+first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+at which time stdin is closed and remains closed until the Sidecar is restarted. If this
+flag is false, a container processes that reads from stdin will never receive an EOF.
+Default is false</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>tty</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Whether this Sidecar should allocate a TTY for itself, also requires &lsquo;stdin&rsquo; to be true.
+Default is false.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>script</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Script is the contents of an executable file to execute.</p>
+<p>If Script is not empty, the Step cannot have an Command or Args.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>workspaces</code><br/>
+<em>
+<a href="#tekton.dev/v1.WorkspaceUsage">
+[]WorkspaceUsage
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>This is an alpha field. You must set the &ldquo;enable-api-fields&rdquo; feature flag to &ldquo;alpha&rdquo;
+for this field to be supported.</p>
+<p>Workspaces is a list of workspaces from the Task that this Sidecar wants
+exclusive access to. Adding a workspace to this list means that any
+other Step or Sidecar that does not also request this Workspace will
+not have access to it.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>restartPolicy</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#containerrestartpolicy-v1-core">
+Kubernetes core/v1.ContainerRestartPolicy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>RestartPolicy refers to kubernetes RestartPolicy. It can only be set for an
+initContainer and must have it&rsquo;s policy set to &ldquo;Always&rdquo;. It is currently
+left optional to help support Kubernetes versions prior to 1.29 when this feature
+was introduced.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.SidecarState">SidecarState
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.TaskRunStatusFields">TaskRunStatusFields</a>)
+</p>
+<div>
+<p>SidecarState reports the results of running a sidecar in a Task.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>ContainerState</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#containerstate-v1-core">
+Kubernetes core/v1.ContainerState
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>ContainerState</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>container</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>imageID</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.SkippedTask">SkippedTask
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineRunStatusFields">PipelineRunStatusFields</a>)
+</p>
+<div>
+<p>SkippedTask is used to describe the Tasks that were skipped due to their When Expressions
 evaluating to False. This is a struct because we are looking into including more details
-about the When Expressions that caused this Task to be skipped.
-
-
-
-_Appears in:_
-- [PipelineRunStatus](#pipelinerunstatus)
-- [PipelineRunStatusFields](#pipelinerunstatusfields)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `name` _string_ | Name is the Pipeline Task name |  |  |
-| `reason` _[SkippingReason](#skippingreason)_ | Reason is the cause of the PipelineTask being skipped. |  |  |
-| `whenExpressions` _[WhenExpression](#whenexpression) array_ | WhenExpressions is the list of checks guarding the execution of the PipelineTask |  | Optional: \{\} <br /> |
-
-
-#### SkippingReason
-
-_Underlying type:_ _string_
-
-SkippingReason explains why a PipelineTask was skipped.
-
-
-
-_Appears in:_
-- [SkippedTask](#skippedtask)
-
-| Field | Description |
-| --- | --- |
-| `When Expressions evaluated to false` | WhenExpressionsSkip means the task was skipped due to at least one of its when expressions evaluating to false<br /> |
-| `Parent Tasks were skipped` | ParentTasksSkip means the task was skipped because its parent was skipped<br /> |
-| `PipelineRun was stopping` | StoppingSkip means the task was skipped because the pipeline run is stopping<br /> |
-| `PipelineRun was gracefully cancelled` | GracefullyCancelledSkip means the task was skipped because the pipeline run has been gracefully cancelled<br /> |
-| `PipelineRun was gracefully stopped` | GracefullyStoppedSkip means the task was skipped because the pipeline run has been gracefully stopped<br /> |
-| `Results were missing` | MissingResultsSkip means the task was skipped because it's missing necessary results<br /> |
-| `PipelineRun timeout has been reached` | PipelineTimedOutSkip means the task was skipped because the PipelineRun has passed its overall timeout.<br /> |
-| `PipelineRun Tasks timeout has been reached` | TasksTimedOutSkip means the task was skipped because the PipelineRun has passed its Timeouts.Tasks.<br /> |
-| `PipelineRun Finally timeout has been reached` | FinallyTimedOutSkip means the task was skipped because the PipelineRun has passed its Timeouts.Finally.<br /> |
-| `Matrix Parameters have an empty array` | EmptyArrayInMatrixParams means the task was skipped because Matrix parameters contain empty array.<br /> |
-| `None` | None means the task was not skipped<br /> |
-
-
-#### Step
-
-
-
-Step runs a subcomponent of a Task
-
-
-
-_Appears in:_
-- [EmbeddedTask](#embeddedtask)
-- [InternalTaskModifier](#internaltaskmodifier)
-- [TaskSpec](#taskspec)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `name` _string_ | Name of the Step specified as a DNS_LABEL.<br />Each Step in a Task must have a unique name. |  |  |
-| `displayName` _string_ | DisplayName is a user-facing name of the step that may be<br />used to populate a UI. |  | Optional: \{\} <br /> |
-| `image` _string_ | Image reference name to run for this Step.<br />More info: https://kubernetes.io/docs/concepts/containers/images |  | Optional: \{\} <br /> |
-| `command` _string array_ | Entrypoint array. Not executed within a shell.<br />The image's ENTRYPOINT is used if this is not provided.<br />Variable references $(VAR_NAME) are expanded using the container's environment. If a variable<br />cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced<br />to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will<br />produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless<br />of whether the variable exists or not. Cannot be updated.<br />More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell |  | Optional: \{\} <br /> |
-| `args` _string array_ | Arguments to the entrypoint.<br />The image's CMD is used if this is not provided.<br />Variable references $(VAR_NAME) are expanded using the container's environment. If a variable<br />cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced<br />to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will<br />produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless<br />of whether the variable exists or not. Cannot be updated.<br />More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell |  | Optional: \{\} <br /> |
-| `workingDir` _string_ | Step's working directory.<br />If not specified, the container runtime's default will be used, which<br />might be configured in the container image.<br />Cannot be updated. |  | Optional: \{\} <br /> |
-| `ports` _[ContainerPort](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#containerport-v1-core) array_ | List of ports to expose from the Step's container. Exposing a port here gives<br />the system additional information about the network connections a<br />container uses, but is primarily informational. Not specifying a port here<br />DOES NOT prevent that port from being exposed. Any port which is<br />listening on the default "0.0.0.0" address inside a container will be<br />accessible from the network.<br />Cannot be updated.<br />Deprecated: This field will be removed in a future release. |  | Optional: \{\} <br /> |
-| `envFrom` _[EnvFromSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#envfromsource-v1-core) array_ | List of sources to populate environment variables in the container.<br />The keys defined within a source must be a C_IDENTIFIER. All invalid keys<br />will be reported as an event when the container is starting. When a key exists in multiple<br />sources, the value associated with the last source will take precedence.<br />Values defined by an Env with a duplicate key will take precedence.<br />Cannot be updated. |  | Optional: \{\} <br /> |
-| `env` _[EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#envvar-v1-core) array_ | List of environment variables to set in the container.<br />Cannot be updated. |  | Optional: \{\} <br /> |
-| `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcerequirements-v1-core)_ | Compute Resources required by this Step.<br />Cannot be updated.<br />More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |  | Optional: \{\} <br /> |
-| `volumeMounts` _[VolumeMount](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#volumemount-v1-core) array_ | Volumes to mount into the Step's filesystem.<br />Cannot be updated. |  | Optional: \{\} <br /> |
-| `volumeDevices` _[VolumeDevice](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#volumedevice-v1-core) array_ | volumeDevices is the list of block devices to be used by the Step. |  | Optional: \{\} <br /> |
-| `livenessProbe` _[Probe](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#probe-v1-core)_ | Periodic probe of container liveness.<br />Step will be restarted if the probe fails.<br />Cannot be updated.<br />More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br />Deprecated: This field will be removed in a future release. |  | Optional: \{\} <br /> |
-| `readinessProbe` _[Probe](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#probe-v1-core)_ | Periodic probe of container service readiness.<br />Step will be removed from service endpoints if the probe fails.<br />Cannot be updated.<br />More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br />Deprecated: This field will be removed in a future release. |  | Optional: \{\} <br /> |
-| `startupProbe` _[Probe](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#probe-v1-core)_ | DeprecatedStartupProbe indicates that the Pod this Step runs in has successfully initialized.<br />If specified, no other probes are executed until this completes successfully.<br />If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.<br />This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,<br />when it might take a long time to load data or warm a cache, than during steady-state operation.<br />This cannot be updated.<br />More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br />Deprecated: This field will be removed in a future release. |  | Optional: \{\} <br /> |
-| `lifecycle` _[Lifecycle](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#lifecycle-v1-core)_ | Actions that the management system should take in response to container lifecycle events.<br />Cannot be updated.<br />Deprecated: This field will be removed in a future release. |  | Optional: \{\} <br /> |
-| `terminationMessagePath` _string_ | Deprecated: This field will be removed in a future release and can't be meaningfully used. |  | Optional: \{\} <br /> |
-| `terminationMessagePolicy` _[TerminationMessagePolicy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#terminationmessagepolicy-v1-core)_ | Deprecated: This field will be removed in a future release and can't be meaningfully used. |  | Optional: \{\} <br /> |
-| `imagePullPolicy` _[PullPolicy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#pullpolicy-v1-core)_ | Image pull policy.<br />One of Always, Never, IfNotPresent.<br />Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.<br />Cannot be updated.<br />More info: https://kubernetes.io/docs/concepts/containers/images#updating-images |  | Optional: \{\} <br /> |
-| `securityContext` _[SecurityContext](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#securitycontext-v1-core)_ | SecurityContext defines the security options the Step should be run with.<br />If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.<br />More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ |  | Optional: \{\} <br /> |
-| `stdin` _boolean_ | Whether this container should allocate a buffer for stdin in the container runtime. If this<br />is not set, reads from stdin in the container will always result in EOF.<br />Default is false.<br />Deprecated: This field will be removed in a future release. |  | Optional: \{\} <br /> |
-| `stdinOnce` _boolean_ | Whether the container runtime should close the stdin channel after it has been opened by<br />a single attach. When stdin is true the stdin stream will remain open across multiple attach<br />sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the<br />first client attaches to stdin, and then remains open and accepts data until the client disconnects,<br />at which time stdin is closed and remains closed until the container is restarted. If this<br />flag is false, a container processes that reads from stdin will never receive an EOF.<br />Default is false<br />Deprecated: This field will be removed in a future release. |  | Optional: \{\} <br /> |
-| `tty` _boolean_ | Whether this container should allocate a DeprecatedTTY for itself, also requires 'stdin' to be true.<br />Default is false.<br />Deprecated: This field will be removed in a future release. |  | Optional: \{\} <br /> |
-| `script` _string_ | Script is the contents of an executable file to execute.<br />If Script is not empty, the Step cannot have an Command and the Args will be passed to the Script. |  | Optional: \{\} <br /> |
-| `timeout` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ | Timeout is the time after which the step times out. Defaults to never.<br />Refer to Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration |  | Optional: \{\} <br /> |
-| `workspaces` _[WorkspaceUsage](#workspaceusage) array_ | This is an alpha field. You must set the "enable-api-fields" feature flag to "alpha"<br />for this field to be supported.<br />Workspaces is a list of workspaces from the Task that this Step wants<br />exclusive access to. Adding a workspace to this list means that any<br />other Step or Sidecar that does not also request this Workspace will<br />not have access to it. |  | Optional: \{\} <br /> |
-| `onError` _[OnErrorType](#onerrortype)_ | OnError defines the exiting behavior of a container on error<br />can be set to [ continue \| stopAndFail ] |  |  |
-| `stdoutConfig` _[StepOutputConfig](#stepoutputconfig)_ | Stores configuration for the stdout stream of the step. |  | Optional: \{\} <br /> |
-| `stderrConfig` _[StepOutputConfig](#stepoutputconfig)_ | Stores configuration for the stderr stream of the step. |  | Optional: \{\} <br /> |
-| `ref` _[Ref](#ref)_ | Contains the reference to an existing StepAction. |  | Optional: \{\} <br /> |
-| `params` _[Params](#params)_ | Params declares parameters passed to this step action. |  | Optional: \{\} <br /> |
-| `results` _[StepResult](#stepresult) array_ | Results declares StepResults produced by the Step.<br />It can be used in an inlined Step when used to store Results to $(step.results.resultName.path).<br />It cannot be used when referencing StepActions using [v1beta1.Step.Ref].<br />The Results declared by the StepActions will be stored here instead. |  | Optional: \{\} <br /> |
-| `when` _[StepWhenExpressions](#stepwhenexpressions)_ |  |  |  |
-
-
-#### StepAction
-
-
-
-StepAction represents the actionable components of Step.
-The Step can only reference it from the cluster or using remote resolution.
-
-
-
-
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `tekton.dev/v1beta1` | | |
-| `kind` _string_ | `StepAction` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  | Optional: \{\} <br /> |
-| `spec` _[StepActionSpec](#stepactionspec)_ | Spec holds the desired state of the Step from the client |  | Optional: \{\} <br /> |
-
-
-
-
-#### StepActionSpec
-
-
-
-StepActionSpec contains the actionable components of a step.
-
-
-
-_Appears in:_
-- [StepAction](#stepaction)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `description` _string_ | Description is a user-facing description of the stepaction that may be<br />used to populate a UI. |  | Optional: \{\} <br /> |
-| `image` _string_ | Image reference name to run for this StepAction.<br />More info: https://kubernetes.io/docs/concepts/containers/images |  | Optional: \{\} <br /> |
-| `command` _string array_ | Entrypoint array. Not executed within a shell.<br />The image's ENTRYPOINT is used if this is not provided.<br />Variable references $(VAR_NAME) are expanded using the container's environment. If a variable<br />cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced<br />to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will<br />produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless<br />of whether the variable exists or not. Cannot be updated.<br />More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell |  | Optional: \{\} <br /> |
-| `args` _[Args](#args)_ | Arguments to the entrypoint.<br />The image's CMD is used if this is not provided.<br />Variable references $(VAR_NAME) are expanded using the container's environment. If a variable<br />cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced<br />to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will<br />produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless<br />of whether the variable exists or not. Cannot be updated.<br />More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell |  | Optional: \{\} <br /> |
-| `env` _[EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#envvar-v1-core) array_ | List of environment variables to set in the container.<br />Cannot be updated. |  | Optional: \{\} <br /> |
-| `script` _string_ | Script is the contents of an executable file to execute.<br />If Script is not empty, the Step cannot have an Command and the Args will be passed to the Script. |  | Optional: \{\} <br /> |
-| `workingDir` _string_ | Step's working directory.<br />If not specified, the container runtime's default will be used, which<br />might be configured in the container image.<br />Cannot be updated. |  | Optional: \{\} <br /> |
-| `params` _[ParamSpecs](#paramspecs)_ | Params is a list of input parameters required to run the stepAction.<br />Params must be supplied as inputs in Steps unless they declare a defaultvalue. |  | Optional: \{\} <br /> |
-| `results` _[StepResult](#stepresult) array_ | Results are values that this StepAction can output |  | Optional: \{\} <br /> |
-| `securityContext` _[SecurityContext](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#securitycontext-v1-core)_ | SecurityContext defines the security options the Step should be run with.<br />If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.<br />More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/<br />The value set in StepAction will take precedence over the value from Task. |  | Optional: \{\} <br /> |
-| `volumeMounts` _[VolumeMount](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#volumemount-v1-core) array_ | Volumes to mount into the Step's filesystem.<br />Cannot be updated. |  | Optional: \{\} <br /> |
-
-
-#### StepOutputConfig
-
-
-
-StepOutputConfig stores configuration for a step output stream.
-
-
-
-_Appears in:_
-- [Step](#step)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `path` _string_ | Path to duplicate stdout stream to on container's local filesystem. |  | Optional: \{\} <br /> |
-
-
-#### StepState
-
-
-
-StepState reports the results of running a step in a Task.
-
-
-
-_Appears in:_
-- [TaskRunStatus](#taskrunstatus)
-- [TaskRunStatusFields](#taskrunstatusfields)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `waiting` _[ContainerStateWaiting](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#containerstatewaiting-v1-core)_ | Details about a waiting container |  | Optional: \{\} <br /> |
-| `running` _[ContainerStateRunning](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#containerstaterunning-v1-core)_ | Details about a running container |  | Optional: \{\} <br /> |
-| `terminated` _[ContainerStateTerminated](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#containerstateterminated-v1-core)_ | Details about a terminated container |  | Optional: \{\} <br /> |
-| `name` _string_ |  |  |  |
-| `container` _string_ |  |  |  |
-| `imageID` _string_ |  |  |  |
-| `results` _[TaskRunStepResult](#taskrunstepresult) array_ |  |  |  |
-| `provenance` _[Provenance](#provenance)_ |  |  |  |
-| `inputs` _[TaskRunStepArtifact](#taskrunstepartifact) array_ |  |  |  |
-| `outputs` _[TaskRunStepArtifact](#taskrunstepartifact) array_ |  |  |  |
-
-
-#### StepTemplate
-
-
-
-StepTemplate is a template for a Step
-
-
-
-_Appears in:_
-- [EmbeddedTask](#embeddedtask)
-- [TaskSpec](#taskspec)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `name` _string_ | Default name for each Step specified as a DNS_LABEL.<br />Each Step in a Task must have a unique name.<br />Cannot be updated.<br />Deprecated: This field will be removed in a future release. |  | Optional: \{\} <br /> |
-| `image` _string_ | Default image name to use for each Step.<br />More info: https://kubernetes.io/docs/concepts/containers/images<br />This field is optional to allow higher level config management to default or override<br />container images in workload controllers like Deployments and StatefulSets. |  | Optional: \{\} <br /> |
-| `command` _string array_ | Entrypoint array. Not executed within a shell.<br />The docker image's ENTRYPOINT is used if this is not provided.<br />Variable references $(VAR_NAME) are expanded using the Step's environment. If a variable<br />cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced<br />to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will<br />produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless<br />of whether the variable exists or not. Cannot be updated.<br />More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell |  | Optional: \{\} <br /> |
-| `args` _string array_ | Arguments to the entrypoint.<br />The image's CMD is used if this is not provided.<br />Variable references $(VAR_NAME) are expanded using the Step's environment. If a variable<br />cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced<br />to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will<br />produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless<br />of whether the variable exists or not. Cannot be updated.<br />More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell |  | Optional: \{\} <br /> |
-| `workingDir` _string_ | Step's working directory.<br />If not specified, the container runtime's default will be used, which<br />might be configured in the container image.<br />Cannot be updated. |  | Optional: \{\} <br /> |
-| `ports` _[ContainerPort](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#containerport-v1-core) array_ | List of ports to expose from the Step's container. Exposing a port here gives<br />the system additional information about the network connections a<br />container uses, but is primarily informational. Not specifying a port here<br />DOES NOT prevent that port from being exposed. Any port which is<br />listening on the default "0.0.0.0" address inside a container will be<br />accessible from the network.<br />Cannot be updated.<br />Deprecated: This field will be removed in a future release. |  | Optional: \{\} <br /> |
-| `envFrom` _[EnvFromSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#envfromsource-v1-core) array_ | List of sources to populate environment variables in the Step.<br />The keys defined within a source must be a C_IDENTIFIER. All invalid keys<br />will be reported as an event when the container is starting. When a key exists in multiple<br />sources, the value associated with the last source will take precedence.<br />Values defined by an Env with a duplicate key will take precedence.<br />Cannot be updated. |  | Optional: \{\} <br /> |
-| `env` _[EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#envvar-v1-core) array_ | List of environment variables to set in the container.<br />Cannot be updated. |  | Optional: \{\} <br /> |
-| `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcerequirements-v1-core)_ | Compute Resources required by this Step.<br />Cannot be updated.<br />More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |  | Optional: \{\} <br /> |
-| `volumeMounts` _[VolumeMount](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#volumemount-v1-core) array_ | Volumes to mount into the Step's filesystem.<br />Cannot be updated. |  | Optional: \{\} <br /> |
-| `volumeDevices` _[VolumeDevice](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#volumedevice-v1-core) array_ | volumeDevices is the list of block devices to be used by the Step. |  | Optional: \{\} <br /> |
-| `livenessProbe` _[Probe](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#probe-v1-core)_ | Periodic probe of container liveness.<br />Container will be restarted if the probe fails.<br />Cannot be updated.<br />More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br />Deprecated: This field will be removed in a future release. |  | Optional: \{\} <br /> |
-| `readinessProbe` _[Probe](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#probe-v1-core)_ | Periodic probe of container service readiness.<br />Container will be removed from service endpoints if the probe fails.<br />Cannot be updated.<br />More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br />Deprecated: This field will be removed in a future release. |  | Optional: \{\} <br /> |
-| `startupProbe` _[Probe](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#probe-v1-core)_ | DeprecatedStartupProbe indicates that the Pod has successfully initialized.<br />If specified, no other probes are executed until this completes successfully.<br />If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.<br />This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,<br />when it might take a long time to load data or warm a cache, than during steady-state operation.<br />This cannot be updated.<br />More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br />Deprecated: This field will be removed in a future release. |  | Optional: \{\} <br /> |
-| `lifecycle` _[Lifecycle](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#lifecycle-v1-core)_ | Actions that the management system should take in response to container lifecycle events.<br />Cannot be updated.<br />Deprecated: This field will be removed in a future release. |  | Optional: \{\} <br /> |
-| `terminationMessagePath` _string_ | Deprecated: This field will be removed in a future release and cannot be meaningfully used. |  | Optional: \{\} <br /> |
-| `terminationMessagePolicy` _[TerminationMessagePolicy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#terminationmessagepolicy-v1-core)_ | Deprecated: This field will be removed in a future release and cannot be meaningfully used. |  | Optional: \{\} <br /> |
-| `imagePullPolicy` _[PullPolicy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#pullpolicy-v1-core)_ | Image pull policy.<br />One of Always, Never, IfNotPresent.<br />Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.<br />Cannot be updated.<br />More info: https://kubernetes.io/docs/concepts/containers/images#updating-images |  | Optional: \{\} <br /> |
-| `securityContext` _[SecurityContext](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#securitycontext-v1-core)_ | SecurityContext defines the security options the Step should be run with.<br />If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.<br />More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ |  | Optional: \{\} <br /> |
-| `stdin` _boolean_ | Whether this Step should allocate a buffer for stdin in the container runtime. If this<br />is not set, reads from stdin in the Step will always result in EOF.<br />Default is false.<br />Deprecated: This field will be removed in a future release. |  | Optional: \{\} <br /> |
-| `stdinOnce` _boolean_ | Whether the container runtime should close the stdin channel after it has been opened by<br />a single attach. When stdin is true the stdin stream will remain open across multiple attach<br />sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the<br />first client attaches to stdin, and then remains open and accepts data until the client disconnects,<br />at which time stdin is closed and remains closed until the container is restarted. If this<br />flag is false, a container processes that reads from stdin will never receive an EOF.<br />Default is false<br />Deprecated: This field will be removed in a future release. |  | Optional: \{\} <br /> |
-| `tty` _boolean_ | Whether this Step should allocate a DeprecatedTTY for itself, also requires 'stdin' to be true.<br />Default is false.<br />Deprecated: This field will be removed in a future release. |  | Optional: \{\} <br /> |
-
-
-
-
-#### Task
-
-
-
-Task represents a collection of sequential steps that are run as part of a
+about the When Expressions that caused this Task to be skipped.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is the Pipeline Task name</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>reason</code><br/>
+<em>
+<a href="#tekton.dev/v1.SkippingReason">
+SkippingReason
+</a>
+</em>
+</td>
+<td>
+<p>Reason is the cause of the PipelineTask being skipped.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>whenExpressions</code><br/>
+<em>
+<a href="#tekton.dev/v1.WhenExpression">
+[]WhenExpression
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>WhenExpressions is the list of checks guarding the execution of the PipelineTask</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.SkippingReason">SkippingReason
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.SkippedTask">SkippedTask</a>)
+</p>
+<div>
+<p>SkippingReason explains why a PipelineTask was skipped.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;Matrix Parameters have an empty array&#34;</p></td>
+<td><p>EmptyArrayInMatrixParams means the task was skipped because Matrix parameters contain empty array.</p>
+</td>
+</tr><tr><td><p>&#34;PipelineRun Finally timeout has been reached&#34;</p></td>
+<td><p>FinallyTimedOutSkip means the task was skipped because the PipelineRun has passed its Timeouts.Finally.</p>
+</td>
+</tr><tr><td><p>&#34;PipelineRun was gracefully cancelled&#34;</p></td>
+<td><p>GracefullyCancelledSkip means the task was skipped because the pipeline run has been gracefully cancelled</p>
+</td>
+</tr><tr><td><p>&#34;PipelineRun was gracefully stopped&#34;</p></td>
+<td><p>GracefullyStoppedSkip means the task was skipped because the pipeline run has been gracefully stopped</p>
+</td>
+</tr><tr><td><p>&#34;Results were missing&#34;</p></td>
+<td><p>MissingResultsSkip means the task was skipped because it&rsquo;s missing necessary results</p>
+</td>
+</tr><tr><td><p>&#34;None&#34;</p></td>
+<td><p>None means the task was not skipped</p>
+</td>
+</tr><tr><td><p>&#34;Parent Tasks were skipped&#34;</p></td>
+<td><p>ParentTasksSkip means the task was skipped because its parent was skipped</p>
+</td>
+</tr><tr><td><p>&#34;PipelineRun timeout has been reached&#34;</p></td>
+<td><p>PipelineTimedOutSkip means the task was skipped because the PipelineRun has passed its overall timeout.</p>
+</td>
+</tr><tr><td><p>&#34;PipelineRun was stopping&#34;</p></td>
+<td><p>StoppingSkip means the task was skipped because the pipeline run is stopping</p>
+</td>
+</tr><tr><td><p>&#34;PipelineRun Tasks timeout has been reached&#34;</p></td>
+<td><p>TasksTimedOutSkip means the task was skipped because the PipelineRun has passed its Timeouts.Tasks.</p>
+</td>
+</tr><tr><td><p>&#34;When Expressions evaluated to false&#34;</p></td>
+<td><p>WhenExpressionsSkip means the task was skipped due to at least one of its when expressions evaluating to false</p>
+</td>
+</tr></tbody>
+</table>
+<h3 id="tekton.dev/v1.Step">Step
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.TaskSpec">TaskSpec</a>)
+</p>
+<div>
+<p>Step runs a subcomponent of a Task</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name of the Step specified as a DNS_LABEL.
+Each Step in a Task must have a unique name.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>displayName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DisplayName is a user-facing name of the step that may be
+used to populate a UI.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>image</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Docker image name.
+More info: <a href="https://kubernetes.io/docs/concepts/containers/images">https://kubernetes.io/docs/concepts/containers/images</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>command</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Entrypoint array. Not executed within a shell.
+The image&rsquo;s ENTRYPOINT is used if this is not provided.
+Variable references $(VAR_NAME) are expanded using the container&rsquo;s environment. If a variable
+cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. &ldquo;$$(VAR_NAME)&rdquo; will
+produce the string literal &ldquo;$(VAR_NAME)&rdquo;. Escaped references will never be expanded, regardless
+of whether the variable exists or not. Cannot be updated.
+More info: <a href="https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell">https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>args</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Arguments to the entrypoint.
+The image&rsquo;s CMD is used if this is not provided.
+Variable references $(VAR_NAME) are expanded using the container&rsquo;s environment. If a variable
+cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. &ldquo;$$(VAR_NAME)&rdquo; will
+produce the string literal &ldquo;$(VAR_NAME)&rdquo;. Escaped references will never be expanded, regardless
+of whether the variable exists or not. Cannot be updated.
+More info: <a href="https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell">https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>workingDir</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Step&rsquo;s working directory.
+If not specified, the container runtime&rsquo;s default will be used, which
+might be configured in the container image.
+Cannot be updated.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>envFrom</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#envfromsource-v1-core">
+[]Kubernetes core/v1.EnvFromSource
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>List of sources to populate environment variables in the Step.
+The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+will be reported as an event when the Step is starting. When a key exists in multiple
+sources, the value associated with the last source will take precedence.
+Values defined by an Env with a duplicate key will take precedence.
+Cannot be updated.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>env</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#envvar-v1-core">
+[]Kubernetes core/v1.EnvVar
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>List of environment variables to set in the Step.
+Cannot be updated.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>computeResources</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#resourcerequirements-v1-core">
+Kubernetes core/v1.ResourceRequirements
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ComputeResources required by this Step.
+Cannot be updated.
+More info: <a href="https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/">https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>volumeMounts</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#volumemount-v1-core">
+[]Kubernetes core/v1.VolumeMount
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Volumes to mount into the Step&rsquo;s filesystem.
+Cannot be updated.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>volumeDevices</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#volumedevice-v1-core">
+[]Kubernetes core/v1.VolumeDevice
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>volumeDevices is the list of block devices to be used by the Step.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>imagePullPolicy</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#pullpolicy-v1-core">
+Kubernetes core/v1.PullPolicy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Image pull policy.
+One of Always, Never, IfNotPresent.
+Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+Cannot be updated.
+More info: <a href="https://kubernetes.io/docs/concepts/containers/images#updating-images">https://kubernetes.io/docs/concepts/containers/images#updating-images</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>securityContext</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#securitycontext-v1-core">
+Kubernetes core/v1.SecurityContext
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>SecurityContext defines the security options the Step should be run with.
+If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+More info: <a href="https://kubernetes.io/docs/tasks/configure-pod-container/security-context/">https://kubernetes.io/docs/tasks/configure-pod-container/security-context/</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>script</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Script is the contents of an executable file to execute.</p>
+<p>If Script is not empty, the Step cannot have an Command and the Args will be passed to the Script.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>timeout</code><br/>
+<em>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+Kubernetes meta/v1.Duration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Timeout is the time after which the step times out. Defaults to never.
+Refer to Go&rsquo;s ParseDuration documentation for expected format: <a href="https://golang.org/pkg/time/#ParseDuration">https://golang.org/pkg/time/#ParseDuration</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>workspaces</code><br/>
+<em>
+<a href="#tekton.dev/v1.WorkspaceUsage">
+[]WorkspaceUsage
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>This is an alpha field. You must set the &ldquo;enable-api-fields&rdquo; feature flag to &ldquo;alpha&rdquo;
+for this field to be supported.</p>
+<p>Workspaces is a list of workspaces from the Task that this Step wants
+exclusive access to. Adding a workspace to this list means that any
+other Step or Sidecar that does not also request this Workspace will
+not have access to it.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>onError</code><br/>
+<em>
+<a href="#tekton.dev/v1.OnErrorType">
+OnErrorType
+</a>
+</em>
+</td>
+<td>
+<p>OnError defines the exiting behavior of a container on error
+can be set to [ continue | stopAndFail ]</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>stdoutConfig</code><br/>
+<em>
+<a href="#tekton.dev/v1.StepOutputConfig">
+StepOutputConfig
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Stores configuration for the stdout stream of the step.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>stderrConfig</code><br/>
+<em>
+<a href="#tekton.dev/v1.StepOutputConfig">
+StepOutputConfig
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Stores configuration for the stderr stream of the step.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ref</code><br/>
+<em>
+<a href="#tekton.dev/v1.Ref">
+Ref
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Contains the reference to an existing StepAction.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>params</code><br/>
+<em>
+<a href="#tekton.dev/v1.Params">
+Params
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Params declares parameters passed to this step action.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>results</code><br/>
+<em>
+<a href="#tekton.dev/v1.StepResult">
+[]StepResult
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Results declares StepResults produced by the Step.</p>
+<p>It can be used in an inlined Step when used to store Results to $(step.results.resultName.path).
+It cannot be used when referencing StepActions using [v1.Step.Ref].
+The Results declared by the StepActions will be stored here instead.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>when</code><br/>
+<em>
+<a href="#tekton.dev/v1.StepWhenExpressions">
+StepWhenExpressions
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>When is a list of when expressions that need to be true for the task to run</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.StepOutputConfig">StepOutputConfig
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.Step">Step</a>)
+</p>
+<div>
+<p>StepOutputConfig stores configuration for a step output stream.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>path</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Path to duplicate stdout stream to on container&rsquo;s local filesystem.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.StepResult">StepResult
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.Step">Step</a>, <a href="#tekton.dev/v1alpha1.StepActionSpec">StepActionSpec</a>, <a href="#tekton.dev/v1beta1.Step">Step</a>, <a href="#tekton.dev/v1beta1.StepActionSpec">StepActionSpec</a>)
+</p>
+<div>
+<p>StepResult used to describe the Results of a Step.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name the given name</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>type</code><br/>
+<em>
+<a href="#tekton.dev/v1.ResultsType">
+ResultsType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The possible types are &lsquo;string&rsquo;, &lsquo;array&rsquo;, and &lsquo;object&rsquo;, with &lsquo;string&rsquo; as the default.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>properties</code><br/>
+<em>
+<a href="#tekton.dev/v1.PropertySpec">
+map[string]github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PropertySpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Properties is the JSON Schema properties to support key-value pairs results.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>description</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Description is a human-readable description of the result</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.StepState">StepState
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.TaskRunStatusFields">TaskRunStatusFields</a>)
+</p>
+<div>
+<p>StepState reports the results of running a step in a Task.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>ContainerState</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#containerstate-v1-core">
+Kubernetes core/v1.ContainerState
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>ContainerState</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>container</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>imageID</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>results</code><br/>
+<em>
+<a href="#tekton.dev/v1.TaskRunStepResult">
+[]TaskRunStepResult
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>provenance</code><br/>
+<em>
+<a href="#tekton.dev/v1.Provenance">
+Provenance
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>terminationReason</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>inputs</code><br/>
+<em>
+<a href="#tekton.dev/v1.TaskRunStepArtifact">
+[]TaskRunStepArtifact
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>outputs</code><br/>
+<em>
+<a href="#tekton.dev/v1.TaskRunStepArtifact">
+[]TaskRunStepArtifact
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.StepTemplate">StepTemplate
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.TaskSpec">TaskSpec</a>)
+</p>
+<div>
+<p>StepTemplate is a template for a Step</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>image</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Image reference name.
+More info: <a href="https://kubernetes.io/docs/concepts/containers/images">https://kubernetes.io/docs/concepts/containers/images</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>command</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Entrypoint array. Not executed within a shell.
+The image&rsquo;s ENTRYPOINT is used if this is not provided.
+Variable references $(VAR_NAME) are expanded using the Step&rsquo;s environment. If a variable
+cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. &ldquo;$$(VAR_NAME)&rdquo; will
+produce the string literal &ldquo;$(VAR_NAME)&rdquo;. Escaped references will never be expanded, regardless
+of whether the variable exists or not. Cannot be updated.
+More info: <a href="https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell">https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>args</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Arguments to the entrypoint.
+The image&rsquo;s CMD is used if this is not provided.
+Variable references $(VAR_NAME) are expanded using the Step&rsquo;s environment. If a variable
+cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. &ldquo;$$(VAR_NAME)&rdquo; will
+produce the string literal &ldquo;$(VAR_NAME)&rdquo;. Escaped references will never be expanded, regardless
+of whether the variable exists or not. Cannot be updated.
+More info: <a href="https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell">https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>workingDir</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Step&rsquo;s working directory.
+If not specified, the container runtime&rsquo;s default will be used, which
+might be configured in the container image.
+Cannot be updated.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>envFrom</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#envfromsource-v1-core">
+[]Kubernetes core/v1.EnvFromSource
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>List of sources to populate environment variables in the Step.
+The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+will be reported as an event when the Step is starting. When a key exists in multiple
+sources, the value associated with the last source will take precedence.
+Values defined by an Env with a duplicate key will take precedence.
+Cannot be updated.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>env</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#envvar-v1-core">
+[]Kubernetes core/v1.EnvVar
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>List of environment variables to set in the Step.
+Cannot be updated.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>computeResources</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#resourcerequirements-v1-core">
+Kubernetes core/v1.ResourceRequirements
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ComputeResources required by this Step.
+Cannot be updated.
+More info: <a href="https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/">https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>volumeMounts</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#volumemount-v1-core">
+[]Kubernetes core/v1.VolumeMount
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Volumes to mount into the Step&rsquo;s filesystem.
+Cannot be updated.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>volumeDevices</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#volumedevice-v1-core">
+[]Kubernetes core/v1.VolumeDevice
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>volumeDevices is the list of block devices to be used by the Step.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>imagePullPolicy</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#pullpolicy-v1-core">
+Kubernetes core/v1.PullPolicy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Image pull policy.
+One of Always, Never, IfNotPresent.
+Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+Cannot be updated.
+More info: <a href="https://kubernetes.io/docs/concepts/containers/images#updating-images">https://kubernetes.io/docs/concepts/containers/images#updating-images</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>securityContext</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#securitycontext-v1-core">
+Kubernetes core/v1.SecurityContext
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>SecurityContext defines the security options the Step should be run with.
+If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+More info: <a href="https://kubernetes.io/docs/tasks/configure-pod-container/security-context/">https://kubernetes.io/docs/tasks/configure-pod-container/security-context/</a></p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.StepWhenExpressions">StepWhenExpressions
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.Step">Step</a>)
+</p>
+<div>
+</div>
+<h3 id="tekton.dev/v1.TaskBreakpoints">TaskBreakpoints
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.TaskRunDebug">TaskRunDebug</a>)
+</p>
+<div>
+<p>TaskBreakpoints defines the breakpoint config for a particular Task</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>onFailure</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>if enabled, pause TaskRun on failure of a step
+failed step will not exit</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>beforeSteps</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.TaskKind">TaskKind
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.TaskRef">TaskRef</a>)
+</p>
+<div>
+<p>TaskKind defines the type of Task used by the pipeline.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;Task&#34;</p></td>
+<td><p>NamespacedTaskKind indicates that the task type has a namespaced scope.</p>
+</td>
+</tr></tbody>
+</table>
+<h3 id="tekton.dev/v1.TaskRef">TaskRef
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineTask">PipelineTask</a>, <a href="#tekton.dev/v1.TaskRunSpec">TaskRunSpec</a>)
+</p>
+<div>
+<p>TaskRef can be used to refer to a specific instance of a task.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name of the referent; More info: <a href="http://kubernetes.io/docs/user-guide/identifiers#names">http://kubernetes.io/docs/user-guide/identifiers#names</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code><br/>
+<em>
+<a href="#tekton.dev/v1.TaskKind">
+TaskKind
+</a>
+</em>
+</td>
+<td>
+<p>TaskKind indicates the Kind of the Task:
+1. Namespaced Task when Kind is set to &ldquo;Task&rdquo;. If Kind is &ldquo;&rdquo;, it defaults to &ldquo;Task&rdquo;.
+2. Custom Task when Kind is non-empty and APIVersion is non-empty</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>apiVersion</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>API version of the referent
+Note: A Task with non-empty APIVersion and Kind is considered a Custom Task</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ResolverRef</code><br/>
+<em>
+<a href="#tekton.dev/v1.ResolverRef">
+ResolverRef
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ResolverRef allows referencing a Task in a remote location
+like a git repo. This field is only supported when the alpha
+feature gate is enabled.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.TaskResult">TaskResult
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.TaskSpec">TaskSpec</a>)
+</p>
+<div>
+<p>TaskResult used to describe the results of a task</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name the given name</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>type</code><br/>
+<em>
+<a href="#tekton.dev/v1.ResultsType">
+ResultsType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Type is the user-specified type of the result. The possible type
+is currently &ldquo;string&rdquo; and will support &ldquo;array&rdquo; in following work.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>properties</code><br/>
+<em>
+<a href="#tekton.dev/v1.PropertySpec">
+map[string]github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PropertySpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Properties is the JSON Schema properties to support key-value pairs results.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>description</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Description is a human-readable description of the result</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>value</code><br/>
+<em>
+<a href="#tekton.dev/v1.ResultValue">
+ResultValue
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Value the expression used to retrieve the value of the result from an underlying Step.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.TaskRunDebug">TaskRunDebug
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.TaskRunSpec">TaskRunSpec</a>)
+</p>
+<div>
+<p>TaskRunDebug defines the breakpoint config for a particular TaskRun</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>breakpoints</code><br/>
+<em>
+<a href="#tekton.dev/v1.TaskBreakpoints">
+TaskBreakpoints
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.TaskRunInputs">TaskRunInputs
+</h3>
+<div>
+<p>TaskRunInputs holds the input values that this task was invoked with.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>params</code><br/>
+<em>
+<a href="#tekton.dev/v1.Params">
+Params
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.TaskRunReason">TaskRunReason
+(<code>string</code> alias)</h3>
+<div>
+<p>TaskRunReason is an enum used to store all TaskRun reason for
+the Succeeded condition that are controlled by the TaskRun itself. Failure
+reasons that emerge from underlying resources are not included here</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;TaskRunCancelled&#34;</p></td>
+<td><p>TaskRunReasonCancelled is the reason set when the TaskRun is cancelled by the user</p>
+</td>
+</tr><tr><td><p>&#34;CreateContainerConfigError&#34;</p></td>
+<td><p>TaskRunReasonCreateContainerConfigError is the reason set when the step of a task fails due to config error (e.g., missing ConfigMap or Secret)</p>
+</td>
+</tr><tr><td><p>&#34;Failed&#34;</p></td>
+<td><p>TaskRunReasonFailed is the reason set when the TaskRun completed with a failure</p>
+</td>
+</tr><tr><td><p>&#34;TaskRunResolutionFailed&#34;</p></td>
+<td><p>TaskRunReasonFailedResolution indicated that the reason for failure status is
+that references within the TaskRun could not be resolved</p>
+</td>
+</tr><tr><td><p>&#34;TaskRunValidationFailed&#34;</p></td>
+<td><p>TaskRunReasonFailedValidation indicated that the reason for failure status is
+that taskrun failed runtime validation</p>
+</td>
+</tr><tr><td><p>&#34;FailureIgnored&#34;</p></td>
+<td><p>TaskRunReasonFailureIgnored is the reason set when the Taskrun has failed due to pod execution error and the failure is ignored for the owning PipelineRun.
+TaskRuns failed due to reconciler/validation error should not use this reason.</p>
+</td>
+</tr><tr><td><p>&#34;TaskRunImagePullFailed&#34;</p></td>
+<td><p>TaskRunReasonImagePullFailed is the reason set when the step of a task fails due to image not being pulled</p>
+</td>
+</tr><tr><td><p>&#34;InitContainerFailed&#34;</p></td>
+<td><p>TaskRunReasonInitContainerFailed indicates an internal Tekton init
+container (prepare, place-scripts, working-dir-initializer) failed
+(non-OOM), e.g., due to node memory pressure or runtime errors.</p>
+</td>
+</tr><tr><td><p>&#34;InitContainerOOM&#34;</p></td>
+<td><p>TaskRunReasonInitContainerOOM indicates an internal Tekton init
+container (prepare, place-scripts, working-dir-initializer) was
+killed due to running out of memory (OOMKilled).</p>
+</td>
+</tr><tr><td><p>&#34;InvalidParamValue&#34;</p></td>
+<td><p>TaskRunReasonInvalidParamValue indicates that the TaskRun Param input value is not allowed.</p>
+</td>
+</tr><tr><td><p>&#34;TaskRunPending&#34;</p></td>
+<td><p>TaskRunReasonPending is the reason set when the TaskRun is in the pending state</p>
+</td>
+</tr><tr><td><p>&#34;PodCreationFailed&#34;</p></td>
+<td><p>TaskRunReasonPodCreationFailed is the reason set when the pod backing the TaskRun fails to be created (e.g., CreateContainerError)</p>
+</td>
+</tr><tr><td><p>&#34;PodEvicted&#34;</p></td>
+<td><p>TaskRunReasonPodEvicted indicates that the TaskRun&rsquo;s pod was evicted
+(e.g., due to exceeding ephemeral storage limits or node pressure).</p>
+</td>
+</tr><tr><td><p>&#34;ResourceVerificationFailed&#34;</p></td>
+<td><p>TaskRunReasonResourceVerificationFailed indicates that the task fails the trusted resource verification,
+it could be the content has changed, signature is invalid or public key is invalid</p>
+</td>
+</tr><tr><td><p>&#34;TaskRunResultLargerThanAllowedLimit&#34;</p></td>
+<td><p>TaskRunReasonResultLargerThanAllowedLimit is the reason set when one of the results exceeds its maximum allowed limit of 1 KB</p>
+</td>
+</tr><tr><td><p>&#34;Running&#34;</p></td>
+<td><p>TaskRunReasonRunning is the reason set when the TaskRun is running</p>
+</td>
+</tr><tr><td><p>&#34;SidecarFailed&#34;</p></td>
+<td><p>TaskRunReasonSidecarFailed indicates a sidecar container failed
+(non-OOM), e.g., bad image or crash.</p>
+</td>
+</tr><tr><td><p>&#34;SidecarOOM&#34;</p></td>
+<td><p>TaskRunReasonSidecarOOM indicates a sidecar container was killed due
+to running out of memory (OOMKilled).</p>
+</td>
+</tr><tr><td><p>&#34;Started&#34;</p></td>
+<td><p>TaskRunReasonStarted is the reason set when the TaskRun has just started</p>
+</td>
+</tr><tr><td><p>&#34;StepFailed&#34;</p></td>
+<td><p>TaskRunReasonStepFailed indicates a step container failed (non-OOM),
+e.g., bad image, crash, or non-zero exit code.</p>
+</td>
+</tr><tr><td><p>&#34;StepOOM&#34;</p></td>
+<td><p>TaskRunReasonStepOOM indicates a step container was killed due to
+running out of memory (OOMKilled).</p>
+</td>
+</tr><tr><td><p>&#34;TaskRunStopSidecarFailed&#34;</p></td>
+<td><p>TaskRunReasonStopSidecarFailed indicates that the sidecar is not properly stopped.</p>
+</td>
+</tr><tr><td><p>&#34;Succeeded&#34;</p></td>
+<td><p>TaskRunReasonSuccessful is the reason set when the TaskRun completed successfully</p>
+</td>
+</tr><tr><td><p>&#34;TaskValidationFailed&#34;</p></td>
+<td><p>TaskRunReasonTaskFailedValidation indicated that the reason for failure status is
+that task failed runtime validation</p>
+</td>
+</tr><tr><td><p>&#34;TaskRunTimeout&#34;</p></td>
+<td><p>TaskRunReasonTimedOut is the reason set when one TaskRun execution has timed out</p>
+</td>
+</tr><tr><td><p>&#34;ToBeRetried&#34;</p></td>
+<td><p>TaskRunReasonToBeRetried is the reason set when the last TaskRun execution failed, and will be retried</p>
+</td>
+</tr></tbody>
+</table>
+<h3 id="tekton.dev/v1.TaskRunResult">TaskRunResult
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.TaskRunStatusFields">TaskRunStatusFields</a>)
+</p>
+<div>
+<p>TaskRunResult used to describe the results of a task</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name the given name</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>type</code><br/>
+<em>
+<a href="#tekton.dev/v1.ResultsType">
+ResultsType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Type is the user-specified type of the result. The possible type
+is currently &ldquo;string&rdquo; and will support &ldquo;array&rdquo; in following work.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>value</code><br/>
+<em>
+<a href="#tekton.dev/v1.ResultValue">
+ResultValue
+</a>
+</em>
+</td>
+<td>
+<p>Value the given value of the result</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.TaskRunSidecarSpec">TaskRunSidecarSpec
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineTaskRunSpec">PipelineTaskRunSpec</a>, <a href="#tekton.dev/v1.TaskRunSpec">TaskRunSpec</a>)
+</p>
+<div>
+<p>TaskRunSidecarSpec is used to override the values of a Sidecar in the corresponding Task.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>The name of the Sidecar to override.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>computeResources</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#resourcerequirements-v1-core">
+Kubernetes core/v1.ResourceRequirements
+</a>
+</em>
+</td>
+<td>
+<p>The resource requirements to apply to the Sidecar.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.TaskRunSpec">TaskRunSpec
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.TaskRun">TaskRun</a>)
+</p>
+<div>
+<p>TaskRunSpec defines the desired state of TaskRun</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>debug</code><br/>
+<em>
+<a href="#tekton.dev/v1.TaskRunDebug">
+TaskRunDebug
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>params</code><br/>
+<em>
+<a href="#tekton.dev/v1.Params">
+Params
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceAccountName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>taskRef</code><br/>
+<em>
+<a href="#tekton.dev/v1.TaskRef">
+TaskRef
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>no more than one of the TaskRef and TaskSpec may be specified.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>taskSpec</code><br/>
+<em>
+<a href="#tekton.dev/v1.TaskSpec">
+TaskSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Specifying TaskSpec can be disabled by setting
+<code>disable-inline-spec</code> feature flag.
+See Task.spec (API version: tekton.dev/v1)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code><br/>
+<em>
+<a href="#tekton.dev/v1.TaskRunSpecStatus">
+TaskRunSpecStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Used for cancelling a TaskRun (and maybe more later on)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>statusMessage</code><br/>
+<em>
+<a href="#tekton.dev/v1.TaskRunSpecStatusMessage">
+TaskRunSpecStatusMessage
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Status message for cancellation.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>retries</code><br/>
+<em>
+int
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Retries represents how many times this TaskRun should be retried in the event of task failure.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>timeout</code><br/>
+<em>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+Kubernetes meta/v1.Duration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Time after which one retry attempt times out. Defaults to 1 hour.
+Refer Go&rsquo;s ParseDuration documentation for expected format: <a href="https://golang.org/pkg/time/#ParseDuration">https://golang.org/pkg/time/#ParseDuration</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>podTemplate</code><br/>
+<em>
+<a href="#tekton.dev/unversioned.PodTemplate">
+PodTemplate
+</a>
+</em>
+</td>
+<td>
+<p>PodTemplate holds pod specific configuration</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>workspaces</code><br/>
+<em>
+<a href="#tekton.dev/v1.WorkspaceBinding">
+[]WorkspaceBinding
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Workspaces is a list of WorkspaceBindings from volumes to workspaces.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>stepSpecs</code><br/>
+<em>
+<a href="#tekton.dev/v1.TaskRunStepSpec">
+[]TaskRunStepSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Specs to apply to Steps in this TaskRun.
+If a field is specified in both a Step and a StepSpec,
+the value from the StepSpec will be used.
+This field is only supported when the alpha feature gate is enabled.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sidecarSpecs</code><br/>
+<em>
+<a href="#tekton.dev/v1.TaskRunSidecarSpec">
+[]TaskRunSidecarSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Specs to apply to Sidecars in this TaskRun.
+If a field is specified in both a Sidecar and a SidecarSpec,
+the value from the SidecarSpec will be used.
+This field is only supported when the alpha feature gate is enabled.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>computeResources</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#resourcerequirements-v1-core">
+Kubernetes core/v1.ResourceRequirements
+</a>
+</em>
+</td>
+<td>
+<p>Compute resources to use for this TaskRun</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>managedBy</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ManagedBy indicates which controller is responsible for reconciling
+this resource. If unset or set to &ldquo;tekton.dev/pipeline&rdquo;, the default
+Tekton controller will manage this resource.
+This field is immutable.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.TaskRunSpecStatus">TaskRunSpecStatus
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.TaskRunSpec">TaskRunSpec</a>)
+</p>
+<div>
+<p>TaskRunSpecStatus defines the TaskRun spec status the user can provide</p>
+</div>
+<h3 id="tekton.dev/v1.TaskRunSpecStatusMessage">TaskRunSpecStatusMessage
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.TaskRunSpec">TaskRunSpec</a>)
+</p>
+<div>
+<p>TaskRunSpecStatusMessage defines human readable status messages for the TaskRun.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;TaskRun cancelled as the PipelineRun it belongs to has been cancelled.&#34;</p></td>
+<td><p>TaskRunCancelledByPipelineMsg indicates that the PipelineRun of which this
+TaskRun was a part of has been cancelled.</p>
+</td>
+</tr><tr><td><p>&#34;TaskRun cancelled as the PipelineRun it belongs to has timed out.&#34;</p></td>
+<td><p>TaskRunCancelledByPipelineTimeoutMsg indicates that the TaskRun was cancelled because the PipelineRun running it timed out.</p>
+</td>
+</tr></tbody>
+</table>
+<h3 id="tekton.dev/v1.TaskRunStatus">TaskRunStatus
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.TaskRun">TaskRun</a>, <a href="#tekton.dev/v1.PipelineRunTaskRunStatus">PipelineRunTaskRunStatus</a>)
+</p>
+<div>
+<p>TaskRunStatus defines the observed state of TaskRun</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>Status</code><br/>
+<em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Status">
+knative.dev/pkg/apis/duck/v1.Status
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>Status</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>TaskRunStatusFields</code><br/>
+<em>
+<a href="#tekton.dev/v1.TaskRunStatusFields">
+TaskRunStatusFields
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>TaskRunStatusFields</code> are embedded into this type.)
+</p>
+<p>TaskRunStatusFields inlines the status fields.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.TaskRunStatusFields">TaskRunStatusFields
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.TaskRunStatus">TaskRunStatus</a>)
+</p>
+<div>
+<p>TaskRunStatusFields holds the fields of TaskRun&rsquo;s status.  This is defined
+separately and inlined so that other types can readily consume these fields
+via duck typing.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>podName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>PodName is the name of the pod responsible for executing this task&rsquo;s steps.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>startTime</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+<p>StartTime is the time the build is actually started.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>completionTime</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+<p>CompletionTime is the time the build completed.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>steps</code><br/>
+<em>
+<a href="#tekton.dev/v1.StepState">
+[]StepState
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Steps describes the state of each build step container.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>retriesStatus</code><br/>
+<em>
+<a href="#tekton.dev/v1.RetriesStatus">
+RetriesStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>RetriesStatus contains the history of TaskRunStatus in case of a retry in order to keep record of failures.
+All TaskRunStatus stored in RetriesStatus will have no date within the RetriesStatus as is redundant.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>results</code><br/>
+<em>
+<a href="#tekton.dev/v1.TaskRunResult">
+[]TaskRunResult
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Results are the list of results written out by the task&rsquo;s containers</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>artifacts</code><br/>
+<em>
+<a href="#tekton.dev/v1.Artifacts">
+Artifacts
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Artifacts are the list of artifacts written out by the task&rsquo;s containers</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sidecars</code><br/>
+<em>
+<a href="#tekton.dev/v1.SidecarState">
+[]SidecarState
+</a>
+</em>
+</td>
+<td>
+<p>The list has one entry per sidecar in the manifest. Each entry is
+represents the imageid of the corresponding sidecar.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>taskSpec</code><br/>
+<em>
+<a href="#tekton.dev/v1.TaskSpec">
+TaskSpec
+</a>
+</em>
+</td>
+<td>
+<p>TaskSpec contains the Spec from the dereferenced Task definition used to instantiate this TaskRun.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>provenance</code><br/>
+<em>
+<a href="#tekton.dev/v1.Provenance">
+Provenance
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Provenance contains some key authenticated metadata about how a software artifact was built (what sources, what inputs/outputs, etc.).</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>spanContext</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<p>SpanContext contains tracing span context fields</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>resolvedTaskNamespace</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ResolvedTaskNamespace is the namespace of the resolved Task, used for
+cross-namespace StepAction resolution. Set by the controller, not user-modifiable.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.TaskRunStepArtifact">TaskRunStepArtifact
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.StepState">StepState</a>)
+</p>
+<div>
+<p>TaskRunStepArtifact represents an artifact produced or used by a step within a task run.
+It directly uses the Artifact type for its structure.</p>
+</div>
+<h3 id="tekton.dev/v1.TaskRunStepResult">TaskRunStepResult
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.StepState">StepState</a>)
+</p>
+<div>
+<p>TaskRunStepResult is a type alias of TaskRunResult</p>
+</div>
+<h3 id="tekton.dev/v1.TaskRunStepSpec">TaskRunStepSpec
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineTaskRunSpec">PipelineTaskRunSpec</a>, <a href="#tekton.dev/v1.TaskRunSpec">TaskRunSpec</a>)
+</p>
+<div>
+<p>TaskRunStepSpec is used to override the values of a Step in the corresponding Task.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>The name of the Step to override.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>computeResources</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#resourcerequirements-v1-core">
+Kubernetes core/v1.ResourceRequirements
+</a>
+</em>
+</td>
+<td>
+<p>The resource requirements to apply to the Step.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.TaskSpec">TaskSpec
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.Task">Task</a>, <a href="#tekton.dev/v1.EmbeddedTask">EmbeddedTask</a>, <a href="#tekton.dev/v1.TaskRunSpec">TaskRunSpec</a>, <a href="#tekton.dev/v1.TaskRunStatusFields">TaskRunStatusFields</a>)
+</p>
+<div>
+<p>TaskSpec defines the desired state of Task.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>params</code><br/>
+<em>
+<a href="#tekton.dev/v1.ParamSpecs">
+ParamSpecs
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Params is a list of input parameters required to run the task. Params
+must be supplied as inputs in TaskRuns unless they declare a default
+value.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>displayName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DisplayName is a user-facing name of the task that may be
+used to populate a UI.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>description</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Description is a user-facing description of the task that may be
+used to populate a UI.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>steps</code><br/>
+<em>
+<a href="#tekton.dev/v1.Step">
+[]Step
+</a>
+</em>
+</td>
+<td>
+<p>Steps are the steps of the build; each step is run sequentially with the
+source mounted into /workspace.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>volumes</code><br/>
+<em>
+<a href="#tekton.dev/v1.Volumes">
+Volumes
+</a>
+</em>
+</td>
+<td>
+<p>Volumes is a collection of volumes that are available to mount into the
+steps of the build.
+See Pod.spec.volumes (API version: v1)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>stepTemplate</code><br/>
+<em>
+<a href="#tekton.dev/v1.StepTemplate">
+StepTemplate
+</a>
+</em>
+</td>
+<td>
+<p>StepTemplate can be used as the basis for all step containers within the
+Task, so that the steps inherit settings on the base container.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sidecars</code><br/>
+<em>
+<a href="#tekton.dev/v1.Sidecar">
+[]Sidecar
+</a>
+</em>
+</td>
+<td>
+<p>Sidecars are run alongside the Task&rsquo;s step containers. They begin before
+the steps start and end after the steps complete.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>workspaces</code><br/>
+<em>
+<a href="#tekton.dev/v1.WorkspaceDeclaration">
+[]WorkspaceDeclaration
+</a>
+</em>
+</td>
+<td>
+<p>Workspaces are the volumes that this Task requires.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>results</code><br/>
+<em>
+<a href="#tekton.dev/v1.TaskResult">
+[]TaskResult
+</a>
+</em>
+</td>
+<td>
+<p>Results are values that this Task can output</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.TimeoutFields">TimeoutFields
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineRunSpec">PipelineRunSpec</a>)
+</p>
+<div>
+<p>TimeoutFields allows granular specification of pipeline, task, and finally timeouts</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>pipeline</code><br/>
+<em>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+Kubernetes meta/v1.Duration
+</a>
+</em>
+</td>
+<td>
+<p>Pipeline sets the maximum allowed duration for execution of the entire pipeline. The sum of individual timeouts for tasks and finally must not exceed this value.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>tasks</code><br/>
+<em>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+Kubernetes meta/v1.Duration
+</a>
+</em>
+</td>
+<td>
+<p>Tasks sets the maximum allowed duration of this pipeline&rsquo;s tasks</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>finally</code><br/>
+<em>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+Kubernetes meta/v1.Duration
+</a>
+</em>
+</td>
+<td>
+<p>Finally sets the maximum allowed duration of this pipeline&rsquo;s finally</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.Volumes">Volumes
+(<code>[]k8s.io/api/core/v1.Volume</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.TaskSpec">TaskSpec</a>)
+</p>
+<div>
+</div>
+<h3 id="tekton.dev/v1.WhenExpression">WhenExpression
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.ChildStatusReference">ChildStatusReference</a>, <a href="#tekton.dev/v1.PipelineRunRunStatus">PipelineRunRunStatus</a>, <a href="#tekton.dev/v1.PipelineRunTaskRunStatus">PipelineRunTaskRunStatus</a>, <a href="#tekton.dev/v1.SkippedTask">SkippedTask</a>)
+</p>
+<div>
+<p>WhenExpression allows a PipelineTask to declare expressions to be evaluated before the Task is run
+to determine whether the Task should be executed or skipped</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>input</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Input is the string for guard checking which can be a static input or an output from a parent Task</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>operator</code><br/>
+<em>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/selection#Operator">
+k8s.io/apimachinery/pkg/selection.Operator
+</a>
+</em>
+</td>
+<td>
+<p>Operator that represents an Input&rsquo;s relationship to the values</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>values</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<p>Values is an array of strings, which is compared against the input, for guard checking
+It must be non-empty</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>cel</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CEL is a string of Common Language Expression, which can be used to conditionally execute
+the task based on the result of the expression evaluation
+More info about CEL syntax: <a href="https://github.com/google/cel-spec/blob/master/doc/langdef.md">https://github.com/google/cel-spec/blob/master/doc/langdef.md</a></p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.WhenExpressions">WhenExpressions
+(<code>[]github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.WhenExpression</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineTask">PipelineTask</a>)
+</p>
+<div>
+<p>WhenExpressions are used to specify whether a Task should be executed or skipped
+All of them need to evaluate to True for a guarded Task to be executed.</p>
+</div>
+<h3 id="tekton.dev/v1.WorkspaceBinding">WorkspaceBinding
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineRunSpec">PipelineRunSpec</a>, <a href="#tekton.dev/v1.TaskRunSpec">TaskRunSpec</a>)
+</p>
+<div>
+<p>WorkspaceBinding maps a Task&rsquo;s declared workspace to a Volume.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is the name of the workspace populated by the volume.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>subPath</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>SubPath is optionally a directory on the volume which should be used
+for this binding (i.e. the volume will be mounted at this sub directory).</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>volumeClaimTemplate</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#persistentvolumeclaim-v1-core">
+Kubernetes core/v1.PersistentVolumeClaim
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>VolumeClaimTemplate is a template for a claim that will be created in the same namespace.
+The PipelineRun controller is responsible for creating a unique claim for each instance of PipelineRun.
+See PersistentVolumeClaim (API version: v1)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>persistentVolumeClaim</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#persistentvolumeclaimvolumesource-v1-core">
+Kubernetes core/v1.PersistentVolumeClaimVolumeSource
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>PersistentVolumeClaimVolumeSource represents a reference to a
+PersistentVolumeClaim in the same namespace. Either this OR EmptyDir can be used.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>emptyDir</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#emptydirvolumesource-v1-core">
+Kubernetes core/v1.EmptyDirVolumeSource
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>EmptyDir represents a temporary directory that shares a Task&rsquo;s lifetime.
+More info: <a href="https://kubernetes.io/docs/concepts/storage/volumes#emptydir">https://kubernetes.io/docs/concepts/storage/volumes#emptydir</a>
+Either this OR PersistentVolumeClaim can be used.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>configMap</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#configmapvolumesource-v1-core">
+Kubernetes core/v1.ConfigMapVolumeSource
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ConfigMap represents a configMap that should populate this workspace.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>secret</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#secretvolumesource-v1-core">
+Kubernetes core/v1.SecretVolumeSource
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Secret represents a secret that should populate this workspace.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>projected</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#projectedvolumesource-v1-core">
+Kubernetes core/v1.ProjectedVolumeSource
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Projected represents a projected volume that should populate this workspace.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>csi</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#csivolumesource-v1-core">
+Kubernetes core/v1.CSIVolumeSource
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CSI (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.WorkspaceDeclaration">WorkspaceDeclaration
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.TaskSpec">TaskSpec</a>)
+</p>
+<div>
+<p>WorkspaceDeclaration is a declaration of a volume that a Task requires.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is the name by which you can bind the volume at runtime.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>description</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Description is an optional human readable description of this volume.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>mountPath</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>MountPath overrides the directory that the volume will be made available at.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>readOnly</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>ReadOnly dictates whether a mounted volume is writable. By default this
+field is false and so mounted volumes are writable.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>optional</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>Optional marks a Workspace as not being required in TaskRuns. By default
+this field is false and so declared workspaces are required.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.WorkspacePipelineDeclaration">WorkspacePipelineDeclaration
+</h3>
+<div>
+<p>WorkspacePipelineDeclaration creates a named slot in a Pipeline that a PipelineRun
+is expected to populate with a workspace binding.</p>
+<p>Deprecated: use PipelineWorkspaceDeclaration type instead</p>
+</div>
+<h3 id="tekton.dev/v1.WorkspacePipelineTaskBinding">WorkspacePipelineTaskBinding
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineTask">PipelineTask</a>)
+</p>
+<div>
+<p>WorkspacePipelineTaskBinding describes how a workspace passed into the pipeline should be
+mapped to a task&rsquo;s declared workspace.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is the name of the workspace as declared by the task</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>workspace</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Workspace is the name of the workspace declared by the pipeline</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>subPath</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>SubPath is optionally a directory on the volume which should be used
+for this binding (i.e. the volume will be mounted at this sub directory).</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1.WorkspaceUsage">WorkspaceUsage
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.Sidecar">Sidecar</a>, <a href="#tekton.dev/v1.Step">Step</a>)
+</p>
+<div>
+<p>WorkspaceUsage is used by a Step or Sidecar to declare that it wants isolated access
+to a Workspace defined in a Task.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is the name of the workspace this Step or Sidecar wants access to.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>mountPath</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>MountPath is the path that the workspace should be mounted to inside the Step or Sidecar,
+overriding any MountPath specified in the Task&rsquo;s WorkspaceDeclaration.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<hr/>
+<h2 id="tekton.dev/v1alpha1">tekton.dev/v1alpha1</h2>
+<div>
+<p>Package v1alpha1 contains API Schema definitions for the pipeline v1alpha1 API group</p>
+</div>
+Resource Types:
+<ul><li>
+<a href="#tekton.dev/v1alpha1.Run">Run</a>
+</li><li>
+<a href="#tekton.dev/v1alpha1.StepAction">StepAction</a>
+</li><li>
+<a href="#tekton.dev/v1alpha1.VerificationPolicy">VerificationPolicy</a>
+</li><li>
+<a href="#tekton.dev/v1alpha1.PipelineResource">PipelineResource</a>
+</li></ul>
+<h3 id="tekton.dev/v1alpha1.Run">Run
+</h3>
+<div>
+<p>Run represents a single execution of a Custom Task.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code><br/>
+string</td>
+<td>
+<code>
+tekton.dev/v1alpha1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code><br/>
+string
+</td>
+<td><code>Run</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#tekton.dev/v1alpha1.RunSpec">
+RunSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>ref</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.TaskRef">
+TaskRef
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#tekton.dev/v1alpha1.EmbeddedRunSpec">
+EmbeddedRunSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec is a specification of a custom task</p>
+<br/>
+<br/>
+<table>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>params</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.Params">
+Params
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code><br/>
+<em>
+<a href="#tekton.dev/v1alpha1.RunSpecStatus">
+RunSpecStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Used for cancelling a run (and maybe more later on)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>statusMessage</code><br/>
+<em>
+<a href="#tekton.dev/v1alpha1.RunSpecStatusMessage">
+RunSpecStatusMessage
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Status message for cancellation.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>retries</code><br/>
+<em>
+int
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Used for propagating retries count to custom tasks</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceAccountName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>podTemplate</code><br/>
+<em>
+<a href="#tekton.dev/unversioned.PodTemplate">
+PodTemplate
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>PodTemplate holds pod specific configuration</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>timeout</code><br/>
+<em>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+Kubernetes meta/v1.Duration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Time after which the custom-task times out.
+Refer Go&rsquo;s ParseDuration documentation for expected format: <a href="https://golang.org/pkg/time/#ParseDuration">https://golang.org/pkg/time/#ParseDuration</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>workspaces</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.WorkspaceBinding">
+[]WorkspaceBinding
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Workspaces is a list of WorkspaceBindings from volumes to workspaces.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code><br/>
+<em>
+<a href="#tekton.dev/v1alpha1.RunStatus">
+RunStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1alpha1.StepAction">StepAction
+</h3>
+<div>
+<p>StepAction represents the actionable components of Step.
+The Step can only reference it from the cluster or using remote resolution.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code><br/>
+string</td>
+<td>
+<code>
+tekton.dev/v1alpha1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code><br/>
+string
+</td>
+<td><code>StepAction</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#tekton.dev/v1alpha1.StepActionSpec">
+StepActionSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec holds the desired state of the Step from the client</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>description</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Description is a user-facing description of the stepaction that may be
+used to populate a UI.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>image</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Image reference name to run for this StepAction.
+More info: <a href="https://kubernetes.io/docs/concepts/containers/images">https://kubernetes.io/docs/concepts/containers/images</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>command</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Entrypoint array. Not executed within a shell.
+The image&rsquo;s ENTRYPOINT is used if this is not provided.
+Variable references $(VAR_NAME) are expanded using the container&rsquo;s environment. If a variable
+cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. &ldquo;$$(VAR_NAME)&rdquo; will
+produce the string literal &ldquo;$(VAR_NAME)&rdquo;. Escaped references will never be expanded, regardless
+of whether the variable exists or not. Cannot be updated.
+More info: <a href="https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell">https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>args</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Arguments to the entrypoint.
+The image&rsquo;s CMD is used if this is not provided.
+Variable references $(VAR_NAME) are expanded using the container&rsquo;s environment. If a variable
+cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. &ldquo;$$(VAR_NAME)&rdquo; will
+produce the string literal &ldquo;$(VAR_NAME)&rdquo;. Escaped references will never be expanded, regardless
+of whether the variable exists or not. Cannot be updated.
+More info: <a href="https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell">https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>env</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#envvar-v1-core">
+[]Kubernetes core/v1.EnvVar
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>List of environment variables to set in the container.
+Cannot be updated.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>script</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Script is the contents of an executable file to execute.</p>
+<p>If Script is not empty, the Step cannot have an Command and the Args will be passed to the Script.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>workingDir</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Step&rsquo;s working directory.
+If not specified, the container runtime&rsquo;s default will be used, which
+might be configured in the container image.
+Cannot be updated.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>params</code><br/>
+<em>
+<a href="#tekton.dev/v1.ParamSpecs">
+ParamSpecs
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Params is a list of input parameters required to run the stepAction.
+Params must be supplied as inputs in Steps unless they declare a defaultvalue.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>results</code><br/>
+<em>
+<a href="#tekton.dev/v1.StepResult">
+[]StepResult
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Results are values that this StepAction can output</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>securityContext</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#securitycontext-v1-core">
+Kubernetes core/v1.SecurityContext
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>SecurityContext defines the security options the Step should be run with.
+If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+More info: <a href="https://kubernetes.io/docs/tasks/configure-pod-container/security-context/">https://kubernetes.io/docs/tasks/configure-pod-container/security-context/</a>
+The value set in StepAction will take precedence over the value from Task.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>volumeMounts</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#volumemount-v1-core">
+[]Kubernetes core/v1.VolumeMount
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Volumes to mount into the Step&rsquo;s filesystem.
+Cannot be updated.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1alpha1.VerificationPolicy">VerificationPolicy
+</h3>
+<div>
+<p>VerificationPolicy defines the rules to verify Tekton resources.
+VerificationPolicy can config the mapping from resources to a list of public
+keys, so when verifying the resources we can use the corresponding public keys.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code><br/>
+string</td>
+<td>
+<code>
+tekton.dev/v1alpha1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code><br/>
+string
+</td>
+<td><code>VerificationPolicy</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#tekton.dev/v1alpha1.VerificationPolicySpec">
+VerificationPolicySpec
+</a>
+</em>
+</td>
+<td>
+<p>Spec holds the desired state of the VerificationPolicy.</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>resources</code><br/>
+<em>
+<a href="#tekton.dev/v1alpha1.ResourcePattern">
+[]ResourcePattern
+</a>
+</em>
+</td>
+<td>
+<p>Resources defines the patterns of resources sources that should be subject to this policy.
+For example, we may want to apply this Policy from a certain GitHub repo.
+Then the ResourcesPattern should be valid regex. E.g. If using gitresolver, and we want to config keys from a certain git repo.
+<code>ResourcesPattern</code> can be <code>https://github.com/tektoncd/catalog.git</code>, we will use regex to filter out those resources.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>authorities</code><br/>
+<em>
+<a href="#tekton.dev/v1alpha1.Authority">
+[]Authority
+</a>
+</em>
+</td>
+<td>
+<p>Authorities defines the rules for validating signatures.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>mode</code><br/>
+<em>
+<a href="#tekton.dev/v1alpha1.ModeType">
+ModeType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Mode controls whether a failing policy will fail the taskrun/pipelinerun, or only log the warnings
+enforce - fail the taskrun/pipelinerun if verification fails (default)
+warn - don&rsquo;t fail the taskrun/pipelinerun if verification fails but log warnings</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1alpha1.PipelineResource">PipelineResource
+</h3>
+<div>
+<p>PipelineResource describes a resource that is an input to or output from a
+Task.</p>
+<p>Deprecated: Unused, preserved only for backwards compatibility</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code><br/>
+string</td>
+<td>
+<code>
+tekton.dev/v1alpha1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code><br/>
+string
+</td>
+<td><code>PipelineResource</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#tekton.dev/v1alpha1.PipelineResourceSpec">
+PipelineResourceSpec
+</a>
+</em>
+</td>
+<td>
+<p>Spec holds the desired state of the PipelineResource from the client</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>description</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Description is a user-facing description of the resource that may be
+used to populate a UI.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>type</code><br/>
+<em>
+<a href="#tekton.dev/v1alpha1.PipelineResourceType">
+PipelineResourceType
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>params</code><br/>
+<em>
+<a href="#tekton.dev/v1alpha1.ResourceParam">
+[]ResourceParam
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>secrets</code><br/>
+<em>
+<a href="#tekton.dev/v1alpha1.SecretParam">
+[]SecretParam
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Secrets to fetch to populate some of resource fields</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code><br/>
+<em>
+<a href="#tekton.dev/v1alpha1.PipelineResourceStatus">
+PipelineResourceStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Status is used to communicate the observed state of the PipelineResource from
+the controller, but was unused as there is no controller for PipelineResource.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1alpha1.Authority">Authority
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1alpha1.VerificationPolicySpec">VerificationPolicySpec</a>)
+</p>
+<div>
+<p>The Authority block defines the keys for validating signatures.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is the name for this authority.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>key</code><br/>
+<em>
+<a href="#tekton.dev/v1alpha1.KeyRef">
+KeyRef
+</a>
+</em>
+</td>
+<td>
+<p>Key contains the public key to validate the resource.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1alpha1.EmbeddedRunSpec">EmbeddedRunSpec
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1alpha1.RunSpec">RunSpec</a>)
+</p>
+<div>
+<p>EmbeddedRunSpec allows custom task definitions to be embedded</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.PipelineTaskMetadata">
+PipelineTaskMetadata
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime#RawExtension">
+k8s.io/apimachinery/pkg/runtime.RawExtension
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec is a specification of a custom task</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>-</code><br/>
+<em>
+[]byte
+</em>
+</td>
+<td>
+<p>Raw is the underlying serialization of this object.</p>
+<p>TODO: Determine how to detect ContentType and ContentEncoding of &lsquo;Raw&rsquo; data.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>-</code><br/>
+<em>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime#Object">
+k8s.io/apimachinery/pkg/runtime.Object
+</a>
+</em>
+</td>
+<td>
+<p>Object can hold a representation of this extension - useful for working with versioned
+structs.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1alpha1.HashAlgorithm">HashAlgorithm
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1alpha1.KeyRef">KeyRef</a>)
+</p>
+<div>
+<p>HashAlgorithm defines the hash algorithm used for the public key</p>
+</div>
+<h3 id="tekton.dev/v1alpha1.KeyRef">KeyRef
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1alpha1.Authority">Authority</a>)
+</p>
+<div>
+<p>KeyRef defines the reference to a public key</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>secretRef</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#secretreference-v1-core">
+Kubernetes core/v1.SecretReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>SecretRef sets a reference to a secret with the key.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>data</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Data contains the inline public key.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>kms</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>KMS contains the KMS url of the public key
+Supported formats differ based on the KMS system used.
+One example of a KMS url could be:
+gcpkms://projects/[PROJECT]/locations/[LOCATION]&gt;/keyRings/[KEYRING]/cryptoKeys/[KEY]/cryptoKeyVersions/[KEY_VERSION]
+For more examples please refer <a href="https://docs.sigstore.dev/cosign/kms_support">https://docs.sigstore.dev/cosign/kms_support</a>.
+Note that the KMS is not supported yet.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>hashAlgorithm</code><br/>
+<em>
+<a href="#tekton.dev/v1alpha1.HashAlgorithm">
+HashAlgorithm
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>HashAlgorithm always defaults to sha256 if the algorithm hasn&rsquo;t been explicitly set</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1alpha1.ModeType">ModeType
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1alpha1.VerificationPolicySpec">VerificationPolicySpec</a>)
+</p>
+<div>
+<p>ModeType indicates the type of a mode for VerificationPolicy</p>
+</div>
+<h3 id="tekton.dev/v1alpha1.ResourcePattern">ResourcePattern
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1alpha1.VerificationPolicySpec">VerificationPolicySpec</a>)
+</p>
+<div>
+<p>ResourcePattern defines the pattern of the resource source</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>pattern</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Pattern defines a resource pattern. Regex is created to filter resources based on <code>Pattern</code>
+Example patterns:
+GitHub resource: <a href="https://github.com/tektoncd/catalog.git">https://github.com/tektoncd/catalog.git</a>, <a href="https://github.com/tektoncd/*">https://github.com/tektoncd/*</a>
+Bundle resource: gcr.io/tekton-releases/catalog/upstream/git-clone, gcr.io/tekton-releases/catalog/upstream/*
+Hub resource: <a href="https://artifacthub.io/*">https://artifacthub.io/*</a>,</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1alpha1.RunReason">RunReason
+(<code>string</code> alias)</h3>
+<div>
+<p>RunReason is an enum used to store all Run reason for the Succeeded condition that are controlled by the Run itself.</p>
+</div>
+<h3 id="tekton.dev/v1alpha1.RunResult">RunResult
+</h3>
+<div>
+<p>RunResult used to describe the results of a task</p>
+</div>
+<h3 id="tekton.dev/v1alpha1.RunSpec">RunSpec
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1alpha1.Run">Run</a>)
+</p>
+<div>
+<p>RunSpec defines the desired state of Run</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>ref</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.TaskRef">
+TaskRef
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#tekton.dev/v1alpha1.EmbeddedRunSpec">
+EmbeddedRunSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec is a specification of a custom task</p>
+<br/>
+<br/>
+<table>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>params</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.Params">
+Params
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code><br/>
+<em>
+<a href="#tekton.dev/v1alpha1.RunSpecStatus">
+RunSpecStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Used for cancelling a run (and maybe more later on)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>statusMessage</code><br/>
+<em>
+<a href="#tekton.dev/v1alpha1.RunSpecStatusMessage">
+RunSpecStatusMessage
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Status message for cancellation.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>retries</code><br/>
+<em>
+int
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Used for propagating retries count to custom tasks</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceAccountName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>podTemplate</code><br/>
+<em>
+<a href="#tekton.dev/unversioned.PodTemplate">
+PodTemplate
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>PodTemplate holds pod specific configuration</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>timeout</code><br/>
+<em>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+Kubernetes meta/v1.Duration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Time after which the custom-task times out.
+Refer Go&rsquo;s ParseDuration documentation for expected format: <a href="https://golang.org/pkg/time/#ParseDuration">https://golang.org/pkg/time/#ParseDuration</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>workspaces</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.WorkspaceBinding">
+[]WorkspaceBinding
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Workspaces is a list of WorkspaceBindings from volumes to workspaces.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1alpha1.RunSpecStatus">RunSpecStatus
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1alpha1.RunSpec">RunSpec</a>)
+</p>
+<div>
+<p>RunSpecStatus defines the taskrun spec status the user can provide</p>
+</div>
+<h3 id="tekton.dev/v1alpha1.RunSpecStatusMessage">RunSpecStatusMessage
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1alpha1.RunSpec">RunSpec</a>)
+</p>
+<div>
+<p>RunSpecStatusMessage defines human readable status messages for the TaskRun.</p>
+</div>
+<h3 id="tekton.dev/v1alpha1.RunStatus">RunStatus
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1alpha1.Run">Run</a>)
+</p>
+<div>
+<p>RunStatus defines the observed state of Run.</p>
+</div>
+<h3 id="tekton.dev/v1alpha1.RunStatusFields">RunStatusFields
+</h3>
+<div>
+<p>RunStatusFields holds the fields of Run&rsquo;s status.  This is defined
+separately and inlined so that other types can readily consume these fields
+via duck typing.</p>
+</div>
+<h3 id="tekton.dev/v1alpha1.StepActionObject">StepActionObject
+</h3>
+<div>
+<p>StepActionObject is implemented by StepAction</p>
+</div>
+<h3 id="tekton.dev/v1alpha1.StepActionSpec">StepActionSpec
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1alpha1.StepAction">StepAction</a>)
+</p>
+<div>
+<p>StepActionSpec contains the actionable components of a step.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>description</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Description is a user-facing description of the stepaction that may be
+used to populate a UI.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>image</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Image reference name to run for this StepAction.
+More info: <a href="https://kubernetes.io/docs/concepts/containers/images">https://kubernetes.io/docs/concepts/containers/images</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>command</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Entrypoint array. Not executed within a shell.
+The image&rsquo;s ENTRYPOINT is used if this is not provided.
+Variable references $(VAR_NAME) are expanded using the container&rsquo;s environment. If a variable
+cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. &ldquo;$$(VAR_NAME)&rdquo; will
+produce the string literal &ldquo;$(VAR_NAME)&rdquo;. Escaped references will never be expanded, regardless
+of whether the variable exists or not. Cannot be updated.
+More info: <a href="https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell">https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>args</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Arguments to the entrypoint.
+The image&rsquo;s CMD is used if this is not provided.
+Variable references $(VAR_NAME) are expanded using the container&rsquo;s environment. If a variable
+cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. &ldquo;$$(VAR_NAME)&rdquo; will
+produce the string literal &ldquo;$(VAR_NAME)&rdquo;. Escaped references will never be expanded, regardless
+of whether the variable exists or not. Cannot be updated.
+More info: <a href="https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell">https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>env</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#envvar-v1-core">
+[]Kubernetes core/v1.EnvVar
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>List of environment variables to set in the container.
+Cannot be updated.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>script</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Script is the contents of an executable file to execute.</p>
+<p>If Script is not empty, the Step cannot have an Command and the Args will be passed to the Script.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>workingDir</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Step&rsquo;s working directory.
+If not specified, the container runtime&rsquo;s default will be used, which
+might be configured in the container image.
+Cannot be updated.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>params</code><br/>
+<em>
+<a href="#tekton.dev/v1.ParamSpecs">
+ParamSpecs
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Params is a list of input parameters required to run the stepAction.
+Params must be supplied as inputs in Steps unless they declare a defaultvalue.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>results</code><br/>
+<em>
+<a href="#tekton.dev/v1.StepResult">
+[]StepResult
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Results are values that this StepAction can output</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>securityContext</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#securitycontext-v1-core">
+Kubernetes core/v1.SecurityContext
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>SecurityContext defines the security options the Step should be run with.
+If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+More info: <a href="https://kubernetes.io/docs/tasks/configure-pod-container/security-context/">https://kubernetes.io/docs/tasks/configure-pod-container/security-context/</a>
+The value set in StepAction will take precedence over the value from Task.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>volumeMounts</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#volumemount-v1-core">
+[]Kubernetes core/v1.VolumeMount
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Volumes to mount into the Step&rsquo;s filesystem.
+Cannot be updated.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1alpha1.VerificationPolicySpec">VerificationPolicySpec
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1alpha1.VerificationPolicy">VerificationPolicy</a>)
+</p>
+<div>
+<p>VerificationPolicySpec defines the patterns and authorities.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>resources</code><br/>
+<em>
+<a href="#tekton.dev/v1alpha1.ResourcePattern">
+[]ResourcePattern
+</a>
+</em>
+</td>
+<td>
+<p>Resources defines the patterns of resources sources that should be subject to this policy.
+For example, we may want to apply this Policy from a certain GitHub repo.
+Then the ResourcesPattern should be valid regex. E.g. If using gitresolver, and we want to config keys from a certain git repo.
+<code>ResourcesPattern</code> can be <code>https://github.com/tektoncd/catalog.git</code>, we will use regex to filter out those resources.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>authorities</code><br/>
+<em>
+<a href="#tekton.dev/v1alpha1.Authority">
+[]Authority
+</a>
+</em>
+</td>
+<td>
+<p>Authorities defines the rules for validating signatures.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>mode</code><br/>
+<em>
+<a href="#tekton.dev/v1alpha1.ModeType">
+ModeType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Mode controls whether a failing policy will fail the taskrun/pipelinerun, or only log the warnings
+enforce - fail the taskrun/pipelinerun if verification fails (default)
+warn - don&rsquo;t fail the taskrun/pipelinerun if verification fails but log warnings</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1alpha1.PipelineResourceSpec">PipelineResourceSpec
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1alpha1.PipelineResource">PipelineResource</a>, <a href="#tekton.dev/v1beta1.PipelineResourceBinding">PipelineResourceBinding</a>)
+</p>
+<div>
+<p>PipelineResourceSpec defines an individual resources used in the pipeline.</p>
+<p>Deprecated: Unused, preserved only for backwards compatibility</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>description</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Description is a user-facing description of the resource that may be
+used to populate a UI.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>type</code><br/>
+<em>
+<a href="#tekton.dev/v1alpha1.PipelineResourceType">
+PipelineResourceType
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>params</code><br/>
+<em>
+<a href="#tekton.dev/v1alpha1.ResourceParam">
+[]ResourceParam
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>secrets</code><br/>
+<em>
+<a href="#tekton.dev/v1alpha1.SecretParam">
+[]SecretParam
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Secrets to fetch to populate some of resource fields</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1alpha1.PipelineResourceStatus">PipelineResourceStatus
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1alpha1.PipelineResource">PipelineResource</a>)
+</p>
+<div>
+<p>PipelineResourceStatus does not contain anything because PipelineResources on their own
+do not have a status</p>
+<p>Deprecated: Unused, preserved only for backwards compatibility</p>
+</div>
+<h3 id="tekton.dev/v1alpha1.PipelineResourceType">PipelineResourceType
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1alpha1.PipelineResourceSpec">PipelineResourceSpec</a>, <a href="#tekton.dev/v1alpha1.ResourceDeclaration">ResourceDeclaration</a>)
+</p>
+<div>
+<p>PipelineResourceType represents the type of endpoint the pipelineResource is, so that the
+controller will know this pipelineResource shouldx be fetched and optionally what
+additional metatdata should be provided for it.</p>
+<p>Deprecated: Unused, preserved only for backwards compatibility</p>
+</div>
+<h3 id="tekton.dev/v1alpha1.ResourceDeclaration">ResourceDeclaration
+</h3>
+<div>
+<p>ResourceDeclaration defines an input or output PipelineResource declared as a requirement
+by another type such as a Task or Condition. The Name field will be used to refer to these
+PipelineResources within the type&rsquo;s definition, and when provided as an Input, the Name will be the
+path to the volume mounted containing this PipelineResource as an input (e.g.
+an input Resource named <code>workspace</code> will be mounted at <code>/workspace</code>).</p>
+<p>Deprecated: Unused, preserved only for backwards compatibility</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name declares the name by which a resource is referenced in the
+definition. Resources may be referenced by name in the definition of a
+Task&rsquo;s steps.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>type</code><br/>
+<em>
+<a href="#tekton.dev/v1alpha1.PipelineResourceType">
+PipelineResourceType
+</a>
+</em>
+</td>
+<td>
+<p>Type is the type of this resource;</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>description</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Description is a user-facing description of the declared resource that may be
+used to populate a UI.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>targetPath</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TargetPath is the path in workspace directory where the resource
+will be copied.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>optional</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>Optional declares the resource as optional.
+By default optional is set to false which makes a resource required.
+optional: true - the resource is considered optional
+optional: false - the resource is considered required (equivalent of not specifying it)</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1alpha1.ResourceParam">ResourceParam
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1alpha1.PipelineResourceSpec">PipelineResourceSpec</a>)
+</p>
+<div>
+<p>ResourceParam declares a string value to use for the parameter called Name, and is used in
+the specific context of PipelineResources.</p>
+<p>Deprecated: Unused, preserved only for backwards compatibility</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>value</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1alpha1.SecretParam">SecretParam
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1alpha1.PipelineResourceSpec">PipelineResourceSpec</a>)
+</p>
+<div>
+<p>SecretParam indicates which secret can be used to populate a field of the resource</p>
+<p>Deprecated: Unused, preserved only for backwards compatibility</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>fieldName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>secretKey</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>secretName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1alpha1.RunResult">RunResult
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1alpha1.RunStatusFields">RunStatusFields</a>)
+</p>
+<div>
+<p>RunResult used to describe the results of a task</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name the given name</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>value</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Value the given value of the result</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1alpha1.RunStatus">RunStatus
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1alpha1.RunStatusFields">RunStatusFields</a>)
+</p>
+<div>
+<p>RunStatus defines the observed state of Run</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>Status</code><br/>
+<em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Status">
+knative.dev/pkg/apis/duck/v1.Status
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>Status</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>RunStatusFields</code><br/>
+<em>
+<a href="#tekton.dev/v1alpha1.RunStatusFields">
+RunStatusFields
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>RunStatusFields</code> are embedded into this type.)
+</p>
+<p>RunStatusFields inlines the status fields.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1alpha1.RunStatusFields">RunStatusFields
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1alpha1.RunStatus">RunStatus</a>)
+</p>
+<div>
+<p>RunStatusFields holds the fields of Run&rsquo;s status.  This is defined
+separately and inlined so that other types can readily consume these fields
+via duck typing.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>startTime</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>StartTime is the time the build is actually started.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>completionTime</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CompletionTime is the time the build completed.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>results</code><br/>
+<em>
+<a href="#tekton.dev/v1alpha1.RunResult">
+[]RunResult
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Results reports any output result values to be consumed by later
+tasks in a pipeline.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>retriesStatus</code><br/>
+<em>
+<a href="#tekton.dev/v1alpha1.RunStatus">
+[]RunStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>RetriesStatus contains the history of RunStatus, in case of a retry.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>extraFields</code><br/>
+<em>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime#RawExtension">
+k8s.io/apimachinery/pkg/runtime.RawExtension
+</a>
+</em>
+</td>
+<td>
+<p>ExtraFields holds arbitrary fields provided by the custom task
+controller.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<hr/>
+<h2 id="tekton.dev/v1beta1">tekton.dev/v1beta1</h2>
+<div>
+<p>Package v1beta1 contains API Schema definitions for the pipeline v1beta1 API group</p>
+</div>
+Resource Types:
+<ul><li>
+<a href="#tekton.dev/v1beta1.CustomRun">CustomRun</a>
+</li><li>
+<a href="#tekton.dev/v1beta1.Pipeline">Pipeline</a>
+</li><li>
+<a href="#tekton.dev/v1beta1.PipelineRun">PipelineRun</a>
+</li><li>
+<a href="#tekton.dev/v1beta1.StepAction">StepAction</a>
+</li><li>
+<a href="#tekton.dev/v1beta1.Task">Task</a>
+</li><li>
+<a href="#tekton.dev/v1beta1.TaskRun">TaskRun</a>
+</li></ul>
+<h3 id="tekton.dev/v1beta1.CustomRun">CustomRun
+</h3>
+<div>
+<p>CustomRun represents a single execution of a Custom Task.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code><br/>
+string</td>
+<td>
+<code>
+tekton.dev/v1beta1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code><br/>
+string
+</td>
+<td><code>CustomRun</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.CustomRunSpec">
+CustomRunSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>customRef</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.TaskRef">
+TaskRef
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>customSpec</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.EmbeddedCustomRunSpec">
+EmbeddedCustomRunSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec is a specification of a custom task</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>params</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.Params">
+Params
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.CustomRunSpecStatus">
+CustomRunSpecStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Used for cancelling a customrun (and maybe more later on)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>statusMessage</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.CustomRunSpecStatusMessage">
+CustomRunSpecStatusMessage
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Status message for cancellation.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>retries</code><br/>
+<em>
+int
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Used for propagating retries count to custom tasks</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceAccountName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>timeout</code><br/>
+<em>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+Kubernetes meta/v1.Duration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Time after which the custom-task times out.
+Refer Go&rsquo;s ParseDuration documentation for expected format: <a href="https://golang.org/pkg/time/#ParseDuration">https://golang.org/pkg/time/#ParseDuration</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>workspaces</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.WorkspaceBinding">
+[]WorkspaceBinding
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Workspaces is a list of WorkspaceBindings from volumes to workspaces.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.CustomRunStatus">
+CustomRunStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.Pipeline">Pipeline
+</h3>
+<div>
+<p>Pipeline describes a list of Tasks to execute. It expresses how outputs
+of tasks feed into inputs of subsequent tasks.</p>
+<p>Deprecated: Please use v1.Pipeline instead.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code><br/>
+string</td>
+<td>
+<code>
+tekton.dev/v1beta1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code><br/>
+string
+</td>
+<td><code>Pipeline</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.PipelineSpec">
+PipelineSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec holds the desired state of the Pipeline from the client</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>displayName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DisplayName is a user-facing name of the pipeline that may be
+used to populate a UI.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>description</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Description is a user-facing description of the pipeline that may be
+used to populate a UI.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>resources</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.PipelineDeclaredResource">
+[]PipelineDeclaredResource
+</a>
+</em>
+</td>
+<td>
+<p>Deprecated: Unused, preserved only for backwards compatibility</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>tasks</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.PipelineTask">
+[]PipelineTask
+</a>
+</em>
+</td>
+<td>
+<p>Tasks declares the graph of Tasks that execute when this Pipeline is run.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>params</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.ParamSpecs">
+ParamSpecs
+</a>
+</em>
+</td>
+<td>
+<p>Params declares a list of input parameters that must be supplied when
+this Pipeline is run.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>workspaces</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.PipelineWorkspaceDeclaration">
+[]PipelineWorkspaceDeclaration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Workspaces declares a set of named workspaces that are expected to be
+provided by a PipelineRun.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>results</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.PipelineResult">
+[]PipelineResult
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Results are values that this pipeline can output once run</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>finally</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.PipelineTask">
+[]PipelineTask
+</a>
+</em>
+</td>
+<td>
+<p>Finally declares the list of Tasks that execute just before leaving the Pipeline
+i.e. either after all Tasks are finished executing successfully
+or after a failure which would result in ending the Pipeline</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.PipelineRun">PipelineRun
+</h3>
+<div>
+<p>PipelineRun represents a single execution of a Pipeline. PipelineRuns are how
+the graph of Tasks declared in a Pipeline are executed; they specify inputs
+to Pipelines such as parameter values and capture operational aspects of the
+Tasks execution such as service account and tolerations. Creating a
+PipelineRun creates TaskRuns for Tasks in the referenced Pipeline.</p>
+<p>Deprecated: Please use v1.PipelineRun instead.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code><br/>
+string</td>
+<td>
+<code>
+tekton.dev/v1beta1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code><br/>
+string
+</td>
+<td><code>PipelineRun</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.PipelineRunSpec">
+PipelineRunSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>pipelineRef</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.PipelineRef">
+PipelineRef
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>pipelineSpec</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.PipelineSpec">
+PipelineSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Specifying PipelineSpec can be disabled by setting
+<code>disable-inline-spec</code> feature flag.
+See Pipeline.spec (API version: tekton.dev/v1beta1)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>resources</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.PipelineResourceBinding">
+[]PipelineResourceBinding
+</a>
+</em>
+</td>
+<td>
+<p>Resources is a list of bindings specifying which actual instances of
+PipelineResources to use for the resources the Pipeline has declared
+it needs.</p>
+<p>Deprecated: Unused, preserved only for backwards compatibility</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>params</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.Params">
+Params
+</a>
+</em>
+</td>
+<td>
+<p>Params is a list of parameter names and values.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceAccountName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.PipelineRunSpecStatus">
+PipelineRunSpecStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Used for cancelling a pipelinerun (and maybe more later on)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>timeouts</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.TimeoutFields">
+TimeoutFields
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Time after which the Pipeline times out.
+Currently three keys are accepted in the map
+pipeline, tasks and finally
+with Timeouts.pipeline &gt;= Timeouts.tasks + Timeouts.finally</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>timeout</code><br/>
+<em>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+Kubernetes meta/v1.Duration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Timeout is the Time after which the Pipeline times out.
+Defaults to never.
+Refer to Go&rsquo;s ParseDuration documentation for expected format: <a href="https://golang.org/pkg/time/#ParseDuration">https://golang.org/pkg/time/#ParseDuration</a></p>
+<p>Deprecated: use pipelineRunSpec.Timeouts.Pipeline instead</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>podTemplate</code><br/>
+<em>
+<a href="#tekton.dev/unversioned.PodTemplate">
+PodTemplate
+</a>
+</em>
+</td>
+<td>
+<p>PodTemplate holds pod specific configuration</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>workspaces</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.WorkspaceBinding">
+[]WorkspaceBinding
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Workspaces holds a set of workspace bindings that must match names
+with those declared in the pipeline.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>taskRunSpecs</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.PipelineTaskRunSpec">
+[]PipelineTaskRunSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TaskRunSpecs holds a set of runtime specs</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>managedBy</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ManagedBy indicates which controller is responsible for reconciling
+this resource. If unset or set to &ldquo;tekton.dev/pipeline&rdquo;, the default
+Tekton controller will manage this resource.
+This field is immutable.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.PipelineRunStatus">
+PipelineRunStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.StepAction">StepAction
+</h3>
+<div>
+<p>StepAction represents the actionable components of Step.
+The Step can only reference it from the cluster or using remote resolution.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code><br/>
+string</td>
+<td>
+<code>
+tekton.dev/v1beta1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code><br/>
+string
+</td>
+<td><code>StepAction</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.StepActionSpec">
+StepActionSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec holds the desired state of the Step from the client</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>description</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Description is a user-facing description of the stepaction that may be
+used to populate a UI.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>image</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Image reference name to run for this StepAction.
+More info: <a href="https://kubernetes.io/docs/concepts/containers/images">https://kubernetes.io/docs/concepts/containers/images</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>command</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Entrypoint array. Not executed within a shell.
+The image&rsquo;s ENTRYPOINT is used if this is not provided.
+Variable references $(VAR_NAME) are expanded using the container&rsquo;s environment. If a variable
+cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. &ldquo;$$(VAR_NAME)&rdquo; will
+produce the string literal &ldquo;$(VAR_NAME)&rdquo;. Escaped references will never be expanded, regardless
+of whether the variable exists or not. Cannot be updated.
+More info: <a href="https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell">https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>args</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.Args">
+Args
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Arguments to the entrypoint.
+The image&rsquo;s CMD is used if this is not provided.
+Variable references $(VAR_NAME) are expanded using the container&rsquo;s environment. If a variable
+cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. &ldquo;$$(VAR_NAME)&rdquo; will
+produce the string literal &ldquo;$(VAR_NAME)&rdquo;. Escaped references will never be expanded, regardless
+of whether the variable exists or not. Cannot be updated.
+More info: <a href="https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell">https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>env</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#envvar-v1-core">
+[]Kubernetes core/v1.EnvVar
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>List of environment variables to set in the container.
+Cannot be updated.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>script</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Script is the contents of an executable file to execute.</p>
+<p>If Script is not empty, the Step cannot have an Command and the Args will be passed to the Script.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>workingDir</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Step&rsquo;s working directory.
+If not specified, the container runtime&rsquo;s default will be used, which
+might be configured in the container image.
+Cannot be updated.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>params</code><br/>
+<em>
+<a href="#tekton.dev/v1.ParamSpecs">
+ParamSpecs
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Params is a list of input parameters required to run the stepAction.
+Params must be supplied as inputs in Steps unless they declare a defaultvalue.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>results</code><br/>
+<em>
+<a href="#tekton.dev/v1.StepResult">
+[]StepResult
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Results are values that this StepAction can output</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>securityContext</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#securitycontext-v1-core">
+Kubernetes core/v1.SecurityContext
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>SecurityContext defines the security options the Step should be run with.
+If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+More info: <a href="https://kubernetes.io/docs/tasks/configure-pod-container/security-context/">https://kubernetes.io/docs/tasks/configure-pod-container/security-context/</a>
+The value set in StepAction will take precedence over the value from Task.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>volumeMounts</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#volumemount-v1-core">
+[]Kubernetes core/v1.VolumeMount
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Volumes to mount into the Step&rsquo;s filesystem.
+Cannot be updated.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.Task">Task
+</h3>
+<div>
+<p>Task represents a collection of sequential steps that are run as part of a
 Pipeline using a set of inputs and producing a set of outputs. Tasks execute
 when TaskRuns are created that provide the input parameters and resources and
-output resources the Task requires.
-
-Deprecated: Please use v1.Task instead.
-
-
-
-
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `tekton.dev/v1beta1` | | |
-| `kind` _string_ | `Task` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  | Optional: \{\} <br /> |
-| `spec` _[TaskSpec](#taskspec)_ | Spec holds the desired state of the Task from the client |  | Optional: \{\} <br /> |
-
-
-#### TaskBreakpoints
-
-
-
-TaskBreakpoints defines the breakpoint config for a particular Task
-
-
-
-_Appears in:_
-- [TaskRunDebug](#taskrundebug)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `onFailure` _string_ | if enabled, pause TaskRun on failure of a step<br />failed step will not exit |  | Optional: \{\} <br /> |
-| `beforeSteps` _string array_ |  |  | Optional: \{\} <br /> |
-
-
-#### TaskKind
-
-_Underlying type:_ _string_
-
-TaskKind defines the type of Task used by the pipeline.
-
-
-
-_Appears in:_
-- [TaskRef](#taskref)
-
-| Field | Description |
-| --- | --- |
-| `Task` | NamespacedTaskKind indicates that the task type has a namespaced scope.<br /> |
-
-
-
-
-
-
-#### TaskRef
-
-
-
-TaskRef can be used to refer to a specific instance of a task.
-
-
-
-_Appears in:_
-- [CustomRunSpec](#customrunspec)
-- [PipelineTask](#pipelinetask)
-- [RunSpec](#runspec)
-- [TaskRunSpec](#taskrunspec)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `name` _string_ | Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names |  |  |
-| `kind` _[TaskKind](#taskkind)_ | TaskKind indicates the Kind of the Task:<br />1. Namespaced Task when Kind is set to "Task". If Kind is "", it defaults to "Task".<br />2. Custom Task when Kind is non-empty and APIVersion is non-empty |  |  |
-| `apiVersion` _string_ | API version of the referent<br />Note: A Task with non-empty APIVersion and Kind is considered a Custom Task |  | Optional: \{\} <br /> |
-| `bundle` _string_ | Bundle url reference to a Tekton Bundle.<br />Deprecated: Please use ResolverRef with the bundles resolver instead.<br />The field is staying there for go client backward compatibility, but is not used/allowed anymore. |  | Optional: \{\} <br /> |
-| `ResolverRef` _[ResolverRef](#resolverref)_ | ResolverRef allows referencing a Task in a remote location<br />like a git repo. This field is only supported when the alpha<br />feature gate is enabled. |  | Optional: \{\} <br /> |
-
-
-#### TaskResource
-
-
-
-TaskResource defines an input or output Resource declared as a requirement
+output resources the Task requires.</p>
+<p>Deprecated: Please use v1.Task instead.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code><br/>
+string</td>
+<td>
+<code>
+tekton.dev/v1beta1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code><br/>
+string
+</td>
+<td><code>Task</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.TaskSpec">
+TaskSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec holds the desired state of the Task from the client</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>resources</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.TaskResources">
+TaskResources
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Resources is a list input and output resource to run the task
+Resources are represented in TaskRuns as bindings to instances of
+PipelineResources.</p>
+<p>Deprecated: Unused, preserved only for backwards compatibility</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>params</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.ParamSpecs">
+ParamSpecs
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Params is a list of input parameters required to run the task. Params
+must be supplied as inputs in TaskRuns unless they declare a default
+value.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>displayName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DisplayName is a user-facing name of the task that may be
+used to populate a UI.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>description</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Description is a user-facing description of the task that may be
+used to populate a UI.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>steps</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.Step">
+[]Step
+</a>
+</em>
+</td>
+<td>
+<p>Steps are the steps of the build; each step is run sequentially with the
+source mounted into /workspace.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>volumes</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.Volumes">
+Volumes
+</a>
+</em>
+</td>
+<td>
+<p>Volumes is a collection of volumes that are available to mount into the
+steps of the build.
+See Pod.spec.volumes (API version: v1)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>stepTemplate</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.StepTemplate">
+StepTemplate
+</a>
+</em>
+</td>
+<td>
+<p>StepTemplate can be used as the basis for all step containers within the
+Task, so that the steps inherit settings on the base container.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sidecars</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.Sidecar">
+[]Sidecar
+</a>
+</em>
+</td>
+<td>
+<p>Sidecars are run alongside the Task&rsquo;s step containers. They begin before
+the steps start and end after the steps complete.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>workspaces</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.WorkspaceDeclaration">
+[]WorkspaceDeclaration
+</a>
+</em>
+</td>
+<td>
+<p>Workspaces are the volumes that this Task requires.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>results</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.TaskResult">
+[]TaskResult
+</a>
+</em>
+</td>
+<td>
+<p>Results are values that this Task can output</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.TaskRun">TaskRun
+</h3>
+<div>
+<p>TaskRun represents a single execution of a Task. TaskRuns are how the steps
+specified in a Task are executed; they specify the parameters and resources
+used to run the steps in a Task.</p>
+<p>Deprecated: Please use v1.TaskRun instead.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code><br/>
+string</td>
+<td>
+<code>
+tekton.dev/v1beta1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code><br/>
+string
+</td>
+<td><code>TaskRun</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.TaskRunSpec">
+TaskRunSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>debug</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.TaskRunDebug">
+TaskRunDebug
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>params</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.Params">
+Params
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>resources</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.TaskRunResources">
+TaskRunResources
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Deprecated: Unused, preserved only for backwards compatibility</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceAccountName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>taskRef</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.TaskRef">
+TaskRef
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>no more than one of the TaskRef and TaskSpec may be specified.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>taskSpec</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.TaskSpec">
+TaskSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Specifying TaskSpec can be disabled by setting
+<code>disable-inline-spec</code> feature flag.
+See Task.spec (API version: tekton.dev/v1beta1)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.TaskRunSpecStatus">
+TaskRunSpecStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Used for cancelling a TaskRun (and maybe more later on)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>statusMessage</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.TaskRunSpecStatusMessage">
+TaskRunSpecStatusMessage
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Status message for cancellation.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>retries</code><br/>
+<em>
+int
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Retries represents how many times this TaskRun should be retried in the event of Task failure.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>timeout</code><br/>
+<em>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+Kubernetes meta/v1.Duration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Time after which one retry attempt times out. Defaults to 1 hour.
+Refer Go&rsquo;s ParseDuration documentation for expected format: <a href="https://golang.org/pkg/time/#ParseDuration">https://golang.org/pkg/time/#ParseDuration</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>podTemplate</code><br/>
+<em>
+<a href="#tekton.dev/unversioned.PodTemplate">
+PodTemplate
+</a>
+</em>
+</td>
+<td>
+<p>PodTemplate holds pod specific configuration</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>workspaces</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.WorkspaceBinding">
+[]WorkspaceBinding
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Workspaces is a list of WorkspaceBindings from volumes to workspaces.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>stepOverrides</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.TaskRunStepOverride">
+[]TaskRunStepOverride
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Overrides to apply to Steps in this TaskRun.
+If a field is specified in both a Step and a StepOverride,
+the value from the StepOverride will be used.
+This field is only supported when the alpha feature gate is enabled.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sidecarOverrides</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.TaskRunSidecarOverride">
+[]TaskRunSidecarOverride
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Overrides to apply to Sidecars in this TaskRun.
+If a field is specified in both a Sidecar and a SidecarOverride,
+the value from the SidecarOverride will be used.
+This field is only supported when the alpha feature gate is enabled.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>computeResources</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#resourcerequirements-v1-core">
+Kubernetes core/v1.ResourceRequirements
+</a>
+</em>
+</td>
+<td>
+<p>Compute resources to use for this TaskRun</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>managedBy</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ManagedBy indicates which controller is responsible for reconciling
+this resource. If unset or set to &ldquo;tekton.dev/pipeline&rdquo;, the default
+Tekton controller will manage this resource.
+This field is immutable.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.TaskRunStatus">
+TaskRunStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.Algorithm">Algorithm
+(<code>string</code> alias)</h3>
+<div>
+<p>Algorithm Standard cryptographic hash algorithm</p>
+</div>
+<h3 id="tekton.dev/v1beta1.Args">Args
+(<code>[]string</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.StepActionSpec">StepActionSpec</a>)
+</p>
+<div>
+</div>
+<h3 id="tekton.dev/v1beta1.ArrayOrString">ArrayOrString
+</h3>
+<div>
+<p>ArrayOrString is deprecated, this is to keep backward compatibility</p>
+<p>Deprecated: Use ParamValue instead.</p>
+</div>
+<h3 id="tekton.dev/v1beta1.Artifact">Artifact
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.Artifacts">Artifacts</a>)
+</p>
+<div>
+<p>Artifact represents an artifact within a system, potentially containing multiple values
+associated with it.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>The artifact&rsquo;s identifying category name</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>values</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.ArtifactValue">
+[]ArtifactValue
+</a>
+</em>
+</td>
+<td>
+<p>A collection of values related to the artifact</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>buildOutput</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>Indicate if the artifact is a build output or a by-product</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.ArtifactValue">ArtifactValue
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.Artifact">Artifact</a>)
+</p>
+<div>
+<p>ArtifactValue represents a specific value or data element within an Artifact.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>digest</code><br/>
+<em>
+map[github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Algorithm]string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>uri</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Algorithm-specific digests for verifying the content (e.g., SHA256)</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.Artifacts">Artifacts
+</h3>
+<div>
+<p>Artifacts represents the collection of input and output artifacts associated with
+a task run or a similar process. Artifacts in this context are units of data or resources
+that the process either consumes as input or produces as output.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>inputs</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.Artifact">
+[]Artifact
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>outputs</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.Artifact">
+[]Artifact
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.ChildStatusReference">ChildStatusReference
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineRunStatusFields">PipelineRunStatusFields</a>)
+</p>
+<div>
+<p>ChildStatusReference is used to point to the statuses of individual TaskRuns and Runs within this PipelineRun.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is the name of the TaskRun or Run this is referencing.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>displayName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>DisplayName is a user-facing name of the pipelineTask that may be
+used to populate a UI.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>pipelineTaskName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>PipelineTaskName is the name of the PipelineTask this is referencing.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>whenExpressions</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.WhenExpression">
+[]WhenExpression
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>WhenExpressions is the list of checks guarding the execution of the PipelineTask</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.CloudEventCondition">CloudEventCondition
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.CloudEventDeliveryState">CloudEventDeliveryState</a>)
+</p>
+<div>
+<p>CloudEventCondition is a string that represents the condition of the event.</p>
+</div>
+<h3 id="tekton.dev/v1beta1.CloudEventDelivery">CloudEventDelivery
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskRunStatusFields">TaskRunStatusFields</a>)
+</p>
+<div>
+<p>CloudEventDelivery is the target of a cloud event along with the state of
+delivery.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>target</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Target points to an addressable</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.CloudEventDeliveryState">
+CloudEventDeliveryState
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.CloudEventDeliveryState">CloudEventDeliveryState
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.CloudEventDelivery">CloudEventDelivery</a>)
+</p>
+<div>
+<p>CloudEventDeliveryState reports the state of a cloud event to be sent.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>condition</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.CloudEventCondition">
+CloudEventCondition
+</a>
+</em>
+</td>
+<td>
+<p>Current status</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sentAt</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>SentAt is the time at which the last attempt to send the event was made</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>message</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Error is the text of error (if any)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>retryCount</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>RetryCount is the number of attempts of sending the cloud event</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.Combination">Combination
+(<code>map[string]string</code> alias)</h3>
+<div>
+<p>Combination is a map, mainly defined to hold a single combination from a Matrix with key as param.Name and value as param.Value</p>
+</div>
+<h3 id="tekton.dev/v1beta1.Combinations">Combinations
+(<code>[]github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Combination</code> alias)</h3>
+<div>
+<p>Combinations is a Combination list</p>
+</div>
+<h3 id="tekton.dev/v1beta1.ConfigSource">ConfigSource
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.Provenance">Provenance</a>)
+</p>
+<div>
+<p>ConfigSource contains the information that can uniquely identify where a remote
+built definition came from i.e. Git repositories, Tekton Bundles in OCI registry
+and hub.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>uri</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>URI indicates the identity of the source of the build definition.
+Example: &ldquo;<a href="https://github.com/tektoncd/catalog&quot;">https://github.com/tektoncd/catalog&rdquo;</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>digest</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<p>Digest is a collection of cryptographic digests for the contents of the artifact specified by URI.
+Example: {&ldquo;sha1&rdquo;: &ldquo;f99d13e554ffcb696dee719fa85b695cb5b0f428&rdquo;}</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>entryPoint</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>EntryPoint identifies the entry point into the build. This is often a path to a
+build definition file and/or a target label within that file.
+Example: &ldquo;task/git-clone/0.10/git-clone.yaml&rdquo;</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.CustomRunReason">CustomRunReason
+(<code>string</code> alias)</h3>
+<div>
+<p>CustomRunReason is an enum used to store all Run reason for the Succeeded condition that are controlled by the CustomRun itself.</p>
+</div>
+<h3 id="tekton.dev/v1beta1.CustomRunResult">CustomRunResult
+</h3>
+<div>
+<p>CustomRunResult used to describe the results of a task</p>
+</div>
+<h3 id="tekton.dev/v1beta1.CustomRunSpec">CustomRunSpec
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.CustomRun">CustomRun</a>)
+</p>
+<div>
+<p>CustomRunSpec defines the desired state of CustomRun</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>customRef</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.TaskRef">
+TaskRef
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>customSpec</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.EmbeddedCustomRunSpec">
+EmbeddedCustomRunSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec is a specification of a custom task</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>params</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.Params">
+Params
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.CustomRunSpecStatus">
+CustomRunSpecStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Used for cancelling a customrun (and maybe more later on)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>statusMessage</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.CustomRunSpecStatusMessage">
+CustomRunSpecStatusMessage
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Status message for cancellation.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>retries</code><br/>
+<em>
+int
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Used for propagating retries count to custom tasks</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceAccountName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>timeout</code><br/>
+<em>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+Kubernetes meta/v1.Duration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Time after which the custom-task times out.
+Refer Go&rsquo;s ParseDuration documentation for expected format: <a href="https://golang.org/pkg/time/#ParseDuration">https://golang.org/pkg/time/#ParseDuration</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>workspaces</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.WorkspaceBinding">
+[]WorkspaceBinding
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Workspaces is a list of WorkspaceBindings from volumes to workspaces.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.CustomRunSpecStatus">CustomRunSpecStatus
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.CustomRunSpec">CustomRunSpec</a>)
+</p>
+<div>
+<p>CustomRunSpecStatus defines the taskrun spec status the user can provide</p>
+</div>
+<h3 id="tekton.dev/v1beta1.CustomRunSpecStatusMessage">CustomRunSpecStatusMessage
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.CustomRunSpec">CustomRunSpec</a>)
+</p>
+<div>
+<p>CustomRunSpecStatusMessage defines human readable status messages for the TaskRun.</p>
+</div>
+<h3 id="tekton.dev/v1beta1.CustomRunStatus">CustomRunStatus
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.CustomRun">CustomRun</a>, <a href="#tekton.dev/v1beta1.PipelineRunRunStatus">PipelineRunRunStatus</a>)
+</p>
+<div>
+<p>CustomRunStatus defines the observed state of CustomRun.</p>
+</div>
+<h3 id="tekton.dev/v1beta1.CustomRunStatusFields">CustomRunStatusFields
+</h3>
+<div>
+<p>CustomRunStatusFields holds the fields of CustomRun&rsquo;s status.  This is defined
+separately and inlined so that other types can readily consume these fields
+via duck typing.</p>
+</div>
+<h3 id="tekton.dev/v1beta1.EmbeddedCustomRunSpec">EmbeddedCustomRunSpec
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.CustomRunSpec">CustomRunSpec</a>)
+</p>
+<div>
+<p>EmbeddedCustomRunSpec allows custom task definitions to be embedded</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.PipelineTaskMetadata">
+PipelineTaskMetadata
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime#RawExtension">
+k8s.io/apimachinery/pkg/runtime.RawExtension
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec is a specification of a custom task</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>-</code><br/>
+<em>
+[]byte
+</em>
+</td>
+<td>
+<p>Raw is the underlying serialization of this object.</p>
+<p>TODO: Determine how to detect ContentType and ContentEncoding of &lsquo;Raw&rsquo; data.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>-</code><br/>
+<em>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime#Object">
+k8s.io/apimachinery/pkg/runtime.Object
+</a>
+</em>
+</td>
+<td>
+<p>Object can hold a representation of this extension - useful for working with versioned
+structs.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.EmbeddedTask">EmbeddedTask
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineTask">PipelineTask</a>)
+</p>
+<div>
+<p>EmbeddedTask is used to define a Task inline within a Pipeline&rsquo;s PipelineTasks.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime#RawExtension">
+k8s.io/apimachinery/pkg/runtime.RawExtension
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec is a specification of a custom task</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>-</code><br/>
+<em>
+[]byte
+</em>
+</td>
+<td>
+<p>Raw is the underlying serialization of this object.</p>
+<p>TODO: Determine how to detect ContentType and ContentEncoding of &lsquo;Raw&rsquo; data.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>-</code><br/>
+<em>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime#Object">
+k8s.io/apimachinery/pkg/runtime.Object
+</a>
+</em>
+</td>
+<td>
+<p>Object can hold a representation of this extension - useful for working with versioned
+structs.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.PipelineTaskMetadata">
+PipelineTaskMetadata
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>TaskSpec</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.TaskSpec">
+TaskSpec
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>TaskSpec</code> are embedded into this type.)
+</p>
+<em>(Optional)</em>
+<p>TaskSpec is a specification of a task</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.IncludeParams">IncludeParams
+</h3>
+<div>
+<p>IncludeParams allows passing in a specific combinations of Parameters into the Matrix.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name the specified combination</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>params</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.Params">
+Params
+</a>
+</em>
+</td>
+<td>
+<p>Params takes only <code>Parameters</code> of type <code>&quot;string&quot;</code>
+The names of the <code>params</code> must match the names of the <code>params</code> in the underlying <code>Task</code></p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.InternalTaskModifier">InternalTaskModifier
+</h3>
+<div>
+<p>InternalTaskModifier implements TaskModifier for resources that are built-in to Tekton Pipelines.</p>
+<p>Deprecated: Unused, preserved only for backwards compatibility</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>stepsToPrepend</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.Step">
+[]Step
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>stepsToAppend</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.Step">
+[]Step
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>volumes</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#volume-v1-core">
+[]Kubernetes core/v1.Volume
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.Matrix">Matrix
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineTask">PipelineTask</a>)
+</p>
+<div>
+<p>Matrix is used to fan out Tasks in a Pipeline</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>params</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.Params">
+Params
+</a>
+</em>
+</td>
+<td>
+<p>Params is a list of parameters used to fan out the pipelineTask
+Params takes only <code>Parameters</code> of type <code>&quot;array&quot;</code>
+Each array element is supplied to the <code>PipelineTask</code> by substituting <code>params</code> of type <code>&quot;string&quot;</code> in the underlying <code>Task</code>.
+The names of the <code>params</code> in the <code>Matrix</code> must match the names of the <code>params</code> in the underlying <code>Task</code> that they will be substituting.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>include</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.IncludeParamsList">
+IncludeParamsList
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Include is a list of IncludeParams which allows passing in specific combinations of Parameters into the Matrix.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.OnErrorType">OnErrorType
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.Step">Step</a>)
+</p>
+<div>
+<p>OnErrorType defines a list of supported exiting behavior of a container on error</p>
+</div>
+<h3 id="tekton.dev/v1beta1.Param">Param
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskRunInputs">TaskRunInputs</a>)
+</p>
+<div>
+<p>Param declares an ParamValues to use for the parameter called name.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>value</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.ParamValue">
+ParamValue
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.ParamSpec">ParamSpec
+</h3>
+<div>
+<p>ParamSpec defines arbitrary parameters needed beyond typed inputs (such as
+resources). Parameter values are provided by users as inputs on a TaskRun
+or PipelineRun.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name declares the name by which a parameter is referenced.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>type</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.ParamType">
+ParamType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Type is the user-specified type of the parameter. The possible types
+are currently &ldquo;string&rdquo;, &ldquo;array&rdquo; and &ldquo;object&rdquo;, and &ldquo;string&rdquo; is the default.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>description</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Description is a user-facing description of the parameter that may be
+used to populate a UI.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>properties</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.PropertySpec">
+map[string]github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PropertySpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Properties is the JSON Schema properties to support key-value pairs parameter.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>default</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.ParamValue">
+ParamValue
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Default is the value a parameter takes if no input value is supplied. If
+default is set, a Task may be executed without a supplied value for the
+parameter.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>enum</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Enum declares a set of allowed param input values for tasks/pipelines that can be validated.
+If Enum is not set, no input validation is performed for the param.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.ParamSpecs">ParamSpecs
+(<code>[]github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.ParamSpec</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineSpec">PipelineSpec</a>, <a href="#tekton.dev/v1beta1.TaskSpec">TaskSpec</a>)
+</p>
+<div>
+<p>ParamSpecs is a list of ParamSpec</p>
+</div>
+<h3 id="tekton.dev/v1beta1.ParamType">ParamType
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.ParamSpec">ParamSpec</a>, <a href="#tekton.dev/v1beta1.ParamValue">ParamValue</a>, <a href="#tekton.dev/v1beta1.PropertySpec">PropertySpec</a>)
+</p>
+<div>
+<p>ParamType indicates the type of an input parameter;
+Used to distinguish between a single string and an array of strings.</p>
+</div>
+<h3 id="tekton.dev/v1beta1.ParamValue">ParamValue
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.Param">Param</a>, <a href="#tekton.dev/v1beta1.ParamSpec">ParamSpec</a>)
+</p>
+<div>
+<p>ParamValue is a type that can hold a single string or string array.
+Used in JSON unmarshalling so that a single JSON field can accept
+either an individual string or an array of strings.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>Type</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.ParamType">
+ParamType
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>StringVal</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Represents the stored type of ParamValues.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ArrayVal</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>ObjectVal</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.Params">Params
+(<code>[]github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Param</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1alpha1.RunSpec">RunSpec</a>, <a href="#tekton.dev/v1beta1.CustomRunSpec">CustomRunSpec</a>, <a href="#tekton.dev/v1beta1.IncludeParams">IncludeParams</a>, <a href="#tekton.dev/v1beta1.Matrix">Matrix</a>, <a href="#tekton.dev/v1beta1.PipelineRunSpec">PipelineRunSpec</a>, <a href="#tekton.dev/v1beta1.PipelineTask">PipelineTask</a>, <a href="#tekton.dev/v1beta1.ResolverRef">ResolverRef</a>, <a href="#tekton.dev/v1beta1.Step">Step</a>, <a href="#tekton.dev/v1beta1.TaskRunSpec">TaskRunSpec</a>)
+</p>
+<div>
+<p>Params is a list of Param</p>
+</div>
+<h3 id="tekton.dev/v1beta1.PipelineDeclaredResource">PipelineDeclaredResource
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineSpec">PipelineSpec</a>)
+</p>
+<div>
+<p>PipelineDeclaredResource is used by a Pipeline to declare the types of the
+PipelineResources that it will required to run and names which can be used to
+refer to these PipelineResources in PipelineTaskResourceBindings.</p>
+<p>Deprecated: Unused, preserved only for backwards compatibility</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is the name that will be used by the Pipeline to refer to this resource.
+It does not directly correspond to the name of any PipelineResources Task
+inputs or outputs, and it does not correspond to the actual names of the
+PipelineResources that will be bound in the PipelineRun.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>type</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.PipelineResourceType">
+PipelineResourceType
+</a>
+</em>
+</td>
+<td>
+<p>Type is the type of the PipelineResource.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>optional</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>Optional declares the resource as optional.
+optional: true - the resource is considered optional
+optional: false - the resource is considered required (default/equivalent of not specifying it)</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.PipelineObject">PipelineObject
+</h3>
+<div>
+<p>PipelineObject is implemented by Pipeline</p>
+</div>
+<h3 id="tekton.dev/v1beta1.PipelineRef">PipelineRef
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineRunSpec">PipelineRunSpec</a>, <a href="#tekton.dev/v1beta1.PipelineTask">PipelineTask</a>)
+</p>
+<div>
+<p>PipelineRef can be used to refer to a specific instance of a Pipeline.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name of the referent; More info: <a href="http://kubernetes.io/docs/user-guide/identifiers#names">http://kubernetes.io/docs/user-guide/identifiers#names</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>apiVersion</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>API version of the referent</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>bundle</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Bundle url reference to a Tekton Bundle.</p>
+<p>Deprecated: Please use ResolverRef with the bundles resolver instead.
+The field is staying there for go client backward compatibility, but is not used/allowed anymore.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ResolverRef</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.ResolverRef">
+ResolverRef
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ResolverRef allows referencing a Pipeline in a remote location
+like a git repo. This field is only supported when the alpha
+feature gate is enabled.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.PipelineResourceBinding">PipelineResourceBinding
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineRunSpec">PipelineRunSpec</a>, <a href="#tekton.dev/v1beta1.TaskResourceBinding">TaskResourceBinding</a>)
+</p>
+<div>
+<p>PipelineResourceBinding connects a reference to an instance of a PipelineResource
+with a PipelineResource dependency that the Pipeline has declared</p>
+<p>Deprecated: Unused, preserved only for backwards compatibility</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is the name of the PipelineResource in the Pipeline&rsquo;s declaration</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>resourceRef</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.PipelineResourceRef">
+PipelineResourceRef
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ResourceRef is a reference to the instance of the actual PipelineResource
+that should be used</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>resourceSpec</code><br/>
+<em>
+<a href="#tekton.dev/v1alpha1.PipelineResourceSpec">
+PipelineResourceSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ResourceSpec is specification of a resource that should be created and
+consumed by the task</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.PipelineResourceInterface">PipelineResourceInterface
+</h3>
+<div>
+<p>PipelineResourceInterface interface to be implemented by different PipelineResource types</p>
+<p>Deprecated: Unused, preserved only for backwards compatibility</p>
+</div>
+<h3 id="tekton.dev/v1beta1.PipelineResourceRef">PipelineResourceRef
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineResourceBinding">PipelineResourceBinding</a>)
+</p>
+<div>
+<p>PipelineResourceRef can be used to refer to a specific instance of a Resource</p>
+<p>Deprecated: Unused, preserved only for backwards compatibility</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name of the referent; More info: <a href="http://kubernetes.io/docs/user-guide/identifiers#names">http://kubernetes.io/docs/user-guide/identifiers#names</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>apiVersion</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>API version of the referent</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.PipelineResourceResult">PipelineResourceResult
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskRunStatusFields">TaskRunStatusFields</a>)
+</p>
+<div>
+<p>PipelineResourceResult has been deprecated with the migration of PipelineResources
+Deprecated: Use RunResult instead</p>
+</div>
+<h3 id="tekton.dev/v1beta1.PipelineResourceType">PipelineResourceType
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineDeclaredResource">PipelineDeclaredResource</a>)
+</p>
+<div>
+<p>PipelineResourceType represents the type of endpoint the pipelineResource is, so that the
+controller will know this pipelineResource should be fetched and optionally what
+additional metatdata should be provided for it.</p>
+<p>Deprecated: Unused, preserved only for backwards compatibility</p>
+</div>
+<h3 id="tekton.dev/v1beta1.PipelineResult">PipelineResult
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineSpec">PipelineSpec</a>)
+</p>
+<div>
+<p>PipelineResult used to describe the results of a pipeline</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name the given name</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>type</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.ResultsType">
+ResultsType
+</a>
+</em>
+</td>
+<td>
+<p>Type is the user-specified type of the result.
+The possible types are &lsquo;string&rsquo;, &lsquo;array&rsquo;, and &lsquo;object&rsquo;, with &lsquo;string&rsquo; as the default.
+&lsquo;array&rsquo; and &lsquo;object&rsquo; types are alpha features.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>description</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Description is a human-readable description of the result</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>value</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.ResultValue">
+ResultValue
+</a>
+</em>
+</td>
+<td>
+<p>Value the expression used to retrieve the value</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.PipelineRunReason">PipelineRunReason
+(<code>string</code> alias)</h3>
+<div>
+<p>PipelineRunReason represents a reason for the pipeline run &ldquo;Succeeded&rdquo; condition</p>
+</div>
+<h3 id="tekton.dev/v1beta1.PipelineRunResult">PipelineRunResult
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineRunStatusFields">PipelineRunStatusFields</a>)
+</p>
+<div>
+<p>PipelineRunResult used to describe the results of a pipeline</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is the result&rsquo;s name as declared by the Pipeline</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>value</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.ResultValue">
+ResultValue
+</a>
+</em>
+</td>
+<td>
+<p>Value is the result returned from the execution of this PipelineRun</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.PipelineRunRunStatus">PipelineRunRunStatus
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineRunStatusFields">PipelineRunStatusFields</a>)
+</p>
+<div>
+<p>PipelineRunRunStatus contains the name of the PipelineTask for this CustomRun or Run and the CustomRun or Run&rsquo;s Status</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>pipelineTaskName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>PipelineTaskName is the name of the PipelineTask.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.CustomRunStatus">
+CustomRunStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Status is the CustomRunStatus for the corresponding CustomRun or Run</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>whenExpressions</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.WhenExpression">
+[]WhenExpression
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>WhenExpressions is the list of checks guarding the execution of the PipelineTask</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.PipelineRunSpec">PipelineRunSpec
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineRun">PipelineRun</a>)
+</p>
+<div>
+<p>PipelineRunSpec defines the desired state of PipelineRun</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>pipelineRef</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.PipelineRef">
+PipelineRef
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>pipelineSpec</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.PipelineSpec">
+PipelineSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Specifying PipelineSpec can be disabled by setting
+<code>disable-inline-spec</code> feature flag.
+See Pipeline.spec (API version: tekton.dev/v1beta1)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>resources</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.PipelineResourceBinding">
+[]PipelineResourceBinding
+</a>
+</em>
+</td>
+<td>
+<p>Resources is a list of bindings specifying which actual instances of
+PipelineResources to use for the resources the Pipeline has declared
+it needs.</p>
+<p>Deprecated: Unused, preserved only for backwards compatibility</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>params</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.Params">
+Params
+</a>
+</em>
+</td>
+<td>
+<p>Params is a list of parameter names and values.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceAccountName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.PipelineRunSpecStatus">
+PipelineRunSpecStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Used for cancelling a pipelinerun (and maybe more later on)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>timeouts</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.TimeoutFields">
+TimeoutFields
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Time after which the Pipeline times out.
+Currently three keys are accepted in the map
+pipeline, tasks and finally
+with Timeouts.pipeline &gt;= Timeouts.tasks + Timeouts.finally</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>timeout</code><br/>
+<em>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+Kubernetes meta/v1.Duration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Timeout is the Time after which the Pipeline times out.
+Defaults to never.
+Refer to Go&rsquo;s ParseDuration documentation for expected format: <a href="https://golang.org/pkg/time/#ParseDuration">https://golang.org/pkg/time/#ParseDuration</a></p>
+<p>Deprecated: use pipelineRunSpec.Timeouts.Pipeline instead</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>podTemplate</code><br/>
+<em>
+<a href="#tekton.dev/unversioned.PodTemplate">
+PodTemplate
+</a>
+</em>
+</td>
+<td>
+<p>PodTemplate holds pod specific configuration</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>workspaces</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.WorkspaceBinding">
+[]WorkspaceBinding
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Workspaces holds a set of workspace bindings that must match names
+with those declared in the pipeline.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>taskRunSpecs</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.PipelineTaskRunSpec">
+[]PipelineTaskRunSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TaskRunSpecs holds a set of runtime specs</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>managedBy</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ManagedBy indicates which controller is responsible for reconciling
+this resource. If unset or set to &ldquo;tekton.dev/pipeline&rdquo;, the default
+Tekton controller will manage this resource.
+This field is immutable.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.PipelineRunSpecStatus">PipelineRunSpecStatus
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineRunSpec">PipelineRunSpec</a>)
+</p>
+<div>
+<p>PipelineRunSpecStatus defines the pipelinerun spec status the user can provide</p>
+</div>
+<h3 id="tekton.dev/v1beta1.PipelineRunStatus">PipelineRunStatus
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineRun">PipelineRun</a>)
+</p>
+<div>
+<p>PipelineRunStatus defines the observed state of PipelineRun</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>Status</code><br/>
+<em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Status">
+knative.dev/pkg/apis/duck/v1.Status
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>Status</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>PipelineRunStatusFields</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.PipelineRunStatusFields">
+PipelineRunStatusFields
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>PipelineRunStatusFields</code> are embedded into this type.)
+</p>
+<p>PipelineRunStatusFields inlines the status fields.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.PipelineRunStatusFields">PipelineRunStatusFields
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineRunStatus">PipelineRunStatus</a>)
+</p>
+<div>
+<p>PipelineRunStatusFields holds the fields of PipelineRunStatus&rsquo; status.
+This is defined separately and inlined so that other types can readily
+consume these fields via duck typing.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>startTime</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+<p>StartTime is the time the PipelineRun is actually started.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>completionTime</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+<p>CompletionTime is the time the PipelineRun completed.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>taskRuns</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.PipelineRunTaskRunStatus">
+map[string]*github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineRunTaskRunStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TaskRuns is a map of PipelineRunTaskRunStatus with the taskRun name as the key.</p>
+<p>Deprecated: use ChildReferences instead. As of v0.45.0, this field is no
+longer populated and is only included for backwards compatibility with
+older server versions.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>runs</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.PipelineRunRunStatus">
+map[string]*github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineRunRunStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Runs is a map of PipelineRunRunStatus with the run name as the key</p>
+<p>Deprecated: use ChildReferences instead. As of v0.45.0, this field is no
+longer populated and is only included for backwards compatibility with
+older server versions.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>pipelineResults</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.PipelineRunResult">
+[]PipelineRunResult
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>PipelineResults are the list of results written out by the pipeline task&rsquo;s containers</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>pipelineSpec</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.PipelineSpec">
+PipelineSpec
+</a>
+</em>
+</td>
+<td>
+<p>PipelineSpec contains the exact spec used to instantiate the run.
+See Pipeline.spec (API version: tekton.dev/v1beta1)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>skippedTasks</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.SkippedTask">
+[]SkippedTask
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>list of tasks that were skipped due to when expressions evaluating to false</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>childReferences</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.ChildStatusReference">
+[]ChildStatusReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>list of TaskRun and Run names, PipelineTask names, and API versions/kinds for children of this PipelineRun.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>finallyStartTime</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>FinallyStartTime is when all non-finally tasks have been completed and only finally tasks are being executed.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>provenance</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.Provenance">
+Provenance
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Provenance contains some key authenticated metadata about how a software artifact was built (what sources, what inputs/outputs, etc.).</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>spanContext</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<p>SpanContext contains tracing span context fields</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.PipelineRunTaskRunStatus">PipelineRunTaskRunStatus
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineRunStatusFields">PipelineRunStatusFields</a>)
+</p>
+<div>
+<p>PipelineRunTaskRunStatus contains the name of the PipelineTask for this TaskRun and the TaskRun&rsquo;s Status</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>pipelineTaskName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>PipelineTaskName is the name of the PipelineTask.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.TaskRunStatus">
+TaskRunStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Status is the TaskRunStatus for the corresponding TaskRun</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>whenExpressions</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.WhenExpression">
+[]WhenExpression
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>WhenExpressions is the list of checks guarding the execution of the PipelineTask</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.PipelineSpec">PipelineSpec
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.Pipeline">Pipeline</a>, <a href="#tekton.dev/v1beta1.PipelineRunSpec">PipelineRunSpec</a>, <a href="#tekton.dev/v1beta1.PipelineRunStatusFields">PipelineRunStatusFields</a>, <a href="#tekton.dev/v1beta1.PipelineTask">PipelineTask</a>)
+</p>
+<div>
+<p>PipelineSpec defines the desired state of Pipeline.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>displayName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DisplayName is a user-facing name of the pipeline that may be
+used to populate a UI.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>description</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Description is a user-facing description of the pipeline that may be
+used to populate a UI.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>resources</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.PipelineDeclaredResource">
+[]PipelineDeclaredResource
+</a>
+</em>
+</td>
+<td>
+<p>Deprecated: Unused, preserved only for backwards compatibility</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>tasks</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.PipelineTask">
+[]PipelineTask
+</a>
+</em>
+</td>
+<td>
+<p>Tasks declares the graph of Tasks that execute when this Pipeline is run.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>params</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.ParamSpecs">
+ParamSpecs
+</a>
+</em>
+</td>
+<td>
+<p>Params declares a list of input parameters that must be supplied when
+this Pipeline is run.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>workspaces</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.PipelineWorkspaceDeclaration">
+[]PipelineWorkspaceDeclaration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Workspaces declares a set of named workspaces that are expected to be
+provided by a PipelineRun.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>results</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.PipelineResult">
+[]PipelineResult
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Results are values that this pipeline can output once run</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>finally</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.PipelineTask">
+[]PipelineTask
+</a>
+</em>
+</td>
+<td>
+<p>Finally declares the list of Tasks that execute just before leaving the Pipeline
+i.e. either after all Tasks are finished executing successfully
+or after a failure which would result in ending the Pipeline</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.PipelineTask">PipelineTask
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineSpec">PipelineSpec</a>)
+</p>
+<div>
+<p>PipelineTask defines a task in a Pipeline, passing inputs from both
+Params and from the output of previous tasks.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is the name of this task within the context of a Pipeline. Name is
+used as a coordinate with the <code>from</code> and <code>runAfter</code> fields to establish
+the execution order of tasks relative to one another.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>displayName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DisplayName is the display name of this task within the context of a Pipeline.
+This display name may be used to populate a UI.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>description</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Description is the description of this task within the context of a Pipeline.
+This description may be used to populate a UI.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>taskRef</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.TaskRef">
+TaskRef
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TaskRef is a reference to a task definition.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>taskSpec</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.EmbeddedTask">
+EmbeddedTask
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TaskSpec is a specification of a task
+Specifying TaskSpec can be disabled by setting
+<code>disable-inline-spec</code> feature flag.
+See Task.spec (API version: tekton.dev/v1beta1)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>when</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.WhenExpressions">
+WhenExpressions
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>WhenExpressions is a list of when expressions that need to be true for the task to run</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>retries</code><br/>
+<em>
+int
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Retries represents how many times this task should be retried in case of task failure: ConditionSucceeded set to False</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>runAfter</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>RunAfter is the list of PipelineTask names that should be executed before
+this Task executes. (Used to force a specific ordering in graph execution.)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>resources</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.PipelineTaskResources">
+PipelineTaskResources
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Deprecated: Unused, preserved only for backwards compatibility</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>params</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.Params">
+Params
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Parameters declares parameters passed to this task.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>matrix</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.Matrix">
+Matrix
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Matrix declares parameters used to fan out this task.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>workspaces</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.WorkspacePipelineTaskBinding">
+[]WorkspacePipelineTaskBinding
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Workspaces maps workspaces from the pipeline spec to the workspaces
+declared in the Task.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>timeout</code><br/>
+<em>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+Kubernetes meta/v1.Duration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Duration after which the TaskRun times out. Defaults to 1 hour.
+Refer Go&rsquo;s ParseDuration documentation for expected format: <a href="https://golang.org/pkg/time/#ParseDuration">https://golang.org/pkg/time/#ParseDuration</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>pipelineRef</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.PipelineRef">
+PipelineRef
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>PipelineRef is a reference to a pipeline definition
+Note: PipelineRef is in preview mode and not yet supported</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>pipelineSpec</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.PipelineSpec">
+PipelineSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>PipelineSpec is a specification of a pipeline
+Note: PipelineSpec is in preview mode and not yet supported
+Specifying PipelineSpec can be disabled by setting
+<code>disable-inline-spec</code> feature flag.
+See Pipeline.spec (API version: tekton.dev/v1beta1)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>onError</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.PipelineTaskOnErrorType">
+PipelineTaskOnErrorType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>OnError defines the exiting behavior of a PipelineRun on error
+can be set to [ continue | stopAndFail ]</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.PipelineTaskInputResource">PipelineTaskInputResource
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineTaskResources">PipelineTaskResources</a>)
+</p>
+<div>
+<p>PipelineTaskInputResource maps the name of a declared PipelineResource input
+dependency in a Task to the resource in the Pipeline&rsquo;s DeclaredPipelineResources
+that should be used. This input may come from a previous task.</p>
+<p>Deprecated: Unused, preserved only for backwards compatibility</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is the name of the PipelineResource as declared by the Task.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>resource</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Resource is the name of the DeclaredPipelineResource to use.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>from</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>From is the list of PipelineTask names that the resource has to come from.
+(Implies an ordering in the execution graph.)</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.PipelineTaskMetadata">PipelineTaskMetadata
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1alpha1.EmbeddedRunSpec">EmbeddedRunSpec</a>, <a href="#tekton.dev/v1beta1.EmbeddedCustomRunSpec">EmbeddedCustomRunSpec</a>, <a href="#tekton.dev/v1beta1.EmbeddedTask">EmbeddedTask</a>, <a href="#tekton.dev/v1beta1.PipelineTaskRunSpec">PipelineTaskRunSpec</a>)
+</p>
+<div>
+<p>PipelineTaskMetadata contains the labels or annotations for an EmbeddedTask</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>labels</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>annotations</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.PipelineTaskOnErrorType">PipelineTaskOnErrorType
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineTask">PipelineTask</a>)
+</p>
+<div>
+<p>PipelineTaskOnErrorType defines a list of supported failure handling behaviors of a PipelineTask on error</p>
+</div>
+<h3 id="tekton.dev/v1beta1.PipelineTaskOutputResource">PipelineTaskOutputResource
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineTaskResources">PipelineTaskResources</a>)
+</p>
+<div>
+<p>PipelineTaskOutputResource maps the name of a declared PipelineResource output
+dependency in a Task to the resource in the Pipeline&rsquo;s DeclaredPipelineResources
+that should be used.</p>
+<p>Deprecated: Unused, preserved only for backwards compatibility</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is the name of the PipelineResource as declared by the Task.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>resource</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Resource is the name of the DeclaredPipelineResource to use.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.PipelineTaskParam">PipelineTaskParam
+</h3>
+<div>
+<p>PipelineTaskParam is used to provide arbitrary string parameters to a Task.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>value</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.PipelineTaskResources">PipelineTaskResources
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineTask">PipelineTask</a>)
+</p>
+<div>
+<p>PipelineTaskResources allows a Pipeline to declare how its DeclaredPipelineResources
+should be provided to a Task as its inputs and outputs.</p>
+<p>Deprecated: Unused, preserved only for backwards compatibility</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>inputs</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.PipelineTaskInputResource">
+[]PipelineTaskInputResource
+</a>
+</em>
+</td>
+<td>
+<p>Inputs holds the mapping from the PipelineResources declared in
+DeclaredPipelineResources to the input PipelineResources required by the Task.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>outputs</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.PipelineTaskOutputResource">
+[]PipelineTaskOutputResource
+</a>
+</em>
+</td>
+<td>
+<p>Outputs holds the mapping from the PipelineResources declared in
+DeclaredPipelineResources to the input PipelineResources required by the Task.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.PipelineTaskRun">PipelineTaskRun
+</h3>
+<div>
+<p>PipelineTaskRun reports the results of running a step in the Task. Each
+task has the potential to succeed or fail (based on the exit code)
+and produces logs.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.PipelineTaskRunSpec">PipelineTaskRunSpec
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineRunSpec">PipelineRunSpec</a>)
+</p>
+<div>
+<p>PipelineTaskRunSpec  can be used to configure specific
+specs for a concrete Task</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>pipelineTaskName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>taskServiceAccountName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>taskPodTemplate</code><br/>
+<em>
+<a href="#tekton.dev/unversioned.PodTemplate">
+PodTemplate
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>stepOverrides</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.TaskRunStepOverride">
+[]TaskRunStepOverride
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>sidecarOverrides</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.TaskRunSidecarOverride">
+[]TaskRunSidecarOverride
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.PipelineTaskMetadata">
+PipelineTaskMetadata
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>computeResources</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#resourcerequirements-v1-core">
+Kubernetes core/v1.ResourceRequirements
+</a>
+</em>
+</td>
+<td>
+<p>Compute resources to use for this TaskRun</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>timeout</code><br/>
+<em>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+Kubernetes meta/v1.Duration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Duration after which the TaskRun times out.
+Refer Go&rsquo;s ParseDuration documentation for expected format: <a href="https://golang.org/pkg/time/#ParseDuration">https://golang.org/pkg/time/#ParseDuration</a></p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.PipelineWorkspaceDeclaration">PipelineWorkspaceDeclaration
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineSpec">PipelineSpec</a>)
+</p>
+<div>
+<p>PipelineWorkspaceDeclaration creates a named slot in a Pipeline that a PipelineRun
+is expected to populate with a workspace binding.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is the name of a workspace to be provided by a PipelineRun.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>description</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Description is a human readable string describing how the workspace will be
+used in the Pipeline. It can be useful to include a bit of detail about which
+tasks are intended to have access to the data on the workspace.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>optional</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>Optional marks a Workspace as not being required in PipelineRuns. By default
+this field is false and so declared workspaces are required.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.PropertySpec">PropertySpec
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.ParamSpec">ParamSpec</a>, <a href="#tekton.dev/v1beta1.TaskResult">TaskResult</a>)
+</p>
+<div>
+<p>PropertySpec defines the struct for object keys</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>type</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.ParamType">
+ParamType
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.Provenance">Provenance
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineRunStatusFields">PipelineRunStatusFields</a>, <a href="#tekton.dev/v1beta1.StepState">StepState</a>, <a href="#tekton.dev/v1beta1.TaskRunStatusFields">TaskRunStatusFields</a>)
+</p>
+<div>
+<p>Provenance contains metadata about resources used in the TaskRun/PipelineRun
+such as the source from where a remote build definition was fetched.
+This field aims to carry minimum amoumt of metadata in *Run status so that
+Tekton Chains can capture them in the provenance.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>configSource</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.ConfigSource">
+ConfigSource
+</a>
+</em>
+</td>
+<td>
+<p>Deprecated: Use RefSource instead</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>refSource</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.RefSource">
+RefSource
+</a>
+</em>
+</td>
+<td>
+<p>RefSource identifies the source where a remote task/pipeline came from.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>featureFlags</code><br/>
+<em>
+github.com/tektoncd/pipeline/pkg/apis/config.FeatureFlags
+</em>
+</td>
+<td>
+<p>FeatureFlags identifies the feature flags that were used during the task/pipeline run</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.Ref">Ref
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.Step">Step</a>)
+</p>
+<div>
+<p>Ref can be used to refer to a specific instance of a StepAction.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name of the referenced step</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ResolverRef</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.ResolverRef">
+ResolverRef
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ResolverRef allows referencing a StepAction in a remote location
+like a git repo.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.RefSource">RefSource
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.Provenance">Provenance</a>)
+</p>
+<div>
+<p>RefSource contains the information that can uniquely identify where a remote
+built definition came from i.e. Git repositories, Tekton Bundles in OCI registry
+and hub.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>uri</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>URI indicates the identity of the source of the build definition.
+Example: &ldquo;<a href="https://github.com/tektoncd/catalog&quot;">https://github.com/tektoncd/catalog&rdquo;</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>digest</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<p>Digest is a collection of cryptographic digests for the contents of the artifact specified by URI.
+Example: {&ldquo;sha1&rdquo;: &ldquo;f99d13e554ffcb696dee719fa85b695cb5b0f428&rdquo;}</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>entryPoint</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>EntryPoint identifies the entry point into the build. This is often a path to a
+build definition file and/or a target label within that file.
+Example: &ldquo;task/git-clone/0.10/git-clone.yaml&rdquo;</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.ResolverName">ResolverName
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.ResolverRef">ResolverRef</a>)
+</p>
+<div>
+<p>ResolverName is the name of a resolver from which a resource can be
+requested.</p>
+</div>
+<h3 id="tekton.dev/v1beta1.ResolverRef">ResolverRef
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineRef">PipelineRef</a>, <a href="#tekton.dev/v1beta1.Ref">Ref</a>, <a href="#tekton.dev/v1beta1.TaskRef">TaskRef</a>)
+</p>
+<div>
+<p>ResolverRef can be used to refer to a Pipeline or Task in a remote
+location like a git repo.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>resolver</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.ResolverName">
+ResolverName
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Resolver is the name of the resolver that should perform
+resolution of the referenced Tekton resource, such as &ldquo;git&rdquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>params</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.Params">
+Params
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Params contains the parameters used to identify the
+referenced Tekton resource. Example entries might include
+&ldquo;repo&rdquo; or &ldquo;path&rdquo; but the set of params ultimately depends on
+the chosen resolver.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.ResourceDeclaration">ResourceDeclaration
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskResource">TaskResource</a>)
+</p>
+<div>
+<p>ResourceDeclaration defines an input or output PipelineResource declared as a requirement
+by another type such as a Task or Condition. The Name field will be used to refer to these
+PipelineResources within the type&rsquo;s definition, and when provided as an Input, the Name will be the
+path to the volume mounted containing this PipelineResource as an input (e.g.
+an input Resource named <code>workspace</code> will be mounted at <code>/workspace</code>).</p>
+<p>Deprecated: Unused, preserved only for backwards compatibility</p>
+</div>
+<h3 id="tekton.dev/v1beta1.ResourceParam">ResourceParam
+</h3>
+<div>
+<p>ResourceParam declares a string value to use for the parameter called Name, and is used in
+the specific context of PipelineResources.</p>
+<p>Deprecated: Unused, preserved only for backwards compatibility</p>
+</div>
+<h3 id="tekton.dev/v1beta1.ResultRef">ResultRef
+</h3>
+<div>
+<p>ResultRef is a type that represents a reference to a task run result</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>pipelineTask</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>result</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>resultsIndex</code><br/>
+<em>
+int
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>property</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.ResultType">ResultType
+</h3>
+<div>
+<p>ResultType of PipelineResourceResult has been deprecated with the migration of PipelineResources
+Deprecated: v1beta1.ResultType is only kept for backward compatibility</p>
+</div>
+<h3 id="tekton.dev/v1beta1.ResultValue">ResultValue
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineResult">PipelineResult</a>, <a href="#tekton.dev/v1beta1.PipelineRunResult">PipelineRunResult</a>, <a href="#tekton.dev/v1beta1.TaskResult">TaskResult</a>, <a href="#tekton.dev/v1beta1.TaskRunResult">TaskRunResult</a>)
+</p>
+<div>
+<p>ResultValue is a type alias of ParamValue</p>
+</div>
+<h3 id="tekton.dev/v1beta1.ResultsType">ResultsType
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineResult">PipelineResult</a>, <a href="#tekton.dev/v1beta1.TaskResult">TaskResult</a>, <a href="#tekton.dev/v1beta1.TaskRunResult">TaskRunResult</a>)
+</p>
+<div>
+<p>ResultsType indicates the type of a result;
+Used to distinguish between a single string and an array of strings.
+Note that there is ResultType used to find out whether a
+RunResult is from a task result or not, which is different from
+this ResultsType.</p>
+</div>
+<h3 id="tekton.dev/v1beta1.RetriesStatus">RetriesStatus
+(<code>[]github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskRunStatus</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskRunStatusFields">TaskRunStatusFields</a>)
+</p>
+<div>
+</div>
+<h3 id="tekton.dev/v1beta1.RunObject">RunObject
+</h3>
+<div>
+<p>RunObject is implemented by Run, CustomRun, TaskRun and PipelineRun</p>
+</div>
+<h3 id="tekton.dev/v1beta1.RunObjectWithRetries">RunObjectWithRetries
+</h3>
+<div>
+<p>RunObjectWithRetries is implemented by Run and CustomRun</p>
+</div>
+<h3 id="tekton.dev/v1beta1.RunResult">RunResult
+</h3>
+<div>
+<p>RunResult is used to write key/value pairs to TaskRun pod termination messages.
+It has been migrated to the result package and kept for backward compatibility</p>
+</div>
+<h3 id="tekton.dev/v1beta1.Sidecar">Sidecar
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskSpec">TaskSpec</a>)
+</p>
+<div>
+<p>Sidecar has nearly the same data structure as Step but does not have the ability to timeout.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name of the Sidecar specified as a DNS_LABEL.
+Each Sidecar in a Task must have a unique name (DNS_LABEL).
+Cannot be updated.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>image</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Image name to be used by the Sidecar.
+More info: <a href="https://kubernetes.io/docs/concepts/containers/images">https://kubernetes.io/docs/concepts/containers/images</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>command</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Entrypoint array. Not executed within a shell.
+The image&rsquo;s ENTRYPOINT is used if this is not provided.
+Variable references $(VAR_NAME) are expanded using the Sidecar&rsquo;s environment. If a variable
+cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. &ldquo;$$(VAR_NAME)&rdquo; will
+produce the string literal &ldquo;$(VAR_NAME)&rdquo;. Escaped references will never be expanded, regardless
+of whether the variable exists or not. Cannot be updated.
+More info: <a href="https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell">https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>args</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Arguments to the entrypoint.
+The image&rsquo;s CMD is used if this is not provided.
+Variable references $(VAR_NAME) are expanded using the container&rsquo;s environment. If a variable
+cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. &ldquo;$$(VAR_NAME)&rdquo; will
+produce the string literal &ldquo;$(VAR_NAME)&rdquo;. Escaped references will never be expanded, regardless
+of whether the variable exists or not. Cannot be updated.
+More info: <a href="https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell">https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>workingDir</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Sidecar&rsquo;s working directory.
+If not specified, the container runtime&rsquo;s default will be used, which
+might be configured in the container image.
+Cannot be updated.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ports</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#containerport-v1-core">
+[]Kubernetes core/v1.ContainerPort
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>List of ports to expose from the Sidecar. Exposing a port here gives
+the system additional information about the network connections a
+container uses, but is primarily informational. Not specifying a port here
+DOES NOT prevent that port from being exposed. Any port which is
+listening on the default &ldquo;0.0.0.0&rdquo; address inside a container will be
+accessible from the network.
+Cannot be updated.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>envFrom</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#envfromsource-v1-core">
+[]Kubernetes core/v1.EnvFromSource
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>List of sources to populate environment variables in the Sidecar.
+The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+will be reported as an event when the Sidecar is starting. When a key exists in multiple
+sources, the value associated with the last source will take precedence.
+Values defined by an Env with a duplicate key will take precedence.
+Cannot be updated.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>env</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#envvar-v1-core">
+[]Kubernetes core/v1.EnvVar
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>List of environment variables to set in the Sidecar.
+Cannot be updated.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>resources</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#resourcerequirements-v1-core">
+Kubernetes core/v1.ResourceRequirements
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Compute Resources required by this Sidecar.
+Cannot be updated.
+More info: <a href="https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/">https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>volumeMounts</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#volumemount-v1-core">
+[]Kubernetes core/v1.VolumeMount
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Volumes to mount into the Sidecar&rsquo;s filesystem.
+Cannot be updated.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>volumeDevices</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#volumedevice-v1-core">
+[]Kubernetes core/v1.VolumeDevice
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>volumeDevices is the list of block devices to be used by the Sidecar.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>livenessProbe</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#probe-v1-core">
+Kubernetes core/v1.Probe
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Periodic probe of Sidecar liveness.
+Container will be restarted if the probe fails.
+Cannot be updated.
+More info: <a href="https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes">https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>readinessProbe</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#probe-v1-core">
+Kubernetes core/v1.Probe
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Periodic probe of Sidecar service readiness.
+Container will be removed from service endpoints if the probe fails.
+Cannot be updated.
+More info: <a href="https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes">https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>startupProbe</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#probe-v1-core">
+Kubernetes core/v1.Probe
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>StartupProbe indicates that the Pod the Sidecar is running in has successfully initialized.
+If specified, no other probes are executed until this completes successfully.
+If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+This can be used to provide different probe parameters at the beginning of a Pod&rsquo;s lifecycle,
+when it might take a long time to load data or warm a cache, than during steady-state operation.
+This cannot be updated.
+More info: <a href="https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes">https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>lifecycle</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#lifecycle-v1-core">
+Kubernetes core/v1.Lifecycle
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Actions that the management system should take in response to Sidecar lifecycle events.
+Cannot be updated.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>terminationMessagePath</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Optional: Path at which the file to which the Sidecar&rsquo;s termination message
+will be written is mounted into the Sidecar&rsquo;s filesystem.
+Message written is intended to be brief final status, such as an assertion failure message.
+Will be truncated by the node if greater than 4096 bytes. The total message length across
+all containers will be limited to 12kb.
+Defaults to /dev/termination-log.
+Cannot be updated.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>terminationMessagePolicy</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#terminationmessagepolicy-v1-core">
+Kubernetes core/v1.TerminationMessagePolicy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Indicate how the termination message should be populated. File will use the contents of
+terminationMessagePath to populate the Sidecar status message on both success and failure.
+FallbackToLogsOnError will use the last chunk of Sidecar log output if the termination
+message file is empty and the Sidecar exited with an error.
+The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+Defaults to File.
+Cannot be updated.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>imagePullPolicy</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#pullpolicy-v1-core">
+Kubernetes core/v1.PullPolicy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Image pull policy.
+One of Always, Never, IfNotPresent.
+Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+Cannot be updated.
+More info: <a href="https://kubernetes.io/docs/concepts/containers/images#updating-images">https://kubernetes.io/docs/concepts/containers/images#updating-images</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>securityContext</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#securitycontext-v1-core">
+Kubernetes core/v1.SecurityContext
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>SecurityContext defines the security options the Sidecar should be run with.
+If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+More info: <a href="https://kubernetes.io/docs/tasks/configure-pod-container/security-context/">https://kubernetes.io/docs/tasks/configure-pod-container/security-context/</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>stdin</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Whether this Sidecar should allocate a buffer for stdin in the container runtime. If this
+is not set, reads from stdin in the Sidecar will always result in EOF.
+Default is false.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>stdinOnce</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Whether the container runtime should close the stdin channel after it has been opened by
+a single attach. When stdin is true the stdin stream will remain open across multiple attach
+sessions. If stdinOnce is set to true, stdin is opened on Sidecar start, is empty until the
+first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+at which time stdin is closed and remains closed until the Sidecar is restarted. If this
+flag is false, a container processes that reads from stdin will never receive an EOF.
+Default is false</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>tty</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Whether this Sidecar should allocate a TTY for itself, also requires &lsquo;stdin&rsquo; to be true.
+Default is false.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>script</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Script is the contents of an executable file to execute.</p>
+<p>If Script is not empty, the Step cannot have an Command or Args.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>workspaces</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.WorkspaceUsage">
+[]WorkspaceUsage
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>This is an alpha field. You must set the &ldquo;enable-api-fields&rdquo; feature flag to &ldquo;alpha&rdquo;
+for this field to be supported.</p>
+<p>Workspaces is a list of workspaces from the Task that this Sidecar wants
+exclusive access to. Adding a workspace to this list means that any
+other Step or Sidecar that does not also request this Workspace will
+not have access to it.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>restartPolicy</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#containerrestartpolicy-v1-core">
+Kubernetes core/v1.ContainerRestartPolicy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>RestartPolicy refers to kubernetes RestartPolicy. It can only be set for an
+initContainer and must have it&rsquo;s policy set to &ldquo;Always&rdquo;. It is currently
+left optional to help support Kubernetes versions prior to 1.29 when this feature
+was introduced.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.SidecarState">SidecarState
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskRunStatusFields">TaskRunStatusFields</a>)
+</p>
+<div>
+<p>SidecarState reports the results of running a sidecar in a Task.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>ContainerState</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#containerstate-v1-core">
+Kubernetes core/v1.ContainerState
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>ContainerState</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>container</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>imageID</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.SkippedTask">SkippedTask
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineRunStatusFields">PipelineRunStatusFields</a>)
+</p>
+<div>
+<p>SkippedTask is used to describe the Tasks that were skipped due to their When Expressions
+evaluating to False. This is a struct because we are looking into including more details
+about the When Expressions that caused this Task to be skipped.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is the Pipeline Task name</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>reason</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.SkippingReason">
+SkippingReason
+</a>
+</em>
+</td>
+<td>
+<p>Reason is the cause of the PipelineTask being skipped.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>whenExpressions</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.WhenExpression">
+[]WhenExpression
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>WhenExpressions is the list of checks guarding the execution of the PipelineTask</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.SkippingReason">SkippingReason
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.SkippedTask">SkippedTask</a>)
+</p>
+<div>
+<p>SkippingReason explains why a PipelineTask was skipped.</p>
+</div>
+<h3 id="tekton.dev/v1beta1.Step">Step
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.InternalTaskModifier">InternalTaskModifier</a>, <a href="#tekton.dev/v1beta1.TaskSpec">TaskSpec</a>)
+</p>
+<div>
+<p>Step runs a subcomponent of a Task</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name of the Step specified as a DNS_LABEL.
+Each Step in a Task must have a unique name.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>displayName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DisplayName is a user-facing name of the step that may be
+used to populate a UI.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>image</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Image reference name to run for this Step.
+More info: <a href="https://kubernetes.io/docs/concepts/containers/images">https://kubernetes.io/docs/concepts/containers/images</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>command</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Entrypoint array. Not executed within a shell.
+The image&rsquo;s ENTRYPOINT is used if this is not provided.
+Variable references $(VAR_NAME) are expanded using the container&rsquo;s environment. If a variable
+cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. &ldquo;$$(VAR_NAME)&rdquo; will
+produce the string literal &ldquo;$(VAR_NAME)&rdquo;. Escaped references will never be expanded, regardless
+of whether the variable exists or not. Cannot be updated.
+More info: <a href="https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell">https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>args</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Arguments to the entrypoint.
+The image&rsquo;s CMD is used if this is not provided.
+Variable references $(VAR_NAME) are expanded using the container&rsquo;s environment. If a variable
+cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. &ldquo;$$(VAR_NAME)&rdquo; will
+produce the string literal &ldquo;$(VAR_NAME)&rdquo;. Escaped references will never be expanded, regardless
+of whether the variable exists or not. Cannot be updated.
+More info: <a href="https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell">https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>workingDir</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Step&rsquo;s working directory.
+If not specified, the container runtime&rsquo;s default will be used, which
+might be configured in the container image.
+Cannot be updated.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ports</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#containerport-v1-core">
+[]Kubernetes core/v1.ContainerPort
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>List of ports to expose from the Step&rsquo;s container. Exposing a port here gives
+the system additional information about the network connections a
+container uses, but is primarily informational. Not specifying a port here
+DOES NOT prevent that port from being exposed. Any port which is
+listening on the default &ldquo;0.0.0.0&rdquo; address inside a container will be
+accessible from the network.
+Cannot be updated.</p>
+<p>Deprecated: This field will be removed in a future release.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>envFrom</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#envfromsource-v1-core">
+[]Kubernetes core/v1.EnvFromSource
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>List of sources to populate environment variables in the container.
+The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+will be reported as an event when the container is starting. When a key exists in multiple
+sources, the value associated with the last source will take precedence.
+Values defined by an Env with a duplicate key will take precedence.
+Cannot be updated.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>env</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#envvar-v1-core">
+[]Kubernetes core/v1.EnvVar
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>List of environment variables to set in the container.
+Cannot be updated.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>resources</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#resourcerequirements-v1-core">
+Kubernetes core/v1.ResourceRequirements
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Compute Resources required by this Step.
+Cannot be updated.
+More info: <a href="https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/">https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>volumeMounts</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#volumemount-v1-core">
+[]Kubernetes core/v1.VolumeMount
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Volumes to mount into the Step&rsquo;s filesystem.
+Cannot be updated.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>volumeDevices</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#volumedevice-v1-core">
+[]Kubernetes core/v1.VolumeDevice
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>volumeDevices is the list of block devices to be used by the Step.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>livenessProbe</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#probe-v1-core">
+Kubernetes core/v1.Probe
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Periodic probe of container liveness.
+Step will be restarted if the probe fails.
+Cannot be updated.
+More info: <a href="https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes">https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes</a></p>
+<p>Deprecated: This field will be removed in a future release.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>readinessProbe</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#probe-v1-core">
+Kubernetes core/v1.Probe
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Periodic probe of container service readiness.
+Step will be removed from service endpoints if the probe fails.
+Cannot be updated.
+More info: <a href="https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes">https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes</a></p>
+<p>Deprecated: This field will be removed in a future release.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>startupProbe</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#probe-v1-core">
+Kubernetes core/v1.Probe
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DeprecatedStartupProbe indicates that the Pod this Step runs in has successfully initialized.
+If specified, no other probes are executed until this completes successfully.
+If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+This can be used to provide different probe parameters at the beginning of a Pod&rsquo;s lifecycle,
+when it might take a long time to load data or warm a cache, than during steady-state operation.
+This cannot be updated.
+More info: <a href="https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes">https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes</a></p>
+<p>Deprecated: This field will be removed in a future release.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>lifecycle</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#lifecycle-v1-core">
+Kubernetes core/v1.Lifecycle
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Actions that the management system should take in response to container lifecycle events.
+Cannot be updated.</p>
+<p>Deprecated: This field will be removed in a future release.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>terminationMessagePath</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Deprecated: This field will be removed in a future release and can&rsquo;t be meaningfully used.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>terminationMessagePolicy</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#terminationmessagepolicy-v1-core">
+Kubernetes core/v1.TerminationMessagePolicy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Deprecated: This field will be removed in a future release and can&rsquo;t be meaningfully used.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>imagePullPolicy</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#pullpolicy-v1-core">
+Kubernetes core/v1.PullPolicy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Image pull policy.
+One of Always, Never, IfNotPresent.
+Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+Cannot be updated.
+More info: <a href="https://kubernetes.io/docs/concepts/containers/images#updating-images">https://kubernetes.io/docs/concepts/containers/images#updating-images</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>securityContext</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#securitycontext-v1-core">
+Kubernetes core/v1.SecurityContext
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>SecurityContext defines the security options the Step should be run with.
+If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+More info: <a href="https://kubernetes.io/docs/tasks/configure-pod-container/security-context/">https://kubernetes.io/docs/tasks/configure-pod-container/security-context/</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>stdin</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Whether this container should allocate a buffer for stdin in the container runtime. If this
+is not set, reads from stdin in the container will always result in EOF.
+Default is false.</p>
+<p>Deprecated: This field will be removed in a future release.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>stdinOnce</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Whether the container runtime should close the stdin channel after it has been opened by
+a single attach. When stdin is true the stdin stream will remain open across multiple attach
+sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+at which time stdin is closed and remains closed until the container is restarted. If this
+flag is false, a container processes that reads from stdin will never receive an EOF.
+Default is false</p>
+<p>Deprecated: This field will be removed in a future release.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>tty</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Whether this container should allocate a DeprecatedTTY for itself, also requires &lsquo;stdin&rsquo; to be true.
+Default is false.</p>
+<p>Deprecated: This field will be removed in a future release.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>script</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Script is the contents of an executable file to execute.</p>
+<p>If Script is not empty, the Step cannot have an Command and the Args will be passed to the Script.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>timeout</code><br/>
+<em>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+Kubernetes meta/v1.Duration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Timeout is the time after which the step times out. Defaults to never.
+Refer to Go&rsquo;s ParseDuration documentation for expected format: <a href="https://golang.org/pkg/time/#ParseDuration">https://golang.org/pkg/time/#ParseDuration</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>workspaces</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.WorkspaceUsage">
+[]WorkspaceUsage
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>This is an alpha field. You must set the &ldquo;enable-api-fields&rdquo; feature flag to &ldquo;alpha&rdquo;
+for this field to be supported.</p>
+<p>Workspaces is a list of workspaces from the Task that this Step wants
+exclusive access to. Adding a workspace to this list means that any
+other Step or Sidecar that does not also request this Workspace will
+not have access to it.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>onError</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.OnErrorType">
+OnErrorType
+</a>
+</em>
+</td>
+<td>
+<p>OnError defines the exiting behavior of a container on error
+can be set to [ continue | stopAndFail ]</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>stdoutConfig</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.StepOutputConfig">
+StepOutputConfig
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Stores configuration for the stdout stream of the step.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>stderrConfig</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.StepOutputConfig">
+StepOutputConfig
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Stores configuration for the stderr stream of the step.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ref</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.Ref">
+Ref
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Contains the reference to an existing StepAction.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>params</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.Params">
+Params
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Params declares parameters passed to this step action.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>results</code><br/>
+<em>
+<a href="#tekton.dev/v1.StepResult">
+[]StepResult
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Results declares StepResults produced by the Step.</p>
+<p>It can be used in an inlined Step when used to store Results to $(step.results.resultName.path).
+It cannot be used when referencing StepActions using [v1beta1.Step.Ref].
+The Results declared by the StepActions will be stored here instead.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>when</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.StepWhenExpressions">
+StepWhenExpressions
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.StepActionObject">StepActionObject
+</h3>
+<div>
+<p>StepActionObject is implemented by StepAction</p>
+</div>
+<h3 id="tekton.dev/v1beta1.StepActionSpec">StepActionSpec
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.StepAction">StepAction</a>)
+</p>
+<div>
+<p>StepActionSpec contains the actionable components of a step.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>description</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Description is a user-facing description of the stepaction that may be
+used to populate a UI.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>image</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Image reference name to run for this StepAction.
+More info: <a href="https://kubernetes.io/docs/concepts/containers/images">https://kubernetes.io/docs/concepts/containers/images</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>command</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Entrypoint array. Not executed within a shell.
+The image&rsquo;s ENTRYPOINT is used if this is not provided.
+Variable references $(VAR_NAME) are expanded using the container&rsquo;s environment. If a variable
+cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. &ldquo;$$(VAR_NAME)&rdquo; will
+produce the string literal &ldquo;$(VAR_NAME)&rdquo;. Escaped references will never be expanded, regardless
+of whether the variable exists or not. Cannot be updated.
+More info: <a href="https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell">https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>args</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.Args">
+Args
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Arguments to the entrypoint.
+The image&rsquo;s CMD is used if this is not provided.
+Variable references $(VAR_NAME) are expanded using the container&rsquo;s environment. If a variable
+cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. &ldquo;$$(VAR_NAME)&rdquo; will
+produce the string literal &ldquo;$(VAR_NAME)&rdquo;. Escaped references will never be expanded, regardless
+of whether the variable exists or not. Cannot be updated.
+More info: <a href="https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell">https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>env</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#envvar-v1-core">
+[]Kubernetes core/v1.EnvVar
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>List of environment variables to set in the container.
+Cannot be updated.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>script</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Script is the contents of an executable file to execute.</p>
+<p>If Script is not empty, the Step cannot have an Command and the Args will be passed to the Script.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>workingDir</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Step&rsquo;s working directory.
+If not specified, the container runtime&rsquo;s default will be used, which
+might be configured in the container image.
+Cannot be updated.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>params</code><br/>
+<em>
+<a href="#tekton.dev/v1.ParamSpecs">
+ParamSpecs
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Params is a list of input parameters required to run the stepAction.
+Params must be supplied as inputs in Steps unless they declare a defaultvalue.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>results</code><br/>
+<em>
+<a href="#tekton.dev/v1.StepResult">
+[]StepResult
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Results are values that this StepAction can output</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>securityContext</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#securitycontext-v1-core">
+Kubernetes core/v1.SecurityContext
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>SecurityContext defines the security options the Step should be run with.
+If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+More info: <a href="https://kubernetes.io/docs/tasks/configure-pod-container/security-context/">https://kubernetes.io/docs/tasks/configure-pod-container/security-context/</a>
+The value set in StepAction will take precedence over the value from Task.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>volumeMounts</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#volumemount-v1-core">
+[]Kubernetes core/v1.VolumeMount
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Volumes to mount into the Step&rsquo;s filesystem.
+Cannot be updated.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.StepOutputConfig">StepOutputConfig
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.Step">Step</a>)
+</p>
+<div>
+<p>StepOutputConfig stores configuration for a step output stream.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>path</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Path to duplicate stdout stream to on container&rsquo;s local filesystem.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.StepState">StepState
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskRunStatusFields">TaskRunStatusFields</a>)
+</p>
+<div>
+<p>StepState reports the results of running a step in a Task.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>ContainerState</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#containerstate-v1-core">
+Kubernetes core/v1.ContainerState
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>ContainerState</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>container</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>imageID</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>results</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.TaskRunStepResult">
+[]TaskRunStepResult
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>provenance</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.Provenance">
+Provenance
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>inputs</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.TaskRunStepArtifact">
+[]TaskRunStepArtifact
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>outputs</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.TaskRunStepArtifact">
+[]TaskRunStepArtifact
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.StepTemplate">StepTemplate
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskSpec">TaskSpec</a>)
+</p>
+<div>
+<p>StepTemplate is a template for a Step</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Default name for each Step specified as a DNS_LABEL.
+Each Step in a Task must have a unique name.
+Cannot be updated.</p>
+<p>Deprecated: This field will be removed in a future release.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>image</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Default image name to use for each Step.
+More info: <a href="https://kubernetes.io/docs/concepts/containers/images">https://kubernetes.io/docs/concepts/containers/images</a>
+This field is optional to allow higher level config management to default or override
+container images in workload controllers like Deployments and StatefulSets.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>command</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Entrypoint array. Not executed within a shell.
+The docker image&rsquo;s ENTRYPOINT is used if this is not provided.
+Variable references $(VAR_NAME) are expanded using the Step&rsquo;s environment. If a variable
+cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. &ldquo;$$(VAR_NAME)&rdquo; will
+produce the string literal &ldquo;$(VAR_NAME)&rdquo;. Escaped references will never be expanded, regardless
+of whether the variable exists or not. Cannot be updated.
+More info: <a href="https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell">https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>args</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Arguments to the entrypoint.
+The image&rsquo;s CMD is used if this is not provided.
+Variable references $(VAR_NAME) are expanded using the Step&rsquo;s environment. If a variable
+cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. &ldquo;$$(VAR_NAME)&rdquo; will
+produce the string literal &ldquo;$(VAR_NAME)&rdquo;. Escaped references will never be expanded, regardless
+of whether the variable exists or not. Cannot be updated.
+More info: <a href="https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell">https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>workingDir</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Step&rsquo;s working directory.
+If not specified, the container runtime&rsquo;s default will be used, which
+might be configured in the container image.
+Cannot be updated.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ports</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#containerport-v1-core">
+[]Kubernetes core/v1.ContainerPort
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>List of ports to expose from the Step&rsquo;s container. Exposing a port here gives
+the system additional information about the network connections a
+container uses, but is primarily informational. Not specifying a port here
+DOES NOT prevent that port from being exposed. Any port which is
+listening on the default &ldquo;0.0.0.0&rdquo; address inside a container will be
+accessible from the network.
+Cannot be updated.</p>
+<p>Deprecated: This field will be removed in a future release.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>envFrom</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#envfromsource-v1-core">
+[]Kubernetes core/v1.EnvFromSource
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>List of sources to populate environment variables in the Step.
+The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+will be reported as an event when the container is starting. When a key exists in multiple
+sources, the value associated with the last source will take precedence.
+Values defined by an Env with a duplicate key will take precedence.
+Cannot be updated.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>env</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#envvar-v1-core">
+[]Kubernetes core/v1.EnvVar
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>List of environment variables to set in the container.
+Cannot be updated.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>resources</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#resourcerequirements-v1-core">
+Kubernetes core/v1.ResourceRequirements
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Compute Resources required by this Step.
+Cannot be updated.
+More info: <a href="https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/">https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>volumeMounts</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#volumemount-v1-core">
+[]Kubernetes core/v1.VolumeMount
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Volumes to mount into the Step&rsquo;s filesystem.
+Cannot be updated.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>volumeDevices</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#volumedevice-v1-core">
+[]Kubernetes core/v1.VolumeDevice
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>volumeDevices is the list of block devices to be used by the Step.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>livenessProbe</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#probe-v1-core">
+Kubernetes core/v1.Probe
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Periodic probe of container liveness.
+Container will be restarted if the probe fails.
+Cannot be updated.
+More info: <a href="https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes">https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes</a></p>
+<p>Deprecated: This field will be removed in a future release.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>readinessProbe</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#probe-v1-core">
+Kubernetes core/v1.Probe
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Periodic probe of container service readiness.
+Container will be removed from service endpoints if the probe fails.
+Cannot be updated.
+More info: <a href="https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes">https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes</a></p>
+<p>Deprecated: This field will be removed in a future release.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>startupProbe</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#probe-v1-core">
+Kubernetes core/v1.Probe
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DeprecatedStartupProbe indicates that the Pod has successfully initialized.
+If specified, no other probes are executed until this completes successfully.
+If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+This can be used to provide different probe parameters at the beginning of a Pod&rsquo;s lifecycle,
+when it might take a long time to load data or warm a cache, than during steady-state operation.
+This cannot be updated.
+More info: <a href="https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes">https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes</a></p>
+<p>Deprecated: This field will be removed in a future release.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>lifecycle</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#lifecycle-v1-core">
+Kubernetes core/v1.Lifecycle
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Actions that the management system should take in response to container lifecycle events.
+Cannot be updated.</p>
+<p>Deprecated: This field will be removed in a future release.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>terminationMessagePath</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Deprecated: This field will be removed in a future release and cannot be meaningfully used.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>terminationMessagePolicy</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#terminationmessagepolicy-v1-core">
+Kubernetes core/v1.TerminationMessagePolicy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Deprecated: This field will be removed in a future release and cannot be meaningfully used.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>imagePullPolicy</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#pullpolicy-v1-core">
+Kubernetes core/v1.PullPolicy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Image pull policy.
+One of Always, Never, IfNotPresent.
+Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+Cannot be updated.
+More info: <a href="https://kubernetes.io/docs/concepts/containers/images#updating-images">https://kubernetes.io/docs/concepts/containers/images#updating-images</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>securityContext</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#securitycontext-v1-core">
+Kubernetes core/v1.SecurityContext
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>SecurityContext defines the security options the Step should be run with.
+If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+More info: <a href="https://kubernetes.io/docs/tasks/configure-pod-container/security-context/">https://kubernetes.io/docs/tasks/configure-pod-container/security-context/</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>stdin</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Whether this Step should allocate a buffer for stdin in the container runtime. If this
+is not set, reads from stdin in the Step will always result in EOF.
+Default is false.</p>
+<p>Deprecated: This field will be removed in a future release.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>stdinOnce</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Whether the container runtime should close the stdin channel after it has been opened by
+a single attach. When stdin is true the stdin stream will remain open across multiple attach
+sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+at which time stdin is closed and remains closed until the container is restarted. If this
+flag is false, a container processes that reads from stdin will never receive an EOF.
+Default is false</p>
+<p>Deprecated: This field will be removed in a future release.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>tty</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Whether this Step should allocate a DeprecatedTTY for itself, also requires &lsquo;stdin&rsquo; to be true.
+Default is false.</p>
+<p>Deprecated: This field will be removed in a future release.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.StepWhenExpressions">StepWhenExpressions
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.Step">Step</a>)
+</p>
+<div>
+</div>
+<h3 id="tekton.dev/v1beta1.TaskBreakpoints">TaskBreakpoints
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskRunDebug">TaskRunDebug</a>)
+</p>
+<div>
+<p>TaskBreakpoints defines the breakpoint config for a particular Task</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>onFailure</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>if enabled, pause TaskRun on failure of a step
+failed step will not exit</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>beforeSteps</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.TaskKind">TaskKind
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskRef">TaskRef</a>)
+</p>
+<div>
+<p>TaskKind defines the type of Task used by the pipeline.</p>
+</div>
+<h3 id="tekton.dev/v1beta1.TaskModifier">TaskModifier
+</h3>
+<div>
+<p>TaskModifier is an interface to be implemented by different PipelineResources</p>
+<p>Deprecated: Unused, preserved only for backwards compatibility</p>
+</div>
+<h3 id="tekton.dev/v1beta1.TaskObject">TaskObject
+</h3>
+<div>
+<p>TaskObject is implemented by Task</p>
+</div>
+<h3 id="tekton.dev/v1beta1.TaskRef">TaskRef
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1alpha1.RunSpec">RunSpec</a>, <a href="#tekton.dev/v1beta1.CustomRunSpec">CustomRunSpec</a>, <a href="#tekton.dev/v1beta1.PipelineTask">PipelineTask</a>, <a href="#tekton.dev/v1beta1.TaskRunSpec">TaskRunSpec</a>)
+</p>
+<div>
+<p>TaskRef can be used to refer to a specific instance of a task.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name of the referent; More info: <a href="http://kubernetes.io/docs/user-guide/identifiers#names">http://kubernetes.io/docs/user-guide/identifiers#names</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.TaskKind">
+TaskKind
+</a>
+</em>
+</td>
+<td>
+<p>TaskKind indicates the Kind of the Task:
+1. Namespaced Task when Kind is set to &ldquo;Task&rdquo;. If Kind is &ldquo;&rdquo;, it defaults to &ldquo;Task&rdquo;.
+2. Custom Task when Kind is non-empty and APIVersion is non-empty</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>apiVersion</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>API version of the referent
+Note: A Task with non-empty APIVersion and Kind is considered a Custom Task</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>bundle</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Bundle url reference to a Tekton Bundle.</p>
+<p>Deprecated: Please use ResolverRef with the bundles resolver instead.
+The field is staying there for go client backward compatibility, but is not used/allowed anymore.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ResolverRef</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.ResolverRef">
+ResolverRef
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ResolverRef allows referencing a Task in a remote location
+like a git repo. This field is only supported when the alpha
+feature gate is enabled.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.TaskResource">TaskResource
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskResources">TaskResources</a>)
+</p>
+<div>
+<p>TaskResource defines an input or output Resource declared as a requirement
 by a Task. The Name field will be used to refer to these Resources within
 the Task definition, and when provided as an Input, the Name will be the
 path to the volume mounted containing this Resource as an input (e.g.
-an input Resource named `workspace` will be mounted at `/workspace`).
-
-Deprecated: Unused, preserved only for backwards compatibility
-
-
-
-_Appears in:_
-- [TaskResources](#taskresources)
-
-
-
-#### TaskResourceBinding
-
-
-
-TaskResourceBinding points to the PipelineResource that
-will be used for the Task input or output called Name.
-
-Deprecated: Unused, preserved only for backwards compatibility
-
-
-
-_Appears in:_
-- [TaskRunInputs](#taskruninputs)
-- [TaskRunOutputs](#taskrunoutputs)
-- [TaskRunResources](#taskrunresources)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `name` _string_ | Name is the name of the PipelineResource in the Pipeline's declaration |  |  |
-| `resourceRef` _[PipelineResourceRef](#pipelineresourceref)_ | ResourceRef is a reference to the instance of the actual PipelineResource<br />that should be used |  | Optional: \{\} <br /> |
-| `resourceSpec` _[PipelineResourceSpec](#pipelineresourcespec)_ | ResourceSpec is specification of a resource that should be created and<br />consumed by the task |  | Optional: \{\} <br /> |
-| `paths` _string array_ | Paths will probably be removed in #1284, and then PipelineResourceBinding can be used instead.<br />The optional Path field corresponds to a path on disk at which the Resource can be found<br />(used when providing the resource via mounted volume, overriding the default logic to fetch the Resource). |  | Optional: \{\} <br /> |
-
-
-#### TaskResources
-
-
-
-TaskResources allows a Pipeline to declare how its DeclaredPipelineResources
-should be provided to a Task as its inputs and outputs.
-
-Deprecated: Unused, preserved only for backwards compatibility
-
-
-
-_Appears in:_
-- [EmbeddedTask](#embeddedtask)
-- [TaskSpec](#taskspec)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `inputs` _[TaskResource](#taskresource) array_ | Inputs holds the mapping from the PipelineResources declared in<br />DeclaredPipelineResources to the input PipelineResources required by the Task. |  |  |
-| `outputs` _[TaskResource](#taskresource) array_ | Outputs holds the mapping from the PipelineResources declared in<br />DeclaredPipelineResources to the input PipelineResources required by the Task. |  |  |
-
-
-#### TaskResult
-
-
-
-TaskResult used to describe the results of a task
-
-
-
-_Appears in:_
-- [EmbeddedTask](#embeddedtask)
-- [TaskSpec](#taskspec)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `name` _string_ | Name the given name |  |  |
-| `type` _[ResultsType](#resultstype)_ | Type is the user-specified type of the result. The possible type<br />is currently "string" and will support "array" in following work. |  | Optional: \{\} <br /> |
-| `properties` _object (keys:string, values:[PropertySpec](#propertyspec))_ | Properties is the JSON Schema properties to support key-value pairs results. |  | Optional: \{\} <br /> |
-| `description` _string_ | Description is a human-readable description of the result |  | Optional: \{\} <br /> |
-| `value` _[ResultValue](#resultvalue)_ | Value the expression used to retrieve the value of the result from an underlying Step. |  | Schemaless: \{\} <br />Optional: \{\} <br /> |
-
-
-#### TaskRun
-
-
-
-TaskRun represents a single execution of a Task. TaskRuns are how the steps
-specified in a Task are executed; they specify the parameters and resources
-used to run the steps in a Task.
-
-Deprecated: Please use v1.TaskRun instead.
-
-
-
-
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `tekton.dev/v1beta1` | | |
-| `kind` _string_ | `TaskRun` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  | Optional: \{\} <br /> |
-| `spec` _[TaskRunSpec](#taskrunspec)_ |  |  | Optional: \{\} <br /> |
-| `status` _[TaskRunStatus](#taskrunstatus)_ |  |  | Optional: \{\} <br /> |
-
-
-
-
-#### TaskRunDebug
-
-
-
-TaskRunDebug defines the breakpoint config for a particular TaskRun
-
-
-
-_Appears in:_
-- [TaskRunSpec](#taskrunspec)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `breakpoints` _[TaskBreakpoints](#taskbreakpoints)_ |  |  | Optional: \{\} <br /> |
-
-
-
-
-
-
-
-
-#### TaskRunResources
-
-
-
-TaskRunResources allows a TaskRun to declare inputs and outputs TaskResourceBinding
-
-Deprecated: Unused, preserved only for backwards compatibility
-
-
-
-_Appears in:_
-- [TaskRunSpec](#taskrunspec)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `inputs` _[TaskResourceBinding](#taskresourcebinding) array_ | Inputs holds the inputs resources this task was invoked with |  |  |
-| `outputs` _[TaskResourceBinding](#taskresourcebinding) array_ | Outputs holds the inputs resources this task was invoked with |  |  |
-
-
-#### TaskRunResult
-
-
-
-TaskRunResult used to describe the results of a task
-
-
-
-_Appears in:_
-- [TaskRunStatus](#taskrunstatus)
-- [TaskRunStatusFields](#taskrunstatusfields)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `name` _string_ | Name the given name |  |  |
-| `type` _[ResultsType](#resultstype)_ | Type is the user-specified type of the result. The possible type<br />is currently "string" and will support "array" in following work. |  | Optional: \{\} <br /> |
-| `value` _[ResultValue](#resultvalue)_ | Value the given value of the result |  | Schemaless: \{\} <br /> |
-
-
-#### TaskRunSidecarOverride
-
-
-
-TaskRunSidecarOverride is used to override the values of a Sidecar in the corresponding Task.
-
-
-
-_Appears in:_
-- [PipelineTaskRunSpec](#pipelinetaskrunspec)
-- [TaskRunSpec](#taskrunspec)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `name` _string_ | The name of the Sidecar to override. |  |  |
-| `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcerequirements-v1-core)_ | The resource requirements to apply to the Sidecar. |  |  |
-
-
-#### TaskRunSpec
-
-
-
-TaskRunSpec defines the desired state of TaskRun
-
-
-
-_Appears in:_
-- [TaskRun](#taskrun)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `debug` _[TaskRunDebug](#taskrundebug)_ |  |  | Optional: \{\} <br /> |
-| `params` _[Params](#params)_ |  |  | Optional: \{\} <br /> |
-| `resources` _[TaskRunResources](#taskrunresources)_ | Deprecated: Unused, preserved only for backwards compatibility |  | Optional: \{\} <br /> |
-| `serviceAccountName` _string_ |  |  | Optional: \{\} <br /> |
-| `taskRef` _[TaskRef](#taskref)_ | no more than one of the TaskRef and TaskSpec may be specified. |  | Optional: \{\} <br /> |
-| `taskSpec` _[TaskSpec](#taskspec)_ | Specifying TaskSpec can be disabled by setting<br />`disable-inline-spec` feature flag.<br />See Task.spec (API version: tekton.dev/v1beta1) |  | Schemaless: \{\} <br />Optional: \{\} <br /> |
-| `status` _[TaskRunSpecStatus](#taskrunspecstatus)_ | Used for cancelling a TaskRun (and maybe more later on) |  | Optional: \{\} <br /> |
-| `statusMessage` _[TaskRunSpecStatusMessage](#taskrunspecstatusmessage)_ | Status message for cancellation. |  | Optional: \{\} <br /> |
-| `retries` _integer_ | Retries represents how many times this TaskRun should be retried in the event of Task failure. |  | Optional: \{\} <br /> |
-| `timeout` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ | Time after which one retry attempt times out. Defaults to 1 hour.<br />Refer Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration |  | Optional: \{\} <br /> |
-| `podTemplate` _[PodTemplate](#podtemplate)_ | PodTemplate holds pod specific configuration |  |  |
-| `workspaces` _[WorkspaceBinding](#workspacebinding) array_ | Workspaces is a list of WorkspaceBindings from volumes to workspaces. |  | Optional: \{\} <br /> |
-| `stepOverrides` _[TaskRunStepOverride](#taskrunstepoverride) array_ | Overrides to apply to Steps in this TaskRun.<br />If a field is specified in both a Step and a StepOverride,<br />the value from the StepOverride will be used.<br />This field is only supported when the alpha feature gate is enabled. |  | Optional: \{\} <br /> |
-| `sidecarOverrides` _[TaskRunSidecarOverride](#taskrunsidecaroverride) array_ | Overrides to apply to Sidecars in this TaskRun.<br />If a field is specified in both a Sidecar and a SidecarOverride,<br />the value from the SidecarOverride will be used.<br />This field is only supported when the alpha feature gate is enabled. |  | Optional: \{\} <br /> |
-| `computeResources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcerequirements-v1-core)_ | Compute resources to use for this TaskRun |  |  |
-| `managedBy` _string_ | ManagedBy indicates which controller is responsible for reconciling<br />this resource. If unset or set to "tekton.dev/pipeline", the default<br />Tekton controller will manage this resource.<br />This field is immutable. |  | Optional: \{\} <br /> |
-
-
-#### TaskRunSpecStatus
-
-_Underlying type:_ _string_
-
-TaskRunSpecStatus defines the TaskRun spec status the user can provide
-
-
-
-_Appears in:_
-- [TaskRunSpec](#taskrunspec)
-
-
-
-#### TaskRunSpecStatusMessage
-
-_Underlying type:_ _string_
-
-TaskRunSpecStatusMessage defines human readable status messages for the TaskRun.
-
-
-
-_Appears in:_
-- [TaskRunSpec](#taskrunspec)
-
-| Field | Description |
-| --- | --- |
-| `TaskRun cancelled as the PipelineRun it belongs to has been cancelled.` | TaskRunCancelledByPipelineMsg indicates that the PipelineRun of which this<br />TaskRun was a part of has been cancelled.<br /> |
-| `TaskRun cancelled as the PipelineRun it belongs to has timed out.` | TaskRunCancelledByPipelineTimeoutMsg indicates that the TaskRun was cancelled because the PipelineRun running it timed out.<br /> |
-
-
-#### TaskRunStatus
-
-
-
-TaskRunStatus defines the observed state of TaskRun
-
-
-
-_Appears in:_
-- [PipelineRunTaskRunStatus](#pipelineruntaskrunstatus)
-- [RetriesStatus](#retriesstatus)
-- [TaskRun](#taskrun)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `observedGeneration` _integer_ | ObservedGeneration is the 'Generation' of the Service that<br />was last processed by the controller. |  | Optional: \{\} <br /> |
-| `conditions` _[Conditions](#conditions)_ | Conditions the latest available observations of a resource's current state. |  | Optional: \{\} <br /> |
-| `annotations` _object (keys:string, values:string)_ | Annotations is additional Status fields for the Resource to save some<br />additional State as well as convey more information to the user. This is<br />roughly akin to Annotations on any k8s resource, just the reconciler conveying<br />richer information outwards. |  |  |
-| `podName` _string_ | PodName is the name of the pod responsible for executing this task's steps. |  |  |
-| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | StartTime is the time the build is actually started. |  |  |
-| `completionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | CompletionTime is the time the build completed. |  |  |
-| `steps` _[StepState](#stepstate) array_ | Steps describes the state of each build step container. |  | Optional: \{\} <br /> |
-| `cloudEvents` _[CloudEventDelivery](#cloudeventdelivery) array_ | CloudEvents describe the state of each cloud event requested via a<br />CloudEventResource.<br />Deprecated: No content written to it. To be Removed (since v0.44.0).<br />Use kubectl describe (CloudEventSent/CloudEventFailed k8s Events) or the<br />tekton_events_sent_total Prometheus metric for delivery visibility instead. |  | Optional: \{\} <br /> |
-| `retriesStatus` _[RetriesStatus](#retriesstatus)_ | RetriesStatus contains the history of TaskRunStatus in case of a retry in order to keep record of failures.<br />All TaskRunStatus stored in RetriesStatus will have no date within the RetriesStatus as is redundant.<br />See TaskRun.status (API version: tekton.dev/v1beta1) |  | Schemaless: \{\} <br />Optional: \{\} <br /> |
-| `resourcesResult` _[PipelineResourceResult](#pipelineresourceresult) array_ | Results from Resources built during the TaskRun.<br />This is tomb-stoned along with the removal of pipelineResources<br />Deprecated: this field is not populated and is preserved only for backwards compatibility |  | Optional: \{\} <br /> |
-| `taskResults` _[TaskRunResult](#taskrunresult) array_ | TaskRunResults are the list of results written out by the task's containers |  | Optional: \{\} <br /> |
-| `sidecars` _[SidecarState](#sidecarstate) array_ | The list has one entry per sidecar in the manifest. Each entry is<br />represents the imageid of the corresponding sidecar. |  |  |
-| `taskSpec` _[TaskSpec](#taskspec)_ | TaskSpec contains the Spec from the dereferenced Task definition used to instantiate this TaskRun.<br />See Task.spec (API version tekton.dev/v1beta1) |  | Schemaless: \{\} <br /> |
-| `provenance` _[Provenance](#provenance)_ | Provenance contains some key authenticated metadata about how a software artifact was built (what sources, what inputs/outputs, etc.). |  | Optional: \{\} <br /> |
-| `spanContext` _object (keys:string, values:string)_ | SpanContext contains tracing span context fields |  |  |
-
-
-#### TaskRunStatusFields
-
-
-
-TaskRunStatusFields holds the fields of TaskRun's status.  This is defined
+an input Resource named <code>workspace</code> will be mounted at <code>/workspace</code>).</p>
+<p>Deprecated: Unused, preserved only for backwards compatibility</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>ResourceDeclaration</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.ResourceDeclaration">
+ResourceDeclaration
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>ResourceDeclaration</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.TaskResourceBinding">TaskResourceBinding
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskRunInputs">TaskRunInputs</a>, <a href="#tekton.dev/v1beta1.TaskRunOutputs">TaskRunOutputs</a>, <a href="#tekton.dev/v1beta1.TaskRunResources">TaskRunResources</a>)
+</p>
+<div>
+<p>TaskResourceBinding points to the PipelineResource that
+will be used for the Task input or output called Name.</p>
+<p>Deprecated: Unused, preserved only for backwards compatibility</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>PipelineResourceBinding</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.PipelineResourceBinding">
+PipelineResourceBinding
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>PipelineResourceBinding</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>paths</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Paths will probably be removed in #1284, and then PipelineResourceBinding can be used instead.
+The optional Path field corresponds to a path on disk at which the Resource can be found
+(used when providing the resource via mounted volume, overriding the default logic to fetch the Resource).</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.TaskResources">TaskResources
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskSpec">TaskSpec</a>)
+</p>
+<div>
+<p>TaskResources allows a Pipeline to declare how its DeclaredPipelineResources
+should be provided to a Task as its inputs and outputs.</p>
+<p>Deprecated: Unused, preserved only for backwards compatibility</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>inputs</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.TaskResource">
+[]TaskResource
+</a>
+</em>
+</td>
+<td>
+<p>Inputs holds the mapping from the PipelineResources declared in
+DeclaredPipelineResources to the input PipelineResources required by the Task.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>outputs</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.TaskResource">
+[]TaskResource
+</a>
+</em>
+</td>
+<td>
+<p>Outputs holds the mapping from the PipelineResources declared in
+DeclaredPipelineResources to the input PipelineResources required by the Task.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.TaskResult">TaskResult
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskSpec">TaskSpec</a>)
+</p>
+<div>
+<p>TaskResult used to describe the results of a task</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name the given name</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>type</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.ResultsType">
+ResultsType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Type is the user-specified type of the result. The possible type
+is currently &ldquo;string&rdquo; and will support &ldquo;array&rdquo; in following work.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>properties</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.PropertySpec">
+map[string]github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PropertySpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Properties is the JSON Schema properties to support key-value pairs results.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>description</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Description is a human-readable description of the result</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>value</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.ResultValue">
+ResultValue
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Value the expression used to retrieve the value of the result from an underlying Step.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.TaskRunConditionType">TaskRunConditionType
+(<code>string</code> alias)</h3>
+<div>
+<p>TaskRunConditionType is an enum used to store TaskRun custom
+conditions such as one used in spire results verification</p>
+</div>
+<h3 id="tekton.dev/v1beta1.TaskRunDebug">TaskRunDebug
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskRunSpec">TaskRunSpec</a>)
+</p>
+<div>
+<p>TaskRunDebug defines the breakpoint config for a particular TaskRun</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>breakpoints</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.TaskBreakpoints">
+TaskBreakpoints
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.TaskRunInputs">TaskRunInputs
+</h3>
+<div>
+<p>TaskRunInputs holds the input values that this task was invoked with.</p>
+<p>Deprecated: Unused, preserved only for backwards compatibility</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>resources</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.TaskResourceBinding">
+[]TaskResourceBinding
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>params</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.Param">
+[]Param
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.TaskRunOutputs">TaskRunOutputs
+</h3>
+<div>
+<p>TaskRunOutputs holds the output values that this task was invoked with.</p>
+<p>Deprecated: Unused, preserved only for backwards compatibility</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>resources</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.TaskResourceBinding">
+[]TaskResourceBinding
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.TaskRunReason">TaskRunReason
+(<code>string</code> alias)</h3>
+<div>
+<p>TaskRunReason is an enum used to store all TaskRun reason for
+the Succeeded condition that are controlled by the TaskRun itself. Failure
+reasons that emerge from underlying resources are not included here</p>
+</div>
+<h3 id="tekton.dev/v1beta1.TaskRunResources">TaskRunResources
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskRunSpec">TaskRunSpec</a>)
+</p>
+<div>
+<p>TaskRunResources allows a TaskRun to declare inputs and outputs TaskResourceBinding</p>
+<p>Deprecated: Unused, preserved only for backwards compatibility</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>inputs</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.TaskResourceBinding">
+[]TaskResourceBinding
+</a>
+</em>
+</td>
+<td>
+<p>Inputs holds the inputs resources this task was invoked with</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>outputs</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.TaskResourceBinding">
+[]TaskResourceBinding
+</a>
+</em>
+</td>
+<td>
+<p>Outputs holds the inputs resources this task was invoked with</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.TaskRunResult">TaskRunResult
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskRunStatusFields">TaskRunStatusFields</a>)
+</p>
+<div>
+<p>TaskRunResult used to describe the results of a task</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name the given name</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>type</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.ResultsType">
+ResultsType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Type is the user-specified type of the result. The possible type
+is currently &ldquo;string&rdquo; and will support &ldquo;array&rdquo; in following work.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>value</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.ResultValue">
+ResultValue
+</a>
+</em>
+</td>
+<td>
+<p>Value the given value of the result</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.TaskRunSidecarOverride">TaskRunSidecarOverride
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineTaskRunSpec">PipelineTaskRunSpec</a>, <a href="#tekton.dev/v1beta1.TaskRunSpec">TaskRunSpec</a>)
+</p>
+<div>
+<p>TaskRunSidecarOverride is used to override the values of a Sidecar in the corresponding Task.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>The name of the Sidecar to override.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>resources</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#resourcerequirements-v1-core">
+Kubernetes core/v1.ResourceRequirements
+</a>
+</em>
+</td>
+<td>
+<p>The resource requirements to apply to the Sidecar.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.TaskRunSpec">TaskRunSpec
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskRun">TaskRun</a>)
+</p>
+<div>
+<p>TaskRunSpec defines the desired state of TaskRun</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>debug</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.TaskRunDebug">
+TaskRunDebug
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>params</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.Params">
+Params
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>resources</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.TaskRunResources">
+TaskRunResources
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Deprecated: Unused, preserved only for backwards compatibility</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceAccountName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>taskRef</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.TaskRef">
+TaskRef
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>no more than one of the TaskRef and TaskSpec may be specified.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>taskSpec</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.TaskSpec">
+TaskSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Specifying TaskSpec can be disabled by setting
+<code>disable-inline-spec</code> feature flag.
+See Task.spec (API version: tekton.dev/v1beta1)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.TaskRunSpecStatus">
+TaskRunSpecStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Used for cancelling a TaskRun (and maybe more later on)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>statusMessage</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.TaskRunSpecStatusMessage">
+TaskRunSpecStatusMessage
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Status message for cancellation.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>retries</code><br/>
+<em>
+int
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Retries represents how many times this TaskRun should be retried in the event of Task failure.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>timeout</code><br/>
+<em>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+Kubernetes meta/v1.Duration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Time after which one retry attempt times out. Defaults to 1 hour.
+Refer Go&rsquo;s ParseDuration documentation for expected format: <a href="https://golang.org/pkg/time/#ParseDuration">https://golang.org/pkg/time/#ParseDuration</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>podTemplate</code><br/>
+<em>
+<a href="#tekton.dev/unversioned.PodTemplate">
+PodTemplate
+</a>
+</em>
+</td>
+<td>
+<p>PodTemplate holds pod specific configuration</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>workspaces</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.WorkspaceBinding">
+[]WorkspaceBinding
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Workspaces is a list of WorkspaceBindings from volumes to workspaces.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>stepOverrides</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.TaskRunStepOverride">
+[]TaskRunStepOverride
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Overrides to apply to Steps in this TaskRun.
+If a field is specified in both a Step and a StepOverride,
+the value from the StepOverride will be used.
+This field is only supported when the alpha feature gate is enabled.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sidecarOverrides</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.TaskRunSidecarOverride">
+[]TaskRunSidecarOverride
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Overrides to apply to Sidecars in this TaskRun.
+If a field is specified in both a Sidecar and a SidecarOverride,
+the value from the SidecarOverride will be used.
+This field is only supported when the alpha feature gate is enabled.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>computeResources</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#resourcerequirements-v1-core">
+Kubernetes core/v1.ResourceRequirements
+</a>
+</em>
+</td>
+<td>
+<p>Compute resources to use for this TaskRun</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>managedBy</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ManagedBy indicates which controller is responsible for reconciling
+this resource. If unset or set to &ldquo;tekton.dev/pipeline&rdquo;, the default
+Tekton controller will manage this resource.
+This field is immutable.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.TaskRunSpecStatus">TaskRunSpecStatus
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskRunSpec">TaskRunSpec</a>)
+</p>
+<div>
+<p>TaskRunSpecStatus defines the TaskRun spec status the user can provide</p>
+</div>
+<h3 id="tekton.dev/v1beta1.TaskRunSpecStatusMessage">TaskRunSpecStatusMessage
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskRunSpec">TaskRunSpec</a>)
+</p>
+<div>
+<p>TaskRunSpecStatusMessage defines human readable status messages for the TaskRun.</p>
+</div>
+<h3 id="tekton.dev/v1beta1.TaskRunStatus">TaskRunStatus
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskRun">TaskRun</a>, <a href="#tekton.dev/v1beta1.PipelineRunTaskRunStatus">PipelineRunTaskRunStatus</a>)
+</p>
+<div>
+<p>TaskRunStatus defines the observed state of TaskRun</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>Status</code><br/>
+<em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Status">
+knative.dev/pkg/apis/duck/v1.Status
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>Status</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>TaskRunStatusFields</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.TaskRunStatusFields">
+TaskRunStatusFields
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>TaskRunStatusFields</code> are embedded into this type.)
+</p>
+<p>TaskRunStatusFields inlines the status fields.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.TaskRunStatusFields">TaskRunStatusFields
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskRunStatus">TaskRunStatus</a>)
+</p>
+<div>
+<p>TaskRunStatusFields holds the fields of TaskRun&rsquo;s status.  This is defined
 separately and inlined so that other types can readily consume these fields
-via duck typing.
-
-
-
-_Appears in:_
-- [TaskRunStatus](#taskrunstatus)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `podName` _string_ | PodName is the name of the pod responsible for executing this task's steps. |  |  |
-| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | StartTime is the time the build is actually started. |  |  |
-| `completionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | CompletionTime is the time the build completed. |  |  |
-| `steps` _[StepState](#stepstate) array_ | Steps describes the state of each build step container. |  | Optional: \{\} <br /> |
-| `cloudEvents` _[CloudEventDelivery](#cloudeventdelivery) array_ | CloudEvents describe the state of each cloud event requested via a<br />CloudEventResource.<br />Deprecated: No content written to it. To be Removed (since v0.44.0).<br />Use kubectl describe (CloudEventSent/CloudEventFailed k8s Events) or the<br />tekton_events_sent_total Prometheus metric for delivery visibility instead. |  | Optional: \{\} <br /> |
-| `retriesStatus` _[RetriesStatus](#retriesstatus)_ | RetriesStatus contains the history of TaskRunStatus in case of a retry in order to keep record of failures.<br />All TaskRunStatus stored in RetriesStatus will have no date within the RetriesStatus as is redundant.<br />See TaskRun.status (API version: tekton.dev/v1beta1) |  | Schemaless: \{\} <br />Optional: \{\} <br /> |
-| `resourcesResult` _[PipelineResourceResult](#pipelineresourceresult) array_ | Results from Resources built during the TaskRun.<br />This is tomb-stoned along with the removal of pipelineResources<br />Deprecated: this field is not populated and is preserved only for backwards compatibility |  | Optional: \{\} <br /> |
-| `taskResults` _[TaskRunResult](#taskrunresult) array_ | TaskRunResults are the list of results written out by the task's containers |  | Optional: \{\} <br /> |
-| `sidecars` _[SidecarState](#sidecarstate) array_ | The list has one entry per sidecar in the manifest. Each entry is<br />represents the imageid of the corresponding sidecar. |  |  |
-| `taskSpec` _[TaskSpec](#taskspec)_ | TaskSpec contains the Spec from the dereferenced Task definition used to instantiate this TaskRun.<br />See Task.spec (API version tekton.dev/v1beta1) |  | Schemaless: \{\} <br /> |
-| `provenance` _[Provenance](#provenance)_ | Provenance contains some key authenticated metadata about how a software artifact was built (what sources, what inputs/outputs, etc.). |  | Optional: \{\} <br /> |
-| `spanContext` _object (keys:string, values:string)_ | SpanContext contains tracing span context fields |  |  |
-
-
-
-
-#### TaskRunStepOverride
-
-
-
-TaskRunStepOverride is used to override the values of a Step in the corresponding Task.
-
-
-
-_Appears in:_
-- [PipelineTaskRunSpec](#pipelinetaskrunspec)
-- [TaskRunSpec](#taskrunspec)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `name` _string_ | The name of the Step to override. |  |  |
-| `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcerequirements-v1-core)_ | The resource requirements to apply to the Step. |  |  |
-
-
-
-
-#### TaskSpec
-
-
-
-TaskSpec defines the desired state of Task.
-
-
-
-_Appears in:_
-- [EmbeddedTask](#embeddedtask)
-- [Task](#task)
-- [TaskRunSpec](#taskrunspec)
-- [TaskRunStatus](#taskrunstatus)
-- [TaskRunStatusFields](#taskrunstatusfields)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `resources` _[TaskResources](#taskresources)_ | Resources is a list input and output resource to run the task<br />Resources are represented in TaskRuns as bindings to instances of<br />PipelineResources.<br />Deprecated: Unused, preserved only for backwards compatibility |  | Optional: \{\} <br /> |
-| `params` _[ParamSpecs](#paramspecs)_ | Params is a list of input parameters required to run the task. Params<br />must be supplied as inputs in TaskRuns unless they declare a default<br />value. |  | Optional: \{\} <br /> |
-| `displayName` _string_ | DisplayName is a user-facing name of the task that may be<br />used to populate a UI. |  | Optional: \{\} <br /> |
-| `description` _string_ | Description is a user-facing description of the task that may be<br />used to populate a UI. |  | Optional: \{\} <br /> |
-| `steps` _[Step](#step) array_ | Steps are the steps of the build; each step is run sequentially with the<br />source mounted into /workspace. |  |  |
-| `volumes` _[Volumes](#volumes)_ | Volumes is a collection of volumes that are available to mount into the<br />steps of the build.<br />See Pod.spec.volumes (API version: v1) |  | Schemaless: \{\} <br /> |
-| `stepTemplate` _[StepTemplate](#steptemplate)_ | StepTemplate can be used as the basis for all step containers within the<br />Task, so that the steps inherit settings on the base container. |  |  |
-| `sidecars` _[Sidecar](#sidecar) array_ | Sidecars are run alongside the Task's step containers. They begin before<br />the steps start and end after the steps complete. |  |  |
-| `workspaces` _[WorkspaceDeclaration](#workspacedeclaration) array_ | Workspaces are the volumes that this Task requires. |  |  |
-| `results` _[TaskResult](#taskresult) array_ | Results are values that this Task can output |  |  |
-
-
-#### TimeoutFields
-
-
-
-TimeoutFields allows granular specification of pipeline, task, and finally timeouts
-
-
-
-_Appears in:_
-- [PipelineRunSpec](#pipelinerunspec)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `pipeline` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ | Pipeline sets the maximum allowed duration for execution of the entire pipeline. The sum of individual timeouts for tasks and finally must not exceed this value. |  |  |
-| `tasks` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ | Tasks sets the maximum allowed duration of this pipeline's tasks |  |  |
-| `finally` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ | Finally sets the maximum allowed duration of this pipeline's finally |  |  |
-
-
-#### Volumes
-
-_Underlying type:_ _[Volume](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#volume-v1-core)_
-
-
-
-
-
-_Appears in:_
-- [EmbeddedTask](#embeddedtask)
-- [TaskSpec](#taskspec)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `name` _string_ | name of the volume.<br />Must be a DNS_LABEL and unique within the pod.<br />More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names |  |  |
-| `hostPath` _[HostPathVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#hostpathvolumesource-v1-core)_ | hostPath represents a pre-existing file or directory on the host<br />machine that is directly exposed to the container. This is generally<br />used for system agents or other privileged things that are allowed<br />to see the host machine. Most containers will NOT need this.<br />More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath |  | Optional: \{\} <br /> |
-| `emptyDir` _[EmptyDirVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#emptydirvolumesource-v1-core)_ | emptyDir represents a temporary directory that shares a pod's lifetime.<br />More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir |  | Optional: \{\} <br /> |
-| `gcePersistentDisk` _[GCEPersistentDiskVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#gcepersistentdiskvolumesource-v1-core)_ | gcePersistentDisk represents a GCE Disk resource that is attached to a<br />kubelet's host machine and then exposed to the pod.<br />Deprecated: GCEPersistentDisk is deprecated. All operations for the in-tree<br />gcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.<br />More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk |  | Optional: \{\} <br /> |
-| `awsElasticBlockStore` _[AWSElasticBlockStoreVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#awselasticblockstorevolumesource-v1-core)_ | awsElasticBlockStore represents an AWS Disk resource that is attached to a<br />kubelet's host machine and then exposed to the pod.<br />Deprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree<br />awsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.<br />More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore |  | Optional: \{\} <br /> |
-| `gitRepo` _[GitRepoVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#gitrepovolumesource-v1-core)_ | gitRepo represents a git repository at a particular revision.<br />Deprecated: GitRepo is deprecated. To provision a container with a git repo, mount an<br />EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir<br />into the Pod's container. |  | Optional: \{\} <br /> |
-| `secret` _[SecretVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#secretvolumesource-v1-core)_ | secret represents a secret that should populate this volume.<br />More info: https://kubernetes.io/docs/concepts/storage/volumes#secret |  | Optional: \{\} <br /> |
-| `nfs` _[NFSVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#nfsvolumesource-v1-core)_ | nfs represents an NFS mount on the host that shares a pod's lifetime<br />More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs |  | Optional: \{\} <br /> |
-| `iscsi` _[ISCSIVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#iscsivolumesource-v1-core)_ | iscsi represents an ISCSI Disk resource that is attached to a<br />kubelet's host machine and then exposed to the pod.<br />More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi |  | Optional: \{\} <br /> |
-| `glusterfs` _[GlusterfsVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#glusterfsvolumesource-v1-core)_ | glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.<br />Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported. |  | Optional: \{\} <br /> |
-| `persistentVolumeClaim` _[PersistentVolumeClaimVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#persistentvolumeclaimvolumesource-v1-core)_ | persistentVolumeClaimVolumeSource represents a reference to a<br />PersistentVolumeClaim in the same namespace.<br />More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims |  | Optional: \{\} <br /> |
-| `rbd` _[RBDVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#rbdvolumesource-v1-core)_ | rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.<br />Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported. |  | Optional: \{\} <br /> |
-| `flexVolume` _[FlexVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#flexvolumesource-v1-core)_ | flexVolume represents a generic volume resource that is<br />provisioned/attached using an exec based plugin.<br />Deprecated: FlexVolume is deprecated. Consider using a CSIDriver instead. |  | Optional: \{\} <br /> |
-| `cinder` _[CinderVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#cindervolumesource-v1-core)_ | cinder represents a cinder volume attached and mounted on kubelets host machine.<br />Deprecated: Cinder is deprecated. All operations for the in-tree cinder type<br />are redirected to the cinder.csi.openstack.org CSI driver.<br />More info: https://examples.k8s.io/mysql-cinder-pd/README.md |  | Optional: \{\} <br /> |
-| `cephfs` _[CephFSVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#cephfsvolumesource-v1-core)_ | cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.<br />Deprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported. |  | Optional: \{\} <br /> |
-| `flocker` _[FlockerVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#flockervolumesource-v1-core)_ | flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.<br />Deprecated: Flocker is deprecated and the in-tree flocker type is no longer supported. |  | Optional: \{\} <br /> |
-| `downwardAPI` _[DownwardAPIVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#downwardapivolumesource-v1-core)_ | downwardAPI represents downward API about the pod that should populate this volume |  | Optional: \{\} <br /> |
-| `fc` _[FCVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#fcvolumesource-v1-core)_ | fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod. |  | Optional: \{\} <br /> |
-| `azureFile` _[AzureFileVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#azurefilevolumesource-v1-core)_ | azureFile represents an Azure File Service mount on the host and bind mount to the pod.<br />Deprecated: AzureFile is deprecated. All operations for the in-tree azureFile type<br />are redirected to the file.csi.azure.com CSI driver. |  | Optional: \{\} <br /> |
-| `configMap` _[ConfigMapVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#configmapvolumesource-v1-core)_ | configMap represents a configMap that should populate this volume |  | Optional: \{\} <br /> |
-| `vsphereVolume` _[VsphereVirtualDiskVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#vspherevirtualdiskvolumesource-v1-core)_ | vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.<br />Deprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type<br />are redirected to the csi.vsphere.vmware.com CSI driver. |  | Optional: \{\} <br /> |
-| `quobyte` _[QuobyteVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#quobytevolumesource-v1-core)_ | quobyte represents a Quobyte mount on the host that shares a pod's lifetime.<br />Deprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported. |  | Optional: \{\} <br /> |
-| `azureDisk` _[AzureDiskVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#azurediskvolumesource-v1-core)_ | azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.<br />Deprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type<br />are redirected to the disk.csi.azure.com CSI driver. |  | Optional: \{\} <br /> |
-| `photonPersistentDisk` _[PhotonPersistentDiskVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#photonpersistentdiskvolumesource-v1-core)_ | photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.<br />Deprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported. |  |  |
-| `projected` _[ProjectedVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#projectedvolumesource-v1-core)_ | projected items for all in one resources secrets, configmaps, and downward API |  |  |
-| `portworxVolume` _[PortworxVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#portworxvolumesource-v1-core)_ | portworxVolume represents a portworx volume attached and mounted on kubelets host machine.<br />Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type<br />are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate<br />is on. |  | Optional: \{\} <br /> |
-| `scaleIO` _[ScaleIOVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#scaleiovolumesource-v1-core)_ | scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.<br />Deprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported. |  | Optional: \{\} <br /> |
-| `storageos` _[StorageOSVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#storageosvolumesource-v1-core)_ | storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.<br />Deprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported. |  | Optional: \{\} <br /> |
-| `csi` _[CSIVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#csivolumesource-v1-core)_ | csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers. |  | Optional: \{\} <br /> |
-| `ephemeral` _[EphemeralVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#ephemeralvolumesource-v1-core)_ | ephemeral represents a volume that is handled by a cluster storage driver.<br />The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,<br />and deleted when the pod is removed.<br />Use this if:<br />a) the volume is only needed while the pod runs,<br />b) features of normal volumes like restoring from snapshot or capacity<br />   tracking are needed,<br />c) the storage driver is specified through a storage class, and<br />d) the storage driver supports dynamic volume provisioning through<br />   a PersistentVolumeClaim (see EphemeralVolumeSource for more<br />   information on the connection between this volume type<br />   and PersistentVolumeClaim).<br />Use PersistentVolumeClaim or one of the vendor-specific<br />APIs for volumes that persist for longer than the lifecycle<br />of an individual pod.<br />Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to<br />be used that way - see the documentation of the driver for<br />more information.<br />A pod can use both types of ephemeral volumes and<br />persistent volumes at the same time. |  | Optional: \{\} <br /> |
-| `image` _[ImageVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#imagevolumesource-v1-core)_ | image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.<br />The volume is resolved at pod startup depending on which PullPolicy value is provided:<br />- Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.<br />- Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.<br />- IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.<br />The volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.<br />A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.<br />The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.<br />The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.<br />The volume will be mounted read-only (ro) and non-executable files (noexec).<br />Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.<br />The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type. |  | Optional: \{\} <br /> |
-
-
-#### WhenExpression
-
-
-
-WhenExpression allows a PipelineTask to declare expressions to be evaluated before the Task is run
-to determine whether the Task should be executed or skipped
-
-
-
-_Appears in:_
-- [ChildStatusReference](#childstatusreference)
-- [PipelineRunRunStatus](#pipelinerunrunstatus)
-- [PipelineRunTaskRunStatus](#pipelineruntaskrunstatus)
-- [SkippedTask](#skippedtask)
-- [WhenExpressions](#whenexpressions)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `input` _string_ | Input is the string for guard checking which can be a static input or an output from a parent Task |  |  |
-| `operator` _[Operator](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#operator-selection-pkg)_ | Operator that represents an Input's relationship to the values |  |  |
-| `values` _string array_ | Values is an array of strings, which is compared against the input, for guard checking<br />It must be non-empty |  |  |
-| `cel` _string_ | CEL is a string of Common Language Expression, which can be used to conditionally execute<br />the task based on the result of the expression evaluation<br />More info about CEL syntax: https://github.com/google/cel-spec/blob/master/doc/langdef.md |  | Optional: \{\} <br /> |
-
-
-#### WhenExpressions
-
-_Underlying type:_ _[WhenExpression](#whenexpression)_
-
-WhenExpressions are used to specify whether a Task should be executed or skipped
-All of them need to evaluate to True for a guarded Task to be executed.
-
-
-
-_Appears in:_
-- [PipelineTask](#pipelinetask)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `input` _string_ | Input is the string for guard checking which can be a static input or an output from a parent Task |  |  |
-| `operator` _[Operator](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#operator-selection-pkg)_ | Operator that represents an Input's relationship to the values |  |  |
-| `values` _string array_ | Values is an array of strings, which is compared against the input, for guard checking<br />It must be non-empty |  |  |
-| `cel` _string_ | CEL is a string of Common Language Expression, which can be used to conditionally execute<br />the task based on the result of the expression evaluation<br />More info about CEL syntax: https://github.com/google/cel-spec/blob/master/doc/langdef.md |  | Optional: \{\} <br /> |
-
-
-#### WorkspaceBinding
-
-
-
-WorkspaceBinding maps a Task's declared workspace to a Volume.
-
-
-
-_Appears in:_
-- [CustomRunSpec](#customrunspec)
-- [PipelineRunSpec](#pipelinerunspec)
-- [RunSpec](#runspec)
-- [TaskRunSpec](#taskrunspec)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `name` _string_ | Name is the name of the workspace populated by the volume. |  |  |
-| `subPath` _string_ | SubPath is optionally a directory on the volume which should be used<br />for this binding (i.e. the volume will be mounted at this sub directory). |  | Optional: \{\} <br /> |
-| `volumeClaimTemplate` _[PersistentVolumeClaim](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#persistentvolumeclaim-v1-core)_ | VolumeClaimTemplate is a template for a claim that will be created in the same namespace.<br />The PipelineRun controller is responsible for creating a unique claim for each instance of PipelineRun.<br />See PersistentVolumeClaim (API version: v1) |  | Schemaless: \{\} <br />Optional: \{\} <br /> |
-| `persistentVolumeClaim` _[PersistentVolumeClaimVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#persistentvolumeclaimvolumesource-v1-core)_ | PersistentVolumeClaimVolumeSource represents a reference to a<br />PersistentVolumeClaim in the same namespace. Either this OR EmptyDir can be used. |  | Optional: \{\} <br /> |
-| `emptyDir` _[EmptyDirVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#emptydirvolumesource-v1-core)_ | EmptyDir represents a temporary directory that shares a Task's lifetime.<br />More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir<br />Either this OR PersistentVolumeClaim can be used. |  | Optional: \{\} <br /> |
-| `configMap` _[ConfigMapVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#configmapvolumesource-v1-core)_ | ConfigMap represents a configMap that should populate this workspace. |  | Optional: \{\} <br /> |
-| `secret` _[SecretVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#secretvolumesource-v1-core)_ | Secret represents a secret that should populate this workspace. |  | Optional: \{\} <br /> |
-| `projected` _[ProjectedVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#projectedvolumesource-v1-core)_ | Projected represents a projected volume that should populate this workspace. |  | Optional: \{\} <br /> |
-| `csi` _[CSIVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#csivolumesource-v1-core)_ | CSI (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers. |  | Optional: \{\} <br /> |
-
-
-#### WorkspaceDeclaration
-
-
-
-WorkspaceDeclaration is a declaration of a volume that a Task requires.
-
-
-
-_Appears in:_
-- [EmbeddedTask](#embeddedtask)
-- [TaskSpec](#taskspec)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `name` _string_ | Name is the name by which you can bind the volume at runtime. |  |  |
-| `description` _string_ | Description is an optional human readable description of this volume. |  | Optional: \{\} <br /> |
-| `mountPath` _string_ | MountPath overrides the directory that the volume will be made available at. |  | Optional: \{\} <br /> |
-| `readOnly` _boolean_ | ReadOnly dictates whether a mounted volume is writable. By default this<br />field is false and so mounted volumes are writable. |  |  |
-| `optional` _boolean_ | Optional marks a Workspace as not being required in TaskRuns. By default<br />this field is false and so declared workspaces are required. |  |  |
-
-
-
-
-#### WorkspacePipelineTaskBinding
-
-
-
-WorkspacePipelineTaskBinding describes how a workspace passed into the pipeline should be
-mapped to a task's declared workspace.
-
-
-
-_Appears in:_
-- [PipelineTask](#pipelinetask)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `name` _string_ | Name is the name of the workspace as declared by the task |  |  |
-| `workspace` _string_ | Workspace is the name of the workspace declared by the pipeline |  | Optional: \{\} <br /> |
-| `subPath` _string_ | SubPath is optionally a directory on the volume which should be used<br />for this binding (i.e. the volume will be mounted at this sub directory). |  | Optional: \{\} <br /> |
-
-
-#### WorkspaceUsage
-
-
-
-WorkspaceUsage is used by a Step or Sidecar to declare that it wants isolated access
-to a Workspace defined in a Task.
-
-
-
-_Appears in:_
-- [Sidecar](#sidecar)
-- [Step](#step)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `name` _string_ | Name is the name of the workspace this Step or Sidecar wants access to. |  |  |
-| `mountPath` _string_ | MountPath is the path that the workspace should be mounted to inside the Step or Sidecar,<br />overriding any MountPath specified in the Task's WorkspaceDeclaration. |  |  |
-
-
+via duck typing.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>podName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>PodName is the name of the pod responsible for executing this task&rsquo;s steps.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>startTime</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+<p>StartTime is the time the build is actually started.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>completionTime</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+<p>CompletionTime is the time the build completed.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>steps</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.StepState">
+[]StepState
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Steps describes the state of each build step container.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>cloudEvents</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.CloudEventDelivery">
+[]CloudEventDelivery
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CloudEvents describe the state of each cloud event requested via a
+CloudEventResource.</p>
+<p>Deprecated: No content written to it. To be Removed (since v0.44.0).
+Use kubectl describe (CloudEventSent/CloudEventFailed k8s Events) or the
+tekton_events_sent_total Prometheus metric for delivery visibility instead.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>retriesStatus</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.RetriesStatus">
+RetriesStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>RetriesStatus contains the history of TaskRunStatus in case of a retry in order to keep record of failures.
+All TaskRunStatus stored in RetriesStatus will have no date within the RetriesStatus as is redundant.
+See TaskRun.status (API version: tekton.dev/v1beta1)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>resourcesResult</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.PipelineResourceResult">
+[]PipelineResourceResult
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Results from Resources built during the TaskRun.
+This is tomb-stoned along with the removal of pipelineResources
+Deprecated: this field is not populated and is preserved only for backwards compatibility</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>taskResults</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.TaskRunResult">
+[]TaskRunResult
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TaskRunResults are the list of results written out by the task&rsquo;s containers</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sidecars</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.SidecarState">
+[]SidecarState
+</a>
+</em>
+</td>
+<td>
+<p>The list has one entry per sidecar in the manifest. Each entry is
+represents the imageid of the corresponding sidecar.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>taskSpec</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.TaskSpec">
+TaskSpec
+</a>
+</em>
+</td>
+<td>
+<p>TaskSpec contains the Spec from the dereferenced Task definition used to instantiate this TaskRun.
+See Task.spec (API version tekton.dev/v1beta1)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>provenance</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.Provenance">
+Provenance
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Provenance contains some key authenticated metadata about how a software artifact was built (what sources, what inputs/outputs, etc.).</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>spanContext</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<p>SpanContext contains tracing span context fields</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.TaskRunStepArtifact">TaskRunStepArtifact
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.StepState">StepState</a>)
+</p>
+<div>
+<p>TaskRunStepArtifact represents an artifact produced or used by a step within a task run.
+It directly uses the Artifact type for its structure.</p>
+</div>
+<h3 id="tekton.dev/v1beta1.TaskRunStepOverride">TaskRunStepOverride
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineTaskRunSpec">PipelineTaskRunSpec</a>, <a href="#tekton.dev/v1beta1.TaskRunSpec">TaskRunSpec</a>)
+</p>
+<div>
+<p>TaskRunStepOverride is used to override the values of a Step in the corresponding Task.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>The name of the Step to override.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>resources</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#resourcerequirements-v1-core">
+Kubernetes core/v1.ResourceRequirements
+</a>
+</em>
+</td>
+<td>
+<p>The resource requirements to apply to the Step.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.TaskRunStepResult">TaskRunStepResult
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.StepState">StepState</a>)
+</p>
+<div>
+<p>TaskRunStepResult is a type alias of TaskRunResult</p>
+</div>
+<h3 id="tekton.dev/v1beta1.TaskSpec">TaskSpec
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.Task">Task</a>, <a href="#tekton.dev/v1beta1.EmbeddedTask">EmbeddedTask</a>, <a href="#tekton.dev/v1beta1.TaskRunSpec">TaskRunSpec</a>, <a href="#tekton.dev/v1beta1.TaskRunStatusFields">TaskRunStatusFields</a>)
+</p>
+<div>
+<p>TaskSpec defines the desired state of Task.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>resources</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.TaskResources">
+TaskResources
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Resources is a list input and output resource to run the task
+Resources are represented in TaskRuns as bindings to instances of
+PipelineResources.</p>
+<p>Deprecated: Unused, preserved only for backwards compatibility</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>params</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.ParamSpecs">
+ParamSpecs
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Params is a list of input parameters required to run the task. Params
+must be supplied as inputs in TaskRuns unless they declare a default
+value.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>displayName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DisplayName is a user-facing name of the task that may be
+used to populate a UI.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>description</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Description is a user-facing description of the task that may be
+used to populate a UI.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>steps</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.Step">
+[]Step
+</a>
+</em>
+</td>
+<td>
+<p>Steps are the steps of the build; each step is run sequentially with the
+source mounted into /workspace.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>volumes</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.Volumes">
+Volumes
+</a>
+</em>
+</td>
+<td>
+<p>Volumes is a collection of volumes that are available to mount into the
+steps of the build.
+See Pod.spec.volumes (API version: v1)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>stepTemplate</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.StepTemplate">
+StepTemplate
+</a>
+</em>
+</td>
+<td>
+<p>StepTemplate can be used as the basis for all step containers within the
+Task, so that the steps inherit settings on the base container.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sidecars</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.Sidecar">
+[]Sidecar
+</a>
+</em>
+</td>
+<td>
+<p>Sidecars are run alongside the Task&rsquo;s step containers. They begin before
+the steps start and end after the steps complete.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>workspaces</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.WorkspaceDeclaration">
+[]WorkspaceDeclaration
+</a>
+</em>
+</td>
+<td>
+<p>Workspaces are the volumes that this Task requires.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>results</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.TaskResult">
+[]TaskResult
+</a>
+</em>
+</td>
+<td>
+<p>Results are values that this Task can output</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.TimeoutFields">TimeoutFields
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineRunSpec">PipelineRunSpec</a>)
+</p>
+<div>
+<p>TimeoutFields allows granular specification of pipeline, task, and finally timeouts</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>pipeline</code><br/>
+<em>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+Kubernetes meta/v1.Duration
+</a>
+</em>
+</td>
+<td>
+<p>Pipeline sets the maximum allowed duration for execution of the entire pipeline. The sum of individual timeouts for tasks and finally must not exceed this value.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>tasks</code><br/>
+<em>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+Kubernetes meta/v1.Duration
+</a>
+</em>
+</td>
+<td>
+<p>Tasks sets the maximum allowed duration of this pipeline&rsquo;s tasks</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>finally</code><br/>
+<em>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+Kubernetes meta/v1.Duration
+</a>
+</em>
+</td>
+<td>
+<p>Finally sets the maximum allowed duration of this pipeline&rsquo;s finally</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.Volumes">Volumes
+(<code>[]k8s.io/api/core/v1.Volume</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskSpec">TaskSpec</a>)
+</p>
+<div>
+</div>
+<h3 id="tekton.dev/v1beta1.WhenExpression">WhenExpression
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.ChildStatusReference">ChildStatusReference</a>, <a href="#tekton.dev/v1beta1.PipelineRunRunStatus">PipelineRunRunStatus</a>, <a href="#tekton.dev/v1beta1.PipelineRunTaskRunStatus">PipelineRunTaskRunStatus</a>, <a href="#tekton.dev/v1beta1.SkippedTask">SkippedTask</a>)
+</p>
+<div>
+<p>WhenExpression allows a PipelineTask to declare expressions to be evaluated before the Task is run
+to determine whether the Task should be executed or skipped</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>input</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Input is the string for guard checking which can be a static input or an output from a parent Task</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>operator</code><br/>
+<em>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/selection#Operator">
+k8s.io/apimachinery/pkg/selection.Operator
+</a>
+</em>
+</td>
+<td>
+<p>Operator that represents an Input&rsquo;s relationship to the values</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>values</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<p>Values is an array of strings, which is compared against the input, for guard checking
+It must be non-empty</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>cel</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CEL is a string of Common Language Expression, which can be used to conditionally execute
+the task based on the result of the expression evaluation
+More info about CEL syntax: <a href="https://github.com/google/cel-spec/blob/master/doc/langdef.md">https://github.com/google/cel-spec/blob/master/doc/langdef.md</a></p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.WhenExpressions">WhenExpressions
+(<code>[]github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.WhenExpression</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineTask">PipelineTask</a>)
+</p>
+<div>
+<p>WhenExpressions are used to specify whether a Task should be executed or skipped
+All of them need to evaluate to True for a guarded Task to be executed.</p>
+</div>
+<h3 id="tekton.dev/v1beta1.WorkspaceBinding">WorkspaceBinding
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1alpha1.RunSpec">RunSpec</a>, <a href="#tekton.dev/v1beta1.CustomRunSpec">CustomRunSpec</a>, <a href="#tekton.dev/v1beta1.PipelineRunSpec">PipelineRunSpec</a>, <a href="#tekton.dev/v1beta1.TaskRunSpec">TaskRunSpec</a>)
+</p>
+<div>
+<p>WorkspaceBinding maps a Task&rsquo;s declared workspace to a Volume.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is the name of the workspace populated by the volume.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>subPath</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>SubPath is optionally a directory on the volume which should be used
+for this binding (i.e. the volume will be mounted at this sub directory).</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>volumeClaimTemplate</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#persistentvolumeclaim-v1-core">
+Kubernetes core/v1.PersistentVolumeClaim
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>VolumeClaimTemplate is a template for a claim that will be created in the same namespace.
+The PipelineRun controller is responsible for creating a unique claim for each instance of PipelineRun.
+See PersistentVolumeClaim (API version: v1)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>persistentVolumeClaim</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#persistentvolumeclaimvolumesource-v1-core">
+Kubernetes core/v1.PersistentVolumeClaimVolumeSource
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>PersistentVolumeClaimVolumeSource represents a reference to a
+PersistentVolumeClaim in the same namespace. Either this OR EmptyDir can be used.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>emptyDir</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#emptydirvolumesource-v1-core">
+Kubernetes core/v1.EmptyDirVolumeSource
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>EmptyDir represents a temporary directory that shares a Task&rsquo;s lifetime.
+More info: <a href="https://kubernetes.io/docs/concepts/storage/volumes#emptydir">https://kubernetes.io/docs/concepts/storage/volumes#emptydir</a>
+Either this OR PersistentVolumeClaim can be used.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>configMap</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#configmapvolumesource-v1-core">
+Kubernetes core/v1.ConfigMapVolumeSource
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ConfigMap represents a configMap that should populate this workspace.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>secret</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#secretvolumesource-v1-core">
+Kubernetes core/v1.SecretVolumeSource
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Secret represents a secret that should populate this workspace.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>projected</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#projectedvolumesource-v1-core">
+Kubernetes core/v1.ProjectedVolumeSource
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Projected represents a projected volume that should populate this workspace.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>csi</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#csivolumesource-v1-core">
+Kubernetes core/v1.CSIVolumeSource
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CSI (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.WorkspaceDeclaration">WorkspaceDeclaration
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskSpec">TaskSpec</a>)
+</p>
+<div>
+<p>WorkspaceDeclaration is a declaration of a volume that a Task requires.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is the name by which you can bind the volume at runtime.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>description</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Description is an optional human readable description of this volume.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>mountPath</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>MountPath overrides the directory that the volume will be made available at.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>readOnly</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>ReadOnly dictates whether a mounted volume is writable. By default this
+field is false and so mounted volumes are writable.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>optional</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>Optional marks a Workspace as not being required in TaskRuns. By default
+this field is false and so declared workspaces are required.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.WorkspacePipelineDeclaration">WorkspacePipelineDeclaration
+</h3>
+<div>
+<p>WorkspacePipelineDeclaration creates a named slot in a Pipeline that a PipelineRun
+is expected to populate with a workspace binding.</p>
+<p>Deprecated: use PipelineWorkspaceDeclaration type instead</p>
+</div>
+<h3 id="tekton.dev/v1beta1.WorkspacePipelineTaskBinding">WorkspacePipelineTaskBinding
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineTask">PipelineTask</a>)
+</p>
+<div>
+<p>WorkspacePipelineTaskBinding describes how a workspace passed into the pipeline should be
+mapped to a task&rsquo;s declared workspace.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is the name of the workspace as declared by the task</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>workspace</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Workspace is the name of the workspace declared by the pipeline</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>subPath</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>SubPath is optionally a directory on the volume which should be used
+for this binding (i.e. the volume will be mounted at this sub directory).</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.WorkspaceUsage">WorkspaceUsage
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.Sidecar">Sidecar</a>, <a href="#tekton.dev/v1beta1.Step">Step</a>)
+</p>
+<div>
+<p>WorkspaceUsage is used by a Step or Sidecar to declare that it wants isolated access
+to a Workspace defined in a Task.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is the name of the workspace this Step or Sidecar wants access to.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>mountPath</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>MountPath is the path that the workspace should be mounted to inside the Step or Sidecar,
+overriding any MountPath specified in the Task&rsquo;s WorkspaceDeclaration.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.CustomRunResult">CustomRunResult
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.CustomRunStatusFields">CustomRunStatusFields</a>)
+</p>
+<div>
+<p>CustomRunResult used to describe the results of a task</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name the given name</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>value</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Value the given value of the result</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.CustomRunStatus">CustomRunStatus
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineRunRunStatus">PipelineRunRunStatus</a>, <a href="#tekton.dev/v1beta1.CustomRunStatusFields">CustomRunStatusFields</a>)
+</p>
+<div>
+<p>CustomRunStatus defines the observed state of CustomRun</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>Status</code><br/>
+<em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Status">
+knative.dev/pkg/apis/duck/v1.Status
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>Status</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>CustomRunStatusFields</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.CustomRunStatusFields">
+CustomRunStatusFields
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>CustomRunStatusFields</code> are embedded into this type.)
+</p>
+<p>CustomRunStatusFields inlines the status fields.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="tekton.dev/v1beta1.CustomRunStatusFields">CustomRunStatusFields
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.CustomRunStatus">CustomRunStatus</a>)
+</p>
+<div>
+<p>CustomRunStatusFields holds the fields of CustomRun&rsquo;s status.  This is defined
+separately and inlined so that other types can readily consume these fields
+via duck typing.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>startTime</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>StartTime is the time the build is actually started.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>completionTime</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CompletionTime is the time the build completed.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>results</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.CustomRunResult">
+[]CustomRunResult
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Results reports any output result values to be consumed by later
+tasks in a pipeline.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>retriesStatus</code><br/>
+<em>
+<a href="#tekton.dev/v1beta1.CustomRunStatus">
+[]CustomRunStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>RetriesStatus contains the history of CustomRunStatus, in case of a retry.
+See CustomRun.status (API version: tekton.dev/v1beta1)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>extraFields</code><br/>
+<em>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime#RawExtension">
+k8s.io/apimachinery/pkg/runtime.RawExtension
+</a>
+</em>
+</td>
+<td>
+<p>ExtraFields holds arbitrary fields provided by the custom task
+controller.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<hr/>
+<p><em>
+Generated with <code>gen-crd-api-reference-docs</code>
+.
+</em></p>

--- a/docs/pipeline-api.md
+++ b/docs/pipeline-api.md
@@ -6,17141 +6,4346 @@ weight: 404
 ---
 -->
 
-<p>Packages:</p>
-<ul>
-<li>
-<a href="#resolution.tekton.dev%2fv1alpha1">resolution.tekton.dev/v1alpha1</a>
-</li>
-<li>
-<a href="#resolution.tekton.dev%2fv1beta1">resolution.tekton.dev/v1beta1</a>
-</li>
-<li>
-<a href="#tekton.dev%2fv1">tekton.dev/v1</a>
-</li>
-<li>
-<a href="#tekton.dev%2fv1alpha1">tekton.dev/v1alpha1</a>
-</li>
-<li>
-<a href="#tekton.dev%2fv1beta1">tekton.dev/v1beta1</a>
-</li>
-</ul>
-<h2 id="resolution.tekton.dev/v1alpha1">resolution.tekton.dev/v1alpha1</h2>
-<div>
-</div>
-Resource Types:
-<ul></ul>
-<h3 id="resolution.tekton.dev/v1alpha1.ResolutionRequest">ResolutionRequest
-</h3>
-<div>
-<p>ResolutionRequest is an object for requesting the content of
-a Tekton resource like a pipeline.yaml.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>metadata</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code><br/>
-<em>
-<a href="#resolution.tekton.dev/v1alpha1.ResolutionRequestSpec">
-ResolutionRequestSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Spec holds the information for the request part of the resource request.</p>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>params</code><br/>
-<em>
-map[string]string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Parameters are the runtime attributes passed to
-the resolver to help it figure out how to resolve the
-resource being requested. For example: repo URL, commit SHA,
-path to file, the kind of authentication to leverage, etc.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code><br/>
-<em>
-<a href="#resolution.tekton.dev/v1alpha1.ResolutionRequestStatus">
-ResolutionRequestStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Status communicates the state of the request and, ultimately,
-the content of the resolved resource.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="resolution.tekton.dev/v1alpha1.ResolutionRequestSpec">ResolutionRequestSpec
-</h3>
-<p>
-(<em>Appears on:</em><a href="#resolution.tekton.dev/v1alpha1.ResolutionRequest">ResolutionRequest</a>)
-</p>
-<div>
-<p>ResolutionRequestSpec are all the fields in the spec of the
-ResolutionRequest CRD.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>params</code><br/>
-<em>
-map[string]string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Parameters are the runtime attributes passed to
-the resolver to help it figure out how to resolve the
-resource being requested. For example: repo URL, commit SHA,
-path to file, the kind of authentication to leverage, etc.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="resolution.tekton.dev/v1alpha1.ResolutionRequestStatus">ResolutionRequestStatus
-</h3>
-<p>
-(<em>Appears on:</em><a href="#resolution.tekton.dev/v1alpha1.ResolutionRequest">ResolutionRequest</a>)
-</p>
-<div>
-<p>ResolutionRequestStatus are all the fields in a ResolutionRequest&rsquo;s
-status subresource.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>Status</code><br/>
-<em>
-<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Status">
-knative.dev/pkg/apis/duck/v1.Status
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>Status</code> are embedded into this type.)
-</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ResolutionRequestStatusFields</code><br/>
-<em>
-<a href="#resolution.tekton.dev/v1alpha1.ResolutionRequestStatusFields">
-ResolutionRequestStatusFields
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>ResolutionRequestStatusFields</code> are embedded into this type.)
-</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="resolution.tekton.dev/v1alpha1.ResolutionRequestStatusFields">ResolutionRequestStatusFields
-</h3>
-<p>
-(<em>Appears on:</em><a href="#resolution.tekton.dev/v1alpha1.ResolutionRequestStatus">ResolutionRequestStatus</a>)
-</p>
-<div>
-<p>ResolutionRequestStatusFields are the ResolutionRequest-specific fields
-for the status subresource.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>data</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Data is a string representation of the resolved content
-of the requested resource in-lined into the ResolutionRequest
-object.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>refSource</code><br/>
-<em>
-<a href="#tekton.dev/v1.RefSource">
-RefSource
-</a>
-</em>
-</td>
-<td>
-<p>RefSource is the source reference of the remote data that records where the remote
-file came from including the url, digest and the entrypoint.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<hr/>
-<h2 id="resolution.tekton.dev/v1beta1">resolution.tekton.dev/v1beta1</h2>
-<div>
-</div>
-Resource Types:
-<ul></ul>
-<h3 id="resolution.tekton.dev/v1beta1.ResolutionRequest">ResolutionRequest
-</h3>
-<div>
-<p>ResolutionRequest is an object for requesting the content of
-a Tekton resource like a pipeline.yaml.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>metadata</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code><br/>
-<em>
-<a href="#resolution.tekton.dev/v1beta1.ResolutionRequestSpec">
-ResolutionRequestSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Spec holds the information for the request part of the resource request.</p>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>params</code><br/>
-<em>
-<a href="#tekton.dev/v1.Param">
-[]Param
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Parameters are the runtime attributes passed to
-the resolver to help it figure out how to resolve the
-resource being requested. For example: repo URL, commit SHA,
-path to file, the kind of authentication to leverage, etc.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>url</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>URL is the runtime url passed to the resolver
-to help it figure out how to resolver the resource being
-requested.
-This is currently at an ALPHA stability level and subject to
-alpha API compatibility policies.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code><br/>
-<em>
-<a href="#resolution.tekton.dev/v1beta1.ResolutionRequestStatus">
-ResolutionRequestStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Status communicates the state of the request and, ultimately,
-the content of the resolved resource.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="resolution.tekton.dev/v1beta1.ResolutionRequestSpec">ResolutionRequestSpec
-</h3>
-<p>
-(<em>Appears on:</em><a href="#resolution.tekton.dev/v1beta1.ResolutionRequest">ResolutionRequest</a>)
-</p>
-<div>
-<p>ResolutionRequestSpec are all the fields in the spec of the
-ResolutionRequest CRD.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>params</code><br/>
-<em>
-<a href="#tekton.dev/v1.Param">
-[]Param
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Parameters are the runtime attributes passed to
-the resolver to help it figure out how to resolve the
-resource being requested. For example: repo URL, commit SHA,
-path to file, the kind of authentication to leverage, etc.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>url</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>URL is the runtime url passed to the resolver
-to help it figure out how to resolver the resource being
-requested.
-This is currently at an ALPHA stability level and subject to
-alpha API compatibility policies.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="resolution.tekton.dev/v1beta1.ResolutionRequestStatus">ResolutionRequestStatus
-</h3>
-<p>
-(<em>Appears on:</em><a href="#resolution.tekton.dev/v1beta1.ResolutionRequest">ResolutionRequest</a>)
-</p>
-<div>
-<p>ResolutionRequestStatus are all the fields in a ResolutionRequest&rsquo;s
-status subresource.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>Status</code><br/>
-<em>
-<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Status">
-knative.dev/pkg/apis/duck/v1.Status
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>Status</code> are embedded into this type.)
-</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ResolutionRequestStatusFields</code><br/>
-<em>
-<a href="#resolution.tekton.dev/v1beta1.ResolutionRequestStatusFields">
-ResolutionRequestStatusFields
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>ResolutionRequestStatusFields</code> are embedded into this type.)
-</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="resolution.tekton.dev/v1beta1.ResolutionRequestStatusFields">ResolutionRequestStatusFields
-</h3>
-<p>
-(<em>Appears on:</em><a href="#resolution.tekton.dev/v1beta1.ResolutionRequestStatus">ResolutionRequestStatus</a>)
-</p>
-<div>
-<p>ResolutionRequestStatusFields are the ResolutionRequest-specific fields
-for the status subresource.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>data</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Data is a string representation of the resolved content
-of the requested resource in-lined into the ResolutionRequest
-object.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>source</code><br/>
-<em>
-<a href="#tekton.dev/v1.RefSource">
-RefSource
-</a>
-</em>
-</td>
-<td>
-<p>Deprecated: Use RefSource instead</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>refSource</code><br/>
-<em>
-<a href="#tekton.dev/v1.RefSource">
-RefSource
-</a>
-</em>
-</td>
-<td>
-<p>RefSource is the source reference of the remote data that records the url, digest
-and the entrypoint.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<hr/>
-<h2 id="tekton.dev/v1">tekton.dev/v1</h2>
-<div>
-<p>Package v1 contains API Schema definitions for the pipeline v1 API group</p>
-</div>
-Resource Types:
-<ul><li>
-<a href="#tekton.dev/v1.Pipeline">Pipeline</a>
-</li><li>
-<a href="#tekton.dev/v1.PipelineRun">PipelineRun</a>
-</li><li>
-<a href="#tekton.dev/v1.Task">Task</a>
-</li><li>
-<a href="#tekton.dev/v1.TaskRun">TaskRun</a>
-</li></ul>
-<h3 id="tekton.dev/v1.Pipeline">Pipeline
-</h3>
-<div>
-<p>Pipeline describes a list of Tasks to execute. It expresses how outputs
-of tasks feed into inputs of subsequent tasks.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code><br/>
-string</td>
-<td>
-<code>
-tekton.dev/v1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code><br/>
-string
-</td>
-<td><code>Pipeline</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code><br/>
-<em>
-<a href="#tekton.dev/v1.PipelineSpec">
-PipelineSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Spec holds the desired state of the Pipeline from the client</p>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>displayName</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>DisplayName is a user-facing name of the pipeline that may be
-used to populate a UI.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>description</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Description is a user-facing description of the pipeline that may be
-used to populate a UI.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>tasks</code><br/>
-<em>
-<a href="#tekton.dev/v1.PipelineTask">
-[]PipelineTask
-</a>
-</em>
-</td>
-<td>
-<p>Tasks declares the graph of Tasks that execute when this Pipeline is run.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>params</code><br/>
-<em>
-<a href="#tekton.dev/v1.ParamSpecs">
-ParamSpecs
-</a>
-</em>
-</td>
-<td>
-<p>Params declares a list of input parameters that must be supplied when
-this Pipeline is run.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>workspaces</code><br/>
-<em>
-<a href="#tekton.dev/v1.PipelineWorkspaceDeclaration">
-[]PipelineWorkspaceDeclaration
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Workspaces declares a set of named workspaces that are expected to be
-provided by a PipelineRun.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>results</code><br/>
-<em>
-<a href="#tekton.dev/v1.PipelineResult">
-[]PipelineResult
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Results are values that this pipeline can output once run</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>finally</code><br/>
-<em>
-<a href="#tekton.dev/v1.PipelineTask">
-[]PipelineTask
-</a>
-</em>
-</td>
-<td>
-<p>Finally declares the list of Tasks that execute just before leaving the Pipeline
-i.e. either after all Tasks are finished executing successfully
-or after a failure which would result in ending the Pipeline</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.PipelineRun">PipelineRun
-</h3>
-<div>
-<p>PipelineRun represents a single execution of a Pipeline. PipelineRuns are how
+# API Reference
+
+## Packages
+- [resolution.tekton.dev/v1alpha1](#resolutiontektondevv1alpha1)
+- [resolution.tekton.dev/v1beta1](#resolutiontektondevv1beta1)
+- [tekton.dev/unversioned](#tektondevunversioned)
+- [tekton.dev/v1](#tektondevv1)
+- [tekton.dev/v1alpha1](#tektondevv1alpha1)
+- [tekton.dev/v1beta1](#tektondevv1beta1)
+
+
+## resolution.tekton.dev/v1alpha1
+
+
+### Resource Types
+- [ResolutionRequest](#resolutionrequest)
+
+
+
+#### ResolutionRequest
+
+
+
+ResolutionRequest is an object for requesting the content of
+a Tekton resource like a pipeline.yaml.
+
+
+
+
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `apiVersion` _string_ | `resolution.tekton.dev/v1alpha1` | | |
+| `kind` _string_ | `ResolutionRequest` | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  | Optional: \{\} <br /> |
+| `spec` _[ResolutionRequestSpec](#resolutionrequestspec)_ | Spec holds the information for the request part of the resource request. |  | Optional: \{\} <br /> |
+| `status` _[ResolutionRequestStatus](#resolutionrequeststatus)_ | Status communicates the state of the request and, ultimately,<br />the content of the resolved resource. |  | Optional: \{\} <br /> |
+
+
+#### ResolutionRequestSpec
+
+
+
+ResolutionRequestSpec are all the fields in the spec of the
+ResolutionRequest CRD.
+
+
+
+_Appears in:_
+- [ResolutionRequest](#resolutionrequest)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `params` _object (keys:string, values:string)_ | Parameters are the runtime attributes passed to<br />the resolver to help it figure out how to resolve the<br />resource being requested. For example: repo URL, commit SHA,<br />path to file, the kind of authentication to leverage, etc. |  | Optional: \{\} <br /> |
+
+
+#### ResolutionRequestStatus
+
+
+
+ResolutionRequestStatus are all the fields in a ResolutionRequest's
+status subresource.
+
+
+
+_Appears in:_
+- [ResolutionRequest](#resolutionrequest)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `observedGeneration` _integer_ | ObservedGeneration is the 'Generation' of the Service that<br />was last processed by the controller. |  | Optional: \{\} <br /> |
+| `conditions` _[Conditions](#conditions)_ | Conditions the latest available observations of a resource's current state. |  | Optional: \{\} <br /> |
+| `annotations` _object (keys:string, values:string)_ | Annotations is additional Status fields for the Resource to save some<br />additional State as well as convey more information to the user. This is<br />roughly akin to Annotations on any k8s resource, just the reconciler conveying<br />richer information outwards. |  |  |
+| `data` _string_ | Data is a string representation of the resolved content<br />of the requested resource in-lined into the ResolutionRequest<br />object. |  |  |
+| `refSource` _[RefSource](#refsource)_ | RefSource is the source reference of the remote data that records where the remote<br />file came from including the url, digest and the entrypoint. |  | Schemaless: \{\} <br /> |
+
+
+#### ResolutionRequestStatusFields
+
+
+
+ResolutionRequestStatusFields are the ResolutionRequest-specific fields
+for the status subresource.
+
+
+
+_Appears in:_
+- [ResolutionRequestStatus](#resolutionrequeststatus)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `data` _string_ | Data is a string representation of the resolved content<br />of the requested resource in-lined into the ResolutionRequest<br />object. |  |  |
+| `refSource` _[RefSource](#refsource)_ | RefSource is the source reference of the remote data that records where the remote<br />file came from including the url, digest and the entrypoint. |  | Schemaless: \{\} <br /> |
+
+
+
+## resolution.tekton.dev/v1beta1
+
+
+### Resource Types
+- [ResolutionRequest](#resolutionrequest)
+
+
+
+#### ResolutionRequest
+
+
+
+ResolutionRequest is an object for requesting the content of
+a Tekton resource like a pipeline.yaml.
+
+
+
+
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `apiVersion` _string_ | `resolution.tekton.dev/v1beta1` | | |
+| `kind` _string_ | `ResolutionRequest` | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  | Optional: \{\} <br /> |
+| `spec` _[ResolutionRequestSpec](#resolutionrequestspec)_ | Spec holds the information for the request part of the resource request. |  | Optional: \{\} <br /> |
+| `status` _[ResolutionRequestStatus](#resolutionrequeststatus)_ | Status communicates the state of the request and, ultimately,<br />the content of the resolved resource. |  | Optional: \{\} <br /> |
+
+
+#### ResolutionRequestSpec
+
+
+
+ResolutionRequestSpec are all the fields in the spec of the
+ResolutionRequest CRD.
+
+
+
+_Appears in:_
+- [ResolutionRequest](#resolutionrequest)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `params` _[Param](#param) array_ | Parameters are the runtime attributes passed to<br />the resolver to help it figure out how to resolve the<br />resource being requested. For example: repo URL, commit SHA,<br />path to file, the kind of authentication to leverage, etc. |  | Optional: \{\} <br /> |
+| `url` _string_ | URL is the runtime url passed to the resolver<br />to help it figure out how to resolver the resource being<br />requested.<br />This is currently at an ALPHA stability level and subject to<br />alpha API compatibility policies. |  | Optional: \{\} <br /> |
+
+
+#### ResolutionRequestStatus
+
+
+
+ResolutionRequestStatus are all the fields in a ResolutionRequest's
+status subresource.
+
+
+
+_Appears in:_
+- [ResolutionRequest](#resolutionrequest)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `observedGeneration` _integer_ | ObservedGeneration is the 'Generation' of the Service that<br />was last processed by the controller. |  | Optional: \{\} <br /> |
+| `conditions` _[Conditions](#conditions)_ | Conditions the latest available observations of a resource's current state. |  | Optional: \{\} <br /> |
+| `annotations` _object (keys:string, values:string)_ | Annotations is additional Status fields for the Resource to save some<br />additional State as well as convey more information to the user. This is<br />roughly akin to Annotations on any k8s resource, just the reconciler conveying<br />richer information outwards. |  |  |
+| `data` _string_ | Data is a string representation of the resolved content<br />of the requested resource in-lined into the ResolutionRequest<br />object. |  |  |
+| `source` _[RefSource](#refsource)_ | Deprecated: Use RefSource instead |  | Schemaless: \{\} <br /> |
+| `refSource` _[RefSource](#refsource)_ | RefSource is the source reference of the remote data that records the url, digest<br />and the entrypoint. |  | Schemaless: \{\} <br /> |
+
+
+#### ResolutionRequestStatusFields
+
+
+
+ResolutionRequestStatusFields are the ResolutionRequest-specific fields
+for the status subresource.
+
+
+
+_Appears in:_
+- [ResolutionRequestStatus](#resolutionrequeststatus)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `data` _string_ | Data is a string representation of the resolved content<br />of the requested resource in-lined into the ResolutionRequest<br />object. |  |  |
+| `source` _[RefSource](#refsource)_ | Deprecated: Use RefSource instead |  | Schemaless: \{\} <br /> |
+| `refSource` _[RefSource](#refsource)_ | RefSource is the source reference of the remote data that records the url, digest<br />and the entrypoint. |  | Schemaless: \{\} <br /> |
+
+
+
+## tekton.dev/unversioned
+
+Package pod contains non-versioned pod configuration
+
+
+
+
+
+
+
+
+
+
+
+#### Volumes
+
+_Underlying type:_ _[Volume](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#volume-v1-core)_
+
+
+
+
+
+_Appears in:_
+- [Template](#template)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | name of the volume.<br />Must be a DNS_LABEL and unique within the pod.<br />More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names |  |  |
+| `hostPath` _[HostPathVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#hostpathvolumesource-v1-core)_ | hostPath represents a pre-existing file or directory on the host<br />machine that is directly exposed to the container. This is generally<br />used for system agents or other privileged things that are allowed<br />to see the host machine. Most containers will NOT need this.<br />More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath |  | Optional: \{\} <br /> |
+| `emptyDir` _[EmptyDirVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#emptydirvolumesource-v1-core)_ | emptyDir represents a temporary directory that shares a pod's lifetime.<br />More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir |  | Optional: \{\} <br /> |
+| `gcePersistentDisk` _[GCEPersistentDiskVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#gcepersistentdiskvolumesource-v1-core)_ | gcePersistentDisk represents a GCE Disk resource that is attached to a<br />kubelet's host machine and then exposed to the pod.<br />Deprecated: GCEPersistentDisk is deprecated. All operations for the in-tree<br />gcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.<br />More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk |  | Optional: \{\} <br /> |
+| `awsElasticBlockStore` _[AWSElasticBlockStoreVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#awselasticblockstorevolumesource-v1-core)_ | awsElasticBlockStore represents an AWS Disk resource that is attached to a<br />kubelet's host machine and then exposed to the pod.<br />Deprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree<br />awsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.<br />More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore |  | Optional: \{\} <br /> |
+| `gitRepo` _[GitRepoVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#gitrepovolumesource-v1-core)_ | gitRepo represents a git repository at a particular revision.<br />Deprecated: GitRepo is deprecated. To provision a container with a git repo, mount an<br />EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir<br />into the Pod's container. |  | Optional: \{\} <br /> |
+| `secret` _[SecretVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#secretvolumesource-v1-core)_ | secret represents a secret that should populate this volume.<br />More info: https://kubernetes.io/docs/concepts/storage/volumes#secret |  | Optional: \{\} <br /> |
+| `nfs` _[NFSVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#nfsvolumesource-v1-core)_ | nfs represents an NFS mount on the host that shares a pod's lifetime<br />More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs |  | Optional: \{\} <br /> |
+| `iscsi` _[ISCSIVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#iscsivolumesource-v1-core)_ | iscsi represents an ISCSI Disk resource that is attached to a<br />kubelet's host machine and then exposed to the pod.<br />More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi |  | Optional: \{\} <br /> |
+| `glusterfs` _[GlusterfsVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#glusterfsvolumesource-v1-core)_ | glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.<br />Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported. |  | Optional: \{\} <br /> |
+| `persistentVolumeClaim` _[PersistentVolumeClaimVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#persistentvolumeclaimvolumesource-v1-core)_ | persistentVolumeClaimVolumeSource represents a reference to a<br />PersistentVolumeClaim in the same namespace.<br />More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims |  | Optional: \{\} <br /> |
+| `rbd` _[RBDVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#rbdvolumesource-v1-core)_ | rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.<br />Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported. |  | Optional: \{\} <br /> |
+| `flexVolume` _[FlexVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#flexvolumesource-v1-core)_ | flexVolume represents a generic volume resource that is<br />provisioned/attached using an exec based plugin.<br />Deprecated: FlexVolume is deprecated. Consider using a CSIDriver instead. |  | Optional: \{\} <br /> |
+| `cinder` _[CinderVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#cindervolumesource-v1-core)_ | cinder represents a cinder volume attached and mounted on kubelets host machine.<br />Deprecated: Cinder is deprecated. All operations for the in-tree cinder type<br />are redirected to the cinder.csi.openstack.org CSI driver.<br />More info: https://examples.k8s.io/mysql-cinder-pd/README.md |  | Optional: \{\} <br /> |
+| `cephfs` _[CephFSVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#cephfsvolumesource-v1-core)_ | cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.<br />Deprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported. |  | Optional: \{\} <br /> |
+| `flocker` _[FlockerVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#flockervolumesource-v1-core)_ | flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.<br />Deprecated: Flocker is deprecated and the in-tree flocker type is no longer supported. |  | Optional: \{\} <br /> |
+| `downwardAPI` _[DownwardAPIVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#downwardapivolumesource-v1-core)_ | downwardAPI represents downward API about the pod that should populate this volume |  | Optional: \{\} <br /> |
+| `fc` _[FCVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#fcvolumesource-v1-core)_ | fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod. |  | Optional: \{\} <br /> |
+| `azureFile` _[AzureFileVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#azurefilevolumesource-v1-core)_ | azureFile represents an Azure File Service mount on the host and bind mount to the pod.<br />Deprecated: AzureFile is deprecated. All operations for the in-tree azureFile type<br />are redirected to the file.csi.azure.com CSI driver. |  | Optional: \{\} <br /> |
+| `configMap` _[ConfigMapVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#configmapvolumesource-v1-core)_ | configMap represents a configMap that should populate this volume |  | Optional: \{\} <br /> |
+| `vsphereVolume` _[VsphereVirtualDiskVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#vspherevirtualdiskvolumesource-v1-core)_ | vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.<br />Deprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type<br />are redirected to the csi.vsphere.vmware.com CSI driver. |  | Optional: \{\} <br /> |
+| `quobyte` _[QuobyteVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#quobytevolumesource-v1-core)_ | quobyte represents a Quobyte mount on the host that shares a pod's lifetime.<br />Deprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported. |  | Optional: \{\} <br /> |
+| `azureDisk` _[AzureDiskVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#azurediskvolumesource-v1-core)_ | azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.<br />Deprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type<br />are redirected to the disk.csi.azure.com CSI driver. |  | Optional: \{\} <br /> |
+| `photonPersistentDisk` _[PhotonPersistentDiskVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#photonpersistentdiskvolumesource-v1-core)_ | photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.<br />Deprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported. |  |  |
+| `projected` _[ProjectedVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#projectedvolumesource-v1-core)_ | projected items for all in one resources secrets, configmaps, and downward API |  |  |
+| `portworxVolume` _[PortworxVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#portworxvolumesource-v1-core)_ | portworxVolume represents a portworx volume attached and mounted on kubelets host machine.<br />Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type<br />are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate<br />is on. |  | Optional: \{\} <br /> |
+| `scaleIO` _[ScaleIOVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#scaleiovolumesource-v1-core)_ | scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.<br />Deprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported. |  | Optional: \{\} <br /> |
+| `storageos` _[StorageOSVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#storageosvolumesource-v1-core)_ | storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.<br />Deprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported. |  | Optional: \{\} <br /> |
+| `csi` _[CSIVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#csivolumesource-v1-core)_ | csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers. |  | Optional: \{\} <br /> |
+| `ephemeral` _[EphemeralVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#ephemeralvolumesource-v1-core)_ | ephemeral represents a volume that is handled by a cluster storage driver.<br />The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,<br />and deleted when the pod is removed.<br />Use this if:<br />a) the volume is only needed while the pod runs,<br />b) features of normal volumes like restoring from snapshot or capacity<br />   tracking are needed,<br />c) the storage driver is specified through a storage class, and<br />d) the storage driver supports dynamic volume provisioning through<br />   a PersistentVolumeClaim (see EphemeralVolumeSource for more<br />   information on the connection between this volume type<br />   and PersistentVolumeClaim).<br />Use PersistentVolumeClaim or one of the vendor-specific<br />APIs for volumes that persist for longer than the lifecycle<br />of an individual pod.<br />Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to<br />be used that way - see the documentation of the driver for<br />more information.<br />A pod can use both types of ephemeral volumes and<br />persistent volumes at the same time. |  | Optional: \{\} <br /> |
+| `image` _[ImageVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#imagevolumesource-v1-core)_ | image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.<br />The volume is resolved at pod startup depending on which PullPolicy value is provided:<br />- Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.<br />- Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.<br />- IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.<br />The volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.<br />A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.<br />The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.<br />The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.<br />The volume will be mounted read-only (ro) and non-executable files (noexec).<br />Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.<br />The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type. |  | Optional: \{\} <br /> |
+
+
+
+## tekton.dev/v1
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Package v1 contains API Schema definitions for the pipeline v1 API group
+
+### Resource Types
+- [Pipeline](#pipeline)
+- [PipelineRun](#pipelinerun)
+- [Task](#task)
+- [TaskRun](#taskrun)
+
+
+
+#### Algorithm
+
+_Underlying type:_ _string_
+
+Algorithm Standard cryptographic hash algorithm
+
+
+
+_Appears in:_
+- [ArtifactValue](#artifactvalue)
+
+
+
+#### Artifact
+
+
+
+Artifact represents an artifact within a system, potentially containing multiple values
+associated with it.
+
+
+
+_Appears in:_
+- [Artifacts](#artifacts)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | The artifact's identifying category name |  |  |
+| `values` _[ArtifactValue](#artifactvalue) array_ | A collection of values related to the artifact |  |  |
+| `buildOutput` _boolean_ | Indicate if the artifact is a build output or a by-product |  |  |
+
+
+#### ArtifactValue
+
+
+
+ArtifactValue represents a specific value or data element within an Artifact.
+
+
+
+_Appears in:_
+- [Artifact](#artifact)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `digest` _object (keys:[Algorithm](#algorithm), values:string)_ |  |  |  |
+| `uri` _string_ |  |  |  |
+
+
+#### Artifacts
+
+
+
+Artifacts represents the collection of input and output artifacts associated with
+a task run or a similar process. Artifacts in this context are units of data or resources
+that the process either consumes as input or produces as output.
+
+
+
+_Appears in:_
+- [TaskRunStatus](#taskrunstatus)
+- [TaskRunStatusFields](#taskrunstatusfields)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `inputs` _[Artifact](#artifact) array_ |  |  |  |
+| `outputs` _[Artifact](#artifact) array_ |  |  |  |
+
+
+#### ChildStatusReference
+
+
+
+ChildStatusReference is used to point to the statuses of individual TaskRuns and Runs within this PipelineRun.
+
+
+
+_Appears in:_
+- [PipelineRunStatus](#pipelinerunstatus)
+- [PipelineRunStatusFields](#pipelinerunstatusfields)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name is the name of the TaskRun or Run this is referencing. |  |  |
+| `displayName` _string_ | DisplayName is a user-facing name of the pipelineTask that may be<br />used to populate a UI. |  |  |
+| `pipelineTaskName` _string_ | PipelineTaskName is the name of the PipelineTask this is referencing. |  |  |
+| `whenExpressions` _[WhenExpression](#whenexpression) array_ | WhenExpressions is the list of checks guarding the execution of the PipelineTask |  | Optional: \{\} <br /> |
+
+
+#### Combination
+
+_Underlying type:_ _object_
+
+Combination is a map, mainly defined to hold a single combination from a Matrix with key as param.Name and value as param.Value
+
+
+
+_Appears in:_
+- [Combinations](#combinations)
+
+
+
+
+
+#### EmbeddedTask
+
+
+
+EmbeddedTask is used to define a Task inline within a Pipeline's PipelineTasks.
+
+
+
+_Appears in:_
+- [PipelineTask](#pipelinetask)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `spec` _[RawExtension](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#rawextension-runtime-pkg)_ | Spec is a specification of a custom task |  | Optional: \{\} <br /> |
+| `metadata` _[PipelineTaskMetadata](#pipelinetaskmetadata)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  | Optional: \{\} <br /> |
+| `params` _[ParamSpecs](#paramspecs)_ | Params is a list of input parameters required to run the task. Params<br />must be supplied as inputs in TaskRuns unless they declare a default<br />value. |  | Optional: \{\} <br /> |
+| `displayName` _string_ | DisplayName is a user-facing name of the task that may be<br />used to populate a UI. |  | Optional: \{\} <br /> |
+| `description` _string_ | Description is a user-facing description of the task that may be<br />used to populate a UI. |  | Optional: \{\} <br /> |
+| `steps` _[Step](#step) array_ | Steps are the steps of the build; each step is run sequentially with the<br />source mounted into /workspace. |  |  |
+| `volumes` _[Volumes](#volumes)_ | Volumes is a collection of volumes that are available to mount into the<br />steps of the build.<br />See Pod.spec.volumes (API version: v1) |  | Schemaless: \{\} <br /> |
+| `stepTemplate` _[StepTemplate](#steptemplate)_ | StepTemplate can be used as the basis for all step containers within the<br />Task, so that the steps inherit settings on the base container. |  |  |
+| `sidecars` _[Sidecar](#sidecar) array_ | Sidecars are run alongside the Task's step containers. They begin before<br />the steps start and end after the steps complete. |  |  |
+| `workspaces` _[WorkspaceDeclaration](#workspacedeclaration) array_ | Workspaces are the volumes that this Task requires. |  |  |
+| `results` _[TaskResult](#taskresult) array_ | Results are values that this Task can output |  |  |
+
+
+
+
+#### Matrix
+
+
+
+Matrix is used to fan out Tasks in a Pipeline
+
+
+
+_Appears in:_
+- [PipelineTask](#pipelinetask)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `params` _[Params](#params)_ | Params is a list of parameters used to fan out the pipelineTask<br />Params takes only `Parameters` of type `"array"`<br />Each array element is supplied to the `PipelineTask` by substituting `params` of type `"string"` in the underlying `Task`.<br />The names of the `params` in the `Matrix` must match the names of the `params` in the underlying `Task` that they will be substituting. |  |  |
+
+
+#### OnErrorType
+
+_Underlying type:_ _string_
+
+OnErrorType defines a list of supported exiting behavior of a container on error
+
+
+
+_Appears in:_
+- [Step](#step)
+
+| Field | Description |
+| --- | --- |
+| `stopAndFail` | StopAndFail indicates exit the taskRun if the container exits with non-zero exit code<br /> |
+| `continue` | Continue indicates continue executing the rest of the steps irrespective of the container exit code<br /> |
+
+
+#### Param
+
+
+
+Param declares an ParamValues to use for the parameter called name.
+
+
+
+_Appears in:_
+- [Params](#params)
+- [ResolutionRequestSpec](#resolutionrequestspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ |  |  |  |
+| `value` _[ParamValue](#paramvalue)_ |  |  | Schemaless: \{\} <br /> |
+
+
+#### ParamSpec
+
+
+
+ParamSpec defines arbitrary parameters needed beyond typed inputs (such as
+resources). Parameter values are provided by users as inputs on a TaskRun
+or PipelineRun.
+
+
+
+_Appears in:_
+- [ParamSpecs](#paramspecs)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name declares the name by which a parameter is referenced. |  |  |
+| `type` _[ParamType](#paramtype)_ | Type is the user-specified type of the parameter. The possible types<br />are currently "string", "array" and "object", and "string" is the default. |  | Optional: \{\} <br /> |
+| `description` _string_ | Description is a user-facing description of the parameter that may be<br />used to populate a UI. |  | Optional: \{\} <br /> |
+| `properties` _object (keys:string, values:[PropertySpec](#propertyspec))_ | Properties is the JSON Schema properties to support key-value pairs parameter. |  | Optional: \{\} <br /> |
+| `default` _[ParamValue](#paramvalue)_ | Default is the value a parameter takes if no input value is supplied. If<br />default is set, a Task may be executed without a supplied value for the<br />parameter. |  | Schemaless: \{\} <br />Optional: \{\} <br /> |
+| `enum` _string array_ | Enum declares a set of allowed param input values for tasks/pipelines that can be validated.<br />If Enum is not set, no input validation is performed for the param. |  | Optional: \{\} <br /> |
+
+
+#### ParamSpecs
+
+_Underlying type:_ _[ParamSpec](#paramspec)_
+
+ParamSpecs is a list of ParamSpec
+
+
+
+_Appears in:_
+- [EmbeddedTask](#embeddedtask)
+- [PipelineSpec](#pipelinespec)
+- [StepActionSpec](#stepactionspec)
+- [StepActionSpec](#stepactionspec)
+- [TaskSpec](#taskspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name declares the name by which a parameter is referenced. |  |  |
+| `type` _[ParamType](#paramtype)_ | Type is the user-specified type of the parameter. The possible types<br />are currently "string", "array" and "object", and "string" is the default. |  | Optional: \{\} <br /> |
+| `description` _string_ | Description is a user-facing description of the parameter that may be<br />used to populate a UI. |  | Optional: \{\} <br /> |
+| `properties` _object (keys:string, values:[PropertySpec](#propertyspec))_ | Properties is the JSON Schema properties to support key-value pairs parameter. |  | Optional: \{\} <br /> |
+| `default` _[ParamValue](#paramvalue)_ | Default is the value a parameter takes if no input value is supplied. If<br />default is set, a Task may be executed without a supplied value for the<br />parameter. |  | Schemaless: \{\} <br />Optional: \{\} <br /> |
+| `enum` _string array_ | Enum declares a set of allowed param input values for tasks/pipelines that can be validated.<br />If Enum is not set, no input validation is performed for the param. |  | Optional: \{\} <br /> |
+
+
+#### ParamType
+
+_Underlying type:_ _string_
+
+ParamType indicates the type of an input parameter;
+Used to distinguish between a single string and an array of strings.
+
+
+
+_Appears in:_
+- [ParamSpec](#paramspec)
+- [ParamValue](#paramvalue)
+- [PropertySpec](#propertyspec)
+
+| Field | Description |
+| --- | --- |
+| `string` |  |
+| `array` |  |
+| `object` |  |
+
+
+#### ParamValue
+
+
+
+ParamValue is a type that can hold a single string, string array, or string map.
+Used in JSON unmarshalling so that a single JSON field can accept
+either an individual string or an array of strings.
+
+
+
+_Appears in:_
+- [Param](#param)
+- [ParamSpec](#paramspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `Type` _[ParamType](#paramtype)_ |  |  |  |
+| `StringVal` _string_ |  |  |  |
+| `ArrayVal` _string array_ |  |  |  |
+| `ObjectVal` _object (keys:string, values:string)_ |  |  |  |
+
+
+#### Params
+
+_Underlying type:_ _[Param](#param)_
+
+Params is a list of Param
+
+
+
+_Appears in:_
+- [IncludeParams](#includeparams)
+- [Matrix](#matrix)
+- [PipelineRunSpec](#pipelinerunspec)
+- [PipelineTask](#pipelinetask)
+- [ResolverRef](#resolverref)
+- [Step](#step)
+- [TaskRunInputs](#taskruninputs)
+- [TaskRunSpec](#taskrunspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ |  |  |  |
+| `value` _[ParamValue](#paramvalue)_ |  |  | Schemaless: \{\} <br /> |
+
+
+#### Pipeline
+
+
+
+Pipeline describes a list of Tasks to execute. It expresses how outputs
+of tasks feed into inputs of subsequent tasks.
+
+
+
+
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `apiVersion` _string_ | `tekton.dev/v1` | | |
+| `kind` _string_ | `Pipeline` | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  | Optional: \{\} <br /> |
+| `spec` _[PipelineSpec](#pipelinespec)_ | Spec holds the desired state of the Pipeline from the client |  | Optional: \{\} <br /> |
+
+
+#### PipelineRef
+
+
+
+PipelineRef can be used to refer to a specific instance of a Pipeline.
+
+
+
+_Appears in:_
+- [PipelineRunSpec](#pipelinerunspec)
+- [PipelineTask](#pipelinetask)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names |  |  |
+| `apiVersion` _string_ | API version of the referent |  | Optional: \{\} <br /> |
+| `ResolverRef` _[ResolverRef](#resolverref)_ | ResolverRef allows referencing a Pipeline in a remote location<br />like a git repo. This field is only supported when the alpha<br />feature gate is enabled. |  | Optional: \{\} <br /> |
+
+
+#### PipelineResult
+
+_Underlying type:_ _[struct{Name string "json:\"name\""; Type ResultsType "json:\"type,omitempty\""; Description string "json:\"description\""; Value ResultValue "json:\"value\""}](#struct{name-string-"json:\"name\"";-type-resultstype-"json:\"type,omitempty\"";-description-string-"json:\"description\"";-value-resultvalue-"json:\"value\""})_
+
+PipelineResult used to describe the results of a pipeline
+
+
+
+_Appears in:_
+- [PipelineSpec](#pipelinespec)
+
+
+
+#### PipelineRun
+
+
+
+PipelineRun represents a single execution of a Pipeline. PipelineRuns are how
 the graph of Tasks declared in a Pipeline are executed; they specify inputs
 to Pipelines such as parameter values and capture operational aspects of the
 Tasks execution such as service account and tolerations. Creating a
-PipelineRun creates TaskRuns for Tasks in the referenced Pipeline.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code><br/>
-string</td>
-<td>
-<code>
-tekton.dev/v1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code><br/>
-string
-</td>
-<td><code>PipelineRun</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code><br/>
-<em>
-<a href="#tekton.dev/v1.PipelineRunSpec">
-PipelineRunSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>pipelineRef</code><br/>
-<em>
-<a href="#tekton.dev/v1.PipelineRef">
-PipelineRef
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-<tr>
-<td>
-<code>pipelineSpec</code><br/>
-<em>
-<a href="#tekton.dev/v1.PipelineSpec">
-PipelineSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Specifying PipelineSpec can be disabled by setting
-<code>disable-inline-spec</code> feature flag.
-See Pipeline.spec (API version: tekton.dev/v1)</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>params</code><br/>
-<em>
-<a href="#tekton.dev/v1.Params">
-Params
-</a>
-</em>
-</td>
-<td>
-<p>Params is a list of parameter names and values.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code><br/>
-<em>
-<a href="#tekton.dev/v1.PipelineRunSpecStatus">
-PipelineRunSpecStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Used for cancelling a pipelinerun (and maybe more later on)</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>timeouts</code><br/>
-<em>
-<a href="#tekton.dev/v1.TimeoutFields">
-TimeoutFields
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Time after which the Pipeline times out.
-Currently three keys are accepted in the map
-pipeline, tasks and finally
-with Timeouts.pipeline &gt;= Timeouts.tasks + Timeouts.finally</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>taskRunTemplate</code><br/>
-<em>
-<a href="#tekton.dev/v1.PipelineTaskRunTemplate">
-PipelineTaskRunTemplate
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>TaskRunTemplate represent template of taskrun</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>workspaces</code><br/>
-<em>
-<a href="#tekton.dev/v1.WorkspaceBinding">
-[]WorkspaceBinding
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Workspaces holds a set of workspace bindings that must match names
-with those declared in the pipeline.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>taskRunSpecs</code><br/>
-<em>
-<a href="#tekton.dev/v1.PipelineTaskRunSpec">
-[]PipelineTaskRunSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>TaskRunSpecs holds a set of runtime specs</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>managedBy</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ManagedBy indicates which controller is responsible for reconciling
-this resource. If unset or set to &ldquo;tekton.dev/pipeline&rdquo;, the default
-Tekton controller will manage this resource.
-This field is immutable.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code><br/>
-<em>
-<a href="#tekton.dev/v1.PipelineRunStatus">
-PipelineRunStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.Task">Task
-</h3>
-<div>
-<p>Task represents a collection of sequential steps that are run as part of a
-Pipeline using a set of inputs and producing a set of outputs. Tasks execute
-when TaskRuns are created that provide the input parameters and resources and
-output resources the Task requires.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code><br/>
-string</td>
-<td>
-<code>
-tekton.dev/v1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code><br/>
-string
-</td>
-<td><code>Task</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code><br/>
-<em>
-<a href="#tekton.dev/v1.TaskSpec">
-TaskSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Spec holds the desired state of the Task from the client</p>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>params</code><br/>
-<em>
-<a href="#tekton.dev/v1.ParamSpecs">
-ParamSpecs
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Params is a list of input parameters required to run the task. Params
-must be supplied as inputs in TaskRuns unless they declare a default
-value.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>displayName</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>DisplayName is a user-facing name of the task that may be
-used to populate a UI.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>description</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Description is a user-facing description of the task that may be
-used to populate a UI.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>steps</code><br/>
-<em>
-<a href="#tekton.dev/v1.Step">
-[]Step
-</a>
-</em>
-</td>
-<td>
-<p>Steps are the steps of the build; each step is run sequentially with the
-source mounted into /workspace.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>volumes</code><br/>
-<em>
-<a href="#tekton.dev/v1.Volumes">
-Volumes
-</a>
-</em>
-</td>
-<td>
-<p>Volumes is a collection of volumes that are available to mount into the
-steps of the build.
-See Pod.spec.volumes (API version: v1)</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>stepTemplate</code><br/>
-<em>
-<a href="#tekton.dev/v1.StepTemplate">
-StepTemplate
-</a>
-</em>
-</td>
-<td>
-<p>StepTemplate can be used as the basis for all step containers within the
-Task, so that the steps inherit settings on the base container.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>sidecars</code><br/>
-<em>
-<a href="#tekton.dev/v1.Sidecar">
-[]Sidecar
-</a>
-</em>
-</td>
-<td>
-<p>Sidecars are run alongside the Task&rsquo;s step containers. They begin before
-the steps start and end after the steps complete.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>workspaces</code><br/>
-<em>
-<a href="#tekton.dev/v1.WorkspaceDeclaration">
-[]WorkspaceDeclaration
-</a>
-</em>
-</td>
-<td>
-<p>Workspaces are the volumes that this Task requires.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>results</code><br/>
-<em>
-<a href="#tekton.dev/v1.TaskResult">
-[]TaskResult
-</a>
-</em>
-</td>
-<td>
-<p>Results are values that this Task can output</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.TaskRun">TaskRun
-</h3>
-<div>
-<p>TaskRun represents a single execution of a Task. TaskRuns are how the steps
-specified in a Task are executed; they specify the parameters and resources
-used to run the steps in a Task.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code><br/>
-string</td>
-<td>
-<code>
-tekton.dev/v1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code><br/>
-string
-</td>
-<td><code>TaskRun</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code><br/>
-<em>
-<a href="#tekton.dev/v1.TaskRunSpec">
-TaskRunSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>debug</code><br/>
-<em>
-<a href="#tekton.dev/v1.TaskRunDebug">
-TaskRunDebug
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-<tr>
-<td>
-<code>params</code><br/>
-<em>
-<a href="#tekton.dev/v1.Params">
-Params
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-<tr>
-<td>
-<code>serviceAccountName</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-<tr>
-<td>
-<code>taskRef</code><br/>
-<em>
-<a href="#tekton.dev/v1.TaskRef">
-TaskRef
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>no more than one of the TaskRef and TaskSpec may be specified.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>taskSpec</code><br/>
-<em>
-<a href="#tekton.dev/v1.TaskSpec">
-TaskSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Specifying TaskSpec can be disabled by setting
-<code>disable-inline-spec</code> feature flag.
-See Task.spec (API version: tekton.dev/v1)</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code><br/>
-<em>
-<a href="#tekton.dev/v1.TaskRunSpecStatus">
-TaskRunSpecStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Used for cancelling a TaskRun (and maybe more later on)</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>statusMessage</code><br/>
-<em>
-<a href="#tekton.dev/v1.TaskRunSpecStatusMessage">
-TaskRunSpecStatusMessage
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Status message for cancellation.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>retries</code><br/>
-<em>
-int
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Retries represents how many times this TaskRun should be retried in the event of task failure.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>timeout</code><br/>
-<em>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
-Kubernetes meta/v1.Duration
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Time after which one retry attempt times out. Defaults to 1 hour.
-Refer Go&rsquo;s ParseDuration documentation for expected format: <a href="https://golang.org/pkg/time/#ParseDuration">https://golang.org/pkg/time/#ParseDuration</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>podTemplate</code><br/>
-<em>
-<a href="#tekton.dev/unversioned.PodTemplate">
-PodTemplate
-</a>
-</em>
-</td>
-<td>
-<p>PodTemplate holds pod specific configuration</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>workspaces</code><br/>
-<em>
-<a href="#tekton.dev/v1.WorkspaceBinding">
-[]WorkspaceBinding
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Workspaces is a list of WorkspaceBindings from volumes to workspaces.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>stepSpecs</code><br/>
-<em>
-<a href="#tekton.dev/v1.TaskRunStepSpec">
-[]TaskRunStepSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Specs to apply to Steps in this TaskRun.
-If a field is specified in both a Step and a StepSpec,
-the value from the StepSpec will be used.
-This field is only supported when the alpha feature gate is enabled.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>sidecarSpecs</code><br/>
-<em>
-<a href="#tekton.dev/v1.TaskRunSidecarSpec">
-[]TaskRunSidecarSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Specs to apply to Sidecars in this TaskRun.
-If a field is specified in both a Sidecar and a SidecarSpec,
-the value from the SidecarSpec will be used.
-This field is only supported when the alpha feature gate is enabled.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>computeResources</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#resourcerequirements-v1-core">
-Kubernetes core/v1.ResourceRequirements
-</a>
-</em>
-</td>
-<td>
-<p>Compute resources to use for this TaskRun</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>managedBy</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ManagedBy indicates which controller is responsible for reconciling
-this resource. If unset or set to &ldquo;tekton.dev/pipeline&rdquo;, the default
-Tekton controller will manage this resource.
-This field is immutable.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code><br/>
-<em>
-<a href="#tekton.dev/v1.TaskRunStatus">
-TaskRunStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.Algorithm">Algorithm
-(<code>string</code> alias)</h3>
-<div>
-<p>Algorithm Standard cryptographic hash algorithm</p>
-</div>
-<h3 id="tekton.dev/v1.Artifact">Artifact
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.Artifacts">Artifacts</a>)
-</p>
-<div>
-<p>Artifact represents an artifact within a system, potentially containing multiple values
-associated with it.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>The artifact&rsquo;s identifying category name</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>values</code><br/>
-<em>
-<a href="#tekton.dev/v1.ArtifactValue">
-[]ArtifactValue
-</a>
-</em>
-</td>
-<td>
-<p>A collection of values related to the artifact</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>buildOutput</code><br/>
-<em>
-bool
-</em>
-</td>
-<td>
-<p>Indicate if the artifact is a build output or a by-product</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.ArtifactValue">ArtifactValue
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.Artifact">Artifact</a>)
-</p>
-<div>
-<p>ArtifactValue represents a specific value or data element within an Artifact.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>digest</code><br/>
-<em>
-map[github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Algorithm]string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>uri</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Algorithm-specific digests for verifying the content (e.g., SHA256)</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.Artifacts">Artifacts
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.TaskRunStatusFields">TaskRunStatusFields</a>)
-</p>
-<div>
-<p>Artifacts represents the collection of input and output artifacts associated with
-a task run or a similar process. Artifacts in this context are units of data or resources
-that the process either consumes as input or produces as output.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>inputs</code><br/>
-<em>
-<a href="#tekton.dev/v1.Artifact">
-[]Artifact
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>outputs</code><br/>
-<em>
-<a href="#tekton.dev/v1.Artifact">
-[]Artifact
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.ChildStatusReference">ChildStatusReference
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineRunStatusFields">PipelineRunStatusFields</a>)
-</p>
-<div>
-<p>ChildStatusReference is used to point to the statuses of individual TaskRuns and Runs within this PipelineRun.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Name is the name of the TaskRun or Run this is referencing.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>displayName</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>DisplayName is a user-facing name of the pipelineTask that may be
-used to populate a UI.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>pipelineTaskName</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>PipelineTaskName is the name of the PipelineTask this is referencing.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>whenExpressions</code><br/>
-<em>
-<a href="#tekton.dev/v1.WhenExpression">
-[]WhenExpression
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>WhenExpressions is the list of checks guarding the execution of the PipelineTask</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.Combination">Combination
-(<code>map[string]string</code> alias)</h3>
-<div>
-<p>Combination is a map, mainly defined to hold a single combination from a Matrix with key as param.Name and value as param.Value</p>
-</div>
-<h3 id="tekton.dev/v1.Combinations">Combinations
-(<code>[]github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Combination</code> alias)</h3>
-<div>
-<p>Combinations is a Combination list</p>
-</div>
-<h3 id="tekton.dev/v1.EmbeddedTask">EmbeddedTask
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineTask">PipelineTask</a>)
-</p>
-<div>
-<p>EmbeddedTask is used to define a Task inline within a Pipeline&rsquo;s PipelineTasks.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>spec</code><br/>
-<em>
-<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime#RawExtension">
-k8s.io/apimachinery/pkg/runtime.RawExtension
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Spec is a specification of a custom task</p>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>-</code><br/>
-<em>
-[]byte
-</em>
-</td>
-<td>
-<p>Raw is the underlying serialization of this object.</p>
-<p>TODO: Determine how to detect ContentType and ContentEncoding of &lsquo;Raw&rsquo; data.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>-</code><br/>
-<em>
-<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime#Object">
-k8s.io/apimachinery/pkg/runtime.Object
-</a>
-</em>
-</td>
-<td>
-<p>Object can hold a representation of this extension - useful for working with versioned
-structs.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>metadata</code><br/>
-<em>
-<a href="#tekton.dev/v1.PipelineTaskMetadata">
-PipelineTaskMetadata
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-<tr>
-<td>
-<code>TaskSpec</code><br/>
-<em>
-<a href="#tekton.dev/v1.TaskSpec">
-TaskSpec
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>TaskSpec</code> are embedded into this type.)
-</p>
-<em>(Optional)</em>
-<p>TaskSpec is a specification of a task</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.IncludeParams">IncludeParams
-</h3>
-<div>
-<p>IncludeParams allows passing in a specific combinations of Parameters into the Matrix.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Name the specified combination</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>params</code><br/>
-<em>
-<a href="#tekton.dev/v1.Params">
-Params
-</a>
-</em>
-</td>
-<td>
-<p>Params takes only <code>Parameters</code> of type <code>&quot;string&quot;</code>
-The names of the <code>params</code> must match the names of the <code>params</code> in the underlying <code>Task</code></p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.Matrix">Matrix
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineTask">PipelineTask</a>)
-</p>
-<div>
-<p>Matrix is used to fan out Tasks in a Pipeline</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>params</code><br/>
-<em>
-<a href="#tekton.dev/v1.Params">
-Params
-</a>
-</em>
-</td>
-<td>
-<p>Params is a list of parameters used to fan out the pipelineTask
-Params takes only <code>Parameters</code> of type <code>&quot;array&quot;</code>
-Each array element is supplied to the <code>PipelineTask</code> by substituting <code>params</code> of type <code>&quot;string&quot;</code> in the underlying <code>Task</code>.
-The names of the <code>params</code> in the <code>Matrix</code> must match the names of the <code>params</code> in the underlying <code>Task</code> that they will be substituting.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>include</code><br/>
-<em>
-<a href="#tekton.dev/v1.IncludeParamsList">
-IncludeParamsList
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Include is a list of IncludeParams which allows passing in specific combinations of Parameters into the Matrix.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.OnErrorType">OnErrorType
-(<code>string</code> alias)</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.Step">Step</a>)
-</p>
-<div>
-<p>OnErrorType defines a list of supported exiting behavior of a container on error</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Value</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody><tr><td><p>&#34;continue&#34;</p></td>
-<td><p>Continue indicates continue executing the rest of the steps irrespective of the container exit code</p>
-</td>
-</tr><tr><td><p>&#34;stopAndFail&#34;</p></td>
-<td><p>StopAndFail indicates exit the taskRun if the container exits with non-zero exit code</p>
-</td>
-</tr></tbody>
-</table>
-<h3 id="tekton.dev/v1.Param">Param
-</h3>
-<p>
-(<em>Appears on:</em><a href="#resolution.tekton.dev/v1beta1.ResolutionRequestSpec">ResolutionRequestSpec</a>)
-</p>
-<div>
-<p>Param declares an ParamValues to use for the parameter called name.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>value</code><br/>
-<em>
-<a href="#tekton.dev/v1.ParamValue">
-ParamValue
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.ParamSpec">ParamSpec
-</h3>
-<div>
-<p>ParamSpec defines arbitrary parameters needed beyond typed inputs (such as
-resources). Parameter values are provided by users as inputs on a TaskRun
-or PipelineRun.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Name declares the name by which a parameter is referenced.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>type</code><br/>
-<em>
-<a href="#tekton.dev/v1.ParamType">
-ParamType
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Type is the user-specified type of the parameter. The possible types
-are currently &ldquo;string&rdquo;, &ldquo;array&rdquo; and &ldquo;object&rdquo;, and &ldquo;string&rdquo; is the default.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>description</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Description is a user-facing description of the parameter that may be
-used to populate a UI.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>properties</code><br/>
-<em>
-<a href="#tekton.dev/v1.PropertySpec">
-map[string]github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PropertySpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Properties is the JSON Schema properties to support key-value pairs parameter.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>default</code><br/>
-<em>
-<a href="#tekton.dev/v1.ParamValue">
-ParamValue
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Default is the value a parameter takes if no input value is supplied. If
-default is set, a Task may be executed without a supplied value for the
-parameter.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>enum</code><br/>
-<em>
-[]string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Enum declares a set of allowed param input values for tasks/pipelines that can be validated.
-If Enum is not set, no input validation is performed for the param.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.ParamSpecs">ParamSpecs
-(<code>[]github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.ParamSpec</code> alias)</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineSpec">PipelineSpec</a>, <a href="#tekton.dev/v1.TaskSpec">TaskSpec</a>, <a href="#tekton.dev/v1alpha1.StepActionSpec">StepActionSpec</a>, <a href="#tekton.dev/v1beta1.StepActionSpec">StepActionSpec</a>)
-</p>
-<div>
-<p>ParamSpecs is a list of ParamSpec</p>
-</div>
-<h3 id="tekton.dev/v1.ParamType">ParamType
-(<code>string</code> alias)</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.ParamSpec">ParamSpec</a>, <a href="#tekton.dev/v1.ParamValue">ParamValue</a>, <a href="#tekton.dev/v1.PropertySpec">PropertySpec</a>)
-</p>
-<div>
-<p>ParamType indicates the type of an input parameter;
-Used to distinguish between a single string and an array of strings.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Value</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody><tr><td><p>&#34;array&#34;</p></td>
-<td></td>
-</tr><tr><td><p>&#34;object&#34;</p></td>
-<td></td>
-</tr><tr><td><p>&#34;string&#34;</p></td>
-<td></td>
-</tr></tbody>
-</table>
-<h3 id="tekton.dev/v1.ParamValue">ParamValue
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.Param">Param</a>, <a href="#tekton.dev/v1.ParamSpec">ParamSpec</a>)
-</p>
-<div>
-<p>ParamValue is a type that can hold a single string, string array, or string map.
-Used in JSON unmarshalling so that a single JSON field can accept
-either an individual string or an array of strings.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>Type</code><br/>
-<em>
-<a href="#tekton.dev/v1.ParamType">
-ParamType
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>StringVal</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Represents the stored type of ParamValues.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ArrayVal</code><br/>
-<em>
-[]string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>ObjectVal</code><br/>
-<em>
-map[string]string
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.Params">Params
-(<code>[]github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.Param</code> alias)</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.IncludeParams">IncludeParams</a>, <a href="#tekton.dev/v1.Matrix">Matrix</a>, <a href="#tekton.dev/v1.PipelineRunSpec">PipelineRunSpec</a>, <a href="#tekton.dev/v1.PipelineTask">PipelineTask</a>, <a href="#tekton.dev/v1.ResolverRef">ResolverRef</a>, <a href="#tekton.dev/v1.Step">Step</a>, <a href="#tekton.dev/v1.TaskRunInputs">TaskRunInputs</a>, <a href="#tekton.dev/v1.TaskRunSpec">TaskRunSpec</a>)
-</p>
-<div>
-<p>Params is a list of Param</p>
-</div>
-<h3 id="tekton.dev/v1.PipelineRef">PipelineRef
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineRunSpec">PipelineRunSpec</a>, <a href="#tekton.dev/v1.PipelineTask">PipelineTask</a>)
-</p>
-<div>
-<p>PipelineRef can be used to refer to a specific instance of a Pipeline.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Name of the referent; More info: <a href="http://kubernetes.io/docs/user-guide/identifiers#names">http://kubernetes.io/docs/user-guide/identifiers#names</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>apiVersion</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>API version of the referent</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ResolverRef</code><br/>
-<em>
-<a href="#tekton.dev/v1.ResolverRef">
-ResolverRef
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ResolverRef allows referencing a Pipeline in a remote location
-like a git repo. This field is only supported when the alpha
-feature gate is enabled.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.PipelineResult">PipelineResult
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineSpec">PipelineSpec</a>)
-</p>
-<div>
-<p>PipelineResult used to describe the results of a pipeline</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Name the given name</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>type</code><br/>
-<em>
-<a href="#tekton.dev/v1.ResultsType">
-ResultsType
-</a>
-</em>
-</td>
-<td>
-<p>Type is the user-specified type of the result.
-The possible types are &lsquo;string&rsquo;, &lsquo;array&rsquo;, and &lsquo;object&rsquo;, with &lsquo;string&rsquo; as the default.
-&lsquo;array&rsquo; and &lsquo;object&rsquo; types are alpha features.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>description</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Description is a human-readable description of the result</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>value</code><br/>
-<em>
-<a href="#tekton.dev/v1.ResultValue">
-ResultValue
-</a>
-</em>
-</td>
-<td>
-<p>Value the expression used to retrieve the value</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.PipelineRunReason">PipelineRunReason
-(<code>string</code> alias)</h3>
-<div>
-<p>PipelineRunReason represents a reason for the pipeline run &ldquo;Succeeded&rdquo; condition</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Value</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody><tr><td><p>&#34;CELEvaluationFailed&#34;</p></td>
-<td><p>ReasonCELEvaluationFailed indicates the pipeline fails the CEL evaluation</p>
-</td>
-</tr><tr><td><p>&#34;Cancelled&#34;</p></td>
-<td><p>PipelineRunReasonCancelled is the reason set when the PipelineRun cancelled by the user
-This reason may be found with a corev1.ConditionFalse status, if the cancellation was processed successfully
-This reason may be found with a corev1.ConditionUnknown status, if the cancellation is being processed or failed</p>
-</td>
-</tr><tr><td><p>&#34;CancelledRunningFinally&#34;</p></td>
-<td><p>PipelineRunReasonCancelledRunningFinally indicates that pipeline has been gracefully cancelled
-and no new Tasks will be scheduled by the controller, but final tasks are now running</p>
-</td>
-</tr><tr><td><p>&#34;Completed&#34;</p></td>
-<td><p>PipelineRunReasonCompleted is the reason set when the PipelineRun completed successfully with one or more skipped Tasks</p>
-</td>
-</tr><tr><td><p>&#34;PipelineRunCouldntCancel&#34;</p></td>
-<td><p>ReasonCouldntCancel indicates that a PipelineRun was cancelled but attempting to update
-all of the running TaskRuns as cancelled failed.</p>
-</td>
-</tr><tr><td><p>&#34;CouldntGetPipeline&#34;</p></td>
-<td><p>ReasonCouldntGetPipeline indicates that the reason for the failure status is that the
-associated Pipeline couldn&rsquo;t be retrieved</p>
-</td>
-</tr><tr><td><p>&#34;CouldntGetPipelineResult&#34;</p></td>
-<td><p>PipelineRunReasonCouldntGetPipelineResult indicates that the pipeline fails to retrieve the
-referenced result. This could be due to failed TaskRuns or Runs that were supposed to produce
-the results</p>
-</td>
-</tr><tr><td><p>&#34;CouldntGetTask&#34;</p></td>
-<td><p>ReasonCouldntGetTask indicates that the reason for the failure status is that the
-associated Pipeline&rsquo;s Tasks couldn&rsquo;t all be retrieved</p>
-</td>
-</tr><tr><td><p>&#34;PipelineRunCouldntTimeOut&#34;</p></td>
-<td><p>ReasonCouldntTimeOut indicates that a PipelineRun was timed out but attempting to update
-all of the running TaskRuns as timed out failed.</p>
-</td>
-</tr><tr><td><p>&#34;CreateRunFailed&#34;</p></td>
-<td><p>ReasonCreateRunFailed indicates that the pipeline fails to create the taskrun or other run resources</p>
-</td>
-</tr><tr><td><p>&#34;Failed&#34;</p></td>
-<td><p>PipelineRunReasonFailed is the reason set when the PipelineRun completed with a failure</p>
-</td>
-</tr><tr><td><p>&#34;PipelineValidationFailed&#34;</p></td>
-<td><p>ReasonFailedValidation indicates that the reason for failure status is
-that pipelinerun failed runtime validation</p>
-</td>
-</tr><tr><td><p>&#34;InvalidPipelineResourceBindings&#34;</p></td>
-<td><p>ReasonInvalidBindings indicates that the reason for the failure status is that the
-PipelineResources bound in the PipelineRun didn&rsquo;t match those declared in the Pipeline</p>
-</td>
-</tr><tr><td><p>&#34;PipelineInvalidGraph&#34;</p></td>
-<td><p>ReasonInvalidGraph indicates that the reason for the failure status is that the
-associated Pipeline is an invalid graph (a.k.a wrong order, cycle, …)</p>
-</td>
-</tr><tr><td><p>&#34;InvalidMatrixParameterTypes&#34;</p></td>
-<td><p>ReasonInvalidMatrixParameterTypes indicates a matrix contains invalid parameter types</p>
-</td>
-</tr><tr><td><p>&#34;InvalidParamValue&#34;</p></td>
-<td><p>PipelineRunReasonInvalidParamValue indicates that the PipelineRun Param input value is not allowed.</p>
-</td>
-</tr><tr><td><p>&#34;InvalidPipelineResultReference&#34;</p></td>
-<td><p>PipelineRunReasonInvalidPipelineResultReference indicates a pipeline result was declared
-by the pipeline but not initialized in the pipelineTask</p>
-</td>
-</tr><tr><td><p>&#34;InvalidTaskResultReference&#34;</p></td>
-<td><p>ReasonInvalidTaskResultReference indicates a task result was declared
-but was not initialized by that task</p>
-</td>
-</tr><tr><td><p>&#34;InvalidTaskRunSpecs&#34;</p></td>
-<td><p>ReasonInvalidTaskRunSpec indicates that PipelineRun.Spec.TaskRunSpecs[].PipelineTaskName is defined with
-a not exist taskName in pipelineSpec.</p>
-</td>
-</tr><tr><td><p>&#34;InvalidWorkspaceBindings&#34;</p></td>
-<td><p>ReasonInvalidWorkspaceBinding indicates that a Pipeline expects a workspace but a
-PipelineRun has provided an invalid binding.</p>
-</td>
-</tr><tr><td><p>&#34;ObjectParameterMissKeys&#34;</p></td>
-<td><p>ReasonObjectParameterMissKeys indicates that the object param value provided from PipelineRun spec
-misses some keys required for the object param declared in Pipeline spec.</p>
-</td>
-</tr><tr><td><p>&#34;ParamArrayIndexingInvalid&#34;</p></td>
-<td><p>ReasonParamArrayIndexingInvalid indicates that the use of param array indexing is out of bound.</p>
-</td>
-</tr><tr><td><p>&#34;ParameterMissing&#34;</p></td>
-<td><p>ReasonParameterMissing indicates that the reason for the failure status is that the
-associated PipelineRun didn&rsquo;t provide all the required parameters</p>
-</td>
-</tr><tr><td><p>&#34;ParameterTypeMismatch&#34;</p></td>
-<td><p>ReasonParameterTypeMismatch indicates that the reason for the failure status is that
-parameter(s) declared in the PipelineRun do not have the some declared type as the
-parameters(s) declared in the Pipeline that they are supposed to override.</p>
-</td>
-</tr><tr><td><p>&#34;PipelineRunPending&#34;</p></td>
-<td><p>PipelineRunReasonPending is the reason set when the PipelineRun is in the pending state</p>
-</td>
-</tr><tr><td><p>&#34;RequiredWorkspaceMarkedOptional&#34;</p></td>
-<td><p>ReasonRequiredWorkspaceMarkedOptional indicates an optional workspace
-has been passed to a Task that is expecting a non-optional workspace</p>
-</td>
-</tr><tr><td><p>&#34;ResolvingPipelineRef&#34;</p></td>
-<td><p>ReasonResolvingPipelineRef indicates that the PipelineRun is waiting for
-its pipelineRef to be asynchronously resolved.</p>
-</td>
-</tr><tr><td><p>&#34;ResourceVerificationFailed&#34;</p></td>
-<td><p>ReasonResourceVerificationFailed indicates that the pipeline fails the trusted resource verification,
-it could be the content has changed, signature is invalid or public key is invalid</p>
-</td>
-</tr><tr><td><p>&#34;Running&#34;</p></td>
-<td><p>PipelineRunReasonRunning is the reason set when the PipelineRun is running</p>
-</td>
-</tr><tr><td><p>&#34;Started&#34;</p></td>
-<td><p>PipelineRunReasonStarted is the reason set when the PipelineRun has just started</p>
-</td>
-</tr><tr><td><p>&#34;StoppedRunningFinally&#34;</p></td>
-<td><p>PipelineRunReasonStoppedRunningFinally indicates that pipeline has been gracefully stopped
-and no new Tasks will be scheduled by the controller, but final tasks are now running</p>
-</td>
-</tr><tr><td><p>&#34;PipelineRunStopping&#34;</p></td>
-<td><p>PipelineRunReasonStopping indicates that no new Tasks will be scheduled by the controller, and the
-pipeline will stop once all running tasks complete their work</p>
-</td>
-</tr><tr><td><p>&#34;Succeeded&#34;</p></td>
-<td><p>PipelineRunReasonSuccessful is the reason set when the PipelineRun completed successfully</p>
-</td>
-</tr><tr><td><p>&#34;PipelineRunTimeout&#34;</p></td>
-<td><p>PipelineRunReasonTimedOut is the reason set when the PipelineRun has timed out</p>
-</td>
-</tr></tbody>
-</table>
-<h3 id="tekton.dev/v1.PipelineRunResult">PipelineRunResult
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineRunStatusFields">PipelineRunStatusFields</a>)
-</p>
-<div>
-<p>PipelineRunResult used to describe the results of a pipeline</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Name is the result&rsquo;s name as declared by the Pipeline</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>value</code><br/>
-<em>
-<a href="#tekton.dev/v1.ResultValue">
-ResultValue
-</a>
-</em>
-</td>
-<td>
-<p>Value is the result returned from the execution of this PipelineRun</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.PipelineRunRunStatus">PipelineRunRunStatus
-</h3>
-<div>
-<p>PipelineRunRunStatus contains the name of the PipelineTask for this Run and the Run&rsquo;s Status</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>pipelineTaskName</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>PipelineTaskName is the name of the PipelineTask.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.CustomRunStatus">
-CustomRunStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Status is the RunStatus for the corresponding Run</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>whenExpressions</code><br/>
-<em>
-<a href="#tekton.dev/v1.WhenExpression">
-[]WhenExpression
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>WhenExpressions is the list of checks guarding the execution of the PipelineTask</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.PipelineRunSpec">PipelineRunSpec
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineRun">PipelineRun</a>)
-</p>
-<div>
-<p>PipelineRunSpec defines the desired state of PipelineRun</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>pipelineRef</code><br/>
-<em>
-<a href="#tekton.dev/v1.PipelineRef">
-PipelineRef
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-<tr>
-<td>
-<code>pipelineSpec</code><br/>
-<em>
-<a href="#tekton.dev/v1.PipelineSpec">
-PipelineSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Specifying PipelineSpec can be disabled by setting
-<code>disable-inline-spec</code> feature flag.
-See Pipeline.spec (API version: tekton.dev/v1)</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>params</code><br/>
-<em>
-<a href="#tekton.dev/v1.Params">
-Params
-</a>
-</em>
-</td>
-<td>
-<p>Params is a list of parameter names and values.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code><br/>
-<em>
-<a href="#tekton.dev/v1.PipelineRunSpecStatus">
-PipelineRunSpecStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Used for cancelling a pipelinerun (and maybe more later on)</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>timeouts</code><br/>
-<em>
-<a href="#tekton.dev/v1.TimeoutFields">
-TimeoutFields
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Time after which the Pipeline times out.
-Currently three keys are accepted in the map
-pipeline, tasks and finally
-with Timeouts.pipeline &gt;= Timeouts.tasks + Timeouts.finally</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>taskRunTemplate</code><br/>
-<em>
-<a href="#tekton.dev/v1.PipelineTaskRunTemplate">
-PipelineTaskRunTemplate
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>TaskRunTemplate represent template of taskrun</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>workspaces</code><br/>
-<em>
-<a href="#tekton.dev/v1.WorkspaceBinding">
-[]WorkspaceBinding
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Workspaces holds a set of workspace bindings that must match names
-with those declared in the pipeline.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>taskRunSpecs</code><br/>
-<em>
-<a href="#tekton.dev/v1.PipelineTaskRunSpec">
-[]PipelineTaskRunSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>TaskRunSpecs holds a set of runtime specs</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>managedBy</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ManagedBy indicates which controller is responsible for reconciling
-this resource. If unset or set to &ldquo;tekton.dev/pipeline&rdquo;, the default
-Tekton controller will manage this resource.
-This field is immutable.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.PipelineRunSpecStatus">PipelineRunSpecStatus
-(<code>string</code> alias)</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineRunSpec">PipelineRunSpec</a>)
-</p>
-<div>
-<p>PipelineRunSpecStatus defines the pipelinerun spec status the user can provide</p>
-</div>
-<h3 id="tekton.dev/v1.PipelineRunStatus">PipelineRunStatus
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineRun">PipelineRun</a>)
-</p>
-<div>
-<p>PipelineRunStatus defines the observed state of PipelineRun</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>Status</code><br/>
-<em>
-<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Status">
-knative.dev/pkg/apis/duck/v1.Status
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>Status</code> are embedded into this type.)
-</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>PipelineRunStatusFields</code><br/>
-<em>
-<a href="#tekton.dev/v1.PipelineRunStatusFields">
-PipelineRunStatusFields
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>PipelineRunStatusFields</code> are embedded into this type.)
-</p>
-<p>PipelineRunStatusFields inlines the status fields.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.PipelineRunStatusFields">PipelineRunStatusFields
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineRunStatus">PipelineRunStatus</a>)
-</p>
-<div>
-<p>PipelineRunStatusFields holds the fields of PipelineRunStatus&rsquo; status.
+PipelineRun creates TaskRuns for Tasks in the referenced Pipeline.
+
+
+
+
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `apiVersion` _string_ | `tekton.dev/v1` | | |
+| `kind` _string_ | `PipelineRun` | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  | Optional: \{\} <br /> |
+| `spec` _[PipelineRunSpec](#pipelinerunspec)_ |  |  | Optional: \{\} <br /> |
+| `status` _[PipelineRunStatus](#pipelinerunstatus)_ |  |  | Optional: \{\} <br /> |
+
+
+
+
+#### PipelineRunResult
+
+
+
+PipelineRunResult used to describe the results of a pipeline
+
+
+
+_Appears in:_
+- [PipelineRunStatus](#pipelinerunstatus)
+- [PipelineRunStatusFields](#pipelinerunstatusfields)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name is the result's name as declared by the Pipeline |  |  |
+| `value` _[ResultValue](#resultvalue)_ | Value is the result returned from the execution of this PipelineRun |  | Schemaless: \{\} <br /> |
+
+
+
+
+#### PipelineRunSpec
+
+
+
+PipelineRunSpec defines the desired state of PipelineRun
+
+
+
+_Appears in:_
+- [PipelineRun](#pipelinerun)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `pipelineRef` _[PipelineRef](#pipelineref)_ |  |  | Optional: \{\} <br /> |
+| `pipelineSpec` _[PipelineSpec](#pipelinespec)_ | Specifying PipelineSpec can be disabled by setting<br />`disable-inline-spec` feature flag.<br />See Pipeline.spec (API version: tekton.dev/v1) |  | Schemaless: \{\} <br />Optional: \{\} <br /> |
+| `params` _[Params](#params)_ | Params is a list of parameter names and values. |  |  |
+| `status` _[PipelineRunSpecStatus](#pipelinerunspecstatus)_ | Used for cancelling a pipelinerun (and maybe more later on) |  | Optional: \{\} <br /> |
+| `timeouts` _[TimeoutFields](#timeoutfields)_ | Time after which the Pipeline times out.<br />Currently three keys are accepted in the map<br />pipeline, tasks and finally<br />with Timeouts.pipeline >= Timeouts.tasks + Timeouts.finally |  | Optional: \{\} <br /> |
+| `taskRunTemplate` _[PipelineTaskRunTemplate](#pipelinetaskruntemplate)_ | TaskRunTemplate represent template of taskrun |  | Optional: \{\} <br /> |
+| `workspaces` _[WorkspaceBinding](#workspacebinding) array_ | Workspaces holds a set of workspace bindings that must match names<br />with those declared in the pipeline. |  | Optional: \{\} <br /> |
+| `taskRunSpecs` _[PipelineTaskRunSpec](#pipelinetaskrunspec) array_ | TaskRunSpecs holds a set of runtime specs |  | Optional: \{\} <br /> |
+| `managedBy` _string_ | ManagedBy indicates which controller is responsible for reconciling<br />this resource. If unset or set to "tekton.dev/pipeline", the default<br />Tekton controller will manage this resource.<br />This field is immutable. |  | Optional: \{\} <br /> |
+
+
+#### PipelineRunSpecStatus
+
+_Underlying type:_ _string_
+
+PipelineRunSpecStatus defines the pipelinerun spec status the user can provide
+
+
+
+_Appears in:_
+- [PipelineRunSpec](#pipelinerunspec)
+
+
+
+#### PipelineRunStatus
+
+
+
+PipelineRunStatus defines the observed state of PipelineRun
+
+
+
+_Appears in:_
+- [PipelineRun](#pipelinerun)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `observedGeneration` _integer_ | ObservedGeneration is the 'Generation' of the Service that<br />was last processed by the controller. |  | Optional: \{\} <br /> |
+| `conditions` _[Conditions](#conditions)_ | Conditions the latest available observations of a resource's current state. |  | Optional: \{\} <br /> |
+| `annotations` _object (keys:string, values:string)_ | Annotations is additional Status fields for the Resource to save some<br />additional State as well as convey more information to the user. This is<br />roughly akin to Annotations on any k8s resource, just the reconciler conveying<br />richer information outwards. |  |  |
+| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | StartTime is the time the PipelineRun is actually started. |  |  |
+| `completionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | CompletionTime is the time the PipelineRun completed. |  |  |
+| `results` _[PipelineRunResult](#pipelinerunresult) array_ | Results are the list of results written out by the pipeline task's containers |  | Optional: \{\} <br /> |
+| `pipelineSpec` _[PipelineSpec](#pipelinespec)_ | PipelineSpec contains the exact spec used to instantiate the run.<br />See Pipeline.spec (API version: tekton.dev/v1) |  | Schemaless: \{\} <br /> |
+| `skippedTasks` _[SkippedTask](#skippedtask) array_ | list of tasks that were skipped due to when expressions evaluating to false |  | Optional: \{\} <br /> |
+| `childReferences` _[ChildStatusReference](#childstatusreference) array_ | list of TaskRun and Run names, PipelineTask names, and API versions/kinds for children of this PipelineRun. |  | Optional: \{\} <br /> |
+| `finallyStartTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | FinallyStartTime is when all non-finally tasks have been completed and only finally tasks are being executed. |  | Optional: \{\} <br /> |
+| `provenance` _[Provenance](#provenance)_ | Provenance contains some key authenticated metadata about how a software artifact was built (what sources, what inputs/outputs, etc.). |  | Optional: \{\} <br /> |
+| `spanContext` _object (keys:string, values:string)_ | SpanContext contains tracing span context fields |  |  |
+
+
+#### PipelineRunStatusFields
+
+
+
+PipelineRunStatusFields holds the fields of PipelineRunStatus' status.
 This is defined separately and inlined so that other types can readily
-consume these fields via duck typing.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>startTime</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta">
-Kubernetes meta/v1.Time
-</a>
-</em>
-</td>
-<td>
-<p>StartTime is the time the PipelineRun is actually started.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>completionTime</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta">
-Kubernetes meta/v1.Time
-</a>
-</em>
-</td>
-<td>
-<p>CompletionTime is the time the PipelineRun completed.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>results</code><br/>
-<em>
-<a href="#tekton.dev/v1.PipelineRunResult">
-[]PipelineRunResult
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Results are the list of results written out by the pipeline task&rsquo;s containers</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>pipelineSpec</code><br/>
-<em>
-<a href="#tekton.dev/v1.PipelineSpec">
-PipelineSpec
-</a>
-</em>
-</td>
-<td>
-<p>PipelineSpec contains the exact spec used to instantiate the run.
-See Pipeline.spec (API version: tekton.dev/v1)</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>skippedTasks</code><br/>
-<em>
-<a href="#tekton.dev/v1.SkippedTask">
-[]SkippedTask
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>list of tasks that were skipped due to when expressions evaluating to false</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>childReferences</code><br/>
-<em>
-<a href="#tekton.dev/v1.ChildStatusReference">
-[]ChildStatusReference
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>list of TaskRun and Run names, PipelineTask names, and API versions/kinds for children of this PipelineRun.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>finallyStartTime</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta">
-Kubernetes meta/v1.Time
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>FinallyStartTime is when all non-finally tasks have been completed and only finally tasks are being executed.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>provenance</code><br/>
-<em>
-<a href="#tekton.dev/v1.Provenance">
-Provenance
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Provenance contains some key authenticated metadata about how a software artifact was built (what sources, what inputs/outputs, etc.).</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>spanContext</code><br/>
-<em>
-map[string]string
-</em>
-</td>
-<td>
-<p>SpanContext contains tracing span context fields</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.PipelineRunTaskRunStatus">PipelineRunTaskRunStatus
-</h3>
-<div>
-<p>PipelineRunTaskRunStatus contains the name of the PipelineTask for this TaskRun and the TaskRun&rsquo;s Status</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>pipelineTaskName</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>PipelineTaskName is the name of the PipelineTask.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code><br/>
-<em>
-<a href="#tekton.dev/v1.TaskRunStatus">
-TaskRunStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Status is the TaskRunStatus for the corresponding TaskRun</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>whenExpressions</code><br/>
-<em>
-<a href="#tekton.dev/v1.WhenExpression">
-[]WhenExpression
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>WhenExpressions is the list of checks guarding the execution of the PipelineTask</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.PipelineSpec">PipelineSpec
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.Pipeline">Pipeline</a>, <a href="#tekton.dev/v1.PipelineRunSpec">PipelineRunSpec</a>, <a href="#tekton.dev/v1.PipelineRunStatusFields">PipelineRunStatusFields</a>, <a href="#tekton.dev/v1.PipelineTask">PipelineTask</a>)
-</p>
-<div>
-<p>PipelineSpec defines the desired state of Pipeline.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>displayName</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>DisplayName is a user-facing name of the pipeline that may be
-used to populate a UI.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>description</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Description is a user-facing description of the pipeline that may be
-used to populate a UI.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>tasks</code><br/>
-<em>
-<a href="#tekton.dev/v1.PipelineTask">
-[]PipelineTask
-</a>
-</em>
-</td>
-<td>
-<p>Tasks declares the graph of Tasks that execute when this Pipeline is run.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>params</code><br/>
-<em>
-<a href="#tekton.dev/v1.ParamSpecs">
-ParamSpecs
-</a>
-</em>
-</td>
-<td>
-<p>Params declares a list of input parameters that must be supplied when
-this Pipeline is run.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>workspaces</code><br/>
-<em>
-<a href="#tekton.dev/v1.PipelineWorkspaceDeclaration">
-[]PipelineWorkspaceDeclaration
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Workspaces declares a set of named workspaces that are expected to be
-provided by a PipelineRun.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>results</code><br/>
-<em>
-<a href="#tekton.dev/v1.PipelineResult">
-[]PipelineResult
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Results are values that this pipeline can output once run</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>finally</code><br/>
-<em>
-<a href="#tekton.dev/v1.PipelineTask">
-[]PipelineTask
-</a>
-</em>
-</td>
-<td>
-<p>Finally declares the list of Tasks that execute just before leaving the Pipeline
-i.e. either after all Tasks are finished executing successfully
-or after a failure which would result in ending the Pipeline</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.PipelineTask">PipelineTask
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineSpec">PipelineSpec</a>)
-</p>
-<div>
-<p>PipelineTask defines a task in a Pipeline, passing inputs from both
-Params and from the output of previous tasks.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Name is the name of this task within the context of a Pipeline. Name is
-used as a coordinate with the <code>from</code> and <code>runAfter</code> fields to establish
-the execution order of tasks relative to one another.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>displayName</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>DisplayName is the display name of this task within the context of a Pipeline.
-This display name may be used to populate a UI.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>description</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Description is the description of this task within the context of a Pipeline.
-This description may be used to populate a UI.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>taskRef</code><br/>
-<em>
-<a href="#tekton.dev/v1.TaskRef">
-TaskRef
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>TaskRef is a reference to a task definition.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>taskSpec</code><br/>
-<em>
-<a href="#tekton.dev/v1.EmbeddedTask">
-EmbeddedTask
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>TaskSpec is a specification of a task
-Specifying TaskSpec can be disabled by setting
-<code>disable-inline-spec</code> feature flag.
-See Task.spec (API version: tekton.dev/v1)</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>when</code><br/>
-<em>
-<a href="#tekton.dev/v1.WhenExpressions">
-WhenExpressions
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>When is a list of when expressions that need to be true for the task to run</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>retries</code><br/>
-<em>
-int
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Retries represents how many times this task should be retried in case of task failure: ConditionSucceeded set to False</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>runAfter</code><br/>
-<em>
-[]string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>RunAfter is the list of PipelineTask names that should be executed before
-this Task executes. (Used to force a specific ordering in graph execution.)</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>params</code><br/>
-<em>
-<a href="#tekton.dev/v1.Params">
-Params
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Parameters declares parameters passed to this task.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>matrix</code><br/>
-<em>
-<a href="#tekton.dev/v1.Matrix">
-Matrix
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Matrix declares parameters used to fan out this task.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>workspaces</code><br/>
-<em>
-<a href="#tekton.dev/v1.WorkspacePipelineTaskBinding">
-[]WorkspacePipelineTaskBinding
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Workspaces maps workspaces from the pipeline spec to the workspaces
-declared in the Task.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>timeout</code><br/>
-<em>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
-Kubernetes meta/v1.Duration
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Duration after which the TaskRun times out. Defaults to 1 hour.
-Refer Go&rsquo;s ParseDuration documentation for expected format: <a href="https://golang.org/pkg/time/#ParseDuration">https://golang.org/pkg/time/#ParseDuration</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>pipelineRef</code><br/>
-<em>
-<a href="#tekton.dev/v1.PipelineRef">
-PipelineRef
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>PipelineRef is a reference to a pipeline definition
-Note: PipelineRef is in preview mode and not yet supported</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>pipelineSpec</code><br/>
-<em>
-<a href="#tekton.dev/v1.PipelineSpec">
-PipelineSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>PipelineSpec is a specification of a pipeline
-Note: PipelineSpec is in preview mode and not yet supported
-Specifying PipelineSpec can be disabled by setting
-<code>disable-inline-spec</code> feature flag.
-See Pipeline.spec (API version: tekton.dev/v1)</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>onError</code><br/>
-<em>
-<a href="#tekton.dev/v1.PipelineTaskOnErrorType">
-PipelineTaskOnErrorType
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>OnError defines the exiting behavior of a PipelineRun on error
-can be set to [ continue | stopAndFail ]</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.PipelineTaskMetadata">PipelineTaskMetadata
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.EmbeddedTask">EmbeddedTask</a>, <a href="#tekton.dev/v1.PipelineTaskRunSpec">PipelineTaskRunSpec</a>)
-</p>
-<div>
-<p>PipelineTaskMetadata contains the labels or annotations for an EmbeddedTask</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>labels</code><br/>
-<em>
-map[string]string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-<tr>
-<td>
-<code>annotations</code><br/>
-<em>
-map[string]string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.PipelineTaskOnErrorType">PipelineTaskOnErrorType
-(<code>string</code> alias)</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineTask">PipelineTask</a>)
-</p>
-<div>
-<p>PipelineTaskOnErrorType defines a list of supported failure handling behaviors of a PipelineTask on error</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Value</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody><tr><td><p>&#34;continue&#34;</p></td>
-<td><p>PipelineTaskContinue indicates to continue executing the rest of the DAG when the PipelineTask fails</p>
-</td>
-</tr><tr><td><p>&#34;stopAndFail&#34;</p></td>
-<td><p>PipelineTaskStopAndFail indicates to stop and fail the PipelineRun if the PipelineTask fails</p>
-</td>
-</tr></tbody>
-</table>
-<h3 id="tekton.dev/v1.PipelineTaskParam">PipelineTaskParam
-</h3>
-<div>
-<p>PipelineTaskParam is used to provide arbitrary string parameters to a Task.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>value</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.PipelineTaskRun">PipelineTaskRun
-</h3>
-<div>
-<p>PipelineTaskRun reports the results of running a step in the Task. Each
-task has the potential to succeed or fail (based on the exit code)
-and produces logs.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.PipelineTaskRunSpec">PipelineTaskRunSpec
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineRunSpec">PipelineRunSpec</a>)
-</p>
-<div>
-<p>PipelineTaskRunSpec  can be used to configure specific
-specs for a concrete Task</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>pipelineTaskName</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>serviceAccountName</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>podTemplate</code><br/>
-<em>
-<a href="#tekton.dev/unversioned.PodTemplate">
-PodTemplate
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>stepSpecs</code><br/>
-<em>
-<a href="#tekton.dev/v1.TaskRunStepSpec">
-[]TaskRunStepSpec
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>sidecarSpecs</code><br/>
-<em>
-<a href="#tekton.dev/v1.TaskRunSidecarSpec">
-[]TaskRunSidecarSpec
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>metadata</code><br/>
-<em>
-<a href="#tekton.dev/v1.PipelineTaskMetadata">
-PipelineTaskMetadata
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-<tr>
-<td>
-<code>computeResources</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#resourcerequirements-v1-core">
-Kubernetes core/v1.ResourceRequirements
-</a>
-</em>
-</td>
-<td>
-<p>Compute resources to use for this TaskRun</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>timeout</code><br/>
-<em>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
-Kubernetes meta/v1.Duration
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Duration after which the TaskRun times out. Overrides the timeout specified
-on the Task&rsquo;s spec if specified. Takes lower precedence to PipelineRun&rsquo;s
-<code>spec.timeouts.tasks</code>
-Refer Go&rsquo;s ParseDuration documentation for expected format: <a href="https://golang.org/pkg/time/#ParseDuration">https://golang.org/pkg/time/#ParseDuration</a></p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.PipelineTaskRunTemplate">PipelineTaskRunTemplate
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineRunSpec">PipelineRunSpec</a>)
-</p>
-<div>
-<p>PipelineTaskRunTemplate is used to specify run specifications for all Task in pipelinerun.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>podTemplate</code><br/>
-<em>
-<a href="#tekton.dev/unversioned.PodTemplate">
-PodTemplate
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-<tr>
-<td>
-<code>serviceAccountName</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.PipelineWorkspaceDeclaration">PipelineWorkspaceDeclaration
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineSpec">PipelineSpec</a>)
-</p>
-<div>
-<p>PipelineWorkspaceDeclaration creates a named slot in a Pipeline that a PipelineRun
-is expected to populate with a workspace binding.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Name is the name of a workspace to be provided by a PipelineRun.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>description</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Description is a human readable string describing how the workspace will be
-used in the Pipeline. It can be useful to include a bit of detail about which
-tasks are intended to have access to the data on the workspace.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>optional</code><br/>
-<em>
-bool
-</em>
-</td>
-<td>
-<p>Optional marks a Workspace as not being required in PipelineRuns. By default
-this field is false and so declared workspaces are required.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.PropertySpec">PropertySpec
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.ParamSpec">ParamSpec</a>, <a href="#tekton.dev/v1.StepResult">StepResult</a>, <a href="#tekton.dev/v1.TaskResult">TaskResult</a>)
-</p>
-<div>
-<p>PropertySpec defines the struct for object keys</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>type</code><br/>
-<em>
-<a href="#tekton.dev/v1.ParamType">
-ParamType
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.Provenance">Provenance
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineRunStatusFields">PipelineRunStatusFields</a>, <a href="#tekton.dev/v1.StepState">StepState</a>, <a href="#tekton.dev/v1.TaskRunStatusFields">TaskRunStatusFields</a>)
-</p>
-<div>
-<p>Provenance contains metadata about resources used in the TaskRun/PipelineRun
+consume these fields via duck typing.
+
+
+
+_Appears in:_
+- [PipelineRunStatus](#pipelinerunstatus)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | StartTime is the time the PipelineRun is actually started. |  |  |
+| `completionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | CompletionTime is the time the PipelineRun completed. |  |  |
+| `results` _[PipelineRunResult](#pipelinerunresult) array_ | Results are the list of results written out by the pipeline task's containers |  | Optional: \{\} <br /> |
+| `pipelineSpec` _[PipelineSpec](#pipelinespec)_ | PipelineSpec contains the exact spec used to instantiate the run.<br />See Pipeline.spec (API version: tekton.dev/v1) |  | Schemaless: \{\} <br /> |
+| `skippedTasks` _[SkippedTask](#skippedtask) array_ | list of tasks that were skipped due to when expressions evaluating to false |  | Optional: \{\} <br /> |
+| `childReferences` _[ChildStatusReference](#childstatusreference) array_ | list of TaskRun and Run names, PipelineTask names, and API versions/kinds for children of this PipelineRun. |  | Optional: \{\} <br /> |
+| `finallyStartTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | FinallyStartTime is when all non-finally tasks have been completed and only finally tasks are being executed. |  | Optional: \{\} <br /> |
+| `provenance` _[Provenance](#provenance)_ | Provenance contains some key authenticated metadata about how a software artifact was built (what sources, what inputs/outputs, etc.). |  | Optional: \{\} <br /> |
+| `spanContext` _object (keys:string, values:string)_ | SpanContext contains tracing span context fields |  |  |
+
+
+
+
+#### PipelineSpec
+
+
+
+PipelineSpec defines the desired state of Pipeline.
+
+
+
+_Appears in:_
+- [Pipeline](#pipeline)
+- [PipelineRunSpec](#pipelinerunspec)
+- [PipelineRunStatus](#pipelinerunstatus)
+- [PipelineRunStatusFields](#pipelinerunstatusfields)
+- [PipelineTask](#pipelinetask)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `displayName` _string_ | DisplayName is a user-facing name of the pipeline that may be<br />used to populate a UI. |  | Optional: \{\} <br /> |
+| `description` _string_ | Description is a user-facing description of the pipeline that may be<br />used to populate a UI. |  | Optional: \{\} <br /> |
+| `tasks` _[PipelineTask](#pipelinetask) array_ | Tasks declares the graph of Tasks that execute when this Pipeline is run. |  |  |
+| `params` _[ParamSpecs](#paramspecs)_ | Params declares a list of input parameters that must be supplied when<br />this Pipeline is run. |  |  |
+| `workspaces` _[PipelineWorkspaceDeclaration](#pipelineworkspacedeclaration) array_ | Workspaces declares a set of named workspaces that are expected to be<br />provided by a PipelineRun. |  | Optional: \{\} <br /> |
+| `results` _[PipelineResult](#pipelineresult) array_ | Results are values that this pipeline can output once run |  | Optional: \{\} <br /> |
+| `finally` _[PipelineTask](#pipelinetask) array_ | Finally declares the list of Tasks that execute just before leaving the Pipeline<br />i.e. either after all Tasks are finished executing successfully<br />or after a failure which would result in ending the Pipeline |  |  |
+
+
+#### PipelineTask
+
+
+
+PipelineTask defines a task in a Pipeline, passing inputs from both
+Params and from the output of previous tasks.
+
+
+
+_Appears in:_
+- [PipelineSpec](#pipelinespec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name is the name of this task within the context of a Pipeline. Name is<br />used as a coordinate with the `from` and `runAfter` fields to establish<br />the execution order of tasks relative to one another. |  |  |
+| `displayName` _string_ | DisplayName is the display name of this task within the context of a Pipeline.<br />This display name may be used to populate a UI. |  | Optional: \{\} <br /> |
+| `description` _string_ | Description is the description of this task within the context of a Pipeline.<br />This description may be used to populate a UI. |  | Optional: \{\} <br /> |
+| `taskRef` _[TaskRef](#taskref)_ | TaskRef is a reference to a task definition. |  | Optional: \{\} <br /> |
+| `taskSpec` _[EmbeddedTask](#embeddedtask)_ | TaskSpec is a specification of a task<br />Specifying TaskSpec can be disabled by setting<br />`disable-inline-spec` feature flag.<br />See Task.spec (API version: tekton.dev/v1) |  | Schemaless: \{\} <br />Optional: \{\} <br /> |
+| `when` _[WhenExpressions](#whenexpressions)_ | When is a list of when expressions that need to be true for the task to run |  | Optional: \{\} <br /> |
+| `retries` _integer_ | Retries represents how many times this task should be retried in case of task failure: ConditionSucceeded set to False |  | Optional: \{\} <br /> |
+| `runAfter` _string array_ | RunAfter is the list of PipelineTask names that should be executed before<br />this Task executes. (Used to force a specific ordering in graph execution.) |  | Optional: \{\} <br /> |
+| `params` _[Params](#params)_ | Parameters declares parameters passed to this task. |  | Optional: \{\} <br /> |
+| `matrix` _[Matrix](#matrix)_ | Matrix declares parameters used to fan out this task. |  | Optional: \{\} <br /> |
+| `workspaces` _[WorkspacePipelineTaskBinding](#workspacepipelinetaskbinding) array_ | Workspaces maps workspaces from the pipeline spec to the workspaces<br />declared in the Task. |  | Optional: \{\} <br /> |
+| `timeout` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ | Duration after which the TaskRun times out. Defaults to 1 hour.<br />Refer Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration |  | Optional: \{\} <br /> |
+| `pipelineRef` _[PipelineRef](#pipelineref)_ | PipelineRef is a reference to a pipeline definition.<br />This is an alpha field. You must set the "enable-api-fields" feature flag<br />to "alpha" for this field to be supported. When enabled, the referenced<br />Pipeline is executed as a child PipelineRun owned by the parent PipelineRun. |  | Optional: \{\} <br /> |
+| `pipelineSpec` _[PipelineSpec](#pipelinespec)_ | PipelineSpec is a specification of a pipeline.<br />This is an alpha field. You must set the "enable-api-fields" feature flag<br />to "alpha" for this field to be supported. When enabled, the embedded<br />Pipeline is executed as a child PipelineRun owned by the parent PipelineRun.<br />Specifying PipelineSpec can be disabled by setting<br />`disable-inline-spec` feature flag.<br />See Pipeline.spec (API version: tekton.dev/v1) |  | Schemaless: \{\} <br />Optional: \{\} <br /> |
+| `onError` _[PipelineTaskOnErrorType](#pipelinetaskonerrortype)_ | OnError defines the exiting behavior of a PipelineRun on error<br />can be set to [ continue \| stopAndFail ] |  | Optional: \{\} <br /> |
+
+
+#### PipelineTaskMetadata
+
+
+
+PipelineTaskMetadata contains the labels or annotations for an EmbeddedTask
+
+
+
+_Appears in:_
+- [EmbeddedTask](#embeddedtask)
+- [PipelineTaskRunSpec](#pipelinetaskrunspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `labels` _object (keys:string, values:string)_ |  |  | Optional: \{\} <br /> |
+| `annotations` _object (keys:string, values:string)_ |  |  | Optional: \{\} <br /> |
+
+
+#### PipelineTaskOnErrorType
+
+_Underlying type:_ _string_
+
+PipelineTaskOnErrorType defines a list of supported failure handling behaviors of a PipelineTask on error
+
+
+
+_Appears in:_
+- [PipelineTask](#pipelinetask)
+
+| Field | Description |
+| --- | --- |
+| `stopAndFail` | PipelineTaskStopAndFail indicates to stop and fail the PipelineRun if the PipelineTask fails<br /> |
+| `continue` | PipelineTaskContinue indicates to continue executing the rest of the DAG when the PipelineTask fails<br /> |
+
+
+
+
+
+
+#### PipelineTaskRunSpec
+
+
+
+PipelineTaskRunSpec  can be used to configure specific
+specs for a concrete Task
+
+
+
+_Appears in:_
+- [PipelineRunSpec](#pipelinerunspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `pipelineTaskName` _string_ |  |  |  |
+| `serviceAccountName` _string_ |  |  |  |
+| `podTemplate` _[PodTemplate](#podtemplate)_ |  |  |  |
+| `stepSpecs` _[TaskRunStepSpec](#taskrunstepspec) array_ |  |  |  |
+| `sidecarSpecs` _[TaskRunSidecarSpec](#taskrunsidecarspec) array_ |  |  |  |
+| `metadata` _[PipelineTaskMetadata](#pipelinetaskmetadata)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  | Optional: \{\} <br /> |
+| `computeResources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcerequirements-v1-core)_ | Compute resources to use for this TaskRun |  |  |
+| `timeout` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ | Duration after which the TaskRun times out. Overrides the timeout specified<br />on the Task's spec if specified. Takes lower precedence to PipelineRun's<br />`spec.timeouts.tasks`<br />Refer Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration |  | Optional: \{\} <br /> |
+
+
+#### PipelineTaskRunTemplate
+
+
+
+PipelineTaskRunTemplate is used to specify run specifications for all Task in pipelinerun.
+
+
+
+_Appears in:_
+- [PipelineRunSpec](#pipelinerunspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `podTemplate` _[PodTemplate](#podtemplate)_ |  |  | Optional: \{\} <br /> |
+| `serviceAccountName` _string_ |  |  | Optional: \{\} <br /> |
+
+
+#### PipelineWorkspaceDeclaration
+
+_Underlying type:_ _[struct{Name string "json:\"name\""; Description string "json:\"description,omitempty\""; Optional bool "json:\"optional,omitempty\""}](#struct{name-string-"json:\"name\"";-description-string-"json:\"description,omitempty\"";-optional-bool-"json:\"optional,omitempty\""})_
+
+PipelineWorkspaceDeclaration creates a named slot in a Pipeline that a PipelineRun
+is expected to populate with a workspace binding.
+
+
+
+_Appears in:_
+- [PipelineSpec](#pipelinespec)
+
+
+
+#### PropertySpec
+
+
+
+PropertySpec defines the struct for object keys
+
+
+
+_Appears in:_
+- [ParamSpec](#paramspec)
+- [StepResult](#stepresult)
+- [TaskResult](#taskresult)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `type` _[ParamType](#paramtype)_ |  |  |  |
+
+
+#### Provenance
+
+
+
+Provenance contains metadata about resources used in the TaskRun/PipelineRun
 such as the source from where a remote build definition was fetched.
 This field aims to carry minimum amoumt of metadata in *Run status so that
-Tekton Chains can capture them in the provenance.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>refSource</code><br/>
-<em>
-<a href="#tekton.dev/v1.RefSource">
-RefSource
-</a>
-</em>
-</td>
-<td>
-<p>RefSource identifies the source where a remote task/pipeline came from.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>featureFlags</code><br/>
-<em>
-github.com/tektoncd/pipeline/pkg/apis/config.FeatureFlags
-</em>
-</td>
-<td>
-<p>FeatureFlags identifies the feature flags that were used during the task/pipeline run</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.Ref">Ref
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.Step">Step</a>)
-</p>
-<div>
-<p>Ref can be used to refer to a specific instance of a StepAction.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Name of the referenced step</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ResolverRef</code><br/>
-<em>
-<a href="#tekton.dev/v1.ResolverRef">
-ResolverRef
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ResolverRef allows referencing a StepAction in a remote location
-like a git repo.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.RefSource">RefSource
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.Provenance">Provenance</a>, <a href="#resolution.tekton.dev/v1alpha1.ResolutionRequestStatusFields">ResolutionRequestStatusFields</a>, <a href="#resolution.tekton.dev/v1beta1.ResolutionRequestStatusFields">ResolutionRequestStatusFields</a>)
-</p>
-<div>
-<p>RefSource contains the information that can uniquely identify where a remote
+Tekton Chains can capture them in the provenance.
+
+
+
+_Appears in:_
+- [PipelineRunStatus](#pipelinerunstatus)
+- [PipelineRunStatusFields](#pipelinerunstatusfields)
+- [StepState](#stepstate)
+- [TaskRunStatus](#taskrunstatus)
+- [TaskRunStatusFields](#taskrunstatusfields)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `refSource` _[RefSource](#refsource)_ | RefSource identifies the source where a remote task/pipeline came from. |  |  |
+| `featureFlags` _[FeatureFlags](#featureflags)_ | FeatureFlags identifies the feature flags that were used during the task/pipeline run |  |  |
+
+
+#### Ref
+
+
+
+Ref can be used to refer to a specific instance of a StepAction.
+
+
+
+_Appears in:_
+- [Step](#step)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name of the referenced step |  |  |
+| `ResolverRef` _[ResolverRef](#resolverref)_ | ResolverRef allows referencing a StepAction in a remote location<br />like a git repo. |  | Optional: \{\} <br /> |
+
+
+#### RefSource
+
+
+
+RefSource contains the information that can uniquely identify where a remote
 built definition came from i.e. Git repositories, Tekton Bundles in OCI registry
-and hub.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>uri</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>URI indicates the identity of the source of the build definition.
-Example: &ldquo;<a href="https://github.com/tektoncd/catalog&quot;">https://github.com/tektoncd/catalog&rdquo;</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>digest</code><br/>
-<em>
-map[string]string
-</em>
-</td>
-<td>
-<p>Digest is a collection of cryptographic digests for the contents of the artifact specified by URI.
-Example: {&ldquo;sha1&rdquo;: &ldquo;f99d13e554ffcb696dee719fa85b695cb5b0f428&rdquo;}</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>entryPoint</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>EntryPoint identifies the entry point into the build. This is often a path to a
-build definition file and/or a target label within that file.
-Example: &ldquo;task/git-clone/0.10/git-clone.yaml&rdquo;</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.ResolverName">ResolverName
-(<code>string</code> alias)</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.ResolverRef">ResolverRef</a>)
-</p>
-<div>
-<p>ResolverName is the name of a resolver from which a resource can be
-requested.</p>
-</div>
-<h3 id="tekton.dev/v1.ResolverRef">ResolverRef
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineRef">PipelineRef</a>, <a href="#tekton.dev/v1.Ref">Ref</a>, <a href="#tekton.dev/v1.TaskRef">TaskRef</a>)
-</p>
-<div>
-<p>ResolverRef can be used to refer to a Pipeline or Task in a remote
+and hub.
+
+
+
+_Appears in:_
+- [Provenance](#provenance)
+- [ResolutionRequestStatus](#resolutionrequeststatus)
+- [ResolutionRequestStatus](#resolutionrequeststatus)
+- [ResolutionRequestStatusFields](#resolutionrequeststatusfields)
+- [ResolutionRequestStatusFields](#resolutionrequeststatusfields)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `uri` _string_ | URI indicates the identity of the source of the build definition.<br />Example: "https://github.com/tektoncd/catalog" |  |  |
+| `digest` _object (keys:string, values:string)_ | Digest is a collection of cryptographic digests for the contents of the artifact specified by URI.<br />Example: \{"sha1": "f99d13e554ffcb696dee719fa85b695cb5b0f428"\} |  |  |
+| `entryPoint` _string_ | EntryPoint identifies the entry point into the build. This is often a path to a<br />build definition file and/or a target label within that file.<br />Example: "task/git-clone/0.10/git-clone.yaml" |  |  |
+
+
+#### ResolverName
+
+_Underlying type:_ _string_
+
+ResolverName is the name of a resolver from which a resource can be
+requested.
+
+
+
+_Appears in:_
+- [ResolverRef](#resolverref)
+
+
+
+#### ResolverRef
+
+
+
+ResolverRef can be used to refer to a Pipeline or Task in a remote
 location like a git repo. This feature is in beta and these fields
-are only available when the beta feature gate is enabled.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>resolver</code><br/>
-<em>
-<a href="#tekton.dev/v1.ResolverName">
-ResolverName
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Resolver is the name of the resolver that should perform
-resolution of the referenced Tekton resource, such as &ldquo;git&rdquo;.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>params</code><br/>
-<em>
-<a href="#tekton.dev/v1.Params">
-Params
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Params contains the parameters used to identify the
-referenced Tekton resource. Example entries might include
-&ldquo;repo&rdquo; or &ldquo;path&rdquo; but the set of params ultimately depends on
-the chosen resolver.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.ResultRef">ResultRef
-</h3>
-<div>
-<p>ResultRef is a type that represents a reference to a task run result</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>pipelineTask</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>result</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>resultsIndex</code><br/>
-<em>
-int
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>property</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.ResultValue">ResultValue
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineResult">PipelineResult</a>, <a href="#tekton.dev/v1.PipelineRunResult">PipelineRunResult</a>, <a href="#tekton.dev/v1.TaskResult">TaskResult</a>, <a href="#tekton.dev/v1.TaskRunResult">TaskRunResult</a>)
-</p>
-<div>
-<p>ResultValue is a type alias of ParamValue</p>
-</div>
-<h3 id="tekton.dev/v1.ResultsType">ResultsType
-(<code>string</code> alias)</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineResult">PipelineResult</a>, <a href="#tekton.dev/v1.StepResult">StepResult</a>, <a href="#tekton.dev/v1.TaskResult">TaskResult</a>, <a href="#tekton.dev/v1.TaskRunResult">TaskRunResult</a>)
-</p>
-<div>
-<p>ResultsType indicates the type of a result;
+are only available when the beta feature gate is enabled.
+
+
+
+_Appears in:_
+- [PipelineRef](#pipelineref)
+- [Ref](#ref)
+- [TaskRef](#taskref)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `resolver` _[ResolverName](#resolvername)_ | Resolver is the name of the resolver that should perform<br />resolution of the referenced Tekton resource, such as "git". |  | Optional: \{\} <br /> |
+| `params` _[Params](#params)_ | Params contains the parameters used to identify the<br />referenced Tekton resource. Example entries might include<br />"repo" or "path" but the set of params ultimately depends on<br />the chosen resolver. |  | Optional: \{\} <br /> |
+
+
+
+
+
+
+#### ResultsType
+
+_Underlying type:_ _string_
+
+ResultsType indicates the type of a result;
 Used to distinguish between a single string and an array of strings.
 Note that there is ResultType used to find out whether a
 RunResult is from a task result or not, which is different from
-this ResultsType.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Value</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody><tr><td><p>&#34;array&#34;</p></td>
-<td></td>
-</tr><tr><td><p>&#34;object&#34;</p></td>
-<td></td>
-</tr><tr><td><p>&#34;string&#34;</p></td>
-<td></td>
-</tr></tbody>
-</table>
-<h3 id="tekton.dev/v1.RetriesStatus">RetriesStatus
-(<code>[]github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskRunStatus</code> alias)</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.TaskRunStatusFields">TaskRunStatusFields</a>)
-</p>
-<div>
-</div>
-<h3 id="tekton.dev/v1.Sidecar">Sidecar
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.TaskSpec">TaskSpec</a>)
-</p>
-<div>
-<p>Sidecar has nearly the same data structure as Step but does not have the ability to timeout.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Name of the Sidecar specified as a DNS_LABEL.
-Each Sidecar in a Task must have a unique name (DNS_LABEL).
-Cannot be updated.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>image</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Image reference name.
-More info: <a href="https://kubernetes.io/docs/concepts/containers/images">https://kubernetes.io/docs/concepts/containers/images</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>command</code><br/>
-<em>
-[]string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Entrypoint array. Not executed within a shell.
-The image&rsquo;s ENTRYPOINT is used if this is not provided.
-Variable references $(VAR_NAME) are expanded using the Sidecar&rsquo;s environment. If a variable
-cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
-to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. &ldquo;$$(VAR_NAME)&rdquo; will
-produce the string literal &ldquo;$(VAR_NAME)&rdquo;. Escaped references will never be expanded, regardless
-of whether the variable exists or not. Cannot be updated.
-More info: <a href="https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell">https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>args</code><br/>
-<em>
-[]string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Arguments to the entrypoint.
-The image&rsquo;s CMD is used if this is not provided.
-Variable references $(VAR_NAME) are expanded using the Sidecar&rsquo;s environment. If a variable
-cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
-to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. &ldquo;$$(VAR_NAME)&rdquo; will
-produce the string literal &ldquo;$(VAR_NAME)&rdquo;. Escaped references will never be expanded, regardless
-of whether the variable exists or not. Cannot be updated.
-More info: <a href="https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell">https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>workingDir</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Sidecar&rsquo;s working directory.
-If not specified, the container runtime&rsquo;s default will be used, which
-might be configured in the container image.
-Cannot be updated.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ports</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#containerport-v1-core">
-[]Kubernetes core/v1.ContainerPort
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>List of ports to expose from the Sidecar. Exposing a port here gives
-the system additional information about the network connections a
-container uses, but is primarily informational. Not specifying a port here
-DOES NOT prevent that port from being exposed. Any port which is
-listening on the default &ldquo;0.0.0.0&rdquo; address inside a container will be
-accessible from the network.
-Cannot be updated.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>envFrom</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#envfromsource-v1-core">
-[]Kubernetes core/v1.EnvFromSource
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>List of sources to populate environment variables in the Sidecar.
-The keys defined within a source must be a C_IDENTIFIER. All invalid keys
-will be reported as an event when the container is starting. When a key exists in multiple
-sources, the value associated with the last source will take precedence.
-Values defined by an Env with a duplicate key will take precedence.
-Cannot be updated.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>env</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#envvar-v1-core">
-[]Kubernetes core/v1.EnvVar
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>List of environment variables to set in the Sidecar.
-Cannot be updated.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>computeResources</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#resourcerequirements-v1-core">
-Kubernetes core/v1.ResourceRequirements
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ComputeResources required by this Sidecar.
-Cannot be updated.
-More info: <a href="https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/">https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>volumeMounts</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#volumemount-v1-core">
-[]Kubernetes core/v1.VolumeMount
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Volumes to mount into the Sidecar&rsquo;s filesystem.
-Cannot be updated.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>volumeDevices</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#volumedevice-v1-core">
-[]Kubernetes core/v1.VolumeDevice
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>volumeDevices is the list of block devices to be used by the Sidecar.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>livenessProbe</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#probe-v1-core">
-Kubernetes core/v1.Probe
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Periodic probe of Sidecar liveness.
-Container will be restarted if the probe fails.
-Cannot be updated.
-More info: <a href="https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes">https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>readinessProbe</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#probe-v1-core">
-Kubernetes core/v1.Probe
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Periodic probe of Sidecar service readiness.
-Container will be removed from service endpoints if the probe fails.
-Cannot be updated.
-More info: <a href="https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes">https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>startupProbe</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#probe-v1-core">
-Kubernetes core/v1.Probe
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>StartupProbe indicates that the Pod the Sidecar is running in has successfully initialized.
-If specified, no other probes are executed until this completes successfully.
-If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
-This can be used to provide different probe parameters at the beginning of a Pod&rsquo;s lifecycle,
-when it might take a long time to load data or warm a cache, than during steady-state operation.
-This cannot be updated.
-More info: <a href="https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes">https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>lifecycle</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#lifecycle-v1-core">
-Kubernetes core/v1.Lifecycle
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Actions that the management system should take in response to Sidecar lifecycle events.
-Cannot be updated.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>terminationMessagePath</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Optional: Path at which the file to which the Sidecar&rsquo;s termination message
-will be written is mounted into the Sidecar&rsquo;s filesystem.
-Message written is intended to be brief final status, such as an assertion failure message.
-Will be truncated by the node if greater than 4096 bytes. The total message length across
-all containers will be limited to 12kb.
-Defaults to /dev/termination-log.
-Cannot be updated.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>terminationMessagePolicy</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#terminationmessagepolicy-v1-core">
-Kubernetes core/v1.TerminationMessagePolicy
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Indicate how the termination message should be populated. File will use the contents of
-terminationMessagePath to populate the Sidecar status message on both success and failure.
-FallbackToLogsOnError will use the last chunk of Sidecar log output if the termination
-message file is empty and the Sidecar exited with an error.
-The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
-Defaults to File.
-Cannot be updated.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>imagePullPolicy</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#pullpolicy-v1-core">
-Kubernetes core/v1.PullPolicy
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Image pull policy.
-One of Always, Never, IfNotPresent.
-Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
-Cannot be updated.
-More info: <a href="https://kubernetes.io/docs/concepts/containers/images#updating-images">https://kubernetes.io/docs/concepts/containers/images#updating-images</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>securityContext</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#securitycontext-v1-core">
-Kubernetes core/v1.SecurityContext
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>SecurityContext defines the security options the Sidecar should be run with.
-If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
-More info: <a href="https://kubernetes.io/docs/tasks/configure-pod-container/security-context/">https://kubernetes.io/docs/tasks/configure-pod-container/security-context/</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>stdin</code><br/>
-<em>
-bool
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Whether this Sidecar should allocate a buffer for stdin in the container runtime. If this
-is not set, reads from stdin in the Sidecar will always result in EOF.
-Default is false.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>stdinOnce</code><br/>
-<em>
-bool
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Whether the container runtime should close the stdin channel after it has been opened by
-a single attach. When stdin is true the stdin stream will remain open across multiple attach
-sessions. If stdinOnce is set to true, stdin is opened on Sidecar start, is empty until the
-first client attaches to stdin, and then remains open and accepts data until the client disconnects,
-at which time stdin is closed and remains closed until the Sidecar is restarted. If this
-flag is false, a container processes that reads from stdin will never receive an EOF.
-Default is false</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>tty</code><br/>
-<em>
-bool
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Whether this Sidecar should allocate a TTY for itself, also requires &lsquo;stdin&rsquo; to be true.
-Default is false.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>script</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Script is the contents of an executable file to execute.</p>
-<p>If Script is not empty, the Step cannot have an Command or Args.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>workspaces</code><br/>
-<em>
-<a href="#tekton.dev/v1.WorkspaceUsage">
-[]WorkspaceUsage
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>This is an alpha field. You must set the &ldquo;enable-api-fields&rdquo; feature flag to &ldquo;alpha&rdquo;
-for this field to be supported.</p>
-<p>Workspaces is a list of workspaces from the Task that this Sidecar wants
-exclusive access to. Adding a workspace to this list means that any
-other Step or Sidecar that does not also request this Workspace will
-not have access to it.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>restartPolicy</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#containerrestartpolicy-v1-core">
-Kubernetes core/v1.ContainerRestartPolicy
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>RestartPolicy refers to kubernetes RestartPolicy. It can only be set for an
-initContainer and must have it&rsquo;s policy set to &ldquo;Always&rdquo;. It is currently
-left optional to help support Kubernetes versions prior to 1.29 when this feature
-was introduced.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.SidecarState">SidecarState
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.TaskRunStatusFields">TaskRunStatusFields</a>)
-</p>
-<div>
-<p>SidecarState reports the results of running a sidecar in a Task.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>ContainerState</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#containerstate-v1-core">
-Kubernetes core/v1.ContainerState
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>ContainerState</code> are embedded into this type.)
-</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>container</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>imageID</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.SkippedTask">SkippedTask
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineRunStatusFields">PipelineRunStatusFields</a>)
-</p>
-<div>
-<p>SkippedTask is used to describe the Tasks that were skipped due to their When Expressions
+this ResultsType.
+
+
+
+_Appears in:_
+- [StepResult](#stepresult)
+- [TaskResult](#taskresult)
+- [TaskRunResult](#taskrunresult)
+
+| Field | Description |
+| --- | --- |
+| `string` |  |
+| `array` |  |
+| `object` |  |
+
+
+#### RetriesStatus
+
+_Underlying type:_ _[TaskRunStatus](#taskrunstatus)_
+
+
+
+
+
+_Appears in:_
+- [TaskRunStatus](#taskrunstatus)
+- [TaskRunStatusFields](#taskrunstatusfields)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `Status` _[Status](https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Status)_ |  |  |  |
+| `TaskRunStatusFields` _[TaskRunStatusFields](#taskrunstatusfields)_ | TaskRunStatusFields inlines the status fields. |  |  |
+
+
+#### Sidecar
+
+
+
+Sidecar has nearly the same data structure as Step but does not have the ability to timeout.
+
+
+
+_Appears in:_
+- [EmbeddedTask](#embeddedtask)
+- [TaskSpec](#taskspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name of the Sidecar specified as a DNS_LABEL.<br />Each Sidecar in a Task must have a unique name (DNS_LABEL).<br />Cannot be updated. |  |  |
+| `image` _string_ | Image reference name.<br />More info: https://kubernetes.io/docs/concepts/containers/images |  | Optional: \{\} <br /> |
+| `command` _string array_ | Entrypoint array. Not executed within a shell.<br />The image's ENTRYPOINT is used if this is not provided.<br />Variable references $(VAR_NAME) are expanded using the Sidecar's environment. If a variable<br />cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced<br />to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will<br />produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless<br />of whether the variable exists or not. Cannot be updated.<br />More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell |  | Optional: \{\} <br /> |
+| `args` _string array_ | Arguments to the entrypoint.<br />The image's CMD is used if this is not provided.<br />Variable references $(VAR_NAME) are expanded using the Sidecar's environment. If a variable<br />cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced<br />to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will<br />produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless<br />of whether the variable exists or not. Cannot be updated.<br />More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell |  | Optional: \{\} <br /> |
+| `workingDir` _string_ | Sidecar's working directory.<br />If not specified, the container runtime's default will be used, which<br />might be configured in the container image.<br />Cannot be updated. |  | Optional: \{\} <br /> |
+| `ports` _[ContainerPort](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#containerport-v1-core) array_ | List of ports to expose from the Sidecar. Exposing a port here gives<br />the system additional information about the network connections a<br />container uses, but is primarily informational. Not specifying a port here<br />DOES NOT prevent that port from being exposed. Any port which is<br />listening on the default "0.0.0.0" address inside a container will be<br />accessible from the network.<br />Cannot be updated. |  | Optional: \{\} <br /> |
+| `envFrom` _[EnvFromSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#envfromsource-v1-core) array_ | List of sources to populate environment variables in the Sidecar.<br />The keys defined within a source must be a C_IDENTIFIER. All invalid keys<br />will be reported as an event when the container is starting. When a key exists in multiple<br />sources, the value associated with the last source will take precedence.<br />Values defined by an Env with a duplicate key will take precedence.<br />Cannot be updated. |  | Optional: \{\} <br /> |
+| `env` _[EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#envvar-v1-core) array_ | List of environment variables to set in the Sidecar.<br />Cannot be updated. |  | Optional: \{\} <br /> |
+| `computeResources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcerequirements-v1-core)_ | ComputeResources required by this Sidecar.<br />Cannot be updated.<br />More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |  | Optional: \{\} <br /> |
+| `volumeMounts` _[VolumeMount](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#volumemount-v1-core) array_ | Volumes to mount into the Sidecar's filesystem.<br />Cannot be updated. |  | Optional: \{\} <br /> |
+| `volumeDevices` _[VolumeDevice](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#volumedevice-v1-core) array_ | volumeDevices is the list of block devices to be used by the Sidecar. |  | Optional: \{\} <br /> |
+| `livenessProbe` _[Probe](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#probe-v1-core)_ | Periodic probe of Sidecar liveness.<br />Container will be restarted if the probe fails.<br />Cannot be updated.<br />More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes |  | Optional: \{\} <br /> |
+| `readinessProbe` _[Probe](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#probe-v1-core)_ | Periodic probe of Sidecar service readiness.<br />Container will be removed from service endpoints if the probe fails.<br />Cannot be updated.<br />More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes |  | Optional: \{\} <br /> |
+| `startupProbe` _[Probe](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#probe-v1-core)_ | StartupProbe indicates that the Pod the Sidecar is running in has successfully initialized.<br />If specified, no other probes are executed until this completes successfully.<br />If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.<br />This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,<br />when it might take a long time to load data or warm a cache, than during steady-state operation.<br />This cannot be updated.<br />More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes |  | Optional: \{\} <br /> |
+| `lifecycle` _[Lifecycle](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#lifecycle-v1-core)_ | Actions that the management system should take in response to Sidecar lifecycle events.<br />Cannot be updated. |  | Optional: \{\} <br /> |
+| `terminationMessagePath` _string_ | Optional: Path at which the file to which the Sidecar's termination message<br />will be written is mounted into the Sidecar's filesystem.<br />Message written is intended to be brief final status, such as an assertion failure message.<br />Will be truncated by the node if greater than 4096 bytes. The total message length across<br />all containers will be limited to 12kb.<br />Defaults to /dev/termination-log.<br />Cannot be updated. |  | Optional: \{\} <br /> |
+| `terminationMessagePolicy` _[TerminationMessagePolicy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#terminationmessagepolicy-v1-core)_ | Indicate how the termination message should be populated. File will use the contents of<br />terminationMessagePath to populate the Sidecar status message on both success and failure.<br />FallbackToLogsOnError will use the last chunk of Sidecar log output if the termination<br />message file is empty and the Sidecar exited with an error.<br />The log output is limited to 2048 bytes or 80 lines, whichever is smaller.<br />Defaults to File.<br />Cannot be updated. |  | Optional: \{\} <br /> |
+| `imagePullPolicy` _[PullPolicy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#pullpolicy-v1-core)_ | Image pull policy.<br />One of Always, Never, IfNotPresent.<br />Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.<br />Cannot be updated.<br />More info: https://kubernetes.io/docs/concepts/containers/images#updating-images |  | Optional: \{\} <br /> |
+| `securityContext` _[SecurityContext](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#securitycontext-v1-core)_ | SecurityContext defines the security options the Sidecar should be run with.<br />If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.<br />More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ |  | Optional: \{\} <br /> |
+| `stdin` _boolean_ | Whether this Sidecar should allocate a buffer for stdin in the container runtime. If this<br />is not set, reads from stdin in the Sidecar will always result in EOF.<br />Default is false. |  | Optional: \{\} <br /> |
+| `stdinOnce` _boolean_ | Whether the container runtime should close the stdin channel after it has been opened by<br />a single attach. When stdin is true the stdin stream will remain open across multiple attach<br />sessions. If stdinOnce is set to true, stdin is opened on Sidecar start, is empty until the<br />first client attaches to stdin, and then remains open and accepts data until the client disconnects,<br />at which time stdin is closed and remains closed until the Sidecar is restarted. If this<br />flag is false, a container processes that reads from stdin will never receive an EOF.<br />Default is false |  | Optional: \{\} <br /> |
+| `tty` _boolean_ | Whether this Sidecar should allocate a TTY for itself, also requires 'stdin' to be true.<br />Default is false. |  | Optional: \{\} <br /> |
+| `script` _string_ | Script is the contents of an executable file to execute.<br />If Script is not empty, the Step cannot have an Command or Args. |  | Optional: \{\} <br /> |
+| `workspaces` _[WorkspaceUsage](#workspaceusage) array_ | This is an alpha field. You must set the "enable-api-fields" feature flag to "alpha"<br />for this field to be supported.<br />Workspaces is a list of workspaces from the Task that this Sidecar wants<br />exclusive access to. Adding a workspace to this list means that any<br />other Step or Sidecar that does not also request this Workspace will<br />not have access to it. |  | Optional: \{\} <br /> |
+| `restartPolicy` _[ContainerRestartPolicy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#containerrestartpolicy-v1-core)_ | RestartPolicy refers to kubernetes RestartPolicy. It can only be set for an<br />initContainer and must have it's policy set to "Always". It is currently<br />left optional to help support Kubernetes versions prior to 1.29 when this feature<br />was introduced. |  | Optional: \{\} <br /> |
+
+
+#### SidecarState
+
+
+
+SidecarState reports the results of running a sidecar in a Task.
+
+
+
+_Appears in:_
+- [TaskRunStatus](#taskrunstatus)
+- [TaskRunStatusFields](#taskrunstatusfields)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `waiting` _[ContainerStateWaiting](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#containerstatewaiting-v1-core)_ | Details about a waiting container |  | Optional: \{\} <br /> |
+| `running` _[ContainerStateRunning](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#containerstaterunning-v1-core)_ | Details about a running container |  | Optional: \{\} <br /> |
+| `terminated` _[ContainerStateTerminated](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#containerstateterminated-v1-core)_ | Details about a terminated container |  | Optional: \{\} <br /> |
+| `name` _string_ |  |  |  |
+| `container` _string_ |  |  |  |
+| `imageID` _string_ |  |  |  |
+
+
+#### SkippedTask
+
+
+
+SkippedTask is used to describe the Tasks that were skipped due to their When Expressions
 evaluating to False. This is a struct because we are looking into including more details
-about the When Expressions that caused this Task to be skipped.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Name is the Pipeline Task name</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>reason</code><br/>
-<em>
-<a href="#tekton.dev/v1.SkippingReason">
-SkippingReason
-</a>
-</em>
-</td>
-<td>
-<p>Reason is the cause of the PipelineTask being skipped.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>whenExpressions</code><br/>
-<em>
-<a href="#tekton.dev/v1.WhenExpression">
-[]WhenExpression
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>WhenExpressions is the list of checks guarding the execution of the PipelineTask</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.SkippingReason">SkippingReason
-(<code>string</code> alias)</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.SkippedTask">SkippedTask</a>)
-</p>
-<div>
-<p>SkippingReason explains why a PipelineTask was skipped.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Value</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody><tr><td><p>&#34;Matrix Parameters have an empty array&#34;</p></td>
-<td><p>EmptyArrayInMatrixParams means the task was skipped because Matrix parameters contain empty array.</p>
-</td>
-</tr><tr><td><p>&#34;PipelineRun Finally timeout has been reached&#34;</p></td>
-<td><p>FinallyTimedOutSkip means the task was skipped because the PipelineRun has passed its Timeouts.Finally.</p>
-</td>
-</tr><tr><td><p>&#34;PipelineRun was gracefully cancelled&#34;</p></td>
-<td><p>GracefullyCancelledSkip means the task was skipped because the pipeline run has been gracefully cancelled</p>
-</td>
-</tr><tr><td><p>&#34;PipelineRun was gracefully stopped&#34;</p></td>
-<td><p>GracefullyStoppedSkip means the task was skipped because the pipeline run has been gracefully stopped</p>
-</td>
-</tr><tr><td><p>&#34;Results were missing&#34;</p></td>
-<td><p>MissingResultsSkip means the task was skipped because it&rsquo;s missing necessary results</p>
-</td>
-</tr><tr><td><p>&#34;None&#34;</p></td>
-<td><p>None means the task was not skipped</p>
-</td>
-</tr><tr><td><p>&#34;Parent Tasks were skipped&#34;</p></td>
-<td><p>ParentTasksSkip means the task was skipped because its parent was skipped</p>
-</td>
-</tr><tr><td><p>&#34;PipelineRun timeout has been reached&#34;</p></td>
-<td><p>PipelineTimedOutSkip means the task was skipped because the PipelineRun has passed its overall timeout.</p>
-</td>
-</tr><tr><td><p>&#34;PipelineRun was stopping&#34;</p></td>
-<td><p>StoppingSkip means the task was skipped because the pipeline run is stopping</p>
-</td>
-</tr><tr><td><p>&#34;PipelineRun Tasks timeout has been reached&#34;</p></td>
-<td><p>TasksTimedOutSkip means the task was skipped because the PipelineRun has passed its Timeouts.Tasks.</p>
-</td>
-</tr><tr><td><p>&#34;When Expressions evaluated to false&#34;</p></td>
-<td><p>WhenExpressionsSkip means the task was skipped due to at least one of its when expressions evaluating to false</p>
-</td>
-</tr></tbody>
-</table>
-<h3 id="tekton.dev/v1.Step">Step
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.TaskSpec">TaskSpec</a>)
-</p>
-<div>
-<p>Step runs a subcomponent of a Task</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Name of the Step specified as a DNS_LABEL.
-Each Step in a Task must have a unique name.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>displayName</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>DisplayName is a user-facing name of the step that may be
-used to populate a UI.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>image</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Docker image name.
-More info: <a href="https://kubernetes.io/docs/concepts/containers/images">https://kubernetes.io/docs/concepts/containers/images</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>command</code><br/>
-<em>
-[]string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Entrypoint array. Not executed within a shell.
-The image&rsquo;s ENTRYPOINT is used if this is not provided.
-Variable references $(VAR_NAME) are expanded using the container&rsquo;s environment. If a variable
-cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
-to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. &ldquo;$$(VAR_NAME)&rdquo; will
-produce the string literal &ldquo;$(VAR_NAME)&rdquo;. Escaped references will never be expanded, regardless
-of whether the variable exists or not. Cannot be updated.
-More info: <a href="https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell">https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>args</code><br/>
-<em>
-[]string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Arguments to the entrypoint.
-The image&rsquo;s CMD is used if this is not provided.
-Variable references $(VAR_NAME) are expanded using the container&rsquo;s environment. If a variable
-cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
-to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. &ldquo;$$(VAR_NAME)&rdquo; will
-produce the string literal &ldquo;$(VAR_NAME)&rdquo;. Escaped references will never be expanded, regardless
-of whether the variable exists or not. Cannot be updated.
-More info: <a href="https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell">https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>workingDir</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Step&rsquo;s working directory.
-If not specified, the container runtime&rsquo;s default will be used, which
-might be configured in the container image.
-Cannot be updated.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>envFrom</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#envfromsource-v1-core">
-[]Kubernetes core/v1.EnvFromSource
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>List of sources to populate environment variables in the Step.
-The keys defined within a source must be a C_IDENTIFIER. All invalid keys
-will be reported as an event when the Step is starting. When a key exists in multiple
-sources, the value associated with the last source will take precedence.
-Values defined by an Env with a duplicate key will take precedence.
-Cannot be updated.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>env</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#envvar-v1-core">
-[]Kubernetes core/v1.EnvVar
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>List of environment variables to set in the Step.
-Cannot be updated.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>computeResources</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#resourcerequirements-v1-core">
-Kubernetes core/v1.ResourceRequirements
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ComputeResources required by this Step.
-Cannot be updated.
-More info: <a href="https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/">https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>volumeMounts</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#volumemount-v1-core">
-[]Kubernetes core/v1.VolumeMount
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Volumes to mount into the Step&rsquo;s filesystem.
-Cannot be updated.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>volumeDevices</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#volumedevice-v1-core">
-[]Kubernetes core/v1.VolumeDevice
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>volumeDevices is the list of block devices to be used by the Step.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>imagePullPolicy</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#pullpolicy-v1-core">
-Kubernetes core/v1.PullPolicy
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Image pull policy.
-One of Always, Never, IfNotPresent.
-Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
-Cannot be updated.
-More info: <a href="https://kubernetes.io/docs/concepts/containers/images#updating-images">https://kubernetes.io/docs/concepts/containers/images#updating-images</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>securityContext</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#securitycontext-v1-core">
-Kubernetes core/v1.SecurityContext
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>SecurityContext defines the security options the Step should be run with.
-If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
-More info: <a href="https://kubernetes.io/docs/tasks/configure-pod-container/security-context/">https://kubernetes.io/docs/tasks/configure-pod-container/security-context/</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>script</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Script is the contents of an executable file to execute.</p>
-<p>If Script is not empty, the Step cannot have an Command and the Args will be passed to the Script.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>timeout</code><br/>
-<em>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
-Kubernetes meta/v1.Duration
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Timeout is the time after which the step times out. Defaults to never.
-Refer to Go&rsquo;s ParseDuration documentation for expected format: <a href="https://golang.org/pkg/time/#ParseDuration">https://golang.org/pkg/time/#ParseDuration</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>workspaces</code><br/>
-<em>
-<a href="#tekton.dev/v1.WorkspaceUsage">
-[]WorkspaceUsage
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>This is an alpha field. You must set the &ldquo;enable-api-fields&rdquo; feature flag to &ldquo;alpha&rdquo;
-for this field to be supported.</p>
-<p>Workspaces is a list of workspaces from the Task that this Step wants
-exclusive access to. Adding a workspace to this list means that any
-other Step or Sidecar that does not also request this Workspace will
-not have access to it.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>onError</code><br/>
-<em>
-<a href="#tekton.dev/v1.OnErrorType">
-OnErrorType
-</a>
-</em>
-</td>
-<td>
-<p>OnError defines the exiting behavior of a container on error
-can be set to [ continue | stopAndFail ]</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>stdoutConfig</code><br/>
-<em>
-<a href="#tekton.dev/v1.StepOutputConfig">
-StepOutputConfig
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Stores configuration for the stdout stream of the step.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>stderrConfig</code><br/>
-<em>
-<a href="#tekton.dev/v1.StepOutputConfig">
-StepOutputConfig
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Stores configuration for the stderr stream of the step.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ref</code><br/>
-<em>
-<a href="#tekton.dev/v1.Ref">
-Ref
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Contains the reference to an existing StepAction.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>params</code><br/>
-<em>
-<a href="#tekton.dev/v1.Params">
-Params
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Params declares parameters passed to this step action.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>results</code><br/>
-<em>
-<a href="#tekton.dev/v1.StepResult">
-[]StepResult
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Results declares StepResults produced by the Step.</p>
-<p>It can be used in an inlined Step when used to store Results to $(step.results.resultName.path).
-It cannot be used when referencing StepActions using [v1.Step.Ref].
-The Results declared by the StepActions will be stored here instead.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>when</code><br/>
-<em>
-<a href="#tekton.dev/v1.StepWhenExpressions">
-StepWhenExpressions
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>When is a list of when expressions that need to be true for the task to run</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.StepOutputConfig">StepOutputConfig
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.Step">Step</a>)
-</p>
-<div>
-<p>StepOutputConfig stores configuration for a step output stream.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>path</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Path to duplicate stdout stream to on container&rsquo;s local filesystem.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.StepResult">StepResult
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.Step">Step</a>, <a href="#tekton.dev/v1alpha1.StepActionSpec">StepActionSpec</a>, <a href="#tekton.dev/v1beta1.Step">Step</a>, <a href="#tekton.dev/v1beta1.StepActionSpec">StepActionSpec</a>)
-</p>
-<div>
-<p>StepResult used to describe the Results of a Step.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Name the given name</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>type</code><br/>
-<em>
-<a href="#tekton.dev/v1.ResultsType">
-ResultsType
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>The possible types are &lsquo;string&rsquo;, &lsquo;array&rsquo;, and &lsquo;object&rsquo;, with &lsquo;string&rsquo; as the default.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>properties</code><br/>
-<em>
-<a href="#tekton.dev/v1.PropertySpec">
-map[string]github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PropertySpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Properties is the JSON Schema properties to support key-value pairs results.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>description</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Description is a human-readable description of the result</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.StepState">StepState
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.TaskRunStatusFields">TaskRunStatusFields</a>)
-</p>
-<div>
-<p>StepState reports the results of running a step in a Task.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>ContainerState</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#containerstate-v1-core">
-Kubernetes core/v1.ContainerState
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>ContainerState</code> are embedded into this type.)
-</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>container</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>imageID</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>results</code><br/>
-<em>
-<a href="#tekton.dev/v1.TaskRunStepResult">
-[]TaskRunStepResult
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>provenance</code><br/>
-<em>
-<a href="#tekton.dev/v1.Provenance">
-Provenance
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>terminationReason</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>inputs</code><br/>
-<em>
-<a href="#tekton.dev/v1.TaskRunStepArtifact">
-[]TaskRunStepArtifact
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>outputs</code><br/>
-<em>
-<a href="#tekton.dev/v1.TaskRunStepArtifact">
-[]TaskRunStepArtifact
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.StepTemplate">StepTemplate
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.TaskSpec">TaskSpec</a>)
-</p>
-<div>
-<p>StepTemplate is a template for a Step</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>image</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Image reference name.
-More info: <a href="https://kubernetes.io/docs/concepts/containers/images">https://kubernetes.io/docs/concepts/containers/images</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>command</code><br/>
-<em>
-[]string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Entrypoint array. Not executed within a shell.
-The image&rsquo;s ENTRYPOINT is used if this is not provided.
-Variable references $(VAR_NAME) are expanded using the Step&rsquo;s environment. If a variable
-cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
-to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. &ldquo;$$(VAR_NAME)&rdquo; will
-produce the string literal &ldquo;$(VAR_NAME)&rdquo;. Escaped references will never be expanded, regardless
-of whether the variable exists or not. Cannot be updated.
-More info: <a href="https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell">https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>args</code><br/>
-<em>
-[]string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Arguments to the entrypoint.
-The image&rsquo;s CMD is used if this is not provided.
-Variable references $(VAR_NAME) are expanded using the Step&rsquo;s environment. If a variable
-cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
-to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. &ldquo;$$(VAR_NAME)&rdquo; will
-produce the string literal &ldquo;$(VAR_NAME)&rdquo;. Escaped references will never be expanded, regardless
-of whether the variable exists or not. Cannot be updated.
-More info: <a href="https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell">https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>workingDir</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Step&rsquo;s working directory.
-If not specified, the container runtime&rsquo;s default will be used, which
-might be configured in the container image.
-Cannot be updated.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>envFrom</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#envfromsource-v1-core">
-[]Kubernetes core/v1.EnvFromSource
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>List of sources to populate environment variables in the Step.
-The keys defined within a source must be a C_IDENTIFIER. All invalid keys
-will be reported as an event when the Step is starting. When a key exists in multiple
-sources, the value associated with the last source will take precedence.
-Values defined by an Env with a duplicate key will take precedence.
-Cannot be updated.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>env</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#envvar-v1-core">
-[]Kubernetes core/v1.EnvVar
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>List of environment variables to set in the Step.
-Cannot be updated.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>computeResources</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#resourcerequirements-v1-core">
-Kubernetes core/v1.ResourceRequirements
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ComputeResources required by this Step.
-Cannot be updated.
-More info: <a href="https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/">https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>volumeMounts</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#volumemount-v1-core">
-[]Kubernetes core/v1.VolumeMount
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Volumes to mount into the Step&rsquo;s filesystem.
-Cannot be updated.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>volumeDevices</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#volumedevice-v1-core">
-[]Kubernetes core/v1.VolumeDevice
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>volumeDevices is the list of block devices to be used by the Step.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>imagePullPolicy</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#pullpolicy-v1-core">
-Kubernetes core/v1.PullPolicy
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Image pull policy.
-One of Always, Never, IfNotPresent.
-Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
-Cannot be updated.
-More info: <a href="https://kubernetes.io/docs/concepts/containers/images#updating-images">https://kubernetes.io/docs/concepts/containers/images#updating-images</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>securityContext</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#securitycontext-v1-core">
-Kubernetes core/v1.SecurityContext
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>SecurityContext defines the security options the Step should be run with.
-If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
-More info: <a href="https://kubernetes.io/docs/tasks/configure-pod-container/security-context/">https://kubernetes.io/docs/tasks/configure-pod-container/security-context/</a></p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.StepWhenExpressions">StepWhenExpressions
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.Step">Step</a>)
-</p>
-<div>
-</div>
-<h3 id="tekton.dev/v1.TaskBreakpoints">TaskBreakpoints
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.TaskRunDebug">TaskRunDebug</a>)
-</p>
-<div>
-<p>TaskBreakpoints defines the breakpoint config for a particular Task</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>onFailure</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>if enabled, pause TaskRun on failure of a step
-failed step will not exit</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>beforeSteps</code><br/>
-<em>
-[]string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.TaskKind">TaskKind
-(<code>string</code> alias)</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.TaskRef">TaskRef</a>)
-</p>
-<div>
-<p>TaskKind defines the type of Task used by the pipeline.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Value</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody><tr><td><p>&#34;Task&#34;</p></td>
-<td><p>NamespacedTaskKind indicates that the task type has a namespaced scope.</p>
-</td>
-</tr></tbody>
-</table>
-<h3 id="tekton.dev/v1.TaskRef">TaskRef
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineTask">PipelineTask</a>, <a href="#tekton.dev/v1.TaskRunSpec">TaskRunSpec</a>)
-</p>
-<div>
-<p>TaskRef can be used to refer to a specific instance of a task.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Name of the referent; More info: <a href="http://kubernetes.io/docs/user-guide/identifiers#names">http://kubernetes.io/docs/user-guide/identifiers#names</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code><br/>
-<em>
-<a href="#tekton.dev/v1.TaskKind">
-TaskKind
-</a>
-</em>
-</td>
-<td>
-<p>TaskKind indicates the Kind of the Task:
-1. Namespaced Task when Kind is set to &ldquo;Task&rdquo;. If Kind is &ldquo;&rdquo;, it defaults to &ldquo;Task&rdquo;.
-2. Custom Task when Kind is non-empty and APIVersion is non-empty</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>apiVersion</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>API version of the referent
-Note: A Task with non-empty APIVersion and Kind is considered a Custom Task</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ResolverRef</code><br/>
-<em>
-<a href="#tekton.dev/v1.ResolverRef">
-ResolverRef
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ResolverRef allows referencing a Task in a remote location
-like a git repo. This field is only supported when the alpha
-feature gate is enabled.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.TaskResult">TaskResult
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.TaskSpec">TaskSpec</a>)
-</p>
-<div>
-<p>TaskResult used to describe the results of a task</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Name the given name</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>type</code><br/>
-<em>
-<a href="#tekton.dev/v1.ResultsType">
-ResultsType
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Type is the user-specified type of the result. The possible type
-is currently &ldquo;string&rdquo; and will support &ldquo;array&rdquo; in following work.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>properties</code><br/>
-<em>
-<a href="#tekton.dev/v1.PropertySpec">
-map[string]github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PropertySpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Properties is the JSON Schema properties to support key-value pairs results.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>description</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Description is a human-readable description of the result</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>value</code><br/>
-<em>
-<a href="#tekton.dev/v1.ResultValue">
-ResultValue
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Value the expression used to retrieve the value of the result from an underlying Step.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.TaskRunDebug">TaskRunDebug
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.TaskRunSpec">TaskRunSpec</a>)
-</p>
-<div>
-<p>TaskRunDebug defines the breakpoint config for a particular TaskRun</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>breakpoints</code><br/>
-<em>
-<a href="#tekton.dev/v1.TaskBreakpoints">
-TaskBreakpoints
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.TaskRunInputs">TaskRunInputs
-</h3>
-<div>
-<p>TaskRunInputs holds the input values that this task was invoked with.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>params</code><br/>
-<em>
-<a href="#tekton.dev/v1.Params">
-Params
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.TaskRunReason">TaskRunReason
-(<code>string</code> alias)</h3>
-<div>
-<p>TaskRunReason is an enum used to store all TaskRun reason for
-the Succeeded condition that are controlled by the TaskRun itself. Failure
-reasons that emerge from underlying resources are not included here</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Value</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody><tr><td><p>&#34;TaskRunCancelled&#34;</p></td>
-<td><p>TaskRunReasonCancelled is the reason set when the TaskRun is cancelled by the user</p>
-</td>
-</tr><tr><td><p>&#34;CreateContainerConfigError&#34;</p></td>
-<td><p>TaskRunReasonCreateContainerConfigError is the reason set when the step of a task fails due to config error (e.g., missing ConfigMap or Secret)</p>
-</td>
-</tr><tr><td><p>&#34;Failed&#34;</p></td>
-<td><p>TaskRunReasonFailed is the reason set when the TaskRun completed with a failure</p>
-</td>
-</tr><tr><td><p>&#34;TaskRunResolutionFailed&#34;</p></td>
-<td><p>TaskRunReasonFailedResolution indicated that the reason for failure status is
-that references within the TaskRun could not be resolved</p>
-</td>
-</tr><tr><td><p>&#34;TaskRunValidationFailed&#34;</p></td>
-<td><p>TaskRunReasonFailedValidation indicated that the reason for failure status is
-that taskrun failed runtime validation</p>
-</td>
-</tr><tr><td><p>&#34;FailureIgnored&#34;</p></td>
-<td><p>TaskRunReasonFailureIgnored is the reason set when the Taskrun has failed due to pod execution error and the failure is ignored for the owning PipelineRun.
-TaskRuns failed due to reconciler/validation error should not use this reason.</p>
-</td>
-</tr><tr><td><p>&#34;TaskRunImagePullFailed&#34;</p></td>
-<td><p>TaskRunReasonImagePullFailed is the reason set when the step of a task fails due to image not being pulled</p>
-</td>
-</tr><tr><td><p>&#34;InitContainerFailed&#34;</p></td>
-<td><p>TaskRunReasonInitContainerFailed indicates an internal Tekton init
-container (prepare, place-scripts, working-dir-initializer) failed
-(non-OOM), e.g., due to node memory pressure or runtime errors.</p>
-</td>
-</tr><tr><td><p>&#34;InitContainerOOM&#34;</p></td>
-<td><p>TaskRunReasonInitContainerOOM indicates an internal Tekton init
-container (prepare, place-scripts, working-dir-initializer) was
-killed due to running out of memory (OOMKilled).</p>
-</td>
-</tr><tr><td><p>&#34;InvalidParamValue&#34;</p></td>
-<td><p>TaskRunReasonInvalidParamValue indicates that the TaskRun Param input value is not allowed.</p>
-</td>
-</tr><tr><td><p>&#34;TaskRunPending&#34;</p></td>
-<td><p>TaskRunReasonPending is the reason set when the TaskRun is in the pending state</p>
-</td>
-</tr><tr><td><p>&#34;PodCreationFailed&#34;</p></td>
-<td><p>TaskRunReasonPodCreationFailed is the reason set when the pod backing the TaskRun fails to be created (e.g., CreateContainerError)</p>
-</td>
-</tr><tr><td><p>&#34;PodEvicted&#34;</p></td>
-<td><p>TaskRunReasonPodEvicted indicates that the TaskRun&rsquo;s pod was evicted
-(e.g., due to exceeding ephemeral storage limits or node pressure).</p>
-</td>
-</tr><tr><td><p>&#34;ResourceVerificationFailed&#34;</p></td>
-<td><p>TaskRunReasonResourceVerificationFailed indicates that the task fails the trusted resource verification,
-it could be the content has changed, signature is invalid or public key is invalid</p>
-</td>
-</tr><tr><td><p>&#34;TaskRunResultLargerThanAllowedLimit&#34;</p></td>
-<td><p>TaskRunReasonResultLargerThanAllowedLimit is the reason set when one of the results exceeds its maximum allowed limit of 1 KB</p>
-</td>
-</tr><tr><td><p>&#34;Running&#34;</p></td>
-<td><p>TaskRunReasonRunning is the reason set when the TaskRun is running</p>
-</td>
-</tr><tr><td><p>&#34;SidecarFailed&#34;</p></td>
-<td><p>TaskRunReasonSidecarFailed indicates a sidecar container failed
-(non-OOM), e.g., bad image or crash.</p>
-</td>
-</tr><tr><td><p>&#34;SidecarOOM&#34;</p></td>
-<td><p>TaskRunReasonSidecarOOM indicates a sidecar container was killed due
-to running out of memory (OOMKilled).</p>
-</td>
-</tr><tr><td><p>&#34;Started&#34;</p></td>
-<td><p>TaskRunReasonStarted is the reason set when the TaskRun has just started</p>
-</td>
-</tr><tr><td><p>&#34;StepFailed&#34;</p></td>
-<td><p>TaskRunReasonStepFailed indicates a step container failed (non-OOM),
-e.g., bad image, crash, or non-zero exit code.</p>
-</td>
-</tr><tr><td><p>&#34;StepOOM&#34;</p></td>
-<td><p>TaskRunReasonStepOOM indicates a step container was killed due to
-running out of memory (OOMKilled).</p>
-</td>
-</tr><tr><td><p>&#34;TaskRunStopSidecarFailed&#34;</p></td>
-<td><p>TaskRunReasonStopSidecarFailed indicates that the sidecar is not properly stopped.</p>
-</td>
-</tr><tr><td><p>&#34;Succeeded&#34;</p></td>
-<td><p>TaskRunReasonSuccessful is the reason set when the TaskRun completed successfully</p>
-</td>
-</tr><tr><td><p>&#34;TaskValidationFailed&#34;</p></td>
-<td><p>TaskRunReasonTaskFailedValidation indicated that the reason for failure status is
-that task failed runtime validation</p>
-</td>
-</tr><tr><td><p>&#34;TaskRunTimeout&#34;</p></td>
-<td><p>TaskRunReasonTimedOut is the reason set when one TaskRun execution has timed out</p>
-</td>
-</tr><tr><td><p>&#34;ToBeRetried&#34;</p></td>
-<td><p>TaskRunReasonToBeRetried is the reason set when the last TaskRun execution failed, and will be retried</p>
-</td>
-</tr></tbody>
-</table>
-<h3 id="tekton.dev/v1.TaskRunResult">TaskRunResult
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.TaskRunStatusFields">TaskRunStatusFields</a>)
-</p>
-<div>
-<p>TaskRunResult used to describe the results of a task</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Name the given name</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>type</code><br/>
-<em>
-<a href="#tekton.dev/v1.ResultsType">
-ResultsType
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Type is the user-specified type of the result. The possible type
-is currently &ldquo;string&rdquo; and will support &ldquo;array&rdquo; in following work.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>value</code><br/>
-<em>
-<a href="#tekton.dev/v1.ResultValue">
-ResultValue
-</a>
-</em>
-</td>
-<td>
-<p>Value the given value of the result</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.TaskRunSidecarSpec">TaskRunSidecarSpec
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineTaskRunSpec">PipelineTaskRunSpec</a>, <a href="#tekton.dev/v1.TaskRunSpec">TaskRunSpec</a>)
-</p>
-<div>
-<p>TaskRunSidecarSpec is used to override the values of a Sidecar in the corresponding Task.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>The name of the Sidecar to override.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>computeResources</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#resourcerequirements-v1-core">
-Kubernetes core/v1.ResourceRequirements
-</a>
-</em>
-</td>
-<td>
-<p>The resource requirements to apply to the Sidecar.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.TaskRunSpec">TaskRunSpec
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.TaskRun">TaskRun</a>)
-</p>
-<div>
-<p>TaskRunSpec defines the desired state of TaskRun</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>debug</code><br/>
-<em>
-<a href="#tekton.dev/v1.TaskRunDebug">
-TaskRunDebug
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-<tr>
-<td>
-<code>params</code><br/>
-<em>
-<a href="#tekton.dev/v1.Params">
-Params
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-<tr>
-<td>
-<code>serviceAccountName</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-<tr>
-<td>
-<code>taskRef</code><br/>
-<em>
-<a href="#tekton.dev/v1.TaskRef">
-TaskRef
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>no more than one of the TaskRef and TaskSpec may be specified.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>taskSpec</code><br/>
-<em>
-<a href="#tekton.dev/v1.TaskSpec">
-TaskSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Specifying TaskSpec can be disabled by setting
-<code>disable-inline-spec</code> feature flag.
-See Task.spec (API version: tekton.dev/v1)</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code><br/>
-<em>
-<a href="#tekton.dev/v1.TaskRunSpecStatus">
-TaskRunSpecStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Used for cancelling a TaskRun (and maybe more later on)</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>statusMessage</code><br/>
-<em>
-<a href="#tekton.dev/v1.TaskRunSpecStatusMessage">
-TaskRunSpecStatusMessage
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Status message for cancellation.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>retries</code><br/>
-<em>
-int
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Retries represents how many times this TaskRun should be retried in the event of task failure.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>timeout</code><br/>
-<em>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
-Kubernetes meta/v1.Duration
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Time after which one retry attempt times out. Defaults to 1 hour.
-Refer Go&rsquo;s ParseDuration documentation for expected format: <a href="https://golang.org/pkg/time/#ParseDuration">https://golang.org/pkg/time/#ParseDuration</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>podTemplate</code><br/>
-<em>
-<a href="#tekton.dev/unversioned.PodTemplate">
-PodTemplate
-</a>
-</em>
-</td>
-<td>
-<p>PodTemplate holds pod specific configuration</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>workspaces</code><br/>
-<em>
-<a href="#tekton.dev/v1.WorkspaceBinding">
-[]WorkspaceBinding
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Workspaces is a list of WorkspaceBindings from volumes to workspaces.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>stepSpecs</code><br/>
-<em>
-<a href="#tekton.dev/v1.TaskRunStepSpec">
-[]TaskRunStepSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Specs to apply to Steps in this TaskRun.
-If a field is specified in both a Step and a StepSpec,
-the value from the StepSpec will be used.
-This field is only supported when the alpha feature gate is enabled.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>sidecarSpecs</code><br/>
-<em>
-<a href="#tekton.dev/v1.TaskRunSidecarSpec">
-[]TaskRunSidecarSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Specs to apply to Sidecars in this TaskRun.
-If a field is specified in both a Sidecar and a SidecarSpec,
-the value from the SidecarSpec will be used.
-This field is only supported when the alpha feature gate is enabled.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>computeResources</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#resourcerequirements-v1-core">
-Kubernetes core/v1.ResourceRequirements
-</a>
-</em>
-</td>
-<td>
-<p>Compute resources to use for this TaskRun</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>managedBy</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ManagedBy indicates which controller is responsible for reconciling
-this resource. If unset or set to &ldquo;tekton.dev/pipeline&rdquo;, the default
-Tekton controller will manage this resource.
-This field is immutable.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.TaskRunSpecStatus">TaskRunSpecStatus
-(<code>string</code> alias)</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.TaskRunSpec">TaskRunSpec</a>)
-</p>
-<div>
-<p>TaskRunSpecStatus defines the TaskRun spec status the user can provide</p>
-</div>
-<h3 id="tekton.dev/v1.TaskRunSpecStatusMessage">TaskRunSpecStatusMessage
-(<code>string</code> alias)</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.TaskRunSpec">TaskRunSpec</a>)
-</p>
-<div>
-<p>TaskRunSpecStatusMessage defines human readable status messages for the TaskRun.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Value</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody><tr><td><p>&#34;TaskRun cancelled as the PipelineRun it belongs to has been cancelled.&#34;</p></td>
-<td><p>TaskRunCancelledByPipelineMsg indicates that the PipelineRun of which this
-TaskRun was a part of has been cancelled.</p>
-</td>
-</tr><tr><td><p>&#34;TaskRun cancelled as the PipelineRun it belongs to has timed out.&#34;</p></td>
-<td><p>TaskRunCancelledByPipelineTimeoutMsg indicates that the TaskRun was cancelled because the PipelineRun running it timed out.</p>
-</td>
-</tr></tbody>
-</table>
-<h3 id="tekton.dev/v1.TaskRunStatus">TaskRunStatus
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.TaskRun">TaskRun</a>, <a href="#tekton.dev/v1.PipelineRunTaskRunStatus">PipelineRunTaskRunStatus</a>)
-</p>
-<div>
-<p>TaskRunStatus defines the observed state of TaskRun</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>Status</code><br/>
-<em>
-<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Status">
-knative.dev/pkg/apis/duck/v1.Status
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>Status</code> are embedded into this type.)
-</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>TaskRunStatusFields</code><br/>
-<em>
-<a href="#tekton.dev/v1.TaskRunStatusFields">
-TaskRunStatusFields
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>TaskRunStatusFields</code> are embedded into this type.)
-</p>
-<p>TaskRunStatusFields inlines the status fields.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.TaskRunStatusFields">TaskRunStatusFields
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.TaskRunStatus">TaskRunStatus</a>)
-</p>
-<div>
-<p>TaskRunStatusFields holds the fields of TaskRun&rsquo;s status.  This is defined
+about the When Expressions that caused this Task to be skipped.
+
+
+
+_Appears in:_
+- [PipelineRunStatus](#pipelinerunstatus)
+- [PipelineRunStatusFields](#pipelinerunstatusfields)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name is the Pipeline Task name |  |  |
+| `reason` _[SkippingReason](#skippingreason)_ | Reason is the cause of the PipelineTask being skipped. |  |  |
+| `whenExpressions` _[WhenExpression](#whenexpression) array_ | WhenExpressions is the list of checks guarding the execution of the PipelineTask |  | Optional: \{\} <br /> |
+
+
+#### SkippingReason
+
+_Underlying type:_ _string_
+
+SkippingReason explains why a PipelineTask was skipped.
+
+
+
+_Appears in:_
+- [SkippedTask](#skippedtask)
+
+| Field | Description |
+| --- | --- |
+| `When Expressions evaluated to false` | WhenExpressionsSkip means the task was skipped due to at least one of its when expressions evaluating to false<br /> |
+| `Parent Tasks were skipped` | ParentTasksSkip means the task was skipped because its parent was skipped<br /> |
+| `PipelineRun was stopping` | StoppingSkip means the task was skipped because the pipeline run is stopping<br /> |
+| `PipelineRun was gracefully cancelled` | GracefullyCancelledSkip means the task was skipped because the pipeline run has been gracefully cancelled<br /> |
+| `PipelineRun was gracefully stopped` | GracefullyStoppedSkip means the task was skipped because the pipeline run has been gracefully stopped<br /> |
+| `Results were missing` | MissingResultsSkip means the task was skipped because it's missing necessary results<br /> |
+| `PipelineRun timeout has been reached` | PipelineTimedOutSkip means the task was skipped because the PipelineRun has passed its overall timeout.<br /> |
+| `PipelineRun Tasks timeout has been reached` | TasksTimedOutSkip means the task was skipped because the PipelineRun has passed its Timeouts.Tasks.<br /> |
+| `PipelineRun Finally timeout has been reached` | FinallyTimedOutSkip means the task was skipped because the PipelineRun has passed its Timeouts.Finally.<br /> |
+| `Matrix Parameters have an empty array` | EmptyArrayInMatrixParams means the task was skipped because Matrix parameters contain empty array.<br /> |
+| `None` | None means the task was not skipped<br /> |
+
+
+#### Step
+
+
+
+Step runs a subcomponent of a Task
+
+
+
+_Appears in:_
+- [EmbeddedTask](#embeddedtask)
+- [TaskSpec](#taskspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name of the Step specified as a DNS_LABEL.<br />Each Step in a Task must have a unique name. |  |  |
+| `displayName` _string_ | DisplayName is a user-facing name of the step that may be<br />used to populate a UI. |  | Optional: \{\} <br /> |
+| `image` _string_ | Docker image name.<br />More info: https://kubernetes.io/docs/concepts/containers/images |  | Optional: \{\} <br /> |
+| `command` _string array_ | Entrypoint array. Not executed within a shell.<br />The image's ENTRYPOINT is used if this is not provided.<br />Variable references $(VAR_NAME) are expanded using the container's environment. If a variable<br />cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced<br />to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will<br />produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless<br />of whether the variable exists or not. Cannot be updated.<br />More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell |  | Optional: \{\} <br /> |
+| `args` _string array_ | Arguments to the entrypoint.<br />The image's CMD is used if this is not provided.<br />Variable references $(VAR_NAME) are expanded using the container's environment. If a variable<br />cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced<br />to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will<br />produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless<br />of whether the variable exists or not. Cannot be updated.<br />More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell |  | Optional: \{\} <br /> |
+| `workingDir` _string_ | Step's working directory.<br />If not specified, the container runtime's default will be used, which<br />might be configured in the container image.<br />Cannot be updated. |  | Optional: \{\} <br /> |
+| `envFrom` _[EnvFromSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#envfromsource-v1-core) array_ | List of sources to populate environment variables in the Step.<br />The keys defined within a source must be a C_IDENTIFIER. All invalid keys<br />will be reported as an event when the Step is starting. When a key exists in multiple<br />sources, the value associated with the last source will take precedence.<br />Values defined by an Env with a duplicate key will take precedence.<br />Cannot be updated. |  | Optional: \{\} <br /> |
+| `env` _[EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#envvar-v1-core) array_ | List of environment variables to set in the Step.<br />Cannot be updated. |  | Optional: \{\} <br /> |
+| `computeResources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcerequirements-v1-core)_ | ComputeResources required by this Step.<br />Cannot be updated.<br />More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |  | Optional: \{\} <br /> |
+| `volumeMounts` _[VolumeMount](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#volumemount-v1-core) array_ | Volumes to mount into the Step's filesystem.<br />Cannot be updated. |  | Optional: \{\} <br /> |
+| `volumeDevices` _[VolumeDevice](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#volumedevice-v1-core) array_ | volumeDevices is the list of block devices to be used by the Step. |  | Optional: \{\} <br /> |
+| `imagePullPolicy` _[PullPolicy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#pullpolicy-v1-core)_ | Image pull policy.<br />One of Always, Never, IfNotPresent.<br />Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.<br />Cannot be updated.<br />More info: https://kubernetes.io/docs/concepts/containers/images#updating-images |  | Optional: \{\} <br /> |
+| `securityContext` _[SecurityContext](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#securitycontext-v1-core)_ | SecurityContext defines the security options the Step should be run with.<br />If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.<br />More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ |  | Optional: \{\} <br /> |
+| `script` _string_ | Script is the contents of an executable file to execute.<br />If Script is not empty, the Step cannot have an Command and the Args will be passed to the Script. |  | Optional: \{\} <br /> |
+| `timeout` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ | Timeout is the time after which the step times out. Defaults to never.<br />Refer to Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration |  | Optional: \{\} <br /> |
+| `workspaces` _[WorkspaceUsage](#workspaceusage) array_ | This is an alpha field. You must set the "enable-api-fields" feature flag to "alpha"<br />for this field to be supported.<br />Workspaces is a list of workspaces from the Task that this Step wants<br />exclusive access to. Adding a workspace to this list means that any<br />other Step or Sidecar that does not also request this Workspace will<br />not have access to it. |  | Optional: \{\} <br /> |
+| `onError` _[OnErrorType](#onerrortype)_ | OnError defines the exiting behavior of a container on error<br />can be set to [ continue \| stopAndFail ] |  |  |
+| `stdoutConfig` _[StepOutputConfig](#stepoutputconfig)_ | Stores configuration for the stdout stream of the step. |  | Optional: \{\} <br /> |
+| `stderrConfig` _[StepOutputConfig](#stepoutputconfig)_ | Stores configuration for the stderr stream of the step. |  | Optional: \{\} <br /> |
+| `ref` _[Ref](#ref)_ | Contains the reference to an existing StepAction. |  | Optional: \{\} <br /> |
+| `params` _[Params](#params)_ | Params declares parameters passed to this step action. |  | Optional: \{\} <br /> |
+| `results` _[StepResult](#stepresult) array_ | Results declares StepResults produced by the Step.<br />It can be used in an inlined Step when used to store Results to $(step.results.resultName.path).<br />It cannot be used when referencing StepActions using [v1.Step.Ref].<br />The Results declared by the StepActions will be stored here instead. |  | Optional: \{\} <br /> |
+| `when` _[StepWhenExpressions](#stepwhenexpressions)_ | When is a list of when expressions that need to be true for the task to run |  | Optional: \{\} <br /> |
+
+
+#### StepOutputConfig
+
+
+
+StepOutputConfig stores configuration for a step output stream.
+
+
+
+_Appears in:_
+- [Step](#step)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `path` _string_ | Path to duplicate stdout stream to on container's local filesystem. |  | Optional: \{\} <br /> |
+
+
+#### StepResult
+
+
+
+StepResult used to describe the Results of a Step.
+
+
+
+_Appears in:_
+- [Step](#step)
+- [Step](#step)
+- [StepActionSpec](#stepactionspec)
+- [StepActionSpec](#stepactionspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name the given name |  |  |
+| `type` _[ResultsType](#resultstype)_ | The possible types are 'string', 'array', and 'object', with 'string' as the default. |  | Optional: \{\} <br /> |
+| `properties` _object (keys:string, values:[PropertySpec](#propertyspec))_ | Properties is the JSON Schema properties to support key-value pairs results. |  | Optional: \{\} <br /> |
+| `description` _string_ | Description is a human-readable description of the result |  | Optional: \{\} <br /> |
+
+
+#### StepState
+
+
+
+StepState reports the results of running a step in a Task.
+
+
+
+_Appears in:_
+- [TaskRunStatus](#taskrunstatus)
+- [TaskRunStatusFields](#taskrunstatusfields)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `waiting` _[ContainerStateWaiting](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#containerstatewaiting-v1-core)_ | Details about a waiting container |  | Optional: \{\} <br /> |
+| `running` _[ContainerStateRunning](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#containerstaterunning-v1-core)_ | Details about a running container |  | Optional: \{\} <br /> |
+| `terminated` _[ContainerStateTerminated](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#containerstateterminated-v1-core)_ | Details about a terminated container |  | Optional: \{\} <br /> |
+| `name` _string_ |  |  |  |
+| `container` _string_ |  |  |  |
+| `imageID` _string_ |  |  |  |
+| `results` _[TaskRunStepResult](#taskrunstepresult) array_ |  |  |  |
+| `provenance` _[Provenance](#provenance)_ |  |  |  |
+| `terminationReason` _string_ |  |  |  |
+| `inputs` _[TaskRunStepArtifact](#taskrunstepartifact) array_ |  |  |  |
+| `outputs` _[TaskRunStepArtifact](#taskrunstepartifact) array_ |  |  |  |
+
+
+#### StepTemplate
+
+
+
+StepTemplate is a template for a Step
+
+
+
+_Appears in:_
+- [EmbeddedTask](#embeddedtask)
+- [TaskSpec](#taskspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `image` _string_ | Image reference name.<br />More info: https://kubernetes.io/docs/concepts/containers/images |  | Optional: \{\} <br /> |
+| `command` _string array_ | Entrypoint array. Not executed within a shell.<br />The image's ENTRYPOINT is used if this is not provided.<br />Variable references $(VAR_NAME) are expanded using the Step's environment. If a variable<br />cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced<br />to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will<br />produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless<br />of whether the variable exists or not. Cannot be updated.<br />More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell |  | Optional: \{\} <br /> |
+| `args` _string array_ | Arguments to the entrypoint.<br />The image's CMD is used if this is not provided.<br />Variable references $(VAR_NAME) are expanded using the Step's environment. If a variable<br />cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced<br />to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will<br />produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless<br />of whether the variable exists or not. Cannot be updated.<br />More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell |  | Optional: \{\} <br /> |
+| `workingDir` _string_ | Step's working directory.<br />If not specified, the container runtime's default will be used, which<br />might be configured in the container image.<br />Cannot be updated. |  | Optional: \{\} <br /> |
+| `envFrom` _[EnvFromSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#envfromsource-v1-core) array_ | List of sources to populate environment variables in the Step.<br />The keys defined within a source must be a C_IDENTIFIER. All invalid keys<br />will be reported as an event when the Step is starting. When a key exists in multiple<br />sources, the value associated with the last source will take precedence.<br />Values defined by an Env with a duplicate key will take precedence.<br />Cannot be updated. |  | Optional: \{\} <br /> |
+| `env` _[EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#envvar-v1-core) array_ | List of environment variables to set in the Step.<br />Cannot be updated. |  | Optional: \{\} <br /> |
+| `computeResources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcerequirements-v1-core)_ | ComputeResources required by this Step.<br />Cannot be updated.<br />More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |  | Optional: \{\} <br /> |
+| `volumeMounts` _[VolumeMount](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#volumemount-v1-core) array_ | Volumes to mount into the Step's filesystem.<br />Cannot be updated. |  | Optional: \{\} <br /> |
+| `volumeDevices` _[VolumeDevice](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#volumedevice-v1-core) array_ | volumeDevices is the list of block devices to be used by the Step. |  | Optional: \{\} <br /> |
+| `imagePullPolicy` _[PullPolicy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#pullpolicy-v1-core)_ | Image pull policy.<br />One of Always, Never, IfNotPresent.<br />Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.<br />Cannot be updated.<br />More info: https://kubernetes.io/docs/concepts/containers/images#updating-images |  | Optional: \{\} <br /> |
+| `securityContext` _[SecurityContext](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#securitycontext-v1-core)_ | SecurityContext defines the security options the Step should be run with.<br />If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.<br />More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ |  | Optional: \{\} <br /> |
+
+
+
+
+#### Task
+
+
+
+Task represents a collection of sequential steps that are run as part of a
+Pipeline using a set of inputs and producing a set of outputs. Tasks execute
+when TaskRuns are created that provide the input parameters and resources and
+output resources the Task requires.
+
+
+
+
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `apiVersion` _string_ | `tekton.dev/v1` | | |
+| `kind` _string_ | `Task` | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  | Optional: \{\} <br /> |
+| `spec` _[TaskSpec](#taskspec)_ | Spec holds the desired state of the Task from the client |  | Optional: \{\} <br /> |
+
+
+#### TaskBreakpoints
+
+
+
+TaskBreakpoints defines the breakpoint config for a particular Task
+
+
+
+_Appears in:_
+- [TaskRunDebug](#taskrundebug)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `onFailure` _string_ | if enabled, pause TaskRun on failure of a step<br />failed step will not exit |  | Optional: \{\} <br /> |
+| `beforeSteps` _string array_ |  |  | Optional: \{\} <br /> |
+
+
+#### TaskKind
+
+_Underlying type:_ _string_
+
+TaskKind defines the type of Task used by the pipeline.
+
+
+
+_Appears in:_
+- [TaskRef](#taskref)
+
+| Field | Description |
+| --- | --- |
+| `Task` | NamespacedTaskKind indicates that the task type has a namespaced scope.<br /> |
+
+
+#### TaskRef
+
+
+
+TaskRef can be used to refer to a specific instance of a task.
+
+
+
+_Appears in:_
+- [PipelineTask](#pipelinetask)
+- [TaskRunSpec](#taskrunspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names |  |  |
+| `kind` _[TaskKind](#taskkind)_ | TaskKind indicates the Kind of the Task:<br />1. Namespaced Task when Kind is set to "Task". If Kind is "", it defaults to "Task".<br />2. Custom Task when Kind is non-empty and APIVersion is non-empty |  |  |
+| `apiVersion` _string_ | API version of the referent<br />Note: A Task with non-empty APIVersion and Kind is considered a Custom Task |  | Optional: \{\} <br /> |
+| `ResolverRef` _[ResolverRef](#resolverref)_ | ResolverRef allows referencing a Task in a remote location<br />like a git repo. This field is only supported when the alpha<br />feature gate is enabled. |  | Optional: \{\} <br /> |
+
+
+#### TaskResult
+
+
+
+TaskResult used to describe the results of a task
+
+
+
+_Appears in:_
+- [EmbeddedTask](#embeddedtask)
+- [TaskSpec](#taskspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name the given name |  |  |
+| `type` _[ResultsType](#resultstype)_ | Type is the user-specified type of the result. The possible type<br />is currently "string" and will support "array" in following work. |  | Optional: \{\} <br /> |
+| `properties` _object (keys:string, values:[PropertySpec](#propertyspec))_ | Properties is the JSON Schema properties to support key-value pairs results. |  | Optional: \{\} <br /> |
+| `description` _string_ | Description is a human-readable description of the result |  | Optional: \{\} <br /> |
+| `value` _[ResultValue](#resultvalue)_ | Value the expression used to retrieve the value of the result from an underlying Step. |  | Schemaless: \{\} <br />Optional: \{\} <br /> |
+
+
+#### TaskRun
+
+
+
+TaskRun represents a single execution of a Task. TaskRuns are how the steps
+specified in a Task are executed; they specify the parameters and resources
+used to run the steps in a Task.
+
+
+
+
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `apiVersion` _string_ | `tekton.dev/v1` | | |
+| `kind` _string_ | `TaskRun` | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  | Optional: \{\} <br /> |
+| `spec` _[TaskRunSpec](#taskrunspec)_ |  |  | Optional: \{\} <br /> |
+| `status` _[TaskRunStatus](#taskrunstatus)_ |  |  | Optional: \{\} <br /> |
+
+
+#### TaskRunDebug
+
+
+
+TaskRunDebug defines the breakpoint config for a particular TaskRun
+
+
+
+_Appears in:_
+- [TaskRunSpec](#taskrunspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `breakpoints` _[TaskBreakpoints](#taskbreakpoints)_ |  |  | Optional: \{\} <br /> |
+
+
+
+
+
+
+#### TaskRunResult
+
+
+
+TaskRunResult used to describe the results of a task
+
+
+
+_Appears in:_
+- [TaskRunStatus](#taskrunstatus)
+- [TaskRunStatusFields](#taskrunstatusfields)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name the given name |  |  |
+| `type` _[ResultsType](#resultstype)_ | Type is the user-specified type of the result. The possible type<br />is currently "string" and will support "array" in following work. |  | Optional: \{\} <br /> |
+| `value` _[ResultValue](#resultvalue)_ | Value the given value of the result |  | Schemaless: \{\} <br /> |
+
+
+#### TaskRunSidecarSpec
+
+
+
+TaskRunSidecarSpec is used to override the values of a Sidecar in the corresponding Task.
+
+
+
+_Appears in:_
+- [PipelineTaskRunSpec](#pipelinetaskrunspec)
+- [TaskRunSpec](#taskrunspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | The name of the Sidecar to override. |  |  |
+| `computeResources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcerequirements-v1-core)_ | The resource requirements to apply to the Sidecar. |  |  |
+
+
+#### TaskRunSpec
+
+
+
+TaskRunSpec defines the desired state of TaskRun
+
+
+
+_Appears in:_
+- [TaskRun](#taskrun)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `debug` _[TaskRunDebug](#taskrundebug)_ |  |  | Optional: \{\} <br /> |
+| `params` _[Params](#params)_ |  |  | Optional: \{\} <br /> |
+| `serviceAccountName` _string_ |  |  | Optional: \{\} <br /> |
+| `taskRef` _[TaskRef](#taskref)_ | no more than one of the TaskRef and TaskSpec may be specified. |  | Optional: \{\} <br /> |
+| `taskSpec` _[TaskSpec](#taskspec)_ | Specifying TaskSpec can be disabled by setting<br />`disable-inline-spec` feature flag.<br />See Task.spec (API version: tekton.dev/v1) |  | Schemaless: \{\} <br />Optional: \{\} <br /> |
+| `status` _[TaskRunSpecStatus](#taskrunspecstatus)_ | Used for cancelling a TaskRun (and maybe more later on) |  | Optional: \{\} <br /> |
+| `statusMessage` _[TaskRunSpecStatusMessage](#taskrunspecstatusmessage)_ | Status message for cancellation. |  | Optional: \{\} <br /> |
+| `retries` _integer_ | Retries represents how many times this TaskRun should be retried in the event of task failure. |  | Optional: \{\} <br /> |
+| `timeout` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ | Time after which one retry attempt times out. Defaults to 1 hour.<br />Refer Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration |  | Optional: \{\} <br /> |
+| `podTemplate` _[PodTemplate](#podtemplate)_ | PodTemplate holds pod specific configuration |  |  |
+| `workspaces` _[WorkspaceBinding](#workspacebinding) array_ | Workspaces is a list of WorkspaceBindings from volumes to workspaces. |  | Optional: \{\} <br /> |
+| `stepSpecs` _[TaskRunStepSpec](#taskrunstepspec) array_ | Specs to apply to Steps in this TaskRun.<br />If a field is specified in both a Step and a StepSpec,<br />the value from the StepSpec will be used.<br />This field is only supported when the alpha feature gate is enabled. |  | Optional: \{\} <br /> |
+| `sidecarSpecs` _[TaskRunSidecarSpec](#taskrunsidecarspec) array_ | Specs to apply to Sidecars in this TaskRun.<br />If a field is specified in both a Sidecar and a SidecarSpec,<br />the value from the SidecarSpec will be used.<br />This field is only supported when the alpha feature gate is enabled. |  | Optional: \{\} <br /> |
+| `computeResources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcerequirements-v1-core)_ | Compute resources to use for this TaskRun |  |  |
+| `managedBy` _string_ | ManagedBy indicates which controller is responsible for reconciling<br />this resource. If unset or set to "tekton.dev/pipeline", the default<br />Tekton controller will manage this resource.<br />This field is immutable. |  | Optional: \{\} <br /> |
+
+
+#### TaskRunSpecStatus
+
+_Underlying type:_ _string_
+
+TaskRunSpecStatus defines the TaskRun spec status the user can provide
+
+
+
+_Appears in:_
+- [TaskRunSpec](#taskrunspec)
+
+
+
+#### TaskRunSpecStatusMessage
+
+_Underlying type:_ _string_
+
+TaskRunSpecStatusMessage defines human readable status messages for the TaskRun.
+
+
+
+_Appears in:_
+- [TaskRunSpec](#taskrunspec)
+
+| Field | Description |
+| --- | --- |
+| `TaskRun cancelled as the PipelineRun it belongs to has been cancelled.` | TaskRunCancelledByPipelineMsg indicates that the PipelineRun of which this<br />TaskRun was a part of has been cancelled.<br /> |
+| `TaskRun cancelled as the PipelineRun it belongs to has timed out.` | TaskRunCancelledByPipelineTimeoutMsg indicates that the TaskRun was cancelled because the PipelineRun running it timed out.<br /> |
+
+
+#### TaskRunStatus
+
+
+
+TaskRunStatus defines the observed state of TaskRun
+
+
+
+_Appears in:_
+- [PipelineRunTaskRunStatus](#pipelineruntaskrunstatus)
+- [RetriesStatus](#retriesstatus)
+- [TaskRun](#taskrun)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `observedGeneration` _integer_ | ObservedGeneration is the 'Generation' of the Service that<br />was last processed by the controller. |  | Optional: \{\} <br /> |
+| `conditions` _[Conditions](#conditions)_ | Conditions the latest available observations of a resource's current state. |  | Optional: \{\} <br /> |
+| `annotations` _object (keys:string, values:string)_ | Annotations is additional Status fields for the Resource to save some<br />additional State as well as convey more information to the user. This is<br />roughly akin to Annotations on any k8s resource, just the reconciler conveying<br />richer information outwards. |  |  |
+| `podName` _string_ | PodName is the name of the pod responsible for executing this task's steps. |  |  |
+| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | StartTime is the time the build is actually started. |  |  |
+| `completionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | CompletionTime is the time the build completed. |  |  |
+| `steps` _[StepState](#stepstate) array_ | Steps describes the state of each build step container. |  | Optional: \{\} <br /> |
+| `retriesStatus` _[RetriesStatus](#retriesstatus)_ | RetriesStatus contains the history of TaskRunStatus in case of a retry in order to keep record of failures.<br />All TaskRunStatus stored in RetriesStatus will have no date within the RetriesStatus as is redundant. |  | Schemaless: \{\} <br />Optional: \{\} <br /> |
+| `results` _[TaskRunResult](#taskrunresult) array_ | Results are the list of results written out by the task's containers |  | Optional: \{\} <br /> |
+| `artifacts` _[Artifacts](#artifacts)_ | Artifacts are the list of artifacts written out by the task's containers |  | Optional: \{\} <br /> |
+| `sidecars` _[SidecarState](#sidecarstate) array_ | The list has one entry per sidecar in the manifest. Each entry is<br />represents the imageid of the corresponding sidecar. |  |  |
+| `taskSpec` _[TaskSpec](#taskspec)_ | TaskSpec contains the Spec from the dereferenced Task definition used to instantiate this TaskRun. |  |  |
+| `provenance` _[Provenance](#provenance)_ | Provenance contains some key authenticated metadata about how a software artifact was built (what sources, what inputs/outputs, etc.). |  | Optional: \{\} <br /> |
+| `spanContext` _object (keys:string, values:string)_ | SpanContext contains tracing span context fields |  |  |
+| `resolvedTaskNamespace` _string_ | ResolvedTaskNamespace is the namespace of the resolved Task, used for<br />cross-namespace StepAction resolution. Set by the controller, not user-modifiable. |  | Optional: \{\} <br /> |
+
+
+#### TaskRunStatusFields
+
+
+
+TaskRunStatusFields holds the fields of TaskRun's status.  This is defined
 separately and inlined so that other types can readily consume these fields
-via duck typing.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>podName</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>PodName is the name of the pod responsible for executing this task&rsquo;s steps.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>startTime</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta">
-Kubernetes meta/v1.Time
-</a>
-</em>
-</td>
-<td>
-<p>StartTime is the time the build is actually started.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>completionTime</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta">
-Kubernetes meta/v1.Time
-</a>
-</em>
-</td>
-<td>
-<p>CompletionTime is the time the build completed.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>steps</code><br/>
-<em>
-<a href="#tekton.dev/v1.StepState">
-[]StepState
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Steps describes the state of each build step container.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>retriesStatus</code><br/>
-<em>
-<a href="#tekton.dev/v1.RetriesStatus">
-RetriesStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>RetriesStatus contains the history of TaskRunStatus in case of a retry in order to keep record of failures.
-All TaskRunStatus stored in RetriesStatus will have no date within the RetriesStatus as is redundant.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>results</code><br/>
-<em>
-<a href="#tekton.dev/v1.TaskRunResult">
-[]TaskRunResult
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Results are the list of results written out by the task&rsquo;s containers</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>artifacts</code><br/>
-<em>
-<a href="#tekton.dev/v1.Artifacts">
-Artifacts
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Artifacts are the list of artifacts written out by the task&rsquo;s containers</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>sidecars</code><br/>
-<em>
-<a href="#tekton.dev/v1.SidecarState">
-[]SidecarState
-</a>
-</em>
-</td>
-<td>
-<p>The list has one entry per sidecar in the manifest. Each entry is
-represents the imageid of the corresponding sidecar.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>taskSpec</code><br/>
-<em>
-<a href="#tekton.dev/v1.TaskSpec">
-TaskSpec
-</a>
-</em>
-</td>
-<td>
-<p>TaskSpec contains the Spec from the dereferenced Task definition used to instantiate this TaskRun.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>provenance</code><br/>
-<em>
-<a href="#tekton.dev/v1.Provenance">
-Provenance
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Provenance contains some key authenticated metadata about how a software artifact was built (what sources, what inputs/outputs, etc.).</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>spanContext</code><br/>
-<em>
-map[string]string
-</em>
-</td>
-<td>
-<p>SpanContext contains tracing span context fields</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>resolvedTaskNamespace</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ResolvedTaskNamespace is the namespace of the resolved Task, used for
-cross-namespace StepAction resolution. Set by the controller, not user-modifiable.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.TaskRunStepArtifact">TaskRunStepArtifact
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.StepState">StepState</a>)
-</p>
-<div>
-<p>TaskRunStepArtifact represents an artifact produced or used by a step within a task run.
-It directly uses the Artifact type for its structure.</p>
-</div>
-<h3 id="tekton.dev/v1.TaskRunStepResult">TaskRunStepResult
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.StepState">StepState</a>)
-</p>
-<div>
-<p>TaskRunStepResult is a type alias of TaskRunResult</p>
-</div>
-<h3 id="tekton.dev/v1.TaskRunStepSpec">TaskRunStepSpec
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineTaskRunSpec">PipelineTaskRunSpec</a>, <a href="#tekton.dev/v1.TaskRunSpec">TaskRunSpec</a>)
-</p>
-<div>
-<p>TaskRunStepSpec is used to override the values of a Step in the corresponding Task.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>The name of the Step to override.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>computeResources</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#resourcerequirements-v1-core">
-Kubernetes core/v1.ResourceRequirements
-</a>
-</em>
-</td>
-<td>
-<p>The resource requirements to apply to the Step.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.TaskSpec">TaskSpec
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.Task">Task</a>, <a href="#tekton.dev/v1.EmbeddedTask">EmbeddedTask</a>, <a href="#tekton.dev/v1.TaskRunSpec">TaskRunSpec</a>, <a href="#tekton.dev/v1.TaskRunStatusFields">TaskRunStatusFields</a>)
-</p>
-<div>
-<p>TaskSpec defines the desired state of Task.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>params</code><br/>
-<em>
-<a href="#tekton.dev/v1.ParamSpecs">
-ParamSpecs
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Params is a list of input parameters required to run the task. Params
-must be supplied as inputs in TaskRuns unless they declare a default
-value.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>displayName</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>DisplayName is a user-facing name of the task that may be
-used to populate a UI.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>description</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Description is a user-facing description of the task that may be
-used to populate a UI.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>steps</code><br/>
-<em>
-<a href="#tekton.dev/v1.Step">
-[]Step
-</a>
-</em>
-</td>
-<td>
-<p>Steps are the steps of the build; each step is run sequentially with the
-source mounted into /workspace.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>volumes</code><br/>
-<em>
-<a href="#tekton.dev/v1.Volumes">
-Volumes
-</a>
-</em>
-</td>
-<td>
-<p>Volumes is a collection of volumes that are available to mount into the
-steps of the build.
-See Pod.spec.volumes (API version: v1)</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>stepTemplate</code><br/>
-<em>
-<a href="#tekton.dev/v1.StepTemplate">
-StepTemplate
-</a>
-</em>
-</td>
-<td>
-<p>StepTemplate can be used as the basis for all step containers within the
-Task, so that the steps inherit settings on the base container.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>sidecars</code><br/>
-<em>
-<a href="#tekton.dev/v1.Sidecar">
-[]Sidecar
-</a>
-</em>
-</td>
-<td>
-<p>Sidecars are run alongside the Task&rsquo;s step containers. They begin before
-the steps start and end after the steps complete.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>workspaces</code><br/>
-<em>
-<a href="#tekton.dev/v1.WorkspaceDeclaration">
-[]WorkspaceDeclaration
-</a>
-</em>
-</td>
-<td>
-<p>Workspaces are the volumes that this Task requires.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>results</code><br/>
-<em>
-<a href="#tekton.dev/v1.TaskResult">
-[]TaskResult
-</a>
-</em>
-</td>
-<td>
-<p>Results are values that this Task can output</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.TimeoutFields">TimeoutFields
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineRunSpec">PipelineRunSpec</a>)
-</p>
-<div>
-<p>TimeoutFields allows granular specification of pipeline, task, and finally timeouts</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>pipeline</code><br/>
-<em>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
-Kubernetes meta/v1.Duration
-</a>
-</em>
-</td>
-<td>
-<p>Pipeline sets the maximum allowed duration for execution of the entire pipeline. The sum of individual timeouts for tasks and finally must not exceed this value.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>tasks</code><br/>
-<em>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
-Kubernetes meta/v1.Duration
-</a>
-</em>
-</td>
-<td>
-<p>Tasks sets the maximum allowed duration of this pipeline&rsquo;s tasks</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>finally</code><br/>
-<em>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
-Kubernetes meta/v1.Duration
-</a>
-</em>
-</td>
-<td>
-<p>Finally sets the maximum allowed duration of this pipeline&rsquo;s finally</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.Volumes">Volumes
-(<code>[]k8s.io/api/core/v1.Volume</code> alias)</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.TaskSpec">TaskSpec</a>)
-</p>
-<div>
-</div>
-<h3 id="tekton.dev/v1.WhenExpression">WhenExpression
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.ChildStatusReference">ChildStatusReference</a>, <a href="#tekton.dev/v1.PipelineRunRunStatus">PipelineRunRunStatus</a>, <a href="#tekton.dev/v1.PipelineRunTaskRunStatus">PipelineRunTaskRunStatus</a>, <a href="#tekton.dev/v1.SkippedTask">SkippedTask</a>)
-</p>
-<div>
-<p>WhenExpression allows a PipelineTask to declare expressions to be evaluated before the Task is run
-to determine whether the Task should be executed or skipped</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>input</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Input is the string for guard checking which can be a static input or an output from a parent Task</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>operator</code><br/>
-<em>
-<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/selection#Operator">
-k8s.io/apimachinery/pkg/selection.Operator
-</a>
-</em>
-</td>
-<td>
-<p>Operator that represents an Input&rsquo;s relationship to the values</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>values</code><br/>
-<em>
-[]string
-</em>
-</td>
-<td>
-<p>Values is an array of strings, which is compared against the input, for guard checking
-It must be non-empty</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>cel</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>CEL is a string of Common Language Expression, which can be used to conditionally execute
-the task based on the result of the expression evaluation
-More info about CEL syntax: <a href="https://github.com/google/cel-spec/blob/master/doc/langdef.md">https://github.com/google/cel-spec/blob/master/doc/langdef.md</a></p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.WhenExpressions">WhenExpressions
-(<code>[]github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.WhenExpression</code> alias)</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineTask">PipelineTask</a>)
-</p>
-<div>
-<p>WhenExpressions are used to specify whether a Task should be executed or skipped
-All of them need to evaluate to True for a guarded Task to be executed.</p>
-</div>
-<h3 id="tekton.dev/v1.WorkspaceBinding">WorkspaceBinding
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineRunSpec">PipelineRunSpec</a>, <a href="#tekton.dev/v1.TaskRunSpec">TaskRunSpec</a>)
-</p>
-<div>
-<p>WorkspaceBinding maps a Task&rsquo;s declared workspace to a Volume.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Name is the name of the workspace populated by the volume.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>subPath</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>SubPath is optionally a directory on the volume which should be used
-for this binding (i.e. the volume will be mounted at this sub directory).</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>volumeClaimTemplate</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#persistentvolumeclaim-v1-core">
-Kubernetes core/v1.PersistentVolumeClaim
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>VolumeClaimTemplate is a template for a claim that will be created in the same namespace.
-The PipelineRun controller is responsible for creating a unique claim for each instance of PipelineRun.
-See PersistentVolumeClaim (API version: v1)</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>persistentVolumeClaim</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#persistentvolumeclaimvolumesource-v1-core">
-Kubernetes core/v1.PersistentVolumeClaimVolumeSource
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>PersistentVolumeClaimVolumeSource represents a reference to a
-PersistentVolumeClaim in the same namespace. Either this OR EmptyDir can be used.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>emptyDir</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#emptydirvolumesource-v1-core">
-Kubernetes core/v1.EmptyDirVolumeSource
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>EmptyDir represents a temporary directory that shares a Task&rsquo;s lifetime.
-More info: <a href="https://kubernetes.io/docs/concepts/storage/volumes#emptydir">https://kubernetes.io/docs/concepts/storage/volumes#emptydir</a>
-Either this OR PersistentVolumeClaim can be used.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>configMap</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#configmapvolumesource-v1-core">
-Kubernetes core/v1.ConfigMapVolumeSource
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ConfigMap represents a configMap that should populate this workspace.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>secret</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#secretvolumesource-v1-core">
-Kubernetes core/v1.SecretVolumeSource
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Secret represents a secret that should populate this workspace.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>projected</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#projectedvolumesource-v1-core">
-Kubernetes core/v1.ProjectedVolumeSource
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Projected represents a projected volume that should populate this workspace.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>csi</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#csivolumesource-v1-core">
-Kubernetes core/v1.CSIVolumeSource
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>CSI (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.WorkspaceDeclaration">WorkspaceDeclaration
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.TaskSpec">TaskSpec</a>)
-</p>
-<div>
-<p>WorkspaceDeclaration is a declaration of a volume that a Task requires.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Name is the name by which you can bind the volume at runtime.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>description</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Description is an optional human readable description of this volume.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>mountPath</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>MountPath overrides the directory that the volume will be made available at.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>readOnly</code><br/>
-<em>
-bool
-</em>
-</td>
-<td>
-<p>ReadOnly dictates whether a mounted volume is writable. By default this
-field is false and so mounted volumes are writable.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>optional</code><br/>
-<em>
-bool
-</em>
-</td>
-<td>
-<p>Optional marks a Workspace as not being required in TaskRuns. By default
-this field is false and so declared workspaces are required.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.WorkspacePipelineDeclaration">WorkspacePipelineDeclaration
-</h3>
-<div>
-<p>WorkspacePipelineDeclaration creates a named slot in a Pipeline that a PipelineRun
-is expected to populate with a workspace binding.</p>
-<p>Deprecated: use PipelineWorkspaceDeclaration type instead</p>
-</div>
-<h3 id="tekton.dev/v1.WorkspacePipelineTaskBinding">WorkspacePipelineTaskBinding
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineTask">PipelineTask</a>)
-</p>
-<div>
-<p>WorkspacePipelineTaskBinding describes how a workspace passed into the pipeline should be
-mapped to a task&rsquo;s declared workspace.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Name is the name of the workspace as declared by the task</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>workspace</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Workspace is the name of the workspace declared by the pipeline</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>subPath</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>SubPath is optionally a directory on the volume which should be used
-for this binding (i.e. the volume will be mounted at this sub directory).</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1.WorkspaceUsage">WorkspaceUsage
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.Sidecar">Sidecar</a>, <a href="#tekton.dev/v1.Step">Step</a>)
-</p>
-<div>
-<p>WorkspaceUsage is used by a Step or Sidecar to declare that it wants isolated access
-to a Workspace defined in a Task.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Name is the name of the workspace this Step or Sidecar wants access to.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>mountPath</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>MountPath is the path that the workspace should be mounted to inside the Step or Sidecar,
-overriding any MountPath specified in the Task&rsquo;s WorkspaceDeclaration.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<hr/>
-<h2 id="tekton.dev/v1alpha1">tekton.dev/v1alpha1</h2>
-<div>
-<p>Package v1alpha1 contains API Schema definitions for the pipeline v1alpha1 API group</p>
-</div>
-Resource Types:
-<ul><li>
-<a href="#tekton.dev/v1alpha1.Run">Run</a>
-</li><li>
-<a href="#tekton.dev/v1alpha1.StepAction">StepAction</a>
-</li><li>
-<a href="#tekton.dev/v1alpha1.VerificationPolicy">VerificationPolicy</a>
-</li><li>
-<a href="#tekton.dev/v1alpha1.PipelineResource">PipelineResource</a>
-</li></ul>
-<h3 id="tekton.dev/v1alpha1.Run">Run
-</h3>
-<div>
-<p>Run represents a single execution of a Custom Task.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code><br/>
-string</td>
-<td>
-<code>
-tekton.dev/v1alpha1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code><br/>
-string
-</td>
-<td><code>Run</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code><br/>
-<em>
-<a href="#tekton.dev/v1alpha1.RunSpec">
-RunSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>ref</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.TaskRef">
-TaskRef
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code><br/>
-<em>
-<a href="#tekton.dev/v1alpha1.EmbeddedRunSpec">
-EmbeddedRunSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Spec is a specification of a custom task</p>
-<br/>
-<br/>
-<table>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>params</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.Params">
-Params
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code><br/>
-<em>
-<a href="#tekton.dev/v1alpha1.RunSpecStatus">
-RunSpecStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Used for cancelling a run (and maybe more later on)</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>statusMessage</code><br/>
-<em>
-<a href="#tekton.dev/v1alpha1.RunSpecStatusMessage">
-RunSpecStatusMessage
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Status message for cancellation.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>retries</code><br/>
-<em>
-int
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Used for propagating retries count to custom tasks</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>serviceAccountName</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-<tr>
-<td>
-<code>podTemplate</code><br/>
-<em>
-<a href="#tekton.dev/unversioned.PodTemplate">
-PodTemplate
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>PodTemplate holds pod specific configuration</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>timeout</code><br/>
-<em>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
-Kubernetes meta/v1.Duration
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Time after which the custom-task times out.
-Refer Go&rsquo;s ParseDuration documentation for expected format: <a href="https://golang.org/pkg/time/#ParseDuration">https://golang.org/pkg/time/#ParseDuration</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>workspaces</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.WorkspaceBinding">
-[]WorkspaceBinding
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Workspaces is a list of WorkspaceBindings from volumes to workspaces.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code><br/>
-<em>
-<a href="#tekton.dev/v1alpha1.RunStatus">
-RunStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1alpha1.StepAction">StepAction
-</h3>
-<div>
-<p>StepAction represents the actionable components of Step.
-The Step can only reference it from the cluster or using remote resolution.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code><br/>
-string</td>
-<td>
-<code>
-tekton.dev/v1alpha1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code><br/>
-string
-</td>
-<td><code>StepAction</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code><br/>
-<em>
-<a href="#tekton.dev/v1alpha1.StepActionSpec">
-StepActionSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Spec holds the desired state of the Step from the client</p>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>description</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Description is a user-facing description of the stepaction that may be
-used to populate a UI.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>image</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Image reference name to run for this StepAction.
-More info: <a href="https://kubernetes.io/docs/concepts/containers/images">https://kubernetes.io/docs/concepts/containers/images</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>command</code><br/>
-<em>
-[]string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Entrypoint array. Not executed within a shell.
-The image&rsquo;s ENTRYPOINT is used if this is not provided.
-Variable references $(VAR_NAME) are expanded using the container&rsquo;s environment. If a variable
-cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
-to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. &ldquo;$$(VAR_NAME)&rdquo; will
-produce the string literal &ldquo;$(VAR_NAME)&rdquo;. Escaped references will never be expanded, regardless
-of whether the variable exists or not. Cannot be updated.
-More info: <a href="https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell">https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>args</code><br/>
-<em>
-[]string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Arguments to the entrypoint.
-The image&rsquo;s CMD is used if this is not provided.
-Variable references $(VAR_NAME) are expanded using the container&rsquo;s environment. If a variable
-cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
-to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. &ldquo;$$(VAR_NAME)&rdquo; will
-produce the string literal &ldquo;$(VAR_NAME)&rdquo;. Escaped references will never be expanded, regardless
-of whether the variable exists or not. Cannot be updated.
-More info: <a href="https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell">https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>env</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#envvar-v1-core">
-[]Kubernetes core/v1.EnvVar
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>List of environment variables to set in the container.
-Cannot be updated.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>script</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Script is the contents of an executable file to execute.</p>
-<p>If Script is not empty, the Step cannot have an Command and the Args will be passed to the Script.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>workingDir</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Step&rsquo;s working directory.
-If not specified, the container runtime&rsquo;s default will be used, which
-might be configured in the container image.
-Cannot be updated.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>params</code><br/>
-<em>
-<a href="#tekton.dev/v1.ParamSpecs">
-ParamSpecs
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Params is a list of input parameters required to run the stepAction.
-Params must be supplied as inputs in Steps unless they declare a defaultvalue.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>results</code><br/>
-<em>
-<a href="#tekton.dev/v1.StepResult">
-[]StepResult
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Results are values that this StepAction can output</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>securityContext</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#securitycontext-v1-core">
-Kubernetes core/v1.SecurityContext
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>SecurityContext defines the security options the Step should be run with.
-If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
-More info: <a href="https://kubernetes.io/docs/tasks/configure-pod-container/security-context/">https://kubernetes.io/docs/tasks/configure-pod-container/security-context/</a>
-The value set in StepAction will take precedence over the value from Task.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>volumeMounts</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#volumemount-v1-core">
-[]Kubernetes core/v1.VolumeMount
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Volumes to mount into the Step&rsquo;s filesystem.
-Cannot be updated.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1alpha1.VerificationPolicy">VerificationPolicy
-</h3>
-<div>
-<p>VerificationPolicy defines the rules to verify Tekton resources.
+via duck typing.
+
+
+
+_Appears in:_
+- [TaskRunStatus](#taskrunstatus)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `podName` _string_ | PodName is the name of the pod responsible for executing this task's steps. |  |  |
+| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | StartTime is the time the build is actually started. |  |  |
+| `completionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | CompletionTime is the time the build completed. |  |  |
+| `steps` _[StepState](#stepstate) array_ | Steps describes the state of each build step container. |  | Optional: \{\} <br /> |
+| `retriesStatus` _[RetriesStatus](#retriesstatus)_ | RetriesStatus contains the history of TaskRunStatus in case of a retry in order to keep record of failures.<br />All TaskRunStatus stored in RetriesStatus will have no date within the RetriesStatus as is redundant. |  | Schemaless: \{\} <br />Optional: \{\} <br /> |
+| `results` _[TaskRunResult](#taskrunresult) array_ | Results are the list of results written out by the task's containers |  | Optional: \{\} <br /> |
+| `artifacts` _[Artifacts](#artifacts)_ | Artifacts are the list of artifacts written out by the task's containers |  | Optional: \{\} <br /> |
+| `sidecars` _[SidecarState](#sidecarstate) array_ | The list has one entry per sidecar in the manifest. Each entry is<br />represents the imageid of the corresponding sidecar. |  |  |
+| `taskSpec` _[TaskSpec](#taskspec)_ | TaskSpec contains the Spec from the dereferenced Task definition used to instantiate this TaskRun. |  |  |
+| `provenance` _[Provenance](#provenance)_ | Provenance contains some key authenticated metadata about how a software artifact was built (what sources, what inputs/outputs, etc.). |  | Optional: \{\} <br /> |
+| `spanContext` _object (keys:string, values:string)_ | SpanContext contains tracing span context fields |  |  |
+| `resolvedTaskNamespace` _string_ | ResolvedTaskNamespace is the namespace of the resolved Task, used for<br />cross-namespace StepAction resolution. Set by the controller, not user-modifiable. |  | Optional: \{\} <br /> |
+
+
+
+
+
+
+#### TaskRunStepSpec
+
+
+
+TaskRunStepSpec is used to override the values of a Step in the corresponding Task.
+
+
+
+_Appears in:_
+- [PipelineTaskRunSpec](#pipelinetaskrunspec)
+- [TaskRunSpec](#taskrunspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | The name of the Step to override. |  |  |
+| `computeResources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcerequirements-v1-core)_ | The resource requirements to apply to the Step. |  |  |
+
+
+#### TaskSpec
+
+
+
+TaskSpec defines the desired state of Task.
+
+
+
+_Appears in:_
+- [EmbeddedTask](#embeddedtask)
+- [Task](#task)
+- [TaskRunSpec](#taskrunspec)
+- [TaskRunStatus](#taskrunstatus)
+- [TaskRunStatusFields](#taskrunstatusfields)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `params` _[ParamSpecs](#paramspecs)_ | Params is a list of input parameters required to run the task. Params<br />must be supplied as inputs in TaskRuns unless they declare a default<br />value. |  | Optional: \{\} <br /> |
+| `displayName` _string_ | DisplayName is a user-facing name of the task that may be<br />used to populate a UI. |  | Optional: \{\} <br /> |
+| `description` _string_ | Description is a user-facing description of the task that may be<br />used to populate a UI. |  | Optional: \{\} <br /> |
+| `steps` _[Step](#step) array_ | Steps are the steps of the build; each step is run sequentially with the<br />source mounted into /workspace. |  |  |
+| `volumes` _[Volumes](#volumes)_ | Volumes is a collection of volumes that are available to mount into the<br />steps of the build.<br />See Pod.spec.volumes (API version: v1) |  | Schemaless: \{\} <br /> |
+| `stepTemplate` _[StepTemplate](#steptemplate)_ | StepTemplate can be used as the basis for all step containers within the<br />Task, so that the steps inherit settings on the base container. |  |  |
+| `sidecars` _[Sidecar](#sidecar) array_ | Sidecars are run alongside the Task's step containers. They begin before<br />the steps start and end after the steps complete. |  |  |
+| `workspaces` _[WorkspaceDeclaration](#workspacedeclaration) array_ | Workspaces are the volumes that this Task requires. |  |  |
+| `results` _[TaskResult](#taskresult) array_ | Results are values that this Task can output |  |  |
+
+
+#### TimeoutFields
+
+
+
+TimeoutFields allows granular specification of pipeline, task, and finally timeouts
+
+
+
+_Appears in:_
+- [PipelineRunSpec](#pipelinerunspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `pipeline` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ | Pipeline sets the maximum allowed duration for execution of the entire pipeline. The sum of individual timeouts for tasks and finally must not exceed this value. |  |  |
+| `tasks` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ | Tasks sets the maximum allowed duration of this pipeline's tasks |  |  |
+| `finally` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ | Finally sets the maximum allowed duration of this pipeline's finally |  |  |
+
+
+#### Volumes
+
+_Underlying type:_ _[Volume](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#volume-v1-core)_
+
+
+
+
+
+_Appears in:_
+- [EmbeddedTask](#embeddedtask)
+- [TaskSpec](#taskspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | name of the volume.<br />Must be a DNS_LABEL and unique within the pod.<br />More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names |  |  |
+| `hostPath` _[HostPathVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#hostpathvolumesource-v1-core)_ | hostPath represents a pre-existing file or directory on the host<br />machine that is directly exposed to the container. This is generally<br />used for system agents or other privileged things that are allowed<br />to see the host machine. Most containers will NOT need this.<br />More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath |  | Optional: \{\} <br /> |
+| `emptyDir` _[EmptyDirVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#emptydirvolumesource-v1-core)_ | emptyDir represents a temporary directory that shares a pod's lifetime.<br />More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir |  | Optional: \{\} <br /> |
+| `gcePersistentDisk` _[GCEPersistentDiskVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#gcepersistentdiskvolumesource-v1-core)_ | gcePersistentDisk represents a GCE Disk resource that is attached to a<br />kubelet's host machine and then exposed to the pod.<br />Deprecated: GCEPersistentDisk is deprecated. All operations for the in-tree<br />gcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.<br />More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk |  | Optional: \{\} <br /> |
+| `awsElasticBlockStore` _[AWSElasticBlockStoreVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#awselasticblockstorevolumesource-v1-core)_ | awsElasticBlockStore represents an AWS Disk resource that is attached to a<br />kubelet's host machine and then exposed to the pod.<br />Deprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree<br />awsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.<br />More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore |  | Optional: \{\} <br /> |
+| `gitRepo` _[GitRepoVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#gitrepovolumesource-v1-core)_ | gitRepo represents a git repository at a particular revision.<br />Deprecated: GitRepo is deprecated. To provision a container with a git repo, mount an<br />EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir<br />into the Pod's container. |  | Optional: \{\} <br /> |
+| `secret` _[SecretVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#secretvolumesource-v1-core)_ | secret represents a secret that should populate this volume.<br />More info: https://kubernetes.io/docs/concepts/storage/volumes#secret |  | Optional: \{\} <br /> |
+| `nfs` _[NFSVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#nfsvolumesource-v1-core)_ | nfs represents an NFS mount on the host that shares a pod's lifetime<br />More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs |  | Optional: \{\} <br /> |
+| `iscsi` _[ISCSIVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#iscsivolumesource-v1-core)_ | iscsi represents an ISCSI Disk resource that is attached to a<br />kubelet's host machine and then exposed to the pod.<br />More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi |  | Optional: \{\} <br /> |
+| `glusterfs` _[GlusterfsVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#glusterfsvolumesource-v1-core)_ | glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.<br />Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported. |  | Optional: \{\} <br /> |
+| `persistentVolumeClaim` _[PersistentVolumeClaimVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#persistentvolumeclaimvolumesource-v1-core)_ | persistentVolumeClaimVolumeSource represents a reference to a<br />PersistentVolumeClaim in the same namespace.<br />More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims |  | Optional: \{\} <br /> |
+| `rbd` _[RBDVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#rbdvolumesource-v1-core)_ | rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.<br />Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported. |  | Optional: \{\} <br /> |
+| `flexVolume` _[FlexVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#flexvolumesource-v1-core)_ | flexVolume represents a generic volume resource that is<br />provisioned/attached using an exec based plugin.<br />Deprecated: FlexVolume is deprecated. Consider using a CSIDriver instead. |  | Optional: \{\} <br /> |
+| `cinder` _[CinderVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#cindervolumesource-v1-core)_ | cinder represents a cinder volume attached and mounted on kubelets host machine.<br />Deprecated: Cinder is deprecated. All operations for the in-tree cinder type<br />are redirected to the cinder.csi.openstack.org CSI driver.<br />More info: https://examples.k8s.io/mysql-cinder-pd/README.md |  | Optional: \{\} <br /> |
+| `cephfs` _[CephFSVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#cephfsvolumesource-v1-core)_ | cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.<br />Deprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported. |  | Optional: \{\} <br /> |
+| `flocker` _[FlockerVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#flockervolumesource-v1-core)_ | flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.<br />Deprecated: Flocker is deprecated and the in-tree flocker type is no longer supported. |  | Optional: \{\} <br /> |
+| `downwardAPI` _[DownwardAPIVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#downwardapivolumesource-v1-core)_ | downwardAPI represents downward API about the pod that should populate this volume |  | Optional: \{\} <br /> |
+| `fc` _[FCVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#fcvolumesource-v1-core)_ | fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod. |  | Optional: \{\} <br /> |
+| `azureFile` _[AzureFileVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#azurefilevolumesource-v1-core)_ | azureFile represents an Azure File Service mount on the host and bind mount to the pod.<br />Deprecated: AzureFile is deprecated. All operations for the in-tree azureFile type<br />are redirected to the file.csi.azure.com CSI driver. |  | Optional: \{\} <br /> |
+| `configMap` _[ConfigMapVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#configmapvolumesource-v1-core)_ | configMap represents a configMap that should populate this volume |  | Optional: \{\} <br /> |
+| `vsphereVolume` _[VsphereVirtualDiskVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#vspherevirtualdiskvolumesource-v1-core)_ | vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.<br />Deprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type<br />are redirected to the csi.vsphere.vmware.com CSI driver. |  | Optional: \{\} <br /> |
+| `quobyte` _[QuobyteVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#quobytevolumesource-v1-core)_ | quobyte represents a Quobyte mount on the host that shares a pod's lifetime.<br />Deprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported. |  | Optional: \{\} <br /> |
+| `azureDisk` _[AzureDiskVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#azurediskvolumesource-v1-core)_ | azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.<br />Deprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type<br />are redirected to the disk.csi.azure.com CSI driver. |  | Optional: \{\} <br /> |
+| `photonPersistentDisk` _[PhotonPersistentDiskVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#photonpersistentdiskvolumesource-v1-core)_ | photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.<br />Deprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported. |  |  |
+| `projected` _[ProjectedVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#projectedvolumesource-v1-core)_ | projected items for all in one resources secrets, configmaps, and downward API |  |  |
+| `portworxVolume` _[PortworxVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#portworxvolumesource-v1-core)_ | portworxVolume represents a portworx volume attached and mounted on kubelets host machine.<br />Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type<br />are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate<br />is on. |  | Optional: \{\} <br /> |
+| `scaleIO` _[ScaleIOVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#scaleiovolumesource-v1-core)_ | scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.<br />Deprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported. |  | Optional: \{\} <br /> |
+| `storageos` _[StorageOSVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#storageosvolumesource-v1-core)_ | storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.<br />Deprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported. |  | Optional: \{\} <br /> |
+| `csi` _[CSIVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#csivolumesource-v1-core)_ | csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers. |  | Optional: \{\} <br /> |
+| `ephemeral` _[EphemeralVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#ephemeralvolumesource-v1-core)_ | ephemeral represents a volume that is handled by a cluster storage driver.<br />The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,<br />and deleted when the pod is removed.<br />Use this if:<br />a) the volume is only needed while the pod runs,<br />b) features of normal volumes like restoring from snapshot or capacity<br />   tracking are needed,<br />c) the storage driver is specified through a storage class, and<br />d) the storage driver supports dynamic volume provisioning through<br />   a PersistentVolumeClaim (see EphemeralVolumeSource for more<br />   information on the connection between this volume type<br />   and PersistentVolumeClaim).<br />Use PersistentVolumeClaim or one of the vendor-specific<br />APIs for volumes that persist for longer than the lifecycle<br />of an individual pod.<br />Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to<br />be used that way - see the documentation of the driver for<br />more information.<br />A pod can use both types of ephemeral volumes and<br />persistent volumes at the same time. |  | Optional: \{\} <br /> |
+| `image` _[ImageVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#imagevolumesource-v1-core)_ | image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.<br />The volume is resolved at pod startup depending on which PullPolicy value is provided:<br />- Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.<br />- Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.<br />- IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.<br />The volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.<br />A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.<br />The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.<br />The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.<br />The volume will be mounted read-only (ro) and non-executable files (noexec).<br />Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.<br />The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type. |  | Optional: \{\} <br /> |
+
+
+#### WhenExpression
+
+
+
+WhenExpression allows a PipelineTask to declare expressions to be evaluated before the Task is run
+to determine whether the Task should be executed or skipped
+
+
+
+_Appears in:_
+- [ChildStatusReference](#childstatusreference)
+- [PipelineRunRunStatus](#pipelinerunrunstatus)
+- [PipelineRunTaskRunStatus](#pipelineruntaskrunstatus)
+- [SkippedTask](#skippedtask)
+- [WhenExpressions](#whenexpressions)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `input` _string_ | Input is the string for guard checking which can be a static input or an output from a parent Task |  |  |
+| `operator` _[Operator](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#operator-selection-pkg)_ | Operator that represents an Input's relationship to the values |  |  |
+| `values` _string array_ | Values is an array of strings, which is compared against the input, for guard checking<br />It must be non-empty |  |  |
+| `cel` _string_ | CEL is a string of Common Language Expression, which can be used to conditionally execute<br />the task based on the result of the expression evaluation<br />More info about CEL syntax: https://github.com/google/cel-spec/blob/master/doc/langdef.md |  | Optional: \{\} <br /> |
+
+
+#### WhenExpressions
+
+_Underlying type:_ _[WhenExpression](#whenexpression)_
+
+WhenExpressions are used to specify whether a Task should be executed or skipped
+All of them need to evaluate to True for a guarded Task to be executed.
+
+
+
+_Appears in:_
+- [PipelineTask](#pipelinetask)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `input` _string_ | Input is the string for guard checking which can be a static input or an output from a parent Task |  |  |
+| `operator` _[Operator](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#operator-selection-pkg)_ | Operator that represents an Input's relationship to the values |  |  |
+| `values` _string array_ | Values is an array of strings, which is compared against the input, for guard checking<br />It must be non-empty |  |  |
+| `cel` _string_ | CEL is a string of Common Language Expression, which can be used to conditionally execute<br />the task based on the result of the expression evaluation<br />More info about CEL syntax: https://github.com/google/cel-spec/blob/master/doc/langdef.md |  | Optional: \{\} <br /> |
+
+
+#### WorkspaceBinding
+
+
+
+WorkspaceBinding maps a Task's declared workspace to a Volume.
+
+
+
+_Appears in:_
+- [PipelineRunSpec](#pipelinerunspec)
+- [TaskRunSpec](#taskrunspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name is the name of the workspace populated by the volume. |  |  |
+| `subPath` _string_ | SubPath is optionally a directory on the volume which should be used<br />for this binding (i.e. the volume will be mounted at this sub directory). |  | Optional: \{\} <br /> |
+| `volumeClaimTemplate` _[PersistentVolumeClaim](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#persistentvolumeclaim-v1-core)_ | VolumeClaimTemplate is a template for a claim that will be created in the same namespace.<br />The PipelineRun controller is responsible for creating a unique claim for each instance of PipelineRun.<br />See PersistentVolumeClaim (API version: v1) |  | Schemaless: \{\} <br />Optional: \{\} <br /> |
+| `persistentVolumeClaim` _[PersistentVolumeClaimVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#persistentvolumeclaimvolumesource-v1-core)_ | PersistentVolumeClaimVolumeSource represents a reference to a<br />PersistentVolumeClaim in the same namespace. Either this OR EmptyDir can be used. |  | Optional: \{\} <br /> |
+| `emptyDir` _[EmptyDirVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#emptydirvolumesource-v1-core)_ | EmptyDir represents a temporary directory that shares a Task's lifetime.<br />More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir<br />Either this OR PersistentVolumeClaim can be used. |  | Optional: \{\} <br /> |
+| `configMap` _[ConfigMapVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#configmapvolumesource-v1-core)_ | ConfigMap represents a configMap that should populate this workspace. |  | Optional: \{\} <br /> |
+| `secret` _[SecretVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#secretvolumesource-v1-core)_ | Secret represents a secret that should populate this workspace. |  | Optional: \{\} <br /> |
+| `projected` _[ProjectedVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#projectedvolumesource-v1-core)_ | Projected represents a projected volume that should populate this workspace. |  | Optional: \{\} <br /> |
+| `csi` _[CSIVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#csivolumesource-v1-core)_ | CSI (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers. |  | Optional: \{\} <br /> |
+
+
+#### WorkspaceDeclaration
+
+
+
+WorkspaceDeclaration is a declaration of a volume that a Task requires.
+
+
+
+_Appears in:_
+- [EmbeddedTask](#embeddedtask)
+- [TaskSpec](#taskspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name is the name by which you can bind the volume at runtime. |  |  |
+| `description` _string_ | Description is an optional human readable description of this volume. |  | Optional: \{\} <br /> |
+| `mountPath` _string_ | MountPath overrides the directory that the volume will be made available at. |  | Optional: \{\} <br /> |
+| `readOnly` _boolean_ | ReadOnly dictates whether a mounted volume is writable. By default this<br />field is false and so mounted volumes are writable. |  |  |
+| `optional` _boolean_ | Optional marks a Workspace as not being required in TaskRuns. By default<br />this field is false and so declared workspaces are required. |  |  |
+
+
+
+
+#### WorkspacePipelineTaskBinding
+
+
+
+WorkspacePipelineTaskBinding describes how a workspace passed into the pipeline should be
+mapped to a task's declared workspace.
+
+
+
+_Appears in:_
+- [PipelineTask](#pipelinetask)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name is the name of the workspace as declared by the task |  |  |
+| `workspace` _string_ | Workspace is the name of the workspace declared by the pipeline |  | Optional: \{\} <br /> |
+| `subPath` _string_ | SubPath is optionally a directory on the volume which should be used<br />for this binding (i.e. the volume will be mounted at this sub directory). |  | Optional: \{\} <br /> |
+
+
+#### WorkspaceUsage
+
+
+
+WorkspaceUsage is used by a Step or Sidecar to declare that it wants isolated access
+to a Workspace defined in a Task.
+
+
+
+_Appears in:_
+- [Sidecar](#sidecar)
+- [Step](#step)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name is the name of the workspace this Step or Sidecar wants access to. |  |  |
+| `mountPath` _string_ | MountPath is the path that the workspace should be mounted to inside the Step or Sidecar,<br />overriding any MountPath specified in the Task's WorkspaceDeclaration. |  |  |
+
+
+
+## tekton.dev/v1alpha1
+
+Package v1alpha1 contains API Schema definitions for the run v1alpha1 API group
+
+### Resource Types
+- [PipelineResource](#pipelineresource)
+- [Run](#run)
+- [StepAction](#stepaction)
+- [VerificationPolicy](#verificationpolicy)
+
+
+
+#### Authority
+
+
+
+The Authority block defines the keys for validating signatures.
+
+
+
+_Appears in:_
+- [VerificationPolicySpec](#verificationpolicyspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name is the name for this authority. |  |  |
+| `key` _[KeyRef](#keyref)_ | Key contains the public key to validate the resource. |  |  |
+
+
+#### EmbeddedRunSpec
+
+
+
+EmbeddedRunSpec allows custom task definitions to be embedded
+
+
+
+_Appears in:_
+- [RunSpec](#runspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `metadata` _[PipelineTaskMetadata](#pipelinetaskmetadata)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  | Optional: \{\} <br /> |
+| `spec` _[RawExtension](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#rawextension-runtime-pkg)_ | Spec is a specification of a custom task |  | Optional: \{\} <br /> |
+
+
+#### HashAlgorithm
+
+_Underlying type:_ _string_
+
+HashAlgorithm defines the hash algorithm used for the public key
+
+
+
+_Appears in:_
+- [KeyRef](#keyref)
+
+| Field | Description |
+| --- | --- |
+| `sha224` |  |
+| `sha256` |  |
+| `sha384` |  |
+| `sha512` |  |
+| `` |  |
+
+
+#### KeyRef
+
+
+
+KeyRef defines the reference to a public key
+
+
+
+_Appears in:_
+- [Authority](#authority)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `secretRef` _[SecretReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#secretreference-v1-core)_ | SecretRef sets a reference to a secret with the key. |  | Optional: \{\} <br /> |
+| `data` _string_ | Data contains the inline public key. |  | Optional: \{\} <br /> |
+| `kms` _string_ | KMS contains the KMS url of the public key<br />Supported formats differ based on the KMS system used.<br />One example of a KMS url could be:<br />gcpkms://projects/[PROJECT]/locations/[LOCATION]>/keyRings/[KEYRING]/cryptoKeys/[KEY]/cryptoKeyVersions/[KEY_VERSION]<br />For more examples please refer https://docs.sigstore.dev/cosign/kms_support.<br />Note that the KMS is not supported yet. |  | Optional: \{\} <br /> |
+| `hashAlgorithm` _[HashAlgorithm](#hashalgorithm)_ | HashAlgorithm always defaults to sha256 if the algorithm hasn't been explicitly set |  | Optional: \{\} <br /> |
+
+
+#### ModeType
+
+_Underlying type:_ _string_
+
+ModeType indicates the type of a mode for VerificationPolicy
+
+
+
+_Appears in:_
+- [VerificationPolicySpec](#verificationpolicyspec)
+
+| Field | Description |
+| --- | --- |
+| `warn` |  |
+| `enforce` |  |
+
+
+#### PipelineResource
+
+
+
+PipelineResource describes a resource that is an input to or output from a
+Task.
+
+Deprecated: Unused, preserved only for backwards compatibility
+
+
+
+
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `apiVersion` _string_ | `tekton.dev/v1alpha1` | | |
+| `kind` _string_ | `PipelineResource` | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  | Optional: \{\} <br /> |
+| `spec` _[PipelineResourceSpec](#pipelineresourcespec)_ | Spec holds the desired state of the PipelineResource from the client |  |  |
+| `status` _[PipelineResourceStatus](#pipelineresourcestatus)_ | Status is used to communicate the observed state of the PipelineResource from<br />the controller, but was unused as there is no controller for PipelineResource. |  | Optional: \{\} <br /> |
+
+
+#### PipelineResourceSpec
+
+
+
+PipelineResourceSpec defines an individual resources used in the pipeline.
+
+Deprecated: Unused, preserved only for backwards compatibility
+
+
+
+_Appears in:_
+- [PipelineResource](#pipelineresource)
+- [PipelineResourceBinding](#pipelineresourcebinding)
+- [TaskResourceBinding](#taskresourcebinding)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `description` _string_ | Description is a user-facing description of the resource that may be<br />used to populate a UI. |  | Optional: \{\} <br /> |
+| `type` _[PipelineResourceType](#pipelineresourcetype)_ |  |  |  |
+| `params` _[ResourceParam](#resourceparam) array_ |  |  |  |
+| `secrets` _[SecretParam](#secretparam) array_ | Secrets to fetch to populate some of resource fields |  | Optional: \{\} <br /> |
+
+
+#### PipelineResourceStatus
+
+
+
+PipelineResourceStatus does not contain anything because PipelineResources on their own
+do not have a status
+
+Deprecated: Unused, preserved only for backwards compatibility
+
+
+
+_Appears in:_
+- [PipelineResource](#pipelineresource)
+
+
+
+
+
+
+
+#### ResourceParam
+
+
+
+ResourceParam declares a string value to use for the parameter called Name, and is used in
+the specific context of PipelineResources.
+
+Deprecated: Unused, preserved only for backwards compatibility
+
+
+
+_Appears in:_
+- [PipelineResourceSpec](#pipelineresourcespec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ |  |  |  |
+| `value` _string_ |  |  |  |
+
+
+#### ResourcePattern
+
+
+
+ResourcePattern defines the pattern of the resource source
+
+
+
+_Appears in:_
+- [VerificationPolicySpec](#verificationpolicyspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `pattern` _string_ | Pattern defines a resource pattern. Regex is created to filter resources based on `Pattern`<br />Example patterns:<br />GitHub resource: https://github.com/tektoncd/catalog.git, https://github.com/tektoncd/*<br />Bundle resource: gcr.io/tekton-releases/catalog/upstream/git-clone, gcr.io/tekton-releases/catalog/upstream/*<br />Hub resource: https://artifacthub.io/*, |  |  |
+
+
+#### Run
+
+
+
+Run represents a single execution of a Custom Task.
+
+
+
+
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `apiVersion` _string_ | `tekton.dev/v1alpha1` | | |
+| `kind` _string_ | `Run` | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  | Optional: \{\} <br /> |
+| `spec` _[RunSpec](#runspec)_ |  |  | Optional: \{\} <br /> |
+| `status` _[RunStatus](#runstatus)_ |  |  | Optional: \{\} <br /> |
+
+
+
+
+
+
+#### RunSpec
+
+
+
+RunSpec defines the desired state of Run
+
+
+
+_Appears in:_
+- [Run](#run)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `ref` _[TaskRef](#taskref)_ |  |  | Optional: \{\} <br /> |
+| `spec` _[EmbeddedRunSpec](#embeddedrunspec)_ | Spec is a specification of a custom task |  | Optional: \{\} <br /> |
+| `params` _[Params](#params)_ |  |  | Optional: \{\} <br /> |
+| `status` _[RunSpecStatus](#runspecstatus)_ | Used for cancelling a run (and maybe more later on) |  | Optional: \{\} <br /> |
+| `statusMessage` _[RunSpecStatusMessage](#runspecstatusmessage)_ | Status message for cancellation. |  | Optional: \{\} <br /> |
+| `retries` _integer_ | Used for propagating retries count to custom tasks |  | Optional: \{\} <br /> |
+| `serviceAccountName` _string_ |  |  | Optional: \{\} <br /> |
+| `podTemplate` _[PodTemplate](#podtemplate)_ | PodTemplate holds pod specific configuration |  | Optional: \{\} <br /> |
+| `timeout` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ | Time after which the custom-task times out.<br />Refer Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration |  | Optional: \{\} <br /> |
+| `workspaces` _[WorkspaceBinding](#workspacebinding) array_ | Workspaces is a list of WorkspaceBindings from volumes to workspaces. |  | Optional: \{\} <br /> |
+
+
+#### RunSpecStatus
+
+_Underlying type:_ _string_
+
+RunSpecStatus defines the taskrun spec status the user can provide
+
+
+
+_Appears in:_
+- [RunSpec](#runspec)
+
+| Field | Description |
+| --- | --- |
+| `RunCancelled` | RunSpecStatusCancelled indicates that the user wants to cancel the run,<br />if not already cancelled or terminated<br /> |
+
+
+#### RunSpecStatusMessage
+
+_Underlying type:_ _string_
+
+RunSpecStatusMessage defines human readable status messages for the TaskRun.
+
+
+
+_Appears in:_
+- [RunSpec](#runspec)
+
+| Field | Description |
+| --- | --- |
+| `Run cancelled as the PipelineRun it belongs to has been cancelled.` | RunCancelledByPipelineMsg indicates that the PipelineRun of which part this Run was<br />has been cancelled.<br /> |
+| `Run cancelled as the PipelineRun it belongs to has timed out.` | RunCancelledByPipelineTimeoutMsg indicates that the Run was cancelled because the PipelineRun running it timed out.<br /> |
+
+
+
+
+
+
+#### SecretParam
+
+
+
+SecretParam indicates which secret can be used to populate a field of the resource
+
+Deprecated: Unused, preserved only for backwards compatibility
+
+
+
+_Appears in:_
+- [PipelineResourceSpec](#pipelineresourcespec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `fieldName` _string_ |  |  |  |
+| `secretKey` _string_ |  |  |  |
+| `secretName` _string_ |  |  |  |
+
+
+#### StepAction
+
+
+
+StepAction represents the actionable components of Step.
+The Step can only reference it from the cluster or using remote resolution.
+
+
+
+
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `apiVersion` _string_ | `tekton.dev/v1alpha1` | | |
+| `kind` _string_ | `StepAction` | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  | Optional: \{\} <br /> |
+| `spec` _[StepActionSpec](#stepactionspec)_ | Spec holds the desired state of the Step from the client |  | Optional: \{\} <br /> |
+
+
+
+
+#### StepActionSpec
+
+
+
+StepActionSpec contains the actionable components of a step.
+
+
+
+_Appears in:_
+- [StepAction](#stepaction)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `description` _string_ | Description is a user-facing description of the stepaction that may be<br />used to populate a UI. |  | Optional: \{\} <br /> |
+| `image` _string_ | Image reference name to run for this StepAction.<br />More info: https://kubernetes.io/docs/concepts/containers/images |  | Optional: \{\} <br /> |
+| `command` _string array_ | Entrypoint array. Not executed within a shell.<br />The image's ENTRYPOINT is used if this is not provided.<br />Variable references $(VAR_NAME) are expanded using the container's environment. If a variable<br />cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced<br />to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will<br />produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless<br />of whether the variable exists or not. Cannot be updated.<br />More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell |  | Optional: \{\} <br /> |
+| `args` _string array_ | Arguments to the entrypoint.<br />The image's CMD is used if this is not provided.<br />Variable references $(VAR_NAME) are expanded using the container's environment. If a variable<br />cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced<br />to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will<br />produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless<br />of whether the variable exists or not. Cannot be updated.<br />More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell |  | Optional: \{\} <br /> |
+| `env` _[EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#envvar-v1-core) array_ | List of environment variables to set in the container.<br />Cannot be updated. |  | Optional: \{\} <br /> |
+| `script` _string_ | Script is the contents of an executable file to execute.<br />If Script is not empty, the Step cannot have an Command and the Args will be passed to the Script. |  | Optional: \{\} <br /> |
+| `workingDir` _string_ | Step's working directory.<br />If not specified, the container runtime's default will be used, which<br />might be configured in the container image.<br />Cannot be updated. |  | Optional: \{\} <br /> |
+| `params` _[ParamSpecs](#paramspecs)_ | Params is a list of input parameters required to run the stepAction.<br />Params must be supplied as inputs in Steps unless they declare a defaultvalue. |  | Optional: \{\} <br /> |
+| `results` _[StepResult](#stepresult) array_ | Results are values that this StepAction can output |  | Optional: \{\} <br /> |
+| `securityContext` _[SecurityContext](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#securitycontext-v1-core)_ | SecurityContext defines the security options the Step should be run with.<br />If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.<br />More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/<br />The value set in StepAction will take precedence over the value from Task. |  | Optional: \{\} <br /> |
+| `volumeMounts` _[VolumeMount](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#volumemount-v1-core) array_ | Volumes to mount into the Step's filesystem.<br />Cannot be updated. |  | Optional: \{\} <br /> |
+
+
+#### VerificationPolicy
+
+
+
+VerificationPolicy defines the rules to verify Tekton resources.
 VerificationPolicy can config the mapping from resources to a list of public
-keys, so when verifying the resources we can use the corresponding public keys.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code><br/>
-string</td>
-<td>
-<code>
-tekton.dev/v1alpha1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code><br/>
-string
-</td>
-<td><code>VerificationPolicy</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code><br/>
-<em>
-<a href="#tekton.dev/v1alpha1.VerificationPolicySpec">
-VerificationPolicySpec
-</a>
-</em>
-</td>
-<td>
-<p>Spec holds the desired state of the VerificationPolicy.</p>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>resources</code><br/>
-<em>
-<a href="#tekton.dev/v1alpha1.ResourcePattern">
-[]ResourcePattern
-</a>
-</em>
-</td>
-<td>
-<p>Resources defines the patterns of resources sources that should be subject to this policy.
-For example, we may want to apply this Policy from a certain GitHub repo.
-Then the ResourcesPattern should be valid regex. E.g. If using gitresolver, and we want to config keys from a certain git repo.
-<code>ResourcesPattern</code> can be <code>https://github.com/tektoncd/catalog.git</code>, we will use regex to filter out those resources.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>authorities</code><br/>
-<em>
-<a href="#tekton.dev/v1alpha1.Authority">
-[]Authority
-</a>
-</em>
-</td>
-<td>
-<p>Authorities defines the rules for validating signatures.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>mode</code><br/>
-<em>
-<a href="#tekton.dev/v1alpha1.ModeType">
-ModeType
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Mode controls whether a failing policy will fail the taskrun/pipelinerun, or only log the warnings
-enforce - fail the taskrun/pipelinerun if verification fails (default)
-warn - don&rsquo;t fail the taskrun/pipelinerun if verification fails but log warnings</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1alpha1.PipelineResource">PipelineResource
-</h3>
-<div>
-<p>PipelineResource describes a resource that is an input to or output from a
-Task.</p>
-<p>Deprecated: Unused, preserved only for backwards compatibility</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code><br/>
-string</td>
-<td>
-<code>
-tekton.dev/v1alpha1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code><br/>
-string
-</td>
-<td><code>PipelineResource</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code><br/>
-<em>
-<a href="#tekton.dev/v1alpha1.PipelineResourceSpec">
-PipelineResourceSpec
-</a>
-</em>
-</td>
-<td>
-<p>Spec holds the desired state of the PipelineResource from the client</p>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>description</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Description is a user-facing description of the resource that may be
-used to populate a UI.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>type</code><br/>
-<em>
-<a href="#tekton.dev/v1alpha1.PipelineResourceType">
-PipelineResourceType
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>params</code><br/>
-<em>
-<a href="#tekton.dev/v1alpha1.ResourceParam">
-[]ResourceParam
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>secrets</code><br/>
-<em>
-<a href="#tekton.dev/v1alpha1.SecretParam">
-[]SecretParam
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Secrets to fetch to populate some of resource fields</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code><br/>
-<em>
-<a href="#tekton.dev/v1alpha1.PipelineResourceStatus">
-PipelineResourceStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Status is used to communicate the observed state of the PipelineResource from
-the controller, but was unused as there is no controller for PipelineResource.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1alpha1.Authority">Authority
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1alpha1.VerificationPolicySpec">VerificationPolicySpec</a>)
-</p>
-<div>
-<p>The Authority block defines the keys for validating signatures.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Name is the name for this authority.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>key</code><br/>
-<em>
-<a href="#tekton.dev/v1alpha1.KeyRef">
-KeyRef
-</a>
-</em>
-</td>
-<td>
-<p>Key contains the public key to validate the resource.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1alpha1.EmbeddedRunSpec">EmbeddedRunSpec
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1alpha1.RunSpec">RunSpec</a>)
-</p>
-<div>
-<p>EmbeddedRunSpec allows custom task definitions to be embedded</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>metadata</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.PipelineTaskMetadata">
-PipelineTaskMetadata
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code><br/>
-<em>
-<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime#RawExtension">
-k8s.io/apimachinery/pkg/runtime.RawExtension
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Spec is a specification of a custom task</p>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>-</code><br/>
-<em>
-[]byte
-</em>
-</td>
-<td>
-<p>Raw is the underlying serialization of this object.</p>
-<p>TODO: Determine how to detect ContentType and ContentEncoding of &lsquo;Raw&rsquo; data.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>-</code><br/>
-<em>
-<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime#Object">
-k8s.io/apimachinery/pkg/runtime.Object
-</a>
-</em>
-</td>
-<td>
-<p>Object can hold a representation of this extension - useful for working with versioned
-structs.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1alpha1.HashAlgorithm">HashAlgorithm
-(<code>string</code> alias)</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1alpha1.KeyRef">KeyRef</a>)
-</p>
-<div>
-<p>HashAlgorithm defines the hash algorithm used for the public key</p>
-</div>
-<h3 id="tekton.dev/v1alpha1.KeyRef">KeyRef
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1alpha1.Authority">Authority</a>)
-</p>
-<div>
-<p>KeyRef defines the reference to a public key</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>secretRef</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#secretreference-v1-core">
-Kubernetes core/v1.SecretReference
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>SecretRef sets a reference to a secret with the key.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>data</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Data contains the inline public key.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>kms</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>KMS contains the KMS url of the public key
-Supported formats differ based on the KMS system used.
-One example of a KMS url could be:
-gcpkms://projects/[PROJECT]/locations/[LOCATION]&gt;/keyRings/[KEYRING]/cryptoKeys/[KEY]/cryptoKeyVersions/[KEY_VERSION]
-For more examples please refer <a href="https://docs.sigstore.dev/cosign/kms_support">https://docs.sigstore.dev/cosign/kms_support</a>.
-Note that the KMS is not supported yet.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>hashAlgorithm</code><br/>
-<em>
-<a href="#tekton.dev/v1alpha1.HashAlgorithm">
-HashAlgorithm
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>HashAlgorithm always defaults to sha256 if the algorithm hasn&rsquo;t been explicitly set</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1alpha1.ModeType">ModeType
-(<code>string</code> alias)</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1alpha1.VerificationPolicySpec">VerificationPolicySpec</a>)
-</p>
-<div>
-<p>ModeType indicates the type of a mode for VerificationPolicy</p>
-</div>
-<h3 id="tekton.dev/v1alpha1.ResourcePattern">ResourcePattern
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1alpha1.VerificationPolicySpec">VerificationPolicySpec</a>)
-</p>
-<div>
-<p>ResourcePattern defines the pattern of the resource source</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>pattern</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Pattern defines a resource pattern. Regex is created to filter resources based on <code>Pattern</code>
-Example patterns:
-GitHub resource: <a href="https://github.com/tektoncd/catalog.git">https://github.com/tektoncd/catalog.git</a>, <a href="https://github.com/tektoncd/*">https://github.com/tektoncd/*</a>
-Bundle resource: gcr.io/tekton-releases/catalog/upstream/git-clone, gcr.io/tekton-releases/catalog/upstream/*
-Hub resource: <a href="https://artifacthub.io/*">https://artifacthub.io/*</a>,</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1alpha1.RunReason">RunReason
-(<code>string</code> alias)</h3>
-<div>
-<p>RunReason is an enum used to store all Run reason for the Succeeded condition that are controlled by the Run itself.</p>
-</div>
-<h3 id="tekton.dev/v1alpha1.RunResult">RunResult
-</h3>
-<div>
-<p>RunResult used to describe the results of a task</p>
-</div>
-<h3 id="tekton.dev/v1alpha1.RunSpec">RunSpec
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1alpha1.Run">Run</a>)
-</p>
-<div>
-<p>RunSpec defines the desired state of Run</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>ref</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.TaskRef">
-TaskRef
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code><br/>
-<em>
-<a href="#tekton.dev/v1alpha1.EmbeddedRunSpec">
-EmbeddedRunSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Spec is a specification of a custom task</p>
-<br/>
-<br/>
-<table>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>params</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.Params">
-Params
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code><br/>
-<em>
-<a href="#tekton.dev/v1alpha1.RunSpecStatus">
-RunSpecStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Used for cancelling a run (and maybe more later on)</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>statusMessage</code><br/>
-<em>
-<a href="#tekton.dev/v1alpha1.RunSpecStatusMessage">
-RunSpecStatusMessage
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Status message for cancellation.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>retries</code><br/>
-<em>
-int
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Used for propagating retries count to custom tasks</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>serviceAccountName</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-<tr>
-<td>
-<code>podTemplate</code><br/>
-<em>
-<a href="#tekton.dev/unversioned.PodTemplate">
-PodTemplate
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>PodTemplate holds pod specific configuration</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>timeout</code><br/>
-<em>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
-Kubernetes meta/v1.Duration
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Time after which the custom-task times out.
-Refer Go&rsquo;s ParseDuration documentation for expected format: <a href="https://golang.org/pkg/time/#ParseDuration">https://golang.org/pkg/time/#ParseDuration</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>workspaces</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.WorkspaceBinding">
-[]WorkspaceBinding
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Workspaces is a list of WorkspaceBindings from volumes to workspaces.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1alpha1.RunSpecStatus">RunSpecStatus
-(<code>string</code> alias)</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1alpha1.RunSpec">RunSpec</a>)
-</p>
-<div>
-<p>RunSpecStatus defines the taskrun spec status the user can provide</p>
-</div>
-<h3 id="tekton.dev/v1alpha1.RunSpecStatusMessage">RunSpecStatusMessage
-(<code>string</code> alias)</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1alpha1.RunSpec">RunSpec</a>)
-</p>
-<div>
-<p>RunSpecStatusMessage defines human readable status messages for the TaskRun.</p>
-</div>
-<h3 id="tekton.dev/v1alpha1.RunStatus">RunStatus
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1alpha1.Run">Run</a>)
-</p>
-<div>
-<p>RunStatus defines the observed state of Run.</p>
-</div>
-<h3 id="tekton.dev/v1alpha1.RunStatusFields">RunStatusFields
-</h3>
-<div>
-<p>RunStatusFields holds the fields of Run&rsquo;s status.  This is defined
-separately and inlined so that other types can readily consume these fields
-via duck typing.</p>
-</div>
-<h3 id="tekton.dev/v1alpha1.StepActionObject">StepActionObject
-</h3>
-<div>
-<p>StepActionObject is implemented by StepAction</p>
-</div>
-<h3 id="tekton.dev/v1alpha1.StepActionSpec">StepActionSpec
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1alpha1.StepAction">StepAction</a>)
-</p>
-<div>
-<p>StepActionSpec contains the actionable components of a step.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>description</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Description is a user-facing description of the stepaction that may be
-used to populate a UI.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>image</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Image reference name to run for this StepAction.
-More info: <a href="https://kubernetes.io/docs/concepts/containers/images">https://kubernetes.io/docs/concepts/containers/images</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>command</code><br/>
-<em>
-[]string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Entrypoint array. Not executed within a shell.
-The image&rsquo;s ENTRYPOINT is used if this is not provided.
-Variable references $(VAR_NAME) are expanded using the container&rsquo;s environment. If a variable
-cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
-to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. &ldquo;$$(VAR_NAME)&rdquo; will
-produce the string literal &ldquo;$(VAR_NAME)&rdquo;. Escaped references will never be expanded, regardless
-of whether the variable exists or not. Cannot be updated.
-More info: <a href="https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell">https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>args</code><br/>
-<em>
-[]string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Arguments to the entrypoint.
-The image&rsquo;s CMD is used if this is not provided.
-Variable references $(VAR_NAME) are expanded using the container&rsquo;s environment. If a variable
-cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
-to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. &ldquo;$$(VAR_NAME)&rdquo; will
-produce the string literal &ldquo;$(VAR_NAME)&rdquo;. Escaped references will never be expanded, regardless
-of whether the variable exists or not. Cannot be updated.
-More info: <a href="https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell">https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>env</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#envvar-v1-core">
-[]Kubernetes core/v1.EnvVar
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>List of environment variables to set in the container.
-Cannot be updated.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>script</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Script is the contents of an executable file to execute.</p>
-<p>If Script is not empty, the Step cannot have an Command and the Args will be passed to the Script.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>workingDir</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Step&rsquo;s working directory.
-If not specified, the container runtime&rsquo;s default will be used, which
-might be configured in the container image.
-Cannot be updated.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>params</code><br/>
-<em>
-<a href="#tekton.dev/v1.ParamSpecs">
-ParamSpecs
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Params is a list of input parameters required to run the stepAction.
-Params must be supplied as inputs in Steps unless they declare a defaultvalue.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>results</code><br/>
-<em>
-<a href="#tekton.dev/v1.StepResult">
-[]StepResult
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Results are values that this StepAction can output</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>securityContext</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#securitycontext-v1-core">
-Kubernetes core/v1.SecurityContext
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>SecurityContext defines the security options the Step should be run with.
-If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
-More info: <a href="https://kubernetes.io/docs/tasks/configure-pod-container/security-context/">https://kubernetes.io/docs/tasks/configure-pod-container/security-context/</a>
-The value set in StepAction will take precedence over the value from Task.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>volumeMounts</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#volumemount-v1-core">
-[]Kubernetes core/v1.VolumeMount
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Volumes to mount into the Step&rsquo;s filesystem.
-Cannot be updated.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1alpha1.VerificationPolicySpec">VerificationPolicySpec
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1alpha1.VerificationPolicy">VerificationPolicy</a>)
-</p>
-<div>
-<p>VerificationPolicySpec defines the patterns and authorities.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>resources</code><br/>
-<em>
-<a href="#tekton.dev/v1alpha1.ResourcePattern">
-[]ResourcePattern
-</a>
-</em>
-</td>
-<td>
-<p>Resources defines the patterns of resources sources that should be subject to this policy.
-For example, we may want to apply this Policy from a certain GitHub repo.
-Then the ResourcesPattern should be valid regex. E.g. If using gitresolver, and we want to config keys from a certain git repo.
-<code>ResourcesPattern</code> can be <code>https://github.com/tektoncd/catalog.git</code>, we will use regex to filter out those resources.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>authorities</code><br/>
-<em>
-<a href="#tekton.dev/v1alpha1.Authority">
-[]Authority
-</a>
-</em>
-</td>
-<td>
-<p>Authorities defines the rules for validating signatures.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>mode</code><br/>
-<em>
-<a href="#tekton.dev/v1alpha1.ModeType">
-ModeType
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Mode controls whether a failing policy will fail the taskrun/pipelinerun, or only log the warnings
-enforce - fail the taskrun/pipelinerun if verification fails (default)
-warn - don&rsquo;t fail the taskrun/pipelinerun if verification fails but log warnings</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1alpha1.PipelineResourceSpec">PipelineResourceSpec
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1alpha1.PipelineResource">PipelineResource</a>, <a href="#tekton.dev/v1beta1.PipelineResourceBinding">PipelineResourceBinding</a>)
-</p>
-<div>
-<p>PipelineResourceSpec defines an individual resources used in the pipeline.</p>
-<p>Deprecated: Unused, preserved only for backwards compatibility</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>description</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Description is a user-facing description of the resource that may be
-used to populate a UI.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>type</code><br/>
-<em>
-<a href="#tekton.dev/v1alpha1.PipelineResourceType">
-PipelineResourceType
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>params</code><br/>
-<em>
-<a href="#tekton.dev/v1alpha1.ResourceParam">
-[]ResourceParam
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>secrets</code><br/>
-<em>
-<a href="#tekton.dev/v1alpha1.SecretParam">
-[]SecretParam
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Secrets to fetch to populate some of resource fields</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1alpha1.PipelineResourceStatus">PipelineResourceStatus
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1alpha1.PipelineResource">PipelineResource</a>)
-</p>
-<div>
-<p>PipelineResourceStatus does not contain anything because PipelineResources on their own
-do not have a status</p>
-<p>Deprecated: Unused, preserved only for backwards compatibility</p>
-</div>
-<h3 id="tekton.dev/v1alpha1.PipelineResourceType">PipelineResourceType
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1alpha1.PipelineResourceSpec">PipelineResourceSpec</a>, <a href="#tekton.dev/v1alpha1.ResourceDeclaration">ResourceDeclaration</a>)
-</p>
-<div>
-<p>PipelineResourceType represents the type of endpoint the pipelineResource is, so that the
-controller will know this pipelineResource shouldx be fetched and optionally what
-additional metatdata should be provided for it.</p>
-<p>Deprecated: Unused, preserved only for backwards compatibility</p>
-</div>
-<h3 id="tekton.dev/v1alpha1.ResourceDeclaration">ResourceDeclaration
-</h3>
-<div>
-<p>ResourceDeclaration defines an input or output PipelineResource declared as a requirement
-by another type such as a Task or Condition. The Name field will be used to refer to these
-PipelineResources within the type&rsquo;s definition, and when provided as an Input, the Name will be the
-path to the volume mounted containing this PipelineResource as an input (e.g.
-an input Resource named <code>workspace</code> will be mounted at <code>/workspace</code>).</p>
-<p>Deprecated: Unused, preserved only for backwards compatibility</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Name declares the name by which a resource is referenced in the
-definition. Resources may be referenced by name in the definition of a
-Task&rsquo;s steps.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>type</code><br/>
-<em>
-<a href="#tekton.dev/v1alpha1.PipelineResourceType">
-PipelineResourceType
-</a>
-</em>
-</td>
-<td>
-<p>Type is the type of this resource;</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>description</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Description is a user-facing description of the declared resource that may be
-used to populate a UI.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>targetPath</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>TargetPath is the path in workspace directory where the resource
-will be copied.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>optional</code><br/>
-<em>
-bool
-</em>
-</td>
-<td>
-<p>Optional declares the resource as optional.
-By default optional is set to false which makes a resource required.
-optional: true - the resource is considered optional
-optional: false - the resource is considered required (equivalent of not specifying it)</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1alpha1.ResourceParam">ResourceParam
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1alpha1.PipelineResourceSpec">PipelineResourceSpec</a>)
-</p>
-<div>
-<p>ResourceParam declares a string value to use for the parameter called Name, and is used in
-the specific context of PipelineResources.</p>
-<p>Deprecated: Unused, preserved only for backwards compatibility</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>value</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1alpha1.SecretParam">SecretParam
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1alpha1.PipelineResourceSpec">PipelineResourceSpec</a>)
-</p>
-<div>
-<p>SecretParam indicates which secret can be used to populate a field of the resource</p>
-<p>Deprecated: Unused, preserved only for backwards compatibility</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>fieldName</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>secretKey</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>secretName</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1alpha1.RunResult">RunResult
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1alpha1.RunStatusFields">RunStatusFields</a>)
-</p>
-<div>
-<p>RunResult used to describe the results of a task</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Name the given name</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>value</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Value the given value of the result</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1alpha1.RunStatus">RunStatus
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1alpha1.RunStatusFields">RunStatusFields</a>)
-</p>
-<div>
-<p>RunStatus defines the observed state of Run</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>Status</code><br/>
-<em>
-<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Status">
-knative.dev/pkg/apis/duck/v1.Status
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>Status</code> are embedded into this type.)
-</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>RunStatusFields</code><br/>
-<em>
-<a href="#tekton.dev/v1alpha1.RunStatusFields">
-RunStatusFields
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>RunStatusFields</code> are embedded into this type.)
-</p>
-<p>RunStatusFields inlines the status fields.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1alpha1.RunStatusFields">RunStatusFields
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1alpha1.RunStatus">RunStatus</a>)
-</p>
-<div>
-<p>RunStatusFields holds the fields of Run&rsquo;s status.  This is defined
-separately and inlined so that other types can readily consume these fields
-via duck typing.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>startTime</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta">
-Kubernetes meta/v1.Time
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>StartTime is the time the build is actually started.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>completionTime</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta">
-Kubernetes meta/v1.Time
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>CompletionTime is the time the build completed.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>results</code><br/>
-<em>
-<a href="#tekton.dev/v1alpha1.RunResult">
-[]RunResult
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Results reports any output result values to be consumed by later
-tasks in a pipeline.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>retriesStatus</code><br/>
-<em>
-<a href="#tekton.dev/v1alpha1.RunStatus">
-[]RunStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>RetriesStatus contains the history of RunStatus, in case of a retry.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>extraFields</code><br/>
-<em>
-<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime#RawExtension">
-k8s.io/apimachinery/pkg/runtime.RawExtension
-</a>
-</em>
-</td>
-<td>
-<p>ExtraFields holds arbitrary fields provided by the custom task
-controller.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<hr/>
-<h2 id="tekton.dev/v1beta1">tekton.dev/v1beta1</h2>
-<div>
-<p>Package v1beta1 contains API Schema definitions for the pipeline v1beta1 API group</p>
-</div>
-Resource Types:
-<ul><li>
-<a href="#tekton.dev/v1beta1.CustomRun">CustomRun</a>
-</li><li>
-<a href="#tekton.dev/v1beta1.Pipeline">Pipeline</a>
-</li><li>
-<a href="#tekton.dev/v1beta1.PipelineRun">PipelineRun</a>
-</li><li>
-<a href="#tekton.dev/v1beta1.StepAction">StepAction</a>
-</li><li>
-<a href="#tekton.dev/v1beta1.Task">Task</a>
-</li><li>
-<a href="#tekton.dev/v1beta1.TaskRun">TaskRun</a>
-</li></ul>
-<h3 id="tekton.dev/v1beta1.CustomRun">CustomRun
-</h3>
-<div>
-<p>CustomRun represents a single execution of a Custom Task.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code><br/>
-string</td>
-<td>
-<code>
-tekton.dev/v1beta1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code><br/>
-string
-</td>
-<td><code>CustomRun</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.CustomRunSpec">
-CustomRunSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>customRef</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.TaskRef">
-TaskRef
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-<tr>
-<td>
-<code>customSpec</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.EmbeddedCustomRunSpec">
-EmbeddedCustomRunSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Spec is a specification of a custom task</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>params</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.Params">
-Params
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.CustomRunSpecStatus">
-CustomRunSpecStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Used for cancelling a customrun (and maybe more later on)</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>statusMessage</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.CustomRunSpecStatusMessage">
-CustomRunSpecStatusMessage
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Status message for cancellation.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>retries</code><br/>
-<em>
-int
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Used for propagating retries count to custom tasks</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>serviceAccountName</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-<tr>
-<td>
-<code>timeout</code><br/>
-<em>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
-Kubernetes meta/v1.Duration
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Time after which the custom-task times out.
-Refer Go&rsquo;s ParseDuration documentation for expected format: <a href="https://golang.org/pkg/time/#ParseDuration">https://golang.org/pkg/time/#ParseDuration</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>workspaces</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.WorkspaceBinding">
-[]WorkspaceBinding
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Workspaces is a list of WorkspaceBindings from volumes to workspaces.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.CustomRunStatus">
-CustomRunStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.Pipeline">Pipeline
-</h3>
-<div>
-<p>Pipeline describes a list of Tasks to execute. It expresses how outputs
-of tasks feed into inputs of subsequent tasks.</p>
-<p>Deprecated: Please use v1.Pipeline instead.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code><br/>
-string</td>
-<td>
-<code>
-tekton.dev/v1beta1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code><br/>
-string
-</td>
-<td><code>Pipeline</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.PipelineSpec">
-PipelineSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Spec holds the desired state of the Pipeline from the client</p>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>displayName</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>DisplayName is a user-facing name of the pipeline that may be
-used to populate a UI.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>description</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Description is a user-facing description of the pipeline that may be
-used to populate a UI.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>resources</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.PipelineDeclaredResource">
-[]PipelineDeclaredResource
-</a>
-</em>
-</td>
-<td>
-<p>Deprecated: Unused, preserved only for backwards compatibility</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>tasks</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.PipelineTask">
-[]PipelineTask
-</a>
-</em>
-</td>
-<td>
-<p>Tasks declares the graph of Tasks that execute when this Pipeline is run.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>params</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.ParamSpecs">
-ParamSpecs
-</a>
-</em>
-</td>
-<td>
-<p>Params declares a list of input parameters that must be supplied when
-this Pipeline is run.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>workspaces</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.PipelineWorkspaceDeclaration">
-[]PipelineWorkspaceDeclaration
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Workspaces declares a set of named workspaces that are expected to be
-provided by a PipelineRun.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>results</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.PipelineResult">
-[]PipelineResult
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Results are values that this pipeline can output once run</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>finally</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.PipelineTask">
-[]PipelineTask
-</a>
-</em>
-</td>
-<td>
-<p>Finally declares the list of Tasks that execute just before leaving the Pipeline
-i.e. either after all Tasks are finished executing successfully
-or after a failure which would result in ending the Pipeline</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.PipelineRun">PipelineRun
-</h3>
-<div>
-<p>PipelineRun represents a single execution of a Pipeline. PipelineRuns are how
+keys, so when verifying the resources we can use the corresponding public keys.
+
+
+
+
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `apiVersion` _string_ | `tekton.dev/v1alpha1` | | |
+| `kind` _string_ | `VerificationPolicy` | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  | Optional: \{\} <br /> |
+| `spec` _[VerificationPolicySpec](#verificationpolicyspec)_ | Spec holds the desired state of the VerificationPolicy. |  |  |
+
+
+#### VerificationPolicySpec
+
+
+
+VerificationPolicySpec defines the patterns and authorities.
+
+
+
+_Appears in:_
+- [VerificationPolicy](#verificationpolicy)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `resources` _[ResourcePattern](#resourcepattern) array_ | Resources defines the patterns of resources sources that should be subject to this policy.<br />For example, we may want to apply this Policy from a certain GitHub repo.<br />Then the ResourcesPattern should be valid regex. E.g. If using gitresolver, and we want to config keys from a certain git repo.<br />`ResourcesPattern` can be `https://github.com/tektoncd/catalog.git`, we will use regex to filter out those resources. |  |  |
+| `authorities` _[Authority](#authority) array_ | Authorities defines the rules for validating signatures. |  |  |
+| `mode` _[ModeType](#modetype)_ | Mode controls whether a failing policy will fail the taskrun/pipelinerun, or only log the warnings<br />enforce - fail the taskrun/pipelinerun if verification fails (default)<br />warn - don't fail the taskrun/pipelinerun if verification fails but log warnings |  | Optional: \{\} <br /> |
+
+
+
+## tekton.dev/v1beta1
+
+Package v1beta1 contains API Schema definitions for the customrun v1beta1 API group
+
+### Resource Types
+- [CustomRun](#customrun)
+- [Pipeline](#pipeline)
+- [PipelineRun](#pipelinerun)
+- [StepAction](#stepaction)
+- [Task](#task)
+- [TaskRun](#taskrun)
+
+
+
+#### Algorithm
+
+_Underlying type:_ _string_
+
+Algorithm Standard cryptographic hash algorithm
+
+
+
+_Appears in:_
+- [ArtifactValue](#artifactvalue)
+
+
+
+#### Args
+
+_Underlying type:_ _string array_
+
+
+
+
+
+_Appears in:_
+- [StepActionSpec](#stepactionspec)
+
+
+
+
+
+#### Artifact
+
+
+
+Artifact represents an artifact within a system, potentially containing multiple values
+associated with it.
+
+
+
+_Appears in:_
+- [Artifacts](#artifacts)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | The artifact's identifying category name |  |  |
+| `values` _[ArtifactValue](#artifactvalue) array_ | A collection of values related to the artifact |  |  |
+| `buildOutput` _boolean_ | Indicate if the artifact is a build output or a by-product |  |  |
+
+
+#### ArtifactValue
+
+
+
+ArtifactValue represents a specific value or data element within an Artifact.
+
+
+
+_Appears in:_
+- [Artifact](#artifact)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `digest` _object (keys:[Algorithm](#algorithm), values:string)_ |  |  |  |
+| `uri` _string_ |  |  |  |
+
+
+
+
+#### ChildStatusReference
+
+
+
+ChildStatusReference is used to point to the statuses of individual TaskRuns and Runs within this PipelineRun.
+
+
+
+_Appears in:_
+- [PipelineRunStatus](#pipelinerunstatus)
+- [PipelineRunStatusFields](#pipelinerunstatusfields)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name is the name of the TaskRun or Run this is referencing. |  |  |
+| `displayName` _string_ | DisplayName is a user-facing name of the pipelineTask that may be<br />used to populate a UI. |  |  |
+| `pipelineTaskName` _string_ | PipelineTaskName is the name of the PipelineTask this is referencing. |  |  |
+| `whenExpressions` _[WhenExpression](#whenexpression) array_ | WhenExpressions is the list of checks guarding the execution of the PipelineTask |  | Optional: \{\} <br /> |
+
+
+#### CloudEventCondition
+
+_Underlying type:_ _string_
+
+CloudEventCondition is a string that represents the condition of the event.
+
+
+
+_Appears in:_
+- [CloudEventDeliveryState](#cloudeventdeliverystate)
+
+| Field | Description |
+| --- | --- |
+| `Unknown` | CloudEventConditionUnknown means that the condition for the event to be<br />triggered was not met yet, or we don't know the state yet.<br /> |
+| `Sent` | CloudEventConditionSent means that the event was sent successfully<br /> |
+| `Failed` | CloudEventConditionFailed means that there was one or more attempts to<br />send the event, and none was successful so far.<br /> |
+
+
+#### CloudEventDelivery
+
+
+
+CloudEventDelivery is the target of a cloud event along with the state of
+delivery.
+
+
+
+_Appears in:_
+- [TaskRunStatus](#taskrunstatus)
+- [TaskRunStatusFields](#taskrunstatusfields)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `target` _string_ | Target points to an addressable |  |  |
+| `status` _[CloudEventDeliveryState](#cloudeventdeliverystate)_ |  |  |  |
+
+
+#### CloudEventDeliveryState
+
+
+
+CloudEventDeliveryState reports the state of a cloud event to be sent.
+
+
+
+_Appears in:_
+- [CloudEventDelivery](#cloudeventdelivery)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `condition` _[CloudEventCondition](#cloudeventcondition)_ | Current status |  |  |
+| `sentAt` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | SentAt is the time at which the last attempt to send the event was made |  | Optional: \{\} <br /> |
+| `message` _string_ | Error is the text of error (if any) |  |  |
+| `retryCount` _integer_ | RetryCount is the number of attempts of sending the cloud event |  |  |
+
+
+#### Combination
+
+_Underlying type:_ _object_
+
+Combination is a map, mainly defined to hold a single combination from a Matrix with key as param.Name and value as param.Value
+
+
+
+_Appears in:_
+- [Combinations](#combinations)
+
+
+
+
+
+#### ConfigSource
+
+
+
+ConfigSource contains the information that can uniquely identify where a remote
+built definition came from i.e. Git repositories, Tekton Bundles in OCI registry
+and hub.
+
+
+
+_Appears in:_
+- [Provenance](#provenance)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `uri` _string_ | URI indicates the identity of the source of the build definition.<br />Example: "https://github.com/tektoncd/catalog" |  |  |
+| `digest` _object (keys:string, values:string)_ | Digest is a collection of cryptographic digests for the contents of the artifact specified by URI.<br />Example: \{"sha1": "f99d13e554ffcb696dee719fa85b695cb5b0f428"\} |  |  |
+| `entryPoint` _string_ | EntryPoint identifies the entry point into the build. This is often a path to a<br />build definition file and/or a target label within that file.<br />Example: "task/git-clone/0.10/git-clone.yaml" |  |  |
+
+
+#### CustomRun
+
+
+
+CustomRun represents a single execution of a Custom Task.
+
+
+
+
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `apiVersion` _string_ | `tekton.dev/v1beta1` | | |
+| `kind` _string_ | `CustomRun` | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  | Optional: \{\} <br /> |
+| `spec` _[CustomRunSpec](#customrunspec)_ |  |  | Optional: \{\} <br /> |
+| `status` _[CustomRunStatus](#customrunstatus)_ |  |  | Optional: \{\} <br /> |
+
+
+
+
+
+
+#### CustomRunSpec
+
+
+
+CustomRunSpec defines the desired state of CustomRun
+
+
+
+_Appears in:_
+- [CustomRun](#customrun)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `customRef` _[TaskRef](#taskref)_ |  |  | Optional: \{\} <br /> |
+| `customSpec` _[EmbeddedCustomRunSpec](#embeddedcustomrunspec)_ | Spec is a specification of a custom task |  | Optional: \{\} <br /> |
+| `params` _[Params](#params)_ |  |  | Optional: \{\} <br /> |
+| `status` _[CustomRunSpecStatus](#customrunspecstatus)_ | Used for cancelling a customrun (and maybe more later on) |  | Optional: \{\} <br /> |
+| `statusMessage` _[CustomRunSpecStatusMessage](#customrunspecstatusmessage)_ | Status message for cancellation. |  | Optional: \{\} <br /> |
+| `retries` _integer_ | Used for propagating retries count to custom tasks |  | Optional: \{\} <br /> |
+| `serviceAccountName` _string_ |  |  | Optional: \{\} <br /> |
+| `timeout` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ | Time after which the custom-task times out.<br />Refer Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration |  | Optional: \{\} <br /> |
+| `workspaces` _[WorkspaceBinding](#workspacebinding) array_ | Workspaces is a list of WorkspaceBindings from volumes to workspaces. |  | Optional: \{\} <br /> |
+
+
+#### CustomRunSpecStatus
+
+_Underlying type:_ _string_
+
+CustomRunSpecStatus defines the taskrun spec status the user can provide
+
+
+
+_Appears in:_
+- [CustomRunSpec](#customrunspec)
+
+| Field | Description |
+| --- | --- |
+| `RunCancelled` | CustomRunSpecStatusCancelled indicates that the user wants to cancel the run,<br />if not already cancelled or terminated<br /> |
+
+
+#### CustomRunSpecStatusMessage
+
+_Underlying type:_ _string_
+
+CustomRunSpecStatusMessage defines human readable status messages for the TaskRun.
+
+
+
+_Appears in:_
+- [CustomRunSpec](#customrunspec)
+
+| Field | Description |
+| --- | --- |
+| `CustomRun cancelled as the PipelineRun it belongs to has been cancelled.` | CustomRunCancelledByPipelineMsg indicates that the PipelineRun of which part this CustomRun was<br />has been cancelled.<br /> |
+| `CustomRun cancelled as the PipelineRun it belongs to has timed out.` | CustomRunCancelledByPipelineTimeoutMsg indicates that the Run was cancelled because the PipelineRun running it timed out.<br /> |
+
+
+
+
+
+
+#### EmbeddedCustomRunSpec
+
+
+
+EmbeddedCustomRunSpec allows custom task definitions to be embedded
+
+
+
+_Appears in:_
+- [CustomRunSpec](#customrunspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `metadata` _[PipelineTaskMetadata](#pipelinetaskmetadata)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  | Optional: \{\} <br /> |
+| `spec` _[RawExtension](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#rawextension-runtime-pkg)_ | Spec is a specification of a custom task |  | Optional: \{\} <br /> |
+
+
+#### EmbeddedTask
+
+
+
+EmbeddedTask is used to define a Task inline within a Pipeline's PipelineTasks.
+
+
+
+_Appears in:_
+- [PipelineTask](#pipelinetask)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `spec` _[RawExtension](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#rawextension-runtime-pkg)_ | Spec is a specification of a custom task |  | Optional: \{\} <br /> |
+| `metadata` _[PipelineTaskMetadata](#pipelinetaskmetadata)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  | Optional: \{\} <br /> |
+| `resources` _[TaskResources](#taskresources)_ | Resources is a list input and output resource to run the task<br />Resources are represented in TaskRuns as bindings to instances of<br />PipelineResources.<br />Deprecated: Unused, preserved only for backwards compatibility |  | Optional: \{\} <br /> |
+| `params` _[ParamSpecs](#paramspecs)_ | Params is a list of input parameters required to run the task. Params<br />must be supplied as inputs in TaskRuns unless they declare a default<br />value. |  | Optional: \{\} <br /> |
+| `displayName` _string_ | DisplayName is a user-facing name of the task that may be<br />used to populate a UI. |  | Optional: \{\} <br /> |
+| `description` _string_ | Description is a user-facing description of the task that may be<br />used to populate a UI. |  | Optional: \{\} <br /> |
+| `steps` _[Step](#step) array_ | Steps are the steps of the build; each step is run sequentially with the<br />source mounted into /workspace. |  |  |
+| `volumes` _[Volumes](#volumes)_ | Volumes is a collection of volumes that are available to mount into the<br />steps of the build.<br />See Pod.spec.volumes (API version: v1) |  | Schemaless: \{\} <br /> |
+| `stepTemplate` _[StepTemplate](#steptemplate)_ | StepTemplate can be used as the basis for all step containers within the<br />Task, so that the steps inherit settings on the base container. |  |  |
+| `sidecars` _[Sidecar](#sidecar) array_ | Sidecars are run alongside the Task's step containers. They begin before<br />the steps start and end after the steps complete. |  |  |
+| `workspaces` _[WorkspaceDeclaration](#workspacedeclaration) array_ | Workspaces are the volumes that this Task requires. |  |  |
+| `results` _[TaskResult](#taskresult) array_ | Results are values that this Task can output |  |  |
+
+
+
+
+
+
+#### Matrix
+
+
+
+Matrix is used to fan out Tasks in a Pipeline
+
+
+
+_Appears in:_
+- [PipelineTask](#pipelinetask)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `params` _[Params](#params)_ | Params is a list of parameters used to fan out the pipelineTask<br />Params takes only `Parameters` of type `"array"`<br />Each array element is supplied to the `PipelineTask` by substituting `params` of type `"string"` in the underlying `Task`.<br />The names of the `params` in the `Matrix` must match the names of the `params` in the underlying `Task` that they will be substituting. |  |  |
+
+
+#### OnErrorType
+
+_Underlying type:_ _string_
+
+OnErrorType defines a list of supported exiting behavior of a container on error
+
+
+
+_Appears in:_
+- [Step](#step)
+
+| Field | Description |
+| --- | --- |
+| `stopAndFail` | StopAndFail indicates exit the taskRun if the container exits with non-zero exit code<br /> |
+| `continue` | Continue indicates continue executing the rest of the steps irrespective of the container exit code<br /> |
+
+
+#### Param
+
+
+
+Param declares an ParamValues to use for the parameter called name.
+
+
+
+_Appears in:_
+- [Params](#params)
+- [TaskRunInputs](#taskruninputs)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ |  |  |  |
+| `value` _[ParamValue](#paramvalue)_ |  |  | Schemaless: \{\} <br /> |
+
+
+#### ParamSpec
+
+
+
+ParamSpec defines arbitrary parameters needed beyond typed inputs (such as
+resources). Parameter values are provided by users as inputs on a TaskRun
+or PipelineRun.
+
+
+
+_Appears in:_
+- [ParamSpecs](#paramspecs)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name declares the name by which a parameter is referenced. |  |  |
+| `type` _[ParamType](#paramtype)_ | Type is the user-specified type of the parameter. The possible types<br />are currently "string", "array" and "object", and "string" is the default. |  | Optional: \{\} <br /> |
+| `description` _string_ | Description is a user-facing description of the parameter that may be<br />used to populate a UI. |  | Optional: \{\} <br /> |
+| `properties` _object (keys:string, values:[PropertySpec](#propertyspec))_ | Properties is the JSON Schema properties to support key-value pairs parameter. |  | Optional: \{\} <br /> |
+| `default` _[ParamValue](#paramvalue)_ | Default is the value a parameter takes if no input value is supplied. If<br />default is set, a Task may be executed without a supplied value for the<br />parameter. |  | Schemaless: \{\} <br />Optional: \{\} <br /> |
+| `enum` _string array_ | Enum declares a set of allowed param input values for tasks/pipelines that can be validated.<br />If Enum is not set, no input validation is performed for the param. |  | Optional: \{\} <br /> |
+
+
+#### ParamSpecs
+
+_Underlying type:_ _[ParamSpec](#paramspec)_
+
+ParamSpecs is a list of ParamSpec
+
+
+
+_Appears in:_
+- [EmbeddedTask](#embeddedtask)
+- [PipelineSpec](#pipelinespec)
+- [TaskSpec](#taskspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name declares the name by which a parameter is referenced. |  |  |
+| `type` _[ParamType](#paramtype)_ | Type is the user-specified type of the parameter. The possible types<br />are currently "string", "array" and "object", and "string" is the default. |  | Optional: \{\} <br /> |
+| `description` _string_ | Description is a user-facing description of the parameter that may be<br />used to populate a UI. |  | Optional: \{\} <br /> |
+| `properties` _object (keys:string, values:[PropertySpec](#propertyspec))_ | Properties is the JSON Schema properties to support key-value pairs parameter. |  | Optional: \{\} <br /> |
+| `default` _[ParamValue](#paramvalue)_ | Default is the value a parameter takes if no input value is supplied. If<br />default is set, a Task may be executed without a supplied value for the<br />parameter. |  | Schemaless: \{\} <br />Optional: \{\} <br /> |
+| `enum` _string array_ | Enum declares a set of allowed param input values for tasks/pipelines that can be validated.<br />If Enum is not set, no input validation is performed for the param. |  | Optional: \{\} <br /> |
+
+
+#### ParamType
+
+_Underlying type:_ _string_
+
+ParamType indicates the type of an input parameter;
+Used to distinguish between a single string and an array of strings.
+
+
+
+_Appears in:_
+- [ParamSpec](#paramspec)
+- [ParamValue](#paramvalue)
+- [PropertySpec](#propertyspec)
+
+| Field | Description |
+| --- | --- |
+| `string` |  |
+| `array` |  |
+| `object` |  |
+
+
+#### ParamValue
+
+
+
+ParamValue is a type that can hold a single string or string array.
+Used in JSON unmarshalling so that a single JSON field can accept
+either an individual string or an array of strings.
+
+
+
+_Appears in:_
+- [Param](#param)
+- [ParamSpec](#paramspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `Type` _[ParamType](#paramtype)_ |  |  |  |
+| `StringVal` _string_ |  |  |  |
+| `ArrayVal` _string array_ |  |  |  |
+| `ObjectVal` _object (keys:string, values:string)_ |  |  |  |
+
+
+#### Params
+
+_Underlying type:_ _[Param](#param)_
+
+Params is a list of Param
+
+
+
+_Appears in:_
+- [CustomRunSpec](#customrunspec)
+- [IncludeParams](#includeparams)
+- [Matrix](#matrix)
+- [PipelineRunSpec](#pipelinerunspec)
+- [PipelineTask](#pipelinetask)
+- [ResolverRef](#resolverref)
+- [RunSpec](#runspec)
+- [Step](#step)
+- [TaskRunSpec](#taskrunspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ |  |  |  |
+| `value` _[ParamValue](#paramvalue)_ |  |  | Schemaless: \{\} <br /> |
+
+
+#### Pipeline
+
+
+
+Pipeline describes a list of Tasks to execute. It expresses how outputs
+of tasks feed into inputs of subsequent tasks.
+
+Deprecated: Please use v1.Pipeline instead.
+
+
+
+
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `apiVersion` _string_ | `tekton.dev/v1beta1` | | |
+| `kind` _string_ | `Pipeline` | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  | Optional: \{\} <br /> |
+| `spec` _[PipelineSpec](#pipelinespec)_ | Spec holds the desired state of the Pipeline from the client |  | Optional: \{\} <br /> |
+
+
+#### PipelineDeclaredResource
+
+
+
+PipelineDeclaredResource is used by a Pipeline to declare the types of the
+PipelineResources that it will required to run and names which can be used to
+refer to these PipelineResources in PipelineTaskResourceBindings.
+
+Deprecated: Unused, preserved only for backwards compatibility
+
+
+
+_Appears in:_
+- [PipelineSpec](#pipelinespec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name is the name that will be used by the Pipeline to refer to this resource.<br />It does not directly correspond to the name of any PipelineResources Task<br />inputs or outputs, and it does not correspond to the actual names of the<br />PipelineResources that will be bound in the PipelineRun. |  |  |
+| `type` _[PipelineResourceType](#pipelineresourcetype)_ | Type is the type of the PipelineResource. |  |  |
+| `optional` _boolean_ | Optional declares the resource as optional.<br />optional: true - the resource is considered optional<br />optional: false - the resource is considered required (default/equivalent of not specifying it) |  |  |
+
+
+
+
+#### PipelineRef
+
+
+
+PipelineRef can be used to refer to a specific instance of a Pipeline.
+
+
+
+_Appears in:_
+- [PipelineRunSpec](#pipelinerunspec)
+- [PipelineTask](#pipelinetask)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names |  |  |
+| `apiVersion` _string_ | API version of the referent |  | Optional: \{\} <br /> |
+| `bundle` _string_ | Bundle url reference to a Tekton Bundle.<br />Deprecated: Please use ResolverRef with the bundles resolver instead.<br />The field is staying there for go client backward compatibility, but is not used/allowed anymore. |  | Optional: \{\} <br /> |
+| `ResolverRef` _[ResolverRef](#resolverref)_ | ResolverRef allows referencing a Pipeline in a remote location<br />like a git repo. This field is only supported when the alpha<br />feature gate is enabled. |  | Optional: \{\} <br /> |
+
+
+#### PipelineResourceBinding
+
+
+
+PipelineResourceBinding connects a reference to an instance of a PipelineResource
+with a PipelineResource dependency that the Pipeline has declared
+
+Deprecated: Unused, preserved only for backwards compatibility
+
+
+
+_Appears in:_
+- [PipelineRunSpec](#pipelinerunspec)
+- [TaskResourceBinding](#taskresourcebinding)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name is the name of the PipelineResource in the Pipeline's declaration |  |  |
+| `resourceRef` _[PipelineResourceRef](#pipelineresourceref)_ | ResourceRef is a reference to the instance of the actual PipelineResource<br />that should be used |  | Optional: \{\} <br /> |
+| `resourceSpec` _[PipelineResourceSpec](#pipelineresourcespec)_ | ResourceSpec is specification of a resource that should be created and<br />consumed by the task |  | Optional: \{\} <br /> |
+
+
+
+
+#### PipelineResourceRef
+
+
+
+PipelineResourceRef can be used to refer to a specific instance of a Resource
+
+Deprecated: Unused, preserved only for backwards compatibility
+
+
+
+_Appears in:_
+- [PipelineResourceBinding](#pipelineresourcebinding)
+- [TaskResourceBinding](#taskresourcebinding)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names |  |  |
+| `apiVersion` _string_ | API version of the referent |  | Optional: \{\} <br /> |
+
+
+
+
+
+
+#### PipelineResult
+
+_Underlying type:_ _[struct{Name string "json:\"name\""; Type ResultsType "json:\"type,omitempty\""; Description string "json:\"description\""; Value ResultValue "json:\"value\""}](#struct{name-string-"json:\"name\"";-type-resultstype-"json:\"type,omitempty\"";-description-string-"json:\"description\"";-value-resultvalue-"json:\"value\""})_
+
+PipelineResult used to describe the results of a pipeline
+
+
+
+_Appears in:_
+- [PipelineSpec](#pipelinespec)
+
+
+
+#### PipelineRun
+
+
+
+PipelineRun represents a single execution of a Pipeline. PipelineRuns are how
 the graph of Tasks declared in a Pipeline are executed; they specify inputs
 to Pipelines such as parameter values and capture operational aspects of the
 Tasks execution such as service account and tolerations. Creating a
-PipelineRun creates TaskRuns for Tasks in the referenced Pipeline.</p>
-<p>Deprecated: Please use v1.PipelineRun instead.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code><br/>
-string</td>
-<td>
-<code>
-tekton.dev/v1beta1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code><br/>
-string
-</td>
-<td><code>PipelineRun</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.PipelineRunSpec">
-PipelineRunSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>pipelineRef</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.PipelineRef">
-PipelineRef
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-<tr>
-<td>
-<code>pipelineSpec</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.PipelineSpec">
-PipelineSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Specifying PipelineSpec can be disabled by setting
-<code>disable-inline-spec</code> feature flag.
-See Pipeline.spec (API version: tekton.dev/v1beta1)</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>resources</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.PipelineResourceBinding">
-[]PipelineResourceBinding
-</a>
-</em>
-</td>
-<td>
-<p>Resources is a list of bindings specifying which actual instances of
-PipelineResources to use for the resources the Pipeline has declared
-it needs.</p>
-<p>Deprecated: Unused, preserved only for backwards compatibility</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>params</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.Params">
-Params
-</a>
-</em>
-</td>
-<td>
-<p>Params is a list of parameter names and values.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>serviceAccountName</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.PipelineRunSpecStatus">
-PipelineRunSpecStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Used for cancelling a pipelinerun (and maybe more later on)</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>timeouts</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.TimeoutFields">
-TimeoutFields
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Time after which the Pipeline times out.
-Currently three keys are accepted in the map
-pipeline, tasks and finally
-with Timeouts.pipeline &gt;= Timeouts.tasks + Timeouts.finally</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>timeout</code><br/>
-<em>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
-Kubernetes meta/v1.Duration
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Timeout is the Time after which the Pipeline times out.
-Defaults to never.
-Refer to Go&rsquo;s ParseDuration documentation for expected format: <a href="https://golang.org/pkg/time/#ParseDuration">https://golang.org/pkg/time/#ParseDuration</a></p>
-<p>Deprecated: use pipelineRunSpec.Timeouts.Pipeline instead</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>podTemplate</code><br/>
-<em>
-<a href="#tekton.dev/unversioned.PodTemplate">
-PodTemplate
-</a>
-</em>
-</td>
-<td>
-<p>PodTemplate holds pod specific configuration</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>workspaces</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.WorkspaceBinding">
-[]WorkspaceBinding
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Workspaces holds a set of workspace bindings that must match names
-with those declared in the pipeline.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>taskRunSpecs</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.PipelineTaskRunSpec">
-[]PipelineTaskRunSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>TaskRunSpecs holds a set of runtime specs</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>managedBy</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ManagedBy indicates which controller is responsible for reconciling
-this resource. If unset or set to &ldquo;tekton.dev/pipeline&rdquo;, the default
-Tekton controller will manage this resource.
-This field is immutable.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.PipelineRunStatus">
-PipelineRunStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.StepAction">StepAction
-</h3>
-<div>
-<p>StepAction represents the actionable components of Step.
-The Step can only reference it from the cluster or using remote resolution.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code><br/>
-string</td>
-<td>
-<code>
-tekton.dev/v1beta1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code><br/>
-string
-</td>
-<td><code>StepAction</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.StepActionSpec">
-StepActionSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Spec holds the desired state of the Step from the client</p>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>description</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Description is a user-facing description of the stepaction that may be
-used to populate a UI.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>image</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Image reference name to run for this StepAction.
-More info: <a href="https://kubernetes.io/docs/concepts/containers/images">https://kubernetes.io/docs/concepts/containers/images</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>command</code><br/>
-<em>
-[]string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Entrypoint array. Not executed within a shell.
-The image&rsquo;s ENTRYPOINT is used if this is not provided.
-Variable references $(VAR_NAME) are expanded using the container&rsquo;s environment. If a variable
-cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
-to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. &ldquo;$$(VAR_NAME)&rdquo; will
-produce the string literal &ldquo;$(VAR_NAME)&rdquo;. Escaped references will never be expanded, regardless
-of whether the variable exists or not. Cannot be updated.
-More info: <a href="https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell">https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>args</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.Args">
-Args
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Arguments to the entrypoint.
-The image&rsquo;s CMD is used if this is not provided.
-Variable references $(VAR_NAME) are expanded using the container&rsquo;s environment. If a variable
-cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
-to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. &ldquo;$$(VAR_NAME)&rdquo; will
-produce the string literal &ldquo;$(VAR_NAME)&rdquo;. Escaped references will never be expanded, regardless
-of whether the variable exists or not. Cannot be updated.
-More info: <a href="https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell">https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>env</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#envvar-v1-core">
-[]Kubernetes core/v1.EnvVar
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>List of environment variables to set in the container.
-Cannot be updated.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>script</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Script is the contents of an executable file to execute.</p>
-<p>If Script is not empty, the Step cannot have an Command and the Args will be passed to the Script.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>workingDir</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Step&rsquo;s working directory.
-If not specified, the container runtime&rsquo;s default will be used, which
-might be configured in the container image.
-Cannot be updated.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>params</code><br/>
-<em>
-<a href="#tekton.dev/v1.ParamSpecs">
-ParamSpecs
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Params is a list of input parameters required to run the stepAction.
-Params must be supplied as inputs in Steps unless they declare a defaultvalue.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>results</code><br/>
-<em>
-<a href="#tekton.dev/v1.StepResult">
-[]StepResult
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Results are values that this StepAction can output</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>securityContext</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#securitycontext-v1-core">
-Kubernetes core/v1.SecurityContext
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>SecurityContext defines the security options the Step should be run with.
-If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
-More info: <a href="https://kubernetes.io/docs/tasks/configure-pod-container/security-context/">https://kubernetes.io/docs/tasks/configure-pod-container/security-context/</a>
-The value set in StepAction will take precedence over the value from Task.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>volumeMounts</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#volumemount-v1-core">
-[]Kubernetes core/v1.VolumeMount
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Volumes to mount into the Step&rsquo;s filesystem.
-Cannot be updated.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.Task">Task
-</h3>
-<div>
-<p>Task represents a collection of sequential steps that are run as part of a
-Pipeline using a set of inputs and producing a set of outputs. Tasks execute
-when TaskRuns are created that provide the input parameters and resources and
-output resources the Task requires.</p>
-<p>Deprecated: Please use v1.Task instead.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code><br/>
-string</td>
-<td>
-<code>
-tekton.dev/v1beta1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code><br/>
-string
-</td>
-<td><code>Task</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.TaskSpec">
-TaskSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Spec holds the desired state of the Task from the client</p>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>resources</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.TaskResources">
-TaskResources
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Resources is a list input and output resource to run the task
-Resources are represented in TaskRuns as bindings to instances of
-PipelineResources.</p>
-<p>Deprecated: Unused, preserved only for backwards compatibility</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>params</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.ParamSpecs">
-ParamSpecs
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Params is a list of input parameters required to run the task. Params
-must be supplied as inputs in TaskRuns unless they declare a default
-value.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>displayName</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>DisplayName is a user-facing name of the task that may be
-used to populate a UI.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>description</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Description is a user-facing description of the task that may be
-used to populate a UI.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>steps</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.Step">
-[]Step
-</a>
-</em>
-</td>
-<td>
-<p>Steps are the steps of the build; each step is run sequentially with the
-source mounted into /workspace.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>volumes</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.Volumes">
-Volumes
-</a>
-</em>
-</td>
-<td>
-<p>Volumes is a collection of volumes that are available to mount into the
-steps of the build.
-See Pod.spec.volumes (API version: v1)</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>stepTemplate</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.StepTemplate">
-StepTemplate
-</a>
-</em>
-</td>
-<td>
-<p>StepTemplate can be used as the basis for all step containers within the
-Task, so that the steps inherit settings on the base container.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>sidecars</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.Sidecar">
-[]Sidecar
-</a>
-</em>
-</td>
-<td>
-<p>Sidecars are run alongside the Task&rsquo;s step containers. They begin before
-the steps start and end after the steps complete.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>workspaces</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.WorkspaceDeclaration">
-[]WorkspaceDeclaration
-</a>
-</em>
-</td>
-<td>
-<p>Workspaces are the volumes that this Task requires.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>results</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.TaskResult">
-[]TaskResult
-</a>
-</em>
-</td>
-<td>
-<p>Results are values that this Task can output</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.TaskRun">TaskRun
-</h3>
-<div>
-<p>TaskRun represents a single execution of a Task. TaskRuns are how the steps
-specified in a Task are executed; they specify the parameters and resources
-used to run the steps in a Task.</p>
-<p>Deprecated: Please use v1.TaskRun instead.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code><br/>
-string</td>
-<td>
-<code>
-tekton.dev/v1beta1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code><br/>
-string
-</td>
-<td><code>TaskRun</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.TaskRunSpec">
-TaskRunSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>debug</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.TaskRunDebug">
-TaskRunDebug
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-<tr>
-<td>
-<code>params</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.Params">
-Params
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-<tr>
-<td>
-<code>resources</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.TaskRunResources">
-TaskRunResources
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Deprecated: Unused, preserved only for backwards compatibility</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>serviceAccountName</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-<tr>
-<td>
-<code>taskRef</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.TaskRef">
-TaskRef
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>no more than one of the TaskRef and TaskSpec may be specified.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>taskSpec</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.TaskSpec">
-TaskSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Specifying TaskSpec can be disabled by setting
-<code>disable-inline-spec</code> feature flag.
-See Task.spec (API version: tekton.dev/v1beta1)</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.TaskRunSpecStatus">
-TaskRunSpecStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Used for cancelling a TaskRun (and maybe more later on)</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>statusMessage</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.TaskRunSpecStatusMessage">
-TaskRunSpecStatusMessage
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Status message for cancellation.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>retries</code><br/>
-<em>
-int
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Retries represents how many times this TaskRun should be retried in the event of Task failure.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>timeout</code><br/>
-<em>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
-Kubernetes meta/v1.Duration
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Time after which one retry attempt times out. Defaults to 1 hour.
-Refer Go&rsquo;s ParseDuration documentation for expected format: <a href="https://golang.org/pkg/time/#ParseDuration">https://golang.org/pkg/time/#ParseDuration</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>podTemplate</code><br/>
-<em>
-<a href="#tekton.dev/unversioned.PodTemplate">
-PodTemplate
-</a>
-</em>
-</td>
-<td>
-<p>PodTemplate holds pod specific configuration</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>workspaces</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.WorkspaceBinding">
-[]WorkspaceBinding
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Workspaces is a list of WorkspaceBindings from volumes to workspaces.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>stepOverrides</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.TaskRunStepOverride">
-[]TaskRunStepOverride
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Overrides to apply to Steps in this TaskRun.
-If a field is specified in both a Step and a StepOverride,
-the value from the StepOverride will be used.
-This field is only supported when the alpha feature gate is enabled.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>sidecarOverrides</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.TaskRunSidecarOverride">
-[]TaskRunSidecarOverride
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Overrides to apply to Sidecars in this TaskRun.
-If a field is specified in both a Sidecar and a SidecarOverride,
-the value from the SidecarOverride will be used.
-This field is only supported when the alpha feature gate is enabled.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>computeResources</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#resourcerequirements-v1-core">
-Kubernetes core/v1.ResourceRequirements
-</a>
-</em>
-</td>
-<td>
-<p>Compute resources to use for this TaskRun</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>managedBy</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ManagedBy indicates which controller is responsible for reconciling
-this resource. If unset or set to &ldquo;tekton.dev/pipeline&rdquo;, the default
-Tekton controller will manage this resource.
-This field is immutable.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.TaskRunStatus">
-TaskRunStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.Algorithm">Algorithm
-(<code>string</code> alias)</h3>
-<div>
-<p>Algorithm Standard cryptographic hash algorithm</p>
-</div>
-<h3 id="tekton.dev/v1beta1.Args">Args
-(<code>[]string</code> alias)</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.StepActionSpec">StepActionSpec</a>)
-</p>
-<div>
-</div>
-<h3 id="tekton.dev/v1beta1.ArrayOrString">ArrayOrString
-</h3>
-<div>
-<p>ArrayOrString is deprecated, this is to keep backward compatibility</p>
-<p>Deprecated: Use ParamValue instead.</p>
-</div>
-<h3 id="tekton.dev/v1beta1.Artifact">Artifact
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.Artifacts">Artifacts</a>)
-</p>
-<div>
-<p>Artifact represents an artifact within a system, potentially containing multiple values
-associated with it.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>The artifact&rsquo;s identifying category name</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>values</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.ArtifactValue">
-[]ArtifactValue
-</a>
-</em>
-</td>
-<td>
-<p>A collection of values related to the artifact</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>buildOutput</code><br/>
-<em>
-bool
-</em>
-</td>
-<td>
-<p>Indicate if the artifact is a build output or a by-product</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.ArtifactValue">ArtifactValue
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.Artifact">Artifact</a>)
-</p>
-<div>
-<p>ArtifactValue represents a specific value or data element within an Artifact.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>digest</code><br/>
-<em>
-map[github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Algorithm]string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>uri</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Algorithm-specific digests for verifying the content (e.g., SHA256)</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.Artifacts">Artifacts
-</h3>
-<div>
-<p>Artifacts represents the collection of input and output artifacts associated with
-a task run or a similar process. Artifacts in this context are units of data or resources
-that the process either consumes as input or produces as output.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>inputs</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.Artifact">
-[]Artifact
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>outputs</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.Artifact">
-[]Artifact
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.ChildStatusReference">ChildStatusReference
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineRunStatusFields">PipelineRunStatusFields</a>)
-</p>
-<div>
-<p>ChildStatusReference is used to point to the statuses of individual TaskRuns and Runs within this PipelineRun.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Name is the name of the TaskRun or Run this is referencing.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>displayName</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>DisplayName is a user-facing name of the pipelineTask that may be
-used to populate a UI.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>pipelineTaskName</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>PipelineTaskName is the name of the PipelineTask this is referencing.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>whenExpressions</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.WhenExpression">
-[]WhenExpression
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>WhenExpressions is the list of checks guarding the execution of the PipelineTask</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.CloudEventCondition">CloudEventCondition
-(<code>string</code> alias)</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.CloudEventDeliveryState">CloudEventDeliveryState</a>)
-</p>
-<div>
-<p>CloudEventCondition is a string that represents the condition of the event.</p>
-</div>
-<h3 id="tekton.dev/v1beta1.CloudEventDelivery">CloudEventDelivery
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskRunStatusFields">TaskRunStatusFields</a>)
-</p>
-<div>
-<p>CloudEventDelivery is the target of a cloud event along with the state of
-delivery.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>target</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Target points to an addressable</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.CloudEventDeliveryState">
-CloudEventDeliveryState
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.CloudEventDeliveryState">CloudEventDeliveryState
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.CloudEventDelivery">CloudEventDelivery</a>)
-</p>
-<div>
-<p>CloudEventDeliveryState reports the state of a cloud event to be sent.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>condition</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.CloudEventCondition">
-CloudEventCondition
-</a>
-</em>
-</td>
-<td>
-<p>Current status</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>sentAt</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta">
-Kubernetes meta/v1.Time
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>SentAt is the time at which the last attempt to send the event was made</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>message</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Error is the text of error (if any)</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>retryCount</code><br/>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>RetryCount is the number of attempts of sending the cloud event</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.Combination">Combination
-(<code>map[string]string</code> alias)</h3>
-<div>
-<p>Combination is a map, mainly defined to hold a single combination from a Matrix with key as param.Name and value as param.Value</p>
-</div>
-<h3 id="tekton.dev/v1beta1.Combinations">Combinations
-(<code>[]github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Combination</code> alias)</h3>
-<div>
-<p>Combinations is a Combination list</p>
-</div>
-<h3 id="tekton.dev/v1beta1.ConfigSource">ConfigSource
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.Provenance">Provenance</a>)
-</p>
-<div>
-<p>ConfigSource contains the information that can uniquely identify where a remote
-built definition came from i.e. Git repositories, Tekton Bundles in OCI registry
-and hub.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>uri</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>URI indicates the identity of the source of the build definition.
-Example: &ldquo;<a href="https://github.com/tektoncd/catalog&quot;">https://github.com/tektoncd/catalog&rdquo;</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>digest</code><br/>
-<em>
-map[string]string
-</em>
-</td>
-<td>
-<p>Digest is a collection of cryptographic digests for the contents of the artifact specified by URI.
-Example: {&ldquo;sha1&rdquo;: &ldquo;f99d13e554ffcb696dee719fa85b695cb5b0f428&rdquo;}</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>entryPoint</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>EntryPoint identifies the entry point into the build. This is often a path to a
-build definition file and/or a target label within that file.
-Example: &ldquo;task/git-clone/0.10/git-clone.yaml&rdquo;</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.CustomRunReason">CustomRunReason
-(<code>string</code> alias)</h3>
-<div>
-<p>CustomRunReason is an enum used to store all Run reason for the Succeeded condition that are controlled by the CustomRun itself.</p>
-</div>
-<h3 id="tekton.dev/v1beta1.CustomRunResult">CustomRunResult
-</h3>
-<div>
-<p>CustomRunResult used to describe the results of a task</p>
-</div>
-<h3 id="tekton.dev/v1beta1.CustomRunSpec">CustomRunSpec
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.CustomRun">CustomRun</a>)
-</p>
-<div>
-<p>CustomRunSpec defines the desired state of CustomRun</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>customRef</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.TaskRef">
-TaskRef
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-<tr>
-<td>
-<code>customSpec</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.EmbeddedCustomRunSpec">
-EmbeddedCustomRunSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Spec is a specification of a custom task</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>params</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.Params">
-Params
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.CustomRunSpecStatus">
-CustomRunSpecStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Used for cancelling a customrun (and maybe more later on)</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>statusMessage</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.CustomRunSpecStatusMessage">
-CustomRunSpecStatusMessage
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Status message for cancellation.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>retries</code><br/>
-<em>
-int
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Used for propagating retries count to custom tasks</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>serviceAccountName</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-<tr>
-<td>
-<code>timeout</code><br/>
-<em>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
-Kubernetes meta/v1.Duration
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Time after which the custom-task times out.
-Refer Go&rsquo;s ParseDuration documentation for expected format: <a href="https://golang.org/pkg/time/#ParseDuration">https://golang.org/pkg/time/#ParseDuration</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>workspaces</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.WorkspaceBinding">
-[]WorkspaceBinding
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Workspaces is a list of WorkspaceBindings from volumes to workspaces.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.CustomRunSpecStatus">CustomRunSpecStatus
-(<code>string</code> alias)</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.CustomRunSpec">CustomRunSpec</a>)
-</p>
-<div>
-<p>CustomRunSpecStatus defines the taskrun spec status the user can provide</p>
-</div>
-<h3 id="tekton.dev/v1beta1.CustomRunSpecStatusMessage">CustomRunSpecStatusMessage
-(<code>string</code> alias)</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.CustomRunSpec">CustomRunSpec</a>)
-</p>
-<div>
-<p>CustomRunSpecStatusMessage defines human readable status messages for the TaskRun.</p>
-</div>
-<h3 id="tekton.dev/v1beta1.CustomRunStatus">CustomRunStatus
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.CustomRun">CustomRun</a>, <a href="#tekton.dev/v1beta1.PipelineRunRunStatus">PipelineRunRunStatus</a>)
-</p>
-<div>
-<p>CustomRunStatus defines the observed state of CustomRun.</p>
-</div>
-<h3 id="tekton.dev/v1beta1.CustomRunStatusFields">CustomRunStatusFields
-</h3>
-<div>
-<p>CustomRunStatusFields holds the fields of CustomRun&rsquo;s status.  This is defined
-separately and inlined so that other types can readily consume these fields
-via duck typing.</p>
-</div>
-<h3 id="tekton.dev/v1beta1.EmbeddedCustomRunSpec">EmbeddedCustomRunSpec
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.CustomRunSpec">CustomRunSpec</a>)
-</p>
-<div>
-<p>EmbeddedCustomRunSpec allows custom task definitions to be embedded</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>metadata</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.PipelineTaskMetadata">
-PipelineTaskMetadata
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code><br/>
-<em>
-<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime#RawExtension">
-k8s.io/apimachinery/pkg/runtime.RawExtension
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Spec is a specification of a custom task</p>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>-</code><br/>
-<em>
-[]byte
-</em>
-</td>
-<td>
-<p>Raw is the underlying serialization of this object.</p>
-<p>TODO: Determine how to detect ContentType and ContentEncoding of &lsquo;Raw&rsquo; data.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>-</code><br/>
-<em>
-<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime#Object">
-k8s.io/apimachinery/pkg/runtime.Object
-</a>
-</em>
-</td>
-<td>
-<p>Object can hold a representation of this extension - useful for working with versioned
-structs.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.EmbeddedTask">EmbeddedTask
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineTask">PipelineTask</a>)
-</p>
-<div>
-<p>EmbeddedTask is used to define a Task inline within a Pipeline&rsquo;s PipelineTasks.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>spec</code><br/>
-<em>
-<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime#RawExtension">
-k8s.io/apimachinery/pkg/runtime.RawExtension
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Spec is a specification of a custom task</p>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>-</code><br/>
-<em>
-[]byte
-</em>
-</td>
-<td>
-<p>Raw is the underlying serialization of this object.</p>
-<p>TODO: Determine how to detect ContentType and ContentEncoding of &lsquo;Raw&rsquo; data.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>-</code><br/>
-<em>
-<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime#Object">
-k8s.io/apimachinery/pkg/runtime.Object
-</a>
-</em>
-</td>
-<td>
-<p>Object can hold a representation of this extension - useful for working with versioned
-structs.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>metadata</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.PipelineTaskMetadata">
-PipelineTaskMetadata
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-<tr>
-<td>
-<code>TaskSpec</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.TaskSpec">
-TaskSpec
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>TaskSpec</code> are embedded into this type.)
-</p>
-<em>(Optional)</em>
-<p>TaskSpec is a specification of a task</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.IncludeParams">IncludeParams
-</h3>
-<div>
-<p>IncludeParams allows passing in a specific combinations of Parameters into the Matrix.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Name the specified combination</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>params</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.Params">
-Params
-</a>
-</em>
-</td>
-<td>
-<p>Params takes only <code>Parameters</code> of type <code>&quot;string&quot;</code>
-The names of the <code>params</code> must match the names of the <code>params</code> in the underlying <code>Task</code></p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.InternalTaskModifier">InternalTaskModifier
-</h3>
-<div>
-<p>InternalTaskModifier implements TaskModifier for resources that are built-in to Tekton Pipelines.</p>
-<p>Deprecated: Unused, preserved only for backwards compatibility</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>stepsToPrepend</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.Step">
-[]Step
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>stepsToAppend</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.Step">
-[]Step
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>volumes</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#volume-v1-core">
-[]Kubernetes core/v1.Volume
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.Matrix">Matrix
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineTask">PipelineTask</a>)
-</p>
-<div>
-<p>Matrix is used to fan out Tasks in a Pipeline</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>params</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.Params">
-Params
-</a>
-</em>
-</td>
-<td>
-<p>Params is a list of parameters used to fan out the pipelineTask
-Params takes only <code>Parameters</code> of type <code>&quot;array&quot;</code>
-Each array element is supplied to the <code>PipelineTask</code> by substituting <code>params</code> of type <code>&quot;string&quot;</code> in the underlying <code>Task</code>.
-The names of the <code>params</code> in the <code>Matrix</code> must match the names of the <code>params</code> in the underlying <code>Task</code> that they will be substituting.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>include</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.IncludeParamsList">
-IncludeParamsList
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Include is a list of IncludeParams which allows passing in specific combinations of Parameters into the Matrix.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.OnErrorType">OnErrorType
-(<code>string</code> alias)</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.Step">Step</a>)
-</p>
-<div>
-<p>OnErrorType defines a list of supported exiting behavior of a container on error</p>
-</div>
-<h3 id="tekton.dev/v1beta1.Param">Param
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskRunInputs">TaskRunInputs</a>)
-</p>
-<div>
-<p>Param declares an ParamValues to use for the parameter called name.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>value</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.ParamValue">
-ParamValue
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.ParamSpec">ParamSpec
-</h3>
-<div>
-<p>ParamSpec defines arbitrary parameters needed beyond typed inputs (such as
-resources). Parameter values are provided by users as inputs on a TaskRun
-or PipelineRun.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Name declares the name by which a parameter is referenced.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>type</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.ParamType">
-ParamType
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Type is the user-specified type of the parameter. The possible types
-are currently &ldquo;string&rdquo;, &ldquo;array&rdquo; and &ldquo;object&rdquo;, and &ldquo;string&rdquo; is the default.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>description</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Description is a user-facing description of the parameter that may be
-used to populate a UI.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>properties</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.PropertySpec">
-map[string]github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PropertySpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Properties is the JSON Schema properties to support key-value pairs parameter.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>default</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.ParamValue">
-ParamValue
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Default is the value a parameter takes if no input value is supplied. If
-default is set, a Task may be executed without a supplied value for the
-parameter.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>enum</code><br/>
-<em>
-[]string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Enum declares a set of allowed param input values for tasks/pipelines that can be validated.
-If Enum is not set, no input validation is performed for the param.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.ParamSpecs">ParamSpecs
-(<code>[]github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.ParamSpec</code> alias)</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineSpec">PipelineSpec</a>, <a href="#tekton.dev/v1beta1.TaskSpec">TaskSpec</a>)
-</p>
-<div>
-<p>ParamSpecs is a list of ParamSpec</p>
-</div>
-<h3 id="tekton.dev/v1beta1.ParamType">ParamType
-(<code>string</code> alias)</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.ParamSpec">ParamSpec</a>, <a href="#tekton.dev/v1beta1.ParamValue">ParamValue</a>, <a href="#tekton.dev/v1beta1.PropertySpec">PropertySpec</a>)
-</p>
-<div>
-<p>ParamType indicates the type of an input parameter;
-Used to distinguish between a single string and an array of strings.</p>
-</div>
-<h3 id="tekton.dev/v1beta1.ParamValue">ParamValue
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.Param">Param</a>, <a href="#tekton.dev/v1beta1.ParamSpec">ParamSpec</a>)
-</p>
-<div>
-<p>ParamValue is a type that can hold a single string or string array.
-Used in JSON unmarshalling so that a single JSON field can accept
-either an individual string or an array of strings.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>Type</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.ParamType">
-ParamType
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>StringVal</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Represents the stored type of ParamValues.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ArrayVal</code><br/>
-<em>
-[]string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>ObjectVal</code><br/>
-<em>
-map[string]string
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.Params">Params
-(<code>[]github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.Param</code> alias)</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1alpha1.RunSpec">RunSpec</a>, <a href="#tekton.dev/v1beta1.CustomRunSpec">CustomRunSpec</a>, <a href="#tekton.dev/v1beta1.IncludeParams">IncludeParams</a>, <a href="#tekton.dev/v1beta1.Matrix">Matrix</a>, <a href="#tekton.dev/v1beta1.PipelineRunSpec">PipelineRunSpec</a>, <a href="#tekton.dev/v1beta1.PipelineTask">PipelineTask</a>, <a href="#tekton.dev/v1beta1.ResolverRef">ResolverRef</a>, <a href="#tekton.dev/v1beta1.Step">Step</a>, <a href="#tekton.dev/v1beta1.TaskRunSpec">TaskRunSpec</a>)
-</p>
-<div>
-<p>Params is a list of Param</p>
-</div>
-<h3 id="tekton.dev/v1beta1.PipelineDeclaredResource">PipelineDeclaredResource
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineSpec">PipelineSpec</a>)
-</p>
-<div>
-<p>PipelineDeclaredResource is used by a Pipeline to declare the types of the
-PipelineResources that it will required to run and names which can be used to
-refer to these PipelineResources in PipelineTaskResourceBindings.</p>
-<p>Deprecated: Unused, preserved only for backwards compatibility</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Name is the name that will be used by the Pipeline to refer to this resource.
-It does not directly correspond to the name of any PipelineResources Task
-inputs or outputs, and it does not correspond to the actual names of the
-PipelineResources that will be bound in the PipelineRun.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>type</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.PipelineResourceType">
-PipelineResourceType
-</a>
-</em>
-</td>
-<td>
-<p>Type is the type of the PipelineResource.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>optional</code><br/>
-<em>
-bool
-</em>
-</td>
-<td>
-<p>Optional declares the resource as optional.
-optional: true - the resource is considered optional
-optional: false - the resource is considered required (default/equivalent of not specifying it)</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.PipelineObject">PipelineObject
-</h3>
-<div>
-<p>PipelineObject is implemented by Pipeline</p>
-</div>
-<h3 id="tekton.dev/v1beta1.PipelineRef">PipelineRef
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineRunSpec">PipelineRunSpec</a>, <a href="#tekton.dev/v1beta1.PipelineTask">PipelineTask</a>)
-</p>
-<div>
-<p>PipelineRef can be used to refer to a specific instance of a Pipeline.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Name of the referent; More info: <a href="http://kubernetes.io/docs/user-guide/identifiers#names">http://kubernetes.io/docs/user-guide/identifiers#names</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>apiVersion</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>API version of the referent</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>bundle</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Bundle url reference to a Tekton Bundle.</p>
-<p>Deprecated: Please use ResolverRef with the bundles resolver instead.
-The field is staying there for go client backward compatibility, but is not used/allowed anymore.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ResolverRef</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.ResolverRef">
-ResolverRef
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ResolverRef allows referencing a Pipeline in a remote location
-like a git repo. This field is only supported when the alpha
-feature gate is enabled.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.PipelineResourceBinding">PipelineResourceBinding
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineRunSpec">PipelineRunSpec</a>, <a href="#tekton.dev/v1beta1.TaskResourceBinding">TaskResourceBinding</a>)
-</p>
-<div>
-<p>PipelineResourceBinding connects a reference to an instance of a PipelineResource
-with a PipelineResource dependency that the Pipeline has declared</p>
-<p>Deprecated: Unused, preserved only for backwards compatibility</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Name is the name of the PipelineResource in the Pipeline&rsquo;s declaration</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>resourceRef</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.PipelineResourceRef">
-PipelineResourceRef
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ResourceRef is a reference to the instance of the actual PipelineResource
-that should be used</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>resourceSpec</code><br/>
-<em>
-<a href="#tekton.dev/v1alpha1.PipelineResourceSpec">
-PipelineResourceSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ResourceSpec is specification of a resource that should be created and
-consumed by the task</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.PipelineResourceInterface">PipelineResourceInterface
-</h3>
-<div>
-<p>PipelineResourceInterface interface to be implemented by different PipelineResource types</p>
-<p>Deprecated: Unused, preserved only for backwards compatibility</p>
-</div>
-<h3 id="tekton.dev/v1beta1.PipelineResourceRef">PipelineResourceRef
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineResourceBinding">PipelineResourceBinding</a>)
-</p>
-<div>
-<p>PipelineResourceRef can be used to refer to a specific instance of a Resource</p>
-<p>Deprecated: Unused, preserved only for backwards compatibility</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Name of the referent; More info: <a href="http://kubernetes.io/docs/user-guide/identifiers#names">http://kubernetes.io/docs/user-guide/identifiers#names</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>apiVersion</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>API version of the referent</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.PipelineResourceResult">PipelineResourceResult
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskRunStatusFields">TaskRunStatusFields</a>)
-</p>
-<div>
-<p>PipelineResourceResult has been deprecated with the migration of PipelineResources
-Deprecated: Use RunResult instead</p>
-</div>
-<h3 id="tekton.dev/v1beta1.PipelineResourceType">PipelineResourceType
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineDeclaredResource">PipelineDeclaredResource</a>)
-</p>
-<div>
-<p>PipelineResourceType represents the type of endpoint the pipelineResource is, so that the
-controller will know this pipelineResource should be fetched and optionally what
-additional metatdata should be provided for it.</p>
-<p>Deprecated: Unused, preserved only for backwards compatibility</p>
-</div>
-<h3 id="tekton.dev/v1beta1.PipelineResult">PipelineResult
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineSpec">PipelineSpec</a>)
-</p>
-<div>
-<p>PipelineResult used to describe the results of a pipeline</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Name the given name</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>type</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.ResultsType">
-ResultsType
-</a>
-</em>
-</td>
-<td>
-<p>Type is the user-specified type of the result.
-The possible types are &lsquo;string&rsquo;, &lsquo;array&rsquo;, and &lsquo;object&rsquo;, with &lsquo;string&rsquo; as the default.
-&lsquo;array&rsquo; and &lsquo;object&rsquo; types are alpha features.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>description</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Description is a human-readable description of the result</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>value</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.ResultValue">
-ResultValue
-</a>
-</em>
-</td>
-<td>
-<p>Value the expression used to retrieve the value</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.PipelineRunReason">PipelineRunReason
-(<code>string</code> alias)</h3>
-<div>
-<p>PipelineRunReason represents a reason for the pipeline run &ldquo;Succeeded&rdquo; condition</p>
-</div>
-<h3 id="tekton.dev/v1beta1.PipelineRunResult">PipelineRunResult
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineRunStatusFields">PipelineRunStatusFields</a>)
-</p>
-<div>
-<p>PipelineRunResult used to describe the results of a pipeline</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Name is the result&rsquo;s name as declared by the Pipeline</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>value</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.ResultValue">
-ResultValue
-</a>
-</em>
-</td>
-<td>
-<p>Value is the result returned from the execution of this PipelineRun</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.PipelineRunRunStatus">PipelineRunRunStatus
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineRunStatusFields">PipelineRunStatusFields</a>)
-</p>
-<div>
-<p>PipelineRunRunStatus contains the name of the PipelineTask for this CustomRun or Run and the CustomRun or Run&rsquo;s Status</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>pipelineTaskName</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>PipelineTaskName is the name of the PipelineTask.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.CustomRunStatus">
-CustomRunStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Status is the CustomRunStatus for the corresponding CustomRun or Run</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>whenExpressions</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.WhenExpression">
-[]WhenExpression
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>WhenExpressions is the list of checks guarding the execution of the PipelineTask</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.PipelineRunSpec">PipelineRunSpec
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineRun">PipelineRun</a>)
-</p>
-<div>
-<p>PipelineRunSpec defines the desired state of PipelineRun</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>pipelineRef</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.PipelineRef">
-PipelineRef
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-<tr>
-<td>
-<code>pipelineSpec</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.PipelineSpec">
-PipelineSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Specifying PipelineSpec can be disabled by setting
-<code>disable-inline-spec</code> feature flag.
-See Pipeline.spec (API version: tekton.dev/v1beta1)</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>resources</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.PipelineResourceBinding">
-[]PipelineResourceBinding
-</a>
-</em>
-</td>
-<td>
-<p>Resources is a list of bindings specifying which actual instances of
-PipelineResources to use for the resources the Pipeline has declared
-it needs.</p>
-<p>Deprecated: Unused, preserved only for backwards compatibility</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>params</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.Params">
-Params
-</a>
-</em>
-</td>
-<td>
-<p>Params is a list of parameter names and values.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>serviceAccountName</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.PipelineRunSpecStatus">
-PipelineRunSpecStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Used for cancelling a pipelinerun (and maybe more later on)</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>timeouts</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.TimeoutFields">
-TimeoutFields
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Time after which the Pipeline times out.
-Currently three keys are accepted in the map
-pipeline, tasks and finally
-with Timeouts.pipeline &gt;= Timeouts.tasks + Timeouts.finally</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>timeout</code><br/>
-<em>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
-Kubernetes meta/v1.Duration
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Timeout is the Time after which the Pipeline times out.
-Defaults to never.
-Refer to Go&rsquo;s ParseDuration documentation for expected format: <a href="https://golang.org/pkg/time/#ParseDuration">https://golang.org/pkg/time/#ParseDuration</a></p>
-<p>Deprecated: use pipelineRunSpec.Timeouts.Pipeline instead</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>podTemplate</code><br/>
-<em>
-<a href="#tekton.dev/unversioned.PodTemplate">
-PodTemplate
-</a>
-</em>
-</td>
-<td>
-<p>PodTemplate holds pod specific configuration</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>workspaces</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.WorkspaceBinding">
-[]WorkspaceBinding
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Workspaces holds a set of workspace bindings that must match names
-with those declared in the pipeline.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>taskRunSpecs</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.PipelineTaskRunSpec">
-[]PipelineTaskRunSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>TaskRunSpecs holds a set of runtime specs</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>managedBy</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ManagedBy indicates which controller is responsible for reconciling
-this resource. If unset or set to &ldquo;tekton.dev/pipeline&rdquo;, the default
-Tekton controller will manage this resource.
-This field is immutable.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.PipelineRunSpecStatus">PipelineRunSpecStatus
-(<code>string</code> alias)</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineRunSpec">PipelineRunSpec</a>)
-</p>
-<div>
-<p>PipelineRunSpecStatus defines the pipelinerun spec status the user can provide</p>
-</div>
-<h3 id="tekton.dev/v1beta1.PipelineRunStatus">PipelineRunStatus
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineRun">PipelineRun</a>)
-</p>
-<div>
-<p>PipelineRunStatus defines the observed state of PipelineRun</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>Status</code><br/>
-<em>
-<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Status">
-knative.dev/pkg/apis/duck/v1.Status
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>Status</code> are embedded into this type.)
-</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>PipelineRunStatusFields</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.PipelineRunStatusFields">
-PipelineRunStatusFields
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>PipelineRunStatusFields</code> are embedded into this type.)
-</p>
-<p>PipelineRunStatusFields inlines the status fields.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.PipelineRunStatusFields">PipelineRunStatusFields
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineRunStatus">PipelineRunStatus</a>)
-</p>
-<div>
-<p>PipelineRunStatusFields holds the fields of PipelineRunStatus&rsquo; status.
+PipelineRun creates TaskRuns for Tasks in the referenced Pipeline.
+
+Deprecated: Please use v1.PipelineRun instead.
+
+
+
+
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `apiVersion` _string_ | `tekton.dev/v1beta1` | | |
+| `kind` _string_ | `PipelineRun` | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  | Optional: \{\} <br /> |
+| `spec` _[PipelineRunSpec](#pipelinerunspec)_ |  |  | Optional: \{\} <br /> |
+| `status` _[PipelineRunStatus](#pipelinerunstatus)_ |  |  | Optional: \{\} <br /> |
+
+
+
+
+#### PipelineRunResult
+
+
+
+PipelineRunResult used to describe the results of a pipeline
+
+
+
+_Appears in:_
+- [PipelineRunStatus](#pipelinerunstatus)
+- [PipelineRunStatusFields](#pipelinerunstatusfields)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name is the result's name as declared by the Pipeline |  |  |
+| `value` _[ResultValue](#resultvalue)_ | Value is the result returned from the execution of this PipelineRun |  | Schemaless: \{\} <br /> |
+
+
+#### PipelineRunRunStatus
+
+
+
+PipelineRunRunStatus contains the name of the PipelineTask for this CustomRun or Run and the CustomRun or Run's Status
+
+
+
+_Appears in:_
+- [PipelineRunStatus](#pipelinerunstatus)
+- [PipelineRunStatusFields](#pipelinerunstatusfields)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `pipelineTaskName` _string_ | PipelineTaskName is the name of the PipelineTask. |  |  |
+| `status` _[CustomRunStatus](#customrunstatus)_ | Status is the CustomRunStatus for the corresponding CustomRun or Run |  | Optional: \{\} <br /> |
+| `whenExpressions` _[WhenExpression](#whenexpression) array_ | WhenExpressions is the list of checks guarding the execution of the PipelineTask |  | Optional: \{\} <br /> |
+
+
+#### PipelineRunSpec
+
+
+
+PipelineRunSpec defines the desired state of PipelineRun
+
+
+
+_Appears in:_
+- [PipelineRun](#pipelinerun)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `pipelineRef` _[PipelineRef](#pipelineref)_ |  |  | Optional: \{\} <br /> |
+| `pipelineSpec` _[PipelineSpec](#pipelinespec)_ | Specifying PipelineSpec can be disabled by setting<br />`disable-inline-spec` feature flag.<br />See Pipeline.spec (API version: tekton.dev/v1beta1) |  | Schemaless: \{\} <br />Optional: \{\} <br /> |
+| `resources` _[PipelineResourceBinding](#pipelineresourcebinding) array_ | Resources is a list of bindings specifying which actual instances of<br />PipelineResources to use for the resources the Pipeline has declared<br />it needs.<br />Deprecated: Unused, preserved only for backwards compatibility |  |  |
+| `params` _[Params](#params)_ | Params is a list of parameter names and values. |  |  |
+| `serviceAccountName` _string_ |  |  | Optional: \{\} <br /> |
+| `status` _[PipelineRunSpecStatus](#pipelinerunspecstatus)_ | Used for cancelling a pipelinerun (and maybe more later on) |  | Optional: \{\} <br /> |
+| `timeouts` _[TimeoutFields](#timeoutfields)_ | Time after which the Pipeline times out.<br />Currently three keys are accepted in the map<br />pipeline, tasks and finally<br />with Timeouts.pipeline >= Timeouts.tasks + Timeouts.finally |  | Optional: \{\} <br /> |
+| `timeout` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ | Timeout is the Time after which the Pipeline times out.<br />Defaults to never.<br />Refer to Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration<br />Deprecated: use pipelineRunSpec.Timeouts.Pipeline instead |  | Optional: \{\} <br /> |
+| `podTemplate` _[PodTemplate](#podtemplate)_ | PodTemplate holds pod specific configuration |  |  |
+| `workspaces` _[WorkspaceBinding](#workspacebinding) array_ | Workspaces holds a set of workspace bindings that must match names<br />with those declared in the pipeline. |  | Optional: \{\} <br /> |
+| `taskRunSpecs` _[PipelineTaskRunSpec](#pipelinetaskrunspec) array_ | TaskRunSpecs holds a set of runtime specs |  | Optional: \{\} <br /> |
+| `managedBy` _string_ | ManagedBy indicates which controller is responsible for reconciling<br />this resource. If unset or set to "tekton.dev/pipeline", the default<br />Tekton controller will manage this resource.<br />This field is immutable. |  | Optional: \{\} <br /> |
+
+
+#### PipelineRunSpecStatus
+
+_Underlying type:_ _string_
+
+PipelineRunSpecStatus defines the pipelinerun spec status the user can provide
+
+
+
+_Appears in:_
+- [PipelineRunSpec](#pipelinerunspec)
+
+
+
+#### PipelineRunStatus
+
+
+
+PipelineRunStatus defines the observed state of PipelineRun
+
+
+
+_Appears in:_
+- [PipelineRun](#pipelinerun)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `observedGeneration` _integer_ | ObservedGeneration is the 'Generation' of the Service that<br />was last processed by the controller. |  | Optional: \{\} <br /> |
+| `conditions` _[Conditions](#conditions)_ | Conditions the latest available observations of a resource's current state. |  | Optional: \{\} <br /> |
+| `annotations` _object (keys:string, values:string)_ | Annotations is additional Status fields for the Resource to save some<br />additional State as well as convey more information to the user. This is<br />roughly akin to Annotations on any k8s resource, just the reconciler conveying<br />richer information outwards. |  |  |
+| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | StartTime is the time the PipelineRun is actually started. |  |  |
+| `completionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | CompletionTime is the time the PipelineRun completed. |  |  |
+| `taskRuns` _object (keys:string, values:[PipelineRunTaskRunStatus](#pipelineruntaskrunstatus))_ | TaskRuns is a map of PipelineRunTaskRunStatus with the taskRun name as the key.<br />Deprecated: use ChildReferences instead. As of v0.45.0, this field is no<br />longer populated and is only included for backwards compatibility with<br />older server versions. |  | Optional: \{\} <br /> |
+| `runs` _object (keys:string, values:[PipelineRunRunStatus](#pipelinerunrunstatus))_ | Runs is a map of PipelineRunRunStatus with the run name as the key<br />Deprecated: use ChildReferences instead. As of v0.45.0, this field is no<br />longer populated and is only included for backwards compatibility with<br />older server versions. |  | Optional: \{\} <br /> |
+| `pipelineResults` _[PipelineRunResult](#pipelinerunresult) array_ | PipelineResults are the list of results written out by the pipeline task's containers |  | Optional: \{\} <br /> |
+| `pipelineSpec` _[PipelineSpec](#pipelinespec)_ | PipelineSpec contains the exact spec used to instantiate the run.<br />See Pipeline.spec (API version: tekton.dev/v1beta1) |  | Schemaless: \{\} <br /> |
+| `skippedTasks` _[SkippedTask](#skippedtask) array_ | list of tasks that were skipped due to when expressions evaluating to false |  | Optional: \{\} <br /> |
+| `childReferences` _[ChildStatusReference](#childstatusreference) array_ | list of TaskRun and Run names, PipelineTask names, and API versions/kinds for children of this PipelineRun. |  | Optional: \{\} <br /> |
+| `finallyStartTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | FinallyStartTime is when all non-finally tasks have been completed and only finally tasks are being executed. |  | Optional: \{\} <br /> |
+| `provenance` _[Provenance](#provenance)_ | Provenance contains some key authenticated metadata about how a software artifact was built (what sources, what inputs/outputs, etc.). |  | Optional: \{\} <br /> |
+| `spanContext` _object (keys:string, values:string)_ | SpanContext contains tracing span context fields |  |  |
+
+
+#### PipelineRunStatusFields
+
+
+
+PipelineRunStatusFields holds the fields of PipelineRunStatus' status.
 This is defined separately and inlined so that other types can readily
-consume these fields via duck typing.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>startTime</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta">
-Kubernetes meta/v1.Time
-</a>
-</em>
-</td>
-<td>
-<p>StartTime is the time the PipelineRun is actually started.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>completionTime</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta">
-Kubernetes meta/v1.Time
-</a>
-</em>
-</td>
-<td>
-<p>CompletionTime is the time the PipelineRun completed.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>taskRuns</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.PipelineRunTaskRunStatus">
-map[string]*github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineRunTaskRunStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>TaskRuns is a map of PipelineRunTaskRunStatus with the taskRun name as the key.</p>
-<p>Deprecated: use ChildReferences instead. As of v0.45.0, this field is no
-longer populated and is only included for backwards compatibility with
-older server versions.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>runs</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.PipelineRunRunStatus">
-map[string]*github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineRunRunStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Runs is a map of PipelineRunRunStatus with the run name as the key</p>
-<p>Deprecated: use ChildReferences instead. As of v0.45.0, this field is no
-longer populated and is only included for backwards compatibility with
-older server versions.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>pipelineResults</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.PipelineRunResult">
-[]PipelineRunResult
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>PipelineResults are the list of results written out by the pipeline task&rsquo;s containers</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>pipelineSpec</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.PipelineSpec">
-PipelineSpec
-</a>
-</em>
-</td>
-<td>
-<p>PipelineSpec contains the exact spec used to instantiate the run.
-See Pipeline.spec (API version: tekton.dev/v1beta1)</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>skippedTasks</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.SkippedTask">
-[]SkippedTask
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>list of tasks that were skipped due to when expressions evaluating to false</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>childReferences</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.ChildStatusReference">
-[]ChildStatusReference
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>list of TaskRun and Run names, PipelineTask names, and API versions/kinds for children of this PipelineRun.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>finallyStartTime</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta">
-Kubernetes meta/v1.Time
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>FinallyStartTime is when all non-finally tasks have been completed and only finally tasks are being executed.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>provenance</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.Provenance">
-Provenance
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Provenance contains some key authenticated metadata about how a software artifact was built (what sources, what inputs/outputs, etc.).</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>spanContext</code><br/>
-<em>
-map[string]string
-</em>
-</td>
-<td>
-<p>SpanContext contains tracing span context fields</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.PipelineRunTaskRunStatus">PipelineRunTaskRunStatus
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineRunStatusFields">PipelineRunStatusFields</a>)
-</p>
-<div>
-<p>PipelineRunTaskRunStatus contains the name of the PipelineTask for this TaskRun and the TaskRun&rsquo;s Status</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>pipelineTaskName</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>PipelineTaskName is the name of the PipelineTask.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.TaskRunStatus">
-TaskRunStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Status is the TaskRunStatus for the corresponding TaskRun</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>whenExpressions</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.WhenExpression">
-[]WhenExpression
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>WhenExpressions is the list of checks guarding the execution of the PipelineTask</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.PipelineSpec">PipelineSpec
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.Pipeline">Pipeline</a>, <a href="#tekton.dev/v1beta1.PipelineRunSpec">PipelineRunSpec</a>, <a href="#tekton.dev/v1beta1.PipelineRunStatusFields">PipelineRunStatusFields</a>, <a href="#tekton.dev/v1beta1.PipelineTask">PipelineTask</a>)
-</p>
-<div>
-<p>PipelineSpec defines the desired state of Pipeline.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>displayName</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>DisplayName is a user-facing name of the pipeline that may be
-used to populate a UI.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>description</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Description is a user-facing description of the pipeline that may be
-used to populate a UI.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>resources</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.PipelineDeclaredResource">
-[]PipelineDeclaredResource
-</a>
-</em>
-</td>
-<td>
-<p>Deprecated: Unused, preserved only for backwards compatibility</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>tasks</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.PipelineTask">
-[]PipelineTask
-</a>
-</em>
-</td>
-<td>
-<p>Tasks declares the graph of Tasks that execute when this Pipeline is run.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>params</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.ParamSpecs">
-ParamSpecs
-</a>
-</em>
-</td>
-<td>
-<p>Params declares a list of input parameters that must be supplied when
-this Pipeline is run.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>workspaces</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.PipelineWorkspaceDeclaration">
-[]PipelineWorkspaceDeclaration
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Workspaces declares a set of named workspaces that are expected to be
-provided by a PipelineRun.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>results</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.PipelineResult">
-[]PipelineResult
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Results are values that this pipeline can output once run</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>finally</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.PipelineTask">
-[]PipelineTask
-</a>
-</em>
-</td>
-<td>
-<p>Finally declares the list of Tasks that execute just before leaving the Pipeline
-i.e. either after all Tasks are finished executing successfully
-or after a failure which would result in ending the Pipeline</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.PipelineTask">PipelineTask
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineSpec">PipelineSpec</a>)
-</p>
-<div>
-<p>PipelineTask defines a task in a Pipeline, passing inputs from both
-Params and from the output of previous tasks.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Name is the name of this task within the context of a Pipeline. Name is
-used as a coordinate with the <code>from</code> and <code>runAfter</code> fields to establish
-the execution order of tasks relative to one another.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>displayName</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>DisplayName is the display name of this task within the context of a Pipeline.
-This display name may be used to populate a UI.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>description</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Description is the description of this task within the context of a Pipeline.
-This description may be used to populate a UI.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>taskRef</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.TaskRef">
-TaskRef
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>TaskRef is a reference to a task definition.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>taskSpec</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.EmbeddedTask">
-EmbeddedTask
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>TaskSpec is a specification of a task
-Specifying TaskSpec can be disabled by setting
-<code>disable-inline-spec</code> feature flag.
-See Task.spec (API version: tekton.dev/v1beta1)</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>when</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.WhenExpressions">
-WhenExpressions
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>WhenExpressions is a list of when expressions that need to be true for the task to run</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>retries</code><br/>
-<em>
-int
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Retries represents how many times this task should be retried in case of task failure: ConditionSucceeded set to False</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>runAfter</code><br/>
-<em>
-[]string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>RunAfter is the list of PipelineTask names that should be executed before
-this Task executes. (Used to force a specific ordering in graph execution.)</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>resources</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.PipelineTaskResources">
-PipelineTaskResources
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Deprecated: Unused, preserved only for backwards compatibility</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>params</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.Params">
-Params
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Parameters declares parameters passed to this task.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>matrix</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.Matrix">
-Matrix
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Matrix declares parameters used to fan out this task.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>workspaces</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.WorkspacePipelineTaskBinding">
-[]WorkspacePipelineTaskBinding
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Workspaces maps workspaces from the pipeline spec to the workspaces
-declared in the Task.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>timeout</code><br/>
-<em>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
-Kubernetes meta/v1.Duration
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Duration after which the TaskRun times out. Defaults to 1 hour.
-Refer Go&rsquo;s ParseDuration documentation for expected format: <a href="https://golang.org/pkg/time/#ParseDuration">https://golang.org/pkg/time/#ParseDuration</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>pipelineRef</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.PipelineRef">
-PipelineRef
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>PipelineRef is a reference to a pipeline definition
-Note: PipelineRef is in preview mode and not yet supported</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>pipelineSpec</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.PipelineSpec">
-PipelineSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>PipelineSpec is a specification of a pipeline
-Note: PipelineSpec is in preview mode and not yet supported
-Specifying PipelineSpec can be disabled by setting
-<code>disable-inline-spec</code> feature flag.
-See Pipeline.spec (API version: tekton.dev/v1beta1)</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>onError</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.PipelineTaskOnErrorType">
-PipelineTaskOnErrorType
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>OnError defines the exiting behavior of a PipelineRun on error
-can be set to [ continue | stopAndFail ]</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.PipelineTaskInputResource">PipelineTaskInputResource
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineTaskResources">PipelineTaskResources</a>)
-</p>
-<div>
-<p>PipelineTaskInputResource maps the name of a declared PipelineResource input
-dependency in a Task to the resource in the Pipeline&rsquo;s DeclaredPipelineResources
-that should be used. This input may come from a previous task.</p>
-<p>Deprecated: Unused, preserved only for backwards compatibility</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Name is the name of the PipelineResource as declared by the Task.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>resource</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Resource is the name of the DeclaredPipelineResource to use.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>from</code><br/>
-<em>
-[]string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>From is the list of PipelineTask names that the resource has to come from.
-(Implies an ordering in the execution graph.)</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.PipelineTaskMetadata">PipelineTaskMetadata
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1alpha1.EmbeddedRunSpec">EmbeddedRunSpec</a>, <a href="#tekton.dev/v1beta1.EmbeddedCustomRunSpec">EmbeddedCustomRunSpec</a>, <a href="#tekton.dev/v1beta1.EmbeddedTask">EmbeddedTask</a>, <a href="#tekton.dev/v1beta1.PipelineTaskRunSpec">PipelineTaskRunSpec</a>)
-</p>
-<div>
-<p>PipelineTaskMetadata contains the labels or annotations for an EmbeddedTask</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>labels</code><br/>
-<em>
-map[string]string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-<tr>
-<td>
-<code>annotations</code><br/>
-<em>
-map[string]string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.PipelineTaskOnErrorType">PipelineTaskOnErrorType
-(<code>string</code> alias)</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineTask">PipelineTask</a>)
-</p>
-<div>
-<p>PipelineTaskOnErrorType defines a list of supported failure handling behaviors of a PipelineTask on error</p>
-</div>
-<h3 id="tekton.dev/v1beta1.PipelineTaskOutputResource">PipelineTaskOutputResource
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineTaskResources">PipelineTaskResources</a>)
-</p>
-<div>
-<p>PipelineTaskOutputResource maps the name of a declared PipelineResource output
-dependency in a Task to the resource in the Pipeline&rsquo;s DeclaredPipelineResources
-that should be used.</p>
-<p>Deprecated: Unused, preserved only for backwards compatibility</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Name is the name of the PipelineResource as declared by the Task.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>resource</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Resource is the name of the DeclaredPipelineResource to use.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.PipelineTaskParam">PipelineTaskParam
-</h3>
-<div>
-<p>PipelineTaskParam is used to provide arbitrary string parameters to a Task.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>value</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.PipelineTaskResources">PipelineTaskResources
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineTask">PipelineTask</a>)
-</p>
-<div>
-<p>PipelineTaskResources allows a Pipeline to declare how its DeclaredPipelineResources
-should be provided to a Task as its inputs and outputs.</p>
-<p>Deprecated: Unused, preserved only for backwards compatibility</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>inputs</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.PipelineTaskInputResource">
-[]PipelineTaskInputResource
-</a>
-</em>
-</td>
-<td>
-<p>Inputs holds the mapping from the PipelineResources declared in
-DeclaredPipelineResources to the input PipelineResources required by the Task.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>outputs</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.PipelineTaskOutputResource">
-[]PipelineTaskOutputResource
-</a>
-</em>
-</td>
-<td>
-<p>Outputs holds the mapping from the PipelineResources declared in
-DeclaredPipelineResources to the input PipelineResources required by the Task.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.PipelineTaskRun">PipelineTaskRun
-</h3>
-<div>
-<p>PipelineTaskRun reports the results of running a step in the Task. Each
-task has the potential to succeed or fail (based on the exit code)
-and produces logs.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.PipelineTaskRunSpec">PipelineTaskRunSpec
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineRunSpec">PipelineRunSpec</a>)
-</p>
-<div>
-<p>PipelineTaskRunSpec  can be used to configure specific
-specs for a concrete Task</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>pipelineTaskName</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>taskServiceAccountName</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>taskPodTemplate</code><br/>
-<em>
-<a href="#tekton.dev/unversioned.PodTemplate">
-PodTemplate
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>stepOverrides</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.TaskRunStepOverride">
-[]TaskRunStepOverride
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>sidecarOverrides</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.TaskRunSidecarOverride">
-[]TaskRunSidecarOverride
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>metadata</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.PipelineTaskMetadata">
-PipelineTaskMetadata
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-<tr>
-<td>
-<code>computeResources</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#resourcerequirements-v1-core">
-Kubernetes core/v1.ResourceRequirements
-</a>
-</em>
-</td>
-<td>
-<p>Compute resources to use for this TaskRun</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>timeout</code><br/>
-<em>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
-Kubernetes meta/v1.Duration
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Duration after which the TaskRun times out.
-Refer Go&rsquo;s ParseDuration documentation for expected format: <a href="https://golang.org/pkg/time/#ParseDuration">https://golang.org/pkg/time/#ParseDuration</a></p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.PipelineWorkspaceDeclaration">PipelineWorkspaceDeclaration
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineSpec">PipelineSpec</a>)
-</p>
-<div>
-<p>PipelineWorkspaceDeclaration creates a named slot in a Pipeline that a PipelineRun
-is expected to populate with a workspace binding.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Name is the name of a workspace to be provided by a PipelineRun.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>description</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Description is a human readable string describing how the workspace will be
-used in the Pipeline. It can be useful to include a bit of detail about which
-tasks are intended to have access to the data on the workspace.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>optional</code><br/>
-<em>
-bool
-</em>
-</td>
-<td>
-<p>Optional marks a Workspace as not being required in PipelineRuns. By default
-this field is false and so declared workspaces are required.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.PropertySpec">PropertySpec
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.ParamSpec">ParamSpec</a>, <a href="#tekton.dev/v1beta1.TaskResult">TaskResult</a>)
-</p>
-<div>
-<p>PropertySpec defines the struct for object keys</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>type</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.ParamType">
-ParamType
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.Provenance">Provenance
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineRunStatusFields">PipelineRunStatusFields</a>, <a href="#tekton.dev/v1beta1.StepState">StepState</a>, <a href="#tekton.dev/v1beta1.TaskRunStatusFields">TaskRunStatusFields</a>)
-</p>
-<div>
-<p>Provenance contains metadata about resources used in the TaskRun/PipelineRun
+consume these fields via duck typing.
+
+
+
+_Appears in:_
+- [PipelineRunStatus](#pipelinerunstatus)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | StartTime is the time the PipelineRun is actually started. |  |  |
+| `completionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | CompletionTime is the time the PipelineRun completed. |  |  |
+| `taskRuns` _object (keys:string, values:[PipelineRunTaskRunStatus](#pipelineruntaskrunstatus))_ | TaskRuns is a map of PipelineRunTaskRunStatus with the taskRun name as the key.<br />Deprecated: use ChildReferences instead. As of v0.45.0, this field is no<br />longer populated and is only included for backwards compatibility with<br />older server versions. |  | Optional: \{\} <br /> |
+| `runs` _object (keys:string, values:[PipelineRunRunStatus](#pipelinerunrunstatus))_ | Runs is a map of PipelineRunRunStatus with the run name as the key<br />Deprecated: use ChildReferences instead. As of v0.45.0, this field is no<br />longer populated and is only included for backwards compatibility with<br />older server versions. |  | Optional: \{\} <br /> |
+| `pipelineResults` _[PipelineRunResult](#pipelinerunresult) array_ | PipelineResults are the list of results written out by the pipeline task's containers |  | Optional: \{\} <br /> |
+| `pipelineSpec` _[PipelineSpec](#pipelinespec)_ | PipelineSpec contains the exact spec used to instantiate the run.<br />See Pipeline.spec (API version: tekton.dev/v1beta1) |  | Schemaless: \{\} <br /> |
+| `skippedTasks` _[SkippedTask](#skippedtask) array_ | list of tasks that were skipped due to when expressions evaluating to false |  | Optional: \{\} <br /> |
+| `childReferences` _[ChildStatusReference](#childstatusreference) array_ | list of TaskRun and Run names, PipelineTask names, and API versions/kinds for children of this PipelineRun. |  | Optional: \{\} <br /> |
+| `finallyStartTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | FinallyStartTime is when all non-finally tasks have been completed and only finally tasks are being executed. |  | Optional: \{\} <br /> |
+| `provenance` _[Provenance](#provenance)_ | Provenance contains some key authenticated metadata about how a software artifact was built (what sources, what inputs/outputs, etc.). |  | Optional: \{\} <br /> |
+| `spanContext` _object (keys:string, values:string)_ | SpanContext contains tracing span context fields |  |  |
+
+
+#### PipelineRunTaskRunStatus
+
+
+
+PipelineRunTaskRunStatus contains the name of the PipelineTask for this TaskRun and the TaskRun's Status
+
+
+
+_Appears in:_
+- [PipelineRunStatus](#pipelinerunstatus)
+- [PipelineRunStatusFields](#pipelinerunstatusfields)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `pipelineTaskName` _string_ | PipelineTaskName is the name of the PipelineTask. |  |  |
+| `status` _[TaskRunStatus](#taskrunstatus)_ | Status is the TaskRunStatus for the corresponding TaskRun |  | Optional: \{\} <br /> |
+| `whenExpressions` _[WhenExpression](#whenexpression) array_ | WhenExpressions is the list of checks guarding the execution of the PipelineTask |  | Optional: \{\} <br /> |
+
+
+#### PipelineSpec
+
+
+
+PipelineSpec defines the desired state of Pipeline.
+
+
+
+_Appears in:_
+- [Pipeline](#pipeline)
+- [PipelineRunSpec](#pipelinerunspec)
+- [PipelineRunStatus](#pipelinerunstatus)
+- [PipelineRunStatusFields](#pipelinerunstatusfields)
+- [PipelineTask](#pipelinetask)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `displayName` _string_ | DisplayName is a user-facing name of the pipeline that may be<br />used to populate a UI. |  | Optional: \{\} <br /> |
+| `description` _string_ | Description is a user-facing description of the pipeline that may be<br />used to populate a UI. |  | Optional: \{\} <br /> |
+| `resources` _[PipelineDeclaredResource](#pipelinedeclaredresource) array_ | Deprecated: Unused, preserved only for backwards compatibility |  |  |
+| `tasks` _[PipelineTask](#pipelinetask) array_ | Tasks declares the graph of Tasks that execute when this Pipeline is run. |  |  |
+| `params` _[ParamSpecs](#paramspecs)_ | Params declares a list of input parameters that must be supplied when<br />this Pipeline is run. |  |  |
+| `workspaces` _[PipelineWorkspaceDeclaration](#pipelineworkspacedeclaration) array_ | Workspaces declares a set of named workspaces that are expected to be<br />provided by a PipelineRun. |  | Optional: \{\} <br /> |
+| `results` _[PipelineResult](#pipelineresult) array_ | Results are values that this pipeline can output once run |  | Optional: \{\} <br /> |
+| `finally` _[PipelineTask](#pipelinetask) array_ | Finally declares the list of Tasks that execute just before leaving the Pipeline<br />i.e. either after all Tasks are finished executing successfully<br />or after a failure which would result in ending the Pipeline |  |  |
+
+
+#### PipelineTask
+
+
+
+PipelineTask defines a task in a Pipeline, passing inputs from both
+Params and from the output of previous tasks.
+
+
+
+_Appears in:_
+- [PipelineSpec](#pipelinespec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name is the name of this task within the context of a Pipeline. Name is<br />used as a coordinate with the `from` and `runAfter` fields to establish<br />the execution order of tasks relative to one another. |  |  |
+| `displayName` _string_ | DisplayName is the display name of this task within the context of a Pipeline.<br />This display name may be used to populate a UI. |  | Optional: \{\} <br /> |
+| `description` _string_ | Description is the description of this task within the context of a Pipeline.<br />This description may be used to populate a UI. |  | Optional: \{\} <br /> |
+| `taskRef` _[TaskRef](#taskref)_ | TaskRef is a reference to a task definition. |  | Optional: \{\} <br /> |
+| `taskSpec` _[EmbeddedTask](#embeddedtask)_ | TaskSpec is a specification of a task<br />Specifying TaskSpec can be disabled by setting<br />`disable-inline-spec` feature flag.<br />See Task.spec (API version: tekton.dev/v1beta1) |  | Schemaless: \{\} <br />Optional: \{\} <br /> |
+| `when` _[WhenExpressions](#whenexpressions)_ | WhenExpressions is a list of when expressions that need to be true for the task to run |  | Optional: \{\} <br /> |
+| `retries` _integer_ | Retries represents how many times this task should be retried in case of task failure: ConditionSucceeded set to False |  | Optional: \{\} <br /> |
+| `runAfter` _string array_ | RunAfter is the list of PipelineTask names that should be executed before<br />this Task executes. (Used to force a specific ordering in graph execution.) |  | Optional: \{\} <br /> |
+| `resources` _[PipelineTaskResources](#pipelinetaskresources)_ | Deprecated: Unused, preserved only for backwards compatibility |  | Optional: \{\} <br /> |
+| `params` _[Params](#params)_ | Parameters declares parameters passed to this task. |  | Optional: \{\} <br /> |
+| `matrix` _[Matrix](#matrix)_ | Matrix declares parameters used to fan out this task. |  | Optional: \{\} <br /> |
+| `workspaces` _[WorkspacePipelineTaskBinding](#workspacepipelinetaskbinding) array_ | Workspaces maps workspaces from the pipeline spec to the workspaces<br />declared in the Task. |  | Optional: \{\} <br /> |
+| `timeout` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ | Duration after which the TaskRun times out. Defaults to 1 hour.<br />Refer Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration |  | Optional: \{\} <br /> |
+| `pipelineRef` _[PipelineRef](#pipelineref)_ | PipelineRef is a reference to a pipeline definition.<br />This is an alpha field. You must set the "enable-api-fields" feature flag<br />to "alpha" for this field to be supported. When enabled, the referenced<br />Pipeline is executed as a child PipelineRun owned by the parent PipelineRun. |  | Optional: \{\} <br /> |
+| `pipelineSpec` _[PipelineSpec](#pipelinespec)_ | PipelineSpec is a specification of a pipeline.<br />This is an alpha field. You must set the "enable-api-fields" feature flag<br />to "alpha" for this field to be supported. When enabled, the embedded<br />Pipeline is executed as a child PipelineRun owned by the parent PipelineRun.<br />Specifying PipelineSpec can be disabled by setting<br />`disable-inline-spec` feature flag.<br />See Pipeline.spec (API version: tekton.dev/v1beta1) |  | Schemaless: \{\} <br />Optional: \{\} <br /> |
+| `onError` _[PipelineTaskOnErrorType](#pipelinetaskonerrortype)_ | OnError defines the exiting behavior of a PipelineRun on error<br />can be set to [ continue \| stopAndFail ] |  | Optional: \{\} <br /> |
+
+
+#### PipelineTaskInputResource
+
+
+
+PipelineTaskInputResource maps the name of a declared PipelineResource input
+dependency in a Task to the resource in the Pipeline's DeclaredPipelineResources
+that should be used. This input may come from a previous task.
+
+Deprecated: Unused, preserved only for backwards compatibility
+
+
+
+_Appears in:_
+- [PipelineTaskResources](#pipelinetaskresources)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name is the name of the PipelineResource as declared by the Task. |  |  |
+| `resource` _string_ | Resource is the name of the DeclaredPipelineResource to use. |  |  |
+| `from` _string array_ | From is the list of PipelineTask names that the resource has to come from.<br />(Implies an ordering in the execution graph.) |  | Optional: \{\} <br /> |
+
+
+#### PipelineTaskMetadata
+
+
+
+PipelineTaskMetadata contains the labels or annotations for an EmbeddedTask
+
+
+
+_Appears in:_
+- [EmbeddedCustomRunSpec](#embeddedcustomrunspec)
+- [EmbeddedRunSpec](#embeddedrunspec)
+- [EmbeddedTask](#embeddedtask)
+- [PipelineTaskRunSpec](#pipelinetaskrunspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `labels` _object (keys:string, values:string)_ |  |  | Optional: \{\} <br /> |
+| `annotations` _object (keys:string, values:string)_ |  |  | Optional: \{\} <br /> |
+
+
+#### PipelineTaskOnErrorType
+
+_Underlying type:_ _string_
+
+PipelineTaskOnErrorType defines a list of supported failure handling behaviors of a PipelineTask on error
+
+
+
+_Appears in:_
+- [PipelineTask](#pipelinetask)
+
+| Field | Description |
+| --- | --- |
+| `stopAndFail` | PipelineTaskStopAndFail indicates to stop and fail the PipelineRun if the PipelineTask fails<br /> |
+| `continue` | PipelineTaskContinue indicates to continue executing the rest of the DAG when the PipelineTask fails<br /> |
+
+
+#### PipelineTaskOutputResource
+
+
+
+PipelineTaskOutputResource maps the name of a declared PipelineResource output
+dependency in a Task to the resource in the Pipeline's DeclaredPipelineResources
+that should be used.
+
+Deprecated: Unused, preserved only for backwards compatibility
+
+
+
+_Appears in:_
+- [PipelineTaskResources](#pipelinetaskresources)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name is the name of the PipelineResource as declared by the Task. |  |  |
+| `resource` _string_ | Resource is the name of the DeclaredPipelineResource to use. |  |  |
+
+
+
+
+#### PipelineTaskResources
+
+
+
+PipelineTaskResources allows a Pipeline to declare how its DeclaredPipelineResources
+should be provided to a Task as its inputs and outputs.
+
+Deprecated: Unused, preserved only for backwards compatibility
+
+
+
+_Appears in:_
+- [PipelineTask](#pipelinetask)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `inputs` _[PipelineTaskInputResource](#pipelinetaskinputresource) array_ | Inputs holds the mapping from the PipelineResources declared in<br />DeclaredPipelineResources to the input PipelineResources required by the Task. |  |  |
+| `outputs` _[PipelineTaskOutputResource](#pipelinetaskoutputresource) array_ | Outputs holds the mapping from the PipelineResources declared in<br />DeclaredPipelineResources to the input PipelineResources required by the Task. |  |  |
+
+
+
+
+#### PipelineTaskRunSpec
+
+
+
+PipelineTaskRunSpec  can be used to configure specific
+specs for a concrete Task
+
+
+
+_Appears in:_
+- [PipelineRunSpec](#pipelinerunspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `pipelineTaskName` _string_ |  |  |  |
+| `taskServiceAccountName` _string_ |  |  |  |
+| `taskPodTemplate` _[PodTemplate](#podtemplate)_ |  |  |  |
+| `stepOverrides` _[TaskRunStepOverride](#taskrunstepoverride) array_ |  |  |  |
+| `sidecarOverrides` _[TaskRunSidecarOverride](#taskrunsidecaroverride) array_ |  |  |  |
+| `metadata` _[PipelineTaskMetadata](#pipelinetaskmetadata)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  | Optional: \{\} <br /> |
+| `computeResources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcerequirements-v1-core)_ | Compute resources to use for this TaskRun |  |  |
+| `timeout` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ | Duration after which the TaskRun times out.<br />Refer Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration |  | Optional: \{\} <br /> |
+
+
+#### PipelineWorkspaceDeclaration
+
+_Underlying type:_ _[struct{Name string "json:\"name\""; Description string "json:\"description,omitempty\""; Optional bool "json:\"optional,omitempty\""}](#struct{name-string-"json:\"name\"";-description-string-"json:\"description,omitempty\"";-optional-bool-"json:\"optional,omitempty\""})_
+
+PipelineWorkspaceDeclaration creates a named slot in a Pipeline that a PipelineRun
+is expected to populate with a workspace binding.
+
+
+
+_Appears in:_
+- [PipelineSpec](#pipelinespec)
+
+
+
+#### PropertySpec
+
+
+
+PropertySpec defines the struct for object keys
+
+
+
+_Appears in:_
+- [ParamSpec](#paramspec)
+- [TaskResult](#taskresult)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `type` _[ParamType](#paramtype)_ |  |  |  |
+
+
+#### Provenance
+
+
+
+Provenance contains metadata about resources used in the TaskRun/PipelineRun
 such as the source from where a remote build definition was fetched.
 This field aims to carry minimum amoumt of metadata in *Run status so that
-Tekton Chains can capture them in the provenance.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>configSource</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.ConfigSource">
-ConfigSource
-</a>
-</em>
-</td>
-<td>
-<p>Deprecated: Use RefSource instead</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>refSource</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.RefSource">
-RefSource
-</a>
-</em>
-</td>
-<td>
-<p>RefSource identifies the source where a remote task/pipeline came from.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>featureFlags</code><br/>
-<em>
-github.com/tektoncd/pipeline/pkg/apis/config.FeatureFlags
-</em>
-</td>
-<td>
-<p>FeatureFlags identifies the feature flags that were used during the task/pipeline run</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.Ref">Ref
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.Step">Step</a>)
-</p>
-<div>
-<p>Ref can be used to refer to a specific instance of a StepAction.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Name of the referenced step</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ResolverRef</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.ResolverRef">
-ResolverRef
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ResolverRef allows referencing a StepAction in a remote location
-like a git repo.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.RefSource">RefSource
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.Provenance">Provenance</a>)
-</p>
-<div>
-<p>RefSource contains the information that can uniquely identify where a remote
+Tekton Chains can capture them in the provenance.
+
+
+
+_Appears in:_
+- [PipelineRunStatus](#pipelinerunstatus)
+- [PipelineRunStatusFields](#pipelinerunstatusfields)
+- [StepState](#stepstate)
+- [TaskRunStatus](#taskrunstatus)
+- [TaskRunStatusFields](#taskrunstatusfields)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `configSource` _[ConfigSource](#configsource)_ | Deprecated: Use RefSource instead |  |  |
+| `refSource` _[RefSource](#refsource)_ | RefSource identifies the source where a remote task/pipeline came from. |  |  |
+| `featureFlags` _[FeatureFlags](#featureflags)_ | FeatureFlags identifies the feature flags that were used during the task/pipeline run |  |  |
+
+
+#### Ref
+
+
+
+Ref can be used to refer to a specific instance of a StepAction.
+
+
+
+_Appears in:_
+- [Step](#step)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name of the referenced step |  |  |
+| `ResolverRef` _[ResolverRef](#resolverref)_ | ResolverRef allows referencing a StepAction in a remote location<br />like a git repo. |  | Optional: \{\} <br /> |
+
+
+#### RefSource
+
+
+
+RefSource contains the information that can uniquely identify where a remote
 built definition came from i.e. Git repositories, Tekton Bundles in OCI registry
-and hub.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>uri</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>URI indicates the identity of the source of the build definition.
-Example: &ldquo;<a href="https://github.com/tektoncd/catalog&quot;">https://github.com/tektoncd/catalog&rdquo;</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>digest</code><br/>
-<em>
-map[string]string
-</em>
-</td>
-<td>
-<p>Digest is a collection of cryptographic digests for the contents of the artifact specified by URI.
-Example: {&ldquo;sha1&rdquo;: &ldquo;f99d13e554ffcb696dee719fa85b695cb5b0f428&rdquo;}</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>entryPoint</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>EntryPoint identifies the entry point into the build. This is often a path to a
-build definition file and/or a target label within that file.
-Example: &ldquo;task/git-clone/0.10/git-clone.yaml&rdquo;</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.ResolverName">ResolverName
-(<code>string</code> alias)</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.ResolverRef">ResolverRef</a>)
-</p>
-<div>
-<p>ResolverName is the name of a resolver from which a resource can be
-requested.</p>
-</div>
-<h3 id="tekton.dev/v1beta1.ResolverRef">ResolverRef
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineRef">PipelineRef</a>, <a href="#tekton.dev/v1beta1.Ref">Ref</a>, <a href="#tekton.dev/v1beta1.TaskRef">TaskRef</a>)
-</p>
-<div>
-<p>ResolverRef can be used to refer to a Pipeline or Task in a remote
-location like a git repo.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>resolver</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.ResolverName">
-ResolverName
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Resolver is the name of the resolver that should perform
-resolution of the referenced Tekton resource, such as &ldquo;git&rdquo;.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>params</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.Params">
-Params
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Params contains the parameters used to identify the
-referenced Tekton resource. Example entries might include
-&ldquo;repo&rdquo; or &ldquo;path&rdquo; but the set of params ultimately depends on
-the chosen resolver.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.ResourceDeclaration">ResourceDeclaration
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskResource">TaskResource</a>)
-</p>
-<div>
-<p>ResourceDeclaration defines an input or output PipelineResource declared as a requirement
-by another type such as a Task or Condition. The Name field will be used to refer to these
-PipelineResources within the type&rsquo;s definition, and when provided as an Input, the Name will be the
-path to the volume mounted containing this PipelineResource as an input (e.g.
-an input Resource named <code>workspace</code> will be mounted at <code>/workspace</code>).</p>
-<p>Deprecated: Unused, preserved only for backwards compatibility</p>
-</div>
-<h3 id="tekton.dev/v1beta1.ResourceParam">ResourceParam
-</h3>
-<div>
-<p>ResourceParam declares a string value to use for the parameter called Name, and is used in
-the specific context of PipelineResources.</p>
-<p>Deprecated: Unused, preserved only for backwards compatibility</p>
-</div>
-<h3 id="tekton.dev/v1beta1.ResultRef">ResultRef
-</h3>
-<div>
-<p>ResultRef is a type that represents a reference to a task run result</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>pipelineTask</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>result</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>resultsIndex</code><br/>
-<em>
-int
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>property</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.ResultType">ResultType
-</h3>
-<div>
-<p>ResultType of PipelineResourceResult has been deprecated with the migration of PipelineResources
-Deprecated: v1beta1.ResultType is only kept for backward compatibility</p>
-</div>
-<h3 id="tekton.dev/v1beta1.ResultValue">ResultValue
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineResult">PipelineResult</a>, <a href="#tekton.dev/v1beta1.PipelineRunResult">PipelineRunResult</a>, <a href="#tekton.dev/v1beta1.TaskResult">TaskResult</a>, <a href="#tekton.dev/v1beta1.TaskRunResult">TaskRunResult</a>)
-</p>
-<div>
-<p>ResultValue is a type alias of ParamValue</p>
-</div>
-<h3 id="tekton.dev/v1beta1.ResultsType">ResultsType
-(<code>string</code> alias)</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineResult">PipelineResult</a>, <a href="#tekton.dev/v1beta1.TaskResult">TaskResult</a>, <a href="#tekton.dev/v1beta1.TaskRunResult">TaskRunResult</a>)
-</p>
-<div>
-<p>ResultsType indicates the type of a result;
+and hub.
+
+
+
+_Appears in:_
+- [Provenance](#provenance)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `uri` _string_ | URI indicates the identity of the source of the build definition.<br />Example: "https://github.com/tektoncd/catalog" |  |  |
+| `digest` _object (keys:string, values:string)_ | Digest is a collection of cryptographic digests for the contents of the artifact specified by URI.<br />Example: \{"sha1": "f99d13e554ffcb696dee719fa85b695cb5b0f428"\} |  |  |
+| `entryPoint` _string_ | EntryPoint identifies the entry point into the build. This is often a path to a<br />build definition file and/or a target label within that file.<br />Example: "task/git-clone/0.10/git-clone.yaml" |  |  |
+
+
+#### ResolverName
+
+_Underlying type:_ _string_
+
+ResolverName is the name of a resolver from which a resource can be
+requested.
+
+
+
+_Appears in:_
+- [ResolverRef](#resolverref)
+
+
+
+#### ResolverRef
+
+
+
+ResolverRef can be used to refer to a Pipeline or Task in a remote
+location like a git repo.
+
+
+
+_Appears in:_
+- [PipelineRef](#pipelineref)
+- [Ref](#ref)
+- [TaskRef](#taskref)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `resolver` _[ResolverName](#resolvername)_ | Resolver is the name of the resolver that should perform<br />resolution of the referenced Tekton resource, such as "git". |  | Optional: \{\} <br /> |
+| `params` _[Params](#params)_ | Params contains the parameters used to identify the<br />referenced Tekton resource. Example entries might include<br />"repo" or "path" but the set of params ultimately depends on<br />the chosen resolver. |  | Optional: \{\} <br /> |
+
+
+
+
+
+
+
+
+
+
+
+
+#### ResultsType
+
+_Underlying type:_ _string_
+
+ResultsType indicates the type of a result;
 Used to distinguish between a single string and an array of strings.
 Note that there is ResultType used to find out whether a
 RunResult is from a task result or not, which is different from
-this ResultsType.</p>
-</div>
-<h3 id="tekton.dev/v1beta1.RetriesStatus">RetriesStatus
-(<code>[]github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskRunStatus</code> alias)</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskRunStatusFields">TaskRunStatusFields</a>)
-</p>
-<div>
-</div>
-<h3 id="tekton.dev/v1beta1.RunObject">RunObject
-</h3>
-<div>
-<p>RunObject is implemented by Run, CustomRun, TaskRun and PipelineRun</p>
-</div>
-<h3 id="tekton.dev/v1beta1.RunObjectWithRetries">RunObjectWithRetries
-</h3>
-<div>
-<p>RunObjectWithRetries is implemented by Run and CustomRun</p>
-</div>
-<h3 id="tekton.dev/v1beta1.RunResult">RunResult
-</h3>
-<div>
-<p>RunResult is used to write key/value pairs to TaskRun pod termination messages.
-It has been migrated to the result package and kept for backward compatibility</p>
-</div>
-<h3 id="tekton.dev/v1beta1.Sidecar">Sidecar
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskSpec">TaskSpec</a>)
-</p>
-<div>
-<p>Sidecar has nearly the same data structure as Step but does not have the ability to timeout.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Name of the Sidecar specified as a DNS_LABEL.
-Each Sidecar in a Task must have a unique name (DNS_LABEL).
-Cannot be updated.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>image</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Image name to be used by the Sidecar.
-More info: <a href="https://kubernetes.io/docs/concepts/containers/images">https://kubernetes.io/docs/concepts/containers/images</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>command</code><br/>
-<em>
-[]string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Entrypoint array. Not executed within a shell.
-The image&rsquo;s ENTRYPOINT is used if this is not provided.
-Variable references $(VAR_NAME) are expanded using the Sidecar&rsquo;s environment. If a variable
-cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
-to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. &ldquo;$$(VAR_NAME)&rdquo; will
-produce the string literal &ldquo;$(VAR_NAME)&rdquo;. Escaped references will never be expanded, regardless
-of whether the variable exists or not. Cannot be updated.
-More info: <a href="https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell">https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>args</code><br/>
-<em>
-[]string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Arguments to the entrypoint.
-The image&rsquo;s CMD is used if this is not provided.
-Variable references $(VAR_NAME) are expanded using the container&rsquo;s environment. If a variable
-cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
-to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. &ldquo;$$(VAR_NAME)&rdquo; will
-produce the string literal &ldquo;$(VAR_NAME)&rdquo;. Escaped references will never be expanded, regardless
-of whether the variable exists or not. Cannot be updated.
-More info: <a href="https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell">https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>workingDir</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Sidecar&rsquo;s working directory.
-If not specified, the container runtime&rsquo;s default will be used, which
-might be configured in the container image.
-Cannot be updated.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ports</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#containerport-v1-core">
-[]Kubernetes core/v1.ContainerPort
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>List of ports to expose from the Sidecar. Exposing a port here gives
-the system additional information about the network connections a
-container uses, but is primarily informational. Not specifying a port here
-DOES NOT prevent that port from being exposed. Any port which is
-listening on the default &ldquo;0.0.0.0&rdquo; address inside a container will be
-accessible from the network.
-Cannot be updated.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>envFrom</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#envfromsource-v1-core">
-[]Kubernetes core/v1.EnvFromSource
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>List of sources to populate environment variables in the Sidecar.
-The keys defined within a source must be a C_IDENTIFIER. All invalid keys
-will be reported as an event when the Sidecar is starting. When a key exists in multiple
-sources, the value associated with the last source will take precedence.
-Values defined by an Env with a duplicate key will take precedence.
-Cannot be updated.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>env</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#envvar-v1-core">
-[]Kubernetes core/v1.EnvVar
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>List of environment variables to set in the Sidecar.
-Cannot be updated.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>resources</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#resourcerequirements-v1-core">
-Kubernetes core/v1.ResourceRequirements
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Compute Resources required by this Sidecar.
-Cannot be updated.
-More info: <a href="https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/">https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>volumeMounts</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#volumemount-v1-core">
-[]Kubernetes core/v1.VolumeMount
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Volumes to mount into the Sidecar&rsquo;s filesystem.
-Cannot be updated.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>volumeDevices</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#volumedevice-v1-core">
-[]Kubernetes core/v1.VolumeDevice
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>volumeDevices is the list of block devices to be used by the Sidecar.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>livenessProbe</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#probe-v1-core">
-Kubernetes core/v1.Probe
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Periodic probe of Sidecar liveness.
-Container will be restarted if the probe fails.
-Cannot be updated.
-More info: <a href="https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes">https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>readinessProbe</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#probe-v1-core">
-Kubernetes core/v1.Probe
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Periodic probe of Sidecar service readiness.
-Container will be removed from service endpoints if the probe fails.
-Cannot be updated.
-More info: <a href="https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes">https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>startupProbe</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#probe-v1-core">
-Kubernetes core/v1.Probe
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>StartupProbe indicates that the Pod the Sidecar is running in has successfully initialized.
-If specified, no other probes are executed until this completes successfully.
-If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
-This can be used to provide different probe parameters at the beginning of a Pod&rsquo;s lifecycle,
-when it might take a long time to load data or warm a cache, than during steady-state operation.
-This cannot be updated.
-More info: <a href="https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes">https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>lifecycle</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#lifecycle-v1-core">
-Kubernetes core/v1.Lifecycle
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Actions that the management system should take in response to Sidecar lifecycle events.
-Cannot be updated.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>terminationMessagePath</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Optional: Path at which the file to which the Sidecar&rsquo;s termination message
-will be written is mounted into the Sidecar&rsquo;s filesystem.
-Message written is intended to be brief final status, such as an assertion failure message.
-Will be truncated by the node if greater than 4096 bytes. The total message length across
-all containers will be limited to 12kb.
-Defaults to /dev/termination-log.
-Cannot be updated.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>terminationMessagePolicy</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#terminationmessagepolicy-v1-core">
-Kubernetes core/v1.TerminationMessagePolicy
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Indicate how the termination message should be populated. File will use the contents of
-terminationMessagePath to populate the Sidecar status message on both success and failure.
-FallbackToLogsOnError will use the last chunk of Sidecar log output if the termination
-message file is empty and the Sidecar exited with an error.
-The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
-Defaults to File.
-Cannot be updated.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>imagePullPolicy</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#pullpolicy-v1-core">
-Kubernetes core/v1.PullPolicy
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Image pull policy.
-One of Always, Never, IfNotPresent.
-Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
-Cannot be updated.
-More info: <a href="https://kubernetes.io/docs/concepts/containers/images#updating-images">https://kubernetes.io/docs/concepts/containers/images#updating-images</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>securityContext</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#securitycontext-v1-core">
-Kubernetes core/v1.SecurityContext
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>SecurityContext defines the security options the Sidecar should be run with.
-If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
-More info: <a href="https://kubernetes.io/docs/tasks/configure-pod-container/security-context/">https://kubernetes.io/docs/tasks/configure-pod-container/security-context/</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>stdin</code><br/>
-<em>
-bool
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Whether this Sidecar should allocate a buffer for stdin in the container runtime. If this
-is not set, reads from stdin in the Sidecar will always result in EOF.
-Default is false.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>stdinOnce</code><br/>
-<em>
-bool
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Whether the container runtime should close the stdin channel after it has been opened by
-a single attach. When stdin is true the stdin stream will remain open across multiple attach
-sessions. If stdinOnce is set to true, stdin is opened on Sidecar start, is empty until the
-first client attaches to stdin, and then remains open and accepts data until the client disconnects,
-at which time stdin is closed and remains closed until the Sidecar is restarted. If this
-flag is false, a container processes that reads from stdin will never receive an EOF.
-Default is false</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>tty</code><br/>
-<em>
-bool
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Whether this Sidecar should allocate a TTY for itself, also requires &lsquo;stdin&rsquo; to be true.
-Default is false.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>script</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Script is the contents of an executable file to execute.</p>
-<p>If Script is not empty, the Step cannot have an Command or Args.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>workspaces</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.WorkspaceUsage">
-[]WorkspaceUsage
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>This is an alpha field. You must set the &ldquo;enable-api-fields&rdquo; feature flag to &ldquo;alpha&rdquo;
-for this field to be supported.</p>
-<p>Workspaces is a list of workspaces from the Task that this Sidecar wants
-exclusive access to. Adding a workspace to this list means that any
-other Step or Sidecar that does not also request this Workspace will
-not have access to it.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>restartPolicy</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#containerrestartpolicy-v1-core">
-Kubernetes core/v1.ContainerRestartPolicy
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>RestartPolicy refers to kubernetes RestartPolicy. It can only be set for an
-initContainer and must have it&rsquo;s policy set to &ldquo;Always&rdquo;. It is currently
-left optional to help support Kubernetes versions prior to 1.29 when this feature
-was introduced.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.SidecarState">SidecarState
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskRunStatusFields">TaskRunStatusFields</a>)
-</p>
-<div>
-<p>SidecarState reports the results of running a sidecar in a Task.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>ContainerState</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#containerstate-v1-core">
-Kubernetes core/v1.ContainerState
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>ContainerState</code> are embedded into this type.)
-</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>container</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>imageID</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.SkippedTask">SkippedTask
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineRunStatusFields">PipelineRunStatusFields</a>)
-</p>
-<div>
-<p>SkippedTask is used to describe the Tasks that were skipped due to their When Expressions
+this ResultsType.
+
+
+
+_Appears in:_
+- [TaskResult](#taskresult)
+- [TaskRunResult](#taskrunresult)
+
+| Field | Description |
+| --- | --- |
+| `string` |  |
+| `array` |  |
+| `object` |  |
+
+
+#### RetriesStatus
+
+_Underlying type:_ _[TaskRunStatus](#taskrunstatus)_
+
+
+
+
+
+_Appears in:_
+- [TaskRunStatus](#taskrunstatus)
+- [TaskRunStatusFields](#taskrunstatusfields)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `Status` _[Status](https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Status)_ |  |  |  |
+| `TaskRunStatusFields` _[TaskRunStatusFields](#taskrunstatusfields)_ | TaskRunStatusFields inlines the status fields. |  |  |
+
+
+
+
+
+
+
+
+#### Sidecar
+
+
+
+Sidecar has nearly the same data structure as Step but does not have the ability to timeout.
+
+
+
+_Appears in:_
+- [EmbeddedTask](#embeddedtask)
+- [TaskSpec](#taskspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name of the Sidecar specified as a DNS_LABEL.<br />Each Sidecar in a Task must have a unique name (DNS_LABEL).<br />Cannot be updated. |  |  |
+| `image` _string_ | Image name to be used by the Sidecar.<br />More info: https://kubernetes.io/docs/concepts/containers/images |  | Optional: \{\} <br /> |
+| `command` _string array_ | Entrypoint array. Not executed within a shell.<br />The image's ENTRYPOINT is used if this is not provided.<br />Variable references $(VAR_NAME) are expanded using the Sidecar's environment. If a variable<br />cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced<br />to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will<br />produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless<br />of whether the variable exists or not. Cannot be updated.<br />More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell |  | Optional: \{\} <br /> |
+| `args` _string array_ | Arguments to the entrypoint.<br />The image's CMD is used if this is not provided.<br />Variable references $(VAR_NAME) are expanded using the container's environment. If a variable<br />cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced<br />to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will<br />produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless<br />of whether the variable exists or not. Cannot be updated.<br />More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell |  | Optional: \{\} <br /> |
+| `workingDir` _string_ | Sidecar's working directory.<br />If not specified, the container runtime's default will be used, which<br />might be configured in the container image.<br />Cannot be updated. |  | Optional: \{\} <br /> |
+| `ports` _[ContainerPort](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#containerport-v1-core) array_ | List of ports to expose from the Sidecar. Exposing a port here gives<br />the system additional information about the network connections a<br />container uses, but is primarily informational. Not specifying a port here<br />DOES NOT prevent that port from being exposed. Any port which is<br />listening on the default "0.0.0.0" address inside a container will be<br />accessible from the network.<br />Cannot be updated. |  | Optional: \{\} <br /> |
+| `envFrom` _[EnvFromSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#envfromsource-v1-core) array_ | List of sources to populate environment variables in the Sidecar.<br />The keys defined within a source must be a C_IDENTIFIER. All invalid keys<br />will be reported as an event when the Sidecar is starting. When a key exists in multiple<br />sources, the value associated with the last source will take precedence.<br />Values defined by an Env with a duplicate key will take precedence.<br />Cannot be updated. |  | Optional: \{\} <br /> |
+| `env` _[EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#envvar-v1-core) array_ | List of environment variables to set in the Sidecar.<br />Cannot be updated. |  | Optional: \{\} <br /> |
+| `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcerequirements-v1-core)_ | Compute Resources required by this Sidecar.<br />Cannot be updated.<br />More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |  | Optional: \{\} <br /> |
+| `volumeMounts` _[VolumeMount](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#volumemount-v1-core) array_ | Volumes to mount into the Sidecar's filesystem.<br />Cannot be updated. |  | Optional: \{\} <br /> |
+| `volumeDevices` _[VolumeDevice](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#volumedevice-v1-core) array_ | volumeDevices is the list of block devices to be used by the Sidecar. |  | Optional: \{\} <br /> |
+| `livenessProbe` _[Probe](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#probe-v1-core)_ | Periodic probe of Sidecar liveness.<br />Container will be restarted if the probe fails.<br />Cannot be updated.<br />More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes |  | Optional: \{\} <br /> |
+| `readinessProbe` _[Probe](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#probe-v1-core)_ | Periodic probe of Sidecar service readiness.<br />Container will be removed from service endpoints if the probe fails.<br />Cannot be updated.<br />More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes |  | Optional: \{\} <br /> |
+| `startupProbe` _[Probe](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#probe-v1-core)_ | StartupProbe indicates that the Pod the Sidecar is running in has successfully initialized.<br />If specified, no other probes are executed until this completes successfully.<br />If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.<br />This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,<br />when it might take a long time to load data or warm a cache, than during steady-state operation.<br />This cannot be updated.<br />More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes |  | Optional: \{\} <br /> |
+| `lifecycle` _[Lifecycle](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#lifecycle-v1-core)_ | Actions that the management system should take in response to Sidecar lifecycle events.<br />Cannot be updated. |  | Optional: \{\} <br /> |
+| `terminationMessagePath` _string_ | Optional: Path at which the file to which the Sidecar's termination message<br />will be written is mounted into the Sidecar's filesystem.<br />Message written is intended to be brief final status, such as an assertion failure message.<br />Will be truncated by the node if greater than 4096 bytes. The total message length across<br />all containers will be limited to 12kb.<br />Defaults to /dev/termination-log.<br />Cannot be updated. |  | Optional: \{\} <br /> |
+| `terminationMessagePolicy` _[TerminationMessagePolicy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#terminationmessagepolicy-v1-core)_ | Indicate how the termination message should be populated. File will use the contents of<br />terminationMessagePath to populate the Sidecar status message on both success and failure.<br />FallbackToLogsOnError will use the last chunk of Sidecar log output if the termination<br />message file is empty and the Sidecar exited with an error.<br />The log output is limited to 2048 bytes or 80 lines, whichever is smaller.<br />Defaults to File.<br />Cannot be updated. |  | Optional: \{\} <br /> |
+| `imagePullPolicy` _[PullPolicy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#pullpolicy-v1-core)_ | Image pull policy.<br />One of Always, Never, IfNotPresent.<br />Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.<br />Cannot be updated.<br />More info: https://kubernetes.io/docs/concepts/containers/images#updating-images |  | Optional: \{\} <br /> |
+| `securityContext` _[SecurityContext](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#securitycontext-v1-core)_ | SecurityContext defines the security options the Sidecar should be run with.<br />If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.<br />More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ |  | Optional: \{\} <br /> |
+| `stdin` _boolean_ | Whether this Sidecar should allocate a buffer for stdin in the container runtime. If this<br />is not set, reads from stdin in the Sidecar will always result in EOF.<br />Default is false. |  | Optional: \{\} <br /> |
+| `stdinOnce` _boolean_ | Whether the container runtime should close the stdin channel after it has been opened by<br />a single attach. When stdin is true the stdin stream will remain open across multiple attach<br />sessions. If stdinOnce is set to true, stdin is opened on Sidecar start, is empty until the<br />first client attaches to stdin, and then remains open and accepts data until the client disconnects,<br />at which time stdin is closed and remains closed until the Sidecar is restarted. If this<br />flag is false, a container processes that reads from stdin will never receive an EOF.<br />Default is false |  | Optional: \{\} <br /> |
+| `tty` _boolean_ | Whether this Sidecar should allocate a TTY for itself, also requires 'stdin' to be true.<br />Default is false. |  | Optional: \{\} <br /> |
+| `script` _string_ | Script is the contents of an executable file to execute.<br />If Script is not empty, the Step cannot have an Command or Args. |  | Optional: \{\} <br /> |
+| `workspaces` _[WorkspaceUsage](#workspaceusage) array_ | This is an alpha field. You must set the "enable-api-fields" feature flag to "alpha"<br />for this field to be supported.<br />Workspaces is a list of workspaces from the Task that this Sidecar wants<br />exclusive access to. Adding a workspace to this list means that any<br />other Step or Sidecar that does not also request this Workspace will<br />not have access to it. |  | Optional: \{\} <br /> |
+| `restartPolicy` _[ContainerRestartPolicy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#containerrestartpolicy-v1-core)_ | RestartPolicy refers to kubernetes RestartPolicy. It can only be set for an<br />initContainer and must have it's policy set to "Always". It is currently<br />left optional to help support Kubernetes versions prior to 1.29 when this feature<br />was introduced. |  | Optional: \{\} <br /> |
+
+
+#### SidecarState
+
+
+
+SidecarState reports the results of running a sidecar in a Task.
+
+
+
+_Appears in:_
+- [TaskRunStatus](#taskrunstatus)
+- [TaskRunStatusFields](#taskrunstatusfields)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `waiting` _[ContainerStateWaiting](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#containerstatewaiting-v1-core)_ | Details about a waiting container |  | Optional: \{\} <br /> |
+| `running` _[ContainerStateRunning](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#containerstaterunning-v1-core)_ | Details about a running container |  | Optional: \{\} <br /> |
+| `terminated` _[ContainerStateTerminated](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#containerstateterminated-v1-core)_ | Details about a terminated container |  | Optional: \{\} <br /> |
+| `name` _string_ |  |  |  |
+| `container` _string_ |  |  |  |
+| `imageID` _string_ |  |  |  |
+
+
+#### SkippedTask
+
+
+
+SkippedTask is used to describe the Tasks that were skipped due to their When Expressions
 evaluating to False. This is a struct because we are looking into including more details
-about the When Expressions that caused this Task to be skipped.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Name is the Pipeline Task name</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>reason</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.SkippingReason">
-SkippingReason
-</a>
-</em>
-</td>
-<td>
-<p>Reason is the cause of the PipelineTask being skipped.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>whenExpressions</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.WhenExpression">
-[]WhenExpression
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>WhenExpressions is the list of checks guarding the execution of the PipelineTask</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.SkippingReason">SkippingReason
-(<code>string</code> alias)</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.SkippedTask">SkippedTask</a>)
-</p>
-<div>
-<p>SkippingReason explains why a PipelineTask was skipped.</p>
-</div>
-<h3 id="tekton.dev/v1beta1.Step">Step
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.InternalTaskModifier">InternalTaskModifier</a>, <a href="#tekton.dev/v1beta1.TaskSpec">TaskSpec</a>)
-</p>
-<div>
-<p>Step runs a subcomponent of a Task</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Name of the Step specified as a DNS_LABEL.
-Each Step in a Task must have a unique name.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>displayName</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>DisplayName is a user-facing name of the step that may be
-used to populate a UI.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>image</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Image reference name to run for this Step.
-More info: <a href="https://kubernetes.io/docs/concepts/containers/images">https://kubernetes.io/docs/concepts/containers/images</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>command</code><br/>
-<em>
-[]string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Entrypoint array. Not executed within a shell.
-The image&rsquo;s ENTRYPOINT is used if this is not provided.
-Variable references $(VAR_NAME) are expanded using the container&rsquo;s environment. If a variable
-cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
-to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. &ldquo;$$(VAR_NAME)&rdquo; will
-produce the string literal &ldquo;$(VAR_NAME)&rdquo;. Escaped references will never be expanded, regardless
-of whether the variable exists or not. Cannot be updated.
-More info: <a href="https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell">https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>args</code><br/>
-<em>
-[]string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Arguments to the entrypoint.
-The image&rsquo;s CMD is used if this is not provided.
-Variable references $(VAR_NAME) are expanded using the container&rsquo;s environment. If a variable
-cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
-to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. &ldquo;$$(VAR_NAME)&rdquo; will
-produce the string literal &ldquo;$(VAR_NAME)&rdquo;. Escaped references will never be expanded, regardless
-of whether the variable exists or not. Cannot be updated.
-More info: <a href="https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell">https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>workingDir</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Step&rsquo;s working directory.
-If not specified, the container runtime&rsquo;s default will be used, which
-might be configured in the container image.
-Cannot be updated.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ports</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#containerport-v1-core">
-[]Kubernetes core/v1.ContainerPort
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>List of ports to expose from the Step&rsquo;s container. Exposing a port here gives
-the system additional information about the network connections a
-container uses, but is primarily informational. Not specifying a port here
-DOES NOT prevent that port from being exposed. Any port which is
-listening on the default &ldquo;0.0.0.0&rdquo; address inside a container will be
-accessible from the network.
-Cannot be updated.</p>
-<p>Deprecated: This field will be removed in a future release.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>envFrom</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#envfromsource-v1-core">
-[]Kubernetes core/v1.EnvFromSource
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>List of sources to populate environment variables in the container.
-The keys defined within a source must be a C_IDENTIFIER. All invalid keys
-will be reported as an event when the container is starting. When a key exists in multiple
-sources, the value associated with the last source will take precedence.
-Values defined by an Env with a duplicate key will take precedence.
-Cannot be updated.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>env</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#envvar-v1-core">
-[]Kubernetes core/v1.EnvVar
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>List of environment variables to set in the container.
-Cannot be updated.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>resources</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#resourcerequirements-v1-core">
-Kubernetes core/v1.ResourceRequirements
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Compute Resources required by this Step.
-Cannot be updated.
-More info: <a href="https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/">https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>volumeMounts</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#volumemount-v1-core">
-[]Kubernetes core/v1.VolumeMount
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Volumes to mount into the Step&rsquo;s filesystem.
-Cannot be updated.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>volumeDevices</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#volumedevice-v1-core">
-[]Kubernetes core/v1.VolumeDevice
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>volumeDevices is the list of block devices to be used by the Step.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>livenessProbe</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#probe-v1-core">
-Kubernetes core/v1.Probe
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Periodic probe of container liveness.
-Step will be restarted if the probe fails.
-Cannot be updated.
-More info: <a href="https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes">https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes</a></p>
-<p>Deprecated: This field will be removed in a future release.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>readinessProbe</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#probe-v1-core">
-Kubernetes core/v1.Probe
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Periodic probe of container service readiness.
-Step will be removed from service endpoints if the probe fails.
-Cannot be updated.
-More info: <a href="https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes">https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes</a></p>
-<p>Deprecated: This field will be removed in a future release.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>startupProbe</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#probe-v1-core">
-Kubernetes core/v1.Probe
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>DeprecatedStartupProbe indicates that the Pod this Step runs in has successfully initialized.
-If specified, no other probes are executed until this completes successfully.
-If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
-This can be used to provide different probe parameters at the beginning of a Pod&rsquo;s lifecycle,
-when it might take a long time to load data or warm a cache, than during steady-state operation.
-This cannot be updated.
-More info: <a href="https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes">https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes</a></p>
-<p>Deprecated: This field will be removed in a future release.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>lifecycle</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#lifecycle-v1-core">
-Kubernetes core/v1.Lifecycle
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Actions that the management system should take in response to container lifecycle events.
-Cannot be updated.</p>
-<p>Deprecated: This field will be removed in a future release.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>terminationMessagePath</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Deprecated: This field will be removed in a future release and can&rsquo;t be meaningfully used.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>terminationMessagePolicy</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#terminationmessagepolicy-v1-core">
-Kubernetes core/v1.TerminationMessagePolicy
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Deprecated: This field will be removed in a future release and can&rsquo;t be meaningfully used.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>imagePullPolicy</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#pullpolicy-v1-core">
-Kubernetes core/v1.PullPolicy
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Image pull policy.
-One of Always, Never, IfNotPresent.
-Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
-Cannot be updated.
-More info: <a href="https://kubernetes.io/docs/concepts/containers/images#updating-images">https://kubernetes.io/docs/concepts/containers/images#updating-images</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>securityContext</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#securitycontext-v1-core">
-Kubernetes core/v1.SecurityContext
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>SecurityContext defines the security options the Step should be run with.
-If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
-More info: <a href="https://kubernetes.io/docs/tasks/configure-pod-container/security-context/">https://kubernetes.io/docs/tasks/configure-pod-container/security-context/</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>stdin</code><br/>
-<em>
-bool
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Whether this container should allocate a buffer for stdin in the container runtime. If this
-is not set, reads from stdin in the container will always result in EOF.
-Default is false.</p>
-<p>Deprecated: This field will be removed in a future release.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>stdinOnce</code><br/>
-<em>
-bool
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Whether the container runtime should close the stdin channel after it has been opened by
-a single attach. When stdin is true the stdin stream will remain open across multiple attach
-sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
-first client attaches to stdin, and then remains open and accepts data until the client disconnects,
-at which time stdin is closed and remains closed until the container is restarted. If this
-flag is false, a container processes that reads from stdin will never receive an EOF.
-Default is false</p>
-<p>Deprecated: This field will be removed in a future release.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>tty</code><br/>
-<em>
-bool
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Whether this container should allocate a DeprecatedTTY for itself, also requires &lsquo;stdin&rsquo; to be true.
-Default is false.</p>
-<p>Deprecated: This field will be removed in a future release.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>script</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Script is the contents of an executable file to execute.</p>
-<p>If Script is not empty, the Step cannot have an Command and the Args will be passed to the Script.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>timeout</code><br/>
-<em>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
-Kubernetes meta/v1.Duration
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Timeout is the time after which the step times out. Defaults to never.
-Refer to Go&rsquo;s ParseDuration documentation for expected format: <a href="https://golang.org/pkg/time/#ParseDuration">https://golang.org/pkg/time/#ParseDuration</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>workspaces</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.WorkspaceUsage">
-[]WorkspaceUsage
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>This is an alpha field. You must set the &ldquo;enable-api-fields&rdquo; feature flag to &ldquo;alpha&rdquo;
-for this field to be supported.</p>
-<p>Workspaces is a list of workspaces from the Task that this Step wants
-exclusive access to. Adding a workspace to this list means that any
-other Step or Sidecar that does not also request this Workspace will
-not have access to it.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>onError</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.OnErrorType">
-OnErrorType
-</a>
-</em>
-</td>
-<td>
-<p>OnError defines the exiting behavior of a container on error
-can be set to [ continue | stopAndFail ]</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>stdoutConfig</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.StepOutputConfig">
-StepOutputConfig
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Stores configuration for the stdout stream of the step.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>stderrConfig</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.StepOutputConfig">
-StepOutputConfig
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Stores configuration for the stderr stream of the step.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ref</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.Ref">
-Ref
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Contains the reference to an existing StepAction.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>params</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.Params">
-Params
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Params declares parameters passed to this step action.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>results</code><br/>
-<em>
-<a href="#tekton.dev/v1.StepResult">
-[]StepResult
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Results declares StepResults produced by the Step.</p>
-<p>It can be used in an inlined Step when used to store Results to $(step.results.resultName.path).
-It cannot be used when referencing StepActions using [v1beta1.Step.Ref].
-The Results declared by the StepActions will be stored here instead.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>when</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.StepWhenExpressions">
-StepWhenExpressions
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.StepActionObject">StepActionObject
-</h3>
-<div>
-<p>StepActionObject is implemented by StepAction</p>
-</div>
-<h3 id="tekton.dev/v1beta1.StepActionSpec">StepActionSpec
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.StepAction">StepAction</a>)
-</p>
-<div>
-<p>StepActionSpec contains the actionable components of a step.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>description</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Description is a user-facing description of the stepaction that may be
-used to populate a UI.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>image</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Image reference name to run for this StepAction.
-More info: <a href="https://kubernetes.io/docs/concepts/containers/images">https://kubernetes.io/docs/concepts/containers/images</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>command</code><br/>
-<em>
-[]string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Entrypoint array. Not executed within a shell.
-The image&rsquo;s ENTRYPOINT is used if this is not provided.
-Variable references $(VAR_NAME) are expanded using the container&rsquo;s environment. If a variable
-cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
-to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. &ldquo;$$(VAR_NAME)&rdquo; will
-produce the string literal &ldquo;$(VAR_NAME)&rdquo;. Escaped references will never be expanded, regardless
-of whether the variable exists or not. Cannot be updated.
-More info: <a href="https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell">https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>args</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.Args">
-Args
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Arguments to the entrypoint.
-The image&rsquo;s CMD is used if this is not provided.
-Variable references $(VAR_NAME) are expanded using the container&rsquo;s environment. If a variable
-cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
-to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. &ldquo;$$(VAR_NAME)&rdquo; will
-produce the string literal &ldquo;$(VAR_NAME)&rdquo;. Escaped references will never be expanded, regardless
-of whether the variable exists or not. Cannot be updated.
-More info: <a href="https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell">https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>env</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#envvar-v1-core">
-[]Kubernetes core/v1.EnvVar
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>List of environment variables to set in the container.
-Cannot be updated.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>script</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Script is the contents of an executable file to execute.</p>
-<p>If Script is not empty, the Step cannot have an Command and the Args will be passed to the Script.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>workingDir</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Step&rsquo;s working directory.
-If not specified, the container runtime&rsquo;s default will be used, which
-might be configured in the container image.
-Cannot be updated.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>params</code><br/>
-<em>
-<a href="#tekton.dev/v1.ParamSpecs">
-ParamSpecs
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Params is a list of input parameters required to run the stepAction.
-Params must be supplied as inputs in Steps unless they declare a defaultvalue.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>results</code><br/>
-<em>
-<a href="#tekton.dev/v1.StepResult">
-[]StepResult
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Results are values that this StepAction can output</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>securityContext</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#securitycontext-v1-core">
-Kubernetes core/v1.SecurityContext
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>SecurityContext defines the security options the Step should be run with.
-If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
-More info: <a href="https://kubernetes.io/docs/tasks/configure-pod-container/security-context/">https://kubernetes.io/docs/tasks/configure-pod-container/security-context/</a>
-The value set in StepAction will take precedence over the value from Task.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>volumeMounts</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#volumemount-v1-core">
-[]Kubernetes core/v1.VolumeMount
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Volumes to mount into the Step&rsquo;s filesystem.
-Cannot be updated.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.StepOutputConfig">StepOutputConfig
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.Step">Step</a>)
-</p>
-<div>
-<p>StepOutputConfig stores configuration for a step output stream.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>path</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Path to duplicate stdout stream to on container&rsquo;s local filesystem.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.StepState">StepState
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskRunStatusFields">TaskRunStatusFields</a>)
-</p>
-<div>
-<p>StepState reports the results of running a step in a Task.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>ContainerState</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#containerstate-v1-core">
-Kubernetes core/v1.ContainerState
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>ContainerState</code> are embedded into this type.)
-</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>container</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>imageID</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>results</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.TaskRunStepResult">
-[]TaskRunStepResult
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>provenance</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.Provenance">
-Provenance
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>inputs</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.TaskRunStepArtifact">
-[]TaskRunStepArtifact
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>outputs</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.TaskRunStepArtifact">
-[]TaskRunStepArtifact
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.StepTemplate">StepTemplate
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskSpec">TaskSpec</a>)
-</p>
-<div>
-<p>StepTemplate is a template for a Step</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Default name for each Step specified as a DNS_LABEL.
-Each Step in a Task must have a unique name.
-Cannot be updated.</p>
-<p>Deprecated: This field will be removed in a future release.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>image</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Default image name to use for each Step.
-More info: <a href="https://kubernetes.io/docs/concepts/containers/images">https://kubernetes.io/docs/concepts/containers/images</a>
-This field is optional to allow higher level config management to default or override
-container images in workload controllers like Deployments and StatefulSets.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>command</code><br/>
-<em>
-[]string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Entrypoint array. Not executed within a shell.
-The docker image&rsquo;s ENTRYPOINT is used if this is not provided.
-Variable references $(VAR_NAME) are expanded using the Step&rsquo;s environment. If a variable
-cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
-to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. &ldquo;$$(VAR_NAME)&rdquo; will
-produce the string literal &ldquo;$(VAR_NAME)&rdquo;. Escaped references will never be expanded, regardless
-of whether the variable exists or not. Cannot be updated.
-More info: <a href="https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell">https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>args</code><br/>
-<em>
-[]string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Arguments to the entrypoint.
-The image&rsquo;s CMD is used if this is not provided.
-Variable references $(VAR_NAME) are expanded using the Step&rsquo;s environment. If a variable
-cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
-to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. &ldquo;$$(VAR_NAME)&rdquo; will
-produce the string literal &ldquo;$(VAR_NAME)&rdquo;. Escaped references will never be expanded, regardless
-of whether the variable exists or not. Cannot be updated.
-More info: <a href="https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell">https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>workingDir</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Step&rsquo;s working directory.
-If not specified, the container runtime&rsquo;s default will be used, which
-might be configured in the container image.
-Cannot be updated.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ports</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#containerport-v1-core">
-[]Kubernetes core/v1.ContainerPort
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>List of ports to expose from the Step&rsquo;s container. Exposing a port here gives
-the system additional information about the network connections a
-container uses, but is primarily informational. Not specifying a port here
-DOES NOT prevent that port from being exposed. Any port which is
-listening on the default &ldquo;0.0.0.0&rdquo; address inside a container will be
-accessible from the network.
-Cannot be updated.</p>
-<p>Deprecated: This field will be removed in a future release.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>envFrom</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#envfromsource-v1-core">
-[]Kubernetes core/v1.EnvFromSource
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>List of sources to populate environment variables in the Step.
-The keys defined within a source must be a C_IDENTIFIER. All invalid keys
-will be reported as an event when the container is starting. When a key exists in multiple
-sources, the value associated with the last source will take precedence.
-Values defined by an Env with a duplicate key will take precedence.
-Cannot be updated.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>env</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#envvar-v1-core">
-[]Kubernetes core/v1.EnvVar
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>List of environment variables to set in the container.
-Cannot be updated.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>resources</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#resourcerequirements-v1-core">
-Kubernetes core/v1.ResourceRequirements
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Compute Resources required by this Step.
-Cannot be updated.
-More info: <a href="https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/">https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>volumeMounts</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#volumemount-v1-core">
-[]Kubernetes core/v1.VolumeMount
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Volumes to mount into the Step&rsquo;s filesystem.
-Cannot be updated.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>volumeDevices</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#volumedevice-v1-core">
-[]Kubernetes core/v1.VolumeDevice
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>volumeDevices is the list of block devices to be used by the Step.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>livenessProbe</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#probe-v1-core">
-Kubernetes core/v1.Probe
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Periodic probe of container liveness.
-Container will be restarted if the probe fails.
-Cannot be updated.
-More info: <a href="https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes">https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes</a></p>
-<p>Deprecated: This field will be removed in a future release.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>readinessProbe</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#probe-v1-core">
-Kubernetes core/v1.Probe
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Periodic probe of container service readiness.
-Container will be removed from service endpoints if the probe fails.
-Cannot be updated.
-More info: <a href="https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes">https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes</a></p>
-<p>Deprecated: This field will be removed in a future release.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>startupProbe</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#probe-v1-core">
-Kubernetes core/v1.Probe
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>DeprecatedStartupProbe indicates that the Pod has successfully initialized.
-If specified, no other probes are executed until this completes successfully.
-If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
-This can be used to provide different probe parameters at the beginning of a Pod&rsquo;s lifecycle,
-when it might take a long time to load data or warm a cache, than during steady-state operation.
-This cannot be updated.
-More info: <a href="https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes">https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes</a></p>
-<p>Deprecated: This field will be removed in a future release.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>lifecycle</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#lifecycle-v1-core">
-Kubernetes core/v1.Lifecycle
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Actions that the management system should take in response to container lifecycle events.
-Cannot be updated.</p>
-<p>Deprecated: This field will be removed in a future release.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>terminationMessagePath</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Deprecated: This field will be removed in a future release and cannot be meaningfully used.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>terminationMessagePolicy</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#terminationmessagepolicy-v1-core">
-Kubernetes core/v1.TerminationMessagePolicy
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Deprecated: This field will be removed in a future release and cannot be meaningfully used.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>imagePullPolicy</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#pullpolicy-v1-core">
-Kubernetes core/v1.PullPolicy
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Image pull policy.
-One of Always, Never, IfNotPresent.
-Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
-Cannot be updated.
-More info: <a href="https://kubernetes.io/docs/concepts/containers/images#updating-images">https://kubernetes.io/docs/concepts/containers/images#updating-images</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>securityContext</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#securitycontext-v1-core">
-Kubernetes core/v1.SecurityContext
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>SecurityContext defines the security options the Step should be run with.
-If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
-More info: <a href="https://kubernetes.io/docs/tasks/configure-pod-container/security-context/">https://kubernetes.io/docs/tasks/configure-pod-container/security-context/</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>stdin</code><br/>
-<em>
-bool
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Whether this Step should allocate a buffer for stdin in the container runtime. If this
-is not set, reads from stdin in the Step will always result in EOF.
-Default is false.</p>
-<p>Deprecated: This field will be removed in a future release.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>stdinOnce</code><br/>
-<em>
-bool
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Whether the container runtime should close the stdin channel after it has been opened by
-a single attach. When stdin is true the stdin stream will remain open across multiple attach
-sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
-first client attaches to stdin, and then remains open and accepts data until the client disconnects,
-at which time stdin is closed and remains closed until the container is restarted. If this
-flag is false, a container processes that reads from stdin will never receive an EOF.
-Default is false</p>
-<p>Deprecated: This field will be removed in a future release.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>tty</code><br/>
-<em>
-bool
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Whether this Step should allocate a DeprecatedTTY for itself, also requires &lsquo;stdin&rsquo; to be true.
-Default is false.</p>
-<p>Deprecated: This field will be removed in a future release.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.StepWhenExpressions">StepWhenExpressions
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.Step">Step</a>)
-</p>
-<div>
-</div>
-<h3 id="tekton.dev/v1beta1.TaskBreakpoints">TaskBreakpoints
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskRunDebug">TaskRunDebug</a>)
-</p>
-<div>
-<p>TaskBreakpoints defines the breakpoint config for a particular Task</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>onFailure</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>if enabled, pause TaskRun on failure of a step
-failed step will not exit</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>beforeSteps</code><br/>
-<em>
-[]string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.TaskKind">TaskKind
-(<code>string</code> alias)</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskRef">TaskRef</a>)
-</p>
-<div>
-<p>TaskKind defines the type of Task used by the pipeline.</p>
-</div>
-<h3 id="tekton.dev/v1beta1.TaskModifier">TaskModifier
-</h3>
-<div>
-<p>TaskModifier is an interface to be implemented by different PipelineResources</p>
-<p>Deprecated: Unused, preserved only for backwards compatibility</p>
-</div>
-<h3 id="tekton.dev/v1beta1.TaskObject">TaskObject
-</h3>
-<div>
-<p>TaskObject is implemented by Task</p>
-</div>
-<h3 id="tekton.dev/v1beta1.TaskRef">TaskRef
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1alpha1.RunSpec">RunSpec</a>, <a href="#tekton.dev/v1beta1.CustomRunSpec">CustomRunSpec</a>, <a href="#tekton.dev/v1beta1.PipelineTask">PipelineTask</a>, <a href="#tekton.dev/v1beta1.TaskRunSpec">TaskRunSpec</a>)
-</p>
-<div>
-<p>TaskRef can be used to refer to a specific instance of a task.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Name of the referent; More info: <a href="http://kubernetes.io/docs/user-guide/identifiers#names">http://kubernetes.io/docs/user-guide/identifiers#names</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.TaskKind">
-TaskKind
-</a>
-</em>
-</td>
-<td>
-<p>TaskKind indicates the Kind of the Task:
-1. Namespaced Task when Kind is set to &ldquo;Task&rdquo;. If Kind is &ldquo;&rdquo;, it defaults to &ldquo;Task&rdquo;.
-2. Custom Task when Kind is non-empty and APIVersion is non-empty</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>apiVersion</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>API version of the referent
-Note: A Task with non-empty APIVersion and Kind is considered a Custom Task</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>bundle</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Bundle url reference to a Tekton Bundle.</p>
-<p>Deprecated: Please use ResolverRef with the bundles resolver instead.
-The field is staying there for go client backward compatibility, but is not used/allowed anymore.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ResolverRef</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.ResolverRef">
-ResolverRef
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ResolverRef allows referencing a Task in a remote location
-like a git repo. This field is only supported when the alpha
-feature gate is enabled.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.TaskResource">TaskResource
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskResources">TaskResources</a>)
-</p>
-<div>
-<p>TaskResource defines an input or output Resource declared as a requirement
+about the When Expressions that caused this Task to be skipped.
+
+
+
+_Appears in:_
+- [PipelineRunStatus](#pipelinerunstatus)
+- [PipelineRunStatusFields](#pipelinerunstatusfields)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name is the Pipeline Task name |  |  |
+| `reason` _[SkippingReason](#skippingreason)_ | Reason is the cause of the PipelineTask being skipped. |  |  |
+| `whenExpressions` _[WhenExpression](#whenexpression) array_ | WhenExpressions is the list of checks guarding the execution of the PipelineTask |  | Optional: \{\} <br /> |
+
+
+#### SkippingReason
+
+_Underlying type:_ _string_
+
+SkippingReason explains why a PipelineTask was skipped.
+
+
+
+_Appears in:_
+- [SkippedTask](#skippedtask)
+
+| Field | Description |
+| --- | --- |
+| `When Expressions evaluated to false` | WhenExpressionsSkip means the task was skipped due to at least one of its when expressions evaluating to false<br /> |
+| `Parent Tasks were skipped` | ParentTasksSkip means the task was skipped because its parent was skipped<br /> |
+| `PipelineRun was stopping` | StoppingSkip means the task was skipped because the pipeline run is stopping<br /> |
+| `PipelineRun was gracefully cancelled` | GracefullyCancelledSkip means the task was skipped because the pipeline run has been gracefully cancelled<br /> |
+| `PipelineRun was gracefully stopped` | GracefullyStoppedSkip means the task was skipped because the pipeline run has been gracefully stopped<br /> |
+| `Results were missing` | MissingResultsSkip means the task was skipped because it's missing necessary results<br /> |
+| `PipelineRun timeout has been reached` | PipelineTimedOutSkip means the task was skipped because the PipelineRun has passed its overall timeout.<br /> |
+| `PipelineRun Tasks timeout has been reached` | TasksTimedOutSkip means the task was skipped because the PipelineRun has passed its Timeouts.Tasks.<br /> |
+| `PipelineRun Finally timeout has been reached` | FinallyTimedOutSkip means the task was skipped because the PipelineRun has passed its Timeouts.Finally.<br /> |
+| `Matrix Parameters have an empty array` | EmptyArrayInMatrixParams means the task was skipped because Matrix parameters contain empty array.<br /> |
+| `None` | None means the task was not skipped<br /> |
+
+
+#### Step
+
+
+
+Step runs a subcomponent of a Task
+
+
+
+_Appears in:_
+- [EmbeddedTask](#embeddedtask)
+- [InternalTaskModifier](#internaltaskmodifier)
+- [TaskSpec](#taskspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name of the Step specified as a DNS_LABEL.<br />Each Step in a Task must have a unique name. |  |  |
+| `displayName` _string_ | DisplayName is a user-facing name of the step that may be<br />used to populate a UI. |  | Optional: \{\} <br /> |
+| `image` _string_ | Image reference name to run for this Step.<br />More info: https://kubernetes.io/docs/concepts/containers/images |  | Optional: \{\} <br /> |
+| `command` _string array_ | Entrypoint array. Not executed within a shell.<br />The image's ENTRYPOINT is used if this is not provided.<br />Variable references $(VAR_NAME) are expanded using the container's environment. If a variable<br />cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced<br />to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will<br />produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless<br />of whether the variable exists or not. Cannot be updated.<br />More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell |  | Optional: \{\} <br /> |
+| `args` _string array_ | Arguments to the entrypoint.<br />The image's CMD is used if this is not provided.<br />Variable references $(VAR_NAME) are expanded using the container's environment. If a variable<br />cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced<br />to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will<br />produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless<br />of whether the variable exists or not. Cannot be updated.<br />More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell |  | Optional: \{\} <br /> |
+| `workingDir` _string_ | Step's working directory.<br />If not specified, the container runtime's default will be used, which<br />might be configured in the container image.<br />Cannot be updated. |  | Optional: \{\} <br /> |
+| `ports` _[ContainerPort](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#containerport-v1-core) array_ | List of ports to expose from the Step's container. Exposing a port here gives<br />the system additional information about the network connections a<br />container uses, but is primarily informational. Not specifying a port here<br />DOES NOT prevent that port from being exposed. Any port which is<br />listening on the default "0.0.0.0" address inside a container will be<br />accessible from the network.<br />Cannot be updated.<br />Deprecated: This field will be removed in a future release. |  | Optional: \{\} <br /> |
+| `envFrom` _[EnvFromSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#envfromsource-v1-core) array_ | List of sources to populate environment variables in the container.<br />The keys defined within a source must be a C_IDENTIFIER. All invalid keys<br />will be reported as an event when the container is starting. When a key exists in multiple<br />sources, the value associated with the last source will take precedence.<br />Values defined by an Env with a duplicate key will take precedence.<br />Cannot be updated. |  | Optional: \{\} <br /> |
+| `env` _[EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#envvar-v1-core) array_ | List of environment variables to set in the container.<br />Cannot be updated. |  | Optional: \{\} <br /> |
+| `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcerequirements-v1-core)_ | Compute Resources required by this Step.<br />Cannot be updated.<br />More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |  | Optional: \{\} <br /> |
+| `volumeMounts` _[VolumeMount](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#volumemount-v1-core) array_ | Volumes to mount into the Step's filesystem.<br />Cannot be updated. |  | Optional: \{\} <br /> |
+| `volumeDevices` _[VolumeDevice](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#volumedevice-v1-core) array_ | volumeDevices is the list of block devices to be used by the Step. |  | Optional: \{\} <br /> |
+| `livenessProbe` _[Probe](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#probe-v1-core)_ | Periodic probe of container liveness.<br />Step will be restarted if the probe fails.<br />Cannot be updated.<br />More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br />Deprecated: This field will be removed in a future release. |  | Optional: \{\} <br /> |
+| `readinessProbe` _[Probe](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#probe-v1-core)_ | Periodic probe of container service readiness.<br />Step will be removed from service endpoints if the probe fails.<br />Cannot be updated.<br />More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br />Deprecated: This field will be removed in a future release. |  | Optional: \{\} <br /> |
+| `startupProbe` _[Probe](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#probe-v1-core)_ | DeprecatedStartupProbe indicates that the Pod this Step runs in has successfully initialized.<br />If specified, no other probes are executed until this completes successfully.<br />If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.<br />This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,<br />when it might take a long time to load data or warm a cache, than during steady-state operation.<br />This cannot be updated.<br />More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br />Deprecated: This field will be removed in a future release. |  | Optional: \{\} <br /> |
+| `lifecycle` _[Lifecycle](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#lifecycle-v1-core)_ | Actions that the management system should take in response to container lifecycle events.<br />Cannot be updated.<br />Deprecated: This field will be removed in a future release. |  | Optional: \{\} <br /> |
+| `terminationMessagePath` _string_ | Deprecated: This field will be removed in a future release and can't be meaningfully used. |  | Optional: \{\} <br /> |
+| `terminationMessagePolicy` _[TerminationMessagePolicy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#terminationmessagepolicy-v1-core)_ | Deprecated: This field will be removed in a future release and can't be meaningfully used. |  | Optional: \{\} <br /> |
+| `imagePullPolicy` _[PullPolicy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#pullpolicy-v1-core)_ | Image pull policy.<br />One of Always, Never, IfNotPresent.<br />Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.<br />Cannot be updated.<br />More info: https://kubernetes.io/docs/concepts/containers/images#updating-images |  | Optional: \{\} <br /> |
+| `securityContext` _[SecurityContext](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#securitycontext-v1-core)_ | SecurityContext defines the security options the Step should be run with.<br />If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.<br />More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ |  | Optional: \{\} <br /> |
+| `stdin` _boolean_ | Whether this container should allocate a buffer for stdin in the container runtime. If this<br />is not set, reads from stdin in the container will always result in EOF.<br />Default is false.<br />Deprecated: This field will be removed in a future release. |  | Optional: \{\} <br /> |
+| `stdinOnce` _boolean_ | Whether the container runtime should close the stdin channel after it has been opened by<br />a single attach. When stdin is true the stdin stream will remain open across multiple attach<br />sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the<br />first client attaches to stdin, and then remains open and accepts data until the client disconnects,<br />at which time stdin is closed and remains closed until the container is restarted. If this<br />flag is false, a container processes that reads from stdin will never receive an EOF.<br />Default is false<br />Deprecated: This field will be removed in a future release. |  | Optional: \{\} <br /> |
+| `tty` _boolean_ | Whether this container should allocate a DeprecatedTTY for itself, also requires 'stdin' to be true.<br />Default is false.<br />Deprecated: This field will be removed in a future release. |  | Optional: \{\} <br /> |
+| `script` _string_ | Script is the contents of an executable file to execute.<br />If Script is not empty, the Step cannot have an Command and the Args will be passed to the Script. |  | Optional: \{\} <br /> |
+| `timeout` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ | Timeout is the time after which the step times out. Defaults to never.<br />Refer to Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration |  | Optional: \{\} <br /> |
+| `workspaces` _[WorkspaceUsage](#workspaceusage) array_ | This is an alpha field. You must set the "enable-api-fields" feature flag to "alpha"<br />for this field to be supported.<br />Workspaces is a list of workspaces from the Task that this Step wants<br />exclusive access to. Adding a workspace to this list means that any<br />other Step or Sidecar that does not also request this Workspace will<br />not have access to it. |  | Optional: \{\} <br /> |
+| `onError` _[OnErrorType](#onerrortype)_ | OnError defines the exiting behavior of a container on error<br />can be set to [ continue \| stopAndFail ] |  |  |
+| `stdoutConfig` _[StepOutputConfig](#stepoutputconfig)_ | Stores configuration for the stdout stream of the step. |  | Optional: \{\} <br /> |
+| `stderrConfig` _[StepOutputConfig](#stepoutputconfig)_ | Stores configuration for the stderr stream of the step. |  | Optional: \{\} <br /> |
+| `ref` _[Ref](#ref)_ | Contains the reference to an existing StepAction. |  | Optional: \{\} <br /> |
+| `params` _[Params](#params)_ | Params declares parameters passed to this step action. |  | Optional: \{\} <br /> |
+| `results` _[StepResult](#stepresult) array_ | Results declares StepResults produced by the Step.<br />It can be used in an inlined Step when used to store Results to $(step.results.resultName.path).<br />It cannot be used when referencing StepActions using [v1beta1.Step.Ref].<br />The Results declared by the StepActions will be stored here instead. |  | Optional: \{\} <br /> |
+| `when` _[StepWhenExpressions](#stepwhenexpressions)_ |  |  |  |
+
+
+#### StepAction
+
+
+
+StepAction represents the actionable components of Step.
+The Step can only reference it from the cluster or using remote resolution.
+
+
+
+
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `apiVersion` _string_ | `tekton.dev/v1beta1` | | |
+| `kind` _string_ | `StepAction` | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  | Optional: \{\} <br /> |
+| `spec` _[StepActionSpec](#stepactionspec)_ | Spec holds the desired state of the Step from the client |  | Optional: \{\} <br /> |
+
+
+
+
+#### StepActionSpec
+
+
+
+StepActionSpec contains the actionable components of a step.
+
+
+
+_Appears in:_
+- [StepAction](#stepaction)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `description` _string_ | Description is a user-facing description of the stepaction that may be<br />used to populate a UI. |  | Optional: \{\} <br /> |
+| `image` _string_ | Image reference name to run for this StepAction.<br />More info: https://kubernetes.io/docs/concepts/containers/images |  | Optional: \{\} <br /> |
+| `command` _string array_ | Entrypoint array. Not executed within a shell.<br />The image's ENTRYPOINT is used if this is not provided.<br />Variable references $(VAR_NAME) are expanded using the container's environment. If a variable<br />cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced<br />to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will<br />produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless<br />of whether the variable exists or not. Cannot be updated.<br />More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell |  | Optional: \{\} <br /> |
+| `args` _[Args](#args)_ | Arguments to the entrypoint.<br />The image's CMD is used if this is not provided.<br />Variable references $(VAR_NAME) are expanded using the container's environment. If a variable<br />cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced<br />to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will<br />produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless<br />of whether the variable exists or not. Cannot be updated.<br />More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell |  | Optional: \{\} <br /> |
+| `env` _[EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#envvar-v1-core) array_ | List of environment variables to set in the container.<br />Cannot be updated. |  | Optional: \{\} <br /> |
+| `script` _string_ | Script is the contents of an executable file to execute.<br />If Script is not empty, the Step cannot have an Command and the Args will be passed to the Script. |  | Optional: \{\} <br /> |
+| `workingDir` _string_ | Step's working directory.<br />If not specified, the container runtime's default will be used, which<br />might be configured in the container image.<br />Cannot be updated. |  | Optional: \{\} <br /> |
+| `params` _[ParamSpecs](#paramspecs)_ | Params is a list of input parameters required to run the stepAction.<br />Params must be supplied as inputs in Steps unless they declare a defaultvalue. |  | Optional: \{\} <br /> |
+| `results` _[StepResult](#stepresult) array_ | Results are values that this StepAction can output |  | Optional: \{\} <br /> |
+| `securityContext` _[SecurityContext](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#securitycontext-v1-core)_ | SecurityContext defines the security options the Step should be run with.<br />If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.<br />More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/<br />The value set in StepAction will take precedence over the value from Task. |  | Optional: \{\} <br /> |
+| `volumeMounts` _[VolumeMount](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#volumemount-v1-core) array_ | Volumes to mount into the Step's filesystem.<br />Cannot be updated. |  | Optional: \{\} <br /> |
+
+
+#### StepOutputConfig
+
+
+
+StepOutputConfig stores configuration for a step output stream.
+
+
+
+_Appears in:_
+- [Step](#step)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `path` _string_ | Path to duplicate stdout stream to on container's local filesystem. |  | Optional: \{\} <br /> |
+
+
+#### StepState
+
+
+
+StepState reports the results of running a step in a Task.
+
+
+
+_Appears in:_
+- [TaskRunStatus](#taskrunstatus)
+- [TaskRunStatusFields](#taskrunstatusfields)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `waiting` _[ContainerStateWaiting](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#containerstatewaiting-v1-core)_ | Details about a waiting container |  | Optional: \{\} <br /> |
+| `running` _[ContainerStateRunning](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#containerstaterunning-v1-core)_ | Details about a running container |  | Optional: \{\} <br /> |
+| `terminated` _[ContainerStateTerminated](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#containerstateterminated-v1-core)_ | Details about a terminated container |  | Optional: \{\} <br /> |
+| `name` _string_ |  |  |  |
+| `container` _string_ |  |  |  |
+| `imageID` _string_ |  |  |  |
+| `results` _[TaskRunStepResult](#taskrunstepresult) array_ |  |  |  |
+| `provenance` _[Provenance](#provenance)_ |  |  |  |
+| `inputs` _[TaskRunStepArtifact](#taskrunstepartifact) array_ |  |  |  |
+| `outputs` _[TaskRunStepArtifact](#taskrunstepartifact) array_ |  |  |  |
+
+
+#### StepTemplate
+
+
+
+StepTemplate is a template for a Step
+
+
+
+_Appears in:_
+- [EmbeddedTask](#embeddedtask)
+- [TaskSpec](#taskspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Default name for each Step specified as a DNS_LABEL.<br />Each Step in a Task must have a unique name.<br />Cannot be updated.<br />Deprecated: This field will be removed in a future release. |  | Optional: \{\} <br /> |
+| `image` _string_ | Default image name to use for each Step.<br />More info: https://kubernetes.io/docs/concepts/containers/images<br />This field is optional to allow higher level config management to default or override<br />container images in workload controllers like Deployments and StatefulSets. |  | Optional: \{\} <br /> |
+| `command` _string array_ | Entrypoint array. Not executed within a shell.<br />The docker image's ENTRYPOINT is used if this is not provided.<br />Variable references $(VAR_NAME) are expanded using the Step's environment. If a variable<br />cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced<br />to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will<br />produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless<br />of whether the variable exists or not. Cannot be updated.<br />More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell |  | Optional: \{\} <br /> |
+| `args` _string array_ | Arguments to the entrypoint.<br />The image's CMD is used if this is not provided.<br />Variable references $(VAR_NAME) are expanded using the Step's environment. If a variable<br />cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced<br />to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will<br />produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless<br />of whether the variable exists or not. Cannot be updated.<br />More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell |  | Optional: \{\} <br /> |
+| `workingDir` _string_ | Step's working directory.<br />If not specified, the container runtime's default will be used, which<br />might be configured in the container image.<br />Cannot be updated. |  | Optional: \{\} <br /> |
+| `ports` _[ContainerPort](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#containerport-v1-core) array_ | List of ports to expose from the Step's container. Exposing a port here gives<br />the system additional information about the network connections a<br />container uses, but is primarily informational. Not specifying a port here<br />DOES NOT prevent that port from being exposed. Any port which is<br />listening on the default "0.0.0.0" address inside a container will be<br />accessible from the network.<br />Cannot be updated.<br />Deprecated: This field will be removed in a future release. |  | Optional: \{\} <br /> |
+| `envFrom` _[EnvFromSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#envfromsource-v1-core) array_ | List of sources to populate environment variables in the Step.<br />The keys defined within a source must be a C_IDENTIFIER. All invalid keys<br />will be reported as an event when the container is starting. When a key exists in multiple<br />sources, the value associated with the last source will take precedence.<br />Values defined by an Env with a duplicate key will take precedence.<br />Cannot be updated. |  | Optional: \{\} <br /> |
+| `env` _[EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#envvar-v1-core) array_ | List of environment variables to set in the container.<br />Cannot be updated. |  | Optional: \{\} <br /> |
+| `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcerequirements-v1-core)_ | Compute Resources required by this Step.<br />Cannot be updated.<br />More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |  | Optional: \{\} <br /> |
+| `volumeMounts` _[VolumeMount](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#volumemount-v1-core) array_ | Volumes to mount into the Step's filesystem.<br />Cannot be updated. |  | Optional: \{\} <br /> |
+| `volumeDevices` _[VolumeDevice](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#volumedevice-v1-core) array_ | volumeDevices is the list of block devices to be used by the Step. |  | Optional: \{\} <br /> |
+| `livenessProbe` _[Probe](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#probe-v1-core)_ | Periodic probe of container liveness.<br />Container will be restarted if the probe fails.<br />Cannot be updated.<br />More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br />Deprecated: This field will be removed in a future release. |  | Optional: \{\} <br /> |
+| `readinessProbe` _[Probe](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#probe-v1-core)_ | Periodic probe of container service readiness.<br />Container will be removed from service endpoints if the probe fails.<br />Cannot be updated.<br />More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br />Deprecated: This field will be removed in a future release. |  | Optional: \{\} <br /> |
+| `startupProbe` _[Probe](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#probe-v1-core)_ | DeprecatedStartupProbe indicates that the Pod has successfully initialized.<br />If specified, no other probes are executed until this completes successfully.<br />If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.<br />This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,<br />when it might take a long time to load data or warm a cache, than during steady-state operation.<br />This cannot be updated.<br />More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br />Deprecated: This field will be removed in a future release. |  | Optional: \{\} <br /> |
+| `lifecycle` _[Lifecycle](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#lifecycle-v1-core)_ | Actions that the management system should take in response to container lifecycle events.<br />Cannot be updated.<br />Deprecated: This field will be removed in a future release. |  | Optional: \{\} <br /> |
+| `terminationMessagePath` _string_ | Deprecated: This field will be removed in a future release and cannot be meaningfully used. |  | Optional: \{\} <br /> |
+| `terminationMessagePolicy` _[TerminationMessagePolicy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#terminationmessagepolicy-v1-core)_ | Deprecated: This field will be removed in a future release and cannot be meaningfully used. |  | Optional: \{\} <br /> |
+| `imagePullPolicy` _[PullPolicy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#pullpolicy-v1-core)_ | Image pull policy.<br />One of Always, Never, IfNotPresent.<br />Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.<br />Cannot be updated.<br />More info: https://kubernetes.io/docs/concepts/containers/images#updating-images |  | Optional: \{\} <br /> |
+| `securityContext` _[SecurityContext](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#securitycontext-v1-core)_ | SecurityContext defines the security options the Step should be run with.<br />If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.<br />More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ |  | Optional: \{\} <br /> |
+| `stdin` _boolean_ | Whether this Step should allocate a buffer for stdin in the container runtime. If this<br />is not set, reads from stdin in the Step will always result in EOF.<br />Default is false.<br />Deprecated: This field will be removed in a future release. |  | Optional: \{\} <br /> |
+| `stdinOnce` _boolean_ | Whether the container runtime should close the stdin channel after it has been opened by<br />a single attach. When stdin is true the stdin stream will remain open across multiple attach<br />sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the<br />first client attaches to stdin, and then remains open and accepts data until the client disconnects,<br />at which time stdin is closed and remains closed until the container is restarted. If this<br />flag is false, a container processes that reads from stdin will never receive an EOF.<br />Default is false<br />Deprecated: This field will be removed in a future release. |  | Optional: \{\} <br /> |
+| `tty` _boolean_ | Whether this Step should allocate a DeprecatedTTY for itself, also requires 'stdin' to be true.<br />Default is false.<br />Deprecated: This field will be removed in a future release. |  | Optional: \{\} <br /> |
+
+
+
+
+#### Task
+
+
+
+Task represents a collection of sequential steps that are run as part of a
+Pipeline using a set of inputs and producing a set of outputs. Tasks execute
+when TaskRuns are created that provide the input parameters and resources and
+output resources the Task requires.
+
+Deprecated: Please use v1.Task instead.
+
+
+
+
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `apiVersion` _string_ | `tekton.dev/v1beta1` | | |
+| `kind` _string_ | `Task` | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  | Optional: \{\} <br /> |
+| `spec` _[TaskSpec](#taskspec)_ | Spec holds the desired state of the Task from the client |  | Optional: \{\} <br /> |
+
+
+#### TaskBreakpoints
+
+
+
+TaskBreakpoints defines the breakpoint config for a particular Task
+
+
+
+_Appears in:_
+- [TaskRunDebug](#taskrundebug)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `onFailure` _string_ | if enabled, pause TaskRun on failure of a step<br />failed step will not exit |  | Optional: \{\} <br /> |
+| `beforeSteps` _string array_ |  |  | Optional: \{\} <br /> |
+
+
+#### TaskKind
+
+_Underlying type:_ _string_
+
+TaskKind defines the type of Task used by the pipeline.
+
+
+
+_Appears in:_
+- [TaskRef](#taskref)
+
+| Field | Description |
+| --- | --- |
+| `Task` | NamespacedTaskKind indicates that the task type has a namespaced scope.<br /> |
+
+
+
+
+
+
+#### TaskRef
+
+
+
+TaskRef can be used to refer to a specific instance of a task.
+
+
+
+_Appears in:_
+- [CustomRunSpec](#customrunspec)
+- [PipelineTask](#pipelinetask)
+- [RunSpec](#runspec)
+- [TaskRunSpec](#taskrunspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names |  |  |
+| `kind` _[TaskKind](#taskkind)_ | TaskKind indicates the Kind of the Task:<br />1. Namespaced Task when Kind is set to "Task". If Kind is "", it defaults to "Task".<br />2. Custom Task when Kind is non-empty and APIVersion is non-empty |  |  |
+| `apiVersion` _string_ | API version of the referent<br />Note: A Task with non-empty APIVersion and Kind is considered a Custom Task |  | Optional: \{\} <br /> |
+| `bundle` _string_ | Bundle url reference to a Tekton Bundle.<br />Deprecated: Please use ResolverRef with the bundles resolver instead.<br />The field is staying there for go client backward compatibility, but is not used/allowed anymore. |  | Optional: \{\} <br /> |
+| `ResolverRef` _[ResolverRef](#resolverref)_ | ResolverRef allows referencing a Task in a remote location<br />like a git repo. This field is only supported when the alpha<br />feature gate is enabled. |  | Optional: \{\} <br /> |
+
+
+#### TaskResource
+
+
+
+TaskResource defines an input or output Resource declared as a requirement
 by a Task. The Name field will be used to refer to these Resources within
 the Task definition, and when provided as an Input, the Name will be the
 path to the volume mounted containing this Resource as an input (e.g.
-an input Resource named <code>workspace</code> will be mounted at <code>/workspace</code>).</p>
-<p>Deprecated: Unused, preserved only for backwards compatibility</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>ResourceDeclaration</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.ResourceDeclaration">
-ResourceDeclaration
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>ResourceDeclaration</code> are embedded into this type.)
-</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.TaskResourceBinding">TaskResourceBinding
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskRunInputs">TaskRunInputs</a>, <a href="#tekton.dev/v1beta1.TaskRunOutputs">TaskRunOutputs</a>, <a href="#tekton.dev/v1beta1.TaskRunResources">TaskRunResources</a>)
-</p>
-<div>
-<p>TaskResourceBinding points to the PipelineResource that
-will be used for the Task input or output called Name.</p>
-<p>Deprecated: Unused, preserved only for backwards compatibility</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>PipelineResourceBinding</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.PipelineResourceBinding">
-PipelineResourceBinding
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>PipelineResourceBinding</code> are embedded into this type.)
-</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>paths</code><br/>
-<em>
-[]string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Paths will probably be removed in #1284, and then PipelineResourceBinding can be used instead.
-The optional Path field corresponds to a path on disk at which the Resource can be found
-(used when providing the resource via mounted volume, overriding the default logic to fetch the Resource).</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.TaskResources">TaskResources
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskSpec">TaskSpec</a>)
-</p>
-<div>
-<p>TaskResources allows a Pipeline to declare how its DeclaredPipelineResources
-should be provided to a Task as its inputs and outputs.</p>
-<p>Deprecated: Unused, preserved only for backwards compatibility</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>inputs</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.TaskResource">
-[]TaskResource
-</a>
-</em>
-</td>
-<td>
-<p>Inputs holds the mapping from the PipelineResources declared in
-DeclaredPipelineResources to the input PipelineResources required by the Task.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>outputs</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.TaskResource">
-[]TaskResource
-</a>
-</em>
-</td>
-<td>
-<p>Outputs holds the mapping from the PipelineResources declared in
-DeclaredPipelineResources to the input PipelineResources required by the Task.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.TaskResult">TaskResult
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskSpec">TaskSpec</a>)
-</p>
-<div>
-<p>TaskResult used to describe the results of a task</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Name the given name</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>type</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.ResultsType">
-ResultsType
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Type is the user-specified type of the result. The possible type
-is currently &ldquo;string&rdquo; and will support &ldquo;array&rdquo; in following work.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>properties</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.PropertySpec">
-map[string]github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PropertySpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Properties is the JSON Schema properties to support key-value pairs results.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>description</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Description is a human-readable description of the result</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>value</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.ResultValue">
-ResultValue
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Value the expression used to retrieve the value of the result from an underlying Step.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.TaskRunConditionType">TaskRunConditionType
-(<code>string</code> alias)</h3>
-<div>
-<p>TaskRunConditionType is an enum used to store TaskRun custom
-conditions such as one used in spire results verification</p>
-</div>
-<h3 id="tekton.dev/v1beta1.TaskRunDebug">TaskRunDebug
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskRunSpec">TaskRunSpec</a>)
-</p>
-<div>
-<p>TaskRunDebug defines the breakpoint config for a particular TaskRun</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>breakpoints</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.TaskBreakpoints">
-TaskBreakpoints
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.TaskRunInputs">TaskRunInputs
-</h3>
-<div>
-<p>TaskRunInputs holds the input values that this task was invoked with.</p>
-<p>Deprecated: Unused, preserved only for backwards compatibility</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>resources</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.TaskResourceBinding">
-[]TaskResourceBinding
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-<tr>
-<td>
-<code>params</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.Param">
-[]Param
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.TaskRunOutputs">TaskRunOutputs
-</h3>
-<div>
-<p>TaskRunOutputs holds the output values that this task was invoked with.</p>
-<p>Deprecated: Unused, preserved only for backwards compatibility</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>resources</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.TaskResourceBinding">
-[]TaskResourceBinding
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.TaskRunReason">TaskRunReason
-(<code>string</code> alias)</h3>
-<div>
-<p>TaskRunReason is an enum used to store all TaskRun reason for
-the Succeeded condition that are controlled by the TaskRun itself. Failure
-reasons that emerge from underlying resources are not included here</p>
-</div>
-<h3 id="tekton.dev/v1beta1.TaskRunResources">TaskRunResources
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskRunSpec">TaskRunSpec</a>)
-</p>
-<div>
-<p>TaskRunResources allows a TaskRun to declare inputs and outputs TaskResourceBinding</p>
-<p>Deprecated: Unused, preserved only for backwards compatibility</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>inputs</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.TaskResourceBinding">
-[]TaskResourceBinding
-</a>
-</em>
-</td>
-<td>
-<p>Inputs holds the inputs resources this task was invoked with</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>outputs</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.TaskResourceBinding">
-[]TaskResourceBinding
-</a>
-</em>
-</td>
-<td>
-<p>Outputs holds the inputs resources this task was invoked with</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.TaskRunResult">TaskRunResult
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskRunStatusFields">TaskRunStatusFields</a>)
-</p>
-<div>
-<p>TaskRunResult used to describe the results of a task</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Name the given name</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>type</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.ResultsType">
-ResultsType
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Type is the user-specified type of the result. The possible type
-is currently &ldquo;string&rdquo; and will support &ldquo;array&rdquo; in following work.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>value</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.ResultValue">
-ResultValue
-</a>
-</em>
-</td>
-<td>
-<p>Value the given value of the result</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.TaskRunSidecarOverride">TaskRunSidecarOverride
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineTaskRunSpec">PipelineTaskRunSpec</a>, <a href="#tekton.dev/v1beta1.TaskRunSpec">TaskRunSpec</a>)
-</p>
-<div>
-<p>TaskRunSidecarOverride is used to override the values of a Sidecar in the corresponding Task.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>The name of the Sidecar to override.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>resources</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#resourcerequirements-v1-core">
-Kubernetes core/v1.ResourceRequirements
-</a>
-</em>
-</td>
-<td>
-<p>The resource requirements to apply to the Sidecar.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.TaskRunSpec">TaskRunSpec
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskRun">TaskRun</a>)
-</p>
-<div>
-<p>TaskRunSpec defines the desired state of TaskRun</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>debug</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.TaskRunDebug">
-TaskRunDebug
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-<tr>
-<td>
-<code>params</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.Params">
-Params
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-<tr>
-<td>
-<code>resources</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.TaskRunResources">
-TaskRunResources
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Deprecated: Unused, preserved only for backwards compatibility</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>serviceAccountName</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-<tr>
-<td>
-<code>taskRef</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.TaskRef">
-TaskRef
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>no more than one of the TaskRef and TaskSpec may be specified.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>taskSpec</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.TaskSpec">
-TaskSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Specifying TaskSpec can be disabled by setting
-<code>disable-inline-spec</code> feature flag.
-See Task.spec (API version: tekton.dev/v1beta1)</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.TaskRunSpecStatus">
-TaskRunSpecStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Used for cancelling a TaskRun (and maybe more later on)</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>statusMessage</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.TaskRunSpecStatusMessage">
-TaskRunSpecStatusMessage
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Status message for cancellation.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>retries</code><br/>
-<em>
-int
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Retries represents how many times this TaskRun should be retried in the event of Task failure.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>timeout</code><br/>
-<em>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
-Kubernetes meta/v1.Duration
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Time after which one retry attempt times out. Defaults to 1 hour.
-Refer Go&rsquo;s ParseDuration documentation for expected format: <a href="https://golang.org/pkg/time/#ParseDuration">https://golang.org/pkg/time/#ParseDuration</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>podTemplate</code><br/>
-<em>
-<a href="#tekton.dev/unversioned.PodTemplate">
-PodTemplate
-</a>
-</em>
-</td>
-<td>
-<p>PodTemplate holds pod specific configuration</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>workspaces</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.WorkspaceBinding">
-[]WorkspaceBinding
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Workspaces is a list of WorkspaceBindings from volumes to workspaces.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>stepOverrides</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.TaskRunStepOverride">
-[]TaskRunStepOverride
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Overrides to apply to Steps in this TaskRun.
-If a field is specified in both a Step and a StepOverride,
-the value from the StepOverride will be used.
-This field is only supported when the alpha feature gate is enabled.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>sidecarOverrides</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.TaskRunSidecarOverride">
-[]TaskRunSidecarOverride
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Overrides to apply to Sidecars in this TaskRun.
-If a field is specified in both a Sidecar and a SidecarOverride,
-the value from the SidecarOverride will be used.
-This field is only supported when the alpha feature gate is enabled.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>computeResources</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#resourcerequirements-v1-core">
-Kubernetes core/v1.ResourceRequirements
-</a>
-</em>
-</td>
-<td>
-<p>Compute resources to use for this TaskRun</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>managedBy</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ManagedBy indicates which controller is responsible for reconciling
-this resource. If unset or set to &ldquo;tekton.dev/pipeline&rdquo;, the default
-Tekton controller will manage this resource.
-This field is immutable.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.TaskRunSpecStatus">TaskRunSpecStatus
-(<code>string</code> alias)</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskRunSpec">TaskRunSpec</a>)
-</p>
-<div>
-<p>TaskRunSpecStatus defines the TaskRun spec status the user can provide</p>
-</div>
-<h3 id="tekton.dev/v1beta1.TaskRunSpecStatusMessage">TaskRunSpecStatusMessage
-(<code>string</code> alias)</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskRunSpec">TaskRunSpec</a>)
-</p>
-<div>
-<p>TaskRunSpecStatusMessage defines human readable status messages for the TaskRun.</p>
-</div>
-<h3 id="tekton.dev/v1beta1.TaskRunStatus">TaskRunStatus
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskRun">TaskRun</a>, <a href="#tekton.dev/v1beta1.PipelineRunTaskRunStatus">PipelineRunTaskRunStatus</a>)
-</p>
-<div>
-<p>TaskRunStatus defines the observed state of TaskRun</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>Status</code><br/>
-<em>
-<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Status">
-knative.dev/pkg/apis/duck/v1.Status
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>Status</code> are embedded into this type.)
-</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>TaskRunStatusFields</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.TaskRunStatusFields">
-TaskRunStatusFields
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>TaskRunStatusFields</code> are embedded into this type.)
-</p>
-<p>TaskRunStatusFields inlines the status fields.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.TaskRunStatusFields">TaskRunStatusFields
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskRunStatus">TaskRunStatus</a>)
-</p>
-<div>
-<p>TaskRunStatusFields holds the fields of TaskRun&rsquo;s status.  This is defined
+an input Resource named `workspace` will be mounted at `/workspace`).
+
+Deprecated: Unused, preserved only for backwards compatibility
+
+
+
+_Appears in:_
+- [TaskResources](#taskresources)
+
+
+
+#### TaskResourceBinding
+
+
+
+TaskResourceBinding points to the PipelineResource that
+will be used for the Task input or output called Name.
+
+Deprecated: Unused, preserved only for backwards compatibility
+
+
+
+_Appears in:_
+- [TaskRunInputs](#taskruninputs)
+- [TaskRunOutputs](#taskrunoutputs)
+- [TaskRunResources](#taskrunresources)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name is the name of the PipelineResource in the Pipeline's declaration |  |  |
+| `resourceRef` _[PipelineResourceRef](#pipelineresourceref)_ | ResourceRef is a reference to the instance of the actual PipelineResource<br />that should be used |  | Optional: \{\} <br /> |
+| `resourceSpec` _[PipelineResourceSpec](#pipelineresourcespec)_ | ResourceSpec is specification of a resource that should be created and<br />consumed by the task |  | Optional: \{\} <br /> |
+| `paths` _string array_ | Paths will probably be removed in #1284, and then PipelineResourceBinding can be used instead.<br />The optional Path field corresponds to a path on disk at which the Resource can be found<br />(used when providing the resource via mounted volume, overriding the default logic to fetch the Resource). |  | Optional: \{\} <br /> |
+
+
+#### TaskResources
+
+
+
+TaskResources allows a Pipeline to declare how its DeclaredPipelineResources
+should be provided to a Task as its inputs and outputs.
+
+Deprecated: Unused, preserved only for backwards compatibility
+
+
+
+_Appears in:_
+- [EmbeddedTask](#embeddedtask)
+- [TaskSpec](#taskspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `inputs` _[TaskResource](#taskresource) array_ | Inputs holds the mapping from the PipelineResources declared in<br />DeclaredPipelineResources to the input PipelineResources required by the Task. |  |  |
+| `outputs` _[TaskResource](#taskresource) array_ | Outputs holds the mapping from the PipelineResources declared in<br />DeclaredPipelineResources to the input PipelineResources required by the Task. |  |  |
+
+
+#### TaskResult
+
+
+
+TaskResult used to describe the results of a task
+
+
+
+_Appears in:_
+- [EmbeddedTask](#embeddedtask)
+- [TaskSpec](#taskspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name the given name |  |  |
+| `type` _[ResultsType](#resultstype)_ | Type is the user-specified type of the result. The possible type<br />is currently "string" and will support "array" in following work. |  | Optional: \{\} <br /> |
+| `properties` _object (keys:string, values:[PropertySpec](#propertyspec))_ | Properties is the JSON Schema properties to support key-value pairs results. |  | Optional: \{\} <br /> |
+| `description` _string_ | Description is a human-readable description of the result |  | Optional: \{\} <br /> |
+| `value` _[ResultValue](#resultvalue)_ | Value the expression used to retrieve the value of the result from an underlying Step. |  | Schemaless: \{\} <br />Optional: \{\} <br /> |
+
+
+#### TaskRun
+
+
+
+TaskRun represents a single execution of a Task. TaskRuns are how the steps
+specified in a Task are executed; they specify the parameters and resources
+used to run the steps in a Task.
+
+Deprecated: Please use v1.TaskRun instead.
+
+
+
+
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `apiVersion` _string_ | `tekton.dev/v1beta1` | | |
+| `kind` _string_ | `TaskRun` | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  | Optional: \{\} <br /> |
+| `spec` _[TaskRunSpec](#taskrunspec)_ |  |  | Optional: \{\} <br /> |
+| `status` _[TaskRunStatus](#taskrunstatus)_ |  |  | Optional: \{\} <br /> |
+
+
+
+
+#### TaskRunDebug
+
+
+
+TaskRunDebug defines the breakpoint config for a particular TaskRun
+
+
+
+_Appears in:_
+- [TaskRunSpec](#taskrunspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `breakpoints` _[TaskBreakpoints](#taskbreakpoints)_ |  |  | Optional: \{\} <br /> |
+
+
+
+
+
+
+
+
+#### TaskRunResources
+
+
+
+TaskRunResources allows a TaskRun to declare inputs and outputs TaskResourceBinding
+
+Deprecated: Unused, preserved only for backwards compatibility
+
+
+
+_Appears in:_
+- [TaskRunSpec](#taskrunspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `inputs` _[TaskResourceBinding](#taskresourcebinding) array_ | Inputs holds the inputs resources this task was invoked with |  |  |
+| `outputs` _[TaskResourceBinding](#taskresourcebinding) array_ | Outputs holds the inputs resources this task was invoked with |  |  |
+
+
+#### TaskRunResult
+
+
+
+TaskRunResult used to describe the results of a task
+
+
+
+_Appears in:_
+- [TaskRunStatus](#taskrunstatus)
+- [TaskRunStatusFields](#taskrunstatusfields)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name the given name |  |  |
+| `type` _[ResultsType](#resultstype)_ | Type is the user-specified type of the result. The possible type<br />is currently "string" and will support "array" in following work. |  | Optional: \{\} <br /> |
+| `value` _[ResultValue](#resultvalue)_ | Value the given value of the result |  | Schemaless: \{\} <br /> |
+
+
+#### TaskRunSidecarOverride
+
+
+
+TaskRunSidecarOverride is used to override the values of a Sidecar in the corresponding Task.
+
+
+
+_Appears in:_
+- [PipelineTaskRunSpec](#pipelinetaskrunspec)
+- [TaskRunSpec](#taskrunspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | The name of the Sidecar to override. |  |  |
+| `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcerequirements-v1-core)_ | The resource requirements to apply to the Sidecar. |  |  |
+
+
+#### TaskRunSpec
+
+
+
+TaskRunSpec defines the desired state of TaskRun
+
+
+
+_Appears in:_
+- [TaskRun](#taskrun)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `debug` _[TaskRunDebug](#taskrundebug)_ |  |  | Optional: \{\} <br /> |
+| `params` _[Params](#params)_ |  |  | Optional: \{\} <br /> |
+| `resources` _[TaskRunResources](#taskrunresources)_ | Deprecated: Unused, preserved only for backwards compatibility |  | Optional: \{\} <br /> |
+| `serviceAccountName` _string_ |  |  | Optional: \{\} <br /> |
+| `taskRef` _[TaskRef](#taskref)_ | no more than one of the TaskRef and TaskSpec may be specified. |  | Optional: \{\} <br /> |
+| `taskSpec` _[TaskSpec](#taskspec)_ | Specifying TaskSpec can be disabled by setting<br />`disable-inline-spec` feature flag.<br />See Task.spec (API version: tekton.dev/v1beta1) |  | Schemaless: \{\} <br />Optional: \{\} <br /> |
+| `status` _[TaskRunSpecStatus](#taskrunspecstatus)_ | Used for cancelling a TaskRun (and maybe more later on) |  | Optional: \{\} <br /> |
+| `statusMessage` _[TaskRunSpecStatusMessage](#taskrunspecstatusmessage)_ | Status message for cancellation. |  | Optional: \{\} <br /> |
+| `retries` _integer_ | Retries represents how many times this TaskRun should be retried in the event of Task failure. |  | Optional: \{\} <br /> |
+| `timeout` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ | Time after which one retry attempt times out. Defaults to 1 hour.<br />Refer Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration |  | Optional: \{\} <br /> |
+| `podTemplate` _[PodTemplate](#podtemplate)_ | PodTemplate holds pod specific configuration |  |  |
+| `workspaces` _[WorkspaceBinding](#workspacebinding) array_ | Workspaces is a list of WorkspaceBindings from volumes to workspaces. |  | Optional: \{\} <br /> |
+| `stepOverrides` _[TaskRunStepOverride](#taskrunstepoverride) array_ | Overrides to apply to Steps in this TaskRun.<br />If a field is specified in both a Step and a StepOverride,<br />the value from the StepOverride will be used.<br />This field is only supported when the alpha feature gate is enabled. |  | Optional: \{\} <br /> |
+| `sidecarOverrides` _[TaskRunSidecarOverride](#taskrunsidecaroverride) array_ | Overrides to apply to Sidecars in this TaskRun.<br />If a field is specified in both a Sidecar and a SidecarOverride,<br />the value from the SidecarOverride will be used.<br />This field is only supported when the alpha feature gate is enabled. |  | Optional: \{\} <br /> |
+| `computeResources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcerequirements-v1-core)_ | Compute resources to use for this TaskRun |  |  |
+| `managedBy` _string_ | ManagedBy indicates which controller is responsible for reconciling<br />this resource. If unset or set to "tekton.dev/pipeline", the default<br />Tekton controller will manage this resource.<br />This field is immutable. |  | Optional: \{\} <br /> |
+
+
+#### TaskRunSpecStatus
+
+_Underlying type:_ _string_
+
+TaskRunSpecStatus defines the TaskRun spec status the user can provide
+
+
+
+_Appears in:_
+- [TaskRunSpec](#taskrunspec)
+
+
+
+#### TaskRunSpecStatusMessage
+
+_Underlying type:_ _string_
+
+TaskRunSpecStatusMessage defines human readable status messages for the TaskRun.
+
+
+
+_Appears in:_
+- [TaskRunSpec](#taskrunspec)
+
+| Field | Description |
+| --- | --- |
+| `TaskRun cancelled as the PipelineRun it belongs to has been cancelled.` | TaskRunCancelledByPipelineMsg indicates that the PipelineRun of which this<br />TaskRun was a part of has been cancelled.<br /> |
+| `TaskRun cancelled as the PipelineRun it belongs to has timed out.` | TaskRunCancelledByPipelineTimeoutMsg indicates that the TaskRun was cancelled because the PipelineRun running it timed out.<br /> |
+
+
+#### TaskRunStatus
+
+
+
+TaskRunStatus defines the observed state of TaskRun
+
+
+
+_Appears in:_
+- [PipelineRunTaskRunStatus](#pipelineruntaskrunstatus)
+- [RetriesStatus](#retriesstatus)
+- [TaskRun](#taskrun)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `observedGeneration` _integer_ | ObservedGeneration is the 'Generation' of the Service that<br />was last processed by the controller. |  | Optional: \{\} <br /> |
+| `conditions` _[Conditions](#conditions)_ | Conditions the latest available observations of a resource's current state. |  | Optional: \{\} <br /> |
+| `annotations` _object (keys:string, values:string)_ | Annotations is additional Status fields for the Resource to save some<br />additional State as well as convey more information to the user. This is<br />roughly akin to Annotations on any k8s resource, just the reconciler conveying<br />richer information outwards. |  |  |
+| `podName` _string_ | PodName is the name of the pod responsible for executing this task's steps. |  |  |
+| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | StartTime is the time the build is actually started. |  |  |
+| `completionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | CompletionTime is the time the build completed. |  |  |
+| `steps` _[StepState](#stepstate) array_ | Steps describes the state of each build step container. |  | Optional: \{\} <br /> |
+| `cloudEvents` _[CloudEventDelivery](#cloudeventdelivery) array_ | CloudEvents describe the state of each cloud event requested via a<br />CloudEventResource.<br />Deprecated: No content written to it. To be Removed (since v0.44.0).<br />Use kubectl describe (CloudEventSent/CloudEventFailed k8s Events) or the<br />tekton_events_sent_total Prometheus metric for delivery visibility instead. |  | Optional: \{\} <br /> |
+| `retriesStatus` _[RetriesStatus](#retriesstatus)_ | RetriesStatus contains the history of TaskRunStatus in case of a retry in order to keep record of failures.<br />All TaskRunStatus stored in RetriesStatus will have no date within the RetriesStatus as is redundant.<br />See TaskRun.status (API version: tekton.dev/v1beta1) |  | Schemaless: \{\} <br />Optional: \{\} <br /> |
+| `resourcesResult` _[PipelineResourceResult](#pipelineresourceresult) array_ | Results from Resources built during the TaskRun.<br />This is tomb-stoned along with the removal of pipelineResources<br />Deprecated: this field is not populated and is preserved only for backwards compatibility |  | Optional: \{\} <br /> |
+| `taskResults` _[TaskRunResult](#taskrunresult) array_ | TaskRunResults are the list of results written out by the task's containers |  | Optional: \{\} <br /> |
+| `sidecars` _[SidecarState](#sidecarstate) array_ | The list has one entry per sidecar in the manifest. Each entry is<br />represents the imageid of the corresponding sidecar. |  |  |
+| `taskSpec` _[TaskSpec](#taskspec)_ | TaskSpec contains the Spec from the dereferenced Task definition used to instantiate this TaskRun.<br />See Task.spec (API version tekton.dev/v1beta1) |  | Schemaless: \{\} <br /> |
+| `provenance` _[Provenance](#provenance)_ | Provenance contains some key authenticated metadata about how a software artifact was built (what sources, what inputs/outputs, etc.). |  | Optional: \{\} <br /> |
+| `spanContext` _object (keys:string, values:string)_ | SpanContext contains tracing span context fields |  |  |
+
+
+#### TaskRunStatusFields
+
+
+
+TaskRunStatusFields holds the fields of TaskRun's status.  This is defined
 separately and inlined so that other types can readily consume these fields
-via duck typing.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>podName</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>PodName is the name of the pod responsible for executing this task&rsquo;s steps.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>startTime</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta">
-Kubernetes meta/v1.Time
-</a>
-</em>
-</td>
-<td>
-<p>StartTime is the time the build is actually started.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>completionTime</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta">
-Kubernetes meta/v1.Time
-</a>
-</em>
-</td>
-<td>
-<p>CompletionTime is the time the build completed.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>steps</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.StepState">
-[]StepState
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Steps describes the state of each build step container.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>cloudEvents</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.CloudEventDelivery">
-[]CloudEventDelivery
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>CloudEvents describe the state of each cloud event requested via a
-CloudEventResource.</p>
-<p>Deprecated: No content written to it. To be Removed (since v0.44.0).
-Use kubectl describe (CloudEventSent/CloudEventFailed k8s Events) or the
-tekton_events_sent_total Prometheus metric for delivery visibility instead.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>retriesStatus</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.RetriesStatus">
-RetriesStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>RetriesStatus contains the history of TaskRunStatus in case of a retry in order to keep record of failures.
-All TaskRunStatus stored in RetriesStatus will have no date within the RetriesStatus as is redundant.
-See TaskRun.status (API version: tekton.dev/v1beta1)</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>resourcesResult</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.PipelineResourceResult">
-[]PipelineResourceResult
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Results from Resources built during the TaskRun.
-This is tomb-stoned along with the removal of pipelineResources
-Deprecated: this field is not populated and is preserved only for backwards compatibility</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>taskResults</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.TaskRunResult">
-[]TaskRunResult
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>TaskRunResults are the list of results written out by the task&rsquo;s containers</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>sidecars</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.SidecarState">
-[]SidecarState
-</a>
-</em>
-</td>
-<td>
-<p>The list has one entry per sidecar in the manifest. Each entry is
-represents the imageid of the corresponding sidecar.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>taskSpec</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.TaskSpec">
-TaskSpec
-</a>
-</em>
-</td>
-<td>
-<p>TaskSpec contains the Spec from the dereferenced Task definition used to instantiate this TaskRun.
-See Task.spec (API version tekton.dev/v1beta1)</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>provenance</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.Provenance">
-Provenance
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Provenance contains some key authenticated metadata about how a software artifact was built (what sources, what inputs/outputs, etc.).</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>spanContext</code><br/>
-<em>
-map[string]string
-</em>
-</td>
-<td>
-<p>SpanContext contains tracing span context fields</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.TaskRunStepArtifact">TaskRunStepArtifact
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.StepState">StepState</a>)
-</p>
-<div>
-<p>TaskRunStepArtifact represents an artifact produced or used by a step within a task run.
-It directly uses the Artifact type for its structure.</p>
-</div>
-<h3 id="tekton.dev/v1beta1.TaskRunStepOverride">TaskRunStepOverride
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineTaskRunSpec">PipelineTaskRunSpec</a>, <a href="#tekton.dev/v1beta1.TaskRunSpec">TaskRunSpec</a>)
-</p>
-<div>
-<p>TaskRunStepOverride is used to override the values of a Step in the corresponding Task.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>The name of the Step to override.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>resources</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#resourcerequirements-v1-core">
-Kubernetes core/v1.ResourceRequirements
-</a>
-</em>
-</td>
-<td>
-<p>The resource requirements to apply to the Step.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.TaskRunStepResult">TaskRunStepResult
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.StepState">StepState</a>)
-</p>
-<div>
-<p>TaskRunStepResult is a type alias of TaskRunResult</p>
-</div>
-<h3 id="tekton.dev/v1beta1.TaskSpec">TaskSpec
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.Task">Task</a>, <a href="#tekton.dev/v1beta1.EmbeddedTask">EmbeddedTask</a>, <a href="#tekton.dev/v1beta1.TaskRunSpec">TaskRunSpec</a>, <a href="#tekton.dev/v1beta1.TaskRunStatusFields">TaskRunStatusFields</a>)
-</p>
-<div>
-<p>TaskSpec defines the desired state of Task.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>resources</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.TaskResources">
-TaskResources
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Resources is a list input and output resource to run the task
-Resources are represented in TaskRuns as bindings to instances of
-PipelineResources.</p>
-<p>Deprecated: Unused, preserved only for backwards compatibility</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>params</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.ParamSpecs">
-ParamSpecs
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Params is a list of input parameters required to run the task. Params
-must be supplied as inputs in TaskRuns unless they declare a default
-value.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>displayName</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>DisplayName is a user-facing name of the task that may be
-used to populate a UI.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>description</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Description is a user-facing description of the task that may be
-used to populate a UI.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>steps</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.Step">
-[]Step
-</a>
-</em>
-</td>
-<td>
-<p>Steps are the steps of the build; each step is run sequentially with the
-source mounted into /workspace.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>volumes</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.Volumes">
-Volumes
-</a>
-</em>
-</td>
-<td>
-<p>Volumes is a collection of volumes that are available to mount into the
-steps of the build.
-See Pod.spec.volumes (API version: v1)</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>stepTemplate</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.StepTemplate">
-StepTemplate
-</a>
-</em>
-</td>
-<td>
-<p>StepTemplate can be used as the basis for all step containers within the
-Task, so that the steps inherit settings on the base container.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>sidecars</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.Sidecar">
-[]Sidecar
-</a>
-</em>
-</td>
-<td>
-<p>Sidecars are run alongside the Task&rsquo;s step containers. They begin before
-the steps start and end after the steps complete.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>workspaces</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.WorkspaceDeclaration">
-[]WorkspaceDeclaration
-</a>
-</em>
-</td>
-<td>
-<p>Workspaces are the volumes that this Task requires.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>results</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.TaskResult">
-[]TaskResult
-</a>
-</em>
-</td>
-<td>
-<p>Results are values that this Task can output</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.TimeoutFields">TimeoutFields
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineRunSpec">PipelineRunSpec</a>)
-</p>
-<div>
-<p>TimeoutFields allows granular specification of pipeline, task, and finally timeouts</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>pipeline</code><br/>
-<em>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
-Kubernetes meta/v1.Duration
-</a>
-</em>
-</td>
-<td>
-<p>Pipeline sets the maximum allowed duration for execution of the entire pipeline. The sum of individual timeouts for tasks and finally must not exceed this value.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>tasks</code><br/>
-<em>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
-Kubernetes meta/v1.Duration
-</a>
-</em>
-</td>
-<td>
-<p>Tasks sets the maximum allowed duration of this pipeline&rsquo;s tasks</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>finally</code><br/>
-<em>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
-Kubernetes meta/v1.Duration
-</a>
-</em>
-</td>
-<td>
-<p>Finally sets the maximum allowed duration of this pipeline&rsquo;s finally</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.Volumes">Volumes
-(<code>[]k8s.io/api/core/v1.Volume</code> alias)</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskSpec">TaskSpec</a>)
-</p>
-<div>
-</div>
-<h3 id="tekton.dev/v1beta1.WhenExpression">WhenExpression
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.ChildStatusReference">ChildStatusReference</a>, <a href="#tekton.dev/v1beta1.PipelineRunRunStatus">PipelineRunRunStatus</a>, <a href="#tekton.dev/v1beta1.PipelineRunTaskRunStatus">PipelineRunTaskRunStatus</a>, <a href="#tekton.dev/v1beta1.SkippedTask">SkippedTask</a>)
-</p>
-<div>
-<p>WhenExpression allows a PipelineTask to declare expressions to be evaluated before the Task is run
-to determine whether the Task should be executed or skipped</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>input</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Input is the string for guard checking which can be a static input or an output from a parent Task</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>operator</code><br/>
-<em>
-<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/selection#Operator">
-k8s.io/apimachinery/pkg/selection.Operator
-</a>
-</em>
-</td>
-<td>
-<p>Operator that represents an Input&rsquo;s relationship to the values</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>values</code><br/>
-<em>
-[]string
-</em>
-</td>
-<td>
-<p>Values is an array of strings, which is compared against the input, for guard checking
-It must be non-empty</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>cel</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>CEL is a string of Common Language Expression, which can be used to conditionally execute
-the task based on the result of the expression evaluation
-More info about CEL syntax: <a href="https://github.com/google/cel-spec/blob/master/doc/langdef.md">https://github.com/google/cel-spec/blob/master/doc/langdef.md</a></p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.WhenExpressions">WhenExpressions
-(<code>[]github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.WhenExpression</code> alias)</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineTask">PipelineTask</a>)
-</p>
-<div>
-<p>WhenExpressions are used to specify whether a Task should be executed or skipped
-All of them need to evaluate to True for a guarded Task to be executed.</p>
-</div>
-<h3 id="tekton.dev/v1beta1.WorkspaceBinding">WorkspaceBinding
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1alpha1.RunSpec">RunSpec</a>, <a href="#tekton.dev/v1beta1.CustomRunSpec">CustomRunSpec</a>, <a href="#tekton.dev/v1beta1.PipelineRunSpec">PipelineRunSpec</a>, <a href="#tekton.dev/v1beta1.TaskRunSpec">TaskRunSpec</a>)
-</p>
-<div>
-<p>WorkspaceBinding maps a Task&rsquo;s declared workspace to a Volume.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Name is the name of the workspace populated by the volume.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>subPath</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>SubPath is optionally a directory on the volume which should be used
-for this binding (i.e. the volume will be mounted at this sub directory).</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>volumeClaimTemplate</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#persistentvolumeclaim-v1-core">
-Kubernetes core/v1.PersistentVolumeClaim
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>VolumeClaimTemplate is a template for a claim that will be created in the same namespace.
-The PipelineRun controller is responsible for creating a unique claim for each instance of PipelineRun.
-See PersistentVolumeClaim (API version: v1)</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>persistentVolumeClaim</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#persistentvolumeclaimvolumesource-v1-core">
-Kubernetes core/v1.PersistentVolumeClaimVolumeSource
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>PersistentVolumeClaimVolumeSource represents a reference to a
-PersistentVolumeClaim in the same namespace. Either this OR EmptyDir can be used.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>emptyDir</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#emptydirvolumesource-v1-core">
-Kubernetes core/v1.EmptyDirVolumeSource
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>EmptyDir represents a temporary directory that shares a Task&rsquo;s lifetime.
-More info: <a href="https://kubernetes.io/docs/concepts/storage/volumes#emptydir">https://kubernetes.io/docs/concepts/storage/volumes#emptydir</a>
-Either this OR PersistentVolumeClaim can be used.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>configMap</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#configmapvolumesource-v1-core">
-Kubernetes core/v1.ConfigMapVolumeSource
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ConfigMap represents a configMap that should populate this workspace.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>secret</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#secretvolumesource-v1-core">
-Kubernetes core/v1.SecretVolumeSource
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Secret represents a secret that should populate this workspace.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>projected</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#projectedvolumesource-v1-core">
-Kubernetes core/v1.ProjectedVolumeSource
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Projected represents a projected volume that should populate this workspace.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>csi</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#csivolumesource-v1-core">
-Kubernetes core/v1.CSIVolumeSource
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>CSI (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.WorkspaceDeclaration">WorkspaceDeclaration
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskSpec">TaskSpec</a>)
-</p>
-<div>
-<p>WorkspaceDeclaration is a declaration of a volume that a Task requires.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Name is the name by which you can bind the volume at runtime.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>description</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Description is an optional human readable description of this volume.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>mountPath</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>MountPath overrides the directory that the volume will be made available at.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>readOnly</code><br/>
-<em>
-bool
-</em>
-</td>
-<td>
-<p>ReadOnly dictates whether a mounted volume is writable. By default this
-field is false and so mounted volumes are writable.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>optional</code><br/>
-<em>
-bool
-</em>
-</td>
-<td>
-<p>Optional marks a Workspace as not being required in TaskRuns. By default
-this field is false and so declared workspaces are required.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.WorkspacePipelineDeclaration">WorkspacePipelineDeclaration
-</h3>
-<div>
-<p>WorkspacePipelineDeclaration creates a named slot in a Pipeline that a PipelineRun
-is expected to populate with a workspace binding.</p>
-<p>Deprecated: use PipelineWorkspaceDeclaration type instead</p>
-</div>
-<h3 id="tekton.dev/v1beta1.WorkspacePipelineTaskBinding">WorkspacePipelineTaskBinding
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineTask">PipelineTask</a>)
-</p>
-<div>
-<p>WorkspacePipelineTaskBinding describes how a workspace passed into the pipeline should be
-mapped to a task&rsquo;s declared workspace.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Name is the name of the workspace as declared by the task</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>workspace</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Workspace is the name of the workspace declared by the pipeline</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>subPath</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>SubPath is optionally a directory on the volume which should be used
-for this binding (i.e. the volume will be mounted at this sub directory).</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.WorkspaceUsage">WorkspaceUsage
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.Sidecar">Sidecar</a>, <a href="#tekton.dev/v1beta1.Step">Step</a>)
-</p>
-<div>
-<p>WorkspaceUsage is used by a Step or Sidecar to declare that it wants isolated access
-to a Workspace defined in a Task.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Name is the name of the workspace this Step or Sidecar wants access to.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>mountPath</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>MountPath is the path that the workspace should be mounted to inside the Step or Sidecar,
-overriding any MountPath specified in the Task&rsquo;s WorkspaceDeclaration.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.CustomRunResult">CustomRunResult
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.CustomRunStatusFields">CustomRunStatusFields</a>)
-</p>
-<div>
-<p>CustomRunResult used to describe the results of a task</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Name the given name</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>value</code><br/>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Value the given value of the result</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.CustomRunStatus">CustomRunStatus
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineRunRunStatus">PipelineRunRunStatus</a>, <a href="#tekton.dev/v1beta1.CustomRunStatusFields">CustomRunStatusFields</a>)
-</p>
-<div>
-<p>CustomRunStatus defines the observed state of CustomRun</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>Status</code><br/>
-<em>
-<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Status">
-knative.dev/pkg/apis/duck/v1.Status
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>Status</code> are embedded into this type.)
-</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>CustomRunStatusFields</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.CustomRunStatusFields">
-CustomRunStatusFields
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>CustomRunStatusFields</code> are embedded into this type.)
-</p>
-<p>CustomRunStatusFields inlines the status fields.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="tekton.dev/v1beta1.CustomRunStatusFields">CustomRunStatusFields
-</h3>
-<p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.CustomRunStatus">CustomRunStatus</a>)
-</p>
-<div>
-<p>CustomRunStatusFields holds the fields of CustomRun&rsquo;s status.  This is defined
-separately and inlined so that other types can readily consume these fields
-via duck typing.</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>startTime</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta">
-Kubernetes meta/v1.Time
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>StartTime is the time the build is actually started.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>completionTime</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta">
-Kubernetes meta/v1.Time
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>CompletionTime is the time the build completed.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>results</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.CustomRunResult">
-[]CustomRunResult
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Results reports any output result values to be consumed by later
-tasks in a pipeline.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>retriesStatus</code><br/>
-<em>
-<a href="#tekton.dev/v1beta1.CustomRunStatus">
-[]CustomRunStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>RetriesStatus contains the history of CustomRunStatus, in case of a retry.
-See CustomRun.status (API version: tekton.dev/v1beta1)</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>extraFields</code><br/>
-<em>
-<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime#RawExtension">
-k8s.io/apimachinery/pkg/runtime.RawExtension
-</a>
-</em>
-</td>
-<td>
-<p>ExtraFields holds arbitrary fields provided by the custom task
-controller.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<hr/>
-<p><em>
-Generated with <code>gen-crd-api-reference-docs</code>
-.
-</em></p>
+via duck typing.
+
+
+
+_Appears in:_
+- [TaskRunStatus](#taskrunstatus)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `podName` _string_ | PodName is the name of the pod responsible for executing this task's steps. |  |  |
+| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | StartTime is the time the build is actually started. |  |  |
+| `completionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | CompletionTime is the time the build completed. |  |  |
+| `steps` _[StepState](#stepstate) array_ | Steps describes the state of each build step container. |  | Optional: \{\} <br /> |
+| `cloudEvents` _[CloudEventDelivery](#cloudeventdelivery) array_ | CloudEvents describe the state of each cloud event requested via a<br />CloudEventResource.<br />Deprecated: No content written to it. To be Removed (since v0.44.0).<br />Use kubectl describe (CloudEventSent/CloudEventFailed k8s Events) or the<br />tekton_events_sent_total Prometheus metric for delivery visibility instead. |  | Optional: \{\} <br /> |
+| `retriesStatus` _[RetriesStatus](#retriesstatus)_ | RetriesStatus contains the history of TaskRunStatus in case of a retry in order to keep record of failures.<br />All TaskRunStatus stored in RetriesStatus will have no date within the RetriesStatus as is redundant.<br />See TaskRun.status (API version: tekton.dev/v1beta1) |  | Schemaless: \{\} <br />Optional: \{\} <br /> |
+| `resourcesResult` _[PipelineResourceResult](#pipelineresourceresult) array_ | Results from Resources built during the TaskRun.<br />This is tomb-stoned along with the removal of pipelineResources<br />Deprecated: this field is not populated and is preserved only for backwards compatibility |  | Optional: \{\} <br /> |
+| `taskResults` _[TaskRunResult](#taskrunresult) array_ | TaskRunResults are the list of results written out by the task's containers |  | Optional: \{\} <br /> |
+| `sidecars` _[SidecarState](#sidecarstate) array_ | The list has one entry per sidecar in the manifest. Each entry is<br />represents the imageid of the corresponding sidecar. |  |  |
+| `taskSpec` _[TaskSpec](#taskspec)_ | TaskSpec contains the Spec from the dereferenced Task definition used to instantiate this TaskRun.<br />See Task.spec (API version tekton.dev/v1beta1) |  | Schemaless: \{\} <br /> |
+| `provenance` _[Provenance](#provenance)_ | Provenance contains some key authenticated metadata about how a software artifact was built (what sources, what inputs/outputs, etc.). |  | Optional: \{\} <br /> |
+| `spanContext` _object (keys:string, values:string)_ | SpanContext contains tracing span context fields |  |  |
+
+
+
+
+#### TaskRunStepOverride
+
+
+
+TaskRunStepOverride is used to override the values of a Step in the corresponding Task.
+
+
+
+_Appears in:_
+- [PipelineTaskRunSpec](#pipelinetaskrunspec)
+- [TaskRunSpec](#taskrunspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | The name of the Step to override. |  |  |
+| `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcerequirements-v1-core)_ | The resource requirements to apply to the Step. |  |  |
+
+
+
+
+#### TaskSpec
+
+
+
+TaskSpec defines the desired state of Task.
+
+
+
+_Appears in:_
+- [EmbeddedTask](#embeddedtask)
+- [Task](#task)
+- [TaskRunSpec](#taskrunspec)
+- [TaskRunStatus](#taskrunstatus)
+- [TaskRunStatusFields](#taskrunstatusfields)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `resources` _[TaskResources](#taskresources)_ | Resources is a list input and output resource to run the task<br />Resources are represented in TaskRuns as bindings to instances of<br />PipelineResources.<br />Deprecated: Unused, preserved only for backwards compatibility |  | Optional: \{\} <br /> |
+| `params` _[ParamSpecs](#paramspecs)_ | Params is a list of input parameters required to run the task. Params<br />must be supplied as inputs in TaskRuns unless they declare a default<br />value. |  | Optional: \{\} <br /> |
+| `displayName` _string_ | DisplayName is a user-facing name of the task that may be<br />used to populate a UI. |  | Optional: \{\} <br /> |
+| `description` _string_ | Description is a user-facing description of the task that may be<br />used to populate a UI. |  | Optional: \{\} <br /> |
+| `steps` _[Step](#step) array_ | Steps are the steps of the build; each step is run sequentially with the<br />source mounted into /workspace. |  |  |
+| `volumes` _[Volumes](#volumes)_ | Volumes is a collection of volumes that are available to mount into the<br />steps of the build.<br />See Pod.spec.volumes (API version: v1) |  | Schemaless: \{\} <br /> |
+| `stepTemplate` _[StepTemplate](#steptemplate)_ | StepTemplate can be used as the basis for all step containers within the<br />Task, so that the steps inherit settings on the base container. |  |  |
+| `sidecars` _[Sidecar](#sidecar) array_ | Sidecars are run alongside the Task's step containers. They begin before<br />the steps start and end after the steps complete. |  |  |
+| `workspaces` _[WorkspaceDeclaration](#workspacedeclaration) array_ | Workspaces are the volumes that this Task requires. |  |  |
+| `results` _[TaskResult](#taskresult) array_ | Results are values that this Task can output |  |  |
+
+
+#### TimeoutFields
+
+
+
+TimeoutFields allows granular specification of pipeline, task, and finally timeouts
+
+
+
+_Appears in:_
+- [PipelineRunSpec](#pipelinerunspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `pipeline` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ | Pipeline sets the maximum allowed duration for execution of the entire pipeline. The sum of individual timeouts for tasks and finally must not exceed this value. |  |  |
+| `tasks` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ | Tasks sets the maximum allowed duration of this pipeline's tasks |  |  |
+| `finally` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ | Finally sets the maximum allowed duration of this pipeline's finally |  |  |
+
+
+#### Volumes
+
+_Underlying type:_ _[Volume](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#volume-v1-core)_
+
+
+
+
+
+_Appears in:_
+- [EmbeddedTask](#embeddedtask)
+- [TaskSpec](#taskspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | name of the volume.<br />Must be a DNS_LABEL and unique within the pod.<br />More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names |  |  |
+| `hostPath` _[HostPathVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#hostpathvolumesource-v1-core)_ | hostPath represents a pre-existing file or directory on the host<br />machine that is directly exposed to the container. This is generally<br />used for system agents or other privileged things that are allowed<br />to see the host machine. Most containers will NOT need this.<br />More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath |  | Optional: \{\} <br /> |
+| `emptyDir` _[EmptyDirVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#emptydirvolumesource-v1-core)_ | emptyDir represents a temporary directory that shares a pod's lifetime.<br />More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir |  | Optional: \{\} <br /> |
+| `gcePersistentDisk` _[GCEPersistentDiskVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#gcepersistentdiskvolumesource-v1-core)_ | gcePersistentDisk represents a GCE Disk resource that is attached to a<br />kubelet's host machine and then exposed to the pod.<br />Deprecated: GCEPersistentDisk is deprecated. All operations for the in-tree<br />gcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.<br />More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk |  | Optional: \{\} <br /> |
+| `awsElasticBlockStore` _[AWSElasticBlockStoreVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#awselasticblockstorevolumesource-v1-core)_ | awsElasticBlockStore represents an AWS Disk resource that is attached to a<br />kubelet's host machine and then exposed to the pod.<br />Deprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree<br />awsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.<br />More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore |  | Optional: \{\} <br /> |
+| `gitRepo` _[GitRepoVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#gitrepovolumesource-v1-core)_ | gitRepo represents a git repository at a particular revision.<br />Deprecated: GitRepo is deprecated. To provision a container with a git repo, mount an<br />EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir<br />into the Pod's container. |  | Optional: \{\} <br /> |
+| `secret` _[SecretVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#secretvolumesource-v1-core)_ | secret represents a secret that should populate this volume.<br />More info: https://kubernetes.io/docs/concepts/storage/volumes#secret |  | Optional: \{\} <br /> |
+| `nfs` _[NFSVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#nfsvolumesource-v1-core)_ | nfs represents an NFS mount on the host that shares a pod's lifetime<br />More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs |  | Optional: \{\} <br /> |
+| `iscsi` _[ISCSIVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#iscsivolumesource-v1-core)_ | iscsi represents an ISCSI Disk resource that is attached to a<br />kubelet's host machine and then exposed to the pod.<br />More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi |  | Optional: \{\} <br /> |
+| `glusterfs` _[GlusterfsVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#glusterfsvolumesource-v1-core)_ | glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.<br />Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported. |  | Optional: \{\} <br /> |
+| `persistentVolumeClaim` _[PersistentVolumeClaimVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#persistentvolumeclaimvolumesource-v1-core)_ | persistentVolumeClaimVolumeSource represents a reference to a<br />PersistentVolumeClaim in the same namespace.<br />More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims |  | Optional: \{\} <br /> |
+| `rbd` _[RBDVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#rbdvolumesource-v1-core)_ | rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.<br />Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported. |  | Optional: \{\} <br /> |
+| `flexVolume` _[FlexVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#flexvolumesource-v1-core)_ | flexVolume represents a generic volume resource that is<br />provisioned/attached using an exec based plugin.<br />Deprecated: FlexVolume is deprecated. Consider using a CSIDriver instead. |  | Optional: \{\} <br /> |
+| `cinder` _[CinderVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#cindervolumesource-v1-core)_ | cinder represents a cinder volume attached and mounted on kubelets host machine.<br />Deprecated: Cinder is deprecated. All operations for the in-tree cinder type<br />are redirected to the cinder.csi.openstack.org CSI driver.<br />More info: https://examples.k8s.io/mysql-cinder-pd/README.md |  | Optional: \{\} <br /> |
+| `cephfs` _[CephFSVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#cephfsvolumesource-v1-core)_ | cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.<br />Deprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported. |  | Optional: \{\} <br /> |
+| `flocker` _[FlockerVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#flockervolumesource-v1-core)_ | flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.<br />Deprecated: Flocker is deprecated and the in-tree flocker type is no longer supported. |  | Optional: \{\} <br /> |
+| `downwardAPI` _[DownwardAPIVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#downwardapivolumesource-v1-core)_ | downwardAPI represents downward API about the pod that should populate this volume |  | Optional: \{\} <br /> |
+| `fc` _[FCVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#fcvolumesource-v1-core)_ | fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod. |  | Optional: \{\} <br /> |
+| `azureFile` _[AzureFileVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#azurefilevolumesource-v1-core)_ | azureFile represents an Azure File Service mount on the host and bind mount to the pod.<br />Deprecated: AzureFile is deprecated. All operations for the in-tree azureFile type<br />are redirected to the file.csi.azure.com CSI driver. |  | Optional: \{\} <br /> |
+| `configMap` _[ConfigMapVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#configmapvolumesource-v1-core)_ | configMap represents a configMap that should populate this volume |  | Optional: \{\} <br /> |
+| `vsphereVolume` _[VsphereVirtualDiskVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#vspherevirtualdiskvolumesource-v1-core)_ | vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.<br />Deprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type<br />are redirected to the csi.vsphere.vmware.com CSI driver. |  | Optional: \{\} <br /> |
+| `quobyte` _[QuobyteVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#quobytevolumesource-v1-core)_ | quobyte represents a Quobyte mount on the host that shares a pod's lifetime.<br />Deprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported. |  | Optional: \{\} <br /> |
+| `azureDisk` _[AzureDiskVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#azurediskvolumesource-v1-core)_ | azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.<br />Deprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type<br />are redirected to the disk.csi.azure.com CSI driver. |  | Optional: \{\} <br /> |
+| `photonPersistentDisk` _[PhotonPersistentDiskVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#photonpersistentdiskvolumesource-v1-core)_ | photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.<br />Deprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported. |  |  |
+| `projected` _[ProjectedVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#projectedvolumesource-v1-core)_ | projected items for all in one resources secrets, configmaps, and downward API |  |  |
+| `portworxVolume` _[PortworxVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#portworxvolumesource-v1-core)_ | portworxVolume represents a portworx volume attached and mounted on kubelets host machine.<br />Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type<br />are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate<br />is on. |  | Optional: \{\} <br /> |
+| `scaleIO` _[ScaleIOVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#scaleiovolumesource-v1-core)_ | scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.<br />Deprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported. |  | Optional: \{\} <br /> |
+| `storageos` _[StorageOSVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#storageosvolumesource-v1-core)_ | storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.<br />Deprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported. |  | Optional: \{\} <br /> |
+| `csi` _[CSIVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#csivolumesource-v1-core)_ | csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers. |  | Optional: \{\} <br /> |
+| `ephemeral` _[EphemeralVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#ephemeralvolumesource-v1-core)_ | ephemeral represents a volume that is handled by a cluster storage driver.<br />The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,<br />and deleted when the pod is removed.<br />Use this if:<br />a) the volume is only needed while the pod runs,<br />b) features of normal volumes like restoring from snapshot or capacity<br />   tracking are needed,<br />c) the storage driver is specified through a storage class, and<br />d) the storage driver supports dynamic volume provisioning through<br />   a PersistentVolumeClaim (see EphemeralVolumeSource for more<br />   information on the connection between this volume type<br />   and PersistentVolumeClaim).<br />Use PersistentVolumeClaim or one of the vendor-specific<br />APIs for volumes that persist for longer than the lifecycle<br />of an individual pod.<br />Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to<br />be used that way - see the documentation of the driver for<br />more information.<br />A pod can use both types of ephemeral volumes and<br />persistent volumes at the same time. |  | Optional: \{\} <br /> |
+| `image` _[ImageVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#imagevolumesource-v1-core)_ | image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.<br />The volume is resolved at pod startup depending on which PullPolicy value is provided:<br />- Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.<br />- Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.<br />- IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.<br />The volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.<br />A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.<br />The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.<br />The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.<br />The volume will be mounted read-only (ro) and non-executable files (noexec).<br />Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.<br />The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type. |  | Optional: \{\} <br /> |
+
+
+#### WhenExpression
+
+
+
+WhenExpression allows a PipelineTask to declare expressions to be evaluated before the Task is run
+to determine whether the Task should be executed or skipped
+
+
+
+_Appears in:_
+- [ChildStatusReference](#childstatusreference)
+- [PipelineRunRunStatus](#pipelinerunrunstatus)
+- [PipelineRunTaskRunStatus](#pipelineruntaskrunstatus)
+- [SkippedTask](#skippedtask)
+- [WhenExpressions](#whenexpressions)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `input` _string_ | Input is the string for guard checking which can be a static input or an output from a parent Task |  |  |
+| `operator` _[Operator](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#operator-selection-pkg)_ | Operator that represents an Input's relationship to the values |  |  |
+| `values` _string array_ | Values is an array of strings, which is compared against the input, for guard checking<br />It must be non-empty |  |  |
+| `cel` _string_ | CEL is a string of Common Language Expression, which can be used to conditionally execute<br />the task based on the result of the expression evaluation<br />More info about CEL syntax: https://github.com/google/cel-spec/blob/master/doc/langdef.md |  | Optional: \{\} <br /> |
+
+
+#### WhenExpressions
+
+_Underlying type:_ _[WhenExpression](#whenexpression)_
+
+WhenExpressions are used to specify whether a Task should be executed or skipped
+All of them need to evaluate to True for a guarded Task to be executed.
+
+
+
+_Appears in:_
+- [PipelineTask](#pipelinetask)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `input` _string_ | Input is the string for guard checking which can be a static input or an output from a parent Task |  |  |
+| `operator` _[Operator](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#operator-selection-pkg)_ | Operator that represents an Input's relationship to the values |  |  |
+| `values` _string array_ | Values is an array of strings, which is compared against the input, for guard checking<br />It must be non-empty |  |  |
+| `cel` _string_ | CEL is a string of Common Language Expression, which can be used to conditionally execute<br />the task based on the result of the expression evaluation<br />More info about CEL syntax: https://github.com/google/cel-spec/blob/master/doc/langdef.md |  | Optional: \{\} <br /> |
+
+
+#### WorkspaceBinding
+
+
+
+WorkspaceBinding maps a Task's declared workspace to a Volume.
+
+
+
+_Appears in:_
+- [CustomRunSpec](#customrunspec)
+- [PipelineRunSpec](#pipelinerunspec)
+- [RunSpec](#runspec)
+- [TaskRunSpec](#taskrunspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name is the name of the workspace populated by the volume. |  |  |
+| `subPath` _string_ | SubPath is optionally a directory on the volume which should be used<br />for this binding (i.e. the volume will be mounted at this sub directory). |  | Optional: \{\} <br /> |
+| `volumeClaimTemplate` _[PersistentVolumeClaim](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#persistentvolumeclaim-v1-core)_ | VolumeClaimTemplate is a template for a claim that will be created in the same namespace.<br />The PipelineRun controller is responsible for creating a unique claim for each instance of PipelineRun.<br />See PersistentVolumeClaim (API version: v1) |  | Schemaless: \{\} <br />Optional: \{\} <br /> |
+| `persistentVolumeClaim` _[PersistentVolumeClaimVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#persistentvolumeclaimvolumesource-v1-core)_ | PersistentVolumeClaimVolumeSource represents a reference to a<br />PersistentVolumeClaim in the same namespace. Either this OR EmptyDir can be used. |  | Optional: \{\} <br /> |
+| `emptyDir` _[EmptyDirVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#emptydirvolumesource-v1-core)_ | EmptyDir represents a temporary directory that shares a Task's lifetime.<br />More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir<br />Either this OR PersistentVolumeClaim can be used. |  | Optional: \{\} <br /> |
+| `configMap` _[ConfigMapVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#configmapvolumesource-v1-core)_ | ConfigMap represents a configMap that should populate this workspace. |  | Optional: \{\} <br /> |
+| `secret` _[SecretVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#secretvolumesource-v1-core)_ | Secret represents a secret that should populate this workspace. |  | Optional: \{\} <br /> |
+| `projected` _[ProjectedVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#projectedvolumesource-v1-core)_ | Projected represents a projected volume that should populate this workspace. |  | Optional: \{\} <br /> |
+| `csi` _[CSIVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#csivolumesource-v1-core)_ | CSI (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers. |  | Optional: \{\} <br /> |
+
+
+#### WorkspaceDeclaration
+
+
+
+WorkspaceDeclaration is a declaration of a volume that a Task requires.
+
+
+
+_Appears in:_
+- [EmbeddedTask](#embeddedtask)
+- [TaskSpec](#taskspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name is the name by which you can bind the volume at runtime. |  |  |
+| `description` _string_ | Description is an optional human readable description of this volume. |  | Optional: \{\} <br /> |
+| `mountPath` _string_ | MountPath overrides the directory that the volume will be made available at. |  | Optional: \{\} <br /> |
+| `readOnly` _boolean_ | ReadOnly dictates whether a mounted volume is writable. By default this<br />field is false and so mounted volumes are writable. |  |  |
+| `optional` _boolean_ | Optional marks a Workspace as not being required in TaskRuns. By default<br />this field is false and so declared workspaces are required. |  |  |
+
+
+
+
+#### WorkspacePipelineTaskBinding
+
+
+
+WorkspacePipelineTaskBinding describes how a workspace passed into the pipeline should be
+mapped to a task's declared workspace.
+
+
+
+_Appears in:_
+- [PipelineTask](#pipelinetask)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name is the name of the workspace as declared by the task |  |  |
+| `workspace` _string_ | Workspace is the name of the workspace declared by the pipeline |  | Optional: \{\} <br /> |
+| `subPath` _string_ | SubPath is optionally a directory on the volume which should be used<br />for this binding (i.e. the volume will be mounted at this sub directory). |  | Optional: \{\} <br /> |
+
+
+#### WorkspaceUsage
+
+
+
+WorkspaceUsage is used by a Step or Sidecar to declare that it wants isolated access
+to a Workspace defined in a Task.
+
+
+
+_Appears in:_
+- [Sidecar](#sidecar)
+- [Step](#step)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name is the name of the workspace this Step or Sidecar wants access to. |  |  |
+| `mountPath` _string_ | MountPath is the path that the workspace should be mounted to inside the Step or Sidecar,<br />overriding any MountPath specified in the Task's WorkspaceDeclaration. |  |  |
+
+

--- a/pkg/apis/pipeline/v1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1/openapi_generated.go
@@ -4280,6 +4280,13 @@ func schema_pkg_apis_pipeline_v1_TaskRunStatus(ref common.ReferenceCallback) com
 							},
 						},
 					},
+					"resolvedTaskNamespace": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ResolvedTaskNamespace is the namespace of the resolved Task, used for cross-namespace StepAction resolution. Set by the controller, not user-modifiable.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"podName"},
 			},
@@ -4419,6 +4426,13 @@ func schema_pkg_apis_pipeline_v1_TaskRunStatusFields(ref common.ReferenceCallbac
 									},
 								},
 							},
+						},
+					},
+					"resolvedTaskNamespace": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ResolvedTaskNamespace is the namespace of the resolved Task, used for cross-namespace StepAction resolution. Set by the controller, not user-modifiable.",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},

--- a/pkg/apis/pipeline/v1/swagger.json
+++ b/pkg/apis/pipeline/v1/swagger.json
@@ -2188,6 +2188,10 @@
           "description": "Provenance contains some key authenticated metadata about how a software artifact was built (what sources, what inputs/outputs, etc.).",
           "$ref": "#/definitions/v1.Provenance"
         },
+        "resolvedTaskNamespace": {
+          "description": "ResolvedTaskNamespace is the namespace of the resolved Task, used for cross-namespace StepAction resolution. Set by the controller, not user-modifiable.",
+          "type": "string"
+        },
         "results": {
           "description": "Results are the list of results written out by the task's containers",
           "type": "array",
@@ -2264,6 +2268,10 @@
         "provenance": {
           "description": "Provenance contains some key authenticated metadata about how a software artifact was built (what sources, what inputs/outputs, etc.).",
           "$ref": "#/definitions/v1.Provenance"
+        },
+        "resolvedTaskNamespace": {
+          "description": "ResolvedTaskNamespace is the namespace of the resolved Task, used for cross-namespace StepAction resolution. Set by the controller, not user-modifiable.",
+          "type": "string"
         },
         "results": {
           "description": "Results are the list of results written out by the task's containers",

--- a/pkg/apis/pipeline/v1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1/taskrun_types.go
@@ -359,6 +359,11 @@ type TaskRunStatusFields struct {
 
 	// SpanContext contains tracing span context fields
 	SpanContext map[string]string `json:"spanContext,omitempty"`
+
+	// ResolvedTaskNamespace is the namespace of the resolved Task, used for
+	// cross-namespace StepAction resolution. Set by the controller, not user-modifiable.
+	// +optional
+	ResolvedTaskNamespace string `json:"resolvedTaskNamespace,omitempty"`
 }
 
 // TaskRunStepSpec is used to override the values of a Step in the corresponding Task.

--- a/pkg/apis/pipeline/v1beta1/taskrun_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_conversion.go
@@ -343,6 +343,9 @@ func (trs *TaskRunStatus) ConvertFrom(ctx context.Context, source v1.TaskRunStat
 		new.convertFrom(ctx, *source.Provenance)
 		trs.Provenance = &new
 	}
+	// Note: source.ResolvedTaskNamespace is intentionally not converted to v1beta1.
+	// v1beta1 is deprecated and has no corresponding field. The value is re-derived
+	// by the controller on fresh reconcile if needed.
 	return nil
 }
 

--- a/pkg/reconciler/taskrun/resources/taskref.go
+++ b/pkg/reconciler/taskrun/resources/taskref.go
@@ -62,10 +62,20 @@ func GetTaskFuncFromTaskRun(ctx context.Context, k8s kubernetes.Interface, tekto
 			if taskrun.Status.Provenance != nil {
 				refSource = taskrun.Status.Provenance.RefSource
 			}
+			// Use the persisted resolved task namespace from Status if available,
+			// otherwise fall back to the TaskRun's namespace. This ensures that
+			// on subsequent reconciles (when TaskSpec is cached in status), the
+			// returned Task metadata preserves the original resolved namespace.
+			// Status is used instead of annotations because it is controller-managed
+			// and cannot be injected by users or malicious Tasks.
+			taskNamespace := taskrun.Namespace
+			if taskrun.Status.ResolvedTaskNamespace != "" {
+				taskNamespace = taskrun.Status.ResolvedTaskNamespace
+			}
 			return &v1.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      name,
-					Namespace: taskrun.Namespace,
+					Namespace: taskNamespace,
 				},
 				Spec: *taskrun.Status.TaskSpec,
 			}, refSource, nil, nil
@@ -138,29 +148,35 @@ func GetTaskFunc(ctx context.Context, k8s kubernetes.Interface, tekton clientset
 // It also requires a kubeclient, tektonclient, requester in case it needs to find that task in
 // cluster or authorize against an external repository. It will figure out whether it needs to look in the cluster or in
 // a remote location to fetch the reference.
-func GetStepActionFunc(tekton clientset.Interface, k8s kubernetes.Interface, requester remoteresource.Requester, tr *v1.TaskRun, taskSpec v1.TaskSpec, step *v1.Step) GetStepAction {
+func GetStepActionFunc(tekton clientset.Interface, k8s kubernetes.Interface, requester remoteresource.Requester, tr *v1.TaskRun, taskSpec v1.TaskSpec, step *v1.Step, taskNamespace string) GetStepAction {
 	trName := tr.Name
-	namespace := tr.Namespace
 	if step.Ref != nil && step.Ref.Resolver != "" && requester != nil {
 		// Return an inline function that implements GetStepAction by calling Resolver.Get with the specified StepAction type and
 		// casting it to a StepAction.
 		return func(ctx context.Context, name string) (*v1beta1.StepAction, *v1.RefSource, error) {
 			// Perform params replacements for StepAction resolver params
 			ApplyParameterSubstitutionInResolverParams(tr, taskSpec, step)
+			// ResolutionRequests must be created in the TaskRun's namespace, not the
+			// Task's namespace, because Kubernetes does not support cross-namespace
+			// owner references. The TaskRun owns the ResolutionRequest, so both must
+			// live in the same namespace.
 			resolverPayload := remoteresource.ResolverPayload{
 				Name:      trName,
-				Namespace: namespace,
+				Namespace: tr.Namespace,
 				ResolutionSpec: &resolutionV1beta1.ResolutionRequestSpec{
 					Params: step.Ref.Params,
 					URL:    step.Ref.Name,
 				},
 			}
 			resolver := resolution.NewResolver(requester, tr, string(step.Ref.Resolver), resolverPayload)
-			return resolveStepAction(ctx, resolver, name, namespace, k8s, tekton)
+			return resolveStepAction(ctx, resolver, name, tr.Namespace, k8s, tekton)
 		}
 	}
+	// For local (non-resolver) StepAction lookups, use taskNamespace — the namespace
+	// where the resolved Task lives. StepActions referenced by a Task should be looked
+	// up in the Task's namespace.
 	local := &LocalStepActionRefResolver{
-		Namespace:    namespace,
+		Namespace:    taskNamespace,
 		Tektonclient: tekton,
 	}
 	return local.GetStepAction

--- a/pkg/reconciler/taskrun/resources/taskref.go
+++ b/pkg/reconciler/taskrun/resources/taskref.go
@@ -39,6 +39,20 @@ import (
 	"knative.dev/pkg/kmeta"
 )
 
+const clusterResolverType = "cluster"
+
+// ResolvedTaskNamespaceForStepActions returns the namespace StepActions should be
+// resolved from for the TaskRun's resolved Task. Only the in-cluster resolver is
+// allowed to move StepAction lookup out of the TaskRun namespace; namespaces on
+// externally resolved Tasks are untrusted metadata and must not authorize local
+// cross-namespace StepAction reads.
+func ResolvedTaskNamespaceForStepActions(taskrun *v1.TaskRun, resolvedTaskNamespace string) string {
+	if taskrun != nil && taskrun.Spec.TaskRef != nil && taskrun.Spec.TaskRef.Resolver == clusterResolverType && resolvedTaskNamespace != "" {
+		return resolvedTaskNamespace
+	}
+	return taskrun.Namespace
+}
+
 // GetTaskKind returns the referenced Task kind (Task, ...) if the TaskRun is using TaskRef.
 func GetTaskKind(taskrun *v1.TaskRun) v1.TaskKind {
 	kind := v1.NamespacedTaskKind
@@ -62,16 +76,7 @@ func GetTaskFuncFromTaskRun(ctx context.Context, k8s kubernetes.Interface, tekto
 			if taskrun.Status.Provenance != nil {
 				refSource = taskrun.Status.Provenance.RefSource
 			}
-			// Use the persisted resolved task namespace from Status if available,
-			// otherwise fall back to the TaskRun's namespace. This ensures that
-			// on subsequent reconciles (when TaskSpec is cached in status), the
-			// returned Task metadata preserves the original resolved namespace.
-			// Status is used instead of annotations because it is controller-managed
-			// and cannot be injected by users or malicious Tasks.
-			taskNamespace := taskrun.Namespace
-			if taskrun.Status.ResolvedTaskNamespace != "" {
-				taskNamespace = taskrun.Status.ResolvedTaskNamespace
-			}
+			taskNamespace := ResolvedTaskNamespaceForStepActions(taskrun, taskrun.Status.ResolvedTaskNamespace)
 			return &v1.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      name,

--- a/pkg/reconciler/taskrun/resources/taskref.go
+++ b/pkg/reconciler/taskrun/resources/taskref.go
@@ -47,7 +47,10 @@ const clusterResolverType = "cluster"
 // externally resolved Tasks are untrusted metadata and must not authorize local
 // cross-namespace StepAction reads.
 func ResolvedTaskNamespaceForStepActions(taskrun *v1.TaskRun, resolvedTaskNamespace string) string {
-	if taskrun != nil && taskrun.Spec.TaskRef != nil && taskrun.Spec.TaskRef.Resolver == clusterResolverType && resolvedTaskNamespace != "" {
+	if taskrun == nil {
+		return ""
+	}
+	if taskrun.Spec.TaskRef != nil && taskrun.Spec.TaskRef.Resolver == clusterResolverType && resolvedTaskNamespace != "" {
 		return resolvedTaskNamespace
 	}
 	return taskrun.Namespace

--- a/pkg/reconciler/taskrun/resources/taskref_test.go
+++ b/pkg/reconciler/taskrun/resources/taskref_test.go
@@ -2129,7 +2129,14 @@ echo hello
 		},
 		Spec: v1.TaskRunSpec{
 			TaskRef: &v1.TaskRef{
-				Name: "my-task",
+				ResolverRef: v1.ResolverRef{
+					Resolver: "cluster",
+					Params: v1.Params{
+						{Name: "name", Value: *v1.NewStructuredValues("my-task")},
+						{Name: "namespace", Value: *v1.NewStructuredValues(taskSourceNamespace)},
+						{Name: "kind", Value: *v1.NewStructuredValues("task")},
+					},
+				},
 			},
 			ServiceAccountName: "default",
 		},
@@ -2173,5 +2180,19 @@ echo hello
 	// Without the Status field, should fall back to TaskRun's namespace
 	if actualTask2.Namespace != taskRunNamespace {
 		t.Errorf("expected task namespace %q (TaskRun namespace fallback), got %q", taskRunNamespace, actualTask2.Namespace)
+	}
+
+	// Non-cluster resolvers must not be able to authorize cross-namespace local
+	// StepAction reads by returning arbitrary metadata.namespace values.
+	taskRunExternalResolver := taskRun.DeepCopy()
+	taskRunExternalResolver.Spec.TaskRef.Resolver = "git"
+
+	fn3 := resources.GetTaskFuncFromTaskRun(ctx, kubeclient, tektonclient, nil, taskRunExternalResolver, []*v1alpha1.VerificationPolicy{})
+	actualTask3, _, _, err := fn3(ctx, "my-task")
+	if err != nil {
+		t.Fatalf("failed to call GetTaskFuncFromTaskRun with external resolver: %s", err.Error())
+	}
+	if actualTask3.Namespace != taskRunNamespace {
+		t.Errorf("expected external resolver task namespace %q (TaskRun namespace fallback), got %q", taskRunNamespace, actualTask3.Namespace)
 	}
 }

--- a/pkg/reconciler/taskrun/resources/taskref_test.go
+++ b/pkg/reconciler/taskrun/resources/taskref_test.go
@@ -919,7 +919,7 @@ func TestGetStepActionFunc_Local(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			tektonclient := fake.NewSimpleClientset(tc.localStepActions...)
-			fn := resources.GetStepActionFunc(tektonclient, nil, nil, tc.taskRun, *tc.taskRun.Spec.TaskSpec, &tc.taskRun.Spec.TaskSpec.Steps[0])
+			fn := resources.GetStepActionFunc(tektonclient, nil, nil, tc.taskRun, *tc.taskRun.Spec.TaskSpec, &tc.taskRun.Spec.TaskSpec.Steps[0], tc.taskRun.Namespace)
 
 			stepAction, refSource, err := fn(ctx, tc.taskRun.Spec.TaskSpec.Steps[0].Ref.Name)
 			if err != nil {
@@ -980,7 +980,7 @@ func TestGetStepActionFunc_RemoteResolution_Success(t *testing.T) {
 				},
 			}
 			tektonclient := fake.NewSimpleClientset()
-			fn := resources.GetStepActionFunc(tektonclient, nil, requester, tr, *tr.Spec.TaskSpec, &tr.Spec.TaskSpec.Steps[0])
+			fn := resources.GetStepActionFunc(tektonclient, nil, requester, tr, *tr.Spec.TaskSpec, &tr.Spec.TaskSpec.Steps[0], tr.Namespace)
 
 			resolvedStepAction, resolvedRefSource, err := fn(ctx, tr.Spec.TaskSpec.Steps[0].Ref.Name)
 			if tc.wantErr {
@@ -1041,7 +1041,7 @@ func TestGetStepActionFunc_RemoteResolution_Error(t *testing.T) {
 				},
 			}
 			tektonclient := fake.NewSimpleClientset()
-			fn := resources.GetStepActionFunc(tektonclient, nil, requester, tr, *tr.Spec.TaskSpec, &tr.Spec.TaskSpec.Steps[0])
+			fn := resources.GetStepActionFunc(tektonclient, nil, requester, tr, *tr.Spec.TaskSpec, &tr.Spec.TaskSpec.Steps[0], tr.Namespace)
 			if _, _, err := fn(ctx, tr.Spec.TaskSpec.Steps[0].Ref.Name); err == nil {
 				t.Fatalf("expected error due to invalid pipeline data but saw none")
 			}
@@ -2024,4 +2024,154 @@ func signInterface(signer signature.Signer, i interface{}) ([]byte, error) {
 	}
 
 	return sig, nil
+}
+
+// TestGetStepActionFunc_CrossNamespace_LocalLookup verifies that when a TaskRun
+// is in namespace "a" but the resolved Task came from namespace "b", the local
+// StepAction lookup uses namespace "b" (the Task's namespace).
+func TestGetStepActionFunc_CrossNamespace_LocalLookup(t *testing.T) {
+	ctx := t.Context()
+
+	taskRunNamespace := "namespace-a"
+	taskNamespace := "namespace-b"
+
+	stepActionInTaskNS := &v1beta1.StepAction{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-step-action",
+			Namespace: taskNamespace,
+		},
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "tekton.dev/v1beta1",
+			Kind:       "StepAction",
+		},
+		Spec: v1beta1.StepActionSpec{
+			Image: "step-action-image",
+		},
+	}
+
+	tektonclient := fake.NewSimpleClientset(stepActionInTaskNS)
+
+	tr := &v1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-taskrun",
+			Namespace: taskRunNamespace,
+		},
+		Spec: v1.TaskRunSpec{
+			TaskSpec: &v1.TaskSpec{
+				Steps: []v1.Step{{
+					Ref: &v1.Ref{
+						Name: "my-step-action",
+					},
+				}},
+			},
+		},
+	}
+
+	// GetStepActionFunc is called with taskNamespace="namespace-b", which should
+	// be used for local lookups. The StepAction exists in namespace-b, not namespace-a.
+	fn := resources.GetStepActionFunc(tektonclient, nil, nil, tr, *tr.Spec.TaskSpec, &tr.Spec.TaskSpec.Steps[0], taskNamespace)
+
+	stepAction, refSource, err := fn(ctx, "my-step-action")
+	if err != nil {
+		t.Fatalf("expected StepAction to be found in task namespace %q, but got error: %v", taskNamespace, err)
+	}
+
+	if stepAction.Name != "my-step-action" {
+		t.Errorf("expected StepAction name %q, got %q", "my-step-action", stepAction.Name)
+	}
+	if stepAction.Namespace != taskNamespace {
+		t.Errorf("expected StepAction namespace %q, got %q", taskNamespace, stepAction.Namespace)
+	}
+	if stepAction.Spec.Image != "step-action-image" {
+		t.Errorf("expected image %q, got %q", "step-action-image", stepAction.Spec.Image)
+	}
+	// Local lookups have nil refSource
+	if refSource != nil {
+		t.Errorf("expected nil refSource for local lookup, got %v", refSource)
+	}
+}
+
+// TestGetTaskFuncFromTaskRun_CrossNamespace_StatusPersistence verifies that
+// the ResolvedTaskNamespace Status field is read on second reconcile when the
+// TaskSpec is already cached in the TaskRun status.
+func TestGetTaskFuncFromTaskRun_CrossNamespace_StatusPersistence(t *testing.T) {
+	ctx := t.Context()
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	taskRunNamespace := "namespace-a"
+	taskSourceNamespace := "namespace-b"
+
+	tektonclient := fake.NewSimpleClientset()
+	kubeclient := fakek8s.NewSimpleClientset(&corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: taskRunNamespace,
+			Name:      "default",
+		},
+	})
+
+	taskSpec := v1.TaskSpec{
+		Steps: []v1.Step{{
+			Image: "myimage",
+			Script: `
+#!/usr/bin/env bash
+echo hello
+`,
+		}},
+	}
+
+	// Simulate second reconcile: TaskSpec is already cached in status,
+	// and the ResolvedTaskNamespace Status field preserves the original namespace.
+	taskRun := &v1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-taskrun",
+			Namespace: taskRunNamespace,
+		},
+		Spec: v1.TaskRunSpec{
+			TaskRef: &v1.TaskRef{
+				Name: "my-task",
+			},
+			ServiceAccountName: "default",
+		},
+		Status: v1.TaskRunStatus{TaskRunStatusFields: v1.TaskRunStatusFields{
+			TaskSpec: &taskSpec,
+			Provenance: &v1.Provenance{
+				RefSource: sampleRefSource.DeepCopy(),
+			},
+			ResolvedTaskNamespace: taskSourceNamespace,
+		}},
+	}
+
+	fn := resources.GetTaskFuncFromTaskRun(ctx, kubeclient, tektonclient, nil, taskRun, []*v1alpha1.VerificationPolicy{})
+
+	actualTask, actualRefSource, _, err := fn(ctx, "my-task")
+	if err != nil {
+		t.Fatalf("failed to call GetTaskFuncFromTaskRun: %s", err.Error())
+	}
+
+	// Verify the returned Task has the namespace from the Status field, not the TaskRun's namespace
+	if actualTask.Namespace != taskSourceNamespace {
+		t.Errorf("expected task namespace %q (from Status), got %q", taskSourceNamespace, actualTask.Namespace)
+	}
+	if actualTask.Name != "my-task" {
+		t.Errorf("expected task name %q, got %q", "my-task", actualTask.Name)
+	}
+	if d := cmp.Diff(sampleRefSource, actualRefSource); d != "" {
+		t.Errorf("refSources did not match: %s", diff.PrintWantGot(d))
+	}
+
+	// Now test without the Status field - should fall back to TaskRun namespace
+	taskRunNoStatus := taskRun.DeepCopy()
+	taskRunNoStatus.Status.ResolvedTaskNamespace = ""
+
+	fn2 := resources.GetTaskFuncFromTaskRun(ctx, kubeclient, tektonclient, nil, taskRunNoStatus, []*v1alpha1.VerificationPolicy{})
+	actualTask2, _, _, err := fn2(ctx, "my-task")
+	if err != nil {
+		t.Fatalf("failed to call GetTaskFuncFromTaskRun without Status field: %s", err.Error())
+	}
+
+	// Without the Status field, should fall back to TaskRun's namespace
+	if actualTask2.Namespace != taskRunNamespace {
+		t.Errorf("expected task namespace %q (TaskRun namespace fallback), got %q", taskRunNamespace, actualTask2.Namespace)
+	}
 }

--- a/pkg/reconciler/taskrun/resources/taskspec.go
+++ b/pkg/reconciler/taskrun/resources/taskspec.go
@@ -119,11 +119,14 @@ func hasStepRefs(taskSpec *v1.TaskSpec) bool {
 	return false
 }
 
-// resolveStepRef resolves a step referecing a StepAction by fetching the remote StepAction, merging it with the Step's specification, and returning the resolved step.
-func resolveStepRef(ctx context.Context, taskSpec v1.TaskSpec, taskRun *v1.TaskRun, tekton clientset.Interface, k8s kubernetes.Interface, requester remoteresource.Requester, step *v1.Step) (*v1.Step, *v1.RefSource, error) {
+// resolveStepRef resolves a step referencing a StepAction by fetching the remote StepAction, merging it with the Step's specification, and returning the resolved step.
+// taskNamespace is the namespace where the resolved Task lives, which may differ from the TaskRun's namespace
+// when using cross-namespace resolution (e.g. cluster resolver). StepActions referenced by the Task should be
+// resolved in the Task's namespace, not the TaskRun's namespace.
+func resolveStepRef(ctx context.Context, taskSpec v1.TaskSpec, taskRun *v1.TaskRun, tekton clientset.Interface, k8s kubernetes.Interface, requester remoteresource.Requester, step *v1.Step, taskNamespace string) (*v1.Step, *v1.RefSource, error) {
 	resolvedStep := step.DeepCopy()
 
-	getStepAction := GetStepActionFunc(tekton, k8s, requester, taskRun, taskSpec, resolvedStep)
+	getStepAction := GetStepActionFunc(tekton, k8s, requester, taskRun, taskSpec, resolvedStep, taskNamespace)
 	stepAction, source, err := getStepAction(ctx, resolvedStep.Ref.Name)
 	if err != nil {
 		return nil, nil, err
@@ -196,7 +199,9 @@ func updateTaskRunProvenance(taskRun *v1.TaskRun, stepName string, stepIndex int
 }
 
 // GetStepActionsData extracts the StepActions and merges them with the inlined Step specification.
-func GetStepActionsData(ctx context.Context, taskSpec v1.TaskSpec, taskRun *v1.TaskRun, tekton clientset.Interface, k8s kubernetes.Interface, requester remoteresource.Requester) ([]v1.Step, error) {
+// taskNamespace is the namespace of the resolved Task, which may differ from the TaskRun's namespace
+// when cross-namespace resolution is used. StepActions referenced by the Task are resolved in this namespace.
+func GetStepActionsData(ctx context.Context, taskSpec v1.TaskSpec, taskRun *v1.TaskRun, tekton clientset.Interface, k8s kubernetes.Interface, requester remoteresource.Requester, taskNamespace string) ([]v1.Step, error) {
 	steps := make([]v1.Step, len(taskSpec.Steps))
 
 	// Init step states and known step states indexes lookup map
@@ -230,7 +235,7 @@ func GetStepActionsData(ctx context.Context, taskSpec v1.TaskSpec, taskRun *v1.T
 		}
 
 		g.Go(func() error {
-			resolvedStep, source, err := resolveStepRef(ctx, taskSpec, taskRun, tekton, k8s, requester, &step)
+			resolvedStep, source, err := resolveStepRef(ctx, taskSpec, taskRun, tekton, k8s, requester, &step, taskNamespace)
 			if err != nil {
 				return fmt.Errorf("failed to resolve step ref for step %q (index %d): %w", step.Name, i, err)
 			}

--- a/pkg/reconciler/taskrun/resources/taskspec_test.go
+++ b/pkg/reconciler/taskrun/resources/taskspec_test.go
@@ -747,7 +747,7 @@ spec:
 	for _, tt := range tests {
 		ctx := t.Context()
 		tektonclient := fake.NewSimpleClientset(stepAction)
-		_, err := GetStepActionsData(ctx, *tt.tr.Spec.TaskSpec, tt.tr, tektonclient, nil, requester)
+		_, err := GetStepActionsData(ctx, *tt.tr.Spec.TaskSpec, tt.tr, tektonclient, nil, requester, tt.tr.Namespace)
 		if err != nil {
 			t.Fatalf("Did not expect an error but got : %s", err)
 		}
@@ -969,7 +969,7 @@ spec:
 				}
 			}
 
-			_, err := GetStepActionsData(ctx, *tt.tr.Spec.TaskSpec, tt.tr, tektonclient, nil, requester)
+			_, err := GetStepActionsData(ctx, *tt.tr.Spec.TaskSpec, tt.tr, tektonclient, nil, requester, tt.tr.Namespace)
 			if err != nil {
 				t.Fatalf("Did not expect an error but got : %s", err)
 			}
@@ -2005,7 +2005,7 @@ func TestGetStepActionsData(t *testing.T) {
 				}
 			}
 
-			got, err := GetStepActionsData(ctx, *tt.tr.Spec.TaskSpec, tt.tr, tektonclient, nil, nil)
+			got, err := GetStepActionsData(ctx, *tt.tr.Spec.TaskSpec, tt.tr, tektonclient, nil, nil, tt.tr.Namespace)
 			if err != nil {
 				t.Fatalf("Did not expect an error but got : %s", err)
 			}
@@ -2234,7 +2234,7 @@ func TestGetStepActionsData_Error(t *testing.T) {
 			ctx := t.Context()
 			tektonclient := fake.NewSimpleClientset(tt.stepAction)
 
-			_, err := GetStepActionsData(ctx, *tt.tr.Spec.TaskSpec, tt.tr, tektonclient, nil, nil)
+			_, err := GetStepActionsData(ctx, *tt.tr.Spec.TaskSpec, tt.tr, tektonclient, nil, nil, tt.tr.Namespace)
 			if err == nil {
 				t.Fatalf("Expected to get an error but did not find any.")
 			}
@@ -2287,7 +2287,7 @@ func TestGetStepActionsData_InvalidStepResultReference(t *testing.T) {
 	expectedError := `failed to resolve step ref for step "step1" (index 0): must be one of the form 1). "steps.<stepName>.results.<resultName>"; 2). "steps.<stepName>.results.<objectResultName>.<individualAttribute>"`
 	ctx := t.Context()
 	tektonclient := fake.NewSimpleClientset(stepAction)
-	if _, err := GetStepActionsData(ctx, *tr.Spec.TaskSpec, tr, tektonclient, nil, nil); err.Error() != expectedError {
+	if _, err := GetStepActionsData(ctx, *tr.Spec.TaskSpec, tr, tektonclient, nil, nil, tr.Namespace); err.Error() != expectedError {
 		t.Errorf("Expected error message %s but got %s", expectedError, err.Error())
 	}
 }

--- a/pkg/reconciler/taskrun/resources/taskspec_test.go
+++ b/pkg/reconciler/taskrun/resources/taskspec_test.go
@@ -2339,7 +2339,7 @@ func TestGetStepActionsDataConcurrentObjectParamDefault(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := GetStepActionsData(t.Context(), taskSpec, tr, tektonclient, nil, nil); err != nil {
+	if _, err := GetStepActionsData(t.Context(), taskSpec, tr, tektonclient, nil, nil, tr.Namespace); err != nil {
 		t.Fatalf("GetStepActionsData returned error: %v", err)
 	}
 	// Concurrent resolution must not have mutated the Task's shared object-param default.

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -529,9 +529,24 @@ func (c *Reconciler) prepare(ctx context.Context, tr *v1.TaskRun) (*v1.TaskSpec,
 		if err := storeTaskSpecAndMergeMeta(ctx, tr, taskSpec, taskMeta); err != nil {
 			logger.Errorf("Failed to store TaskSpec on TaskRun.Status for taskrun %s: %v", tr.Name, err)
 		}
+
+		// Persist the resolved Task's namespace in the Status so that subsequent
+		// reconcile loops (which take the cached fast path in GetTaskFuncFromTaskRun)
+		// can recover the correct namespace for StepAction resolution.
+		// Status is controller-managed and cannot be injected by users or malicious Tasks.
+		if taskMeta.Namespace != "" && taskMeta.Namespace != tr.Namespace {
+			tr.Status.ResolvedTaskNamespace = taskMeta.Namespace
+		}
 	}
 
-	steps, err := resources.GetStepActionsData(ctx, *taskSpec, tr, c.PipelineClientSet, c.KubeClientSet, c.resolutionRequester)
+	// Determine the Task's namespace for StepAction resolution.
+	// The setter block above already persists taskMeta.Namespace into
+	// ResolvedTaskNamespace when they differ, so we only need to check Status.
+	taskNamespace := tr.Namespace
+	if tr.Status.ResolvedTaskNamespace != "" {
+		taskNamespace = tr.Status.ResolvedTaskNamespace
+	}
+	steps, err := resources.GetStepActionsData(ctx, *taskSpec, tr, c.PipelineClientSet, c.KubeClientSet, c.resolutionRequester, taskNamespace)
 	switch {
 	case errors.Is(err, remote.ErrRequestInProgress):
 		message := fmt.Sprintf("TaskRun %s/%s awaiting remote StepAction", tr.Namespace, tr.Name)

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -530,22 +530,20 @@ func (c *Reconciler) prepare(ctx context.Context, tr *v1.TaskRun) (*v1.TaskSpec,
 			logger.Errorf("Failed to store TaskSpec on TaskRun.Status for taskrun %s: %v", tr.Name, err)
 		}
 
-		// Persist the resolved Task's namespace in the Status so that subsequent
-		// reconcile loops (which take the cached fast path in GetTaskFuncFromTaskRun)
-		// can recover the correct namespace for StepAction resolution.
-		// Status is controller-managed and cannot be injected by users or malicious Tasks.
-		if taskMeta.Namespace != "" && taskMeta.Namespace != tr.Namespace {
-			tr.Status.ResolvedTaskNamespace = taskMeta.Namespace
+		// Persist the resolved Task's namespace in Status only when it comes from
+		// the in-cluster resolver. Namespaces on Tasks returned by external
+		// resolvers are untrusted metadata and must not authorize cross-namespace
+		// local StepAction reads.
+		tr.Status.ResolvedTaskNamespace = ""
+		if taskNamespace := resources.ResolvedTaskNamespaceForStepActions(tr, taskMeta.Namespace); taskNamespace != tr.Namespace {
+			tr.Status.ResolvedTaskNamespace = taskNamespace
 		}
 	}
 
-	// Determine the Task's namespace for StepAction resolution.
-	// The setter block above already persists taskMeta.Namespace into
-	// ResolvedTaskNamespace when they differ, so we only need to check Status.
-	taskNamespace := tr.Namespace
-	if tr.Status.ResolvedTaskNamespace != "" {
-		taskNamespace = tr.Status.ResolvedTaskNamespace
-	}
+	// Determine the trusted Task namespace for StepAction resolution. Cached
+	// status is only honored for the in-cluster resolver; all other TaskRefs fall
+	// back to the TaskRun namespace.
+	taskNamespace := resources.ResolvedTaskNamespaceForStepActions(tr, tr.Status.ResolvedTaskNamespace)
 	steps, err := resources.GetStepActionsData(ctx, *taskSpec, tr, c.PipelineClientSet, c.KubeClientSet, c.resolutionRequester, taskNamespace)
 	switch {
 	case errors.Is(err, remote.ErrRequestInProgress):

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -2289,6 +2289,72 @@ spec:
 	}
 }
 
+func TestReconcile_ClusterResolvedTaskUsesTaskNamespaceForLocalStepAction(t *testing.T) {
+	const (
+		taskRunNamespace = "taskrun-ns"
+		taskNamespace    = "task-ns"
+	)
+	tr := parse.MustParseV1TaskRun(t, `
+metadata:
+  name: cross-namespace-task
+  namespace: taskrun-ns
+spec:
+  taskRef:
+    resolver: cluster
+`)
+	task := parse.MustParseV1Task(t, `
+metadata:
+  name: resolved-task
+  namespace: task-ns
+spec:
+  steps:
+  - name: referenced-step
+    ref:
+      name: local-action
+`)
+	stepAction := parse.MustParseV1beta1StepAction(t, `
+metadata:
+  name: local-action
+  namespace: task-ns
+spec:
+  image: busybox
+  command: ["echo", "resolved"]
+`)
+	taskBytes, err := yaml.Marshal(task)
+	if err != nil {
+		t.Fatal(err)
+	}
+	taskRequest := getResolvedResolutionRequest(t, "cluster", taskBytes, taskRunNamespace, tr.Name)
+	d := test.Data{
+		TaskRuns:           []*v1.TaskRun{tr},
+		StepActions:        []*v1beta1.StepAction{stepAction},
+		ResolutionRequests: []*resolutionv1beta1.ResolutionRequest{&taskRequest},
+		ConfigMaps: []*corev1.ConfigMap{{
+			ObjectMeta: metav1.ObjectMeta{Name: config.GetFeatureFlagsConfigName(), Namespace: system.Namespace()},
+		}},
+	}
+	testAssets, cancel := getTaskRunController(t, d)
+	defer cancel()
+	createServiceAccount(t, testAssets, "default", taskRunNamespace)
+
+	if err := testAssets.Controller.Reconciler.Reconcile(testAssets.Ctx, getRunName(tr)); controller.IsPermanentError(err) {
+		t.Fatalf("reconcile returned a permanent error: %v", err)
+	}
+	got, err := testAssets.Clients.Pipeline.TektonV1().TaskRuns(taskRunNamespace).Get(testAssets.Ctx, tr.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status.ResolvedTaskNamespace != taskNamespace {
+		t.Fatalf("resolved task namespace = %q, want %q", got.Status.ResolvedTaskNamespace, taskNamespace)
+	}
+	if got.Status.TaskSpec == nil || len(got.Status.TaskSpec.Steps) != 1 {
+		t.Fatalf("resolved TaskSpec steps = %#v, want one step", got.Status.TaskSpec)
+	}
+	if got.Status.TaskSpec.Steps[0].Image != "busybox" {
+		t.Fatalf("resolved StepAction image = %q, want %q", got.Status.TaskSpec.Steps[0].Image, "busybox")
+	}
+}
+
 func TestReconcile_RemoteStepAction_Error(t *testing.T) {
 	namespace := "foo"
 	trName := "test-task-run-success"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

When resolving StepActions through a Task that was resolved by the Cluster resolver, use the resolved Task's namespace rather than falling back to the TaskRun/PipelineRun namespace. Previously, StepActions referenced by a cluster-resolved Task could be looked up in the wrong namespace.

This also records the resolved Task namespace in TaskRun status so StepAction resolution can consistently use the same namespace as the resolved Task.

Fixes #8380

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Fix StepAction resolution for cluster-resolved Tasks so StepActions are resolved from the resolved Task namespace, and expose the resolved Task namespace in TaskRun status.
```
