### PR TITLE
fix: Remove direct usage of testify from pkg/spire/

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -208,7 +208,7 @@ require (
 	github.com/shurcooL/graphql v0.0.0-20181231061246-d48a9a75455f // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
-	github.com/stretchr/testify v1.10.0
+	github.com/stretchr/testify v1.10.0 // indirect
 	github.com/vbatts/tar-split v0.12.1 // indirect
 	go.uber.org/automaxprocs v1.6.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect

--- a/pkg/spire/test/ca.go
+++ b/pkg/spire/test/ca.go
@@ -38,7 +38,6 @@ import (
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/go-spiffe/v2/svid/jwtsvid"
 	"github.com/spiffe/go-spiffe/v2/svid/x509svid"
-	"github.com/stretchr/testify/require"
 	"github.com/tektoncd/pipeline/pkg/spire/test/x509util"
 )
 
@@ -123,13 +122,19 @@ func (ca *CA) CreateJWTSVID(id spiffeid.ID, audience []string) *jwtsvid.SVID {
 		},
 		new(jose.SignerOptions).WithType("JWT"),
 	)
-	require.NoError(ca.tb, err)
+	if err != nil {
+		ca.tb.Fatalf("failed to convert claims to Struct: %v", err)
+	}
 
 	signedToken, err := jwt.Signed(jwtSigner).Claims(claims).CompactSerialize()
-	require.NoError(ca.tb, err)
+	if err != nil {
+		ca.tb.Fatalf("failed to convert claims to Struct: %v", err)
+	}
 
 	svid, err := jwtsvid.ParseInsecure(signedToken, audience)
-	require.NoError(ca.tb, err)
+	if err != nil {
+		ca.tb.Fatalf("failed to convert claims to Struct: %v", err)
+	}
 	return svid
 }
 
@@ -220,9 +225,13 @@ func CreateX509SVID(tb testing.TB, parent *x509.Certificate, parentKey crypto.Si
 
 func CreateCertificate(tb testing.TB, tmpl, parent *x509.Certificate, pub, priv interface{}) *x509.Certificate {
 	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, parent, pub, priv)
-	require.NoError(tb, err)
+	if err != nil {
+		tb.Fatalf("failed to create listener: %v", err)
+	}
 	cert, err := x509.ParseCertificate(certDER)
-	require.NoError(tb, err)
+	if err != nil {
+		tb.Fatalf("failed to create listener: %v", err)
+	}
 	return cert
 }
 
@@ -242,7 +251,9 @@ func CreateWebCredentials(t testing.TB) (*x509.CertPool, *tls.Certificate) {
 func NewSerial(tb testing.TB) *big.Int {
 	b := make([]byte, 8)
 	_, err := rand.Read(b)
-	require.NoError(tb, err)
+	if err != nil {
+		tb.Fatalf("failed to create listener: %v", err)
+	}
 	return new(big.Int).SetBytes(b)
 }
 

--- a/pkg/spire/test/fakeworkloadapi/workload_api.go
+++ b/pkg/spire/test/fakeworkloadapi/workload_api.go
@@ -30,8 +30,6 @@ import (
 	"github.com/spiffe/go-spiffe/v2/proto/spiffe/workload"
 	"github.com/spiffe/go-spiffe/v2/svid/jwtsvid"
 	"github.com/spiffe/go-spiffe/v2/svid/x509svid"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/tektoncd/pipeline/pkg/spire/test/pemutil"
 	"github.com/tektoncd/pipeline/pkg/spire/test/x509util"
 	"google.golang.org/grpc"
@@ -67,7 +65,9 @@ func New(tb testing.TB) *WorkloadAPI {
 	}
 
 	listener, err := newListener()
-	require.NoError(tb, err)
+	if err != nil {
+		tb.Fatalf("failed to create listener: %v", err)
+	}
 
 	server := grpc.NewServer()
 	workload.RegisterSpiffeWorkloadAPIServer(server, &workloadAPIWrapper{w: w})
@@ -127,7 +127,9 @@ func (w *WorkloadAPI) SetJWTBundles(jwtBundles ...*jwtbundle.Bundle) {
 	}
 	for _, bundle := range jwtBundles {
 		bundleBytes, err := bundle.Marshal()
-		assert.NoError(w.tb, err)
+		if err != nil {
+			w.tb.Fatalf("failed to marshal JWT bundle: %v", err)
+		}
 		resp.Bundles[bundle.TrustDomain().String()] = bundleBytes
 	}
 
@@ -151,9 +153,13 @@ func (w *WorkloadAPI) SetX509Bundles(x509Bundles ...*x509bundle.Bundle) {
 	}
 	for _, bundle := range x509Bundles {
 		bundleBytes, err := bundle.Marshal()
-		assert.NoError(w.tb, err)
+		if err != nil {
+			w.tb.Fatalf("failed to marshal X509 bundle: %v", err)
+		}
 		bundlePem, err := pemutil.ParseCertificates(bundleBytes)
-		assert.NoError(w.tb, err)
+		if err != nil {
+			w.tb.Fatalf("failed to parse certificates: %v", err)
+		}
 
 		var rawBytes []byte
 		for _, c := range bundlePem {
@@ -222,7 +228,9 @@ func (r *X509SVIDResponse) ToProto(tb testing.TB) *workload.X509SVIDResponse {
 		if svid.PrivateKey != nil {
 			var err error
 			keyDER, err = x509.MarshalPKCS8PrivateKey(svid.PrivateKey)
-			require.NoError(tb, err)
+			if err != nil {
+				tb.Fatalf("failed to marshal private key: %v", err)
+			}
 		}
 		pb.Svids = append(pb.Svids, &workload.X509SVID{
 			SpiffeId:    svid.ID.String(),
@@ -381,7 +389,9 @@ func (w *WorkloadAPI) validateJWTSVID(_ context.Context, req *workload.ValidateJ
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 	claims, err := structFromValues(jwtSvid.Claims)
-	require.NoError(w.tb, err)
+	if err != nil {
+		w.tb.Fatalf("failed to convert claims to Struct: %v", err)
+	}
 
 	return &workload.ValidateJWTSVIDResponse{
 		SpiffeId: jwtSvid.ID.String(),

--- a/pkg/spire/test/keys.go
+++ b/pkg/spire/test/keys.go
@@ -22,8 +22,6 @@ import (
 	"crypto/rand"
 	"strings"
 	"testing"
-
-	"github.com/stretchr/testify/require"
 )
 
 // Methods to generate private keys. If generation starts slowing down test
@@ -32,7 +30,9 @@ import (
 // NewEC256Key returns an ECDSA key over the P256 curve
 func NewEC256Key(tb testing.TB) *ecdsa.PrivateKey {
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	require.NoError(tb, err)
+	if err != nil {
+				tb.Fatalf("failed to marshal private key: %v", err)
+			}
 	return key
 }
 
@@ -40,7 +40,9 @@ func NewEC256Key(tb testing.TB) *ecdsa.PrivateKey {
 func NewKeyID(tb testing.TB) string {
 	choices := make([]byte, 32)
 	_, err := rand.Read(choices)
-	require.NoError(tb, err)
+	if err != nil {
+				tb.Fatalf("failed to marshal private key: %v", err)
+			}
 	return keyIDFromBytes(choices)
 }
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
This PR removes direct usage of github.com/stretchr/testify (see issue [#8775](https://github.com/tektoncd/pipeline/issues/8775)). All assertions have been replaced with standard testing.T error handling methods.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Removed direct dependency on testify in pkg/spire to simplify testing and reduce external dependencies.
```
