### PR TITLE
Fix subpath capitalisation

### DIFF
--- a/tekton/release-pipeline.yaml
+++ b/tekton/release-pipeline.yaml
@@ -78,7 +78,7 @@ spec:
       workspaces:
         - name: output
           workspace: workarea
-          subpath: git
+          subPath: git
       params:
         - name: url
           value: https://$(params.package)
@@ -107,7 +107,7 @@ spec:
       workspaces:
         - name: source-to-release
           workspace: workarea
-          subpath: git
+          subPath: git
     - name: unit-tests
       runAfter: [precheck]
       when:
@@ -129,7 +129,7 @@ spec:
       workspaces:
         - name: source
           workspace: workarea
-          subpath: git
+          subPath: git
     - name: build
       runAfter: [precheck]
       when:
@@ -151,7 +151,7 @@ spec:
       workspaces:
         - name: source
           workspace: workarea
-          subpath: git
+          subPath: git
     - name: publish-images
       runAfter: [unit-tests, build]
       taskRef:
@@ -189,10 +189,10 @@ spec:
       workspaces:
         - name: source
           workspace: workarea
-          subpath: git
+          subPath: git
         - name: output
           workspace: workarea
-          subpath: bucket
+          subPath: bucket
         - name: release-secret
           workspace: release-images-secret
       timeout: 2h
@@ -212,7 +212,7 @@ spec:
           workspace: release-secret
         - name: source
           workspace: workarea
-          subpath: bucket
+          subPath: bucket
       params:
         - name: location
           value: $(params.releaseBucket)/previous/$(params.versionTag)
@@ -240,7 +240,7 @@ spec:
           workspace: release-secret
         - name: source
           workspace: workarea
-          subpath: bucket
+          subPath: bucket
       params:
         - name: location
           value: $(params.releaseBucket)/latest


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
The latest Tekton Pipelines release is stricter about validation and rejects the incorrect `subpath` field name. Update this to the expected `subPath`.

Follow-up to https://github.com/tektoncd/plumbing/pull/2537
/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
