### PR TITLE
fix(docs): remove duplicated block from artifacts.md

### DIFF
--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -106,54 +106,6 @@ spec:
           EOF
 ```
 
-The content is written by the `Step` to a file `$(artifacts.path)`:
-
-```yaml
-apiVersion: tekton.dev/v1
-kind: TaskRun
-metadata:
-  generateName: step-artifacts-
-spec:
-  taskSpec:
-    description: |
-      A simple task that populates artifacts to TaskRun stepState
-    steps:
-      - name: artifacts-producer
-        image: bash:latest
-        script: |
-          cat > $(artifacts.path) << EOF
-          {
-            "inputs":[
-              {
-                "name":"source",
-                "values":[
-                  {
-                    "uri":"pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c",
-                    "digest":{
-                      "sha256":"b35cacccfdb1e24dc497d15d553891345fd155713ffe647c281c583269eaaae0"
-                    }
-                  }
-                ]
-              }
-            ],
-            "outputs":[
-              {
-                "name":"image",
-                "values":[
-                  {
-                    "uri":"pkg:oci/nginx:stable-alpine3.17-slim?repository_url=docker.io/library",
-                    "digest":{
-                      "sha256":"df85b9e3983fe2ce20ef76ad675ecf435cc99fc9350adc54fa230bae8c32ce48",
-                      "sha1":"95588b8f34c31eb7d62c92aaa4e6506639b06ef2"
-                    }
-                  }
-                ]
-              }
-            ]
-          }
-          EOF
-```
-
 It is recommended to use [purl format](https://github.com/package-url/purl-spec/blob/master/PURL-SPECIFICATION.rst) for artifacts uri as shown in the example. 
 
 ### Output Artifacts in SLSA Provenance


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

I found a duplicated block of documentation while reading https://tekton.dev/docs/pipelines/artifacts/#artifact-provenance-data

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
