### PR TITLE
fix(lint): resolve golangci-lint errors in testing context

### DIFF
--- a/cmd/entrypoint/runner_test.go
+++ b/cmd/entrypoint/runner_test.go
@@ -41,7 +41,7 @@ func TestRealRunnerSignalForwarding(t *testing.T) {
 	rr := realRunner{}
 	rr.signals = make(chan os.Signal, 1)
 	rr.signal(syscall.SIGINT)
-	if err := rr.Run(context.Background(), "sleep", "3600"); err.Error() == "signal: interrupt" {
+	if err := rr.Run(t.Context(), "sleep", "3600"); err.Error() == "signal: interrupt" {
 		t.Logf("SIGINT forwarded to Entrypoint")
 	} else {
 		t.Fatalf("Unexpected error received: %v", err)
@@ -66,7 +66,7 @@ func TestRealRunnerStdoutAndStderrPaths(t *testing.T) {
 	errReader, errWriter, _ := os.Pipe()
 	os.Stderr = errWriter
 
-	if err := rr.Run(context.Background(), "sh", "-c", fmt.Sprintf("echo %s && echo %s >&2", expectedString, expectedString)); err != nil {
+	if err := rr.Run(t.Context(), "sh", "-c", fmt.Sprintf("echo %s && echo %s >&2", expectedString, expectedString)); err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
@@ -116,7 +116,7 @@ func TestRealRunnerStdoutAndStderrSamePath(t *testing.T) {
 		stdoutPath: path,
 		stderrPath: path,
 	}
-	if err := rr.Run(context.Background(), "sh", "-c", fmt.Sprintf("echo %s && echo %s >&2", expectedString, expectedString)); err != nil {
+	if err := rr.Run(t.Context(), "sh", "-c", fmt.Sprintf("echo %s && echo %s >&2", expectedString, expectedString)); err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
@@ -156,7 +156,7 @@ func TestRealRunnerStdoutPathWithSignal(t *testing.T) {
 		rr.signal(syscall.SIGINT)
 	}()
 
-	if err := rr.Run(context.Background(), "sh", "-c", fmt.Sprintf("echo %s && sleep 20", expectedString)); err == nil || err.Error() != expectedError {
+	if err := rr.Run(t.Context(), "sh", "-c", fmt.Sprintf("echo %s && sleep 20", expectedString)); err == nil || err.Error() != expectedError {
 		t.Fatalf("Expected error %v but got %v", expectedError, err)
 	}
 	if got, err := os.ReadFile(path); err != nil {
@@ -170,7 +170,7 @@ func TestRealRunnerStdoutPathWithSignal(t *testing.T) {
 func TestRealRunnerTimeout(t *testing.T) {
 	rr := realRunner{}
 	timeout := time.Millisecond
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := context.WithTimeout(t.Context(), timeout)
 	defer cancel()
 
 	if err := rr.Run(ctx, "sleep", "0.01"); err != nil {
@@ -206,7 +206,7 @@ func TestRealRunnerCancel(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		rr := realRunner{}
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(t.Context())
 		go func() {
 			time.Sleep(tc.timeout)
 			cancel()

--- a/internal/sidecarlogresults/sidecarlogresults_test.go
+++ b/internal/sidecarlogresults/sidecarlogresults_test.go
@@ -18,7 +18,6 @@ package sidecarlogresults
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -544,7 +543,7 @@ func TestGetResultsFromSidecarLogs(t *testing.T) {
 		wantError: true,
 	}} {
 		t.Run(c.desc, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			clientset := fakekubeclientset.NewSimpleClientset()
 			pod := &corev1.Pod{
 				TypeMeta: metav1.TypeMeta{
@@ -567,7 +566,7 @@ func TestGetResultsFromSidecarLogs(t *testing.T) {
 					Phase: c.podPhase,
 				},
 			}
-			pod, err := clientset.CoreV1().Pods(pod.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+			pod, err := clientset.CoreV1().Pods(pod.Namespace).Create(t.Context(), pod, metav1.CreateOptions{})
 			if err != nil {
 				t.Errorf("Error occurred while creating pod %s: %s", pod.Name, err.Error())
 			}

--- a/pkg/apis/config/feature_flags_test.go
+++ b/pkg/apis/config/feature_flags_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package config_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -333,7 +332,7 @@ func TestGetVerificationNoMatchPolicy(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			store := config.NewStore(logging.FromContext(ctx).Named("config-store"))
 			featureflags := &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
@@ -387,7 +386,7 @@ func TestIsSpireEnabled(t *testing.T) {
 		},
 		want: true,
 	}}
-	ctx := context.Background()
+	ctx := t.Context()
 	store := config.NewStore(logging.FromContext(ctx).Named("config-store"))
 	for _, tc := range testCases {
 		featureflags := &corev1.ConfigMap{

--- a/pkg/apis/config/featureflags_validation_test.go
+++ b/pkg/apis/config/featureflags_validation_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package config_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/tektoncd/pipeline/pkg/apis/config"
@@ -64,7 +63,7 @@ func TestValidateEnabledAPIFields(t *testing.T) {
 			cfg := &config.Config{
 				FeatureFlags: flags,
 			}
-			ctx := config.ToContext(context.Background(), cfg)
+			ctx := config.ToContext(t.Context(), cfg)
 			if err := config.ValidateEnabledAPIFields(ctx, "test feature", tc.wantVersion); err != nil {
 				t.Errorf("unexpected error for compatible feature gates: %q", err)
 			}
@@ -105,7 +104,7 @@ func TestValidateEnabledAPIFieldsError(t *testing.T) {
 			cfg := &config.Config{
 				FeatureFlags: flags,
 			}
-			ctx := config.ToContext(context.Background(), cfg)
+			ctx := config.ToContext(t.Context(), cfg)
 			fieldErr := config.ValidateEnabledAPIFields(ctx, "test feature", tc.wantVersion)
 
 			if fieldErr == nil {

--- a/pkg/apis/config/resolver/store_test.go
+++ b/pkg/apis/config/resolver/store_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package resolver_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -39,7 +38,7 @@ func TestStoreLoadWithContext(t *testing.T) {
 	store := resolver.NewStore(logtesting.TestLogger(t))
 	store.OnConfigChanged(featuresConfig)
 
-	cfg := resolver.FromContext(store.ToContext(context.Background()))
+	cfg := resolver.FromContext(store.ToContext(t.Context()))
 
 	if d := cmp.Diff(expected, cfg); d != "" {
 		t.Errorf("Unexpected config %s", diff.PrintWantGot(d))

--- a/pkg/apis/config/store_test.go
+++ b/pkg/apis/config/store_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package config_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -59,7 +58,7 @@ func TestStoreLoadWithContext(t *testing.T) {
 	store.OnConfigChanged(eventsConfig)
 	store.OnConfigChanged(tracingConfig)
 
-	cfg := config.FromContext(store.ToContext(context.Background()))
+	cfg := config.FromContext(store.ToContext(t.Context()))
 
 	if d := cmp.Diff(expected, cfg); d != "" {
 		t.Errorf("Unexpected config %s", diff.PrintWantGot(d))
@@ -78,7 +77,7 @@ func TestStoreLoadWithContext_Empty(t *testing.T) {
 
 	store := config.NewStore(logtesting.TestLogger(t))
 
-	got := config.FromContext(store.ToContext(context.Background()))
+	got := config.FromContext(store.ToContext(t.Context()))
 
 	if d := cmp.Diff(want, got); d != "" {
 		t.Errorf("Unexpected config %s", diff.PrintWantGot(d))

--- a/pkg/apis/pipeline/v1/container_validation_test.go
+++ b/pkg/apis/pipeline/v1/container_validation_test.go
@@ -83,7 +83,7 @@ func TestRef_Valid(t *testing.T) {
 	}}
 	for _, ts := range tests {
 		t.Run(ts.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if ts.wc != nil {
 				ctx = ts.wc(ctx)
 			}
@@ -162,7 +162,7 @@ func TestRef_Invalid(t *testing.T) {
 	}}
 	for _, ts := range tests {
 		t.Run(ts.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if ts.wc != nil {
 				ctx = ts.wc(ctx)
 			}
@@ -212,7 +212,7 @@ func TestStepValidate(t *testing.T) {
 	}}
 	for _, st := range tests {
 		t.Run(st.name, func(t *testing.T) {
-			ctx := cfgtesting.EnableAlphaAPIFields(context.Background())
+			ctx := cfgtesting.EnableAlphaAPIFields(t.Context())
 			if err := st.Step.Validate(ctx); err != nil {
 				t.Errorf("Step.Validate() = %v", err)
 			}
@@ -292,7 +292,7 @@ func TestStepValidateError(t *testing.T) {
 	}}
 	for _, st := range tests {
 		t.Run(st.name, func(t *testing.T) {
-			ctx := cfgtesting.EnableAlphaAPIFields(context.Background())
+			ctx := cfgtesting.EnableAlphaAPIFields(t.Context())
 			err := st.Step.Validate(ctx)
 			if err == nil {
 				t.Fatalf("Expected an error, got nothing for %v", st.Step)
@@ -318,7 +318,7 @@ func TestSidecarValidate(t *testing.T) {
 
 	for _, sct := range tests {
 		t.Run(sct.name, func(t *testing.T) {
-			err := sct.sidecar.Validate(context.Background())
+			err := sct.sidecar.Validate(t.Context())
 			if err != nil {
 				t.Errorf("Sidecar.Validate() returned error for valid Sidecar: %v", err)
 			}
@@ -368,7 +368,7 @@ func TestSidecarValidateError(t *testing.T) {
 
 	for _, sct := range tests {
 		t.Run(sct.name, func(t *testing.T) {
-			err := sct.sidecar.Validate(context.Background())
+			err := sct.sidecar.Validate(t.Context())
 			if err == nil {
 				t.Fatalf("Expected an error, got nothing for %v", sct.sidecar)
 			}

--- a/pkg/apis/pipeline/v1/param_types_test.go
+++ b/pkg/apis/pipeline/v1/param_types_test.go
@@ -18,7 +18,6 @@ package v1_test
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"reflect"
 	"testing"
@@ -151,7 +150,7 @@ func TestParamSpec_SetDefaults(t *testing.T) {
 	}}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			tc.before.SetDefaults(ctx)
 			if d := cmp.Diff(tc.defaultsApplied, tc.before); d != "" {
 				t.Error(diff.PrintWantGot(d))

--- a/pkg/apis/pipeline/v1/pipeline_conversion_test.go
+++ b/pkg/apis/pipeline/v1/pipeline_conversion_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1_test
 
 import (
-	"context"
 	"testing"
 
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
@@ -26,11 +25,11 @@ import (
 func TestPipelineConversionBadType(t *testing.T) {
 	good, bad := &v1.Pipeline{}, &v1.Task{}
 
-	if err := good.ConvertTo(context.Background(), bad); err == nil {
+	if err := good.ConvertTo(t.Context(), bad); err == nil {
 		t.Errorf("ConvertTo() = %#v, wanted error", bad)
 	}
 
-	if err := good.ConvertFrom(context.Background(), bad); err == nil {
+	if err := good.ConvertFrom(t.Context(), bad); err == nil {
 		t.Errorf("ConvertFrom() = %#v, wanted error", good)
 	}
 }

--- a/pkg/apis/pipeline/v1/pipeline_defaults_test.go
+++ b/pkg/apis/pipeline/v1/pipeline_defaults_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -29,7 +28,7 @@ import (
 func TestPipeline_SetDefaults(t *testing.T) {
 	p := &v1.Pipeline{}
 	want := &v1.Pipeline{}
-	ctx := context.Background()
+	ctx := t.Context()
 	p.SetDefaults(ctx)
 	if d := cmp.Diff(want, p); d != "" {
 		t.Errorf("Mismatch of Pipeline: empty pipeline must not change after setting defaults: %s", diff.PrintWantGot(d))
@@ -147,7 +146,7 @@ func TestPipelineSpec_SetDefaults(t *testing.T) {
 	}}
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			tc.ps.SetDefaults(ctx)
 			if d := cmp.Diff(tc.want, tc.ps); d != "" {
 				t.Errorf("Mismatch of pipelineSpec after setting defaults: %s", diff.PrintWantGot(d))
@@ -239,9 +238,9 @@ func TestPipelineTask_SetDefaults(t *testing.T) {
 	}}
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if len(tc.defaults) > 0 {
-				ctx = dfttesting.SetDefaults(context.Background(), t, tc.defaults)
+				ctx = dfttesting.SetDefaults(t.Context(), t, tc.defaults)
 			}
 			tc.pt.SetDefaults(ctx)
 			if d := cmp.Diff(tc.want, tc.pt); d != "" {

--- a/pkg/apis/pipeline/v1/pipeline_types_test.go
+++ b/pkg/apis/pipeline/v1/pipeline_types_test.go
@@ -135,7 +135,7 @@ func TestPipelineTask_OnError(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if tt.wc != nil {
 				ctx = tt.wc(ctx)
 			}
@@ -347,7 +347,7 @@ func TestPipelineTask_ValidateRefOrSpec(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if tt.wc != nil {
 				ctx = tt.wc(ctx)
 			}
@@ -422,7 +422,7 @@ func TestPipelineTask_ValidateRefOrSpec_APIVersionsCompatibility(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if test.wc != nil {
 				ctx = test.wc(ctx)
 			}
@@ -558,7 +558,7 @@ func TestPipelineTask_ValidateRegularTask_Success(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := cfgtesting.SetFeatureFlags(context.Background(), t, tt.configMap)
+			ctx := cfgtesting.SetFeatureFlags(t.Context(), t, tt.configMap)
 			err := tt.tasks.validateTask(ctx)
 			if err != nil {
 				t.Errorf("PipelineTask.validateTask() returned error for valid pipeline task: %v", err)
@@ -669,7 +669,7 @@ func TestPipelineTask_ValidateRegularTask_Failure(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := cfgtesting.SetFeatureFlags(context.Background(), t, tt.configMap)
+			ctx := cfgtesting.SetFeatureFlags(t.Context(), t, tt.configMap)
 			err := tt.task.validateTask(ctx)
 			if err == nil {
 				t.Error("PipelineTask.validateTask() did not return error for invalid pipeline task")
@@ -719,7 +719,7 @@ func TestPipelineTask_Validate_Failure(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if tt.wc != nil {
 				ctx = tt.wc(ctx)
 			}
@@ -1127,7 +1127,7 @@ func TestPipelineTask_ValidateMatrix(t *testing.T) {
 				FeatureFlags: featureFlags,
 				Defaults:     defaults,
 			}
-			ctx := config.ToContext(context.Background(), cfg)
+			ctx := config.ToContext(t.Context(), cfg)
 			if d := cmp.Diff(tt.wantErrs.Error(), tt.pt.validateMatrix(ctx).Error()); d != "" {
 				t.Errorf("PipelineTask.validateMatrix() errors diff %s", diff.PrintWantGot(d))
 			}

--- a/pkg/apis/pipeline/v1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1/pipeline_validation_test.go
@@ -318,7 +318,7 @@ func TestPipeline_Validate_Success(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if tt.wc != nil {
 				ctx = tt.wc(ctx)
 			}
@@ -643,7 +643,7 @@ func TestPipeline_Validate_Failure(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if tt.wc != nil {
 				ctx = tt.wc(ctx)
 			}
@@ -1354,7 +1354,7 @@ func TestPipelineSpec_Validate_Failure(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if tt.wc != nil {
 				ctx = tt.wc(ctx)
 			}
@@ -1380,7 +1380,7 @@ func TestPipelineSpec_Validate_Failure_CycleDAG(t *testing.T) {
 			Name: "baz", TaskRef: &TaskRef{Name: "baz-task"}, RunAfter: []string{"bar"},
 		}},
 	}
-	err := ps.Validate(context.Background())
+	err := ps.Validate(t.Context())
 	if err == nil {
 		t.Errorf("PipelineSpec.Validate() did not return error for invalid pipelineSpec: %s", name)
 	}
@@ -1447,7 +1447,7 @@ func TestValidatePipelineTasks_Failure(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := ValidatePipelineTasks(context.Background(), tt.tasks, tt.finalTasks)
+			err := ValidatePipelineTasks(t.Context(), tt.tasks, tt.finalTasks)
 			if err == nil {
 				t.Error("ValidatePipelineTasks() did not return error for invalid pipeline tasks")
 			}
@@ -1634,7 +1634,7 @@ func TestFinallyTaskResultsToPipelineResults_Success(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if tt.wc != nil {
 				ctx = tt.wc(ctx)
 			}
@@ -1734,7 +1734,7 @@ func TestFinallyTaskResultsToPipelineResults_Failure(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if tt.wc != nil {
 				ctx = tt.wc(ctx)
 			}
@@ -2058,7 +2058,7 @@ func TestValidatePipelineParameterVariables_Success(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := cfgtesting.EnableAlphaAPIFields(context.Background())
+			ctx := cfgtesting.EnableAlphaAPIFields(t.Context())
 			if tt.configMap != nil {
 				ctx = cfgtesting.SetFeatureFlags(ctx, t, tt.configMap)
 			}
@@ -2654,7 +2654,7 @@ func TestValidatePipelineParameterVariables_Failure(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if tt.configMap != nil {
 				ctx = cfgtesting.SetFeatureFlags(ctx, t, tt.configMap)
 			}
@@ -2925,7 +2925,7 @@ func TestValidatePipelineWithFinalTasks_Success(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if tt.wc != nil {
 				ctx = tt.wc(ctx)
 			}
@@ -3393,7 +3393,7 @@ func TestValidatePipelineWithFinalTasks_Failure(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if tt.wc != nil {
 				ctx = tt.wc(ctx)
 			}
@@ -4143,7 +4143,7 @@ func TestMatrixIncompatibleAPIVersions(t *testing.T) {
 				Defaults:     defaults,
 				FeatureFlags: featureFlags,
 			}
-			ctx := config.ToContext(context.Background(), cfg)
+			ctx := config.ToContext(t.Context(), cfg)
 			err := test.pt.validateMatrix(ctx)
 			if test.wantErr != nil {
 				if d := cmp.Diff(test.wantErr.Error(), err.Error()); d != "" {
@@ -4677,7 +4677,7 @@ func Test_validateMatrix(t *testing.T) {
 				Defaults:     defaults,
 			}
 
-			ctx := config.ToContext(context.Background(), cfg)
+			ctx := config.ToContext(t.Context(), cfg)
 			if d := cmp.Diff(tt.wantErrs.Error(), validateMatrix(ctx, tt.tasks).Error()); d != "" {
 				t.Errorf("validateMatrix() errors diff %s", diff.PrintWantGot(d))
 			}
@@ -4741,12 +4741,12 @@ func TestPipelineWithBetaFields(t *testing.T) {
 	for _, tt := range tts {
 		t.Run(tt.name, func(t *testing.T) {
 			pipeline := Pipeline{ObjectMeta: metav1.ObjectMeta{Name: "foo"}, Spec: tt.spec}
-			ctx := cfgtesting.EnableStableAPIFields(context.Background())
+			ctx := cfgtesting.EnableStableAPIFields(t.Context())
 			if err := pipeline.Validate(ctx); err == nil {
 				t.Errorf("no error when using beta field when `enable-api-fields` is stable")
 			}
 
-			ctx = cfgtesting.EnableBetaAPIFields(context.Background())
+			ctx = cfgtesting.EnableBetaAPIFields(t.Context())
 			if err := pipeline.Validate(ctx); err != nil {
 				t.Errorf("unexpected error when using beta field: %s", err)
 			}

--- a/pkg/apis/pipeline/v1/pipelineref_validation_test.go
+++ b/pkg/apis/pipeline/v1/pipelineref_validation_test.go
@@ -115,7 +115,7 @@ func TestPipelineRef_Invalid(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if tc.withContext != nil {
 				ctx = tc.withContext(ctx)
 			}
@@ -163,7 +163,7 @@ func TestPipelineRef_Valid(t *testing.T) {
 
 	for _, ts := range tests {
 		t.Run(ts.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if ts.wc != nil {
 				ctx = ts.wc(ctx)
 			}

--- a/pkg/apis/pipeline/v1/pipelinerun_conversion_test.go
+++ b/pkg/apis/pipeline/v1/pipelinerun_conversion_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1_test
 
 import (
-	"context"
 	"testing"
 
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
@@ -26,11 +25,11 @@ import (
 func TestPipelineRunConversionBadType(t *testing.T) {
 	good, bad := &v1.PipelineRun{}, &v1.Pipeline{}
 
-	if err := good.ConvertTo(context.Background(), bad); err == nil {
+	if err := good.ConvertTo(t.Context(), bad); err == nil {
 		t.Errorf("ConvertTo() = %#v, wanted error", bad)
 	}
 
-	if err := good.ConvertFrom(context.Background(), bad); err == nil {
+	if err := good.ConvertFrom(t.Context(), bad); err == nil {
 		t.Errorf("ConvertFrom() = %#v, wanted error", good)
 	}
 }

--- a/pkg/apis/pipeline/v1/pipelinerun_defaults_test.go
+++ b/pkg/apis/pipeline/v1/pipelinerun_defaults_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1_test
 
 import (
-	"context"
 	"strconv"
 	"testing"
 	"time"
@@ -141,7 +140,7 @@ func TestPipelineRunSpec_SetDefaults(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			tc.prs.SetDefaults(ctx)
 
 			sortParamSpecs := func(x, y v1.ParamSpec) bool {
@@ -434,7 +433,7 @@ func TestPipelineRunDefaulting(t *testing.T) {
 	}}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := cfgtesting.SetDefaults(context.Background(), t, tc.defaults)
+			ctx := cfgtesting.SetDefaults(t.Context(), t, tc.defaults)
 			got := tc.in
 			got.SetDefaults(ctx)
 			if !cmp.Equal(got, tc.want, ignoreUnexportedResources) {
@@ -482,7 +481,7 @@ func TestPipelineRunDefaultingOnCreate(t *testing.T) {
 	}}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := apis.WithinCreate(cfgtesting.SetDefaults(context.Background(), t, tc.defaults))
+			ctx := apis.WithinCreate(cfgtesting.SetDefaults(t.Context(), t, tc.defaults))
 			got := tc.in
 			got.SetDefaults(ctx)
 			if !cmp.Equal(got, tc.want, ignoreUnexportedResources) {

--- a/pkg/apis/pipeline/v1/pipelinerun_types_test.go
+++ b/pkg/apis/pipeline/v1/pipelinerun_types_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1_test
 
 import (
-	"context"
 	"errors"
 	"testing"
 	"time"
@@ -266,7 +265,7 @@ func TestPipelineRunIsTimeoutConditionSet(t *testing.T) {
 }
 
 func TestPipelineRunSetTimeoutCondition(t *testing.T) {
-	ctx := config.ToContext(context.Background(), &config.Config{
+	ctx := config.ToContext(t.Context(), &config.Config{
 		Defaults: &config.Defaults{
 			DefaultTimeoutMinutes: 120,
 		},
@@ -355,7 +354,7 @@ func TestPipelineRunHasTimedOutForALongTime(t *testing.T) {
 				}},
 			}
 
-			if pr.HasTimedOutForALongTime(context.Background(), testClock) != tc.expected {
+			if pr.HasTimedOutForALongTime(t.Context(), testClock) != tc.expected {
 				t.Errorf("Expected HasTimedOut to be %t when using pipeline.timeouts.pipeline", tc.expected)
 			}
 		})
@@ -398,7 +397,7 @@ func TestPipelineRunHasTimedOut(t *testing.T) {
 				}},
 			}
 
-			if pr.HasTimedOut(context.Background(), testClock) != tc.expected {
+			if pr.HasTimedOut(t.Context(), testClock) != tc.expected {
 				t.Errorf("Expected HasTimedOut to be %t when using pipeline.timeouts.pipeline", tc.expected)
 			}
 		})
@@ -413,7 +412,7 @@ func TestPipelineRunHasTimedOut(t *testing.T) {
 				}},
 			}
 
-			if pr.HaveTasksTimedOut(context.Background(), testClock) != tc.expected {
+			if pr.HaveTasksTimedOut(t.Context(), testClock) != tc.expected {
 				t.Errorf("Expected HasTimedOut to be %t when using pipeline.timeouts.pipeline", tc.expected)
 			}
 		})
@@ -429,7 +428,7 @@ func TestPipelineRunHasTimedOut(t *testing.T) {
 				}},
 			}
 
-			if pr.HasFinallyTimedOut(context.Background(), testClock) != tc.expected {
+			if pr.HasFinallyTimedOut(t.Context(), testClock) != tc.expected {
 				t.Errorf("Expected HasTimedOut to be %t when using pipeline.timeouts.pipeline", tc.expected)
 			}
 		})

--- a/pkg/apis/pipeline/v1/pipelinerun_validation_test.go
+++ b/pkg/apis/pipeline/v1/pipelinerun_validation_test.go
@@ -349,7 +349,7 @@ func TestPipelineRun_Invalid(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if tc.wc != nil {
 				ctx = tc.wc(ctx)
 			}
@@ -809,7 +809,7 @@ func TestPipelineRun_Validate(t *testing.T) {
 
 	for _, ts := range tests {
 		t.Run(ts.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if ts.wc != nil {
 				ctx = ts.wc(ctx)
 			}
@@ -1099,7 +1099,7 @@ func TestPipelineRunSpec_Invalidate(t *testing.T) {
 
 	for _, ps := range tests {
 		t.Run(ps.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if ps.withContext != nil {
 				ctx = ps.withContext(ctx)
 			}
@@ -1170,7 +1170,7 @@ func TestPipelineRunSpec_Validate(t *testing.T) {
 
 	for _, ps := range tests {
 		t.Run(ps.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if ps.withContext != nil {
 				ctx = ps.withContext(ctx)
 			}
@@ -1356,7 +1356,7 @@ func TestPipelineRun_InvalidTimeouts(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			err := tc.pr.Validate(ctx)
 			if d := cmp.Diff(tc.want.Error(), err.Error()); d != "" {
 				t.Error(diff.PrintWantGot(d))
@@ -1440,7 +1440,7 @@ func TestPipelineRunWithTimeout_Validate(t *testing.T) {
 
 	for _, ts := range tests {
 		t.Run(ts.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if ts.wc != nil {
 				ctx = ts.wc(ctx)
 			}
@@ -1501,12 +1501,12 @@ func TestPipelineRunSpecBetaFeatures(t *testing.T) {
 			pr := v1.PipelineRun{ObjectMeta: metav1.ObjectMeta{Name: "foo"}, Spec: v1.PipelineRunSpec{
 				PipelineSpec: &tt.spec,
 			}}
-			ctx := cfgtesting.EnableStableAPIFields(context.Background())
+			ctx := cfgtesting.EnableStableAPIFields(t.Context())
 			if err := pr.Validate(ctx); err == nil {
 				t.Errorf("no error when using beta field when `enable-api-fields` is stable")
 			}
 
-			ctx = cfgtesting.EnableBetaAPIFields(context.Background())
+			ctx = cfgtesting.EnableBetaAPIFields(t.Context())
 			if err := pr.Validate(ctx); err != nil {
 				t.Errorf("unexpected error when using beta field: %s", err)
 			}
@@ -1672,7 +1672,7 @@ func TestPipelineRunSpec_ValidateUpdate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := config.ToContext(context.Background(), &config.Config{
+			ctx := config.ToContext(t.Context(), &config.Config{
 				FeatureFlags: &config.FeatureFlags{},
 				Defaults:     &config.Defaults{},
 			})

--- a/pkg/apis/pipeline/v1/result_defaults_test.go
+++ b/pkg/apis/pipeline/v1/result_defaults_test.go
@@ -14,7 +14,6 @@ limitations under the License.
 package v1_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -85,7 +84,7 @@ func TestTaskResult_SetDefaults(t *testing.T) {
 	}}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			tc.before.SetDefaults(ctx)
 			if d := cmp.Diff(tc.after, tc.before); d != "" {
 				t.Error(diff.PrintWantGot(d))
@@ -157,7 +156,7 @@ func TestStepResult_SetDefaults(t *testing.T) {
 	}}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			tc.before.SetDefaults(ctx)
 			if d := cmp.Diff(tc.after, tc.before); d != "" {
 				t.Error(diff.PrintWantGot(d))

--- a/pkg/apis/pipeline/v1/result_validation_test.go
+++ b/pkg/apis/pipeline/v1/result_validation_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1_test
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -64,7 +63,7 @@ func TestResultsValidate(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if err := tt.Result.Validate(ctx); err != nil {
 				t.Errorf("TaskSpec.Validate() = %v", err)
 			}
@@ -115,7 +114,7 @@ func TestResultsValidateError(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.Result.Validate(context.Background())
+			err := tt.Result.Validate(t.Context())
 			if err == nil {
 				t.Fatalf("Expected an error, got nothing for %v", tt.Result)
 			}
@@ -144,7 +143,7 @@ func TestResultsValidateValue(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if err := tt.Result.Validate(ctx); err != nil {
 				t.Errorf("TaskSpec.Validate() = %v", err)
 			}
@@ -236,7 +235,7 @@ func TestResultsValidateValueError(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			err := tt.Result.Validate(ctx)
 			if err == nil {
 				t.Fatalf("Expected an error, got nothing for %v", tt.Result)
@@ -337,7 +336,7 @@ func TestStepResultsValidate(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if err := tt.Result.Validate(ctx); err != nil {
 				t.Errorf("TaskSpec.Validate() = %v", err)
 			}
@@ -400,7 +399,7 @@ func TestStepResultsValidateError(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.Result.Validate(context.Background())
+			err := tt.Result.Validate(t.Context())
 			if err == nil {
 				t.Fatalf("Expected an error, got nothing for %v", tt.Result)
 			}

--- a/pkg/apis/pipeline/v1/task_conversion_test.go
+++ b/pkg/apis/pipeline/v1/task_conversion_test.go
@@ -33,11 +33,11 @@ func (c *convertible) ConvertFrom(ctx context.Context, source apis.Convertible) 
 func TestTaskConversionBadType(t *testing.T) {
 	good, bad := &v1.Task{}, &convertible{}
 
-	if err := good.ConvertTo(context.Background(), bad); err == nil {
+	if err := good.ConvertTo(t.Context(), bad); err == nil {
 		t.Errorf("ConvertTo() = %#v, wanted error", bad)
 	}
 
-	if err := good.ConvertFrom(context.Background(), bad); err == nil {
+	if err := good.ConvertFrom(t.Context(), bad); err == nil {
 		t.Errorf("ConvertFrom() = %#v, wanted error", good)
 	}
 }

--- a/pkg/apis/pipeline/v1/task_defaults_test.go
+++ b/pkg/apis/pipeline/v1/task_defaults_test.go
@@ -16,7 +16,6 @@ limitations under the License.
 package v1_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -87,7 +86,7 @@ func TestTask_SetDefaults(t *testing.T) {
 	}}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := cfgtesting.SetDefaults(context.Background(), t, map[string]string{
+			ctx := cfgtesting.SetDefaults(t.Context(), t, map[string]string{
 				"default-resolver-type": "git",
 			})
 			got := tc.in

--- a/pkg/apis/pipeline/v1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1/task_validation_test.go
@@ -59,7 +59,7 @@ func TestTaskValidate(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if tt.wc != nil {
 				ctx = tt.wc(ctx)
 			}
@@ -134,7 +134,7 @@ func TestTaskSpecValidatePropagatedParamsAndWorkspaces(t *testing.T) {
 				Workspaces:   tt.fields.Workspaces,
 				Results:      tt.fields.Results,
 			}
-			ctx := cfgtesting.EnableBetaAPIFields(context.Background())
+			ctx := cfgtesting.EnableBetaAPIFields(t.Context())
 			ts.SetDefaults(ctx)
 			if err := ts.Validate(ctx); err != nil {
 				t.Errorf("TaskSpec.Validate() = %v", err)
@@ -501,7 +501,7 @@ func TestTaskSpecValidate(t *testing.T) {
 				Workspaces:   tt.fields.Workspaces,
 				Results:      tt.fields.Results,
 			}
-			ctx := cfgtesting.EnableAlphaAPIFields(context.Background())
+			ctx := cfgtesting.EnableAlphaAPIFields(t.Context())
 			ts.SetDefaults(ctx)
 			if err := ts.Validate(ctx); err != nil {
 				t.Errorf("TaskSpec.Validate() = %v", err)
@@ -538,7 +538,7 @@ func TestTaskSpecStepActionReferenceValidate(t *testing.T) {
 			ts := &v1.TaskSpec{
 				Steps: tt.Steps,
 			}
-			ctx := context.Background()
+			ctx := t.Context()
 			ts.SetDefaults(ctx)
 			if err := ts.Validate(ctx); err != nil {
 				t.Errorf("TaskSpec.Validate() = %v", err)
@@ -742,7 +742,7 @@ func TestTaskValidateError(t *testing.T) {
 					Steps:  tt.fields.Steps,
 				},
 			}
-			ctx := cfgtesting.EnableAlphaAPIFields(context.Background())
+			ctx := cfgtesting.EnableAlphaAPIFields(t.Context())
 			task.SetDefaults(ctx)
 			err := task.Validate(ctx)
 			if err == nil {
@@ -1351,7 +1351,7 @@ func TestTaskSpecValidateError(t *testing.T) {
 				Workspaces:   tt.fields.Workspaces,
 				Results:      tt.fields.Results,
 			}
-			ctx := cfgtesting.EnableAlphaAPIFields(context.Background())
+			ctx := cfgtesting.EnableAlphaAPIFields(t.Context())
 			ts.SetDefaults(ctx)
 			err := ts.Validate(ctx)
 			if err == nil {
@@ -1493,7 +1493,7 @@ func TestTaskSpecValidateErrorWithStepActionRef(t *testing.T) {
 			ts := v1.TaskSpec{
 				Steps: tt.Steps,
 			}
-			ctx := context.Background()
+			ctx := t.Context()
 			ctx = apis.WithinCreate(ctx)
 			ts.SetDefaults(ctx)
 			err := ts.Validate(ctx)
@@ -1598,7 +1598,7 @@ func TestTaskSpecValidateErrorWithStepResultRef(t *testing.T) {
 			ts := v1.TaskSpec{
 				Steps: tt.Steps,
 			}
-			ctx := context.Background()
+			ctx := t.Context()
 			ctx = apis.WithinCreate(ctx)
 			ts.SetDefaults(ctx)
 			err := ts.Validate(ctx)
@@ -1678,7 +1678,7 @@ func TestTaskSpecValidateSuccessWithArtifactsRefFlagEnabled(t *testing.T) {
 			ts := v1.TaskSpec{
 				Steps: tt.Steps,
 			}
-			ctx := config.ToContext(context.Background(), &config.Config{
+			ctx := config.ToContext(t.Context(), &config.Config{
 				FeatureFlags: &config.FeatureFlags{
 					EnableArtifacts: true,
 				},
@@ -1711,7 +1711,7 @@ func TestTaskSpecValidateSuccessWithArtifactsRefFlagNotEnabled(t *testing.T) {
 			ts := v1.TaskSpec{
 				Steps: tt.Steps,
 			}
-			ctx := config.ToContext(context.Background(), &config.Config{
+			ctx := config.ToContext(t.Context(), &config.Config{
 				FeatureFlags: nil,
 			})
 			ctx = apis.WithinCreate(ctx)
@@ -1816,7 +1816,7 @@ func TestTaskSpecValidateErrorWithArtifactsRefFlagNotEnabled(t *testing.T) {
 			ts := v1.TaskSpec{
 				Steps: tt.Steps,
 			}
-			ctx := context.Background()
+			ctx := t.Context()
 			ctx = apis.WithinCreate(ctx)
 			ts.SetDefaults(ctx)
 			err := ts.Validate(ctx)
@@ -1912,7 +1912,7 @@ func TestTaskSpecValidateErrorWithArtifactsRef(t *testing.T) {
 			ts := v1.TaskSpec{
 				Steps: tt.Steps,
 			}
-			ctx := context.Background()
+			ctx := t.Context()
 			ctx = apis.WithinCreate(ctx)
 			ts.SetDefaults(ctx)
 			err := ts.Validate(ctx)
@@ -1960,7 +1960,7 @@ func TestStepAndSidecarWorkspaces(t *testing.T) {
 				Sidecars:   tt.fields.Sidecars,
 				Workspaces: tt.fields.Workspaces,
 			}
-			ctx := cfgtesting.EnableAlphaAPIFields(context.Background())
+			ctx := cfgtesting.EnableAlphaAPIFields(t.Context())
 			ts.SetDefaults(ctx)
 			if err := ts.Validate(ctx); err != nil {
 				t.Errorf("TaskSpec.Validate() = %v", err)
@@ -2017,7 +2017,7 @@ func TestStepAndSidecarWorkspacesErrors(t *testing.T) {
 				Sidecars: tt.fields.Sidecars,
 			}
 
-			ctx := cfgtesting.EnableAlphaAPIFields(context.Background())
+			ctx := cfgtesting.EnableAlphaAPIFields(t.Context())
 			ts.SetDefaults(ctx)
 			err := ts.Validate(ctx)
 			if err == nil {
@@ -2081,7 +2081,7 @@ func TestStepOnError(t *testing.T) {
 				Params: tt.params,
 				Steps:  tt.steps,
 			}
-			ctx := context.Background()
+			ctx := t.Context()
 			ts.SetDefaults(ctx)
 			err := ts.Validate(ctx)
 			if tt.expectedError == nil && err != nil {
@@ -2190,7 +2190,7 @@ func TestIncompatibleAPIVersions(t *testing.T) {
 			testName := fmt.Sprintf("(using %s) %s", version, tt.name)
 			t.Run(testName, func(t *testing.T) {
 				ts := tt.spec
-				ctx := context.Background()
+				ctx := t.Context()
 				if version == "alpha" {
 					ctx = cfgtesting.EnableAlphaAPIFields(ctx)
 				}
@@ -2403,7 +2403,7 @@ func TestTaskSpecValidateUsageOfDeclaredParams(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := v1.ValidateUsageOfDeclaredParameters(context.Background(), tt.Steps, tt.Params)
+			err := v1.ValidateUsageOfDeclaredParameters(t.Context(), tt.Steps, tt.Params)
 			if err == nil {
 				t.Fatalf("Expected an error, got nothing")
 			}
@@ -2627,7 +2627,7 @@ func TestParamEnum_Success(t *testing.T) {
 
 	for _, tc := range tcs {
 		cfg := map[string]string{"enable-param-enum": "true"}
-		ctx := cfgtesting.SetFeatureFlags(context.Background(), t, cfg)
+		ctx := cfgtesting.SetFeatureFlags(t.Context(), t, cfg)
 
 		err := v1.ValidateParameterVariables(ctx, []v1.Step{{Image: "foo"}}, tc.params)
 		if err != nil {
@@ -2704,7 +2704,7 @@ func TestParamEnum_Failure(t *testing.T) {
 	}}
 
 	for _, tc := range tcs {
-		ctx := cfgtesting.SetFeatureFlags(context.Background(), t, tc.configMap)
+		ctx := cfgtesting.SetFeatureFlags(t.Context(), t, tc.configMap)
 
 		err := v1.ValidateParameterVariables(ctx, []v1.Step{{Image: "foo"}}, tc.params)
 
@@ -2785,7 +2785,7 @@ func TestTaskSpecValidate_StepResults(t *testing.T) {
 					Results: tt.fields.Results,
 				}},
 			}
-			ctx := config.ToContext(context.Background(), &config.Config{
+			ctx := config.ToContext(t.Context(), &config.Config{
 				FeatureFlags: &config.FeatureFlags{},
 			})
 			ts.SetDefaults(ctx)
@@ -2845,7 +2845,7 @@ func TestTaskSpecValidate_StepResults_Error(t *testing.T) {
 					Results: tt.fields.Results,
 				}},
 			}
-			ctx := context.Background()
+			ctx := t.Context()
 			if tt.isCreate {
 				ctx = apis.WithinCreate(ctx)
 			}
@@ -2885,7 +2885,7 @@ func TestTaskSpecValidate_StepWhen_Error(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := config.ToContext(context.Background(), &config.Config{
+			ctx := config.ToContext(t.Context(), &config.Config{
 				FeatureFlags: &config.FeatureFlags{
 					EnableCELInWhenExpression: tt.EnableCEL,
 				},

--- a/pkg/apis/pipeline/v1/taskref_validation_test.go
+++ b/pkg/apis/pipeline/v1/taskref_validation_test.go
@@ -64,7 +64,7 @@ func TestTaskRef_Valid(t *testing.T) {
 	}}
 	for _, ts := range tests {
 		t.Run(ts.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if ts.wc != nil {
 				ctx = ts.wc(ctx)
 			}
@@ -162,7 +162,7 @@ func TestTaskRef_Invalid(t *testing.T) {
 	}}
 	for _, ts := range tests {
 		t.Run(ts.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if ts.wc != nil {
 				ctx = ts.wc(ctx)
 			}

--- a/pkg/apis/pipeline/v1/taskrun_conversion_test.go
+++ b/pkg/apis/pipeline/v1/taskrun_conversion_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1_test
 
 import (
-	"context"
 	"testing"
 
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
@@ -26,11 +25,11 @@ import (
 func TestTaskRunConversionBadType(t *testing.T) {
 	good, bad := &v1.TaskRun{}, &v1.Task{}
 
-	if err := good.ConvertTo(context.Background(), bad); err == nil {
+	if err := good.ConvertTo(t.Context(), bad); err == nil {
 		t.Errorf("ConvertTo() = %#v, wanted error", bad)
 	}
 
-	if err := good.ConvertFrom(context.Background(), bad); err == nil {
+	if err := good.ConvertFrom(t.Context(), bad); err == nil {
 		t.Errorf("ConvertFrom() = %#v, wanted error", good)
 	}
 }

--- a/pkg/apis/pipeline/v1/taskrun_defaults_test.go
+++ b/pkg/apis/pipeline/v1/taskrun_defaults_test.go
@@ -16,7 +16,6 @@ limitations under the License.
 package v1_test
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -111,7 +110,7 @@ func TestTaskRunSpec_SetDefaults(t *testing.T) {
 	}}
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			tc.trs.SetDefaults(ctx)
 
 			if d := cmp.Diff(tc.want, tc.trs); d != "" {
@@ -417,7 +416,7 @@ func TestTaskRunDefaulting(t *testing.T) {
 	}}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := cfgtesting.SetDefaults(context.Background(), t, tc.defaults)
+			ctx := cfgtesting.SetDefaults(t.Context(), t, tc.defaults)
 			got := tc.in
 			got.SetDefaults(ctx)
 			if !cmp.Equal(got, tc.want, ignoreUnexportedResources) {
@@ -463,7 +462,7 @@ func TestTaskRunDefaultingOnCreate(t *testing.T) {
 	}}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := apis.WithinCreate(cfgtesting.SetDefaults(context.Background(), t, tc.defaults))
+			ctx := apis.WithinCreate(cfgtesting.SetDefaults(t.Context(), t, tc.defaults))
 			got := tc.in
 			got.SetDefaults(ctx)
 			if !cmp.Equal(got, tc.want, ignoreUnexportedResources) {

--- a/pkg/apis/pipeline/v1/taskrun_types_test.go
+++ b/pkg/apis/pipeline/v1/taskrun_types_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1_test
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -367,7 +366,7 @@ func TestHasTimedOut(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := tc.taskRun.HasTimedOut(context.Background(), testClock)
+			result := tc.taskRun.HasTimedOut(t.Context(), testClock)
 			if d := cmp.Diff(tc.expectedStatus, result); d != "" {
 				t.Fatal(diff.PrintWantGot(d))
 			}

--- a/pkg/apis/pipeline/v1/taskrun_validation_test.go
+++ b/pkg/apis/pipeline/v1/taskrun_validation_test.go
@@ -124,7 +124,7 @@ func TestTaskRun_Invalidate(t *testing.T) {
 	}}
 	for _, ts := range tests {
 		t.Run(ts.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if ts.wc != nil {
 				ctx = ts.wc(ctx)
 			}
@@ -441,7 +441,7 @@ func TestTaskRun_Validate(t *testing.T) {
 	}}
 	for _, ts := range tests {
 		t.Run(ts.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if ts.wc != nil {
 				ctx = ts.wc(ctx)
 			}
@@ -489,7 +489,7 @@ func TestTaskRun_Workspaces_Invalid(t *testing.T) {
 	}}
 	for _, ts := range tests {
 		t.Run(ts.name, func(t *testing.T) {
-			err := ts.tr.Validate(context.Background())
+			err := ts.tr.Validate(t.Context())
 			if err == nil {
 				t.Errorf("Expected error for invalid TaskRun but got none")
 			}
@@ -865,7 +865,7 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 
 	for _, ts := range tests {
 		t.Run(ts.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if ts.wc != nil {
 				ctx = ts.wc(ctx)
 			}
@@ -975,7 +975,7 @@ func TestTaskRunSpec_Validate(t *testing.T) {
 
 	for _, ts := range tests {
 		t.Run(ts.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if ts.wc != nil {
 				ctx = ts.wc(ctx)
 			}
@@ -1112,7 +1112,7 @@ func TestTaskRunSpec_ValidateUpdate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := config.ToContext(context.Background(), &config.Config{
+			ctx := config.ToContext(t.Context(), &config.Config{
 				FeatureFlags: &config.FeatureFlags{},
 				Defaults:     &config.Defaults{},
 			})

--- a/pkg/apis/pipeline/v1/when_validation_test.go
+++ b/pkg/apis/pipeline/v1/when_validation_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
 	"testing"
 
 	"github.com/tektoncd/pipeline/pkg/apis/config"
@@ -56,7 +55,7 @@ func TestWhenExpressions_Valid(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := tt.wes.validate(context.Background()); err != nil {
+			if err := tt.wes.validate(t.Context()); err != nil {
 				t.Errorf("WhenExpressions.validate() returned an error for valid when expressions: %s", tt.wes)
 			}
 		})
@@ -99,7 +98,7 @@ func TestWhenExpressions_Invalid(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := tt.wes.validate(context.Background()); err == nil {
+			if err := tt.wes.validate(t.Context()); err == nil {
 				t.Errorf("WhenExpressions.validate() did not return error for invalid when expressions: %s, %s", tt.wes, err)
 			}
 		})
@@ -107,7 +106,7 @@ func TestWhenExpressions_Invalid(t *testing.T) {
 }
 
 func TestCELinWhenExpressions_Valid(t *testing.T) {
-	ctx := config.ToContext(context.Background(), &config.Config{
+	ctx := config.ToContext(t.Context(), &config.Config{
 		FeatureFlags: &config.FeatureFlags{
 			EnableCELInWhenExpression: true,
 		},
@@ -190,7 +189,7 @@ func TestCELWhenExpressions_Invalid(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := config.ToContext(context.Background(), &config.Config{
+			ctx := config.ToContext(t.Context(), &config.Config{
 				FeatureFlags: &config.FeatureFlags{
 					EnableCELInWhenExpression: tt.enableCELInWhenExpression,
 				},

--- a/pkg/apis/pipeline/v1/workspace_validation_test.go
+++ b/pkg/apis/pipeline/v1/workspace_validation_test.go
@@ -112,7 +112,7 @@ func TestWorkspaceBindingValidateValid(t *testing.T) {
 		},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if tc.wc != nil {
 				ctx = tc.wc(ctx)
 			}
@@ -181,7 +181,7 @@ func TestWorkspaceBindingValidateInvalid(t *testing.T) {
 		wc: cfgtesting.EnableBetaAPIFields,
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if tc.wc != nil {
 				ctx = tc.wc(ctx)
 			}

--- a/pkg/apis/pipeline/v1alpha1/run_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/run_validation_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1alpha1_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -182,7 +181,7 @@ func TestRun_Invalid(t *testing.T) {
 		want: apis.ErrMultipleOneOf("spec.params[foo].name"),
 	}} {
 		t.Run(c.name, func(t *testing.T) {
-			err := c.run.Validate(context.Background())
+			err := c.run.Validate(t.Context())
 			if d := cmp.Diff(c.want.Error(), err.Error()); d != "" {
 				t.Error(diff.PrintWantGot(d))
 			}
@@ -290,7 +289,7 @@ func TestRun_Valid(t *testing.T) {
 		},
 	}} {
 		t.Run(c.name, func(t *testing.T) {
-			if err := c.run.Validate(context.Background()); err != nil {
+			if err := c.run.Validate(t.Context()); err != nil {
 				t.Fatalf("validating valid Run: %v", err)
 			}
 		})
@@ -346,7 +345,7 @@ func TestRun_Workspaces_Invalid(t *testing.T) {
 	}}
 	for _, ts := range tests {
 		t.Run(ts.name, func(t *testing.T) {
-			err := ts.run.Validate(context.Background())
+			err := ts.run.Validate(t.Context())
 			if err == nil {
 				t.Errorf("Expected error for invalid Run but got none")
 			} else if d := cmp.Diff(ts.wantErr.Error(), err.Error()); d != "" {

--- a/pkg/apis/pipeline/v1alpha1/stepaction_conversion_test.go
+++ b/pkg/apis/pipeline/v1alpha1/stepaction_conversion_test.go
@@ -1,7 +1,6 @@
 package v1alpha1_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -16,11 +15,11 @@ import (
 func TestPipelineConversionBadType(t *testing.T) {
 	good, bad := &v1alpha1.StepAction{}, &v1beta1.Task{}
 
-	if err := good.ConvertTo(context.Background(), bad); err == nil {
+	if err := good.ConvertTo(t.Context(), bad); err == nil {
 		t.Errorf("ConvertTo() = %#v, wanted error", bad)
 	}
 
-	if err := good.ConvertFrom(context.Background(), bad); err == nil {
+	if err := good.ConvertFrom(t.Context(), bad); err == nil {
 		t.Errorf("ConvertFrom() = %#v, wanted error", good)
 	}
 }
@@ -92,7 +91,7 @@ spec:
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			v1Beta1StepAction := &v1beta1.StepAction{}
-			if err := test.v1AlphaStepAction.ConvertTo(context.Background(), v1Beta1StepAction); err != nil {
+			if err := test.v1AlphaStepAction.ConvertTo(t.Context(), v1Beta1StepAction); err != nil {
 				t.Errorf("ConvertTo() = %v", err)
 				return
 			}
@@ -101,7 +100,7 @@ spec:
 				t.Errorf("expected v1Task is different from what's converted: %s", d)
 			}
 			gotV1alpha1 := &v1alpha1.StepAction{}
-			if err := gotV1alpha1.ConvertFrom(context.Background(), v1Beta1StepAction); err != nil {
+			if err := gotV1alpha1.ConvertFrom(t.Context(), v1Beta1StepAction); err != nil {
 				t.Errorf("ConvertFrom() = %v", err)
 			}
 			t.Logf("ConvertFrom() = %#v", gotV1alpha1)

--- a/pkg/apis/pipeline/v1alpha1/stepaction_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/stepaction_validation_test.go
@@ -47,7 +47,7 @@ func TestStepActionValidate(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if tt.wc != nil {
 				ctx = tt.wc(ctx)
 			}
@@ -312,7 +312,7 @@ func TestStepActionSpecValidate(t *testing.T) {
 				Results:      tt.fields.Results,
 				VolumeMounts: tt.fields.VolumeMounts,
 			}
-			ctx := context.Background()
+			ctx := t.Context()
 			sa.SetDefaults(ctx)
 			if err := sa.Validate(ctx); err != nil {
 				t.Errorf("StepActionSpec.Validate() = %v", err)
@@ -651,7 +651,7 @@ func TestStepActionValidateError(t *testing.T) {
 					VolumeMounts: tt.fields.VolumeMounts,
 				},
 			}
-			ctx := context.Background()
+			ctx := t.Context()
 			sa.SetDefaults(ctx)
 			err := sa.Validate(ctx)
 			if err == nil {
@@ -1071,7 +1071,7 @@ func TestStepActionSpecValidateError(t *testing.T) {
 				Params:  tt.fields.Params,
 				Results: tt.fields.Results,
 			}
-			ctx := context.Background()
+			ctx := t.Context()
 			sa.SetDefaults(ctx)
 			err := sa.Validate(ctx)
 			if err == nil {

--- a/pkg/apis/pipeline/v1alpha1/verificationpolicy_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/verificationpolicy_validation_test.go
@@ -14,7 +14,6 @@ limitations under the License.
 package v1alpha1_test
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -228,7 +227,7 @@ func TestVerificationPolicy_Invalid(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.verificationPolicy.Validate(context.Background())
+			err := tt.verificationPolicy.Validate(t.Context())
 			if d := cmp.Diff(tt.want.Error(), err.Error()); d != "" {
 				t.Error("VerificationPolicy validate error mismatch", diff.PrintWantGot(d))
 			}
@@ -340,7 +339,7 @@ func TestVerificationPolicy_Valid(t *testing.T) {
 		}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.verificationPolicy.Validate(context.Background())
+			err := tt.verificationPolicy.Validate(t.Context())
 			if err != nil {
 				t.Errorf("validating valid VerificationPolicy: %v", err)
 			}

--- a/pkg/apis/pipeline/v1beta1/container_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/container_validation_test.go
@@ -77,7 +77,7 @@ func TestRef_Valid(t *testing.T) {
 	}}
 	for _, ts := range tests {
 		t.Run(ts.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if ts.wc != nil {
 				ctx = ts.wc(ctx)
 			}
@@ -156,7 +156,7 @@ func TestRef_Invalid(t *testing.T) {
 	}}
 	for _, ts := range tests {
 		t.Run(ts.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if ts.wc != nil {
 				ctx = ts.wc(ctx)
 			}

--- a/pkg/apis/pipeline/v1beta1/customrun_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/customrun_validation_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1beta1_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -181,7 +180,7 @@ func TestCustomRun_Invalid(t *testing.T) {
 		want: apis.ErrMultipleOneOf("spec.params[foo].name"),
 	}} {
 		t.Run(c.name, func(t *testing.T) {
-			err := c.customRun.Validate(context.Background())
+			err := c.customRun.Validate(t.Context())
 			if d := cmp.Diff(c.want.Error(), err.Error()); d != "" {
 				t.Error(diff.PrintWantGot(d))
 			}
@@ -289,7 +288,7 @@ func TestRun_Valid(t *testing.T) {
 		},
 	}} {
 		t.Run(c.name, func(t *testing.T) {
-			if err := c.customRun.Validate(context.Background()); err != nil {
+			if err := c.customRun.Validate(t.Context()); err != nil {
 				t.Fatalf("validating valid customRun: %v", err)
 			}
 		})
@@ -345,7 +344,7 @@ func TestRun_Workspaces_Invalid(t *testing.T) {
 	}}
 	for _, ts := range tests {
 		t.Run(ts.name, func(t *testing.T) {
-			err := ts.customRun.Validate(context.Background())
+			err := ts.customRun.Validate(t.Context())
 			if err == nil {
 				t.Errorf("Expected error for invalid customRun but got none")
 			} else if d := cmp.Diff(ts.wantErr.Error(), err.Error()); d != "" {

--- a/pkg/apis/pipeline/v1beta1/param_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/param_types_test.go
@@ -18,7 +18,6 @@ package v1beta1_test
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"reflect"
 	"testing"
@@ -150,7 +149,7 @@ func TestParamSpec_SetDefaults(t *testing.T) {
 	}}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			tc.before.SetDefaults(ctx)
 			if d := cmp.Diff(tc.defaultsApplied, tc.before); d != "" {
 				t.Error(diff.PrintWantGot(d))

--- a/pkg/apis/pipeline/v1beta1/pipeline_conversion_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_conversion_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1beta1_test
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -35,11 +34,11 @@ import (
 func TestPipelineConversionBadType(t *testing.T) {
 	good, bad := &v1beta1.Pipeline{}, &v1beta1.Task{}
 
-	if err := good.ConvertTo(context.Background(), bad); err == nil {
+	if err := good.ConvertTo(t.Context(), bad); err == nil {
 		t.Errorf("ConvertTo() = %#v, wanted error", bad)
 	}
 
-	if err := good.ConvertFrom(context.Background(), bad); err == nil {
+	if err := good.ConvertFrom(t.Context(), bad); err == nil {
 		t.Errorf("ConvertFrom() = %#v, wanted error", good)
 	}
 }
@@ -233,13 +232,13 @@ func TestPipelineConversion(t *testing.T) {
 			for _, version := range versions {
 				t.Run(test.name, func(t *testing.T) {
 					ver := version
-					if err := test.in.ConvertTo(context.Background(), ver); err != nil {
+					if err := test.in.ConvertTo(t.Context(), ver); err != nil {
 						t.Errorf("ConvertTo() = %v", err)
 						return
 					}
 					t.Logf("ConvertTo() = %#v", ver)
 					got := &v1beta1.Pipeline{}
-					if err := got.ConvertFrom(context.Background(), ver); err != nil {
+					if err := got.ConvertFrom(t.Context(), ver); err != nil {
 						t.Errorf("ConvertFrom() = %v", err)
 					}
 					t.Logf("ConvertFrom() = %#v", got)
@@ -303,12 +302,12 @@ func TestPipelineConversionFromDeprecated(t *testing.T) {
 		for _, version := range versions {
 			t.Run(test.name, func(t *testing.T) {
 				ver := version
-				if err := test.in.ConvertTo(context.Background(), ver); err != nil {
+				if err := test.in.ConvertTo(t.Context(), ver); err != nil {
 					t.Errorf("ConvertTo() = %v", err)
 				}
 				t.Logf("ConvertTo() = %#v", ver)
 				got := &v1beta1.Pipeline{}
-				if err := got.ConvertFrom(context.Background(), ver); err != nil {
+				if err := got.ConvertFrom(t.Context(), ver); err != nil {
 					t.Errorf("ConvertFrom() = %v", err)
 				}
 				t.Logf("ConvertFrom() = %#v", got)

--- a/pkg/apis/pipeline/v1beta1/pipeline_defaults_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_defaults_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1beta1_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -29,7 +28,7 @@ import (
 func TestPipeline_SetDefaults(t *testing.T) {
 	p := &v1beta1.Pipeline{}
 	want := &v1beta1.Pipeline{}
-	ctx := context.Background()
+	ctx := t.Context()
 	p.SetDefaults(ctx)
 	if d := cmp.Diff(want, p); d != "" {
 		t.Errorf("Mismatch of Pipeline: empty pipeline must not change after setting defaults: %s", diff.PrintWantGot(d))
@@ -147,7 +146,7 @@ func TestPipelineSpec_SetDefaults(t *testing.T) {
 	}}
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			tc.ps.SetDefaults(ctx)
 			if d := cmp.Diff(tc.want, tc.ps); d != "" {
 				t.Errorf("Mismatch of pipelineSpec after setting defaults: %s", diff.PrintWantGot(d))
@@ -239,9 +238,9 @@ func TestPipelineTask_SetDefaults(t *testing.T) {
 	}}
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if len(tc.defaults) > 0 {
-				ctx = dfttesting.SetDefaults(context.Background(), t, tc.defaults)
+				ctx = dfttesting.SetDefaults(t.Context(), t, tc.defaults)
 			}
 			tc.pt.SetDefaults(ctx)
 			if d := cmp.Diff(tc.want, tc.pt); d != "" {

--- a/pkg/apis/pipeline/v1beta1/pipeline_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types_test.go
@@ -135,7 +135,7 @@ func TestPipelineTask_OnError(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if tt.wc != nil {
 				ctx = tt.wc(ctx)
 			}
@@ -347,7 +347,7 @@ func TestPipelineTask_ValidateRefOrSpec(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if tt.wc != nil {
 				ctx = tt.wc(ctx)
 			}
@@ -422,7 +422,7 @@ func TestPipelineTask_ValidateRefOrSpec_APIVersionsCompatibility(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if test.wc != nil {
 				ctx = test.wc(ctx)
 			}
@@ -554,7 +554,7 @@ func TestPipelineTask_ValidateRegularTask_Success(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := cfgtesting.SetFeatureFlags(context.Background(), t, tt.configMap)
+			ctx := cfgtesting.SetFeatureFlags(t.Context(), t, tt.configMap)
 			err := tt.tasks.validateTask(ctx)
 			if err != nil {
 				t.Errorf("PipelineTask.validateTask() returned error for valid pipeline task: %v", err)
@@ -665,7 +665,7 @@ func TestPipelineTask_ValidateRegularTask_Failure(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := cfgtesting.SetFeatureFlags(context.Background(), t, tt.configMap)
+			ctx := cfgtesting.SetFeatureFlags(t.Context(), t, tt.configMap)
 			err := tt.task.validateTask(ctx)
 			if err == nil {
 				t.Error("PipelineTask.validateTask() did not return error for invalid pipeline task")
@@ -716,7 +716,7 @@ func TestPipelineTask_Validate_Failure(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if tt.wc != nil {
 				ctx = tt.wc(ctx)
 			}
@@ -878,7 +878,7 @@ func TestPipelineTaskList_Validate(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if tt.wc != nil {
 				ctx = tt.wc(ctx)
 			}
@@ -1083,7 +1083,7 @@ func TestPipelineTask_ValidateMatrix(t *testing.T) {
 				FeatureFlags: featureFlags,
 				Defaults:     defaults,
 			}
-			ctx := config.ToContext(context.Background(), cfg)
+			ctx := config.ToContext(t.Context(), cfg)
 			if d := cmp.Diff(tt.wantErrs.Error(), tt.pt.validateMatrix(ctx).Error()); d != "" {
 				t.Errorf("PipelineTask.validateMatrix() errors diff %s", diff.PrintWantGot(d))
 			}

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
@@ -195,7 +195,7 @@ func TestPipeline_Validate_Success(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if tt.wc != nil {
 				ctx = tt.wc(ctx)
 			}
@@ -520,7 +520,7 @@ func TestPipeline_Validate_Failure(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if tt.wc != nil {
 				ctx = tt.wc(ctx)
 			}
@@ -1272,7 +1272,7 @@ func TestPipelineSpec_Validate_Failure(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if tt.wc != nil {
 				ctx = tt.wc(ctx)
 			}
@@ -1298,7 +1298,7 @@ func TestPipelineSpec_Validate_Failure_CycleDAG(t *testing.T) {
 			Name: "baz", TaskRef: &TaskRef{Name: "baz-task"}, RunAfter: []string{"bar"},
 		}},
 	}
-	err := ps.Validate(context.Background())
+	err := ps.Validate(t.Context())
 	if err == nil {
 		t.Errorf("PipelineSpec.Validate() did not return error for invalid pipelineSpec: %s", name)
 	}
@@ -1365,7 +1365,7 @@ func TestValidatePipelineTasks_Failure(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := ValidatePipelineTasks(context.Background(), tt.tasks, tt.finalTasks)
+			err := ValidatePipelineTasks(t.Context(), tt.tasks, tt.finalTasks)
 			if err == nil {
 				t.Error("ValidatePipelineTasks() did not return error for invalid pipeline tasks")
 			}
@@ -1552,7 +1552,7 @@ func TestFinallyTaskResultsToPipelineResults_Success(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if tt.wc != nil {
 				ctx = tt.wc(ctx)
 			}
@@ -1652,7 +1652,7 @@ func TestFinallyTaskResultsToPipelineResults_Failure(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if tt.wc != nil {
 				ctx = tt.wc(ctx)
 			}
@@ -1976,7 +1976,7 @@ func TestValidatePipelineParameterVariables_Success(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if tt.configMap != nil {
 				ctx = cfgtesting.SetFeatureFlags(ctx, t, tt.configMap)
 			}
@@ -2574,7 +2574,7 @@ func TestValidatePipelineParameterVariables_Failure(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if tt.configMap != nil {
 				ctx = cfgtesting.SetFeatureFlags(ctx, t, tt.configMap)
 			}
@@ -2844,7 +2844,7 @@ func TestValidatePipelineWithFinalTasks_Success(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if tt.wc != nil {
 				ctx = tt.wc(ctx)
 			}
@@ -3312,7 +3312,7 @@ func TestValidatePipelineWithFinalTasks_Failure(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if tt.wc != nil {
 				ctx = tt.wc(ctx)
 			}
@@ -4062,7 +4062,7 @@ func TestMatrixIncompatibleAPIVersions(t *testing.T) {
 				Defaults:     defaults,
 				FeatureFlags: featureFlags,
 			}
-			ctx := config.ToContext(context.Background(), cfg)
+			ctx := config.ToContext(t.Context(), cfg)
 			err := test.pt.validateMatrix(ctx)
 			if test.wantErr != nil {
 				if d := cmp.Diff(test.wantErr.Error(), err.Error()); d != "" {
@@ -4596,7 +4596,7 @@ func Test_validateMatrix(t *testing.T) {
 				Defaults:     defaults,
 			}
 
-			ctx := config.ToContext(context.Background(), cfg)
+			ctx := config.ToContext(t.Context(), cfg)
 			if d := cmp.Diff(tt.wantErrs.Error(), validateMatrix(ctx, tt.tasks).Error()); d != "" {
 				t.Errorf("validateMatrix() errors diff %s", diff.PrintWantGot(d))
 			}
@@ -4663,12 +4663,12 @@ func TestPipelineWithBetaFields(t *testing.T) {
 	for _, tt := range tts {
 		t.Run(tt.name, func(t *testing.T) {
 			pipeline := Pipeline{ObjectMeta: metav1.ObjectMeta{Name: "foo"}, Spec: tt.spec}
-			ctx := cfgtesting.EnableStableAPIFields(context.Background())
+			ctx := cfgtesting.EnableStableAPIFields(t.Context())
 			if err := pipeline.Validate(ctx); err == nil {
 				t.Errorf("no error when using beta field when `enable-api-fields` is stable")
 			}
 
-			ctx = cfgtesting.EnableBetaAPIFields(context.Background())
+			ctx = cfgtesting.EnableBetaAPIFields(t.Context())
 			if err := pipeline.Validate(ctx); err != nil {
 				t.Errorf("unexpected error when using beta field: %s", err)
 			}

--- a/pkg/apis/pipeline/v1beta1/pipelineref_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelineref_validation_test.go
@@ -115,7 +115,7 @@ func TestPipelineRef_Invalid(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if tc.withContext != nil {
 				ctx = tc.withContext(ctx)
 			}
@@ -163,7 +163,7 @@ func TestPipelineRef_Valid(t *testing.T) {
 
 	for _, ts := range tests {
 		t.Run(ts.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if ts.wc != nil {
 				ctx = ts.wc(ctx)
 			}

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_conversion_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_conversion_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1beta1_test
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -131,11 +130,11 @@ var (
 func TestPipelineRunConversionBadType(t *testing.T) {
 	good, bad := &v1beta1.PipelineRun{}, &v1beta1.Pipeline{}
 
-	if err := good.ConvertTo(context.Background(), bad); err == nil {
+	if err := good.ConvertTo(t.Context(), bad); err == nil {
 		t.Errorf("ConvertTo() = %#v, wanted error", bad)
 	}
 
-	if err := good.ConvertFrom(context.Background(), bad); err == nil {
+	if err := good.ConvertFrom(t.Context(), bad); err == nil {
 		t.Errorf("ConvertFrom() = %#v, wanted error", good)
 	}
 }
@@ -384,7 +383,7 @@ func TestPipelineRunConversion(t *testing.T) {
 		for _, version := range versions {
 			t.Run(test.name, func(t *testing.T) {
 				ver := version
-				ctx := context.Background()
+				ctx := t.Context()
 				if err := test.in.ConvertTo(ctx, ver); err != nil {
 					t.Errorf("ConvertTo() = %v", err)
 					return
@@ -472,12 +471,12 @@ func TestPipelineRunConversionFromDeprecated(t *testing.T) {
 		for _, version := range versions {
 			t.Run(test.name, func(t *testing.T) {
 				ver := version
-				if err := test.in.ConvertTo(context.Background(), ver); err != nil {
+				if err := test.in.ConvertTo(t.Context(), ver); err != nil {
 					t.Errorf("ConvertTo() = %v", err)
 				}
 				t.Logf("ConvertTo() = %#v", ver)
 				got := &v1beta1.PipelineRun{}
-				if err := got.ConvertFrom(context.Background(), ver); err != nil {
+				if err := got.ConvertFrom(t.Context(), ver); err != nil {
 					t.Errorf("ConvertFrom() = %v", err)
 				}
 				t.Logf("ConvertFrom() = %#v", got)
@@ -520,7 +519,7 @@ func TestPipelineRunConversionRoundTrip(t *testing.T) {
 		for _, version := range versions {
 			t.Run(test.name, func(t *testing.T) {
 				ver := version
-				ctx := context.Background()
+				ctx := t.Context()
 
 				if err := test.in.ConvertTo(ctx, ver); err != nil {
 					t.Errorf("ConvertTo() = %v", err)

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_defaults_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_defaults_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1beta1_test
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -138,7 +137,7 @@ func TestPipelineRunSpec_SetDefaults(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			tc.prs.SetDefaults(ctx)
 
 			sortParamSpecs := func(x, y v1beta1.ParamSpec) bool {
@@ -389,7 +388,7 @@ func TestPipelineRunDefaulting(t *testing.T) {
 	}}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := cfgtesting.SetDefaults(context.Background(), t, tc.defaults)
+			ctx := cfgtesting.SetDefaults(t.Context(), t, tc.defaults)
 			got := tc.in
 			got.SetDefaults(ctx)
 			if !cmp.Equal(got, tc.want, ignoreUnexportedResources) {
@@ -433,7 +432,7 @@ func TestPipelineRunDefaultingOnCreate(t *testing.T) {
 	}}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := apis.WithinCreate(cfgtesting.SetDefaults(context.Background(), t, tc.defaults))
+			ctx := apis.WithinCreate(cfgtesting.SetDefaults(t.Context(), t, tc.defaults))
 			got := tc.in
 			got.SetDefaults(ctx)
 			if !cmp.Equal(got, tc.want, ignoreUnexportedResources) {

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_types_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1beta1_test
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -268,7 +267,7 @@ func TestPipelineRunIsTimeoutConditionSet(t *testing.T) {
 }
 
 func TestPipelineRunSetTimeoutCondition(t *testing.T) {
-	ctx := config.ToContext(context.Background(), &config.Config{
+	ctx := config.ToContext(t.Context(), &config.Config{
 		Defaults: &config.Defaults{
 			DefaultTimeoutMinutes: 120,
 		},
@@ -370,7 +369,7 @@ func TestPipelineRunHasTimedOutForALongTime(t *testing.T) {
 					StartTime: &metav1.Time{Time: tc.starttime},
 				}},
 			}
-			if pr.HasTimedOutForALongTime(context.Background(), testClock) != tc.expected {
+			if pr.HasTimedOutForALongTime(t.Context(), testClock) != tc.expected {
 				t.Errorf("Expected HasTimedOut to be %t when using pipeline.timeout", tc.expected)
 			}
 		})
@@ -385,7 +384,7 @@ func TestPipelineRunHasTimedOutForALongTime(t *testing.T) {
 				}},
 			}
 
-			if pr.HasTimedOutForALongTime(context.Background(), testClock) != tc.expected {
+			if pr.HasTimedOutForALongTime(t.Context(), testClock) != tc.expected {
 				t.Errorf("Expected HasTimedOut to be %t when using pipeline.timeouts.pipeline", tc.expected)
 			}
 		})
@@ -427,7 +426,7 @@ func TestPipelineRunHasTimedOut(t *testing.T) {
 					StartTime: &metav1.Time{Time: tc.starttime},
 				}},
 			}
-			if pr.HasTimedOut(context.Background(), testClock) != tc.expected {
+			if pr.HasTimedOut(t.Context(), testClock) != tc.expected {
 				t.Errorf("Expected HasTimedOut to be %t when using pipeline.timeout", tc.expected)
 			}
 		})
@@ -442,7 +441,7 @@ func TestPipelineRunHasTimedOut(t *testing.T) {
 				}},
 			}
 
-			if pr.HasTimedOut(context.Background(), testClock) != tc.expected {
+			if pr.HasTimedOut(t.Context(), testClock) != tc.expected {
 				t.Errorf("Expected HasTimedOut to be %t when using pipeline.timeouts.pipeline", tc.expected)
 			}
 		})
@@ -457,7 +456,7 @@ func TestPipelineRunHasTimedOut(t *testing.T) {
 				}},
 			}
 
-			if pr.HaveTasksTimedOut(context.Background(), testClock) != tc.expected {
+			if pr.HaveTasksTimedOut(t.Context(), testClock) != tc.expected {
 				t.Errorf("Expected HasTimedOut to be %t when using pipeline.timeouts.pipeline", tc.expected)
 			}
 		})
@@ -473,7 +472,7 @@ func TestPipelineRunHasTimedOut(t *testing.T) {
 				}},
 			}
 
-			if pr.HasFinallyTimedOut(context.Background(), testClock) != tc.expected {
+			if pr.HasFinallyTimedOut(t.Context(), testClock) != tc.expected {
 				t.Errorf("Expected HasTimedOut to be %t when using pipeline.timeouts.pipeline", tc.expected)
 			}
 		})

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_validation_test.go
@@ -526,7 +526,7 @@ func TestPipelineRun_Invalid(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if tc.wc != nil {
 				ctx = tc.wc(ctx)
 			}
@@ -986,7 +986,7 @@ func TestPipelineRun_Validate(t *testing.T) {
 
 	for _, ts := range tests {
 		t.Run(ts.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if ts.wc != nil {
 				ctx = ts.wc(ctx)
 			}
@@ -1248,7 +1248,7 @@ func TestPipelineRunSpec_Invalidate(t *testing.T) {
 
 	for _, ps := range tests {
 		t.Run(ps.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if ps.withContext != nil {
 				ctx = ps.withContext(ctx)
 			}
@@ -1331,7 +1331,7 @@ func TestPipelineRunSpec_Validate(t *testing.T) {
 
 	for _, ps := range tests {
 		t.Run(ps.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if ps.withContext != nil {
 				ctx = ps.withContext(ctx)
 			}
@@ -1534,7 +1534,7 @@ func TestPipelineRun_InvalidTimeouts(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			err := tc.pr.Validate(ctx)
 			if d := cmp.Diff(tc.want.Error(), err.Error()); d != "" {
 				t.Error(diff.PrintWantGot(d))
@@ -1618,7 +1618,7 @@ func TestPipelineRunWithTimeout_Validate(t *testing.T) {
 
 	for _, ts := range tests {
 		t.Run(ts.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if ts.wc != nil {
 				ctx = ts.wc(ctx)
 			}
@@ -1682,12 +1682,12 @@ func TestPipelineRunSpecBetaFeatures(t *testing.T) {
 			pr := v1beta1.PipelineRun{ObjectMeta: metav1.ObjectMeta{Name: "foo"}, Spec: v1beta1.PipelineRunSpec{
 				PipelineSpec: &tt.spec,
 			}}
-			ctx := cfgtesting.EnableStableAPIFields(context.Background())
+			ctx := cfgtesting.EnableStableAPIFields(t.Context())
 			if err := pr.Validate(ctx); err == nil {
 				t.Errorf("no error when using beta field when `enable-api-fields` is stable")
 			}
 
-			ctx = cfgtesting.EnableBetaAPIFields(context.Background())
+			ctx = cfgtesting.EnableBetaAPIFields(t.Context())
 			if err := pr.Validate(ctx); err != nil {
 				t.Errorf("unexpected error when using beta field: %s", err)
 			}
@@ -1852,7 +1852,7 @@ func TestPipelineRunSpec_ValidateUpdate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := config.ToContext(context.Background(), &config.Config{
+			ctx := config.ToContext(t.Context(), &config.Config{
 				FeatureFlags: &config.FeatureFlags{},
 				Defaults:     &config.Defaults{},
 			})

--- a/pkg/apis/pipeline/v1beta1/result_defaults_test.go
+++ b/pkg/apis/pipeline/v1beta1/result_defaults_test.go
@@ -14,7 +14,6 @@ limitations under the License.
 package v1beta1_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -85,7 +84,7 @@ func TestTaskResult_SetDefaults(t *testing.T) {
 	}}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			tc.before.SetDefaults(ctx)
 			if d := cmp.Diff(tc.after, tc.before); d != "" {
 				t.Error(diff.PrintWantGot(d))

--- a/pkg/apis/pipeline/v1beta1/result_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/result_validation_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1beta1_test
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -63,7 +62,7 @@ func TestResultsValidate(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if err := tt.Result.Validate(ctx); err != nil {
 				t.Errorf("TaskSpec.Validate() = %v", err)
 			}
@@ -114,7 +113,7 @@ func TestResultsValidateError(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			err := tt.Result.Validate(ctx)
 			if err == nil {
 				t.Fatalf("Expected an error, got nothing for %v", tt.Result)
@@ -144,7 +143,7 @@ func TestResultsValidateValue(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if err := tt.Result.Validate(ctx); err != nil {
 				t.Errorf("TaskSpec.Validate() = %v", err)
 			}
@@ -236,7 +235,7 @@ func TestResultsValidateValueError(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			err := tt.Result.Validate(ctx)
 			if err == nil {
 				t.Fatalf("Expected an error, got nothing for %v", tt.Result)

--- a/pkg/apis/pipeline/v1beta1/stepaction_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/stepaction_validation_test.go
@@ -47,7 +47,7 @@ func TestStepActionValidate(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if tt.wc != nil {
 				ctx = tt.wc(ctx)
 			}
@@ -280,7 +280,7 @@ func TestStepActionSpecValidate(t *testing.T) {
 				Results:      tt.fields.Results,
 				VolumeMounts: tt.fields.VolumeMounts,
 			}
-			ctx := context.Background()
+			ctx := t.Context()
 			sa.SetDefaults(ctx)
 			if err := sa.Validate(ctx); err != nil {
 				t.Errorf("StepActionSpec.Validate() = %v", err)
@@ -556,7 +556,7 @@ func TestStepActionValidateError(t *testing.T) {
 					VolumeMounts: tt.fields.VolumeMounts,
 				},
 			}
-			ctx := context.Background()
+			ctx := t.Context()
 			sa.SetDefaults(ctx)
 			err := sa.Validate(ctx)
 			if err == nil {
@@ -961,7 +961,7 @@ func TestStepActionSpecValidateError(t *testing.T) {
 				Params:  tt.fields.Params,
 				Results: tt.fields.Results,
 			}
-			ctx := context.Background()
+			ctx := t.Context()
 			sa.SetDefaults(ctx)
 			err := sa.Validate(ctx)
 			if err == nil {

--- a/pkg/apis/pipeline/v1beta1/task_conversion_test.go
+++ b/pkg/apis/pipeline/v1beta1/task_conversion_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1beta1_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -33,11 +32,11 @@ import (
 func TestTaskConversionBadType(t *testing.T) {
 	good, bad := &v1beta1.Task{}, &v1beta1.Pipeline{}
 
-	if err := good.ConvertTo(context.Background(), bad); err == nil {
+	if err := good.ConvertTo(t.Context(), bad); err == nil {
 		t.Errorf("ConvertTo() = %#v, wanted error", bad)
 	}
 
-	if err := good.ConvertFrom(context.Background(), bad); err == nil {
+	if err := good.ConvertFrom(t.Context(), bad); err == nil {
 		t.Errorf("ConvertFrom() = %#v, wanted error", bad)
 	}
 }
@@ -425,7 +424,7 @@ spec:
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			v1Task := &v1.Task{}
-			if err := test.v1beta1Task.ConvertTo(context.Background(), v1Task); err != nil {
+			if err := test.v1beta1Task.ConvertTo(t.Context(), v1Task); err != nil {
 				t.Errorf("ConvertTo() = %v", err)
 				return
 			}
@@ -434,7 +433,7 @@ spec:
 				t.Errorf("expected v1Task is different from what's converted: %s", d)
 			}
 			gotV1beta1 := &v1beta1.Task{}
-			if err := gotV1beta1.ConvertFrom(context.Background(), v1Task); err != nil {
+			if err := gotV1beta1.ConvertFrom(t.Context(), v1Task); err != nil {
 				t.Errorf("ConvertFrom() = %v", err)
 			}
 			t.Logf("ConvertFrom() = %#v", gotV1beta1)
@@ -506,12 +505,12 @@ func TestTaskConversionFromDeprecated(t *testing.T) {
 		for _, version := range versions {
 			t.Run(test.name, func(t *testing.T) {
 				ver := version
-				if err := test.in.ConvertTo(context.Background(), ver); err != nil {
+				if err := test.in.ConvertTo(t.Context(), ver); err != nil {
 					t.Errorf("ConvertTo() = %v", err)
 				}
 				t.Logf("ConvertTo() = %#v", ver)
 				got := &v1beta1.Task{}
-				if err := got.ConvertFrom(context.Background(), ver); err != nil {
+				if err := got.ConvertFrom(t.Context(), ver); err != nil {
 					t.Errorf("ConvertFrom() = %v", err)
 				}
 				t.Logf("ConvertFrom() = %#v", got)

--- a/pkg/apis/pipeline/v1beta1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation_test.go
@@ -70,7 +70,7 @@ func TestTaskValidate(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if tt.wc != nil {
 				ctx = tt.wc(ctx)
 			}
@@ -145,7 +145,7 @@ func TestTaskSpecValidatePropagatedParamsAndWorkspaces(t *testing.T) {
 				Workspaces:   tt.fields.Workspaces,
 				Results:      tt.fields.Results,
 			}
-			ctx := context.Background()
+			ctx := t.Context()
 			ts.SetDefaults(ctx)
 			if err := ts.Validate(ctx); err != nil {
 				t.Errorf("TaskSpec.Validate() = %v", err)
@@ -553,7 +553,7 @@ func TestTaskSpecValidate(t *testing.T) {
 				Workspaces:   tt.fields.Workspaces,
 				Results:      tt.fields.Results,
 			}
-			ctx := context.Background()
+			ctx := t.Context()
 			ts.SetDefaults(ctx)
 			if err := ts.Validate(ctx); err != nil {
 				t.Errorf("TaskSpec.Validate() = %v", err)
@@ -590,7 +590,7 @@ func TestTaskSpecStepActionReferenceValidate(t *testing.T) {
 			ts := &v1beta1.TaskSpec{
 				Steps: tt.Steps,
 			}
-			ctx := context.Background()
+			ctx := t.Context()
 			ts.SetDefaults(ctx)
 			if err := ts.Validate(ctx); err != nil {
 				t.Errorf("TaskSpec.Validate() = %v", err)
@@ -793,7 +793,7 @@ func TestTaskValidateError(t *testing.T) {
 					Params: tt.fields.Params,
 					Steps:  tt.fields.Steps,
 				}}
-			ctx := cfgtesting.EnableAlphaAPIFields(context.Background())
+			ctx := cfgtesting.EnableAlphaAPIFields(t.Context())
 			task.SetDefaults(ctx)
 			err := task.Validate(ctx)
 			if err == nil {
@@ -1445,7 +1445,7 @@ func TestTaskSpecValidateError(t *testing.T) {
 				Results:      tt.fields.Results,
 				Resources:    tt.fields.Resources,
 			}
-			ctx := context.Background()
+			ctx := t.Context()
 			ts.SetDefaults(ctx)
 			err := ts.Validate(ctx)
 			if err == nil {
@@ -1585,7 +1585,7 @@ func TestTaskSpecValidateErrorWithStepActionRef(t *testing.T) {
 			ts := v1beta1.TaskSpec{
 				Steps: tt.Steps,
 			}
-			ctx := context.Background()
+			ctx := t.Context()
 			ts.SetDefaults(ctx)
 			err := ts.Validate(ctx)
 			if err == nil {
@@ -1688,7 +1688,7 @@ func TestTaskSpecValidateErrorWithStepResultRef(t *testing.T) {
 			ts := v1beta1.TaskSpec{
 				Steps: tt.Steps,
 			}
-			ctx := context.Background()
+			ctx := t.Context()
 			ctx = apis.WithinCreate(ctx)
 			ts.SetDefaults(ctx)
 			err := ts.Validate(ctx)
@@ -1727,7 +1727,7 @@ func TestTaskSpecValidateErrorSidecarName(t *testing.T) {
 				}},
 				Sidecars: tt.sidecars,
 			}
-			err := ts.Validate(context.Background())
+			err := ts.Validate(t.Context())
 			if err == nil {
 				t.Fatalf("Expected an error, got nothing for %v", ts)
 			}
@@ -1772,7 +1772,7 @@ func TestStepAndSidecarWorkspaces(t *testing.T) {
 				Sidecars:   tt.fields.Sidecars,
 				Workspaces: tt.fields.Workspaces,
 			}
-			ctx := cfgtesting.EnableAlphaAPIFields(context.Background())
+			ctx := cfgtesting.EnableAlphaAPIFields(t.Context())
 			ts.SetDefaults(ctx)
 			if err := ts.Validate(ctx); err != nil {
 				t.Errorf("TaskSpec.Validate() = %v", err)
@@ -1829,7 +1829,7 @@ func TestStepAndSidecarWorkspacesErrors(t *testing.T) {
 				Sidecars: tt.fields.Sidecars,
 			}
 
-			ctx := cfgtesting.EnableAlphaAPIFields(context.Background())
+			ctx := cfgtesting.EnableAlphaAPIFields(t.Context())
 			ts.SetDefaults(ctx)
 			err := ts.Validate(ctx)
 			if err == nil {
@@ -1893,7 +1893,7 @@ func TestStepOnError(t *testing.T) {
 				Params: tt.params,
 				Steps:  tt.steps,
 			}
-			ctx := context.Background()
+			ctx := t.Context()
 			ts.SetDefaults(ctx)
 			err := ts.Validate(ctx)
 			if tt.expectedError == nil && err != nil {
@@ -2000,7 +2000,7 @@ func TestIncompatibleAPIVersions(t *testing.T) {
 			testName := fmt.Sprintf("(using %s) %s", version, tt.name)
 			t.Run(testName, func(t *testing.T) {
 				ts := tt.spec
-				ctx := context.Background()
+				ctx := t.Context()
 				if version == "alpha" {
 					ctx = cfgtesting.EnableAlphaAPIFields(ctx)
 				}
@@ -2227,7 +2227,7 @@ func TestParamEnum_Success(t *testing.T) {
 
 	for _, tc := range tcs {
 		cfg := map[string]string{"enable-param-enum": "true"}
-		ctx := cfgtesting.SetFeatureFlags(context.Background(), t, cfg)
+		ctx := cfgtesting.SetFeatureFlags(t.Context(), t, cfg)
 
 		err := v1.ValidateParameterVariables(ctx, []v1.Step{{Image: "foo"}}, tc.params)
 		if err != nil {
@@ -2304,7 +2304,7 @@ func TestParamEnum_Failure(t *testing.T) {
 	}}
 
 	for _, tc := range tcs {
-		ctx := cfgtesting.SetFeatureFlags(context.Background(), t, tc.configMap)
+		ctx := cfgtesting.SetFeatureFlags(t.Context(), t, tc.configMap)
 
 		err := v1beta1.ValidateParameterVariables(ctx, []v1beta1.Step{{Image: "foo"}}, tc.params)
 
@@ -2385,7 +2385,7 @@ func TestTaskSpecValidate_StepResults(t *testing.T) {
 					Results: tt.fields.Results,
 				}},
 			}
-			ctx := context.Background()
+			ctx := t.Context()
 			ts.SetDefaults(ctx)
 			if err := ts.Validate(ctx); err != nil {
 				t.Errorf("TaskSpec.Validate() = %v", err)
@@ -2443,7 +2443,7 @@ func TestTaskSpecValidate_StepResults_Error(t *testing.T) {
 					Results: tt.fields.Results,
 				}},
 			}
-			ctx := context.Background()
+			ctx := t.Context()
 			if tt.isCreate {
 				ctx = apis.WithinCreate(ctx)
 			}
@@ -2526,7 +2526,7 @@ func TestTaskSpecValidateSuccessWithArtifactsRefFlagEnabled(t *testing.T) {
 			ts := v1beta1.TaskSpec{
 				Steps: tt.Steps,
 			}
-			ctx := config.ToContext(context.Background(), &config.Config{
+			ctx := config.ToContext(t.Context(), &config.Config{
 				FeatureFlags: &config.FeatureFlags{
 					EnableArtifacts: true,
 				},
@@ -2632,7 +2632,7 @@ func TestTaskSpecValidateErrorWithArtifactsRefFlagNotEnabled(t *testing.T) {
 			ts := v1beta1.TaskSpec{
 				Steps: tt.Steps,
 			}
-			ctx := context.Background()
+			ctx := t.Context()
 			ctx = apis.WithinCreate(ctx)
 			ts.SetDefaults(ctx)
 			err := ts.Validate(ctx)
@@ -2728,7 +2728,7 @@ func TestTaskSpecValidateErrorWithArtifactsRef(t *testing.T) {
 			ts := v1beta1.TaskSpec{
 				Steps: tt.Steps,
 			}
-			ctx := context.Background()
+			ctx := t.Context()
 			ctx = apis.WithinCreate(ctx)
 			ts.SetDefaults(ctx)
 			err := ts.Validate(ctx)
@@ -2768,7 +2768,7 @@ func TestTaskSpecValidate_StepWhen_Error(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := config.ToContext(context.Background(), &config.Config{
+			ctx := config.ToContext(t.Context(), &config.Config{
 				FeatureFlags: &config.FeatureFlags{
 					EnableCELInWhenExpression: tt.EnableCEL,
 				},

--- a/pkg/apis/pipeline/v1beta1/taskref_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskref_validation_test.go
@@ -63,7 +63,7 @@ func TestTaskRef_Valid(t *testing.T) {
 	}}
 	for _, ts := range tests {
 		t.Run(ts.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if ts.wc != nil {
 				ctx = ts.wc(ctx)
 			}
@@ -134,7 +134,7 @@ func TestTaskRef_Invalid(t *testing.T) {
 	}}
 	for _, ts := range tests {
 		t.Run(ts.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if ts.wc != nil {
 				ctx = ts.wc(ctx)
 			}

--- a/pkg/apis/pipeline/v1beta1/taskrun_conversion_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_conversion_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1beta1_test
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -37,11 +36,11 @@ import (
 func TestTaskRunConversionBadType(t *testing.T) {
 	good, bad := &v1beta1.TaskRun{}, &v1beta1.Task{}
 
-	if err := good.ConvertTo(context.Background(), bad); err == nil {
+	if err := good.ConvertTo(t.Context(), bad); err == nil {
 		t.Errorf("ConvertTo() = %#v, wanted error", bad)
 	}
 
-	if err := good.ConvertFrom(context.Background(), bad); err == nil {
+	if err := good.ConvertFrom(t.Context(), bad); err == nil {
 		t.Errorf("ConvertFrom() = %#v, wanted error", good)
 	}
 }
@@ -373,13 +372,13 @@ func TestTaskRunConversion(t *testing.T) {
 		for _, version := range versions {
 			t.Run(test.name, func(t *testing.T) {
 				ver := version
-				if err := test.in.ConvertTo(context.Background(), ver); err != nil {
+				if err := test.in.ConvertTo(t.Context(), ver); err != nil {
 					t.Errorf("ConvertTo() = %v", err)
 					return
 				}
 				t.Logf("ConvertTo() =%v", ver)
 				got := &v1beta1.TaskRun{}
-				if err := got.ConvertFrom(context.Background(), ver); err != nil {
+				if err := got.ConvertFrom(t.Context(), ver); err != nil {
 					t.Errorf("ConvertFrom() = %v", err)
 				}
 				t.Logf("ConvertFrom() =%v", got)
@@ -660,12 +659,12 @@ func TestTaskRunConversionFromDeprecated(t *testing.T) {
 		for _, version := range versions {
 			t.Run(test.name, func(t *testing.T) {
 				ver := version
-				if err := test.in.ConvertTo(context.Background(), ver); err != nil {
+				if err := test.in.ConvertTo(t.Context(), ver); err != nil {
 					t.Errorf("ConvertTo() = %v", err)
 				}
 				t.Logf("ConvertTo() = %#v", ver)
 				got := &v1beta1.TaskRun{}
-				if err := got.ConvertFrom(context.Background(), ver); err != nil {
+				if err := got.ConvertFrom(t.Context(), ver); err != nil {
 					t.Errorf("ConvertFrom() = %v", err)
 				}
 				t.Logf("ConvertFrom() = %#v", got)
@@ -750,7 +749,7 @@ func TestTaskRunConvertTo(t *testing.T) {
 		for _, version := range versions {
 			t.Run(test.name, func(t *testing.T) {
 				ver := version
-				if err := test.in.ConvertTo(context.Background(), ver); err != nil {
+				if err := test.in.ConvertTo(t.Context(), ver); err != nil {
 					t.Errorf("ConvertTo() = %v", err)
 				}
 				if d := cmp.Diff(test.want, ver); d != "" {
@@ -816,7 +815,7 @@ func TestTaskRunConvertFrom(t *testing.T) {
 		for _, version := range versions {
 			t.Run(test.name, func(t *testing.T) {
 				got := version
-				if err := got.ConvertFrom(context.Background(), test.in); err != nil {
+				if err := got.ConvertFrom(t.Context(), test.in); err != nil {
 					t.Errorf("ConvertFrom() = %v", err)
 				}
 				t.Logf("ConvertFrom() =%v", got)

--- a/pkg/apis/pipeline/v1beta1/taskrun_defaults_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_defaults_test.go
@@ -16,7 +16,6 @@ limitations under the License.
 package v1beta1_test
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -111,7 +110,7 @@ func TestTaskRunSpec_SetDefaults(t *testing.T) {
 	}}
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			tc.trs.SetDefaults(ctx)
 
 			if d := cmp.Diff(tc.want, tc.trs); d != "" {
@@ -391,7 +390,7 @@ func TestTaskRunDefaulting(t *testing.T) {
 	}}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := cfgtesting.SetDefaults(context.Background(), t, tc.defaults)
+			ctx := cfgtesting.SetDefaults(t.Context(), t, tc.defaults)
 			got := tc.in
 			got.SetDefaults(ctx)
 			if !cmp.Equal(got, tc.want, ignoreUnexportedResources) {
@@ -437,7 +436,7 @@ func TestTaskRunDefaultingOnCreate(t *testing.T) {
 	}}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := apis.WithinCreate(cfgtesting.SetDefaults(context.Background(), t, tc.defaults))
+			ctx := apis.WithinCreate(cfgtesting.SetDefaults(t.Context(), t, tc.defaults))
 			got := tc.in
 			got.SetDefaults(ctx)
 			if !cmp.Equal(got, tc.want, ignoreUnexportedResources) {

--- a/pkg/apis/pipeline/v1beta1/taskrun_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_types_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1beta1_test
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -425,7 +424,7 @@ func TestHasTimedOut(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := tc.taskRun.HasTimedOut(context.Background(), testClock)
+			result := tc.taskRun.HasTimedOut(t.Context(), testClock)
 			if d := cmp.Diff(tc.expectedStatus, result); d != "" {
 				t.Fatal(diff.PrintWantGot(d))
 			}

--- a/pkg/apis/pipeline/v1beta1/taskrun_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_validation_test.go
@@ -163,7 +163,7 @@ func TestTaskRun_Invalidate(t *testing.T) {
 	}}
 	for _, ts := range tests {
 		t.Run(ts.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if ts.wc != nil {
 				ctx = ts.wc(ctx)
 			}
@@ -471,7 +471,7 @@ func TestTaskRun_Validate(t *testing.T) {
 	}}
 	for _, ts := range tests {
 		t.Run(ts.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if ts.wc != nil {
 				ctx = ts.wc(ctx)
 			}
@@ -519,7 +519,7 @@ func TestTaskRun_Workspaces_Invalid(t *testing.T) {
 	}}
 	for _, ts := range tests {
 		t.Run(ts.name, func(t *testing.T) {
-			err := ts.tr.Validate(context.Background())
+			err := ts.tr.Validate(t.Context())
 			if err == nil {
 				t.Errorf("Expected error for invalid TaskRun but got none")
 			}
@@ -848,7 +848,7 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 
 	for _, ts := range tests {
 		t.Run(ts.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if ts.wc != nil {
 				ctx = ts.wc(ctx)
 			}
@@ -946,7 +946,7 @@ func TestTaskRunSpec_Validate(t *testing.T) {
 
 	for _, ts := range tests {
 		t.Run(ts.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if ts.wc != nil {
 				ctx = ts.wc(ctx)
 			}
@@ -1083,7 +1083,7 @@ func TestTaskRunSpec_ValidateUpdate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := config.ToContext(context.Background(), &config.Config{
+			ctx := config.ToContext(t.Context(), &config.Config{
 				FeatureFlags: &config.FeatureFlags{},
 				Defaults:     &config.Defaults{},
 			})

--- a/pkg/apis/pipeline/v1beta1/when_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/when_validation_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"context"
 	"testing"
 
 	"github.com/tektoncd/pipeline/pkg/apis/config"
@@ -56,7 +55,7 @@ func TestWhenExpressions_Valid(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := tt.wes.validate(context.Background()); err != nil {
+			if err := tt.wes.validate(t.Context()); err != nil {
 				t.Errorf("WhenExpressions.validate() returned an error for valid when expressions: %s", tt.wes)
 			}
 		})
@@ -99,7 +98,7 @@ func TestWhenExpressions_Invalid(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := tt.wes.validate(context.Background()); err == nil {
+			if err := tt.wes.validate(t.Context()); err == nil {
 				t.Errorf("WhenExpressions.validate() did not return error for invalid when expressions: %s, %s", tt.wes, err)
 			}
 		})
@@ -107,7 +106,7 @@ func TestWhenExpressions_Invalid(t *testing.T) {
 }
 
 func TestCELinWhenExpressions_Valid(t *testing.T) {
-	ctx := config.ToContext(context.Background(), &config.Config{
+	ctx := config.ToContext(t.Context(), &config.Config{
 		FeatureFlags: &config.FeatureFlags{
 			EnableCELInWhenExpression: true,
 		},
@@ -190,7 +189,7 @@ func TestCELWhenExpressions_Invalid(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := config.ToContext(context.Background(), &config.Config{
+			ctx := config.ToContext(t.Context(), &config.Config{
 				FeatureFlags: &config.FeatureFlags{
 					EnableCELInWhenExpression: tt.enableCELInWhenExpression,
 				},

--- a/pkg/apis/pipeline/v1beta1/workspace_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/workspace_validation_test.go
@@ -111,7 +111,7 @@ func TestWorkspaceBindingValidateValid(t *testing.T) {
 		},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if tc.wc != nil {
 				ctx = tc.wc(ctx)
 			}
@@ -178,7 +178,7 @@ func TestWorkspaceBindingValidateInvalid(t *testing.T) {
 		},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if tc.wc != nil {
 				ctx = tc.wc(ctx)
 			}

--- a/pkg/apis/resolution/v1alpha1/resolution_request_conversion_test.go
+++ b/pkg/apis/resolution/v1alpha1/resolution_request_conversion_test.go
@@ -18,7 +18,6 @@
 package v1alpha1_test
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -34,11 +33,11 @@ import (
 func TestResolutionRequestConversionBadType(t *testing.T) {
 	good, bad := &v1alpha1.ResolutionRequest{}, &pipelinev1.Task{}
 
-	if err := good.ConvertTo(context.Background(), bad); err == nil {
+	if err := good.ConvertTo(t.Context(), bad); err == nil {
 		t.Errorf("ConvertTo() = %#v, wanted error", bad)
 	}
 
-	if err := good.ConvertFrom(context.Background(), bad); err == nil {
+	if err := good.ConvertFrom(t.Context(), bad); err == nil {
 		t.Errorf("ConvertFrom() = %#v, wanted error", good)
 	}
 }
@@ -103,7 +102,7 @@ func TestResolutionRequestConvertTo(t *testing.T) {
 		for _, version := range versions {
 			t.Run(tc.name, func(t *testing.T) {
 				got := version
-				if err := tc.in.ConvertTo(context.Background(), got); err != nil {
+				if err := tc.in.ConvertTo(t.Context(), got); err != nil {
 					t.Fatalf("ConvertTo() = %v", err)
 				}
 				t.Logf("ConvertTo() = %#v", got)
@@ -203,7 +202,7 @@ func TestResolutionRequestConvertFrom(t *testing.T) {
 		for _, version := range versions {
 			t.Run(tc.name, func(t *testing.T) {
 				got := version
-				err := got.ConvertFrom(context.Background(), tc.in)
+				err := got.ConvertFrom(t.Context(), tc.in)
 				if tc.expectedErr != nil {
 					if err == nil {
 						t.Fatalf("expected error '%s', but did not get an error", tc.expectedErr.Error())

--- a/pkg/apis/resolution/v1beta1/resolution_request_conversion_test.go
+++ b/pkg/apis/resolution/v1beta1/resolution_request_conversion_test.go
@@ -18,7 +18,6 @@
 package v1beta1_test
 
 import (
-	"context"
 	"testing"
 
 	pipelinev1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -28,11 +27,11 @@ import (
 func TestResolutionRequestConversionBadType(t *testing.T) {
 	good, bad := &v1beta1.ResolutionRequest{}, &pipelinev1beta1.Task{}
 
-	if err := good.ConvertTo(context.Background(), bad); err == nil {
+	if err := good.ConvertTo(t.Context(), bad); err == nil {
 		t.Errorf("ConvertTo() = %#v, wanted error", bad)
 	}
 
-	if err := good.ConvertFrom(context.Background(), bad); err == nil {
+	if err := good.ConvertFrom(t.Context(), bad); err == nil {
 		t.Errorf("ConvertFrom() = %#v, wanted error", good)
 	}
 }

--- a/pkg/apis/version/featureflags_validation_test.go
+++ b/pkg/apis/version/featureflags_validation_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package version_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/tektoncd/pipeline/pkg/apis/config"
@@ -65,7 +64,7 @@ func TestValidateEnabledAPIFields(t *testing.T) {
 			cfg := &config.Config{
 				FeatureFlags: flags,
 			}
-			ctx := config.ToContext(context.Background(), cfg)
+			ctx := config.ToContext(t.Context(), cfg)
 			if err := version.ValidateEnabledAPIFields(ctx, "test feature", tc.wantVersion); err != nil {
 				t.Errorf("unexpected error for compatible feature gates: %q", err)
 			}
@@ -106,7 +105,7 @@ func TestValidateEnabledAPIFieldsError(t *testing.T) {
 			cfg := &config.Config{
 				FeatureFlags: flags,
 			}
-			ctx := config.ToContext(context.Background(), cfg)
+			ctx := config.ToContext(t.Context(), cfg)
 			fieldErr := version.ValidateEnabledAPIFields(ctx, "test feature", tc.wantVersion)
 
 			if fieldErr == nil {

--- a/pkg/entrypoint/entrypointer_test.go
+++ b/pkg/entrypoint/entrypointer_test.go
@@ -406,7 +406,7 @@ func TestReadResultsFromDisk(t *testing.T) {
 		},
 	} {
 		t.Run(c.desc, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			terminationPath := "termination"
 			if terminationFile, err := os.CreateTemp(t.TempDir(), "termination"); err != nil {
 				t.Fatalf("unexpected error creating temporary termination file: %v", err)
@@ -653,7 +653,7 @@ func TestEntrypointerResults(t *testing.T) {
 		signVerify:      true,
 	}} {
 		t.Run(c.desc, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			fw, fpw := &fakeWaiter{}, &fakePostWriter{}
 			var fr Runner = &fakeRunner{}
 			timeout := time.Duration(0)
@@ -759,7 +759,7 @@ func Test_waitingCancellation(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
+			ctx, cancel := context.WithCancel(t.Context())
 			fw := &fakeWaiter{}
 			err := Entrypointer{
 				Waiter: fw,

--- a/pkg/internal/affinityassistant/affinityassistant_types_test.go
+++ b/pkg/internal/affinityassistant/affinityassistant_types_test.go
@@ -14,7 +14,6 @@ limitations under the License.
 package affinityassistant
 
 import (
-	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -56,7 +55,7 @@ func Test_GetAffinityAssistantBehavior(t *testing.T) {
 	}}
 
 	for _, tc := range tcs {
-		ctx := cfgtesting.SetFeatureFlags(context.Background(), t, tc.configMap)
+		ctx := cfgtesting.SetFeatureFlags(t.Context(), t, tc.configMap)
 		get, err := GetAffinityAssistantBehavior(ctx)
 		if err != nil {
 			t.Fatalf("%s: unexpected error when getting affinity assistant behavior: %v", tc.name, err)

--- a/pkg/internal/affinityassistant/transformer_test.go
+++ b/pkg/internal/affinityassistant/transformer_test.go
@@ -16,7 +16,6 @@ limitations under the License.
 package affinityassistant_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -76,7 +75,7 @@ func TestNewTransformer(t *testing.T) {
 		},
 	}} {
 		t.Run(tc.description, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			f := affinityassistant.NewTransformer(ctx, tc.annotations)
 			got, err := f(&corev1.Pod{})
 			if err != nil {
@@ -228,7 +227,7 @@ func TestNewTransformerWithNodeAffinity(t *testing.T) {
 	},
 	} {
 		t.Run(tc.description, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			f := affinityassistant.NewTransformer(ctx, tc.annotations)
 			got, err := f(tc.pod)
 			if err != nil {

--- a/pkg/internal/defaultresourcerequirements/transformer_test.go
+++ b/pkg/internal/defaultresourcerequirements/transformer_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package defaultresourcerequirements
 
 import (
-	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -392,7 +391,7 @@ func TestNewTransformer(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			// add default container resource requirements on the context
 			ctx = config.ToContext(ctx, &config.Config{
 				Defaults: &config.Defaults{

--- a/pkg/pod/creds_init_test.go
+++ b/pkg/pod/creds_init_test.go
@@ -60,7 +60,7 @@ func TestCredsInit(t *testing.T) {
 		},
 		wantArgs:         nil,
 		wantVolumeMounts: nil,
-		ctx:              context.Background(),
+		ctx:              t.Context(),
 	}, {
 		desc: "service account has no annotated secrets; nothing to initialize",
 		objs: []runtime.Object{
@@ -82,7 +82,7 @@ func TestCredsInit(t *testing.T) {
 		},
 		wantArgs:         nil,
 		wantVolumeMounts: nil,
-		ctx:              context.Background(),
+		ctx:              t.Context(),
 	}, {
 		desc: "service account has annotated secret and no HOME env var passed in; initialize creds in /tekton/creds",
 		objs: []runtime.Object{
@@ -121,7 +121,7 @@ func TestCredsInit(t *testing.T) {
 			Name:      "tekton-internal-secret-volume-my-creds-9l9zj",
 			MountPath: "/tekton/creds-secrets/my-creds",
 		}},
-		ctx: context.Background(),
+		ctx: t.Context(),
 	}, {
 		desc: "service account has duplicate dockerconfigjson secret and no HOME env var passed in; initialize creds in /tekton/creds",
 		objs: []runtime.Object{
@@ -154,7 +154,7 @@ func TestCredsInit(t *testing.T) {
 			Name:      "tekton-internal-secret-volume-my-docker-creds-9l9zj",
 			MountPath: "/tekton/creds-secrets/my-docker-creds",
 		}},
-		ctx: context.Background(),
+		ctx: t.Context(),
 	}, {
 		desc: "service account with secret and HOME env var passed in",
 		objs: []runtime.Object{
@@ -193,7 +193,7 @@ func TestCredsInit(t *testing.T) {
 			Name:      "tekton-internal-secret-volume-my-creds-9l9zj",
 			MountPath: "/tekton/creds-secrets/my-creds",
 		}},
-		ctx: context.Background(),
+		ctx: t.Context(),
 	}, {
 		desc: "disabling legacy credential helper (creds-init) via feature-flag results in no args or volumes",
 		objs: []runtime.Object{
@@ -224,7 +224,7 @@ func TestCredsInit(t *testing.T) {
 		envVars:          []corev1.EnvVar{customHomeEnvVar},
 		wantArgs:         nil,
 		wantVolumeMounts: nil,
-		ctx: config.ToContext(context.Background(), &config.Config{
+		ctx: config.ToContext(t.Context(), &config.Config{
 			FeatureFlags: &config.FeatureFlags{
 				DisableCredsInit: true,
 			},
@@ -257,7 +257,7 @@ func TestCredsInit(t *testing.T) {
 			Name:      "tekton-internal-secret-volume-foo-bar-com-9l9zj",
 			MountPath: "/tekton/creds-secrets/foo.bar.com",
 		}},
-		ctx: context.Background(),
+		ctx: t.Context(),
 	}, {
 		desc: "service account has empty-named secrets",
 		objs: []runtime.Object{
@@ -290,7 +290,7 @@ func TestCredsInit(t *testing.T) {
 			Name:      "tekton-internal-secret-volume-my-creds-9l9zj",
 			MountPath: "/tekton/creds-secrets/my-creds",
 		}},
-		ctx: context.Background(),
+		ctx: t.Context(),
 	}, {
 		desc: "service account has not found secrets",
 		objs: []runtime.Object{
@@ -328,7 +328,7 @@ func TestCredsInit(t *testing.T) {
 		events: []string{
 			`Warning FailedToRetrieveSecret Unable to retrieve some secrets (not-exist-1, not-exist-2); attempting to use them may not succeed.`,
 		},
-		ctx: context.Background(),
+		ctx: t.Context(),
 	}} {
 		t.Run(c.desc, func(t *testing.T) {
 			names.TestingSeed()
@@ -438,7 +438,7 @@ func TestCheckGitSSHSecret(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			store := config.NewStore(logtesting.TestLogger(t))
 			store.OnConfigChanged(tc.configMap)
-			err := checkGitSSHSecret(store.ToContext(context.Background()), tc.secret)
+			err := checkGitSSHSecret(store.ToContext(t.Context()), tc.secret)
 
 			if wantError := tc.wantErrorMsg != ""; wantError {
 				if err == nil {

--- a/pkg/pod/entrypoint_lookup_impl_test.go
+++ b/pkg/pod/entrypoint_lookup_impl_test.go
@@ -98,7 +98,7 @@ func generateSecret(host string, username string, password string) *corev1.Secre
 }
 
 func TestGetImageWithImagePullSecrets(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 

--- a/pkg/pod/entrypoint_lookup_test.go
+++ b/pkg/pod/entrypoint_lookup_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func TestResolveEntrypoints(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 

--- a/pkg/pod/entrypoint_test.go
+++ b/pkg/pod/entrypoint_test.go
@@ -97,7 +97,7 @@ func TestOrderContainers(t *testing.T) {
 		},
 		TerminationMessagePath: "/tekton/termination",
 	}}
-	got, err := orderContainers(context.Background(), []string{}, steps, nil, nil, true, false)
+	got, err := orderContainers(t.Context(), []string{}, steps, nil, nil, true, false)
 	if err != nil {
 		t.Fatalf("orderContainers: %v", err)
 	}
@@ -165,7 +165,7 @@ func TestOrderContainersWithResultsSidecarLogs(t *testing.T) {
 		},
 		TerminationMessagePath: "/tekton/termination",
 	}}
-	got, err := orderContainers(context.Background(), []string{"-dont_send_results_to_termination_path"}, steps, nil, nil, true, false)
+	got, err := orderContainers(t.Context(), []string{"-dont_send_results_to_termination_path"}, steps, nil, nil, true, false)
 	if err != nil {
 		t.Fatalf("orderContainers: %v", err)
 	}
@@ -211,7 +211,7 @@ func TestOrderContainersWithNoWait(t *testing.T) {
 		VolumeMounts:           []corev1.VolumeMount{volumeMount},
 		TerminationMessagePath: "/tekton/termination",
 	}}
-	got, err := orderContainers(context.Background(), []string{}, steps, nil, nil, false, false)
+	got, err := orderContainers(t.Context(), []string{}, steps, nil, nil, false, false)
 	if err != nil {
 		t.Fatalf("orderContainers: %v", err)
 	}
@@ -247,7 +247,7 @@ func TestOrderContainersWithDebugOnFailure(t *testing.T) {
 			OnFailure: "enabled",
 		},
 	}
-	got, err := orderContainers(context.Background(), []string{}, steps, nil, taskRunDebugConfig, true, false)
+	got, err := orderContainers(t.Context(), []string{}, steps, nil, taskRunDebugConfig, true, false)
 	if err != nil {
 		t.Fatalf("orderContainers: %v", err)
 	}
@@ -284,7 +284,7 @@ func TestTestOrderContainersWithDebugBeforeStep(t *testing.T) {
 			BeforeSteps: []string{"my-task"},
 		},
 	}
-	got, err := orderContainers(context.Background(), []string{}, steps, nil, taskRunDebugConfig, true, false)
+	got, err := orderContainers(t.Context(), []string{}, steps, nil, taskRunDebugConfig, true, false)
 	if err != nil {
 		t.Fatalf("orderContainers: %v", err)
 	}
@@ -323,7 +323,7 @@ func TestTestOrderContainersWithAllBreakpoints(t *testing.T) {
 			BeforeSteps: []string{"my-task"},
 		},
 	}
-	got, err := orderContainers(context.Background(), []string{}, steps, nil, taskRunDebugConfig, true, false)
+	got, err := orderContainers(t.Context(), []string{}, steps, nil, taskRunDebugConfig, true, false)
 	if err != nil {
 		t.Fatalf("orderContainers: %v", err)
 	}
@@ -351,7 +351,7 @@ func TestOrderContainersWithEnabelKeepPodOnCancel(t *testing.T) {
 		VolumeMounts:           []corev1.VolumeMount{downwardMount},
 		TerminationMessagePath: "/tekton/termination",
 	}}
-	got, err := orderContainers(context.Background(), []string{}, steps, nil, nil, false, true)
+	got, err := orderContainers(t.Context(), []string{}, steps, nil, nil, false, true)
 	if err != nil {
 		t.Fatalf("orderContainers: %v", err)
 	}
@@ -426,7 +426,7 @@ func TestEntryPointStepActionResults(t *testing.T) {
 		VolumeMounts:           []corev1.VolumeMount{downwardMount},
 		TerminationMessagePath: "/tekton/termination",
 	}}
-	ctx := context.Background()
+	ctx := t.Context()
 	got, err := orderContainers(ctx, []string{}, steps, &taskSpec, nil, true, false)
 	if err != nil {
 		t.Fatalf("orderContainers: %v", err)
@@ -450,7 +450,7 @@ func TestEntryPointStepWhen(t *testing.T) {
 			When:    v1.StepWhenExpressions{{Input: "foo", Operator: selection.In, Values: []string{"foo", "bar"}}},
 		},
 	}}
-	got, err := orderContainers(context.Background(), []string{}, containers, &ts, nil, true, false)
+	got, err := orderContainers(t.Context(), []string{}, containers, &ts, nil, true, false)
 	if err != nil {
 		t.Fatalf("orderContainers: %v", err)
 	}
@@ -545,7 +545,7 @@ func TestEntryPointResults(t *testing.T) {
 		},
 		TerminationMessagePath: "/tekton/termination",
 	}}
-	got, err := orderContainers(context.Background(), []string{}, steps, &taskSpec, nil, true, false)
+	got, err := orderContainers(t.Context(), []string{}, steps, &taskSpec, nil, true, false)
 	if err != nil {
 		t.Fatalf("orderContainers: %v", err)
 	}
@@ -586,7 +586,7 @@ func TestEntryPointResultsSingleStep(t *testing.T) {
 		VolumeMounts:           []corev1.VolumeMount{downwardMount},
 		TerminationMessagePath: "/tekton/termination",
 	}}
-	got, err := orderContainers(context.Background(), []string{}, steps, &taskSpec, nil, true, false)
+	got, err := orderContainers(t.Context(), []string{}, steps, &taskSpec, nil, true, false)
 	if err != nil {
 		t.Fatalf("orderContainers: %v", err)
 	}
@@ -623,7 +623,7 @@ func TestEntryPointSingleResultsSingleStep(t *testing.T) {
 		VolumeMounts:           []corev1.VolumeMount{downwardMount},
 		TerminationMessagePath: "/tekton/termination",
 	}}
-	got, err := orderContainers(context.Background(), []string{}, steps, &taskSpec, nil, true, false)
+	got, err := orderContainers(t.Context(), []string{}, steps, &taskSpec, nil, true, false)
 	if err != nil {
 		t.Fatalf("orderContainers: %v", err)
 	}
@@ -694,7 +694,7 @@ func TestEntryPointOnError(t *testing.T) {
 		err: errors.New("task step onError must be either \"continue\" or \"stopAndFail\" but it is set to an invalid value \"invalid-on-error\""),
 	}} {
 		t.Run(tc.desc, func(t *testing.T) {
-			got, err := orderContainers(context.Background(), []string{}, steps, &tc.taskSpec, nil, true, false)
+			got, err := orderContainers(t.Context(), []string{}, steps, &tc.taskSpec, nil, true, false)
 			if len(tc.wantContainers) == 0 {
 				if err == nil {
 					t.Fatalf("expected an error for an invalid value for onError but received none")
@@ -793,7 +793,7 @@ func TestEntryPointStepOutputConfigs(t *testing.T) {
 		},
 		TerminationMessagePath: "/tekton/termination",
 	}}
-	got, err := orderContainers(context.Background(), []string{}, steps, &taskSpec, nil, true, false)
+	got, err := orderContainers(t.Context(), []string{}, steps, &taskSpec, nil, true, false)
 	if err != nil {
 		t.Fatalf("orderContainers: %v", err)
 	}
@@ -884,7 +884,7 @@ func TestUpdateReady(t *testing.T) {
 		wantPatch: false,
 	}} {
 		t.Run(c.desc, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 			kubeclient := fakek8s.NewSimpleClientset(&c.pod)
@@ -1077,7 +1077,7 @@ func TestStopSidecars(t *testing.T) {
 		wantContainers: []corev1.Container{stepContainer, sidecarContainer, injectedSidecar},
 	}} {
 		t.Run(c.desc, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if c.resultExtractionMethod != "" {
 				ctx = config.ToContext(ctx, &config.Config{
 					FeatureFlags: &config.FeatureFlags{
@@ -1134,7 +1134,7 @@ func TestCancelPod(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := CancelPod(context.Background(), kubeClient, tc.args.namespace, tc.args.podName)
+			err := CancelPod(t.Context(), kubeClient, tc.args.namespace, tc.args.podName)
 			if (err != nil) != tc.expectedErr {
 				t.Errorf("expected error: %v, but got: %v", tc.expectedErr, err)
 			}

--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package pod
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -2645,7 +2644,7 @@ _EOF_
 				KubeClient:      kubeclient,
 				EntrypointCache: entrypointCache,
 			}
-			got, err := builder.Build(store.ToContext(context.Background()), tr, c.ts)
+			got, err := builder.Build(store.ToContext(t.Context()), tr, c.ts)
 			if err != nil {
 				t.Fatalf("builder.Build: %v", err)
 			}
@@ -2852,7 +2851,7 @@ debug-fail-continue-heredoc-randomly-generated-mz4c7
 				EntrypointCache: entrypointCache,
 			}
 
-			got, err := builder.Build(store.ToContext(context.Background()), tr, c.ts)
+			got, err := builder.Build(store.ToContext(t.Context()), tr, c.ts)
 			if err != nil {
 				t.Fatalf("builder.Build: %v", err)
 			}
@@ -3058,7 +3057,7 @@ func TestPodBuild_TaskLevelResourceRequirements(t *testing.T) {
 				Spec: tc.trs,
 			}
 
-			gotPod, err := builder.Build(store.ToContext(context.Background()), tr, tc.ts)
+			gotPod, err := builder.Build(store.ToContext(t.Context()), tr, tc.ts)
 			if err != nil {
 				t.Fatalf("builder.Build: %v", err)
 			}
@@ -3210,7 +3209,7 @@ func TestPodBuildwithSpireEnabled(t *testing.T) {
 				EntrypointCache: entrypointCache,
 			}
 
-			got, err := builder.Build(store.ToContext(context.Background()), tr, c.ts)
+			got, err := builder.Build(store.ToContext(t.Context()), tr, c.ts)
 			if err != nil {
 				t.Fatalf("builder.Build: %v", err)
 			}
@@ -3768,7 +3767,7 @@ func TestPodBuildWithK8s129(t *testing.T) {
 		KubeClient:      kubeclient,
 		EntrypointCache: entrypointCache,
 	}
-	got, err := builder.Build(store.ToContext(context.Background()), tr, ts)
+	got, err := builder.Build(store.ToContext(t.Context()), tr, ts)
 	if err != nil {
 		t.Errorf("Pod build failed: %s", err)
 	}

--- a/pkg/pod/status_test.go
+++ b/pkg/pod/status_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package pod
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -221,7 +220,7 @@ func TestSetTaskRunStatusBasedOnStepStatus_sidecar_logs(t *testing.T) {
 					Phase: corev1.PodRunning,
 				},
 			}
-			pod, err := kubeclient.CoreV1().Pods(pod.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+			pod, err := kubeclient.CoreV1().Pods(pod.Namespace).Create(t.Context(), pod, metav1.CreateOptions{})
 			if err != nil {
 				t.Errorf("Error occurred while creating pod %s: %s", pod.Name, err.Error())
 			}
@@ -234,7 +233,7 @@ func TestSetTaskRunStatusBasedOnStepStatus_sidecar_logs(t *testing.T) {
 				featureFlags.EnableArtifacts = true
 				ts.Steps = []v1.Step{{Name: "name", Script: `echo aaa >> /tekton/steps/step-name/artifacts/provenance.json`}}
 			}
-			ctx := config.ToContext(context.Background(), &config.Config{
+			ctx := config.ToContext(t.Context(), &config.Config{
 				FeatureFlags: featureFlags,
 			})
 			gotErr := setTaskRunStatusBasedOnStepStatus(ctx, logger, []corev1.ContainerStatus{{}}, &c.tr, pod.Status.Phase, kubeclient, ts)
@@ -476,7 +475,7 @@ func TestMakeTaskRunStatus_StepResults(t *testing.T) {
 
 			logger, _ := logging.NewLogger("", "status")
 			kubeclient := fakek8s.NewSimpleClientset()
-			got, err := MakeTaskRunStatus(context.Background(), logger, c.tr, &c.pod, kubeclient, c.tr.Spec.TaskSpec)
+			got, err := MakeTaskRunStatus(t.Context(), logger, c.tr, &c.pod, kubeclient, c.tr.Spec.TaskSpec)
 			if err != nil {
 				t.Errorf("MakeTaskRunResult: %s", err)
 			}
@@ -649,7 +648,7 @@ func TestMakeTaskRunStatus_StepProvenance(t *testing.T) {
 
 			logger, _ := logging.NewLogger("", "status")
 			kubeclient := fakek8s.NewSimpleClientset()
-			got, err := MakeTaskRunStatus(context.Background(), logger, c.tr, &c.pod, kubeclient, c.tr.Spec.TaskSpec)
+			got, err := MakeTaskRunStatus(t.Context(), logger, c.tr, &c.pod, kubeclient, c.tr.Spec.TaskSpec)
 			if err != nil {
 				t.Errorf("MakeTaskRunResult: %s", err)
 			}
@@ -791,7 +790,7 @@ func TestMakeTaskRunStatus_StepArtifacts(t *testing.T) {
 
 			logger, _ := logging.NewLogger("", "status")
 			kubeclient := fakek8s.NewSimpleClientset()
-			got, err := MakeTaskRunStatus(context.Background(), logger, c.tr, &c.pod, kubeclient, c.tr.Spec.TaskSpec)
+			got, err := MakeTaskRunStatus(t.Context(), logger, c.tr, &c.pod, kubeclient, c.tr.Spec.TaskSpec)
 			if err != nil {
 				t.Errorf("MakeTaskRunResult: %s", err)
 			}
@@ -1969,7 +1968,7 @@ func TestMakeTaskRunStatus(t *testing.T) {
 			}
 			logger, _ := logging.NewLogger("", "status")
 			kubeclient := fakek8s.NewSimpleClientset()
-			got, err := MakeTaskRunStatus(context.Background(), logger, tr, &c.pod, kubeclient, &v1.TaskSpec{})
+			got, err := MakeTaskRunStatus(t.Context(), logger, tr, &c.pod, kubeclient, &v1.TaskSpec{})
 			if err != nil {
 				t.Errorf("MakeTaskRunResult: %s", err)
 			}
@@ -2056,7 +2055,7 @@ func TestMakeRunStatus_OnError(t *testing.T) {
 
 			logger, _ := logging.NewLogger("", "status")
 			kubeclient := fakek8s.NewSimpleClientset()
-			got, err := MakeTaskRunStatus(context.Background(), logger, tr, &pod, kubeclient, &v1.TaskSpec{})
+			got, err := MakeTaskRunStatus(t.Context(), logger, tr, &pod, kubeclient, &v1.TaskSpec{})
 			if err != nil {
 				t.Errorf("Unexpected err in MakeTaskRunResult: %s", err)
 			}
@@ -2180,7 +2179,7 @@ func TestMakeTaskRunStatus_SidecarNotCompleted(t *testing.T) {
 			}
 			logger, _ := logging.NewLogger("", "status")
 			kubeclient := fakek8s.NewSimpleClientset()
-			ctx := config.ToContext(context.Background(), &config.Config{
+			ctx := config.ToContext(t.Context(), &config.Config{
 				FeatureFlags: &config.FeatureFlags{
 					ResultExtractionMethod: config.ResultExtractionMethodSidecarLogs,
 					MaxResultSize:          1024,
@@ -2457,7 +2456,7 @@ func TestMakeTaskRunStatusAlpha(t *testing.T) {
 			}
 			logger, _ := logging.NewLogger("", "status")
 			kubeclient := fakek8s.NewSimpleClientset()
-			got, err := MakeTaskRunStatus(context.Background(), logger, tr, &c.pod, kubeclient, &c.taskSpec)
+			got, err := MakeTaskRunStatus(t.Context(), logger, tr, &c.pod, kubeclient, &c.taskSpec)
 			if err != nil {
 				t.Errorf("MakeTaskRunResult: %s", err)
 			}
@@ -2591,7 +2590,7 @@ func TestMakeRunStatusJSONError(t *testing.T) {
 
 	logger, _ := logging.NewLogger("", "status")
 	kubeclient := fakek8s.NewSimpleClientset()
-	gotTr, err := MakeTaskRunStatus(context.Background(), logger, tr, pod, kubeclient, &v1.TaskSpec{})
+	gotTr, err := MakeTaskRunStatus(t.Context(), logger, tr, pod, kubeclient, &v1.TaskSpec{})
 	if err == nil {
 		t.Error("Expected error, got nil")
 	}
@@ -3125,7 +3124,7 @@ func TestGetStepTerminationReasonFromContainerStatus(t *testing.T) {
 			logger, _ := logging.NewLogger("", "status")
 			kubeclient := fakek8s.NewSimpleClientset()
 
-			trs, err := MakeTaskRunStatus(context.Background(), logger, tr, &test.pod, kubeclient, &v1.TaskSpec{})
+			trs, err := MakeTaskRunStatus(t.Context(), logger, tr, &test.pod, kubeclient, &v1.TaskSpec{})
 			if err != nil {
 				t.Errorf("MakeTaskRunResult: %s", err)
 			}

--- a/pkg/reconciler/apiserver/apiserver_test.go
+++ b/pkg/reconciler/apiserver/apiserver_test.go
@@ -1,7 +1,6 @@
 package apiserver_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -54,7 +53,7 @@ func TestDryRunCreate_Valid_DifferentGVKs(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			tektonclient := fake.NewSimpleClientset()
-			mutatedObj, err := apiserver.DryRunValidate(context.Background(), "default", tc.obj, tektonclient)
+			mutatedObj, err := apiserver.DryRunValidate(t.Context(), "default", tc.obj, tektonclient)
 			if (err != nil) != tc.wantErr {
 				t.Errorf("wantErr was %t but got err %v", tc.wantErr, err)
 			}
@@ -107,7 +106,7 @@ func TestDryRunCreate_Invalid_DifferentGVKs(t *testing.T) {
 			tektonclient.PrependReactor("create", "stepactions", func(action ktesting.Action) (bool, runtime.Object, error) {
 				return true, nil, apierrors.NewBadRequest("bad request")
 			})
-			_, err := apiserver.DryRunValidate(context.Background(), "default", tc.obj, tektonclient)
+			_, err := apiserver.DryRunValidate(t.Context(), "default", tc.obj, tektonclient)
 			if d := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); d != "" {
 				t.Errorf("wrong error: %s", d)
 			}
@@ -161,7 +160,7 @@ func TestDryRunCreate_DifferentErrTypes(t *testing.T) {
 			tektonclient.PrependReactor("create", "tasks", func(action ktesting.Action) (bool, runtime.Object, error) {
 				return true, nil, tc.webhookErr
 			})
-			_, err := apiserver.DryRunValidate(context.Background(), "default", &v1.Task{}, tektonclient)
+			_, err := apiserver.DryRunValidate(t.Context(), "default", &v1.Task{}, tektonclient)
 			if d := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); d != "" {
 				t.Errorf("wrong error: %s", d)
 			}

--- a/pkg/reconciler/pipelinerun/affinity_assistant_test.go
+++ b/pkg/reconciler/pipelinerun/affinity_assistant_test.go
@@ -350,7 +350,7 @@ func TestCreateOrUpdateAffinityAssistantsAndPVCsPerPipelineRun(t *testing.T) {
 			}
 
 			kubeClientSet := fakek8s.NewSimpleClientset()
-			ctx := cfgtesting.SetFeatureFlags(context.Background(), t, featureFlags)
+			ctx := cfgtesting.SetFeatureFlags(t.Context(), t, featureFlags)
 			c := Reconciler{
 				KubeClientSet: kubeClientSet,
 				pvcHandler:    volumeclaim.NewPVCHandler(kubeClientSet, zap.NewExample().Sugar()),
@@ -510,7 +510,7 @@ func TestCreateOrUpdateAffinityAssistantsAndPVCsPerWorkspaceOrDisabled(t *testin
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			kubeClientSet := fakek8s.NewSimpleClientset()
 			c := Reconciler{
 				KubeClientSet: kubeClientSet,
@@ -586,7 +586,7 @@ func TestCreateOrUpdateAffinityAssistantsAndPVCs_Failure(t *testing.T) {
 	}}
 
 	for _, tc := range testCases {
-		ctx := context.Background()
+		ctx := t.Context()
 		kubeClientSet := fakek8s.NewSimpleClientset()
 		c := Reconciler{
 			KubeClientSet: kubeClientSet,
@@ -1069,7 +1069,7 @@ func TestCleanupAffinityAssistants_Success(t *testing.T) {
 		}
 
 		_, c, _ := seedTestData(data)
-		ctx := cfgtesting.SetFeatureFlags(context.Background(), t, tc.cfgMap)
+		ctx := cfgtesting.SetFeatureFlags(t.Context(), t, tc.cfgMap)
 
 		// mocks `kubernetes.io/pvc-protection` finalizer behavior by adding DeletionTimestamp when deleting pvcs with the finalizer
 		// see details in: https://kubernetes.io/docs/concepts/overview/working-with-objects/finalizers/#how-finalizers-work
@@ -1130,7 +1130,7 @@ func TestCleanupAffinityAssistantsAndPVCs_Failure(t *testing.T) {
 		},
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	c := Reconciler{
 		KubeClientSet: fakek8s.NewSimpleClientset(),
 	}
@@ -1174,7 +1174,7 @@ func TestThatCleanupIsAvoided(t *testing.T) {
 	store := config.NewStore(logtesting.TestLogger(t))
 	store.OnConfigChanged(configMap)
 
-	_ = c.cleanupAffinityAssistantsAndPVCs(store.ToContext(context.Background()), testPRWithPVC)
+	_ = c.cleanupAffinityAssistantsAndPVCs(store.ToContext(t.Context()), testPRWithPVC)
 
 	if len(fakeClientSet.Actions()) != 0 {
 		t.Errorf("Expected 0 k8s client requests, did %d request", len(fakeClientSet.Actions()))

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -2397,7 +2397,7 @@ spec:
 		t.Errorf("expected skipped reason to be '%s', but was '%s", v1.PipelineTimedOutSkip, reconciledRun.Status.SkippedTasks[0].Reason)
 	}
 
-	updatedTaskRun, err := clients.Pipeline.TektonV1().TaskRuns("foo").Get(context.Background(), trs[0].Name, metav1.GetOptions{})
+	updatedTaskRun, err := clients.Pipeline.TektonV1().TaskRuns("foo").Get(t.Context(), trs[0].Name, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("error getting updated TaskRun: %#v", err)
 	}
@@ -2912,7 +2912,7 @@ status:
 			t.Errorf("expected skipped reason to be '%s', but was '%s", v1.TasksTimedOutSkip, reconciledRun.Status.SkippedTasks[0].Reason)
 		}
 
-		updatedTaskRun, err := clients.Pipeline.TektonV1().TaskRuns("foo").Get(context.Background(), trs[0].Name, metav1.GetOptions{})
+		updatedTaskRun, err := clients.Pipeline.TektonV1().TaskRuns("foo").Get(t.Context(), trs[0].Name, metav1.GetOptions{})
 		if err != nil {
 			t.Fatalf("error getting updated TaskRun: %#v", err)
 		}
@@ -3122,7 +3122,7 @@ status:
 		}
 
 		if tc.wantFinallyTimeout {
-			updatedTaskRun, err := clients.Pipeline.TektonV1().TaskRuns("foo").Get(context.Background(), tc.trs[1].Name, metav1.GetOptions{})
+			updatedTaskRun, err := clients.Pipeline.TektonV1().TaskRuns("foo").Get(t.Context(), tc.trs[1].Name, metav1.GetOptions{})
 			if err != nil {
 				t.Fatalf("error getting updated TaskRun: %#v", err)
 			}
@@ -5799,7 +5799,7 @@ spec:
 			defer prt.Cancel()
 
 			_, clients := prt.reconcileRun("foo", prName, []string{}, false)
-			trs, _ := clients.Pipeline.TektonV1().TaskRuns(namespace).List(context.TODO(), metav1.ListOptions{})
+			trs, _ := clients.Pipeline.TektonV1().TaskRuns(namespace).List(t.Context(), metav1.ListOptions{})
 
 			if d := cmp.Diff(tt.expected, trs.Items[0].Spec.Workspaces[0], cmpopts.IgnoreFields(v1.WorkspaceBinding{}, "Name")); d != "" {
 				t.Errorf("expected to see Workspace %v created. Diff %s", tt.expected, diff.PrintWantGot(d))
@@ -6893,7 +6893,7 @@ metadata:
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			// mock first reconcile
-			if err := storePipelineSpecAndMergeMeta(context.Background(), pr, tc.reconcile1Args.pipelineSpec, tc.reconcile1Args.resolvedObjectMeta); err != nil {
+			if err := storePipelineSpecAndMergeMeta(t.Context(), pr, tc.reconcile1Args.pipelineSpec, tc.reconcile1Args.resolvedObjectMeta); err != nil {
 				t.Errorf("storePipelineSpec() error = %v", err)
 			}
 			if d := cmp.Diff(tc.wantPipelineRun, pr); d != "" {
@@ -6901,7 +6901,7 @@ metadata:
 			}
 
 			// mock second reconcile
-			if err := storePipelineSpecAndMergeMeta(context.Background(), pr, tc.reconcile2Args.pipelineSpec, tc.reconcile2Args.resolvedObjectMeta); err != nil {
+			if err := storePipelineSpecAndMergeMeta(t.Context(), pr, tc.reconcile2Args.pipelineSpec, tc.reconcile2Args.resolvedObjectMeta); err != nil {
 				t.Errorf("storePipelineSpec() error = %v", err)
 			}
 			if d := cmp.Diff(tc.wantPipelineRun, pr); d != "" {
@@ -6923,7 +6923,7 @@ func Test_storePipelineSpec_metadata(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "foo", Labels: pipelinerunlabels, Annotations: pipelinerunannotations},
 	}
 	meta := metav1.ObjectMeta{Name: "bar", Labels: pipelinelabels, Annotations: pipelineannotations}
-	if err := storePipelineSpecAndMergeMeta(context.Background(), pr, &v1.PipelineSpec{}, &resolutionutil.ResolvedObjectMeta{
+	if err := storePipelineSpecAndMergeMeta(t.Context(), pr, &v1.PipelineSpec{}, &resolutionutil.ResolvedObjectMeta{
 		ObjectMeta: &meta,
 	}); err != nil {
 		t.Errorf("storePipelineSpecAndMergeMeta error = %v", err)
@@ -6942,7 +6942,7 @@ func TestReconcileOutOfSyncPipelineRun(t *testing.T) {
 	// the reconciler is able to coverge back to a consistent state with the orphaned
 	// TaskRuns back in the PipelineRun status.
 	// For more details, see https://github.com/tektoncd/pipeline/issues/2558
-	ctx := context.Background()
+	ctx := t.Context()
 
 	namespace := "foo"
 	prOutOfSyncName := "test-pipeline-run-out-of-sync"
@@ -8765,7 +8765,7 @@ func TestReconcile_OptionalWorkspacesOmitted(t *testing.T) {
 	prName := "test-pipeline-run-success"
 	trName := "test-pipeline-run-success-unit-test-1"
 
-	ctx := context.Background()
+	ctx := t.Context()
 	cfg := config.NewStore(logtesting.TestLogger(t))
 	ctx = cfg.ToContext(ctx)
 
@@ -8840,7 +8840,7 @@ spec:
 func TestReconcile_DependencyValidationsImmediatelyFailPipelineRun(t *testing.T) {
 	names.TestingSeed()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	cfg := config.NewStore(logtesting.TestLogger(t))
 	ctx = cfg.ToContext(ctx)
 
@@ -9620,7 +9620,7 @@ spec:
 			expectedError: `expected workspace "not-source" to be provided by pipelinerun for pipeline task "resolved-pipelinetask"`,
 		},
 	}
-	ctx := cfgtesting.EnableAlphaAPIFields(context.Background())
+	ctx := cfgtesting.EnableAlphaAPIFields(t.Context())
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := Reconciler{
@@ -9737,7 +9737,7 @@ spec:
 			c := Reconciler{
 				KubeClientSet: fakek8s.NewSimpleClientset(),
 			}
-			_, _, err := c.getTaskrunWorkspaces(context.Background(), tt.pr, tt.rprt)
+			_, _, err := c.getTaskrunWorkspaces(t.Context(), tt.pr, tt.rprt)
 			if err != nil {
 				t.Errorf("Pipeline.getTaskrunWorkspaces() returned error for valid pipeline: %v", err)
 			}
@@ -9804,7 +9804,7 @@ func Test_taskWorkspaceByWorkspaceVolumeSource(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			c := Reconciler{}
-			ctx := context.Background()
+			ctx := t.Context()
 			binding := c.taskWorkspaceByWorkspaceVolumeSource(ctx, tc.pipelineWorkspaceName, tc.prName, tc.wb, tc.taskWorkspaceName, "", *kmeta.NewControllerRef(testPr), tc.aaBehavior)
 			if d := cmp.Diff(tc.expectedBinding, binding); d != "" {
 				t.Errorf("WorkspaceBinding diff: %s", diff.PrintWantGot(d))

--- a/pkg/reconciler/pipelinerun/pipelinerun_updatestatus_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_updatestatus_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package pipelinerun
 
 import (
-	"context"
 	"regexp"
 	"strings"
 	"testing"
@@ -563,7 +562,7 @@ metadata:
 
 	for _, tc := range tcs {
 		t.Run(tc.prName, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			cfg := config.NewStore(logtesting.TestLogger(t))
 
 			ctx = cfg.ToContext(ctx)
@@ -659,7 +658,7 @@ func TestValidateChildObjectsInPipelineRunStatus(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			cfg := config.NewStore(logtesting.TestLogger(t))
 			cfg.OnConfigChanged(&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{Name: config.GetFeatureFlagsConfigName()},

--- a/pkg/reconciler/pipelinerun/pipelinespec/pipelinespec_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinespec/pipelinespec_test.go
@@ -57,7 +57,7 @@ func TestGetPipelineSpec_Ref(t *testing.T) {
 	gt := func(ctx context.Context, n string) (*v1.Pipeline, *v1.RefSource, *trustedresources.VerificationResult, error) {
 		return pipeline, nil, nil, nil
 	}
-	resolvedObjectMeta, pipelineSpec, err := pipelinespec.GetPipelineData(context.Background(), pr, gt)
+	resolvedObjectMeta, pipelineSpec, err := pipelinespec.GetPipelineData(t.Context(), pr, gt)
 
 	if err != nil {
 		t.Fatalf("Did not expect error getting pipeline spec but got: %s", err)
@@ -95,7 +95,7 @@ func TestGetPipelineSpec_Embedded(t *testing.T) {
 	gt := func(ctx context.Context, n string) (*v1.Pipeline, *v1.RefSource, *trustedresources.VerificationResult, error) {
 		return nil, nil, nil, errors.New("shouldn't be called")
 	}
-	resolvedObjectMeta, pipelineSpec, err := pipelinespec.GetPipelineData(context.Background(), pr, gt)
+	resolvedObjectMeta, pipelineSpec, err := pipelinespec.GetPipelineData(t.Context(), pr, gt)
 
 	if err != nil {
 		t.Fatalf("Did not expect error getting pipeline spec but got: %s", err)
@@ -123,7 +123,7 @@ func TestGetPipelineSpec_Invalid(t *testing.T) {
 	gt := func(ctx context.Context, n string) (*v1.Pipeline, *v1.RefSource, *trustedresources.VerificationResult, error) {
 		return nil, nil, nil, errors.New("shouldn't be called")
 	}
-	_, _, err := pipelinespec.GetPipelineData(context.Background(), tr, gt)
+	_, _, err := pipelinespec.GetPipelineData(t.Context(), tr, gt)
 	if err == nil {
 		t.Fatalf("Expected error resolving spec with no embedded or referenced pipeline spec but didn't get error")
 	}
@@ -216,7 +216,7 @@ func TestGetPipelineData_ResolutionSuccess(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := cfgtesting.SetDefaults(context.Background(), t, tc.defaults)
+			ctx := cfgtesting.SetDefaults(t.Context(), t, tc.defaults)
 			getPipeline := func(ctx context.Context, n string) (*v1.Pipeline, *v1.RefSource, *trustedresources.VerificationResult, error) {
 				return &v1.Pipeline{
 					ObjectMeta: *tc.sourceMeta.DeepCopy(),
@@ -256,7 +256,7 @@ func TestGetPipelineSpec_Error(t *testing.T) {
 	gt := func(ctx context.Context, n string) (*v1.Pipeline, *v1.RefSource, *trustedresources.VerificationResult, error) {
 		return nil, nil, nil, errors.New("something went wrong")
 	}
-	_, _, err := pipelinespec.GetPipelineData(context.Background(), tr, gt)
+	_, _, err := pipelinespec.GetPipelineData(t.Context(), tr, gt)
 	if err == nil {
 		t.Fatalf("Expected error when unable to find referenced Pipeline but got none")
 	}
@@ -278,7 +278,7 @@ func TestGetPipelineData_ResolutionError(t *testing.T) {
 	getPipeline := func(ctx context.Context, n string) (*v1.Pipeline, *v1.RefSource, *trustedresources.VerificationResult, error) {
 		return nil, nil, nil, errors.New("something went wrong")
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := pipelinespec.GetPipelineData(ctx, pr, getPipeline)
 	if err == nil {
 		t.Fatalf("Expected error when unable to find referenced Pipeline but got none")
@@ -301,7 +301,7 @@ func TestGetPipelineData_ResolvedNilPipeline(t *testing.T) {
 	getPipeline := func(ctx context.Context, n string) (*v1.Pipeline, *v1.RefSource, *trustedresources.VerificationResult, error) {
 		return nil, nil, nil, nil
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := pipelinespec.GetPipelineData(ctx, pr, getPipeline)
 	if err == nil {
 		t.Fatalf("Expected error when unable to find referenced Pipeline but got none")

--- a/pkg/reconciler/pipelinerun/resources/apply_test.go
+++ b/pkg/reconciler/pipelinerun/resources/apply_test.go
@@ -1794,7 +1794,7 @@ func TestApplyParameters(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			ctx := context.Background()
+			ctx := t.Context()
 			if tt.wc != nil {
 				ctx = tt.wc(ctx)
 			}
@@ -2108,7 +2108,7 @@ func TestApplyParameters_ArrayIndexing(t *testing.T) {
 					Params: tt.params,
 				},
 			}
-			got := resources.ApplyParameters(context.Background(), &tt.original, run)
+			got := resources.ApplyParameters(t.Context(), &tt.original, run)
 			if d := cmp.Diff(&tt.expected, got); d != "" {
 				t.Errorf("ApplyParameters() got diff %s", diff.PrintWantGot(d))
 			}
@@ -2360,7 +2360,7 @@ func TestApplyReplacementsMatrix(t *testing.T) {
 					Params: tt.params,
 				},
 			}
-			got := resources.ApplyParameters(context.Background(), &tt.original, run)
+			got := resources.ApplyParameters(t.Context(), &tt.original, run)
 			if d := cmp.Diff(&tt.expected, got); d != "" {
 				t.Errorf("ApplyParameters() got diff %s", diff.PrintWantGot(d))
 			}
@@ -3839,7 +3839,7 @@ func TestApplyFinallyResultsToPipelineResults(t *testing.T) {
 		},
 	} {
 		t.Run(tc.description, func(t *testing.T) {
-			received, _ := resources.ApplyTaskResultsToPipelineResults(context.Background(), tc.results, tc.taskResults, tc.runResults, nil /* skippedTasks */)
+			received, _ := resources.ApplyTaskResultsToPipelineResults(t.Context(), tc.results, tc.taskResults, tc.runResults, nil /* skippedTasks */)
 			if d := cmp.Diff(tc.expected, received); d != "" {
 				t.Error(diff.PrintWantGot(d))
 			}
@@ -4172,7 +4172,7 @@ func TestApplyTaskResultsToPipelineResults_Success(t *testing.T) {
 		}},
 	}} {
 		t.Run(tc.description, func(t *testing.T) {
-			received, err := resources.ApplyTaskResultsToPipelineResults(context.Background(), tc.results, tc.taskResults, tc.runResults, tc.taskstatus)
+			received, err := resources.ApplyTaskResultsToPipelineResults(t.Context(), tc.results, tc.taskResults, tc.runResults, tc.taskstatus)
 			if err != nil {
 				t.Errorf("Got unecpected error:%v", err)
 			}
@@ -4388,7 +4388,7 @@ func TestApplyTaskResultsToPipelineResults_Error(t *testing.T) {
 		expectedError:   errors.New("invalid pipelineresults [foo], the referenced results don't exist"),
 	}} {
 		t.Run(tc.description, func(t *testing.T) {
-			received, err := resources.ApplyTaskResultsToPipelineResults(context.Background(), tc.results, tc.taskResults, tc.runResults, nil /*skipped tasks*/)
+			received, err := resources.ApplyTaskResultsToPipelineResults(t.Context(), tc.results, tc.taskResults, tc.runResults, nil /*skipped tasks*/)
 			if err == nil {
 				t.Errorf("Expect error but got nil")
 				return
@@ -5294,7 +5294,7 @@ func TestApplyParametersToWorkspaceBindings(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			resources.ApplyParametersToWorkspaceBindings(context.TODO(), tt.pr)
+			resources.ApplyParametersToWorkspaceBindings(t.Context(), tt.pr)
 			if d := cmp.Diff(tt.expectedPr, tt.pr); d != "" {
 				t.Fatalf("TestApplyParametersToWorkspaceBindings() %s, got: %v", tt.name, diff.PrintWantGot(d))
 			}

--- a/pkg/reconciler/pipelinerun/resources/pipelineref_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelineref_test.go
@@ -154,7 +154,7 @@ func TestLocalPipelineRef(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 			tektonclient := fake.NewSimpleClientset(tc.pipelines...)
@@ -183,7 +183,7 @@ func TestLocalPipelineRef(t *testing.T) {
 }
 
 func TestGetPipelineFunc_Local(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	testcases := []struct {
 		name            string
@@ -241,7 +241,7 @@ func TestGetPipelineFunc_Local(t *testing.T) {
 }
 
 func TestGetPipelineFuncSpecAlreadyFetched(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	tektonclient := fake.NewSimpleClientset(simplePipeline(), samplePipeline)
@@ -564,7 +564,7 @@ func TestGetPipelineFunc_RemoteResolutionInvalidData(t *testing.T) {
 }
 
 func TestGetPipelineFunc_V1beta1Pipeline_VerifyNoError(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	signer, _, k8sclient, vps := test.SetupVerificationPolicies(t)
 	tektonclient := fake.NewSimpleClientset()
 
@@ -741,7 +741,7 @@ func TestGetPipelineFunc_V1beta1Pipeline_VerifyNoError(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := test.SetupTrustedResourceConfig(context.Background(), tc.verificationNoMatchPolicy)
+			ctx := test.SetupTrustedResourceConfig(t.Context(), tc.verificationNoMatchPolicy)
 			fn := resources.GetPipelineFunc(ctx, k8sclient, tektonclient, tc.requester, &tc.pipelinerun, tc.policies)
 
 			gotResolvedPipeline, gotSource, gotVerificationResult, err := fn(ctx, pipelineRef.Name)
@@ -862,7 +862,7 @@ func TestGetPipelineFunc_V1beta1Pipeline_VerifyError(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := test.SetupTrustedResourceConfig(context.Background(), tc.verificationNoMatchPolicy)
+			ctx := test.SetupTrustedResourceConfig(t.Context(), tc.verificationNoMatchPolicy)
 			pr := &v1.PipelineRun{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "trusted-resources"},
 				Spec: v1.PipelineRunSpec{
@@ -886,7 +886,7 @@ func TestGetPipelineFunc_V1beta1Pipeline_VerifyError(t *testing.T) {
 }
 
 func TestGetPipelineFunc_V1Pipeline_VerifyNoError(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	signer, _, k8sclient, vps := test.SetupVerificationPolicies(t)
 	tektonclient := fake.NewSimpleClientset()
 
@@ -1071,7 +1071,7 @@ func TestGetPipelineFunc_V1Pipeline_VerifyNoError(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := test.SetupTrustedResourceConfig(context.Background(), tc.verificationNoMatchPolicy)
+			ctx := test.SetupTrustedResourceConfig(t.Context(), tc.verificationNoMatchPolicy)
 			fn := resources.GetPipelineFunc(ctx, k8sclient, tektonclient, tc.requester, &tc.pipelinerun, tc.policies)
 
 			gotResolvedPipeline, gotSource, gotVerificationResult, err := fn(ctx, pipelineRef.Name)
@@ -1191,7 +1191,7 @@ func TestGetPipelineFunc_V1Pipeline_VerifyError(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := test.SetupTrustedResourceConfig(context.Background(), tc.verificationNoMatchPolicy)
+			ctx := test.SetupTrustedResourceConfig(t.Context(), tc.verificationNoMatchPolicy)
 			pr := &v1.PipelineRun{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "trusted-resources"},
 				Spec: v1.PipelineRunSpec{
@@ -1256,7 +1256,7 @@ func TestGetPipelineFunc_GetFuncError(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			store := config.NewStore(logging.FromContext(ctx).Named("config-store"))
 			featureflags := &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
@@ -2378,7 +2378,7 @@ func TestResolvePipelineRun_CustomTask(t *testing.T) {
 		return nil, kerrors.NewNotFound(v1.Resource("run"), name)
 	}
 	pipelineState := PipelineRunState{}
-	ctx := context.Background()
+	ctx := t.Context()
 	cfg := config.NewStore(logtesting.TestLogger(t))
 	ctx = cfg.ToContext(ctx)
 	for _, task := range pts {
@@ -2433,7 +2433,7 @@ func TestResolvePipelineRun_PipelineTaskHasNoResources(t *testing.T) {
 	}
 	pipelineState := PipelineRunState{}
 	for _, task := range pts {
-		ps, err := ResolvePipelineTask(context.Background(), pr, getTask, getTaskRun, nopGetCustomRun, task, nil)
+		ps, err := ResolvePipelineTask(t.Context(), pr, getTask, getTaskRun, nopGetCustomRun, task, nil)
 		if err != nil {
 			t.Errorf("Error getting tasks for fake pipeline %s: %s", p.ObjectMeta.Name, err)
 		}
@@ -2470,7 +2470,7 @@ func TestResolvePipelineRun_PipelineTaskHasPipelineRef(t *testing.T) {
 		},
 	}
 
-	_, err := ResolvePipelineTask(context.Background(), pr, getTask, getTaskRun, nopGetCustomRun, pt, nil)
+	_, err := ResolvePipelineTask(t.Context(), pr, getTask, getTaskRun, nopGetCustomRun, pt, nil)
 	if err == nil {
 		t.Errorf("Error getting tasks for fake pipeline %s, expected an error but got nil.", p.ObjectMeta.Name)
 	}
@@ -2522,7 +2522,7 @@ func TestResolvePipelineRun_TaskDoesntExist(t *testing.T) {
 		},
 	}
 	for _, pt := range pts {
-		_, err := ResolvePipelineTask(context.Background(), pr, getTask, getTaskRun, nopGetCustomRun, pt, nil)
+		_, err := ResolvePipelineTask(t.Context(), pr, getTask, getTaskRun, nopGetCustomRun, pt, nil)
 		var tnf *TaskNotFoundError
 		switch {
 		case err == nil:
@@ -2566,7 +2566,7 @@ func TestResolvePipelineRun_VerificationFailed(t *testing.T) {
 		},
 	}
 	for _, pt := range pts {
-		rt, _ := ResolvePipelineTask(context.Background(), pr, getTask, getTaskRun, nopGetCustomRun, pt, nil)
+		rt, _ := ResolvePipelineTask(t.Context(), pr, getTask, getTaskRun, nopGetCustomRun, pt, nil)
 		if d := cmp.Diff(verificationResult, rt.ResolvedTask.VerificationResult, cmpopts.EquateErrors()); d != "" {
 			t.Error(diff.PrintWantGot(d))
 		}
@@ -2588,7 +2588,7 @@ func TestResolvePipelineRun_TransientError(t *testing.T) {
 			Name: "pipelinerun",
 		},
 	}
-	_, err := ResolvePipelineTask(context.Background(), pr, getTask, getTaskRun, nopGetCustomRun, pt, nil)
+	_, err := ResolvePipelineTask(t.Context(), pr, getTask, getTaskRun, nopGetCustomRun, pt, nil)
 	if !resolutioncommon.IsErrTransient(err) {
 		t.Error("Transient error while getting Task did not result in a transient error")
 	}
@@ -2831,7 +2831,7 @@ func TestResolvePipeline_WhenExpressions(t *testing.T) {
 	}
 
 	t.Run("When Expressions exist", func(t *testing.T) {
-		_, err := ResolvePipelineTask(context.Background(), pr, getTask, getTaskRun, nopGetCustomRun, pt, nil)
+		_, err := ResolvePipelineTask(t.Context(), pr, getTask, getTaskRun, nopGetCustomRun, pt, nil)
 		if err != nil {
 			t.Fatalf("Did not expect error when resolving PipelineRun: %v", err)
 		}
@@ -2930,7 +2930,7 @@ func TestIsCustomTask(t *testing.T) {
 		want: false,
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			cfg := config.NewStore(logtesting.TestLogger(t))
 			ctx = cfg.ToContext(ctx)
 			rpt, err := ResolvePipelineTask(ctx, pr, getTask, getTaskRun, getRun, tc.pt, nil)
@@ -3672,7 +3672,7 @@ func TestIsMatrixed(t *testing.T) {
 		want: false,
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			cfg := config.NewStore(logtesting.TestLogger(t))
 			cfg.OnConfigChanged(&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{Name: config.GetFeatureFlagsConfigName()},
@@ -3831,7 +3831,7 @@ func TestResolvePipelineRunTask_WithMatrix(t *testing.T) {
 		pst: pipelineRunState,
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			cfg := config.NewStore(logtesting.TestLogger(t))
 			cfg.OnConfigChanged(&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{Name: config.GetFeatureFlagsConfigName()},
@@ -3996,7 +3996,7 @@ func TestResolvePipelineRunTask_WithMatrixedCustomTask(t *testing.T) {
 		pst: pipelineRunState,
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			cfg := config.NewStore(logtesting.TestLogger(t))
 			cfg.OnConfigChanged(&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{Name: config.GetFeatureFlagsConfigName()},

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package resources
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -1916,7 +1915,7 @@ func TestGetPipelineConditionStatus(t *testing.T) {
 				FinalTasksGraph: dfinally,
 				TimeoutsState:   timeoutsState,
 			}
-			c := facts.GetPipelineConditionStatus(context.Background(), pr, zap.NewNop().Sugar(), testClock)
+			c := facts.GetPipelineConditionStatus(t.Context(), pr, zap.NewNop().Sugar(), testClock)
 			wantCondition := &apis.Condition{
 				Type:   apis.ConditionSucceeded,
 				Status: tc.expectedStatus,
@@ -2060,7 +2059,7 @@ func TestGetPipelineConditionStatus_WithFinalTasks(t *testing.T) {
 					Clock: testClock,
 				},
 			}
-			c := facts.GetPipelineConditionStatus(context.Background(), pr, zap.NewNop().Sugar(), testClock)
+			c := facts.GetPipelineConditionStatus(t.Context(), pr, zap.NewNop().Sugar(), testClock)
 			wantCondition := &apis.Condition{
 				Type:   apis.ConditionSucceeded,
 				Status: tc.expectedStatus,
@@ -2102,7 +2101,7 @@ func TestGetPipelineConditionStatus_PipelineTimeoutDeprecated(t *testing.T) {
 			Clock: testClock,
 		},
 	}
-	c := facts.GetPipelineConditionStatus(context.Background(), pr, zap.NewNop().Sugar(), testClock)
+	c := facts.GetPipelineConditionStatus(t.Context(), pr, zap.NewNop().Sugar(), testClock)
 	if c.Status != corev1.ConditionFalse && c.Reason != v1.PipelineRunReasonTimedOut.String() {
 		t.Fatalf("Expected to get status %s but got %s for state %v", corev1.ConditionFalse, c.Status, oneFinishedState)
 	}
@@ -2135,7 +2134,7 @@ func TestGetPipelineConditionStatus_PipelineTimeouts(t *testing.T) {
 			Clock: testClock,
 		},
 	}
-	c := facts.GetPipelineConditionStatus(context.Background(), pr, zap.NewNop().Sugar(), testClock)
+	c := facts.GetPipelineConditionStatus(t.Context(), pr, zap.NewNop().Sugar(), testClock)
 	if c.Status != corev1.ConditionFalse && c.Reason != v1.PipelineRunReasonTimedOut.String() {
 		t.Fatalf("Expected to get status %s but got %s for state %v", corev1.ConditionFalse, c.Status, oneFinishedState)
 	}
@@ -2210,7 +2209,7 @@ func TestGetPipelineConditionStatus_OnError(t *testing.T) {
 			Clock: testClock,
 		},
 	}
-	c := facts.GetPipelineConditionStatus(context.Background(), pr, zap.NewNop().Sugar(), testClock)
+	c := facts.GetPipelineConditionStatus(t.Context(), pr, zap.NewNop().Sugar(), testClock)
 	if c.Status != corev1.ConditionTrue {
 		t.Fatalf("Expected to get status %s but got %s", corev1.ConditionTrue, c.Status)
 	}

--- a/pkg/reconciler/pipelinerun/tracing_test.go
+++ b/pkg/reconciler/pipelinerun/tracing_test.go
@@ -14,7 +14,6 @@ limitations under the License.
 package pipelinerun
 
 import (
-	"context"
 	"testing"
 
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
@@ -91,7 +90,7 @@ func TestInitTracing(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			pr := tc.pipelineRun
-			ctx := initTracing(context.Background(), tc.tracerProvider, pr)
+			ctx := initTracing(t.Context(), tc.tracerProvider, pr)
 
 			if ctx == nil {
 				t.Fatalf("returned nil context from initTracing")

--- a/pkg/reconciler/resolutionrequest/resolutionrequest_test.go
+++ b/pkg/reconciler/resolutionrequest/resolutionrequest_test.go
@@ -131,7 +131,7 @@ func TestReconcile(t *testing.T) {
 						Type:    apis.ConditionSucceeded,
 						Status:  corev1.ConditionFalse,
 						Reason:  resolutioncommon.ReasonResolutionTimedOut,
-						Message: timeoutMessage(config.FromContextOrDefaults(context.TODO()).Defaults.DefaultMaximumResolutionTimeout),
+						Message: timeoutMessage(config.FromContextOrDefaults(t.Context()).Defaults.DefaultMaximumResolutionTimeout),
 					}},
 				},
 				ResolutionRequestStatusFields: v1beta1.ResolutionRequestStatusFields{},

--- a/pkg/reconciler/taskrun/resources/apply_test.go
+++ b/pkg/reconciler/taskrun/resources/apply_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package resources_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -1201,7 +1200,7 @@ func TestApplyWorkspaces(t *testing.T) {
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			vols := workspace.CreateVolumes(tc.binds)
-			got := resources.ApplyWorkspaces(context.Background(), tc.spec, tc.decls, tc.binds, vols)
+			got := resources.ApplyWorkspaces(t.Context(), tc.spec, tc.decls, tc.binds, vols)
 			if d := cmp.Diff(tc.want, got); d != "" {
 				t.Errorf("TestApplyWorkspaces() got diff %s", diff.PrintWantGot(d))
 			}
@@ -1268,7 +1267,7 @@ func TestApplyWorkspaces_IsolatedWorkspaces(t *testing.T) {
 		}}},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			vols := workspace.CreateVolumes(tc.binds)
 			got := resources.ApplyWorkspaces(ctx, tc.spec, tc.decls, tc.binds, vols)
 			if d := cmp.Diff(tc.want, got); d != "" {

--- a/pkg/reconciler/taskrun/resources/taskref_test.go
+++ b/pkg/reconciler/taskrun/resources/taskref_test.go
@@ -240,7 +240,7 @@ func TestLocalTaskRef(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 			tektonclient := fake.NewSimpleClientset(tc.tasks...)
@@ -610,7 +610,7 @@ func TestStepActionRef(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 			tektonclient := fake.NewSimpleClientset(tc.stepactions...)
@@ -673,7 +673,7 @@ func TestStepActionRef_Error(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 			tektonclient := fake.NewSimpleClientset(tc.stepactions...)
@@ -695,7 +695,7 @@ func TestStepActionRef_Error(t *testing.T) {
 }
 
 func TestGetTaskFunc_Local(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	testcases := []struct {
 		name         string
@@ -772,7 +772,7 @@ func TestGetTaskFunc_Local(t *testing.T) {
 }
 
 func TestGetStepActionFunc_Local(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	testcases := []struct {
 		name             string
@@ -825,7 +825,7 @@ func TestGetStepActionFunc_Local(t *testing.T) {
 }
 
 func TestGetStepActionFunc_RemoteResolution_Success(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	stepRef := &v1.Ref{ResolverRef: v1.ResolverRef{Resolver: "git"}}
 
 	testcases := []struct {
@@ -891,7 +891,7 @@ func TestGetStepActionFunc_RemoteResolution_Success(t *testing.T) {
 }
 
 func TestGetStepActionFunc_RemoteResolution_Error(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	stepRef := &v1.Ref{ResolverRef: v1.ResolverRef{Resolver: "git"}}
 
 	testcases := []struct {
@@ -936,7 +936,7 @@ func TestGetStepActionFunc_RemoteResolution_Error(t *testing.T) {
 }
 
 func TestGetTaskFuncFromTaskRunSpecAlreadyFetched(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	tektonclient := fake.NewSimpleClientset(simpleNamespacedTask)
@@ -1000,7 +1000,7 @@ echo hello
 }
 
 func TestGetTaskFunc_RemoteResolution(t *testing.T) {
-	ctx := cfgtesting.EnableStableAPIFields(context.Background())
+	ctx := cfgtesting.EnableStableAPIFields(t.Context())
 	cfg := config.FromContextOrDefaults(ctx)
 	ctx = config.ToContext(ctx, cfg)
 	taskRef := &v1.TaskRef{ResolverRef: v1.ResolverRef{Resolver: "git"}}
@@ -1072,7 +1072,7 @@ func TestGetTaskFunc_RemoteResolution(t *testing.T) {
 }
 
 func TestGetTaskFunc_RemoteResolution_ValidationFailure(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	cfg := config.FromContextOrDefaults(ctx)
 	ctx = config.ToContext(ctx, cfg)
 	taskRef := &v1.TaskRef{ResolverRef: v1.ResolverRef{Resolver: "git"}}
@@ -1126,7 +1126,7 @@ func TestGetTaskFunc_RemoteResolution_ValidationFailure(t *testing.T) {
 }
 
 func TestGetTaskFunc_RemoteResolution_ReplacedParams(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	cfg := config.FromContextOrDefaults(ctx)
 	ctx = config.ToContext(ctx, cfg)
 	task := parse.MustParseV1TaskAndSetDefaults(t, taskYAMLString)
@@ -1234,7 +1234,7 @@ func TestGetTaskFunc_RemoteResolution_ReplacedParams(t *testing.T) {
 }
 
 func TestGetPipelineFunc_RemoteResolutionInvalidData(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	cfg := config.FromContextOrDefaults(ctx)
 	ctx = config.ToContext(ctx, cfg)
 	taskRef := &v1.TaskRef{ResolverRef: v1.ResolverRef{Resolver: "git"}}
@@ -1255,7 +1255,7 @@ func TestGetPipelineFunc_RemoteResolutionInvalidData(t *testing.T) {
 }
 
 func TestGetTaskFunc_V1beta1Task_VerifyNoError(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	signer, _, k8sclient, vps := test.SetupVerificationPolicies(t)
 	tektonclient := fake.NewSimpleClientset()
 
@@ -1359,7 +1359,7 @@ func TestGetTaskFunc_V1beta1Task_VerifyNoError(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := test.SetupTrustedResourceConfig(context.Background(), tc.verificationNoMatchPolicy)
+			ctx := test.SetupTrustedResourceConfig(t.Context(), tc.verificationNoMatchPolicy)
 			tr := &v1.TaskRun{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "trusted-resources"},
 				Spec: v1.TaskRunSpec{
@@ -1389,7 +1389,7 @@ func TestGetTaskFunc_V1beta1Task_VerifyNoError(t *testing.T) {
 }
 
 func TestGetTaskFunc_V1beta1Task_VerifyError(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	signer, _, k8sclient, vps := test.SetupVerificationPolicies(t)
 	tektonclient := fake.NewSimpleClientset()
 
@@ -1509,7 +1509,7 @@ func TestGetTaskFunc_V1beta1Task_VerifyError(t *testing.T) {
 }
 
 func TestGetTaskFunc_V1Task_VerifyNoError(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	signer, _, k8sclient, vps := test.SetupVerificationPolicies(t)
 	tektonclient := fake.NewSimpleClientset()
 
@@ -1653,7 +1653,7 @@ func TestGetTaskFunc_V1Task_VerifyNoError(t *testing.T) {
 }
 
 func TestGetTaskFunc_V1Task_VerifyError(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	signer, _, k8sclient, vps := test.SetupVerificationPolicies(t)
 	tektonclient := fake.NewSimpleClientset()
 
@@ -1768,7 +1768,7 @@ func TestGetTaskFunc_V1Task_VerifyError(t *testing.T) {
 }
 
 func TestGetTaskFunc_GetFuncError(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	_, k8sclient, vps := test.SetupMatchAllVerificationPolicies(t, "trusted-resources")
 	tektonclient := fake.NewSimpleClientset()
 

--- a/pkg/reconciler/taskrun/resources/taskspec_test.go
+++ b/pkg/reconciler/taskrun/resources/taskspec_test.go
@@ -63,7 +63,7 @@ func TestGetTaskSpec_Ref(t *testing.T) {
 	gt := func(ctx context.Context, n string) (*v1.Task, *v1.RefSource, *trustedresources.VerificationResult, error) {
 		return task, sampleRefSource.DeepCopy(), nil, nil
 	}
-	resolvedObjectMeta, taskSpec, err := resources.GetTaskData(context.Background(), tr, gt)
+	resolvedObjectMeta, taskSpec, err := resources.GetTaskData(t.Context(), tr, gt)
 	if err != nil {
 		t.Fatalf("Did not expect error getting task spec but got: %s", err)
 	}
@@ -96,7 +96,7 @@ func TestGetTaskSpec_Embedded(t *testing.T) {
 	gt := func(ctx context.Context, n string) (*v1.Task, *v1.RefSource, *trustedresources.VerificationResult, error) {
 		return nil, nil, nil, errors.New("shouldn't be called")
 	}
-	resolvedObjectMeta, taskSpec, err := resources.GetTaskData(context.Background(), tr, gt)
+	resolvedObjectMeta, taskSpec, err := resources.GetTaskData(t.Context(), tr, gt)
 	if err != nil {
 		t.Fatalf("Did not expect error getting task spec but got: %s", err)
 	}
@@ -124,7 +124,7 @@ func TestGetTaskSpec_Invalid(t *testing.T) {
 	gt := func(ctx context.Context, n string) (*v1.Task, *v1.RefSource, *trustedresources.VerificationResult, error) {
 		return nil, nil, nil, errors.New("shouldn't be called")
 	}
-	_, _, err := resources.GetTaskData(context.Background(), tr, gt)
+	_, _, err := resources.GetTaskData(t.Context(), tr, gt)
 	if err == nil {
 		t.Fatalf("Expected error resolving spec with no embedded or referenced task spec but didn't get error")
 	}
@@ -144,7 +144,7 @@ func TestGetTaskSpec_Error(t *testing.T) {
 	gt := func(ctx context.Context, n string) (*v1.Task, *v1.RefSource, *trustedresources.VerificationResult, error) {
 		return nil, nil, nil, errors.New("something went wrong")
 	}
-	_, _, err := resources.GetTaskData(context.Background(), tr, gt)
+	_, _, err := resources.GetTaskData(t.Context(), tr, gt)
 	if err == nil {
 		t.Fatalf("Expected error when unable to find referenced Task but got none")
 	}
@@ -187,7 +187,7 @@ func TestGetTaskData_ResolutionSuccess(t *testing.T) {
 			Spec:       *sourceSpec.DeepCopy(),
 		}, sampleRefSource.DeepCopy(), nil, nil
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	resolvedMeta, resolvedSpec, err := resources.GetTaskData(ctx, tr, getTask)
 	if err != nil {
 		t.Fatalf("Unexpected error getting mocked data: %v", err)
@@ -221,7 +221,7 @@ func TestGetPipelineData_ResolutionError(t *testing.T) {
 	getTask := func(ctx context.Context, n string) (*v1.Task, *v1.RefSource, *trustedresources.VerificationResult, error) {
 		return nil, nil, nil, errors.New("something went wrong")
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := resources.GetTaskData(ctx, tr, getTask)
 	if err == nil {
 		t.Fatalf("Expected error when unable to find referenced Task but got none")
@@ -244,7 +244,7 @@ func TestGetTaskData_ResolvedNilTask(t *testing.T) {
 	getTask := func(ctx context.Context, n string) (*v1.Task, *v1.RefSource, *trustedresources.VerificationResult, error) {
 		return nil, nil, nil, nil
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, err := resources.GetTaskData(ctx, tr, getTask)
 	if err == nil {
 		t.Fatalf("Expected error when unable to find referenced Task but got none")
@@ -292,7 +292,7 @@ func TestGetTaskData_VerificationResult(t *testing.T) {
 			Spec:       *sourceSpec.DeepCopy(),
 		}, nil, verificationResult, nil
 	}
-	r, _, err := resources.GetTaskData(context.Background(), tr, getTask)
+	r, _, err := resources.GetTaskData(t.Context(), tr, getTask)
 	if err != nil {
 		t.Fatalf("Did not expect error but got: %s", err)
 	}
@@ -625,7 +625,7 @@ spec:
 		},
 	}}
 	for _, tt := range tests {
-		ctx := context.Background()
+		ctx := t.Context()
 		tektonclient := fake.NewSimpleClientset(stepAction)
 		_, err := resources.GetStepActionsData(ctx, *tt.tr.Spec.TaskSpec, tt.tr, tektonclient, nil, requester)
 		if err != nil {
@@ -1575,7 +1575,7 @@ func TestGetStepActionsData(t *testing.T) {
 	}}
 
 	for _, tt := range tests {
-		ctx := context.Background()
+		ctx := t.Context()
 		tektonclient := fake.NewSimpleClientset(tt.stepAction)
 
 		got, err := resources.GetStepActionsData(ctx, *tt.tr.Spec.TaskSpec, tt.tr, tektonclient, nil, nil)
@@ -1802,7 +1802,7 @@ func TestGetStepActionsData_Error(t *testing.T) {
 		expectedError: errors.New("invalid parameter substitution: commands. Please check the types of the default value and the passed value"),
 	}}
 	for _, tt := range tests {
-		ctx := context.Background()
+		ctx := t.Context()
 		tektonclient := fake.NewSimpleClientset(tt.stepAction)
 
 		_, err := resources.GetStepActionsData(ctx, *tt.tr.Spec.TaskSpec, tt.tr, tektonclient, nil, nil)
@@ -1855,7 +1855,7 @@ func TestGetStepActionsData_InvalidStepResultReference(t *testing.T) {
 	}
 
 	expectedError := `must be one of the form 1). "steps.<stepName>.results.<resultName>"; 2). "steps.<stepName>.results.<objectResultName>.<individualAttribute>"`
-	ctx := context.Background()
+	ctx := t.Context()
 	tektonclient := fake.NewSimpleClientset(stepAction)
 	if _, err := resources.GetStepActionsData(ctx, *tr.Spec.TaskSpec, tr, tektonclient, nil, nil); err.Error() != expectedError {
 		t.Errorf("Expected error message %s but got %s", expectedError, err.Error())

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -2282,7 +2282,7 @@ status:
 			" got %d. Actions: %#v", len(actions), actions)
 	}
 
-	newTr, err := clients.Pipeline.TektonV1().TaskRuns(noTaskRun.Namespace).Get(context.Background(), noTaskRun.Name, metav1.GetOptions{})
+	newTr, err := clients.Pipeline.TektonV1().TaskRuns(noTaskRun.Namespace).Get(t.Context(), noTaskRun.Name, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Expected TaskRun %s to exist but instead got error when getting it: %v", noTaskRun.Name, err)
 	}
@@ -3982,7 +3982,7 @@ spec:
 		Kind:     "Task",
 		TaskSpec: &v1.TaskSpec{Steps: simpleTask.Spec.Steps, Workspaces: simpleTask.Spec.Workspaces},
 	}
-	ctx := cfgtesting.EnableAlphaAPIFields(context.Background())
+	ctx := cfgtesting.EnableAlphaAPIFields(t.Context())
 	workspaceVolumes := workspace.CreateVolumes(taskRun.Spec.Workspaces)
 	taskSpec, err := applyParamsContextsResultsAndWorkspaces(ctx, taskRun, rtr, workspaceVolumes)
 	if err != nil {
@@ -4092,7 +4092,7 @@ spec:
 	}
 
 	workspaceVolumes := workspace.CreateVolumes(taskRun.Spec.Workspaces)
-	ctx := cfgtesting.EnableAlphaAPIFields(context.Background())
+	ctx := cfgtesting.EnableAlphaAPIFields(t.Context())
 	taskSpec, err := applyParamsContextsResultsAndWorkspaces(ctx, taskRun, rtr, workspaceVolumes)
 	if err != nil {
 		t.Errorf("update task spec threw an error: %v", err)
@@ -4254,7 +4254,7 @@ status:
 
 	createServiceAccount(t, testAssets, "default", taskRun.Namespace)
 
-	err := testAssets.Controller.Reconciler.Reconcile(context.Background(), getRunName(taskRun))
+	err := testAssets.Controller.Reconciler.Reconcile(t.Context(), getRunName(taskRun))
 	isRequeued, _ := controller.IsRequeueKey(err)
 	if err != nil && !isRequeued {
 		t.Errorf("expected no error reconciling valid TaskRun but got %v", err)
@@ -4335,7 +4335,7 @@ status:
 
 	createServiceAccount(t, testAssets, "default", taskRun.Namespace)
 
-	err := testAssets.Controller.Reconciler.Reconcile(context.Background(), getRunName(taskRun))
+	err := testAssets.Controller.Reconciler.Reconcile(t.Context(), getRunName(taskRun))
 	isRequeued, _ := controller.IsRequeueKey(err)
 	if err != nil && !isRequeued {
 		t.Errorf("expected no error reconciling valid TaskRun but got %v", err)
@@ -4403,7 +4403,7 @@ spec:
 	defer cancel()
 	clients := testAssets.Clients
 
-	err := testAssets.Controller.Reconciler.Reconcile(context.Background(), getRunName(taskRun))
+	err := testAssets.Controller.Reconciler.Reconcile(t.Context(), getRunName(taskRun))
 	if err == nil {
 		t.Fatalf("expected error reconciling invalid TaskRun but got none")
 	}
@@ -4542,7 +4542,7 @@ spec:
 		t.Fatal(err)
 	}
 
-	if err := testAssets.Controller.Reconciler.Reconcile(context.Background(), getRunName(taskRun)); err == nil {
+	if err := testAssets.Controller.Reconciler.Reconcile(t.Context(), getRunName(taskRun)); err == nil {
 		t.Errorf("Expected error reconciling invalid TaskRun due to invalid workspace but got %v", err)
 	}
 }
@@ -5317,7 +5317,7 @@ spec:
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			// mock first reconcile
-			if err := storeTaskSpecAndMergeMeta(context.Background(), tr, tc.reconcile1Args.taskSpec, tc.reconcile1Args.resolvedObjectMeta); err != nil {
+			if err := storeTaskSpecAndMergeMeta(t.Context(), tr, tc.reconcile1Args.taskSpec, tc.reconcile1Args.resolvedObjectMeta); err != nil {
 				t.Errorf("storePipelineSpec() error = %v", err)
 			}
 			if d := cmp.Diff(tc.wantTaskRun, tr); d != "" {
@@ -5325,7 +5325,7 @@ spec:
 			}
 
 			// mock second reconcile
-			if err := storeTaskSpecAndMergeMeta(context.Background(), tr, tc.reconcile2Args.taskSpec, tc.reconcile2Args.resolvedObjectMeta); err != nil {
+			if err := storeTaskSpecAndMergeMeta(t.Context(), tr, tc.reconcile2Args.taskSpec, tc.reconcile2Args.resolvedObjectMeta); err != nil {
 				t.Errorf("storePipelineSpec() error = %v", err)
 			}
 			if d := cmp.Diff(tc.wantTaskRun, tr); d != "" {
@@ -5350,7 +5350,7 @@ func Test_storeTaskSpec_metadata(t *testing.T) {
 		ObjectMeta: &metav1.ObjectMeta{Labels: tasklabels, Annotations: taskannotations},
 	}
 
-	if err := storeTaskSpecAndMergeMeta(context.Background(), tr, &v1.TaskSpec{}, &resolvedMeta); err != nil {
+	if err := storeTaskSpecAndMergeMeta(t.Context(), tr, &v1.TaskSpec{}, &resolvedMeta); err != nil {
 		t.Errorf("storeTaskSpecAndMergeMeta error = %v", err)
 	}
 	if d := cmp.Diff(wantedlabels, tr.ObjectMeta.Labels); d != "" {
@@ -6123,7 +6123,7 @@ status:
 					Phase: corev1.PodRunning,
 				},
 			}
-			pod, err := clientset.CoreV1().Pods(pod.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+			pod, err := clientset.CoreV1().Pods(pod.Namespace).Create(t.Context(), pod, metav1.CreateOptions{})
 			if err != nil {
 				t.Errorf("Error occurred while creating pod %s: %s", pod.Name, err.Error())
 			}

--- a/pkg/reconciler/taskrun/tracing_test.go
+++ b/pkg/reconciler/taskrun/tracing_test.go
@@ -14,7 +14,6 @@ limitations under the License.
 package taskrun
 
 import (
-	"context"
 	"testing"
 
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
@@ -91,7 +90,7 @@ func TestInitTracing(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			tr := tc.taskRun
-			ctx := initTracing(context.Background(), tc.tracerProvider, tr)
+			ctx := initTracing(t.Context(), tc.tracerProvider, tr)
 
 			if ctx == nil {
 				t.Fatalf("returned nil context from initTracing")

--- a/pkg/reconciler/taskrun/validate_taskrun_test.go
+++ b/pkg/reconciler/taskrun/validate_taskrun_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package taskrun
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -30,7 +29,7 @@ import (
 )
 
 func TestValidateResolvedTask_ValidParams(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	task := &v1.Task{
 		ObjectMeta: metav1.ObjectMeta{Name: "foo"},
 		Spec: v1.TaskSpec{
@@ -130,7 +129,7 @@ func TestValidateResolvedTask_ValidParams(t *testing.T) {
 }
 
 func TestValidateResolvedTask_ExtraValidParams(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	tcs := []struct {
 		name   string
 		task   v1.Task
@@ -231,7 +230,7 @@ func TestValidateResolvedTask_ExtraValidParams(t *testing.T) {
 }
 
 func TestValidateResolvedTask_InvalidParams(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	tcs := []struct {
 		name    string
 		task    v1.Task
@@ -919,7 +918,7 @@ func TestEnumValidation_Success(t *testing.T) {
 	}}
 
 	for _, tc := range tcs {
-		if err := ValidateEnumParam(context.Background(), tc.params, tc.paramSpecs); err != nil {
+		if err := ValidateEnumParam(t.Context(), tc.params, tc.paramSpecs); err != nil {
 			t.Errorf("expected err is nil, but got %v", err)
 		}
 	}
@@ -952,7 +951,7 @@ func TestEnumValidation_Failure(t *testing.T) {
 	}}
 
 	for _, tc := range tcs {
-		if err := ValidateEnumParam(context.Background(), tc.params, tc.paramSpecs); err == nil {
+		if err := ValidateEnumParam(t.Context(), tc.params, tc.paramSpecs); err == nil {
 			t.Errorf("expected error from ValidateEnumParam() = %v, but got none", tc.expectedErr)
 		} else if d := cmp.Diff(tc.expectedErr.Error(), err.Error()); d != "" {
 			t.Errorf("expected error does not match: %s", diff.PrintWantGot(d))

--- a/pkg/reconciler/volumeclaim/pvchandler_test.go
+++ b/pkg/reconciler/volumeclaim/pvchandler_test.go
@@ -73,7 +73,7 @@ func TestCreatePersistentVolumeClaimsForWorkspaces(t *testing.T) {
 			Spec: corev1.PersistentVolumeClaimSpec{},
 		},
 	}}
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -139,7 +139,7 @@ func TestCreatePersistentVolumeClaimsForWorkspacesWithoutMetadata(t *testing.T) 
 			Spec: corev1.PersistentVolumeClaimSpec{},
 		},
 	}}
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -182,7 +182,7 @@ func TestCreateExistPersistentVolumeClaims(t *testing.T) {
 			Spec: corev1.PersistentVolumeClaimSpec{},
 		},
 	}}
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -232,7 +232,7 @@ func TestCreateExistPersistentVolumeClaims(t *testing.T) {
 	}
 
 	expectedPVCName := fmt.Sprintf("%s-%s", "pvc", "5435cf73f0")
-	pvcList, err := fakekubeclient.CoreV1().PersistentVolumeClaims(namespace).List(context.Background(), metav1.ListOptions{})
+	pvcList, err := fakekubeclient.CoreV1().PersistentVolumeClaims(namespace).List(t.Context(), metav1.ListOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -245,7 +245,7 @@ func TestCreateExistPersistentVolumeClaims(t *testing.T) {
 }
 
 func TestPurgeFinalizerAndDeletePVCForWorkspace(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	kubeClientSet := fakek8s.NewSimpleClientset()
 
 	// seed data

--- a/pkg/remote/oci/resolver_test.go
+++ b/pkg/remote/oci/resolver_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package oci_test
 
 import (
-	"context"
 	"fmt"
 	"net/http/httptest"
 	"net/url"
@@ -167,7 +166,7 @@ func TestOCIResolver(t *testing.T) {
 			}
 
 			resolver := oci.NewResolver(ref, authn.DefaultKeychain)
-			listActual, err := resolver.List(context.Background())
+			listActual, err := resolver.List(t.Context())
 			if tc.wantErr != "" {
 				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
 					t.Fatalf("expected error containing %q but got: %v", tc.wantErr, err)
@@ -186,7 +185,7 @@ func TestOCIResolver(t *testing.T) {
 			}
 
 			for _, obj := range tc.objs {
-				actual, refSource, err := resolver.Get(context.Background(), strings.ToLower(obj.GetObjectKind().GroupVersionKind().Kind), test.GetObjectName(obj))
+				actual, refSource, err := resolver.Get(t.Context(), strings.ToLower(obj.GetObjectKind().GroupVersionKind().Kind), test.GetObjectName(obj))
 				if err != nil {
 					t.Fatalf("could not retrieve object from image: %#v", err)
 				}

--- a/pkg/remote/resolution/resolver_test.go
+++ b/pkg/remote/resolution/resolver_test.go
@@ -14,7 +14,6 @@ limitations under the License.
 package resolution
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -53,7 +52,7 @@ func TestGet_Successful(t *testing.T) {
 		resolvedData:        pipelineBytes,
 		resolvedAnnotations: nil,
 	}} {
-		ctx := context.Background()
+		ctx := t.Context()
 		owner := &v1beta1.PipelineRun{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "foo",
@@ -181,7 +180,7 @@ func TestGet_Errors(t *testing.T) {
 		expectedGetErr:   &DataAccessError{},
 		resolvedResource: invalidStepAction,
 	}} {
-		ctx := context.Background()
+		ctx := t.Context()
 		owner := &v1beta1.PipelineRun{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "foo",

--- a/pkg/remoteresolution/remote/resolution/resolver_test.go
+++ b/pkg/remoteresolution/remote/resolution/resolver_test.go
@@ -14,7 +14,6 @@ limitations under the License.
 package resolution
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -57,7 +56,7 @@ func TestGet_Successful(t *testing.T) {
 		resolvedData:        pipelineBytes,
 		resolvedAnnotations: nil,
 	}} {
-		ctx := context.Background()
+		ctx := t.Context()
 		owner := &v1beta1.PipelineRun{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "foo",
@@ -114,7 +113,7 @@ func TestGet_Errors(t *testing.T) {
 		expectedGetErr:   &resolution.DataAccessError{},
 		resolvedResource: invalidDataResource,
 	}} {
-		ctx := context.Background()
+		ctx := t.Context()
 		owner := &v1beta1.PipelineRun{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "foo",

--- a/pkg/remoteresolution/resolver/bundle/resolver_test.go
+++ b/pkg/remoteresolution/resolver/bundle/resolver_test.go
@@ -58,7 +58,7 @@ const (
 
 func TestGetSelector(t *testing.T) {
 	resolver := bundle.Resolver{}
-	sel := resolver.GetSelector(context.Background())
+	sel := resolver.GetSelector(t.Context())
 	if typ, has := sel[resolutioncommon.LabelKeyResolverType]; !has {
 		t.Fatalf("unexpected selector: %v", sel)
 	} else if typ != bundle.LabelValueBundleResolverType {
@@ -71,7 +71,7 @@ func TestValidateParamsSecret(t *testing.T) {
 	config := map[string]string{
 		bundleresolution.ConfigServiceAccount: "default",
 	}
-	ctx := framework.InjectResolverConfigToContext(context.Background(), config)
+	ctx := framework.InjectResolverConfigToContext(t.Context(), config)
 
 	paramsWithTask := []pipelinev1.Param{{
 		Name:  bundleresolution.ParamKind,
@@ -115,7 +115,7 @@ func TestValidateParamsServiceAccount(t *testing.T) {
 	config := map[string]string{
 		bundleresolution.ConfigServiceAccount: "default",
 	}
-	ctx := framework.InjectResolverConfigToContext(context.Background(), config)
+	ctx := framework.InjectResolverConfigToContext(t.Context(), config)
 
 	paramsWithTask := []pipelinev1.Param{{
 		Name:  bundleresolution.ParamKind,
@@ -149,7 +149,7 @@ func TestValidateParamsServiceAccount(t *testing.T) {
 		Value: *pipelinev1.NewStructuredValues("baz"),
 	}}
 	req = v1beta1.ResolutionRequestSpec{Params: paramsWithPipeline}
-	if err := resolver.Validate(context.Background(), &req); err != nil {
+	if err := resolver.Validate(t.Context(), &req); err != nil {
 		t.Fatalf("unexpected error validating params: %v", err)
 	}
 }
@@ -199,7 +199,7 @@ func TestValidateMissing(t *testing.T) {
 		Value: *pipelinev1.NewStructuredValues("baz"),
 	}}
 	req := v1beta1.ResolutionRequestSpec{Params: paramsMissingBundle}
-	err = resolver.Validate(context.Background(), &req)
+	err = resolver.Validate(t.Context(), &req)
 	if err == nil {
 		t.Fatalf("expected missing kind err")
 	}
@@ -215,7 +215,7 @@ func TestValidateMissing(t *testing.T) {
 		Value: *pipelinev1.NewStructuredValues("baz"),
 	}}
 	req = v1beta1.ResolutionRequestSpec{Params: paramsMissingName}
-	err = resolver.Validate(context.Background(), &req)
+	err = resolver.Validate(t.Context(), &req)
 	if err == nil {
 		t.Fatalf("expected missing name err")
 	}

--- a/pkg/remoteresolution/resolver/cluster/resolver_test.go
+++ b/pkg/remoteresolution/resolver/cluster/resolver_test.go
@@ -54,7 +54,7 @@ const (
 
 func TestGetSelector(t *testing.T) {
 	resolver := cluster.Resolver{}
-	sel := resolver.GetSelector(context.Background())
+	sel := resolver.GetSelector(t.Context())
 	if typ, has := sel[resolutioncommon.LabelKeyResolverType]; !has {
 		t.Fatalf("unexpected selector: %v", sel)
 	} else if typ != cluster.LabelValueClusterResolverType {
@@ -76,7 +76,7 @@ func TestValidate(t *testing.T) {
 		Value: *pipelinev1.NewStructuredValues("baz"),
 	}}
 
-	ctx := framework.InjectResolverConfigToContext(context.Background(), map[string]string{
+	ctx := framework.InjectResolverConfigToContext(t.Context(), map[string]string{
 		clusterresolution.AllowedNamespacesKey: "foo,bar",
 		clusterresolution.BlockedNamespacesKey: "abc,def",
 	})
@@ -193,7 +193,7 @@ func TestValidateFailure(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			resolver := &cluster.Resolver{}
 
-			ctx := context.Background()
+			ctx := t.Context()
 			if len(tc.conf) > 0 {
 				ctx = framework.InjectResolverConfigToContext(ctx, tc.conf)
 			}

--- a/pkg/remoteresolution/resolver/git/resolver_test.go
+++ b/pkg/remoteresolution/resolver/git/resolver_test.go
@@ -53,7 +53,7 @@ import (
 
 func TestGetSelector(t *testing.T) {
 	resolver := Resolver{}
-	sel := resolver.GetSelector(context.Background())
+	sel := resolver.GetSelector(t.Context())
 	if typ, has := sel[common.LabelKeyResolverType]; !has {
 		t.Fatalf("unexpected selector: %v", sel)
 	} else if typ != labelValueGitResolverType {
@@ -128,7 +128,7 @@ func TestValidateParams(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			resolver := Resolver{}
-			err := resolver.Validate(context.Background(), &v1beta1.ResolutionRequestSpec{Params: toParams(tt.params)})
+			err := resolver.Validate(t.Context(), &v1beta1.ResolutionRequestSpec{Params: toParams(tt.params)})
 			if tt.wantErr == "" {
 				if err != nil {
 					t.Fatalf("unexpected error validating params: %v", err)
@@ -204,7 +204,7 @@ func TestValidateParams_Failure(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			resolver := &Resolver{}
-			err := resolver.Validate(context.Background(), &v1beta1.ResolutionRequestSpec{Params: toParams(tc.params)})
+			err := resolver.Validate(t.Context(), &v1beta1.ResolutionRequestSpec{Params: toParams(tc.params)})
 			if err == nil {
 				t.Fatalf("got no error, but expected: %s", tc.expectedErr)
 			}
@@ -218,7 +218,7 @@ func TestValidateParams_Failure(t *testing.T) {
 func TestGetResolutionTimeoutDefault(t *testing.T) {
 	resolver := Resolver{}
 	defaultTimeout := 30 * time.Minute
-	timeout, err := resolver.GetResolutionTimeout(context.Background(), defaultTimeout, map[string]string{})
+	timeout, err := resolver.GetResolutionTimeout(t.Context(), defaultTimeout, map[string]string{})
 	if err != nil {
 		t.Fatalf("couldn't get default-timeout: %v", err)
 	}
@@ -234,7 +234,7 @@ func TestGetResolutionTimeoutCustom(t *testing.T) {
 	config := map[string]string{
 		gitresolution.DefaultTimeoutKey: configTimeout.String(),
 	}
-	ctx := resolutionframework.InjectResolverConfigToContext(context.Background(), config)
+	ctx := resolutionframework.InjectResolverConfigToContext(t.Context(), config)
 	timeout, err := resolver.GetResolutionTimeout(ctx, defaultTimeout, map[string]string{})
 	if err != nil {
 		t.Fatalf("couldn't get default-timeout: %v", err)
@@ -253,7 +253,7 @@ func TestGetResolutionTimeoutCustomIdentifier(t *testing.T) {
 		gitresolution.DefaultTimeoutKey:          configTimeout.String(),
 		"foo." + gitresolution.DefaultTimeoutKey: identifierConfigTImeout.String(),
 	}
-	ctx := resolutionframework.InjectResolverConfigToContext(context.Background(), config)
+	ctx := resolutionframework.InjectResolverConfigToContext(t.Context(), config)
 	timeout, err := resolver.GetResolutionTimeout(ctx, defaultTimeout, map[string]string{"configKey": "foo"})
 	if err != nil {
 		t.Fatalf("couldn't get default-timeout: %v", err)

--- a/pkg/remoteresolution/resolver/http/resolver_test.go
+++ b/pkg/remoteresolution/resolver/http/resolver_test.go
@@ -70,7 +70,7 @@ const emptyStr = "empty"
 
 func TestGetSelector(t *testing.T) {
 	resolver := Resolver{}
-	sel := resolver.GetSelector(context.Background())
+	sel := resolver.GetSelector(t.Context())
 	if typ, has := sel[resolutioncommon.LabelKeyResolverType]; !has {
 		t.Fatalf("unexpected selector: %v", sel)
 	} else if typ != LabelValueHttpResolverType {
@@ -413,7 +413,7 @@ func TestResolverReconcileBasicAuth(t *testing.T) {
 
 func TestGetName(t *testing.T) {
 	resolver := Resolver{}
-	ctx := context.Background()
+	ctx := t.Context()
 
 	if d := cmp.Diff(httpResolverName, resolver.GetName(ctx)); d != "" {
 		t.Errorf("invalid name: %s", diff.PrintWantGot(d))

--- a/pkg/remoteresolution/resolver/hub/resolver_test.go
+++ b/pkg/remoteresolution/resolver/hub/resolver_test.go
@@ -35,7 +35,7 @@ import (
 
 func TestGetSelector(t *testing.T) {
 	resolver := Resolver{}
-	sel := resolver.GetSelector(context.Background())
+	sel := resolver.GetSelector(t.Context())
 	if typ, has := sel[resolutioncommon.LabelKeyResolverType]; !has {
 		t.Fatalf("unexpected selector: %v", sel)
 	} else if typ != LabelValueHubResolverType {

--- a/pkg/resolution/common/context_test.go
+++ b/pkg/resolution/common/context_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package common_test
 
 import (
-	"context"
 	"testing"
 
 	common "github.com/tektoncd/pipeline/pkg/resolution/common"
@@ -27,7 +26,7 @@ func TestRequestNamespace(t *testing.T) {
 	namespaceA := "foo"
 	namespaceB := "bar"
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx = common.InjectRequestNamespace(ctx, namespaceA)
 	if common.RequestNamespace(ctx) != namespaceA {
 		t.Fatalf("expected namespace to be stored as part of context")
@@ -38,7 +37,7 @@ func TestRequestNamespace(t *testing.T) {
 		t.Fatalf("expected stored namespace to be immutable once set")
 	}
 
-	ctx = context.Background()
+	ctx = t.Context()
 	if common.RequestNamespace(ctx) != "" {
 		t.Fatalf("expected empty namespace returned if no value was previously injected")
 	}
@@ -48,7 +47,7 @@ func TestRequestName(t *testing.T) {
 	nameA := "foo"
 	nameB := "bar"
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx = common.InjectRequestName(ctx, nameA)
 	if common.RequestName(ctx) != nameA {
 		t.Fatalf("expected namespace to be stored as part of context")
@@ -59,7 +58,7 @@ func TestRequestName(t *testing.T) {
 		t.Fatalf("expected stored namespace to be immutable once set")
 	}
 
-	ctx = context.Background()
+	ctx = t.Context()
 	if common.RequestName(ctx) != "" {
 		t.Fatalf("expected empty namespace returned if no value was previously injected")
 	}

--- a/pkg/resolution/resolver/bundle/resolver_test.go
+++ b/pkg/resolution/resolver/bundle/resolver_test.go
@@ -56,7 +56,7 @@ const (
 
 func TestGetSelector(t *testing.T) {
 	resolver := bundle.Resolver{}
-	sel := resolver.GetSelector(context.Background())
+	sel := resolver.GetSelector(t.Context())
 	if typ, has := sel[common.LabelKeyResolverType]; !has {
 		t.Fatalf("unexpected selector: %v", sel)
 	} else if typ != bundle.LabelValueBundleResolverType {
@@ -69,7 +69,7 @@ func TestValidateParamsSecret(t *testing.T) {
 	config := map[string]string{
 		bundle.ConfigServiceAccount: "default",
 	}
-	ctx := framework.InjectResolverConfigToContext(context.Background(), config)
+	ctx := framework.InjectResolverConfigToContext(t.Context(), config)
 
 	paramsWithTask := []pipelinev1.Param{{
 		Name:  bundle.ParamKind,
@@ -112,7 +112,7 @@ func TestValidateParamsServiceAccount(t *testing.T) {
 	config := map[string]string{
 		bundle.ConfigServiceAccount: "default",
 	}
-	ctx := framework.InjectResolverConfigToContext(context.Background(), config)
+	ctx := framework.InjectResolverConfigToContext(t.Context(), config)
 
 	paramsWithTask := []pipelinev1.Param{{
 		Name:  bundle.ParamKind,
@@ -128,7 +128,7 @@ func TestValidateParamsServiceAccount(t *testing.T) {
 		Value: *pipelinev1.NewStructuredValues("baz"),
 	}}
 
-	if err := resolver.ValidateParams(context.Background(), paramsWithTask); err != nil {
+	if err := resolver.ValidateParams(t.Context(), paramsWithTask); err != nil {
 		t.Fatalf("unexpected error validating params: %v", err)
 	}
 
@@ -212,7 +212,7 @@ func TestValidateParamsMissing(t *testing.T) {
 		Name:  bundle.ParamImagePullSecret,
 		Value: *pipelinev1.NewStructuredValues("baz"),
 	}}
-	err = resolver.ValidateParams(context.Background(), paramsMissingBundle)
+	err = resolver.ValidateParams(t.Context(), paramsMissingBundle)
 	if err == nil {
 		t.Fatalf("expected missing kind err")
 	}
@@ -227,7 +227,7 @@ func TestValidateParamsMissing(t *testing.T) {
 		Name:  bundle.ParamImagePullSecret,
 		Value: *pipelinev1.NewStructuredValues("baz"),
 	}}
-	err = resolver.ValidateParams(context.Background(), paramsMissingName)
+	err = resolver.ValidateParams(t.Context(), paramsMissingName)
 	if err == nil {
 		t.Fatalf("expected missing name err")
 	}
@@ -716,7 +716,7 @@ func pushToRegistry(t *testing.T, registry, imageName string, data []runtime.Obj
 func TestGetResolutionTimeoutDefault(t *testing.T) {
 	resolver := bundle.Resolver{}
 	defaultTimeout := 30 * time.Minute
-	timeout, err := resolver.GetResolutionTimeout(context.Background(), defaultTimeout, map[string]string{})
+	timeout, err := resolver.GetResolutionTimeout(t.Context(), defaultTimeout, map[string]string{})
 	if err != nil {
 		t.Fatalf("couldn't get default-timeout: %v", err)
 	}
@@ -732,7 +732,7 @@ func TestGetResolutionTimeoutCustom(t *testing.T) {
 	config := map[string]string{
 		bundle.ConfigTimeoutKey: configTimeout.String(),
 	}
-	ctx := framework.InjectResolverConfigToContext(context.Background(), config)
+	ctx := framework.InjectResolverConfigToContext(t.Context(), config)
 	timeout, err := resolver.GetResolutionTimeout(ctx, defaultTimeout, map[string]string{})
 	if err != nil {
 		t.Fatalf("couldn't get default-timeout: %v", err)
@@ -757,7 +757,7 @@ func TestGetResolutionBackoffCustom(t *testing.T) {
 		bundle.ConfigBackoffSteps:    strconv.Itoa(configBackoffSteps),
 		bundle.ConfigBackoffCap:      configBackoffCap.String(),
 	}
-	ctx := framework.InjectResolverConfigToContext(context.Background(), config)
+	ctx := framework.InjectResolverConfigToContext(t.Context(), config)
 	backoffConfig, err := bundle.GetBundleResolverBackoff(ctx)
 	// timeout, err := resolver.GetResolutionTimeout(ctx, defaultTimeout, map[string]string{})
 	if err != nil {

--- a/pkg/resolution/resolver/cluster/resolver_test.go
+++ b/pkg/resolution/resolver/cluster/resolver_test.go
@@ -52,7 +52,7 @@ const (
 
 func TestGetSelector(t *testing.T) {
 	resolver := cluster.Resolver{}
-	sel := resolver.GetSelector(context.Background())
+	sel := resolver.GetSelector(t.Context())
 	if typ, has := sel[common.LabelKeyResolverType]; !has {
 		t.Fatalf("unexpected selector: %v", sel)
 	} else if typ != cluster.LabelValueClusterResolverType {
@@ -74,7 +74,7 @@ func TestValidateParams(t *testing.T) {
 		Value: *pipelinev1.NewStructuredValues("baz"),
 	}}
 
-	ctx := framework.InjectResolverConfigToContext(context.Background(), map[string]string{
+	ctx := framework.InjectResolverConfigToContext(t.Context(), map[string]string{
 		cluster.AllowedNamespacesKey: "foo,bar",
 		cluster.BlockedNamespacesKey: "abc,def",
 	})
@@ -189,7 +189,7 @@ func TestValidateParamsFailure(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			resolver := &cluster.Resolver{}
 
-			ctx := context.Background()
+			ctx := t.Context()
 			if len(tc.conf) > 0 {
 				ctx = framework.InjectResolverConfigToContext(ctx, tc.conf)
 			}

--- a/pkg/resolution/resolver/git/config_test.go
+++ b/pkg/resolution/resolver/git/config_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package git
 
 import (
-	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -129,7 +128,7 @@ func TestGetGitResolverConfig(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := resolutionframework.InjectResolverConfigToContext(context.Background(), tc.config)
+			ctx := resolutionframework.InjectResolverConfigToContext(t.Context(), tc.config)
 			gitResolverConfig, err := GetGitResolverConfig(ctx)
 			if tc.wantErr {
 				if err == nil {

--- a/pkg/resolution/resolver/git/repository_test.go
+++ b/pkg/resolution/resolver/git/repository_test.go
@@ -53,7 +53,7 @@ func TestClone(t *testing.T) {
 			}
 
 			mockCmdRemote := remote{url: test.url, username: test.username, password: test.password, cmdExecutor: executor}
-			repo, cleanup, err := mockCmdRemote.clone(context.Background())
+			repo, cleanup, err := mockCmdRemote.clone(t.Context())
 			defer cleanup()
 			if test.expectErr != "" {
 				if err.Error() != test.expectErr {
@@ -116,7 +116,7 @@ func TestCheckout(t *testing.T) {
 		t.Fatalf("coun't delete branch to orphan commit: %v", err)
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	type testCase struct {
 		revision         string

--- a/pkg/resolution/resolver/git/resolver_test.go
+++ b/pkg/resolution/resolver/git/resolver_test.go
@@ -48,7 +48,7 @@ import (
 
 func TestGetSelector(t *testing.T) {
 	resolver := Resolver{}
-	sel := resolver.GetSelector(context.Background())
+	sel := resolver.GetSelector(t.Context())
 	if typ, has := sel[common.LabelKeyResolverType]; !has {
 		t.Fatalf("unexpected selector: %v", sel)
 	} else if typ != labelValueGitResolverType {
@@ -123,7 +123,7 @@ func TestValidateParams(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			resolver := Resolver{}
-			err := resolver.ValidateParams(context.Background(), toParams(tt.params))
+			err := resolver.ValidateParams(t.Context(), toParams(tt.params))
 			if tt.wantErr == "" {
 				if err != nil {
 					t.Fatalf("unexpected error validating params: %v", err)
@@ -199,7 +199,7 @@ func TestValidateParams_Failure(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			resolver := &Resolver{}
-			err := resolver.ValidateParams(context.Background(), toParams(tc.params))
+			err := resolver.ValidateParams(t.Context(), toParams(tc.params))
 			if err == nil {
 				t.Fatalf("got no error, but expected: %s", tc.expectedErr)
 			}
@@ -213,7 +213,7 @@ func TestValidateParams_Failure(t *testing.T) {
 func TestGetResolutionTimeoutDefault(t *testing.T) {
 	resolver := Resolver{}
 	defaultTimeout := 30 * time.Minute
-	timeout, err := resolver.GetResolutionTimeout(context.Background(), defaultTimeout, map[string]string{})
+	timeout, err := resolver.GetResolutionTimeout(t.Context(), defaultTimeout, map[string]string{})
 	if err != nil {
 		t.Fatalf("couldn't get default-timeout: %v", err)
 	}
@@ -229,7 +229,7 @@ func TestGetResolutionTimeoutCustom(t *testing.T) {
 	config := map[string]string{
 		DefaultTimeoutKey: configTimeout.String(),
 	}
-	ctx := framework.InjectResolverConfigToContext(context.Background(), config)
+	ctx := framework.InjectResolverConfigToContext(t.Context(), config)
 	timeout, err := resolver.GetResolutionTimeout(ctx, defaultTimeout, map[string]string{})
 	if err != nil {
 		t.Fatalf("couldn't get default-timeout: %v", err)
@@ -248,7 +248,7 @@ func TestGetResolutionTimeoutCustomIdentifier(t *testing.T) {
 		DefaultTimeoutKey:          configTimeout.String(),
 		"foo." + DefaultTimeoutKey: identifierConfigTImeout.String(),
 	}
-	ctx := framework.InjectResolverConfigToContext(context.Background(), config)
+	ctx := framework.InjectResolverConfigToContext(t.Context(), config)
 	timeout, err := resolver.GetResolutionTimeout(ctx, defaultTimeout, map[string]string{"configKey": "foo"})
 	if err != nil {
 		t.Fatalf("couldn't get default-timeout: %v", err)
@@ -1045,7 +1045,7 @@ func TestGetScmConfigForParamConfigKey(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := framework.InjectResolverConfigToContext(context.Background(), tc.config)
+			ctx := framework.InjectResolverConfigToContext(t.Context(), tc.config)
 			gitResolverConfig, err := GetScmConfigForParamConfigKey(ctx, tc.params)
 			if tc.wantErr {
 				if err == nil {

--- a/pkg/resolution/resolver/http/resolver_test.go
+++ b/pkg/resolution/resolver/http/resolver_test.go
@@ -67,7 +67,7 @@ const emptyStr = "empty"
 
 func TestGetSelector(t *testing.T) {
 	resolver := Resolver{}
-	sel := resolver.GetSelector(context.Background())
+	sel := resolver.GetSelector(t.Context())
 	if typ, has := sel[common.LabelKeyResolverType]; !has {
 		t.Fatalf("unexpected selector: %v", sel)
 	} else if typ != LabelValueHttpResolverType {
@@ -481,7 +481,7 @@ func TestResolverReconcileBasicAuth(t *testing.T) {
 
 func TestGetName(t *testing.T) {
 	resolver := Resolver{}
-	ctx := context.Background()
+	ctx := t.Context()
 
 	if d := cmp.Diff(httpResolverName, resolver.GetName(ctx)); d != "" {
 		t.Errorf("invalid name: %s", diff.PrintWantGot(d))

--- a/pkg/resolution/resolver/hub/resolver_test.go
+++ b/pkg/resolution/resolver/hub/resolver_test.go
@@ -37,7 +37,7 @@ import (
 
 func TestGetSelector(t *testing.T) {
 	resolver := Resolver{}
-	sel := resolver.GetSelector(context.Background())
+	sel := resolver.GetSelector(t.Context())
 	if typ, has := sel[common.LabelKeyResolverType]; !has {
 		t.Fatalf("unexpected selector: %v", sel)
 	} else if typ != LabelValueHubResolverType {

--- a/pkg/spire/spire_mock_test.go
+++ b/pkg/spire/spire_mock_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package spire
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -39,7 +38,7 @@ func TestMock_TaskRunSign(t *testing.T) {
 		cc ControllerAPIClient = spireMockClient
 	)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	var err error
 
 	for _, tr := range testTaskRuns() {
@@ -86,7 +85,7 @@ func TestMock_CheckHashSimilarities(t *testing.T) {
 		cc ControllerAPIClient = spireMockClient
 	)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	trs := testTaskRuns()
 	tr1, tr2 := trs[0], trs[1]
 
@@ -202,7 +201,7 @@ func TestMock_CheckTamper(t *testing.T) {
 			cc ControllerAPIClient = spireMockClient
 		)
 
-		ctx := context.Background()
+		ctx := t.Context()
 		for _, tr := range testTaskRuns() {
 			err := cc.AppendStatusInternalAnnotation(ctx, tr)
 			if err != nil {
@@ -274,7 +273,7 @@ func TestMock_TaskRunResultsSign(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
-		ctx := context.Background()
+		ctx := t.Context()
 		for _, tr := range testTaskRuns() {
 			var err error
 			if !tt.skipEntryCreate {
@@ -498,7 +497,7 @@ func TestMock_TaskRunResultsSignTamper(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
-		ctx := context.Background()
+		ctx := t.Context()
 		for _, tr := range testTaskRuns() {
 			var err error
 			// Pod should not be nil, but it isn't used in mocking

--- a/pkg/spire/spire_test.go
+++ b/pkg/spire/spire_test.go
@@ -349,7 +349,7 @@ func TestCheckTamper(t *testing.T) {
 }
 
 func TestNoSVID(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	cfg := &config.SpireConfig{SocketPath: "tcp://127.0.0.1:12345"} // bogus SocketPath
 	ec := NewEntrypointerAPIClient(cfg)
 	defer ec.Close()
@@ -632,7 +632,7 @@ func TestTaskRunResultsSignTamper(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
-		ctx := context.Background()
+		ctx := t.Context()
 		for _, tr := range testTaskRuns() {
 			t.Run(tt.desc+" "+tr.ObjectMeta.Name, func(t *testing.T) {
 				results := []result.RunResult{{

--- a/pkg/taskrunmetrics/metrics_test.go
+++ b/pkg/taskrunmetrics/metrics_test.go
@@ -67,7 +67,7 @@ func TestUninitializedMetrics(t *testing.T) {
 		Status: corev1.ConditionUnknown,
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	if err := metrics.DurationAndCount(ctx, &v1.TaskRun{}, beforeCondition); err == nil {
 		t.Error("DurationCount recording expected to return error but got nil")

--- a/pkg/tracing/tracing_test.go
+++ b/pkg/tracing/tracing_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package tracing
 
 import (
-	"context"
 	"testing"
 
 	"github.com/tektoncd/pipeline/pkg/apis/config"
@@ -35,7 +34,7 @@ func TestNewTracerProvider(t *testing.T) {
 	tp := New("test-service", zap.NewNop().Sugar())
 
 	tracer := tp.Tracer("tracer")
-	_, span := tracer.Start(context.TODO(), "example")
+	_, span := tracer.Start(t.Context(), "example")
 
 	// tp.Tracer should return a nooptracer initially
 	// recording is always false for spans created by nooptracer
@@ -54,7 +53,7 @@ func TestOnStore(t *testing.T) {
 	tp.OnStore(nil)("config-tracing", cfg)
 
 	tracer := tp.Tracer("tracer")
-	_, span := tracer.Start(context.TODO(), "example")
+	_, span := tracer.Start(t.Context(), "example")
 
 	// tp.Tracer should return a nooptracer when tracing is disabled
 	// recording is always false for spans created by nooptracer
@@ -112,7 +111,7 @@ func TestOnStoreWithEnabled(t *testing.T) {
 	tp.OnStore(nil)("config-tracing", cfg)
 
 	tracer := tp.Tracer("tracer")
-	_, span := tracer.Start(context.TODO(), "example")
+	_, span := tracer.Start(t.Context(), "example")
 
 	if !span.IsRecording() {
 		t.Fatalf("Span is not recording with tracing enabled")

--- a/pkg/trustedresources/verifier/verifier_test.go
+++ b/pkg/trustedresources/verifier/verifier_test.go
@@ -42,7 +42,7 @@ const (
 )
 
 func TestFromPolicy_Success(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	_, key256, k8sclient, vps := test.SetupVerificationPolicies(t)
 	keyInDataVp, keyInSecretVp := vps[0], vps[1]
 
@@ -68,7 +68,7 @@ func TestFromPolicy_Success(t *testing.T) {
 			},
 		},
 	}
-	ctx = context.WithValue(context.TODO(), fakekms.KmsCtxKey{}, key256)
+	ctx = context.WithValue(t.Context(), fakekms.KmsCtxKey{}, key256)
 
 	_, key384, pub, err := test.GenerateKeys(elliptic.P384(), crypto.SHA256)
 	if err != nil {
@@ -221,7 +221,7 @@ func TestFromPolicy_Error(t *testing.T) {
 	}}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := FromPolicy(context.Background(), fakek8s.NewSimpleClientset(), tc.policy)
+			_, err := FromPolicy(t.Context(), fakek8s.NewSimpleClientset(), tc.policy)
 			if !errors.Is(err, tc.expectedError) {
 				t.Errorf("FromPolicy got: %v, want: %v", err, tc.expectedError)
 			}
@@ -230,7 +230,7 @@ func TestFromPolicy_Error(t *testing.T) {
 }
 
 func TestFromKeyRef_Success(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	fileKey, keypath := test.GetKeysFromFile(ctx, t)
 
 	_, secretKey, pub, err := test.GenerateKeys(elliptic.P256(), crypto.SHA256)
@@ -272,7 +272,7 @@ func TestFromKeyRef_Success(t *testing.T) {
 }
 
 func TestFromKeyRef_Error(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	_, keypath := test.GetKeysFromFile(ctx, t)
 	tcs := []struct {
 		name          string
@@ -320,7 +320,7 @@ func TestFromSecret_Success(t *testing.T) {
 
 	k8sclient := fakek8s.NewSimpleClientset(secretData)
 
-	v, err := fromSecret(context.Background(), fmt.Sprintf("k8s://%s/secret", namespace), crypto.SHA256, k8sclient)
+	v, err := fromSecret(t.Context(), fmt.Sprintf("k8s://%s/secret", namespace), crypto.SHA256, k8sclient)
 	checkVerifier(t, keys, v)
 	if err != nil {
 		t.Errorf("couldn't construct expected verifier from secret: %v", err)
@@ -382,7 +382,7 @@ func TestFromSecret_Error(t *testing.T) {
 	}}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := fromSecret(context.Background(), tc.secretref, crypto.SHA256, k8sclient)
+			_, err := fromSecret(t.Context(), tc.secretref, crypto.SHA256, k8sclient)
 			if !errors.Is(err, tc.expectedError) {
 				t.Errorf("FromSecret got: %v, want: %v", err, tc.expectedError)
 			}

--- a/pkg/trustedresources/verify_test.go
+++ b/pkg/trustedresources/verify_test.go
@@ -18,7 +18,6 @@ package trustedresources
 
 import (
 	"bytes"
-	"context"
 	"crypto"
 	"crypto/elliptic"
 	"crypto/sha256"
@@ -270,7 +269,7 @@ func TestVerifyResource_Task_Success(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := test.SetupTrustedResourceConfig(context.Background(), tc.verificationNoMatchPolicy)
+			ctx := test.SetupTrustedResourceConfig(t.Context(), tc.verificationNoMatchPolicy)
 			vr := VerifyResource(ctx, tc.task, k8sclient, tc.source, tc.verificationPolicies)
 			if tc.expectedVerificationResult.VerificationResultType != vr.VerificationResultType && errors.Is(vr.Err, tc.expectedVerificationResult.Err) {
 				t.Errorf("VerificationResult mismatch: want %v, got %v", tc.expectedVerificationResult, vr)
@@ -280,7 +279,7 @@ func TestVerifyResource_Task_Success(t *testing.T) {
 }
 
 func TestVerifyResource_Task_Error(t *testing.T) {
-	ctx := logging.WithLogger(context.Background(), zaptest.NewLogger(t).Sugar())
+	ctx := logging.WithLogger(t.Context(), zaptest.NewLogger(t).Sugar())
 	ctx = test.SetupTrustedResourceConfig(ctx, config.FailNoMatchPolicy)
 	sv, _, k8sclient, vps := test.SetupVerificationPolicies(t)
 
@@ -421,7 +420,7 @@ func TestVerifyResource_Pipeline_Success(t *testing.T) {
 	}}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := test.SetupTrustedResourceConfig(context.Background(), tc.verificationNoMatchPolicy)
+			ctx := test.SetupTrustedResourceConfig(t.Context(), tc.verificationNoMatchPolicy)
 			vr := VerifyResource(ctx, tc.pipeline, k8sclient, tc.source, vps)
 			if tc.expectedVerificationResult.VerificationResultType != vr.VerificationResultType && errors.Is(vr.Err, tc.expectedVerificationResult.Err) {
 				t.Errorf("VerificationResult mismatch: want %v, got %v", tc.expectedVerificationResult, vr)
@@ -431,7 +430,7 @@ func TestVerifyResource_Pipeline_Success(t *testing.T) {
 }
 
 func TestVerifyResource_Pipeline_Error(t *testing.T) {
-	ctx := logging.WithLogger(context.Background(), zaptest.NewLogger(t).Sugar())
+	ctx := logging.WithLogger(t.Context(), zaptest.NewLogger(t).Sugar())
 	ctx = test.SetupTrustedResourceConfig(ctx, config.FailNoMatchPolicy)
 	sv, _, k8sclient, vps := test.SetupVerificationPolicies(t)
 
@@ -498,7 +497,7 @@ func TestVerifyResource_V1Task_Success(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	vr := VerifyResource(context.Background(), signedTask, k8sclient, &v1.RefSource{URI: "git+https://github.com/tektoncd/catalog.git"}, vps)
+	vr := VerifyResource(t.Context(), signedTask, k8sclient, &v1.RefSource{URI: "git+https://github.com/tektoncd/catalog.git"}, vps)
 	if vr.VerificationResultType != VerificationPass {
 		t.Errorf("VerificationResult mismatch: want %v, got %v", VerificationPass, vr.VerificationResultType)
 	}
@@ -512,7 +511,7 @@ func TestVerifyResource_V1Task_Error(t *testing.T) {
 	}
 	modifiedTask := signedTask.DeepCopy()
 	modifiedTask.Annotations["foo"] = "modified"
-	vr := VerifyResource(context.Background(), modifiedTask, k8sclient, &v1.RefSource{URI: "git+https://github.com/tektoncd/catalog.git"}, vps)
+	vr := VerifyResource(t.Context(), modifiedTask, k8sclient, &v1.RefSource{URI: "git+https://github.com/tektoncd/catalog.git"}, vps)
 	if vr.VerificationResultType != VerificationError && !errors.Is(vr.Err, ErrResourceVerificationFailed) {
 		t.Errorf("VerificationResult mismatch: want %v, got %v", VerificationResult{VerificationResultType: VerificationError, Err: ErrResourceVerificationFailed}, vr)
 	}
@@ -524,7 +523,7 @@ func TestVerifyResource_V1Pipeline_Success(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	vr := VerifyResource(context.Background(), signed, k8sclient, &v1.RefSource{URI: "git+https://github.com/tektoncd/catalog.git"}, vps)
+	vr := VerifyResource(t.Context(), signed, k8sclient, &v1.RefSource{URI: "git+https://github.com/tektoncd/catalog.git"}, vps)
 	if vr.VerificationResultType != VerificationPass {
 		t.Errorf("VerificationResult mismatch: want %v, got %v", VerificationPass, vr.VerificationResultType)
 	}
@@ -538,7 +537,7 @@ func TestVerifyResource_V1Pipeline_Error(t *testing.T) {
 	}
 	modifiedTask := signed.DeepCopy()
 	modifiedTask.Annotations["foo"] = "modified"
-	vr := VerifyResource(context.Background(), modifiedTask, k8sclient, &v1.RefSource{URI: "git+https://github.com/tektoncd/catalog.git"}, vps)
+	vr := VerifyResource(t.Context(), modifiedTask, k8sclient, &v1.RefSource{URI: "git+https://github.com/tektoncd/catalog.git"}, vps)
 	if vr.VerificationResultType != VerificationError && !errors.Is(vr.Err, ErrResourceVerificationFailed) {
 		t.Errorf("VerificationResult mismatch: want %v, got %v", VerificationResult{VerificationResultType: VerificationError, Err: ErrResourceVerificationFailed}, vr)
 	}

--- a/pkg/workspace/apply_test.go
+++ b/pkg/workspace/apply_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package workspace_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -742,7 +741,7 @@ func TestApply(t *testing.T) {
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			vols := workspace.CreateVolumes(tc.workspaces)
-			ts, err := workspace.Apply(context.Background(), tc.ts, tc.workspaces, vols)
+			ts, err := workspace.Apply(t.Context(), tc.ts, tc.workspaces, vols)
 			if err != nil {
 				t.Fatalf("Did not expect error but got %v", err)
 			}
@@ -799,7 +798,7 @@ func TestApply_PropagatedWorkspacesFromWorkspaceBindingToDeclarations(t *testing
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			vols := workspace.CreateVolumes(tc.workspaces)
-			ts, err := workspace.Apply(context.Background(), tc.ts, tc.workspaces, vols)
+			ts, err := workspace.Apply(t.Context(), tc.ts, tc.workspaces, vols)
 			if err != nil {
 				t.Fatalf("Did not expect error but got %v", err)
 			}
@@ -1118,7 +1117,7 @@ func TestApply_IsolatedWorkspaces(t *testing.T) {
 		},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := config.ToContext(context.Background(), &config.Config{
+			ctx := config.ToContext(t.Context(), &config.Config{
 				FeatureFlags: &config.FeatureFlags{
 					EnableAPIFields: "alpha",
 				},
@@ -1149,7 +1148,7 @@ func TestApplyWithMissingWorkspaceDeclaration(t *testing.T) {
 		},
 	}}
 	vols := workspace.CreateVolumes(bindings)
-	if _, err := workspace.Apply(context.Background(), ts, bindings, vols); err != nil {
+	if _, err := workspace.Apply(t.Context(), ts, bindings, vols); err != nil {
 		t.Errorf("Did not expect error because of workspace propagation but got %v", err)
 	}
 }

--- a/pkg/workspace/validate_test.go
+++ b/pkg/workspace/validate_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package workspace_test
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -78,7 +77,7 @@ func TestValidateBindingsValid(t *testing.T) {
 		bindings: []v1.WorkspaceBinding{},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
-			if err := workspace.ValidateBindings(context.Background(), tc.declarations, tc.bindings); err != nil {
+			if err := workspace.ValidateBindings(t.Context(), tc.declarations, tc.bindings); err != nil {
 				t.Errorf("didnt expect error for valid bindings but got: %v", err)
 			}
 		})
@@ -154,7 +153,7 @@ func TestValidateBindingsInvalid(t *testing.T) {
 		}},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
-			if err := workspace.ValidateBindings(context.Background(), tc.declarations, tc.bindings); err == nil {
+			if err := workspace.ValidateBindings(t.Context(), tc.declarations, tc.bindings); err == nil {
 				t.Errorf("expected error for invalid bindings but didn't get any!")
 			}
 		})

--- a/test/affinity_assistant_test.go
+++ b/test/affinity_assistant_test.go
@@ -34,7 +34,7 @@ import (
 
 // TestAffinityAssistant_PerWorkspace tests the taskrun pod scheduling and the PVC lifecycle status
 func TestAffinityAssistant_PerWorkspace(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	c, namespace := setup(ctx, t)
@@ -118,7 +118,7 @@ spec:
 // TestAffinityAssistant_PerPipelineRun tests that mounting multiple PVC based workspaces to a pipeline task is allowed and
 // all the pods are scheduled to the same node in AffinityAssistantPerPipelineRuns mode
 func TestAffinityAssistant_PerPipelineRun(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	c, namespace := setup(ctx, t)

--- a/test/artifacts_test.go
+++ b/test/artifacts_test.go
@@ -58,7 +58,7 @@ func TestSurfaceArtifacts(t *testing.T) {
 			featureFlags := getFeatureFlagsBaseOnAPIFlag(t)
 			checkFlagsEnabled := requireAllGates(requireEnableStepArtifactsGate)
 
-			ctx := context.Background()
+			ctx := t.Context()
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 			c, namespace := setup(ctx, t)
@@ -132,7 +132,7 @@ func TestSurfaceArtifactsThroughTerminationMessageScriptProducesArtifacts(t *tes
 	featureFlags := getFeatureFlagsBaseOnAPIFlag(t)
 	checkFlagsEnabled := requireAllGates(requireEnableStepArtifactsGate)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	c, namespace := setup(ctx, t)
@@ -220,7 +220,7 @@ func TestConsumeArtifacts(t *testing.T) {
 				"enable-artifacts": "true",
 			})
 
-			ctx := context.Background()
+			ctx := t.Context()
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 			c, namespace := setup(ctx, t)
@@ -314,7 +314,7 @@ func TestStepProduceResultsAndArtifacts(t *testing.T) {
 				"enable-artifacts": "true",
 			})
 
-			ctx := context.Background()
+			ctx := t.Context()
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 			c, namespace := setup(ctx, t)

--- a/test/cancel_test.go
+++ b/test/cancel_test.go
@@ -44,7 +44,7 @@ func TestTaskRunPipelineRunCancel(t *testing.T) {
 	for _, numRetries := range []int{0, 1} {
 		specStatus := v1.PipelineRunSpecStatusCancelled
 		t.Run(fmt.Sprintf("retries=%d,status=%s", numRetries, specStatus), func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 			requirements := []func(context.Context, *testing.T, *clients, string){}
@@ -189,7 +189,7 @@ spec:
 func TestCancelActivePipelineRunWithCompletedTaskRuns(t *testing.T) {
 	specStatus := v1.PipelineRunSpecStatusCancelled
 	t.Run("status="+specStatus, func(t *testing.T) {
-		ctx := context.Background()
+		ctx := t.Context()
 		ctx, cancel := context.WithCancel(ctx)
 		defer cancel()
 		requirements := []func(context.Context, *testing.T, *clients, string){}

--- a/test/conformance_test.go
+++ b/test/conformance_test.go
@@ -42,7 +42,7 @@ type conditionFn func(name string) ConditionAccessorFn
 // searve as part of the OSS conformance test suite but aims to keep the
 // devel conformant and to prevent regressions.
 func TestTaskRun(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	c, namespace := setup(ctx, t)

--- a/test/conversion_test.go
+++ b/test/conversion_test.go
@@ -658,7 +658,7 @@ status:
 // TestCRDConversionStrategy tests if webhook conversion strategy is
 // set to versioned CRDs.
 func TestCRDConversionStrategy(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -677,7 +677,7 @@ func TestCRDConversionStrategy(t *testing.T) {
 		resolutionv1beta1.Kind("resolutionrequests"),
 	}
 	for _, kind := range kinds {
-		gotCRD, err := c.ApixClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.Background(), kind.String(), metav1.GetOptions{})
+		gotCRD, err := c.ApixClient.ApiextensionsV1().CustomResourceDefinitions().Get(t.Context(), kind.String(), metav1.GetOptions{})
 		if err != nil {
 			t.Fatalf("Couldn't get expected CRD %s: %s", kind, err)
 		}
@@ -696,7 +696,7 @@ func TestCRDConversionStrategy(t *testing.T) {
 // executed by the webhook for roundtrip. And then it creates the v1 Task CRD using v1Clients
 // and requests it by v1beta1Clients to compare with v1beta1.
 func TestTaskCRDConversion(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -723,7 +723,7 @@ func TestTaskCRDConversion(t *testing.T) {
 	}
 
 	v1beta1TaskRoundTrip := &v1beta1.Task{}
-	if err := v1beta1TaskRoundTrip.ConvertFrom(context.Background(), v1TaskGot); err != nil {
+	if err := v1beta1TaskRoundTrip.ConvertFrom(t.Context(), v1TaskGot); err != nil {
 		t.Fatalf("Failed to convert roundtrip v1beta1TaskGot ConvertFrom v1 = %v", err)
 	}
 	if d := cmp.Diff(v1beta1Task, v1beta1TaskRoundTrip, filterMetadata...); d != "" {
@@ -747,7 +747,7 @@ func TestTaskCRDConversion(t *testing.T) {
 	}
 
 	v1TaskRoundTrip := &v1.Task{}
-	if err := v1beta1TaskGot.ConvertTo(context.Background(), v1TaskRoundTrip); err != nil {
+	if err := v1beta1TaskGot.ConvertTo(t.Context(), v1TaskRoundTrip); err != nil {
 		t.Fatalf("Failed to convert roundtrip v1beta1TaskGot ConvertTo v1 = %v", err)
 	}
 	if d := cmp.Diff(v1Task, v1TaskRoundTrip, filterMetadata...); d != "" {
@@ -760,7 +760,7 @@ func TestTaskCRDConversion(t *testing.T) {
 // executed by the webhook for roundtrip. And then it creates the v1 TaskRun CRD using
 // v1Clients and requests it by v1beta1Clients to compare with v1beta1.
 func TestTaskRunCRDConversion(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -797,7 +797,7 @@ func TestTaskRunCRDConversion(t *testing.T) {
 	}
 
 	v1beta1TaskRunRoundTrip := &v1beta1.TaskRun{}
-	if err := v1beta1TaskRunRoundTrip.ConvertFrom(context.Background(), v1TaskRunGot); err != nil {
+	if err := v1beta1TaskRunRoundTrip.ConvertFrom(t.Context(), v1TaskRunGot); err != nil {
 		t.Fatalf("Failed to convert roundtrip v1beta1TaskRunGot ConvertFrom v1 = %v", err)
 	}
 	if d := cmp.Diff(v1beta1TaskRunRoundTripExpected, v1beta1TaskRunRoundTrip, filterV1beta1TaskRunFields...); d != "" {
@@ -832,7 +832,7 @@ func TestTaskRunCRDConversion(t *testing.T) {
 	}
 
 	v1TaskRunRoundTrip := &v1.TaskRun{}
-	if err := v1beta1TaskRunGot.ConvertTo(context.Background(), v1TaskRunRoundTrip); err != nil {
+	if err := v1beta1TaskRunGot.ConvertTo(t.Context(), v1TaskRunRoundTrip); err != nil {
 		t.Fatalf("Failed to convert roundtrip v1beta1TaskRunGot ConvertTo v1 = %v", err)
 	}
 	if d := cmp.Diff(v1TaskRunRoundTripExpected, v1TaskRunRoundTrip, filterV1TaskRunFields...); d != "" {
@@ -845,7 +845,7 @@ func TestTaskRunCRDConversion(t *testing.T) {
 // by the webhook for roundtrip. And then it creates the v1 Pipeline CRD using v1Clients
 // and requests it by v1beta1Clients to compare with v1beta1.
 func TestPipelineCRDConversion(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -872,7 +872,7 @@ func TestPipelineCRDConversion(t *testing.T) {
 	}
 
 	v1beta1PipelineRoundTrip := &v1beta1.Pipeline{}
-	if err := v1beta1PipelineRoundTrip.ConvertFrom(context.Background(), v1PipelineGot); err != nil {
+	if err := v1beta1PipelineRoundTrip.ConvertFrom(t.Context(), v1PipelineGot); err != nil {
 		t.Fatalf("Filed to convert roundtrip v1beta1PipelineGot ConvertFrom v1 = %v", err)
 	}
 	if d := cmp.Diff(v1beta1Pipeline, v1beta1PipelineRoundTrip, filterMetadata...); d != "" {
@@ -896,7 +896,7 @@ func TestPipelineCRDConversion(t *testing.T) {
 	}
 
 	v1PipelineRoundTrip := &v1.Pipeline{}
-	if err := v1beta1PipelineGot.ConvertTo(context.Background(), v1PipelineRoundTrip); err != nil {
+	if err := v1beta1PipelineGot.ConvertTo(t.Context(), v1PipelineRoundTrip); err != nil {
 		t.Fatalf("Failed to convert roundtrip v1beta1PipelineGot ConvertTo v1 = %v", err)
 	}
 	if d := cmp.Diff(v1Pipeline, v1PipelineRoundTrip, filterMetadata...); d != "" {
@@ -909,7 +909,7 @@ func TestPipelineCRDConversion(t *testing.T) {
 // the webhook for roundtrip. And then it creates the v1 PipelineRun CRD using v1Clients
 // and requests it by v1beta1Clients to compare with v1beta1.
 func TestPipelineRunCRDConversion(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	t.Parallel()
@@ -945,7 +945,7 @@ func TestPipelineRunCRDConversion(t *testing.T) {
 	}
 
 	v1beta1PRRoundTrip := &v1beta1.PipelineRun{}
-	if err := v1beta1PRRoundTrip.ConvertFrom(context.Background(), v1PipelineRunGot); err != nil {
+	if err := v1beta1PRRoundTrip.ConvertFrom(t.Context(), v1PipelineRunGot); err != nil {
 		t.Fatalf("Error roundtrip v1beta1PipelineRun ConvertFrom v1PipelineRunGot = %v", err)
 	}
 	if d := cmp.Diff(v1beta1PRRoundTripExpected, v1beta1PRRoundTrip, filterV1beta1PipelineRunFields...); d != "" {
@@ -980,7 +980,7 @@ func TestPipelineRunCRDConversion(t *testing.T) {
 	}
 
 	v1PRRoundTrip := &v1.PipelineRun{}
-	if err := v1beta1PipelineRunGot.ConvertTo(context.Background(), v1PRRoundTrip); err != nil {
+	if err := v1beta1PipelineRunGot.ConvertTo(t.Context(), v1PRRoundTrip); err != nil {
 		t.Fatalf("Error roundtrip v1beta1PipelineRunGot ConvertTo v1 = %v", err)
 	}
 	if d := cmp.Diff(v1PRRoundTripExpected, v1PRRoundTrip, filterV1PipelineRunFields...); d != "" {

--- a/test/custom-task-ctrls/wait-task-beta/pkg/reconciler/reconciler_test.go
+++ b/test/custom-task-ctrls/wait-task-beta/pkg/reconciler/reconciler_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package reconciler
 
 import (
-	"context"
 	"strings"
 	"testing"
 	"time"
@@ -374,7 +373,7 @@ func TestReconcile(t *testing.T) {
 		expectedCustomRun: expectedRetryTimedOutCustomRunYAML,
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			rec := &Reconciler{
 				Clock: testClock,
 			}

--- a/test/custom_task_test.go
+++ b/test/custom_task_test.go
@@ -60,7 +60,7 @@ var (
 )
 
 func TestCustomTask(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	c, namespace := setup(ctx, t)
@@ -254,7 +254,7 @@ spec:
 // the metric that is emitted to track how long it took.
 func WaitForCustomRunSpecCancelled(ctx context.Context, c *clients, name string, desc string) error {
 	metricName := fmt.Sprintf("WaitForRunSpecCancelled/%s/%s", name, desc)
-	_, span := trace.StartSpan(context.Background(), metricName)
+	_, span := trace.StartSpan(ctx, metricName)
 	defer span.End()
 
 	return pollImmediateWithContext(ctx, func() (bool, error) {
@@ -270,11 +270,11 @@ func WaitForCustomRunSpecCancelled(ctx context.Context, c *clients, name string,
 // verify that pipelinerun timeout works and leads to the correct Run Spec.status
 func TestPipelineRunCustomTaskTimeout(t *testing.T) {
 	// cancel the context after we have waited a suitable buffer beyond the given deadline.
-	ctx, cancel := context.WithTimeout(context.Background(), timeout+2*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), timeout+2*time.Minute)
 	defer cancel()
 	c, namespace := setup(ctx, t)
-	knativetest.CleanupOnInterrupt(func() { tearDown(context.Background(), t, c, namespace) }, t.Logf)
-	defer tearDown(context.Background(), t, c, namespace)
+	knativetest.CleanupOnInterrupt(func() { tearDown(t.Context(), t, c, namespace) }, t.Logf)
+	defer tearDown(t.Context(), t, c, namespace)
 
 	pipeline := parse.MustParseV1Pipeline(t, fmt.Sprintf(`
 metadata:
@@ -405,7 +405,7 @@ func cleanUpV1beta1Controller(t *testing.T) {
 }
 
 func TestWaitCustomTask_V1_PipelineRun(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	c, namespace := setup(ctx, t)

--- a/test/dag_test.go
+++ b/test/dag_test.go
@@ -49,7 +49,7 @@ const sleepDuration = 15 * time.Second
 //	                            |
 //	                     pipeline-task-4
 func TestDAGPipelineRun(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	c, namespace := setup(ctx, t)

--- a/test/duplicate_test.go
+++ b/test/duplicate_test.go
@@ -36,7 +36,7 @@ import (
 func TestDuplicatePodTaskRun(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	c, namespace := setup(ctx, t)
 

--- a/test/entrypoint_test.go
+++ b/test/entrypoint_test.go
@@ -35,7 +35,7 @@ import (
 // that doesn't have a cmd defined. In addition to making sure the steps
 // are executed in the order specified
 func TestEntrypointRunningStepsInOrder(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	c, namespace := setup(ctx, t)

--- a/test/examples_test.go
+++ b/test/examples_test.go
@@ -102,7 +102,7 @@ type waitFunc func(ctx context.Context, t *testing.T, c *clients, name string)
 func exampleTest(path string, waitValidateFunc waitFunc, createFunc createFunc, kind string) func(t *testing.T) {
 	return func(t *testing.T) {
 		t.Parallel()
-		ctx := context.Background()
+		ctx := t.Context()
 		ctx, cancel := context.WithCancel(ctx)
 		defer cancel()
 

--- a/test/hermetic_taskrun_test.go
+++ b/test/hermetic_taskrun_test.go
@@ -33,7 +33,7 @@ import (
 // it does this by first running the TaskRun normally to make sure it passes
 // Then, it enables hermetic mode and makes sure the same TaskRun fails because it no longer has access to a network.
 func TestHermeticTaskRun(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 

--- a/test/ignore_step_error_test.go
+++ b/test/ignore_step_error_test.go
@@ -34,7 +34,7 @@ import (
 )
 
 func TestFailingStepOnContinue(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	c, namespace := setup(ctx, t)

--- a/test/ignore_task_error_test.go
+++ b/test/ignore_task_error_test.go
@@ -34,7 +34,7 @@ import (
 )
 
 func TestFailingPipelineTaskOnContinue(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	c, namespace := setup(ctx, t, requireAnyGate(map[string]string{"enable-api-fields": "beta"}))

--- a/test/larger_results_sidecar_logs_test.go
+++ b/test/larger_results_sidecar_logs_test.go
@@ -62,7 +62,7 @@ func TestLargerResultsSidecarLogs(t *testing.T) {
 
 	for _, td := range tds {
 		t.Run(td.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 

--- a/test/matrix_test.go
+++ b/test/matrix_test.go
@@ -46,7 +46,7 @@ var requireAlphaFeatureFlag = requireAnyGate(map[string]string{
 // and whole array replacements by consuming results produced by other PipelineTasks.
 func TestPipelineRunMatrixed(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	c, namespace := setup(ctx, t, requireAlphaFeatureFlag)
@@ -584,7 +584,7 @@ spec:
 // which will cause the entire PipelineRun to fail.
 func TestPipelineRunMatrixedFailed(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	c, namespace := setup(ctx, t, requireAlphaFeatureFlag)

--- a/test/parse/yaml.go
+++ b/test/parse/yaml.go
@@ -14,7 +14,6 @@
 package parse
 
 import (
-	"context"
 	"testing"
 
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
@@ -83,7 +82,7 @@ kind: Task
 func MustParseV1beta1TaskAndSetDefaults(t *testing.T, yaml string) *v1beta1.Task {
 	t.Helper()
 	task := MustParseV1beta1Task(t, yaml)
-	task.SetDefaults(context.Background())
+	task.SetDefaults(t.Context())
 	return task
 }
 
@@ -113,7 +112,7 @@ kind: Task
 func MustParseV1TaskAndSetDefaults(t *testing.T, yaml string) *v1.Task {
 	t.Helper()
 	task := MustParseV1Task(t, yaml)
-	task.SetDefaults(context.Background())
+	task.SetDefaults(t.Context())
 	return task
 }
 
@@ -154,7 +153,7 @@ kind: Pipeline
 func MustParseV1beta1PipelineAndSetDefaults(t *testing.T, yaml string) *v1beta1.Pipeline {
 	t.Helper()
 	p := MustParseV1beta1Pipeline(t, yaml)
-	p.SetDefaults(context.Background())
+	p.SetDefaults(t.Context())
 	return p
 }
 
@@ -173,7 +172,7 @@ kind: Pipeline
 func MustParseV1PipelineAndSetDefaults(t *testing.T, yaml string) *v1.Pipeline {
 	t.Helper()
 	p := MustParseV1Pipeline(t, yaml)
-	p.SetDefaults(context.Background())
+	p.SetDefaults(t.Context())
 	return p
 }
 

--- a/test/per_feature_flags_test.go
+++ b/test/per_feature_flags_test.go
@@ -124,7 +124,7 @@ func testMinimumEndToEndSubSet(t *testing.T, configMapData map[string]string) {
 // testFanInFanOut tests DAG built with a small fan-in fan-out pipeline and
 // examines the sequence of the PipelineTasks being run.
 func testFanInFanOut(t *testing.T, configMapData map[string]string) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	c, namespace := setup(ctx, t)
@@ -241,7 +241,7 @@ spec:
 // verifies the TaskRun produced by the Finally Task after a failed TaskRun
 // with its results.
 func testResultsAndFinally(t *testing.T, configMapData map[string]string) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	c, namespace := setup(ctx, t)
@@ -326,7 +326,7 @@ spec:
 // testParams tests the parameter propagation by comparing the expected
 // TaskRuns run from the PipelineRun specified in Finally Task.
 func testParams(t *testing.T, configMapData map[string]string) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	c, namespace := setup(ctx, t)

--- a/test/pipelinefinally_test.go
+++ b/test/pipelinefinally_test.go
@@ -41,7 +41,7 @@ var requireAlphaFeatureFlags = requireAnyGate(map[string]string{
 })
 
 func TestPipelineLevelFinally_OneDAGTaskFailed_InvalidTaskResult_Failure(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	c, namespace := setup(ctx, t)
@@ -391,7 +391,7 @@ spec:
 }
 
 func TestPipelineLevelFinally_OneFinalTaskFailed_Failure(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	c, namespace := setup(ctx, t)
@@ -459,7 +459,7 @@ spec:
 }
 
 func TestPipelineLevelFinally_OneFinalTask_CancelledRunFinally(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	c, namespace := setup(ctx, t, requireAlphaFeatureFlags)
@@ -574,7 +574,7 @@ spec:
 }
 
 func TestPipelineLevelFinally_OneFinalTask_StoppedRunFinally(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	c, namespace := setup(ctx, t, requireAlphaFeatureFlags)
@@ -689,7 +689,7 @@ spec:
 }
 
 func TestPipelineLevelFinally_OneDAGNotProducingResult_SecondDAGUsingResult_Failure(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	c, namespace := setup(ctx, t)

--- a/test/pipelinerun_test.go
+++ b/test/pipelinerun_test.go
@@ -93,7 +93,7 @@ spec:
 	for i, td := range tds {
 		t.Run(td.name, func(t *testing.T) {
 			t.Parallel()
-			ctx := context.Background()
+			ctx := t.Context()
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 			c, namespace := setup(ctx, t)
@@ -297,7 +297,7 @@ spec:
 	for i, td := range tds {
 		t.Run(td.name, func(t *testing.T) {
 			t.Parallel()
-			ctx := context.Background()
+			ctx := t.Context()
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 			c, namespace := setup(ctx, t)
@@ -419,7 +419,7 @@ spec:
 // TestPipelineRunRefDeleted tests that a running PipelineRun doesn't fail when the Pipeline
 // it references is deleted.
 func TestPipelineRunRefDeleted(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	c, namespace := setup(ctx, t)
@@ -492,7 +492,7 @@ spec:
 // transition PipelineRun states during the test, which the TestPipelineRun suite does not
 // support.
 func TestPipelineRunPending(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	c, namespace := setup(ctx, t)
@@ -951,7 +951,7 @@ func getLimitRange(name, namespace, resourceCPU, resourceMemory, resourceEphemer
 }
 
 func TestPipelineRunTaskFailed(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	c, namespace := setup(ctx, t)

--- a/test/premption_test.go
+++ b/test/premption_test.go
@@ -36,7 +36,7 @@ import (
 // TestTaskRunPremption tests that Taskrun can run again
 // after its pod has been prempted before completion.
 func TestTaskRunPremption(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	c, namespace := setup(ctx, t)

--- a/test/propagated_params_test.go
+++ b/test/propagated_params_test.go
@@ -68,7 +68,7 @@ func TestPropagatedParams(t *testing.T) {
 	for _, td := range tds {
 		t.Run(td.name, func(t *testing.T) {
 			t.Parallel()
-			ctx := context.Background()
+			ctx := t.Context()
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 

--- a/test/propagated_results_test.go
+++ b/test/propagated_results_test.go
@@ -61,7 +61,7 @@ func TestPropagatedResults(t *testing.T) {
 	for _, td := range tds {
 		t.Run(td.name, func(t *testing.T) {
 			t.Parallel()
-			ctx := context.Background()
+			ctx := t.Context()
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 

--- a/test/resolvers_test.go
+++ b/test/resolvers_test.go
@@ -79,7 +79,7 @@ var (
 )
 
 func TestHubResolver(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	c, namespace := setup(ctx, t, hubFeatureFlags)
 
 	t.Parallel()
@@ -138,7 +138,7 @@ spec:
 }
 
 func TestHubResolver_Failure(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	c, namespace := setup(ctx, t, hubFeatureFlags)
 
 	t.Parallel()
@@ -201,7 +201,7 @@ spec:
 }
 
 func TestGitResolver_Clone(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	c, namespace := setup(ctx, t, gitFeatureFlags)
 
 	t.Parallel()
@@ -302,7 +302,7 @@ func TestGitResolver_Clone_Failure(t *testing.T) {
 				commit = defaultCommit
 			}
 
-			ctx := context.Background()
+			ctx := t.Context()
 			c, namespace := setup(ctx, t, gitFeatureFlags)
 
 			t.Parallel()
@@ -367,7 +367,7 @@ spec:
 }
 
 func TestClusterResolver(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	c, namespace := setup(ctx, t, clusterFeatureFlags)
 
 	t.Parallel()
@@ -430,7 +430,7 @@ spec:
 }
 
 func TestClusterResolver_Failure(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	c, namespace := setup(ctx, t, clusterFeatureFlags)
 
 	t.Parallel()
@@ -472,7 +472,7 @@ spec:
 }
 
 func TestGitResolver_API(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	c, namespace := setup(ctx, t, gitFeatureFlags)
 
 	t.Parallel()
@@ -534,7 +534,7 @@ spec:
 }
 
 func TestGitResolver_API_Identifier(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	c, namespace := setup(ctx, t, gitFeatureFlags)
 
 	t.Parallel()

--- a/test/retry_test.go
+++ b/test/retry_test.go
@@ -34,7 +34,7 @@ import (
 // TestTaskRunRetry tests that retries behave as expected, by creating multiple
 // Pods for the same TaskRun each time it fails, up to the configured max.
 func TestTaskRunRetry(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	c, namespace := setup(ctx, t)

--- a/test/secret.go
+++ b/test/secret.go
@@ -36,7 +36,7 @@ import (
 // otherwise.
 func CreateGCPServiceAccountSecret(t *testing.T, c kubernetes.Interface, namespace string, secretName string) (bool, error) {
 	t.Helper()
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	file := os.Getenv("GCP_SERVICE_ACCOUNT_KEY_PATH")

--- a/test/serviceaccount_test.go
+++ b/test/serviceaccount_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 func TestPipelineRunWithServiceAccounts(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -194,7 +194,7 @@ spec:
 }
 
 func TestPipelineRunWithServiceAccountNameAndTaskRunSpec(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 

--- a/test/sidecar_test.go
+++ b/test/sidecar_test.go
@@ -57,7 +57,7 @@ func TestSidecarTaskSupport(t *testing.T) {
 		sidecarCommand: []string{"echo", "\"hello from sidecar\""},
 	}}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	t.Parallel()
 
 	for _, test := range tests {

--- a/test/start_time_test.go
+++ b/test/start_time_test.go
@@ -41,7 +41,7 @@ import (
 // duration of the test so smaller is better (while still supporting the
 // test's intended purpose).
 func TestStartTime(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	c, namespace := setup(ctx, t)

--- a/test/status_test.go
+++ b/test/status_test.go
@@ -44,7 +44,7 @@ var (
 // verify a very simple "hello world" TaskRun and PipelineRun failure
 // execution lead to the correct TaskRun status.
 func TestTaskRunPipelineRunStatus(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	c, namespace := setup(ctx, t)
@@ -120,7 +120,7 @@ spec:
 // i.e. refSource info, and the child TaskRun status should contain the provnenace
 // about the remote task i.e. refSource info .
 func TestProvenanceFieldInPipelineRunTaskRunStatus(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	c, namespace := setup(ctx, t, requireAnyGate(map[string]string{"enable-api-fields": "beta"}))

--- a/test/step_output_test.go
+++ b/test/step_output_test.go
@@ -36,12 +36,12 @@ import (
 // TestStepOutput verifies that step output streams can be copied to local files and task results.
 func TestStepOutput(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
 	defer cancel()
 	clients, namespace := setup(ctx, t, requireAnyGate(map[string]string{"enable-api-fields": "alpha"}))
 
-	knativetest.CleanupOnInterrupt(func() { tearDown(context.Background(), t, clients, namespace) }, t.Logf)
-	defer tearDown(context.Background(), t, clients, namespace)
+	knativetest.CleanupOnInterrupt(func() { tearDown(t.Context(), t, clients, namespace) }, t.Logf)
+	defer tearDown(t.Context(), t, clients, namespace)
 
 	wantResultName := "step-cat-stdout"
 	wantResultValue := "hello world"
@@ -114,12 +114,12 @@ func TestStepOutput(t *testing.T) {
 // when a workspace is defined for the task.
 func TestStepOutputWithWorkspace(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
 	defer cancel()
 	clients, namespace := setup(ctx, t, requireAnyGate(map[string]string{"enable-api-fields": "alpha"}))
 
-	knativetest.CleanupOnInterrupt(func() { tearDown(context.Background(), t, clients, namespace) }, t.Logf)
-	defer tearDown(context.Background(), t, clients, namespace)
+	knativetest.CleanupOnInterrupt(func() { tearDown(t.Context(), t, clients, namespace) }, t.Logf)
+	defer tearDown(t.Context(), t, clients, namespace)
 
 	wantResultName := "step-cat-stdout"
 	wantResultValue := "hello world"

--- a/test/step_when_test.go
+++ b/test/step_when_test.go
@@ -198,7 +198,7 @@ spec:
 	}
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 			c, namespace := setup(ctx, t)
@@ -402,7 +402,7 @@ spec:
 		t.Run(tc.desc, func(t *testing.T) {
 			featureFlags := getFeatureFlagsBaseOnAPIFlag(t)
 
-			ctx := context.Background()
+			ctx := t.Context()
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 			c, namespace := setup(ctx, t)

--- a/test/stepaction_results_test.go
+++ b/test/stepaction_results_test.go
@@ -57,7 +57,7 @@ func TestStepResultsStepActions(t *testing.T) {
 
 	for _, td := range tds {
 		t.Run(td.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 

--- a/test/task_results_from_failed_tasks_test.go
+++ b/test/task_results_from_failed_tasks_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 func TestTaskResultsFromFailedTasks(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	c, namespace := setup(ctx, t)

--- a/test/taskrun_test.go
+++ b/test/taskrun_test.go
@@ -42,7 +42,7 @@ import (
 )
 
 func TestTaskRunFailure(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -165,7 +165,7 @@ spec:
 }
 
 func TestTaskRunStatus(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	c, namespace := setup(ctx, t)
@@ -242,7 +242,7 @@ spec:
 }
 
 func TestTaskRunStepsTerminationReasons(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	c, namespace := setup(ctx, t)
 	defer tearDown(ctx, t, c, namespace)
 	fqImageName := getTestImage(busyboxImage)
@@ -516,7 +516,7 @@ func cancelTaskRun(t *testing.T, ctx context.Context, taskRunName string, c *cli
 }
 
 func TestTaskRunRetryFailure(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -606,7 +606,7 @@ spec:
 }
 
 func TestTaskRunResolveDefaultParameterSubstitutionOnStepAction(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 

--- a/test/tektonbundles_test.go
+++ b/test/tektonbundles_test.go
@@ -54,7 +54,7 @@ var resolverFeatureFlags = requireAllGates(map[string]string{
 // TestTektonBundlesResolver is an integration test which tests a simple, working Tekton bundle using OCI
 // images using the remote resolution bundles resolver.
 func TestTektonBundlesResolver(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	c, namespace := setup(ctx, t, withRegistry, resolverFeatureFlags)
 
 	t.Parallel()

--- a/test/timeout_test.go
+++ b/test/timeout_test.go
@@ -43,12 +43,12 @@ import (
 func TestPipelineRunTimeout(t *testing.T) {
 	t.Parallel()
 	// cancel the context after we have waited a suitable buffer beyond the given deadline.
-	ctx, cancel := context.WithTimeout(context.Background(), timeout+2*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), timeout+2*time.Minute)
 	defer cancel()
 	c, namespace := setup(ctx, t)
 
-	knativetest.CleanupOnInterrupt(func() { tearDown(context.Background(), t, c, namespace) }, t.Logf)
-	defer tearDown(context.Background(), t, c, namespace)
+	knativetest.CleanupOnInterrupt(func() { tearDown(t.Context(), t, c, namespace) }, t.Logf)
+	defer tearDown(t.Context(), t, c, namespace)
 
 	t.Logf("Creating Task in namespace %s", namespace)
 	task := parse.MustParseV1Task(t, fmt.Sprintf(`
@@ -161,12 +161,12 @@ spec:
 // TestStepTimeout is an integration test that will verify a Step can be timed out.
 func TestStepTimeout(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
 	defer cancel()
 	c, namespace := setup(ctx, t)
 
-	knativetest.CleanupOnInterrupt(func() { tearDown(context.Background(), t, c, namespace) }, t.Logf)
-	defer tearDown(context.Background(), t, c, namespace)
+	knativetest.CleanupOnInterrupt(func() { tearDown(t.Context(), t, c, namespace) }, t.Logf)
+	defer tearDown(t.Context(), t, c, namespace)
 
 	t.Logf("Creating Task with Step step-no-timeout, Step step-timeout, and Step step-canceled in namespace %s", namespace)
 
@@ -223,12 +223,12 @@ spec:
 // TestStepTimeoutWithWS is an integration test that will verify a Step can be timed out.
 func TestStepTimeoutWithWS(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
 	defer cancel()
 	c, namespace := setup(ctx, t)
 
-	knativetest.CleanupOnInterrupt(func() { tearDown(context.Background(), t, c, namespace) }, t.Logf)
-	defer tearDown(context.Background(), t, c, namespace)
+	knativetest.CleanupOnInterrupt(func() { tearDown(t.Context(), t, c, namespace) }, t.Logf)
+	defer tearDown(t.Context(), t, c, namespace)
 
 	taskRun := parse.MustParseV1TaskRun(t, `
 metadata:
@@ -263,12 +263,12 @@ spec:
 func TestTaskRunTimeout(t *testing.T) {
 	t.Parallel()
 	timeout := 1 * time.Second
-	ctx, cancel := context.WithTimeout(context.Background(), timeout+2*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), timeout+2*time.Minute)
 	defer cancel()
 	c, namespace := setup(ctx, t)
 
-	knativetest.CleanupOnInterrupt(func() { tearDown(context.Background(), t, c, namespace) }, t.Logf)
-	defer tearDown(context.Background(), t, c, namespace)
+	knativetest.CleanupOnInterrupt(func() { tearDown(t.Context(), t, c, namespace) }, t.Logf)
+	defer tearDown(t.Context(), t, c, namespace)
 
 	t.Logf("Creating Task and TaskRun in namespace %s", namespace)
 	task := parse.MustParseV1Task(t, fmt.Sprintf(`
@@ -319,12 +319,12 @@ spec:
 
 func TestPipelineTaskTimeout(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := context.WithTimeout(context.Background(), timeout+2*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), timeout+2*time.Minute)
 	defer cancel()
 	c, namespace := setup(ctx, t)
 
-	knativetest.CleanupOnInterrupt(func() { tearDown(context.Background(), t, c, namespace) }, t.Logf)
-	defer tearDown(context.Background(), t, c, namespace)
+	knativetest.CleanupOnInterrupt(func() { tearDown(t.Context(), t, c, namespace) }, t.Logf)
+	defer tearDown(t.Context(), t, c, namespace)
 
 	t.Logf("Creating Tasks in namespace %s", namespace)
 	task1 := parse.MustParseV1Task(t, fmt.Sprintf(`
@@ -440,12 +440,12 @@ spec:
 func TestPipelineRunTasksTimeout(t *testing.T) {
 	t.Parallel()
 	// cancel the context after we have waited a suitable buffer beyond the given deadline.
-	ctx, cancel := context.WithTimeout(context.Background(), timeout+2*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), timeout+2*time.Minute)
 	defer cancel()
 	c, namespace := setup(ctx, t)
 
-	knativetest.CleanupOnInterrupt(func() { tearDown(context.Background(), t, c, namespace) }, t.Logf)
-	defer tearDown(context.Background(), t, c, namespace)
+	knativetest.CleanupOnInterrupt(func() { tearDown(t.Context(), t, c, namespace) }, t.Logf)
+	defer tearDown(t.Context(), t, c, namespace)
 
 	t.Logf("Creating Task in namespace %s", namespace)
 	task := parse.MustParseV1Task(t, fmt.Sprintf(`
@@ -565,12 +565,12 @@ spec:
 func TestPipelineRunTimeoutWithCompletedTaskRuns(t *testing.T) {
 	t.Parallel()
 	// cancel the context after we have waited a suitable buffer beyond the given deadline.
-	ctx, cancel := context.WithTimeout(context.Background(), timeout+2*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), timeout+2*time.Minute)
 	defer cancel()
 	c, namespace := setup(ctx, t)
 
-	knativetest.CleanupOnInterrupt(func() { tearDown(context.Background(), t, c, namespace) }, t.Logf)
-	defer tearDown(context.Background(), t, c, namespace)
+	knativetest.CleanupOnInterrupt(func() { tearDown(t.Context(), t, c, namespace) }, t.Logf)
+	defer tearDown(t.Context(), t, c, namespace)
 
 	t.Logf("Creating Task in namespace %s", namespace)
 	task := parse.MustParseV1Task(t, fmt.Sprintf(`

--- a/test/trusted_resources_test.go
+++ b/test/trusted_resources_test.go
@@ -56,7 +56,7 @@ func init() {
 }
 
 func TestTrustedResourcesVerify_VerificationPolicy_Success(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -170,7 +170,7 @@ spec:
 }
 
 func TestTrustedResourcesVerify_VerificationPolicy_Error(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 

--- a/test/upgrade_test.go
+++ b/test/upgrade_test.go
@@ -200,14 +200,14 @@ status:
 // runs created are successful and as expected.
 func TestSimpleTaskRun(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	c, namespace := setup(ctx, t)
 
 	taskRunName := helpers.ObjectNameForTest(t)
 
-	knativetest.CleanupOnInterrupt(func() { tearDown(context.Background(), t, c, namespace) }, t.Logf)
-	defer tearDown(context.Background(), t, c, namespace)
+	knativetest.CleanupOnInterrupt(func() { tearDown(t.Context(), t, c, namespace) }, t.Logf)
+	defer tearDown(t.Context(), t, c, namespace)
 
 	t.Logf("Creating Task in namespace %s", namespace)
 	task := parse.MustParseV1Task(t, fmt.Sprintf(simpleTaskYaml, task1Name, namespace))
@@ -240,12 +240,12 @@ func TestSimpleTaskRun(t *testing.T) {
 // and verifies the runs created are successful and as expected.
 func TestSimplePipelineRun(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	c, namespace := setup(ctx, t)
 
-	knativetest.CleanupOnInterrupt(func() { tearDown(context.Background(), t, c, namespace) }, t.Logf)
-	defer tearDown(context.Background(), t, c, namespace)
+	knativetest.CleanupOnInterrupt(func() { tearDown(t.Context(), t, c, namespace) }, t.Logf)
+	defer tearDown(t.Context(), t, c, namespace)
 
 	t.Logf("Creating Task in namespace %s", namespace)
 	task := parse.MustParseV1Task(t, fmt.Sprintf(simpleTaskYaml, task1Name, namespace))

--- a/test/wait.go
+++ b/test/wait.go
@@ -87,7 +87,7 @@ func pollImmediateWithContext(ctx context.Context, fn func() (bool, error)) erro
 // version will be used to determine the client to be applied for the wait.
 func WaitForTaskRunState(ctx context.Context, c *clients, name string, inState ConditionAccessorFn, desc, version string) error {
 	metricName := fmt.Sprintf("WaitForTaskRunState/%s/%s", name, desc)
-	_, span := trace.StartSpan(context.Background(), metricName)
+	_, span := trace.StartSpan(ctx, metricName)
 	defer span.End()
 
 	return pollImmediateWithContext(ctx, func() (bool, error) {
@@ -114,7 +114,7 @@ func WaitForTaskRunState(ctx context.Context, c *clients, name string, inState C
 // track how long it took for name to get into the state checked by inState.
 func WaitForDeploymentState(ctx context.Context, c *clients, name string, namespace string, inState func(d *appsv1.Deployment) (bool, error), desc string) error {
 	metricName := fmt.Sprintf("WaitForDeploymentState/%s/%s", name, desc)
-	_, span := trace.StartSpan(context.Background(), metricName)
+	_, span := trace.StartSpan(ctx, metricName)
 	defer span.End()
 
 	return pollImmediateWithContext(ctx, func() (bool, error) {
@@ -132,7 +132,7 @@ func WaitForDeploymentState(ctx context.Context, c *clients, name string, namesp
 // track how long it took for name to get into the state checked by inState.
 func WaitForPodState(ctx context.Context, c *clients, name string, namespace string, inState func(r *corev1.Pod) (bool, error), desc string) error {
 	metricName := fmt.Sprintf("WaitForPodState/%s/%s", name, desc)
-	_, span := trace.StartSpan(context.Background(), metricName)
+	_, span := trace.StartSpan(ctx, metricName)
 	defer span.End()
 
 	return pollImmediateWithContext(ctx, func() (bool, error) {
@@ -150,7 +150,7 @@ func WaitForPodState(ctx context.Context, c *clients, name string, namespace str
 // track how long it took to delete all the PVCs in the namespace.
 func WaitForPVCIsDeleted(ctx context.Context, c *clients, polltimeout time.Duration, name, namespace, desc string) error {
 	metricName := fmt.Sprintf("WaitForPVCIsDeleted/%s/%s", name, desc)
-	_, span := trace.StartSpan(context.Background(), metricName)
+	_, span := trace.StartSpan(ctx, metricName)
 	defer span.End()
 
 	ctx, cancel := context.WithTimeout(ctx, polltimeout)
@@ -176,7 +176,7 @@ func WaitForPVCIsDeleted(ctx context.Context, c *clients, polltimeout time.Durat
 // version will be used to determine the client to be applied for the wait.
 func WaitForPipelineRunState(ctx context.Context, c *clients, name string, polltimeout time.Duration, inState ConditionAccessorFn, desc, version string) error {
 	metricName := fmt.Sprintf("WaitForPipelineRunState/%s/%s", name, desc)
-	_, span := trace.StartSpan(context.Background(), metricName)
+	_, span := trace.StartSpan(ctx, metricName)
 	defer span.End()
 
 	ctx, cancel := context.WithTimeout(ctx, polltimeout)
@@ -206,7 +206,7 @@ func WaitForPipelineRunState(ctx context.Context, c *clients, name string, pollt
 // track how long it took for name to get into the state checked by inState.
 func WaitForServiceExternalIPState(ctx context.Context, c *clients, namespace, name string, inState func(s *corev1.Service) (bool, error), desc string) error {
 	metricName := fmt.Sprintf("WaitForServiceExternalIPState/%s/%s", name, desc)
-	_, span := trace.StartSpan(context.Background(), metricName)
+	_, span := trace.StartSpan(ctx, metricName)
 	defer span.End()
 
 	return pollImmediateWithContext(ctx, func() (bool, error) {

--- a/test/windows_script_test.go
+++ b/test/windows_script_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 func TestWindowsScript(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -102,7 +102,7 @@ spec:
 }
 
 func TestWindowsScriptFailure(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 

--- a/test/windows_test.go
+++ b/test/windows_test.go
@@ -40,7 +40,7 @@ var (
 )
 
 func TestWindows(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -97,7 +97,7 @@ spec:
 }
 
 func TestWindowsFailure(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 

--- a/test/workingdir_test.go
+++ b/test/workingdir_test.go
@@ -33,7 +33,7 @@ import (
 )
 
 func TestWorkingDirCreated(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	c, namespace := setup(ctx, t)
@@ -106,7 +106,7 @@ spec:
 }
 
 func TestWorkingDirIgnoredNonSlashWorkspace(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	c, namespace := setup(ctx, t)

--- a/test/workspace_test.go
+++ b/test/workspace_test.go
@@ -34,7 +34,7 @@ import (
 )
 
 func TestWorkspaceReadOnlyDisallowsWrite(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	c, namespace := setup(ctx, t)
@@ -111,7 +111,7 @@ spec:
 }
 
 func TestWorkspacePipelineRunDuplicateWorkspaceEntriesInvalid(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	c, namespace := setup(ctx, t)
@@ -181,7 +181,7 @@ spec:
 }
 
 func TestWorkspacePipelineRunMissingWorkspaceInvalid(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	c, namespace := setup(ctx, t)
@@ -251,7 +251,7 @@ spec:
 // randomized volume name matches the workspaces.<name>.volume variable injected into
 // a user's task specs.
 func TestWorkspaceVolumeNameMatchesVolumeVariableReplacement(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	c, namespace := setup(ctx, t)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Since Go 1.24, the golangci-lint linter `usetesing` reports errors when `context.Background()` or `context.TODO()` are used in tests. This commit updates the codebase to use `t.Context()` as recommended by Go 1.24 release documentation.

Refactor some `TestRealWaiter*` functions to send errors through a `chan error` instead of calling `t.Errorf` inside goroutines. This ensures that all logging and test assertions occur in the main test thread to avoid panics caused by logging after the test has completed.

Fixes https://github.com/tektoncd/pipeline/issues/8805
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
