### PR TITLE
fix: Avoid errors in PVC handler if PVC is already deleted

### DIFF
--- a/pkg/reconciler/volumeclaim/pvchandler.go
+++ b/pkg/reconciler/volumeclaim/pvchandler.go
@@ -92,6 +92,11 @@ func (c *defaultPVCHandler) CreatePVCFromVolumeClaimTemplate(ctx context.Context
 func (c *defaultPVCHandler) PurgeFinalizerAndDeletePVCForWorkspace(ctx context.Context, pvcName, namespace string) error {
 	p, err := c.clientset.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, pvcName, metav1.GetOptions{})
 	if err != nil {
+		// check if the PVC exists, otherwise skip the deletion
+		if apierrors.IsNotFound(err) {
+			c.logger.Debugf("PVC %s no longer exists, skipping deletion as it has already been removed", pvcName)
+			return nil
+		}
 		return fmt.Errorf("failed to get the PVC %s: %w", pvcName, err)
 	}
 

--- a/pkg/reconciler/volumeclaim/pvchandler_test.go
+++ b/pkg/reconciler/volumeclaim/pvchandler_test.go
@@ -251,6 +251,7 @@ func TestPurgeFinalizerAndDeletePVCForWorkspace(t *testing.T) {
 	// seed data
 	namespace := "my-ns"
 	pvcName := "my-pvc"
+	nonExistingPvcName := "non-existing-pvc"
 	pvc := &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      pvcName,
@@ -279,6 +280,10 @@ func TestPurgeFinalizerAndDeletePVCForWorkspace(t *testing.T) {
 	pvcHandler := defaultPVCHandler{kubeClientSet, zap.NewExample().Sugar()}
 	if err := pvcHandler.PurgeFinalizerAndDeletePVCForWorkspace(ctx, pvcName, namespace); err != nil {
 		t.Fatalf("unexpected error when calling PurgeFinalizerAndDeletePVCForWorkspace: %v", err)
+	}
+	// check that pvc deletion is skipped when the pvc does not exist
+	if err := pvcHandler.PurgeFinalizerAndDeletePVCForWorkspace(ctx, nonExistingPvcName, namespace); err != nil {
+		t.Fatalf("the deletion of non existing pvc %s was not skipped; an unexpected error occurred: %v", nonExistingPvcName, err)
 	}
 
 	// validate the `kubernetes.io/pvc-protection` finalizer is removed


### PR DESCRIPTION
# Changes
This PR updates the PVC handling logic to avoid returning errors when the pipelines-controller pod restarts and encounters PVCs that have already been deleted. This issue currently arises only when the PVC auto-removal behavior is enabled by setting the coschedule feature flag to `pipelineruns` or `isolate-pipelineruns`.

Fixes [#8757](https://github.com/tektoncd/pipeline/issues/8757)
# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
PVCs that have already been deleted will no longer cause errors during resource cleanup operations.
```