### PR TITLE
Do not propagate managed-by annotation to Pods

### DIFF
--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	tknreconciler "github.com/tektoncd/pipeline/pkg/reconciler"
 	"github.com/tektoncd/pipeline/pkg/spire"
 	"github.com/tektoncd/pipeline/test/diff"
 	"github.com/tektoncd/pipeline/test/names"
@@ -2621,6 +2622,7 @@ _EOF_
 			} else {
 				trAnnotations = c.trAnnotation
 				trAnnotations[ReleaseAnnotation] = fakeVersion
+
 			}
 			testTaskRunName := taskRunName
 			if c.trName != "" {
@@ -3256,6 +3258,7 @@ func TestMakeLabels(t *testing.T) {
 		"foo":                       "bar",
 		"hello":                     "world",
 		pipeline.TaskRunUIDLabelKey: string(taskRunUID),
+		tknreconciler.KubernetesManagedByAnnotationKey: "foo",
 	}
 	got := makeLabels(&v1.TaskRun{
 		ObjectMeta: metav1.ObjectMeta{
@@ -3266,7 +3269,7 @@ func TestMakeLabels(t *testing.T) {
 				"hello": "world",
 			},
 		},
-	})
+	}, "foo")
 	if d := cmp.Diff(want, got); d != "" {
 		t.Errorf("Diff labels %s", diff.PrintWantGot(d))
 	}

--- a/pkg/reconciler/constant.go
+++ b/pkg/reconciler/constant.go
@@ -19,4 +19,7 @@ package reconciler
 const (
 	// KubectlLastAppliedAnnotationKey is the key used by kubectl to store its last applied configuration (using kubectl apply)
 	KubectlLastAppliedAnnotationKey = "kubectl.kubernetes.io/last-applied-configuration"
+
+	// KubernetesLastAppliedAnnotationKey is the key used by tools to tell who is managing an object
+	KubernetesManagedByAnnotationKey = "app.kubernetes.io/managed-by"
 )


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Closes #8827

Let's make sure we are not propagating `app.kubernetes.io/managed-by`
annotation to Pods. Doing it can lead to weird behavior, for example
with applied with Helm, or if some admission controller is looking for
pipeline's Pods and do not get it if the `TaskRun` or `PipelineRun`
was created with an `app.kubernetes.io/managed-by`.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/kind bug
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Pod created by the Pipeline controller will now always have app.kubernetes.io/managed-by set to the default configuration. Prior to this change, it would be overriden by the value of that label set on TaskRun (or PipelineRun).
```
