### PR TITLE
[TEP-0056]: Extract common status helper functions from `pipelinerun_test.go`.

### DIFF
--- a/pkg/reconciler/testing/status.go
+++ b/pkg/reconciler/testing/status.go
@@ -1,0 +1,113 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"github.com/tektoncd/pipeline/test/diff"
+	corev1 "k8s.io/api/core/v1"
+	"knative.dev/pkg/apis"
+)
+
+const (
+	taskRun     = pipeline.TaskRunControllerName
+	customRun   = pipeline.CustomRunControllerName
+	pipelineRun = pipeline.PipelineRunControllerName
+)
+
+func CheckPipelineRunConditionStatusAndReason(
+	t *testing.T,
+	prStatus v1.PipelineRunStatus,
+	expectedStatus corev1.ConditionStatus,
+	expectedReason string,
+) {
+	t.Helper()
+
+	actualCondition := prStatus.GetCondition(apis.ConditionSucceeded)
+	if actualCondition == nil {
+		t.Fatalf("want condition, got nil")
+	}
+	if actualCondition.Status != expectedStatus {
+		t.Errorf("want status %v, got %v", expectedStatus, actualCondition.Status)
+	}
+	if actualCondition.Reason != expectedReason {
+		t.Errorf("want reason %s, got %s", expectedReason, actualCondition.Reason)
+	}
+}
+
+func VerifyTaskRunStatusesCount(t *testing.T, prStatus v1.PipelineRunStatus, expectedCount int) {
+	t.Helper()
+	verifyCount(t, prStatus, expectedCount, taskRun)
+}
+
+func verifyCount(t *testing.T, prStatus v1.PipelineRunStatus, expectedCount int, kind string) {
+	t.Helper()
+
+	actualCount := len(filterChildRefsForKind(prStatus.ChildReferences, kind))
+	if actualCount != expectedCount {
+		oneOrMany := kind
+		if expectedCount > 1 {
+			oneOrMany += "s"
+		}
+		t.Errorf("Expected PipelineRun status ChildReferences to have %d %s, but was %d", expectedCount, oneOrMany, actualCount)
+	}
+}
+
+func filterChildRefsForKind(childRefs []v1.ChildStatusReference, kind string) []v1.ChildStatusReference {
+	var filtered []v1.ChildStatusReference
+	for _, cr := range childRefs {
+		if cr.Kind == kind {
+			filtered = append(filtered, cr)
+		}
+	}
+	return filtered
+}
+
+func VerifyTaskRunStatusesNames(t *testing.T, prStatus v1.PipelineRunStatus, expectedNames ...string) {
+	t.Helper()
+	verifyNames(t, prStatus, expectedNames, taskRun)
+}
+
+func verifyNames(t *testing.T, prStatus v1.PipelineRunStatus, expectedNames []string, kind string) {
+	t.Helper()
+
+	actualNames := make(map[string]bool)
+	for _, cr := range filterChildRefsForKind(prStatus.ChildReferences, kind) {
+		actualNames[cr.Name] = true
+	}
+
+	for _, expectedName := range expectedNames {
+		if actualNames[expectedName] {
+			continue
+		}
+
+		t.Errorf("Expected PipelineRun status to include %s status for %s but was %v", kind, expectedName, prStatus.ChildReferences)
+	}
+}
+
+func VerifyTaskRunStatusesWhenExpressions(t *testing.T, prStatus v1.PipelineRunStatus, trName string, expectedWhen []v1.WhenExpression) {
+	t.Helper()
+
+	var actualWhen []v1.WhenExpression
+	for _, cr := range prStatus.ChildReferences {
+		if cr.Name == trName {
+			actualWhen = append(actualWhen, cr.WhenExpressions...)
+		}
+	}
+
+	if d := cmp.Diff(expectedWhen, actualWhen); d != "" {
+		t.Errorf("Expected to see When Expressions %v created. Diff %s", trName, diff.PrintWantGot(d))
+	}
+}
+
+func VerifyCustomRunOrRunStatusesCount(t *testing.T, prStatus v1.PipelineRunStatus, expectedCount int) {
+	t.Helper()
+	verifyCount(t, prStatus, expectedCount, customRun)
+}
+
+func VerifyCustomRunOrRunStatusesNames(t *testing.T, prStatus v1.PipelineRunStatus, expectedNames ...string) {
+	t.Helper()
+	verifyNames(t, prStatus, expectedNames, customRun)
+}

--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -892,7 +892,7 @@ spec:
 	for _, param := range resolvedTR.Spec.Params {
 		if param.Name == "array-param" {
 			paramArr := param.Value.ArrayVal
-			for i, _ := range paramArr {
+			for i := range paramArr {
 				if paramArr[i] != arrayParam[i] {
 					t.Errorf("Expect Params to match %s: %v", arrayParam[i], paramArr[i])
 				}

--- a/test/parse/yaml.go
+++ b/test/parse/yaml.go
@@ -20,6 +20,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned/scheme"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -192,4 +193,20 @@ func mustParseYAML(t *testing.T, yaml string, i runtime.Object) {
 	if _, _, err := scheme.Codecs.UniversalDeserializer().Decode([]byte(yaml), nil, i); err != nil {
 		t.Fatalf("mustParseYAML (%s): %v", yaml, err)
 	}
+}
+
+// MustParseTaskRunWithObjectMeta parses YAML to *v1.TaskRun and adds objectMeta to it
+func MustParseTaskRunWithObjectMeta(t *testing.T, objectMeta metav1.ObjectMeta, asYAML string) *v1.TaskRun {
+	t.Helper()
+	tr := MustParseV1TaskRun(t, asYAML)
+	tr.ObjectMeta = objectMeta
+	return tr
+}
+
+// MustParseCustomRunWithObjectMeta parses YAML to *v1beta1.CustomRun and adds objectMeta to it
+func MustParseCustomRunWithObjectMeta(t *testing.T, objectMeta metav1.ObjectMeta, asYAML string) *v1beta1.CustomRun {
+	t.Helper()
+	r := MustParseCustomRun(t, asYAML)
+	r.ObjectMeta = objectMeta
+	return r
 }

--- a/test/util.go
+++ b/test/util.go
@@ -66,7 +66,6 @@ func setup(ctx context.Context, t *testing.T, fn ...func(context.Context, *testi
 	t.Helper()
 	skipIfExcluded(t)
 
-	t.Helper()
 	namespace := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("arendelle")
 
 	initializeLogsAndMetrics(t)


### PR DESCRIPTION


# Changes

Create `pkg/reconciler/testing/status.go` and move status related helper functions for `TaskRun/CustomRun` and later `PipelineRun` there. Remove duplication from helper functions.

Move yaml parsing helper functions to `test/parse/yaml.go`.

Rename import `ttesting ==> th`, short for "testing helpers".

Issue #8760, #7166.

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
