### PR TITLE
Resolvers: remove default TEKTON_HUB_API URI

### DIFF
--- a/config/resolvers/resolvers-deployment.yaml
+++ b/config/resolvers/resolvers-deployment.yaml
@@ -101,11 +101,10 @@ spec:
           value: tekton.dev/resolution
         - name: PROBES_PORT
           value: "8080"
-      # Override this env var to set a private hub api endpoint
+        - name: TEKTON_HUB_API
+          value: "" # Override this env var to set a private hub api endpoint
         - name: ARTIFACT_HUB_API
           value: "https://artifacthub.io/"
-        - name: TEKTON_HUB_API
-          value: "https://api.hub.tekton.dev/"
         volumeMounts:
           - name: tmp-clone-volume
             mountPath: "/tmp"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

With the hub deprecation and up-coming shutdown of the hub.tekton.dev instance, we should stop having a default value for the TEKTON_HUB_API uri.

This doesn't stop users to use their own instance of the tektoncd/hub with the resolver.

/kind cleanup
/cc @afrittoli 

Closes #8858

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Removing the default value of `TEKTON_HUB_API` in the resolvers deployment as the public instance of tektoncd/hub (hub.tekton.dev) will be shutdown in September. It's still possible to set this environment variable to a value for users who self host an instance of tektoncd/hub
```
