### PR TITLE
Re-register metrics only during real update

### DIFF
--- a/pkg/pipelinerunmetrics/metrics_test.go
+++ b/pkg/pipelinerunmetrics/metrics_test.go
@@ -89,44 +89,107 @@ func TestUninitializedMetrics(t *testing.T) {
 }
 
 func TestOnStore(t *testing.T) {
-	log := zap.NewExample()
-	defer log.Sync()
-	logger := log.Sugar()
+	unregisterMetrics()
+	log := zap.NewExample().Sugar()
 
+	// 1. Initial state
+	initialCfg := &config.Config{Metrics: &config.Metrics{
+		PipelinerunLevel:        config.PipelinerunLevelAtPipelinerun,
+		DurationPipelinerunType: config.DurationPipelinerunTypeLastValue,
+	}}
+	ctx := config.ToContext(t.Context(), initialCfg)
+	r, err := NewRecorder(ctx)
+	if err != nil {
+		t.Fatalf("NewRecorder failed: %v", err)
+	}
+	onStoreCallback := OnStore(log, r)
+
+	// Check initial state
+	if reflect.ValueOf(r.insertTag).Pointer() != reflect.ValueOf(pipelinerunInsertTag).Pointer() {
+		t.Fatalf("Initial insertTag function is incorrect")
+	}
+	initialHash := r.hash
+
+	// 2. Call with wrong name - should not change anything
+	onStoreCallback("wrong-name", &config.Metrics{PipelinerunLevel: config.PipelinerunLevelAtNS})
+	if r.hash != initialHash {
+		t.Errorf("Hash changed after call with wrong name")
+	}
+	if reflect.ValueOf(r.insertTag).Pointer() != reflect.ValueOf(pipelinerunInsertTag).Pointer() {
+		t.Errorf("insertTag changed after call with wrong name")
+	}
+
+	// 3. Call with wrong type - should log an error and not change anything
+	onStoreCallback(config.GetMetricsConfigName(), &config.Store{})
+	if r.hash != initialHash {
+		t.Errorf("Hash changed after call with wrong type")
+	}
+	if reflect.ValueOf(r.insertTag).Pointer() != reflect.ValueOf(pipelinerunInsertTag).Pointer() {
+		t.Errorf("insertTag changed after call with wrong type")
+	}
+
+	// 4. Call with a valid new config - should change
+	newCfg := &config.Metrics{
+		PipelinerunLevel:        config.PipelinerunLevelAtNS,
+		DurationPipelinerunType: config.DurationPipelinerunTypeLastValue,
+	}
+	onStoreCallback(config.GetMetricsConfigName(), newCfg)
+	if r.hash == initialHash {
+		t.Errorf("Hash did not change after valid config update")
+	}
+	if reflect.ValueOf(r.insertTag).Pointer() != reflect.ValueOf(nilInsertTag).Pointer() {
+		t.Errorf("insertTag did not change after valid config update")
+	}
+	newHash := r.hash
+
+	// 5. Call with the same config again - should not change
+	onStoreCallback(config.GetMetricsConfigName(), newCfg)
+	if r.hash != newHash {
+		t.Errorf("Hash changed after second call with same config")
+	}
+	if reflect.ValueOf(r.insertTag).Pointer() != reflect.ValueOf(nilInsertTag).Pointer() {
+		t.Errorf("insertTag changed after second call with same config")
+	}
+
+	// 6. Call with an invalid config - should update hash but not insertTag
+	invalidCfg := &config.Metrics{PipelinerunLevel: "invalid-level"}
+	onStoreCallback(config.GetMetricsConfigName(), invalidCfg)
+	if r.hash == newHash {
+		t.Errorf("Hash did not change after invalid config update")
+	}
+	// Because viewRegister fails, the insertTag function should not be updated and should remain `nilInsertTag` from the previous step.
+	if reflect.ValueOf(r.insertTag).Pointer() != reflect.ValueOf(nilInsertTag).Pointer() {
+		t.Errorf("insertTag changed after invalid config update")
+	}
+}
+
+func TestUpdateConfig(t *testing.T) {
+	// Test that the config is updated when it changes, and not when it doesn't.
 	ctx := getConfigContext(false)
-	metrics, err := NewRecorder(ctx)
+	r, err := NewRecorder(ctx)
 	if err != nil {
 		t.Fatalf("NewRecorder: %v", err)
 	}
 
-	// We check that there's no change when incorrect config is passed
-	OnStore(logger, metrics)(config.GetMetricsConfigName(), &config.Store{})
-	// Comparing function assign to struct with the one which should yield same value
-	if reflect.ValueOf(metrics.insertTag).Pointer() != reflect.ValueOf(pipelinerunInsertTag).Pointer() {
-		t.Fatal("metrics recorder shouldn't change during this OnStore call")
+	// First, update with a new config.
+	newConfig := &config.Metrics{
+		PipelinerunLevel: config.PipelinerunLevelAtPipeline,
+	}
+	if !r.updateConfig(newConfig) {
+		t.Error("updateConfig should have returned true, but returned false")
 	}
 
-	// Test when incorrect value in configmap is pass
-	cfg := &config.Metrics{
-		TaskrunLevel:            "foo",
-		PipelinerunLevel:        "bar",
-		DurationTaskrunType:     config.DurationTaskrunTypeHistogram,
-		DurationPipelinerunType: config.DurationPipelinerunTypeLastValue,
-	}
-	OnStore(logger, metrics)(config.GetMetricsConfigName(), cfg)
-	if reflect.ValueOf(metrics.insertTag).Pointer() != reflect.ValueOf(pipelinerunInsertTag).Pointer() {
-		t.Fatal("metrics recorder shouldn't change during this OnStore call")
+	// Then, update with the same config.
+	if r.updateConfig(newConfig) {
+		t.Error("updateConfig should have returned false, but returned true")
 	}
 
-	cfg = &config.Metrics{
-		TaskrunLevel:            config.TaskrunLevelAtNS,
-		PipelinerunLevel:        config.PipelinerunLevelAtNS,
-		DurationTaskrunType:     config.DurationTaskrunTypeHistogram,
-		DurationPipelinerunType: config.DurationPipelinerunTypeLastValue,
+	// Finally, update with a different config.
+	differentConfig := &config.Metrics{
+		PipelinerunLevel: config.PipelinerunLevelAtNS,
 	}
-	OnStore(logger, metrics)(config.GetMetricsConfigName(), cfg)
-	if reflect.ValueOf(metrics.insertTag).Pointer() != reflect.ValueOf(nilInsertTag).Pointer() {
-		t.Fatal("metrics recorder didn't change during OnStore call")
+	if !r.updateConfig(differentConfig) {
+		t.Error("updateConfig should have returned true, but returned false")
 	}
 }
 


### PR DESCRIPTION
Before this, metrics were beign registered and unregisterd even when anything in configMap used to change including revision, etc. This causes gap in the metrics and gives us incorrect data over a long time if configmap revision changes.

Assisted-by: Gemini for unit testing

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
