### PR TITLE
taskrun: include actual result size in error when exceeding maxResultSize

### DIFF
--- a/pkg/pod/status_test.go
+++ b/pkg/pod/status_test.go
@@ -141,7 +141,7 @@ func TestSetTaskRunStatusBasedOnStepStatus_sidecar_logs(t *testing.T) {
 			},
 		},
 		maxResultSize: 1,
-		wantErr:       sidecarlogresults.ErrSizeExceeded,
+		wantErr:       fmt.Errorf("%d bytes %w of %d bytes", 9, sidecarlogresults.ErrSizeExceeded, 1),
 	}, {
 		desc: "test result with sidecar logs bad format",
 		tr: v1.TaskRun{
@@ -177,7 +177,7 @@ func TestSetTaskRunStatusBasedOnStepStatus_sidecar_logs(t *testing.T) {
 			},
 		},
 		maxResultSize:   1,
-		wantErr:         sidecarlogresults.ErrSizeExceeded,
+		wantErr:         fmt.Errorf("%d bytes %w of %d bytes", 9, sidecarlogresults.ErrSizeExceeded, 1),
 		enableArtifacts: true,
 	}, {
 		desc: "test artifact with sidecar logs bad format",

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -215,8 +215,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, tr *v1.TaskRun) pkgrecon
 	if err = c.reconcile(ctx, tr, rtr); err != nil {
 		logger.Errorf("Reconcile: %v", err.Error())
 		if errors.Is(err, sidecarlogresults.ErrSizeExceeded) {
-			cfg := config.FromContextOrDefaults(ctx)
-			message := fmt.Sprintf("%s TaskRun \"%q\" failed: results exceeded size limit %d bytes", pipelineErrors.UserErrorLabel, tr.Name, cfg.FeatureFlags.MaxResultSize)
+			message := fmt.Sprintf("%s TaskRun \"%q\" failed: %s", pipelineErrors.UserErrorLabel, tr.Name, err.Error())
 			err := c.failTaskRun(ctx, tr, v1.TaskRunReasonResultLargerThanAllowedLimit, message)
 			return c.finishReconcileUpdateEmitEvents(ctx, tr, before, err)
 		}


### PR DESCRIPTION
Fixes #8868

# Changes

Previously, when a TaskRun failed due to a result exceeding the maxResultSize, the error message did not include the actual size of the offending result. This makes it harder for users to figure out how much they exceeded the configured limit.

Example: 
```
  Conditions:
    Last Transition Time:  2025-07-03T17:59:57Z
    Message:               [User error]  TaskRun ""max-size-run"" failed: results exceeded size limit 20 bytes
    Reason:                TaskRunResultLargerThanAllowedLimit
```

This change improves the error message to include the actual size to debug pipelines with large results.
Example: 
```
  Conditions:
    Last Transition Time:  2025-07-05T12:08:56Z
    Message:               [User error]  TaskRun ""max-size-run"" failed: 47 bytes results size exceeds configured limit of 20 bytes
    Reason:                TaskRunResultLargerThanAllowedLimit
```

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Improved error message when a TaskRun result exceeds `maxResultSize` to include the actual result size, making it easier to debug oversized results
```
