### PR TITLE
Nr. 1 - [TEP-0056]: Add Pipelines-in-Pipelines task resolution for `PipelineSpec`.

### DIFF
--- a/pkg/apis/pipeline/v1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1/pipelinerun_types.go
@@ -84,6 +84,16 @@ func (pr *PipelineRun) HasStarted() bool {
 	return pr.Status.StartTime != nil && !pr.Status.StartTime.IsZero()
 }
 
+// IsSuccessful returns true if the PipelineRun's status indicates that it has succeeded.
+func (pr *PipelineRun) IsSuccessful() bool {
+	return pr != nil && pr.Status.GetCondition(apis.ConditionSucceeded).IsTrue()
+}
+
+// IsFailure returns true if the PipelineRun's status indicates that it has failed.
+func (pr *PipelineRun) IsFailure() bool {
+	return pr != nil && pr.Status.GetCondition(apis.ConditionSucceeded).IsFalse()
+}
+
 // IsCancelled returns true if the PipelineRun's spec status is set to Cancelled state
 func (pr *PipelineRun) IsCancelled() bool {
 	return pr.Spec.Status == PipelineRunSpecStatusCancelled

--- a/pkg/apis/pipeline/v1/pipelinerun_types_test.go
+++ b/pkg/apis/pipeline/v1/pipelinerun_types_test.go
@@ -781,3 +781,83 @@ func TestPipelineRunMarkFailedCondition(t *testing.T) {
 		})
 	}
 }
+
+func TestPipelineRunIsSuccessful(t *testing.T) {
+	tcs := []struct {
+		name        string
+		pipelineRun *v1.PipelineRun
+		want        bool
+	}{{
+		name: "nil pipelinerun",
+		want: false,
+	}, {
+		name: "still running",
+		pipelineRun: &v1.PipelineRun{Status: v1.PipelineRunStatus{Status: duckv1.Status{Conditions: []apis.Condition{{
+			Type:   apis.ConditionSucceeded,
+			Status: corev1.ConditionUnknown,
+		}}}}},
+		want: false,
+	}, {
+		name: "succeeded",
+		pipelineRun: &v1.PipelineRun{Status: v1.PipelineRunStatus{Status: duckv1.Status{Conditions: []apis.Condition{{
+			Type:   apis.ConditionSucceeded,
+			Status: corev1.ConditionTrue,
+		}}}}},
+		want: true,
+	}, {
+		name: "failed",
+		pipelineRun: &v1.PipelineRun{Status: v1.PipelineRunStatus{Status: duckv1.Status{Conditions: []apis.Condition{{
+			Type:   apis.ConditionSucceeded,
+			Status: corev1.ConditionFalse,
+		}}}}},
+		want: false,
+	}}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.pipelineRun.IsSuccessful()
+			if tc.want != got {
+				t.Errorf("wanted IsSuccessful to be %t but was %t", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestPipelineRunIsFailure(t *testing.T) {
+	tcs := []struct {
+		name        string
+		pipelineRun *v1.PipelineRun
+		want        bool
+	}{{
+		name: "nil pipelinerun",
+		want: false,
+	}, {
+		name: "still running",
+		pipelineRun: &v1.PipelineRun{Status: v1.PipelineRunStatus{Status: duckv1.Status{Conditions: []apis.Condition{{
+			Type:   apis.ConditionSucceeded,
+			Status: corev1.ConditionUnknown,
+		}}}}},
+		want: false,
+	}, {
+		name: "succeeded",
+		pipelineRun: &v1.PipelineRun{Status: v1.PipelineRunStatus{Status: duckv1.Status{Conditions: []apis.Condition{{
+			Type:   apis.ConditionSucceeded,
+			Status: corev1.ConditionTrue,
+		}}}}},
+		want: false,
+	}, {
+		name: "failed",
+		pipelineRun: &v1.PipelineRun{Status: v1.PipelineRunStatus{Status: duckv1.Status{Conditions: []apis.Condition{{
+			Type:   apis.ConditionSucceeded,
+			Status: corev1.ConditionFalse,
+		}}}}},
+		want: true,
+	}}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.pipelineRun.IsFailure()
+			if tc.want != got {
+				t.Errorf("wanted IsFailure to be %t but was %t", tc.want, got)
+			}
+		})
+	}
+}

--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -2622,7 +2622,6 @@ _EOF_
 			} else {
 				trAnnotations = c.trAnnotation
 				trAnnotations[ReleaseAnnotation] = fakeVersion
-
 			}
 			testTaskRunName := taskRunName
 			if c.trName != "" {

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -359,6 +359,10 @@ func (c *Reconciler) resolvePipelineState(
 			return nil, fmt.Errorf("failed to list VerificationPolicies from namespace %s with error %w", pr.Namespace, err)
 		}
 
+		getChildPipelineRunFunc := func(name string) (*v1.PipelineRun, error) {
+			return c.pipelineRunLister.PipelineRuns(pr.Namespace).Get(name)
+		}
+
 		getTaskFunc := tresources.GetTaskFunc(
 			ctx,
 			c.KubeClientSet,
@@ -386,6 +390,7 @@ func (c *Reconciler) resolvePipelineState(
 
 		resolvedTask, err := resources.ResolvePipelineTask(ctx,
 			*pr,
+			getChildPipelineRunFunc,
 			getTaskFunc,
 			getTaskRunFunc,
 			getCustomRunFunc,

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -61,8 +61,12 @@ func (e *TaskNotFoundError) Error() string {
 	return fmt.Sprintf("Couldn't retrieve Task %q: %s", e.Name, e.Msg)
 }
 
-// ResolvedPipelineTask contains a PipelineTask and its associated TaskRun(s) or CustomRuns, if they exist.
+// ResolvedPipelineTask contains a PipelineTask and its associated child PipelineRun(s) (Pipelines-in-Pipelines), TaskRun(s) or CustomRuns, if they exist.
 type ResolvedPipelineTask struct {
+	ChildPipelineRunNames []string
+	ChildPipelineRuns     []*v1.PipelineRun
+	ResolvedPipeline      ResolvedPipeline
+
 	TaskRunNames []string
 	TaskRuns     []*v1.TaskRun
 	ResolvedTask *resources.ResolvedTask
@@ -142,10 +146,29 @@ func (t ResolvedPipelineTask) IsCustomTask() bool {
 	return t.CustomTask
 }
 
+// IsChildPipeline returns true if the PipelineTask references a child (PinP) Pipeline.
+func (t ResolvedPipelineTask) IsChildPipeline() bool {
+	return t.PipelineTask.PipelineSpec != nil
+}
+
 // getReason returns the latest reason if the run has completed successfully
 // If the PipelineTask has a Matrix, getReason returns the failure reason for any failure
 // otherwise, it returns an empty string
 func (t ResolvedPipelineTask) getReason() string {
+	if t.IsChildPipeline() {
+		if len(t.ChildPipelineRuns) == 0 {
+			return ""
+		}
+		for _, childPipelineRun := range t.ChildPipelineRuns {
+			if !childPipelineRun.IsSuccessful() && len(childPipelineRun.Status.Conditions) >= 1 {
+				return childPipelineRun.Status.Conditions[0].Reason
+			}
+		}
+		if len(t.ChildPipelineRuns) >= 1 && len(t.ChildPipelineRuns[0].Status.Conditions) >= 1 {
+			return t.ChildPipelineRuns[0].Status.Conditions[0].Reason
+		}
+	}
+
 	if t.IsCustomTask() {
 		if len(t.CustomRuns) == 0 {
 			return ""
@@ -178,6 +201,20 @@ func (t ResolvedPipelineTask) getReason() string {
 // isSuccessful returns true only if the run has completed successfully
 // If the PipelineTask has a Matrix, isSuccessful returns true if all runs have completed successfully
 func (t ResolvedPipelineTask) isSuccessful() bool {
+	if t.IsChildPipeline() {
+		if len(t.ChildPipelineRuns) == 0 {
+			return false
+		}
+
+		for _, childPipelineRun := range t.ChildPipelineRuns {
+			if !childPipelineRun.IsSuccessful() {
+				return false
+			}
+		}
+
+		return true
+	}
+
 	if t.IsCustomTask() {
 		if len(t.CustomRuns) == 0 {
 			return false
@@ -205,6 +242,17 @@ func (t ResolvedPipelineTask) isSuccessful() bool {
 // If the PipelineTask has a Matrix, isFailure returns true if any run has failed and all other runs are done.
 func (t ResolvedPipelineTask) isFailure() bool {
 	var isDone bool
+	if t.IsChildPipeline() {
+		if len(t.ChildPipelineRuns) == 0 {
+			return false
+		}
+		isDone = true
+		for _, childPipelineRun := range t.ChildPipelineRuns {
+			isDone = isDone && childPipelineRun.IsDone()
+		}
+		return t.haveAnyChildPipelineRunsFailed() && isDone
+	}
+
 	if t.IsCustomTask() {
 		if len(t.CustomRuns) == 0 {
 			return false
@@ -215,6 +263,7 @@ func (t ResolvedPipelineTask) isFailure() bool {
 		}
 		return t.haveAnyRunsFailed() && isDone
 	}
+
 	if len(t.TaskRuns) == 0 {
 		return false
 	}
@@ -310,13 +359,27 @@ func (t ResolvedPipelineTask) isScheduled() bool {
 	return len(t.TaskRuns) > 0
 }
 
-// haveAnyRunsFailed returns true when any of the taskRuns/customRuns have succeeded condition with status set to false
+// haveAnyRunsFailed returns true when any of the child (PinP) PipelineRuns/TaskRuns/CustomRuns have succeeded condition with status set to false
 func (t ResolvedPipelineTask) haveAnyRunsFailed() bool {
+	if t.IsChildPipeline() {
+		return t.haveAnyChildPipelineRunsFailed()
+	}
+
 	if t.IsCustomTask() {
 		return t.haveAnyCustomRunsFailed()
 	}
 
 	return t.haveAnyTaskRunsFailed()
+}
+
+// haveAnyChildPipelineRunsFailed returns true when any of the child (PinP) PipelineRuns have succeeded condition with status set to false
+func (t ResolvedPipelineTask) haveAnyChildPipelineRunsFailed() bool {
+	for _, childPipelineRun := range t.ChildPipelineRuns {
+		if childPipelineRun.IsFailure() {
+			return true
+		}
+	}
+	return false
 }
 
 // haveAnyTaskRunsFailed returns true when any of the TaskRuns have succeeded condition with status set to false
@@ -594,9 +657,14 @@ func ValidateTaskRunSpecs(p *v1.PipelineSpec, pr *v1.PipelineRun) error {
 //
 // If the Pipeline Task is a Custom Task, it retrieves any CustomRuns and updates the ResolvedPipelineTask with this information.
 // It also sets the ResolvedPipelineTask's RunName(s) with the names of CustomRuns that should be or already have been created.
+//
+// If the Pipeline Task is a Pipeline, it retrieves any child (PinP) PipelineRuns, plus the Pipeline spec and updates the
+// ResolvedPipelineTask with this information. It also sets the ResolvedPipelineTask's ChildPipelineRunName(s) with the names
+// of child (PinP) PipelineRuns that should be or already have been created.
 func ResolvePipelineTask(
 	ctx context.Context,
 	pipelineRun v1.PipelineRun,
+	getChildPipelineRun GetPipelineRun,
 	getTask resources.GetTask,
 	getTaskRun resources.GetTaskRun,
 	getRun GetRun,
@@ -621,7 +689,24 @@ func ResolvePipelineTask(
 	if rpt.PipelineTask.IsMatrixed() {
 		numCombinations = rpt.PipelineTask.Matrix.CountCombinations()
 	}
-	if rpt.IsCustomTask() {
+
+	switch {
+	case rpt.IsChildPipeline():
+		rpt.ChildPipelineRunNames = GetNamesOfChildPipelineRuns(
+			pipelineRun.Status.ChildReferences,
+			pipelineTask.Name,
+			pipelineRun.Name,
+			numCombinations,
+		)
+
+		// happy path: no pipelineRef, no local/remote resolution, no getPipeline
+		for _, childPipelineRunName := range rpt.ChildPipelineRunNames {
+			if err := rpt.setChildPipelineRunsAndResolvedPipeline(ctx, childPipelineRunName, getChildPipelineRun, pipelineTask); err != nil {
+				return nil, err
+			}
+		}
+
+	case rpt.IsCustomTask():
 		rpt.CustomRunNames = getNamesOfCustomRuns(pipelineRun.Status.ChildReferences, pipelineTask.Name, pipelineRun.Name, numCombinations)
 		for _, runName := range rpt.CustomRunNames {
 			run, err := getRun(runName)
@@ -632,7 +717,8 @@ func ResolvePipelineTask(
 				rpt.CustomRuns = append(rpt.CustomRuns, run)
 			}
 		}
-	} else {
+
+	default:
 		rpt.TaskRunNames = GetNamesOfTaskRuns(pipelineRun.Status.ChildReferences, pipelineTask.Name, pipelineRun.Name, numCombinations)
 		for _, taskRunName := range rpt.TaskRunNames {
 			if err := rpt.setTaskRunsAndResolvedTask(ctx, taskRunName, getTask, getTaskRun, pipelineTask); err != nil {
@@ -642,6 +728,36 @@ func ResolvePipelineTask(
 	}
 
 	return &rpt, nil
+}
+
+func (t *ResolvedPipelineTask) setChildPipelineRunsAndResolvedPipeline(
+	ctx context.Context,
+	childPipelineRunName string,
+	getChildPipelineRun GetPipelineRun,
+	pipelineTask v1.PipelineTask,
+) error {
+	childPipelineRun, err := getChildPipelineRun(childPipelineRunName)
+	if err != nil {
+		if !kerrors.IsNotFound(err) {
+			return fmt.Errorf("error retrieving child PipelineRun %s: %w", childPipelineRunName, err)
+		}
+	}
+	if childPipelineRun != nil {
+		t.ChildPipelineRuns = append(t.ChildPipelineRuns, childPipelineRun)
+	}
+
+	rp := ResolvedPipeline{}
+	switch {
+	case pipelineTask.PipelineSpec != nil:
+		rp.PipelineSpec = pipelineTask.PipelineSpec
+	case pipelineTask.PipelineRef != nil:
+		return fmt.Errorf("PipelineRef for PipelineTask %q is not yet implemented", pipelineTask.Name)
+	default:
+		return fmt.Errorf("PipelineSpec in PipelineTask %q missing", pipelineTask.Name)
+	}
+
+	t.ResolvedPipeline = rp
+	return nil
 }
 
 // setTaskRunsAndResolvedTask fetches the named TaskRun using the input function getTaskRun,
@@ -720,7 +836,7 @@ func resolveTask(
 		// If the alpha feature is enabled, and the user has configured pipelineSpec or pipelineRef, it will enter here.
 		// Currently, the controller is not yet adapted, and to avoid a panic, an error message is provided here.
 		// TODO: Adjust the logic here once the feature is supported in the future.
-		return nil, fmt.Errorf("Currently, Task %q does not support PipelineRef or PipelineSpec, please use TaskRef or TaskSpec instead", pipelineTask.Name)
+		return nil, fmt.Errorf("Currently, Task %q does not support PipelineRef, please use PipelineSpec, TaskRef or TaskSpec instead", pipelineTask.Name)
 	}
 	rt.TaskSpec.SetDefaults(ctx)
 	return rt, nil
@@ -744,6 +860,15 @@ func GetNamesOfTaskRuns(childRefs []v1.ChildStatusReference, ptName, prName stri
 	return getNewRunNames(ptName, prName, numberOfTaskRuns)
 }
 
+// GetNamesOfChildPipelineRuns should return unique names for child (PinP) `PipelineRuns` if one has not already been
+// defined, and the existing one otherwise.
+func GetNamesOfChildPipelineRuns(childRefs []v1.ChildStatusReference, ptName, prName string, numberOfPipelineRuns int) []string {
+	if pipelineRunNames := getChildPipelineRunNamesFromChildRefs(childRefs, ptName); pipelineRunNames != nil {
+		return pipelineRunNames
+	}
+	return getNewRunNames(ptName, prName, numberOfPipelineRuns)
+}
+
 // getTaskRunNamesFromChildRefs returns the names of TaskRuns defined in childRefs that are associated with the named Pipeline Task.
 func getTaskRunNamesFromChildRefs(childRefs []v1.ChildStatusReference, ptName string) []string {
 	var taskRunNames []string
@@ -757,25 +882,27 @@ func getTaskRunNamesFromChildRefs(childRefs []v1.ChildStatusReference, ptName st
 
 func getNewRunNames(ptName, prName string, numberOfRuns int) []string {
 	var runNames []string
-	// If it is a singular TaskRun/CustomRun, we only append the ptName
+	// If it is a singular PipelineRun/TaskRun/CustomRun, we only append the ptName
 	if numberOfRuns == 1 {
 		runName := kmeta.ChildName(prName, "-"+ptName)
 		return append(runNames, runName)
 	}
-	// For a matrix we append i to the end of the fanned out TaskRuns/CustomRun "matrixed-pr-taskrun-0"
+
+	// For a matrix we append i to the end of the fanned out PipelineRun/TaskRun/CustomRun "matrixed-pr-taskrun-0"
 	for i := range numberOfRuns {
 		runName := kmeta.ChildName(prName, fmt.Sprintf("-%s-%d", ptName, i))
-		// check if the taskRun name ends with a matrix instance count
+		// check if the PipelineRun/TaskRun/CustomRun name ends with a matrix instance count
 		if !strings.HasSuffix(runName, fmt.Sprintf("-%d", i)) {
 			runName = kmeta.ChildName(prName, "-"+ptName)
 			// kmeta.ChildName limits the size of a name to max of 63 characters based on k8s guidelines
-			// truncate the name such that "-<matrix-id>" can be appended to the TaskRun/CustomRun name
+			// truncate the name such that "-<matrix-id>" can be appended to the PipelineRun/TaskRun/CustomRun name
 			longest := 63 - len(fmt.Sprintf("-%d", numberOfRuns))
 			runName = runName[0:longest]
 			runName = fmt.Sprintf("%s-%d", runName, i)
 		}
 		runNames = append(runNames, runName)
 	}
+
 	return runNames
 }
 
@@ -813,6 +940,20 @@ func getRunNamesFromChildRefs(childRefs []v1.ChildStatusReference, ptName string
 		}
 	}
 	return runNames
+}
+
+// getChildPipelineRunNamesFromChildRefs returns the names of child (PinP) PipelineRuns defined in childRefs that are
+// associated with the named Pipeline Task.
+func getChildPipelineRunNamesFromChildRefs(childRefs []v1.ChildStatusReference, ptName string) []string {
+	var childPipelineRunNames []string
+	for _, cr := range childRefs {
+		if cr.PipelineTaskName == ptName {
+			if cr.Kind == pipeline.PipelineRunControllerName {
+				childPipelineRunNames = append(childPipelineRunNames, cr.Name)
+			}
+		}
+	}
+	return childPipelineRunNames
 }
 
 func (t *ResolvedPipelineTask) hasResultReferences() bool {

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
@@ -59,6 +59,24 @@ func nopGetTaskRun(string) (*v1.TaskRun, error) {
 	return nil, errors.New("GetTaskRun should not be called")
 }
 
+func nopGetPipelineRun(string) (*v1.PipelineRun, error) {
+	return nil, errors.New("GetPipelineRun should not be called")
+}
+
+func getTaskFn(vr *trustedresources.VerificationResult, err error) resources.GetTask {
+	return func(_ context.Context, name string) (*v1.Task, *v1.RefSource, *trustedresources.VerificationResult, error) {
+		return task, nil, vr, err
+	}
+}
+
+func getTaskRunFn(tr *v1.TaskRun) resources.GetTaskRun {
+	return func(name string) (*v1.TaskRun, error) { return tr, nil }
+}
+
+func getRunFn(cr *v1beta1.CustomRun) GetRun {
+	return func(name string) (*v1beta1.CustomRun, error) { return cr, nil }
+}
+
 var pts = []v1.PipelineTask{{
 	Name:    "mytask1",
 	TaskRef: &v1.TaskRef{Name: "task"},
@@ -180,6 +198,38 @@ var pts = []v1.PipelineTask{{
 			Value: v1.ParamValue{ArrayVal: []string{"safari", "chrome"}},
 		}},
 	},
+}, {
+	Name: "mytask22",
+	PipelineSpec: &v1.PipelineSpec{
+		Tasks: []v1.PipelineTask{{
+			Name: "pip-child-task",
+			TaskSpec: &v1.EmbeddedTask{
+				TaskSpec: v1.TaskSpec{
+					Steps: []v1.Step{{
+						Name:   "hello-pip",
+						Image:  "mirror.gcr.io/alpine",
+						Script: "echo \"Hello from mytask22-pip-child-task!\"",
+					}},
+				},
+			},
+		}},
+	},
+}, {
+	Name: "mytask23",
+	PipelineSpec: &v1.PipelineSpec{
+		Tasks: []v1.PipelineTask{{
+			Name: "pip-child-task",
+			TaskSpec: &v1.EmbeddedTask{
+				TaskSpec: v1.TaskSpec{
+					Steps: []v1.Step{{
+						Name:   "goodbye-pip",
+						Image:  "mirror.gcr.io/alpine",
+						Script: "echo \"Goodbye from mytask23-pip-child-task!\"",
+					}},
+				},
+			},
+		}},
+	},
 }}
 
 var p = &v1.Pipeline{
@@ -237,6 +287,20 @@ var customRuns = []v1beta1.CustomRun{{
 	Spec: v1beta1.CustomRunSpec{},
 }}
 
+var prs = []v1.PipelineRun{{
+	ObjectMeta: metav1.ObjectMeta{
+		Namespace: "namespace",
+		Name:      "pipelinerun-mytask22",
+	},
+	Spec: v1.PipelineRunSpec{},
+}, {
+	ObjectMeta: metav1.ObjectMeta{
+		Namespace: "namespace",
+		Name:      "pipelinerun-mytask23",
+	},
+	Spec: v1.PipelineRunSpec{},
+}}
+
 var matrixedPipelineTask = &v1.PipelineTask{
 	Name: "task",
 	TaskSpec: &v1.EmbeddedTask{
@@ -281,6 +345,12 @@ func makeCustomRunStarted(run v1beta1.CustomRun) *v1beta1.CustomRun {
 	return newRun
 }
 
+func makePipelineRunStarted(pr v1.PipelineRun) *v1.PipelineRun {
+	newPr := newPipelineRun(pr)
+	newPr.Status.Conditions[0].Status = corev1.ConditionUnknown
+	return newPr
+}
+
 func makeSucceeded(tr v1.TaskRun) *v1.TaskRun {
 	newTr := newTaskRun(tr)
 	newTr.Status.Conditions[0].Status = corev1.ConditionTrue
@@ -293,6 +363,13 @@ func makeCustomRunSucceeded(run v1beta1.CustomRun) *v1beta1.CustomRun {
 	newRun.Status.Conditions[0].Status = corev1.ConditionTrue
 	newRun.Status.Conditions[0].Reason = "Succeeded"
 	return newRun
+}
+
+func makePipelineRunSucceeded(pr v1.PipelineRun) *v1.PipelineRun {
+	newPr := newPipelineRun(pr)
+	newPr.Status.Conditions[0].Status = corev1.ConditionTrue
+	newPr.Status.Conditions[0].Reason = "Succeeded"
+	return newPr
 }
 
 func makeFailed(tr v1.TaskRun) *v1.TaskRun {
@@ -314,6 +391,13 @@ func makeCustomRunFailed(run v1beta1.CustomRun) *v1beta1.CustomRun {
 	newRun.Status.Conditions[0].Status = corev1.ConditionFalse
 	newRun.Status.Conditions[0].Reason = "Failed"
 	return newRun
+}
+
+func makePipelineRunFailed(pr v1.PipelineRun) *v1.PipelineRun {
+	newPr := newPipelineRun(pr)
+	newPr.Status.Conditions[0].Status = corev1.ConditionFalse
+	newPr.Status.Conditions[0].Reason = "Failed"
+	return newPr
 }
 
 func withCancelled(tr *v1.TaskRun) *v1.TaskRun {
@@ -406,6 +490,21 @@ func newCustomRun(run v1beta1.CustomRun) *v1beta1.CustomRun {
 		},
 		Spec: run.Spec,
 		Status: v1beta1.CustomRunStatus{
+			Status: duckv1.Status{
+				Conditions: []apis.Condition{{Type: apis.ConditionSucceeded}},
+			},
+		},
+	}
+}
+
+func newPipelineRun(pr v1.PipelineRun) *v1.PipelineRun {
+	return &v1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: pr.Namespace,
+			Name:      pr.Name,
+		},
+		Spec: pr.Spec,
+		Status: v1.PipelineRunStatus{
 			Status: duckv1.Status{
 				Conditions: []apis.Condition{{Type: apis.ConditionSucceeded}},
 			},
@@ -1270,6 +1369,12 @@ func TestIsFailure(t *testing.T) {
 		},
 		want: false,
 	}, {
+		name: "child pipelinerun not started",
+		rpt: ResolvedPipelineTask{
+			PipelineTask: &pts[21],
+		},
+		want: false,
+	}, {
 		name: "taskrun running",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1.PipelineTask{Name: "task"},
@@ -1282,6 +1387,13 @@ func TestIsFailure(t *testing.T) {
 			PipelineTask: &v1.PipelineTask{Name: "task"},
 			CustomTask:   true,
 			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunStarted(customRuns[0])},
+		},
+		want: false,
+	}, {
+		name: "child pipelinerun running",
+		rpt: ResolvedPipelineTask{
+			PipelineTask:      &pts[21],
+			ChildPipelineRuns: []*v1.PipelineRun{makePipelineRunStarted(prs[0])},
 		},
 		want: false,
 	}, {
@@ -1300,6 +1412,13 @@ func TestIsFailure(t *testing.T) {
 		},
 		want: false,
 	}, {
+		name: "child pipelinerun succeeded",
+		rpt: ResolvedPipelineTask{
+			PipelineTask:      &pts[21],
+			ChildPipelineRuns: []*v1.PipelineRun{makePipelineRunSucceeded(prs[0])},
+		},
+		want: false,
+	}, {
 		name: "taskrun failed",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1.PipelineTask{Name: "task"},
@@ -1312,6 +1431,13 @@ func TestIsFailure(t *testing.T) {
 			PipelineTask: &v1.PipelineTask{Name: "task"},
 			CustomTask:   true,
 			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunFailed(customRuns[0])},
+		},
+		want: true,
+	}, {
+		name: "child pipelinerun failed",
+		rpt: ResolvedPipelineTask{
+			PipelineTask:      &pts[21],
+			ChildPipelineRuns: []*v1.PipelineRun{makePipelineRunFailed(prs[0])},
 		},
 		want: true,
 	}, {
@@ -2382,7 +2508,7 @@ func TestResolvePipelineRun_CustomTask(t *testing.T) {
 	cfg := config.NewStore(logtesting.TestLogger(t))
 	ctx = cfg.ToContext(ctx)
 	for _, task := range pts {
-		ps, err := ResolvePipelineTask(ctx, pr, nopGetTask, nopGetTaskRun, getRun, task, nil)
+		ps, err := ResolvePipelineTask(ctx, pr, nopGetPipelineRun, nopGetTask, nopGetTaskRun, getRun, task, nil)
 		if err != nil {
 			t.Fatalf("ResolvePipelineTask: %v", err)
 		}
@@ -2410,6 +2536,53 @@ func TestResolvePipelineRun_CustomTask(t *testing.T) {
 	}
 }
 
+func TestResolvePipelineRun_ChildPipeline(t *testing.T) {
+	cfg := config.NewStore(logtesting.TestLogger(t))
+	ctx := cfg.ToContext(t.Context())
+
+	parentPr := v1.PipelineRun{ObjectMeta: metav1.ObjectMeta{Name: "pipelinerun"}}
+	pinpPts := []v1.PipelineTask{pts[21], pts[22]}
+	getChildPipelineRun := func(name string) (*v1.PipelineRun, error) {
+		if name == "pipelinerun-mytask23" {
+			return &prs[1], nil
+		}
+		return nil, kerrors.NewNotFound(v1.Resource("pipelinerun"), name)
+	}
+	expectedState := PipelineRunState{{
+		PipelineTask:          &pinpPts[0],
+		ChildPipelineRunNames: []string{"pipelinerun-mytask22"},
+		ChildPipelineRuns:     nil,
+		ResolvedPipeline:      ResolvedPipeline{PipelineSpec: pinpPts[0].PipelineSpec},
+	}, {
+		PipelineTask:          &pinpPts[1],
+		ChildPipelineRunNames: []string{"pipelinerun-mytask23"},
+		ChildPipelineRuns:     []*v1.PipelineRun{&prs[1]},
+		ResolvedPipeline:      ResolvedPipeline{PipelineSpec: pinpPts[1].PipelineSpec},
+	}}
+	actualState := PipelineRunState{}
+
+	for _, pipelineTask := range pinpPts {
+		ps, err := ResolvePipelineTask(
+			ctx,
+			parentPr,
+			getChildPipelineRun,
+			nopGetTask,
+			nopGetTaskRun,
+			nopGetCustomRun,
+			pipelineTask,
+			nil,
+		)
+		if err != nil {
+			t.Fatalf("ResolvePipelineTask: %v", err)
+		}
+		actualState = append(actualState, ps)
+	}
+
+	if d := cmp.Diff(expectedState, actualState); d != "" {
+		t.Errorf("Unexpected pipeline state: %s", diff.PrintWantGot(d))
+	}
+}
+
 func TestResolvePipelineRun_PipelineTaskHasNoResources(t *testing.T) {
 	pts := []v1.PipelineTask{{
 		Name:    "mytask1",
@@ -2422,10 +2595,8 @@ func TestResolvePipelineRun_PipelineTaskHasNoResources(t *testing.T) {
 		TaskRef: &v1.TaskRef{Name: "task"},
 	}}
 
-	getTask := func(ctx context.Context, name string) (*v1.Task, *v1.RefSource, *trustedresources.VerificationResult, error) {
-		return task, nil, nil, nil
-	}
-	getTaskRun := func(name string) (*v1.TaskRun, error) { return &trs[0], nil }
+	getTask := getTaskFn(nil, nil)
+	getTaskRun := getTaskRunFn(&trs[0])
 	pr := v1.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "pipelinerun",
@@ -2433,7 +2604,7 @@ func TestResolvePipelineRun_PipelineTaskHasNoResources(t *testing.T) {
 	}
 	pipelineState := PipelineRunState{}
 	for _, task := range pts {
-		ps, err := ResolvePipelineTask(t.Context(), pr, getTask, getTaskRun, nopGetCustomRun, task, nil)
+		ps, err := ResolvePipelineTask(t.Context(), pr, nopGetPipelineRun, getTask, getTaskRun, nopGetCustomRun, task, nil)
 		if err != nil {
 			t.Errorf("Error getting tasks for fake pipeline %s: %s", p.ObjectMeta.Name, err)
 		}
@@ -2460,21 +2631,19 @@ func TestResolvePipelineRun_PipelineTaskHasPipelineRef(t *testing.T) {
 		PipelineRef: &v1.PipelineRef{Name: "pipeline"},
 	}
 
-	getTask := func(ctx context.Context, name string) (*v1.Task, *v1.RefSource, *trustedresources.VerificationResult, error) {
-		return task, nil, nil, nil
-	}
-	getTaskRun := func(name string) (*v1.TaskRun, error) { return &trs[0], nil }
+	getTask := getTaskFn(nil, nil)
+	getTaskRun := getTaskRunFn(&trs[0])
 	pr := v1.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "pipelinerun",
 		},
 	}
 
-	_, err := ResolvePipelineTask(t.Context(), pr, getTask, getTaskRun, nopGetCustomRun, pt, nil)
+	_, err := ResolvePipelineTask(t.Context(), pr, nopGetPipelineRun, getTask, getTaskRun, nopGetCustomRun, pt, nil)
 	if err == nil {
 		t.Errorf("Error getting tasks for fake pipeline %s, expected an error but got nil.", p.ObjectMeta.Name)
 	}
-	if !strings.Contains(err.Error(), "does not support PipelineRef or PipelineSpec") {
+	if !strings.Contains(err.Error(), "does not support PipelineRef, please use PipelineSpec, TaskRef or TaskSpec instead") {
 		t.Errorf("Error getting tasks for fake pipeline %s: expected contains keyword but got %s", p.ObjectMeta.Name, err)
 	}
 }
@@ -2522,7 +2691,7 @@ func TestResolvePipelineRun_TaskDoesntExist(t *testing.T) {
 		},
 	}
 	for _, pt := range pts {
-		_, err := ResolvePipelineTask(t.Context(), pr, getTask, getTaskRun, nopGetCustomRun, pt, nil)
+		_, err := ResolvePipelineTask(t.Context(), pr, nopGetPipelineRun, getTask, getTaskRun, nopGetCustomRun, pt, nil)
 		var tnf *TaskNotFoundError
 		switch {
 		case err == nil:
@@ -2556,17 +2725,15 @@ func TestResolvePipelineRun_VerificationFailed(t *testing.T) {
 		},
 	}}
 	verificationResult := &trustedresources.VerificationResult{VerificationResultType: trustedresources.VerificationError, Err: trustedresources.ErrResourceVerificationFailed}
-	getTask := func(ctx context.Context, name string) (*v1.Task, *v1.RefSource, *trustedresources.VerificationResult, error) {
-		return task, nil, verificationResult, nil
-	}
-	getTaskRun := func(name string) (*v1.TaskRun, error) { return nil, nil } //nolint:nilnil
+	getTask := getTaskFn(verificationResult, nil)
+	getTaskRun := getTaskRunFn(nil)
 	pr := v1.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "pipelinerun",
 		},
 	}
 	for _, pt := range pts {
-		rt, _ := ResolvePipelineTask(t.Context(), pr, getTask, getTaskRun, nopGetCustomRun, pt, nil)
+		rt, _ := ResolvePipelineTask(t.Context(), pr, nopGetPipelineRun, getTask, getTaskRun, nopGetCustomRun, pt, nil)
 		if d := cmp.Diff(verificationResult, rt.ResolvedTask.VerificationResult, cmpopts.EquateErrors()); d != "" {
 			t.Error(diff.PrintWantGot(d))
 		}
@@ -2579,16 +2746,14 @@ func TestResolvePipelineRun_TransientError(t *testing.T) {
 		TaskRef: &v1.TaskRef{Name: "task"},
 	}
 
-	getTask := func(ctx context.Context, name string) (*v1.Task, *v1.RefSource, *trustedresources.VerificationResult, error) {
-		return task, nil, nil, apierrors.NewTimeoutError("some dang ol' timeout", 5)
-	}
-	getTaskRun := func(name string) (*v1.TaskRun, error) { return nil, nil } //nolint:nilnil
+	getTask := getTaskFn(nil, apierrors.NewTimeoutError("some dang ol' timeout", 5))
+	getTaskRun := getTaskRunFn(nil)
 	pr := v1.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "pipelinerun",
 		},
 	}
-	_, err := ResolvePipelineTask(t.Context(), pr, getTask, getTaskRun, nopGetCustomRun, pt, nil)
+	_, err := ResolvePipelineTask(t.Context(), pr, nopGetPipelineRun, getTask, getTaskRun, nopGetCustomRun, pt, nil)
 	if !resolutioncommon.IsErrTransient(err) {
 		t.Error("Transient error while getting Task did not result in a transient error")
 	}
@@ -2811,15 +2976,13 @@ func TestResolvePipeline_WhenExpressions(t *testing.T) {
 		When:    []v1.WhenExpression{ptwe1},
 	}
 
-	getTask := func(_ context.Context, name string) (*v1.Task, *v1.RefSource, *trustedresources.VerificationResult, error) {
-		return task, nil, nil, nil
-	}
 	pr := v1.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "pipelinerun",
 		},
 	}
 
+	getTask := getTaskFn(nil, nil)
 	getTaskRun := func(name string) (*v1.TaskRun, error) {
 		switch name {
 		case "pipelinerun-mytask1-always-true-0":
@@ -2831,7 +2994,7 @@ func TestResolvePipeline_WhenExpressions(t *testing.T) {
 	}
 
 	t.Run("When Expressions exist", func(t *testing.T) {
-		_, err := ResolvePipelineTask(t.Context(), pr, getTask, getTaskRun, nopGetCustomRun, pt, nil)
+		_, err := ResolvePipelineTask(t.Context(), pr, nopGetPipelineRun, getTask, getTaskRun, nopGetCustomRun, pt, nil)
 		if err != nil {
 			t.Fatalf("Did not expect error when resolving PipelineRun: %v", err)
 		}
@@ -2844,11 +3007,9 @@ func TestIsCustomTask(t *testing.T) {
 			Name: "pipelinerun",
 		},
 	}
-	getTask := func(ctx context.Context, name string) (*v1.Task, *v1.RefSource, *trustedresources.VerificationResult, error) {
-		return task, nil, nil, nil
-	}
-	getTaskRun := func(name string) (*v1.TaskRun, error) { return nil, nil }    //nolint:nilnil
-	getRun := func(name string) (*v1beta1.CustomRun, error) { return nil, nil } //nolint:nilnil
+	getTask := getTaskFn(nil, nil)
+	getTaskRun := getTaskRunFn(nil)
+	getRun := getRunFn(nil)
 
 	for _, tc := range []struct {
 		name string
@@ -2933,13 +3094,58 @@ func TestIsCustomTask(t *testing.T) {
 			ctx := t.Context()
 			cfg := config.NewStore(logtesting.TestLogger(t))
 			ctx = cfg.ToContext(ctx)
-			rpt, err := ResolvePipelineTask(ctx, pr, getTask, getTaskRun, getRun, tc.pt, nil)
+			rpt, err := ResolvePipelineTask(ctx, pr, nopGetPipelineRun, getTask, getTaskRun, getRun, tc.pt, nil)
 			if err != nil {
 				t.Fatalf("Did not expect error when resolving PipelineRun: %v", err)
 			}
 			got := rpt.IsCustomTask()
 			if d := cmp.Diff(tc.want, got); d != "" {
 				t.Errorf("IsCustomTask: %s", diff.PrintWantGot(d))
+			}
+		})
+	}
+}
+
+func TestIsChildPipeline(t *testing.T) {
+	pr := v1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pipelinerun",
+		},
+	}
+	getTask := getTaskFn(nil, nil)
+	getTaskRun := getTaskRunFn(nil)
+	getChildPipelineRun := func(name string) (*v1.PipelineRun, error) { return nil, nil } //nolint:nilnil
+
+	for _, tc := range []struct {
+		name string
+		pt   v1.PipelineTask
+		want bool
+	}{{
+		name: "parent pipeline with child pipeline using PipelineSpec",
+		pt: v1.PipelineTask{
+			PipelineSpec: &v1.PipelineSpec{
+				Tasks: []v1.PipelineTask{{Name: "pip-child-task"}},
+			},
+		},
+		want: true,
+	}, {
+		name: "pipeline with task using TaskSpec",
+		pt: v1.PipelineTask{
+			TaskSpec: &v1.EmbeddedTask{},
+		},
+		want: false,
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := t.Context()
+			cfg := config.NewStore(logtesting.TestLogger(t))
+			ctx = cfg.ToContext(ctx)
+			rpt, err := ResolvePipelineTask(ctx, pr, getChildPipelineRun, getTask, getTaskRun, nopGetCustomRun, tc.pt, nil)
+			if err != nil {
+				t.Fatalf("Did not expect error when resolving PipelineRun: %v", err)
+			}
+			got := rpt.IsChildPipeline()
+			if d := cmp.Diff(tc.want, got); d != "" {
+				t.Errorf("IsChildPipeline: %s", diff.PrintWantGot(d))
 			}
 		})
 	}
@@ -3608,17 +3814,71 @@ func TestGetRunName(t *testing.T) {
 	}
 }
 
+func TestGetNamesOfChildPipelineRuns(t *testing.T) {
+	prName := "mypipelinerun"
+	childRefs := []v1.ChildStatusReference{{
+		TypeMeta:         runtime.TypeMeta{Kind: "PipelineRun"},
+		Name:             "mypipelinerun-mychildpipelinetask",
+		PipelineTaskName: "mychildpipelinetask",
+	}}
+
+	for _, tc := range []struct {
+		name         string
+		ptName       string
+		prName       string
+		wantCprNames []string
+	}{{
+		name:         "existing child pipelinerun",
+		ptName:       "mychildpipelinetask",
+		wantCprNames: []string{"mypipelinerun-mychildpipelinetask"},
+	}, {
+		name:         "new child pipelinerun",
+		ptName:       "mynewchildpipelinetask",
+		wantCprNames: []string{"mypipelinerun-mynewchildpipelinetask"},
+	}, {
+		name:   "new pipelinetask with long names",
+		ptName: "longtask-0123456789-0123456789-0123456789-0123456789-0123456789",
+		wantCprNames: []string{
+			"mypipelineruna56c4ee0aab148ee219d40b21dfe935a-longtask-01234567",
+		},
+	}, {
+		name:   "new child pipelinetask, pipelinerun with long name",
+		ptName: "mynewchildpipelinetask",
+		prName: "pipeline-run-0123456789-0123456789-0123456789-0123456789",
+		wantCprNames: []string{
+			"pipeline1276ed292277c9bebded38d907a517fe-mynewchildpipelinetask",
+		},
+	}, {
+		name:   "new child pipelinerun, pipelinetask and pipelinerun with long name",
+		ptName: "mychildpipelinetask-0123456789-0123456789-0123456789-0123456789-0123456789",
+		prName: "pipeline-run-0123456789-0123456789-0123456789-0123456789",
+		wantCprNames: []string{
+			"pipeline-run-0123456789-012345628c128b6df49e753c1f628b073961e99",
+		},
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			testPrName := prName
+			if tc.prName != "" {
+				testPrName = tc.prName
+			}
+			namesOfChildPipelineRunsFromChildRefs := GetNamesOfChildPipelineRuns(childRefs, tc.ptName, testPrName, 1)
+			sort.Strings(namesOfChildPipelineRunsFromChildRefs)
+			if d := cmp.Diff(tc.wantCprNames, namesOfChildPipelineRunsFromChildRefs); d != "" {
+				t.Errorf("GetNamesOfChildPipelineRuns: %s", diff.PrintWantGot(d))
+			}
+		})
+	}
+}
+
 func TestIsMatrixed(t *testing.T) {
 	pr := v1.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "pipelinerun",
 		},
 	}
-	getTask := func(ctx context.Context, name string) (*v1.Task, *v1.RefSource, *trustedresources.VerificationResult, error) {
-		return task, nil, nil, nil
-	}
-	getTaskRun := func(name string) (*v1.TaskRun, error) { return &trs[0], nil }
-	getRun := func(name string) (*v1beta1.CustomRun, error) { return &customRuns[0], nil }
+	getTask := getTaskFn(nil, nil)
+	getTaskRun := getTaskRunFn(&trs[0])
+	getRun := getRunFn(&customRuns[0])
 
 	for _, tc := range []struct {
 		name string
@@ -3681,7 +3941,7 @@ func TestIsMatrixed(t *testing.T) {
 				},
 			})
 			ctx = cfg.ToContext(ctx)
-			rpt, err := ResolvePipelineTask(ctx, pr, getTask, getTaskRun, getRun, tc.pt, nil)
+			rpt, err := ResolvePipelineTask(ctx, pr, nopGetPipelineRun, getTask, getTaskRun, getRun, tc.pt, nil)
 			if err != nil {
 				t.Fatalf("Did not expect error when resolving PipelineRun: %v", err)
 			}
@@ -3790,11 +4050,9 @@ func TestResolvePipelineRunTask_WithMatrix(t *testing.T) {
 		},
 	}}
 
-	getTask := func(ctx context.Context, name string) (*v1.Task, *v1.RefSource, *trustedresources.VerificationResult, error) {
-		return task, nil, nil, nil
-	}
+	getTask := getTaskFn(nil, nil)
 	getTaskRun := func(name string) (*v1.TaskRun, error) { return taskRunsMap[name], nil }
-	getRun := func(name string) (*v1beta1.CustomRun, error) { return &customRuns[0], nil }
+	getRun := getRunFn(&customRuns[0])
 
 	for _, tc := range []struct {
 		name string
@@ -3840,7 +4098,7 @@ func TestResolvePipelineRunTask_WithMatrix(t *testing.T) {
 				},
 			})
 			ctx = cfg.ToContext(ctx)
-			rpt, err := ResolvePipelineTask(ctx, pr, getTask, getTaskRun, getRun, tc.pt, tc.pst)
+			rpt, err := ResolvePipelineTask(ctx, pr, nopGetPipelineRun, getTask, getTaskRun, getRun, tc.pt, tc.pst)
 			if err != nil {
 				t.Fatalf("Did not expect error when resolving PipelineRun: %v", err)
 			}
@@ -3942,10 +4200,8 @@ func TestResolvePipelineRunTask_WithMatrixedCustomTask(t *testing.T) {
 		},
 	}}
 
-	getTask := func(ctx context.Context, name string) (*v1.Task, *v1.RefSource, *trustedresources.VerificationResult, error) {
-		return task, nil, nil, nil
-	}
-	getTaskRun := func(name string) (*v1.TaskRun, error) { return &trs[0], nil }
+	getTask := getTaskFn(nil, nil)
+	getTaskRun := getTaskRunFn(&trs[0])
 	getRun := func(name string) (*v1beta1.CustomRun, error) { return runsMap[name], nil }
 
 	for _, tc := range []struct {
@@ -4008,7 +4264,7 @@ func TestResolvePipelineRunTask_WithMatrixedCustomTask(t *testing.T) {
 			if tc.getRun == nil {
 				tc.getRun = getRun
 			}
-			rpt, err := ResolvePipelineTask(ctx, pr, getTask, getTaskRun, tc.getRun, tc.pt, tc.pst)
+			rpt, err := ResolvePipelineTask(ctx, pr, nopGetPipelineRun, getTask, getTaskRun, tc.getRun, tc.pt, tc.pst)
 			if err != nil {
 				t.Fatalf("Did not expect error when resolving PipelineRun: %v", err)
 			}
@@ -4038,6 +4294,12 @@ func TestIsSuccessful(t *testing.T) {
 		},
 		want: false,
 	}, {
+		name: "child pipelinerun not started",
+		rpt: ResolvedPipelineTask{
+			PipelineTask: &pts[21],
+		},
+		want: false,
+	}, {
 		name: "taskrun running",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1.PipelineTask{Name: "task"},
@@ -4050,6 +4312,13 @@ func TestIsSuccessful(t *testing.T) {
 			PipelineTask: &v1.PipelineTask{Name: "task"},
 			CustomTask:   true,
 			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunStarted(customRuns[0])},
+		},
+		want: false,
+	}, {
+		name: "child pipelinerun running",
+		rpt: ResolvedPipelineTask{
+			PipelineTask:      &pts[21],
+			ChildPipelineRuns: []*v1.PipelineRun{makePipelineRunStarted(prs[0])},
 		},
 		want: false,
 	}, {
@@ -4068,6 +4337,13 @@ func TestIsSuccessful(t *testing.T) {
 		},
 		want: true,
 	}, {
+		name: "child pipelinerun succeeded",
+		rpt: ResolvedPipelineTask{
+			PipelineTask:      &pts[21],
+			ChildPipelineRuns: []*v1.PipelineRun{makePipelineRunSucceeded(prs[0])},
+		},
+		want: true,
+	}, {
 		name: "taskrun failed",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1.PipelineTask{Name: "task"},
@@ -4080,6 +4356,13 @@ func TestIsSuccessful(t *testing.T) {
 			PipelineTask: &v1.PipelineTask{Name: "task"},
 			CustomTask:   true,
 			CustomRuns:   []*v1beta1.CustomRun{makeCustomRunFailed(customRuns[0])},
+		},
+		want: false,
+	}, {
+		name: "child pipelinerun failed",
+		rpt: ResolvedPipelineTask{
+			PipelineTask:      &pts[21],
+			ChildPipelineRuns: []*v1.PipelineRun{makePipelineRunFailed(prs[0])},
 		},
 		want: false,
 	}, {
@@ -4855,6 +5138,13 @@ func TestGetReason(t *testing.T) {
 			},
 		},
 		{
+			name: "child pipelinerun created but the conditions were not initialized",
+			rpt: ResolvedPipelineTask{
+				PipelineTask:      &pts[21],
+				ChildPipelineRuns: []*v1.PipelineRun{&prs[0]},
+			},
+		},
+		{
 			name: "taskrun not started",
 			rpt: ResolvedPipelineTask{
 				PipelineTask: &v1.PipelineTask{Name: "task"},
@@ -4865,6 +5155,12 @@ func TestGetReason(t *testing.T) {
 			rpt: ResolvedPipelineTask{
 				PipelineTask: &v1.PipelineTask{Name: "task"},
 				CustomTask:   true,
+			},
+		},
+		{
+			name: "child pipelinerun not started",
+			rpt: ResolvedPipelineTask{
+				PipelineTask: &pts[21],
 			},
 		},
 		{
@@ -4880,6 +5176,13 @@ func TestGetReason(t *testing.T) {
 				PipelineTask: &v1.PipelineTask{Name: "task"},
 				CustomTask:   true,
 				CustomRuns:   []*v1beta1.CustomRun{makeCustomRunStarted(customRuns[0])},
+			},
+		},
+		{
+			name: "child pipelinerun running",
+			rpt: ResolvedPipelineTask{
+				PipelineTask:      &pts[21],
+				ChildPipelineRuns: []*v1.PipelineRun{makePipelineRunStarted(prs[0])},
 			},
 		},
 		{
@@ -4900,6 +5203,14 @@ func TestGetReason(t *testing.T) {
 			want: "Succeeded",
 		},
 		{
+			name: "child pipelinerun succeeded",
+			rpt: ResolvedPipelineTask{
+				PipelineTask:      &pts[21],
+				ChildPipelineRuns: []*v1.PipelineRun{makePipelineRunSucceeded(prs[0])},
+			},
+			want: "Succeeded",
+		},
+		{
 			name: "taskrun failed",
 			rpt: ResolvedPipelineTask{
 				PipelineTask: &v1.PipelineTask{Name: "task"},
@@ -4913,6 +5224,14 @@ func TestGetReason(t *testing.T) {
 				PipelineTask: &v1.PipelineTask{Name: "task"},
 				CustomTask:   true,
 				CustomRuns:   []*v1beta1.CustomRun{makeCustomRunFailed(customRuns[0])},
+			},
+			want: "Failed",
+		},
+		{
+			name: "child pipelinerun failed",
+			rpt: ResolvedPipelineTask{
+				PipelineTask:      &pts[21],
+				ChildPipelineRuns: []*v1.PipelineRun{makePipelineRunFailed(prs[0])},
 			},
 			want: "Failed",
 		},

--- a/pkg/reconciler/pipelinerun/resources/pipelinespec.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinespec.go
@@ -1,0 +1,14 @@
+package resources
+
+import v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+
+// ResolvedPipeline contains the data that is needed to execute
+// a child (PinP) PipelineRun.
+type ResolvedPipeline struct {
+	PipelineName string
+	Kind         string
+	PipelineSpec *v1.PipelineSpec
+}
+
+// GetPipelineRun is a function used to retrieve child (PinP) PipelineRuns
+type GetPipelineRun func(name string) (*v1.PipelineRun, error)


### PR DESCRIPTION
> [!IMPORTANT]
> **Pull request number 1.**
> The numbering `Nr. 1 - [TEP-0056]` means the PRs must be merged in order. They build on each other.

# Changes

[[TEP-0056](https://github.com/tektoncd/community/blob/main/teps/0056-pipelines-in-pipelines.md)]: First PR of **Pipelines-in-Pipelines** feature implementation. The `PipelineSpec` functionality is implemented first.

Extend `ResolvedPipelineTask` data structure to store child `PipelineRuns` and the resolved pipeline in `ResolvedPipeline` data structure equal to `ResolvedTask`.

Add `GetPipelineRun` function alias for convenience.

Add condition to `func ResolvePipelineTask` which checks if the given `PipelineTask` is a child (PinP) `Pipeline` and resolves it by getting the actual `Spec`. In our "happy path" case it's right on the `PipelineTask` because we use `PipelineSpec` and don't need to fetch it from anywhere.

A few downstream methods with tests equal to resolving a `TaskRun` were added.

Extend `resolvePipelineState` with getter for child `PipelineRuns` using lister.

Issue #8760, #7166.

Release notes will be added with the last PR which will make this feature functional for users.

/kind feature

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
