### PR TITLE
Stop emitting deprecated metrics

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -15,17 +15,11 @@ We expose several kinds of exporters, including Prometheus, Google Stackdriver, 
 |-----------------------------------------------------------------------------------------| ----------- |-------------------------------------------------| ----------- |
 | `tekton_pipelines_controller_pipelinerun_duration_seconds_[bucket, sum, count]`         | Histogram/LastValue(Gauge) | `*pipeline`=&lt;pipeline_name&gt; <br> `*pipelinerun`=&lt;pipelinerun_name&gt; <br> `status`=&lt;status&gt; <br> `namespace`=&lt;pipelinerun-namespace&gt; | experimental |
 | `tekton_pipelines_controller_pipelinerun_taskrun_duration_seconds_[bucket, sum, count]` | Histogram/LastValue(Gauge) | `*pipeline`=&lt;pipeline_name&gt; <br> `*pipelinerun`=&lt;pipelinerun_name&gt; <br> `status`=&lt;status&gt; <br> `*task`=&lt;task_name&gt; <br> `*taskrun`=&lt;taskrun_name&gt;<br> `namespace`=&lt;pipelineruns-taskruns-namespace&gt;  <br> `*reason`=&lt;reason&gt; | experimental |
-| `tekton_pipelines_controller_pipelinerun_count` | Counter | `status`=&lt;status&gt;  <br> `*reason`=&lt;reason&gt; | deprecate |
 | `tekton_pipelines_controller_pipelinerun_total` | Counter | `status`=&lt;status&gt;                         | experimental |
-| `tekton_pipelines_controller_running_pipelineruns_count` | Gauge |                                                 | deprecate |
 | `tekton_pipelines_controller_running_pipelineruns` | Gauge |                                                 | experimental |
 | `tekton_pipelines_controller_taskrun_duration_seconds_[bucket, sum, count]` | Histogram/LastValue(Gauge) | `status`=&lt;status&gt; <br> `*task`=&lt;task_name&gt; <br> `*taskrun`=&lt;taskrun_name&gt;<br> `namespace`=&lt;pipelineruns-taskruns-namespace&gt; <br> `*reason`=&lt;reason&gt; | experimental |
-| `tekton_pipelines_controller_taskrun_count` | Counter | `status`=&lt;status&gt; <br> `*reason`=&lt;reason&gt; | deprecate |
 | `tekton_pipelines_controller_taskrun_total` | Counter | `status`=&lt;status&gt;                         | experimental |
-| `tekton_pipelines_controller_running_taskruns_count` | Gauge |                                                 | deprecate |
 | `tekton_pipelines_controller_running_taskruns` | Gauge |                                                 | experimental |
-| `tekton_pipelines_controller_running_taskruns_throttled_by_quota_count` | Gauge | <br> `namespace`=&lt;pipelinerun-namespace&gt;  | deprecate |
-| `tekton_pipelines_controller_running_taskruns_throttled_by_node_count`  | Gauge | <br> `namespace`=&lt;pipelinerun-namespace&gt;  | deprecate |
 | `tekton_pipelines_controller_running_taskruns_throttled_by_quota` | Gauge | <br> `namespace`=&lt;pipelinerun-namespace&gt; | experimental |
 | `tekton_pipelines_controller_running_taskruns_throttled_by_node`  | Gauge | <br> `namespace`=&lt;pipelinerun-namespace&gt; | experimental |
 | `tekton_pipelines_controller_client_latency_[bucket, sum, count]` | Histogram |                                                 | experimental |

--- a/pkg/pipelinerunmetrics/metrics.go
+++ b/pkg/pipelinerunmetrics/metrics.go
@@ -61,40 +61,20 @@ var (
 		stats.UnitDimensionless)
 	prDurationView *view.View
 
-	prCount = stats.Float64("pipelinerun_count",
-		"number of pipelineruns",
-		stats.UnitDimensionless)
-	prCountView *view.View
-
 	prTotal = stats.Float64("pipelinerun_total",
 		"Number of pipelineruns",
 		stats.UnitDimensionless)
 	prTotalView *view.View
-
-	runningPRsCount = stats.Float64("running_pipelineruns_count",
-		"Number of pipelineruns executing currently",
-		stats.UnitDimensionless)
-	runningPRsCountView *view.View
 
 	runningPRs = stats.Float64("running_pipelineruns",
 		"Number of pipelineruns executing currently",
 		stats.UnitDimensionless)
 	runningPRsView *view.View
 
-	runningPRsWaitingOnPipelineResolutionCount = stats.Float64("running_pipelineruns_waiting_on_pipeline_resolution_count",
-		"Number of pipelineruns executing currently that are waiting on resolution requests for their pipeline references.",
-		stats.UnitDimensionless)
-	runningPRsWaitingOnPipelineResolutionCountView *view.View
-
 	runningPRsWaitingOnPipelineResolution = stats.Float64("running_pipelineruns_waiting_on_pipeline_resolution",
 		"Number of pipelineruns executing currently that are waiting on resolution requests for their pipeline references.",
 		stats.UnitDimensionless)
 	runningPRsWaitingOnPipelineResolutionView *view.View
-
-	runningPRsWaitingOnTaskResolutionCount = stats.Float64("running_pipelineruns_waiting_on_task_resolution_count",
-		"Number of pipelineruns executing currently that are waiting on resolution requests for the task references of their taskrun children.",
-		stats.UnitDimensionless)
-	runningPRsWaitingOnTaskResolutionCountView *view.View
 
 	runningPRsWaitingOnTaskResolution = stats.Float64("running_pipelineruns_waiting_on_task_resolution",
 		"Number of pipelineruns executing currently that are waiting on resolution requests for the task references of their taskrun children.",
@@ -201,9 +181,7 @@ func viewRegister(cfg *config.Metrics) error {
 		}
 	}
 
-	prCountViewTags := []tag.Key{statusTag}
 	if cfg.CountWithReason {
-		prCountViewTags = append(prCountViewTags, reasonTag)
 		prunTag = append(prunTag, reasonTag)
 	}
 
@@ -214,12 +192,6 @@ func viewRegister(cfg *config.Metrics) error {
 		TagKeys:     append([]tag.Key{statusTag, namespaceTag}, prunTag...),
 	}
 
-	prCountView = &view.View{
-		Description: prCount.Description(),
-		Measure:     prCount,
-		Aggregation: view.Count(),
-		TagKeys:     prCountViewTags,
-	}
 	prTotalView = &view.View{
 		Description: prTotal.Description(),
 		Measure:     prTotal,
@@ -227,11 +199,6 @@ func viewRegister(cfg *config.Metrics) error {
 		TagKeys:     []tag.Key{statusTag},
 	}
 
-	runningPRsCountView = &view.View{
-		Description: runningPRsCount.Description(),
-		Measure:     runningPRsCount,
-		Aggregation: view.LastValue(),
-	}
 	runningPRsView = &view.View{
 		Description: runningPRs.Description(),
 		Measure:     runningPRs,
@@ -239,22 +206,12 @@ func viewRegister(cfg *config.Metrics) error {
 		TagKeys:     runningPRTag,
 	}
 
-	runningPRsWaitingOnPipelineResolutionCountView = &view.View{
-		Description: runningPRsWaitingOnPipelineResolutionCount.Description(),
-		Measure:     runningPRsWaitingOnPipelineResolutionCount,
-		Aggregation: view.LastValue(),
-	}
 	runningPRsWaitingOnPipelineResolutionView = &view.View{
 		Description: runningPRsWaitingOnPipelineResolution.Description(),
 		Measure:     runningPRsWaitingOnPipelineResolution,
 		Aggregation: view.LastValue(),
 	}
 
-	runningPRsWaitingOnTaskResolutionCountView = &view.View{
-		Description: runningPRsWaitingOnTaskResolutionCount.Description(),
-		Measure:     runningPRsWaitingOnTaskResolutionCount,
-		Aggregation: view.LastValue(),
-	}
 	runningPRsWaitingOnTaskResolutionView = &view.View{
 		Description: runningPRsWaitingOnTaskResolution.Description(),
 		Measure:     runningPRsWaitingOnTaskResolution,
@@ -263,26 +220,18 @@ func viewRegister(cfg *config.Metrics) error {
 
 	return view.Register(
 		prDurationView,
-		prCountView,
 		prTotalView,
-		runningPRsCountView,
 		runningPRsView,
-		runningPRsWaitingOnPipelineResolutionCountView,
 		runningPRsWaitingOnPipelineResolutionView,
-		runningPRsWaitingOnTaskResolutionCountView,
 		runningPRsWaitingOnTaskResolutionView,
 	)
 }
 
 func viewUnregister() {
 	view.Unregister(prDurationView,
-		prCountView,
 		prTotalView,
-		runningPRsCountView,
 		runningPRsView,
-		runningPRsWaitingOnPipelineResolutionCountView,
 		runningPRsWaitingOnPipelineResolutionView,
-		runningPRsWaitingOnTaskResolutionCountView,
 		runningPRsWaitingOnTaskResolutionView)
 }
 
@@ -412,7 +361,6 @@ func (r *Recorder) DurationAndCount(pr *v1.PipelineRun, beforeCondition *apis.Co
 	}
 
 	metrics.Record(ctx, prDuration.M(duration.Seconds()))
-	metrics.Record(ctx, prCount.M(1))
 	metrics.Record(ctx, prTotal.M(1))
 
 	return nil
@@ -491,11 +439,9 @@ func (r *Recorder) RunningPipelineRuns(lister listers.PipelineRunLister) error {
 	if err != nil {
 		return err
 	}
-	metrics.Record(ctx, runningPRsWaitingOnPipelineResolutionCount.M(float64(prsWaitResolvingPipelineRef)))
 	metrics.Record(ctx, runningPRsWaitingOnPipelineResolution.M(float64(prsWaitResolvingPipelineRef)))
-	metrics.Record(ctx, runningPRsWaitingOnTaskResolutionCount.M(float64(trsWaitResolvingTaskRef)))
 	metrics.Record(ctx, runningPRsWaitingOnTaskResolution.M(float64(trsWaitResolvingTaskRef)))
-	metrics.Record(ctx, runningPRsCount.M(float64(runningPipelineRuns)))
+	metrics.Record(ctx, runningPRs.M(float64(runningPipelineRuns)))
 
 	return nil
 }

--- a/pkg/pipelinerunmetrics/metrics_test.go
+++ b/pkg/pipelinerunmetrics/metrics_test.go
@@ -532,11 +532,9 @@ func TestRecordPipelineRunDurationCount(t *testing.T) {
 				metricstest.CheckStatsNotReported(t, "pipelinerun_duration_seconds")
 			}
 			if test.expectedCountTags != nil {
-				metricstest.CheckCountData(t, "pipelinerun_count", test.expectedCountTags, test.expectedCount)
 				delete(test.expectedCountTags, "reason")
 				metricstest.CheckCountData(t, "pipelinerun_total", test.expectedCountTags, test.expectedCount)
 			} else {
-				metricstest.CheckStatsNotReported(t, "pipelinerun_count")
 				metricstest.CheckStatsNotReported(t, "pipelinerun_total")
 			}
 		})
@@ -582,7 +580,6 @@ func TestRecordRunningPipelineRunsCount(t *testing.T) {
 	if err := metrics.RunningPipelineRuns(informer.Lister()); err != nil {
 		t.Errorf("RunningPipelineRuns: %v", err)
 	}
-	metricstest.CheckLastValueData(t, "running_pipelineruns_count", map[string]string{}, 1)
 	metricstest.CheckLastValueData(t, "running_pipelineruns", map[string]string{}, 1)
 }
 
@@ -787,15 +784,13 @@ func TestRecordRunningPipelineRunsResolutionWaitCounts(t *testing.T) {
 		if err := metrics.RunningPipelineRuns(informer.Lister()); err != nil {
 			t.Errorf("RunningTaskRuns: %v", err)
 		}
-		metricstest.CheckLastValueData(t, "running_pipelineruns_waiting_on_pipeline_resolution_count", map[string]string{}, tc.prWaitCount)
-		metricstest.CheckLastValueData(t, "running_pipelineruns_waiting_on_task_resolution_count", map[string]string{}, tc.trWaitCount)
 		metricstest.CheckLastValueData(t, "running_pipelineruns_waiting_on_pipeline_resolution", map[string]string{}, tc.prWaitCount)
 		metricstest.CheckLastValueData(t, "running_pipelineruns_waiting_on_task_resolution", map[string]string{}, tc.trWaitCount)
 	}
 }
 
 func unregisterMetrics() {
-	metricstest.Unregister("pipelinerun_duration_seconds", "pipelinerun_count", "pipelinerun_total", "running_pipelineruns_waiting_on_pipeline_resolution_count", "running_pipelineruns_waiting_on_pipeline_resolution", "running_pipelineruns_waiting_on_task_resolution_count", "running_pipelineruns_waiting_on_task_resolution", "running_pipelineruns_count", "running_pipelineruns")
+	metricstest.Unregister("pipelinerun_duration_seconds", "pipelinerun_total", "running_pipelineruns_waiting_on_pipeline_resolution", "running_pipelineruns_waiting_on_task_resolution", "running_pipelineruns")
 
 	// Allow the recorder singleton to be recreated.
 	once = sync.Once{}

--- a/pkg/taskrunmetrics/metrics.go
+++ b/pkg/taskrunmetrics/metrics.go
@@ -57,12 +57,8 @@ var (
 
 	trDurationView                             *view.View
 	prTRDurationView                           *view.View
-	trCountView                                *view.View
 	trTotalView                                *view.View
-	runningTRsCountView                        *view.View
 	runningTRsView                             *view.View
-	runningTRsThrottledByQuotaCountView        *view.View
-	runningTRsThrottledByNodeCountView         *view.View
 	runningTRsThrottledByQuotaView             *view.View
 	runningTRsThrottledByNodeView              *view.View
 	runningTRsWaitingOnTaskResolutionCountView *view.View
@@ -78,28 +74,12 @@ var (
 		"The pipelinerun's taskrun execution time in seconds",
 		stats.UnitDimensionless)
 
-	trCount = stats.Float64("taskrun_count",
-		"number of taskruns",
-		stats.UnitDimensionless)
-
 	trTotal = stats.Float64("taskrun_total",
 		"Number of taskruns",
 		stats.UnitDimensionless)
 
-	runningTRsCount = stats.Float64("running_taskruns_count",
-		"Number of taskruns executing currently",
-		stats.UnitDimensionless)
-
 	runningTRs = stats.Float64("running_taskruns",
 		"Number of taskruns executing currently",
-		stats.UnitDimensionless)
-
-	runningTRsThrottledByQuotaCount = stats.Float64("running_taskruns_throttled_by_quota_count",
-		"Number of taskruns executing currently, but whose underlying Pods or Containers are suspended by k8s because of defined ResourceQuotas.  Such suspensions can occur as part of initial scheduling of the Pod, or scheduling of any of the subsequent Container(s) in the Pod after the first Container is started",
-		stats.UnitDimensionless)
-
-	runningTRsThrottledByNodeCount = stats.Float64("running_taskruns_throttled_by_node_count",
-		"Number of taskruns executing currently, but whose underlying Pods or Containers are suspended by k8s because of Node level constraints. Such suspensions can occur as part of initial scheduling of the Pod, or scheduling of any of the subsequent Container(s) in the Pod after the first Container is started",
 		stats.UnitDimensionless)
 
 	runningTRsWaitingOnTaskResolutionCount = stats.Float64("running_taskruns_waiting_on_task_resolution_count",
@@ -217,9 +197,7 @@ func viewRegister(cfg *config.Metrics) error {
 		}
 	}
 
-	trCountViewTags := []tag.Key{statusTag}
 	if cfg.CountWithReason {
-		trCountViewTags = append(trCountViewTags, reasonTag)
 		trunTag = append(trunTag, reasonTag)
 	}
 
@@ -236,37 +214,16 @@ func viewRegister(cfg *config.Metrics) error {
 		TagKeys:     append([]tag.Key{statusTag, namespaceTag}, append(trunTag, prunTag...)...),
 	}
 
-	trCountView = &view.View{
-		Description: trCount.Description(),
-		Measure:     trCount,
-		Aggregation: view.Count(),
-		TagKeys:     trCountViewTags,
-	}
 	trTotalView = &view.View{
 		Description: trTotal.Description(),
 		Measure:     trTotal,
 		Aggregation: view.Count(),
 		TagKeys:     []tag.Key{statusTag},
 	}
-	runningTRsCountView = &view.View{
-		Description: runningTRsCount.Description(),
-		Measure:     runningTRsCount,
-		Aggregation: view.LastValue(),
-	}
 
 	runningTRsView = &view.View{
 		Description: runningTRs.Description(),
 		Measure:     runningTRs,
-		Aggregation: view.LastValue(),
-	}
-	runningTRsThrottledByQuotaCountView = &view.View{
-		Description: runningTRsThrottledByQuotaCount.Description(),
-		Measure:     runningTRsThrottledByQuotaCount,
-		Aggregation: view.LastValue(),
-	}
-	runningTRsThrottledByNodeCountView = &view.View{
-		Description: runningTRsThrottledByNodeCount.Description(),
-		Measure:     runningTRsThrottledByNodeCount,
 		Aggregation: view.LastValue(),
 	}
 	runningTRsWaitingOnTaskResolutionCountView = &view.View{
@@ -300,12 +257,8 @@ func viewRegister(cfg *config.Metrics) error {
 	return view.Register(
 		trDurationView,
 		prTRDurationView,
-		trCountView,
 		trTotalView,
-		runningTRsCountView,
 		runningTRsView,
-		runningTRsThrottledByQuotaCountView,
-		runningTRsThrottledByNodeCountView,
 		runningTRsWaitingOnTaskResolutionCountView,
 		runningTRsThrottledByQuotaView,
 		runningTRsThrottledByNodeView,
@@ -317,12 +270,8 @@ func viewUnregister() {
 	view.Unregister(
 		trDurationView,
 		prTRDurationView,
-		trCountView,
 		trTotalView,
-		runningTRsCountView,
 		runningTRsView,
-		runningTRsThrottledByQuotaCountView,
-		runningTRsThrottledByNodeCountView,
 		runningTRsWaitingOnTaskResolutionCountView,
 		runningTRsThrottledByQuotaView,
 		runningTRsThrottledByNodeView,
@@ -467,7 +416,6 @@ func (r *Recorder) DurationAndCount(ctx context.Context, tr *v1.TaskRun, beforeC
 	}
 
 	metrics.Record(ctx, durationStat.M(duration.Seconds()))
-	metrics.Record(ctx, trCount.M(1))
 	metrics.Record(ctx, trTotal.M(1))
 
 	return nil
@@ -492,9 +440,7 @@ func (r *Recorder) RunningTaskRuns(ctx context.Context, lister listers.TaskRunLi
 
 	var runningTrs int
 	trsThrottledByQuota := map[string]int{}
-	trsThrottledByQuotaCount := 0
 	trsThrottledByNode := map[string]int{}
-	trsThrottledByNodeCount := 0
 	var trsWaitResolvingTaskRef int
 	for _, pr := range trs {
 		// initialize metrics with namespace tag to zero if unset; will then update as needed below
@@ -516,12 +462,10 @@ func (r *Recorder) RunningTaskRuns(ctx context.Context, lister listers.TaskRunLi
 		if succeedCondition != nil && succeedCondition.Status == corev1.ConditionUnknown {
 			switch succeedCondition.Reason {
 			case pod.ReasonExceededResourceQuota:
-				trsThrottledByQuotaCount++
 				cnt := trsThrottledByQuota[pr.Namespace]
 				cnt++
 				trsThrottledByQuota[pr.Namespace] = cnt
 			case pod.ReasonExceededNodeResources:
-				trsThrottledByNodeCount++
 				cnt := trsThrottledByNode[pr.Namespace]
 				cnt++
 				trsThrottledByNode[pr.Namespace] = cnt
@@ -535,11 +479,8 @@ func (r *Recorder) RunningTaskRuns(ctx context.Context, lister listers.TaskRunLi
 	if err != nil {
 		return err
 	}
-	metrics.Record(ctx, runningTRsCount.M(float64(runningTrs)))
 	metrics.Record(ctx, runningTRs.M(float64(runningTrs)))
 	metrics.Record(ctx, runningTRsWaitingOnTaskResolutionCount.M(float64(trsWaitResolvingTaskRef)))
-	metrics.Record(ctx, runningTRsThrottledByQuotaCount.M(float64(trsThrottledByQuotaCount)))
-	metrics.Record(ctx, runningTRsThrottledByNodeCount.M(float64(trsThrottledByNodeCount)))
 
 	for ns, cnt := range trsThrottledByQuota {
 		var mutators []tag.Mutator

--- a/pkg/taskrunmetrics/metrics_test.go
+++ b/pkg/taskrunmetrics/metrics_test.go
@@ -556,11 +556,9 @@ func TestRecordTaskRunDurationCount(t *testing.T) {
 				t.Errorf("DurationAndCount: %v", err)
 			}
 			if c.expectedCountTags != nil {
-				metricstest.CheckCountData(t, "taskrun_count", c.expectedCountTags, c.expectedCount)
 				delete(c.expectedCountTags, "reason")
 				metricstest.CheckCountData(t, "taskrun_total", c.expectedCountTags, c.expectedCount)
 			} else {
-				metricstest.CheckStatsNotReported(t, "taskrun_count")
 				metricstest.CheckStatsNotReported(t, "taskrun_total")
 			}
 			if c.expectedDurationTags != nil {
@@ -610,7 +608,6 @@ func TestRecordRunningTaskRunsCount(t *testing.T) {
 	if err := metrics.RunningTaskRuns(ctx, informer.Lister()); err != nil {
 		t.Errorf("RunningTaskRuns: %v", err)
 	}
-	metricstest.CheckLastValueData(t, "running_taskruns_count", map[string]string{}, 1)
 }
 
 func TestRecordRunningTaskRunsThrottledCounts(t *testing.T) {
@@ -727,13 +724,11 @@ func TestRecordRunningTaskRunsThrottledCounts(t *testing.T) {
 		if err := metrics.RunningTaskRuns(ctx, informer.Lister()); err != nil {
 			t.Errorf("RunningTaskRuns: %v", err)
 		}
-		metricstest.CheckLastValueData(t, "running_taskruns_throttled_by_quota_count", map[string]string{}, tc.quotaCount)
 		nsMap := map[string]string{}
 		if tc.addNS {
 			nsMap = map[string]string{namespaceTag.Name(): "test"}
 		}
 		metricstest.CheckLastValueData(t, "running_taskruns_throttled_by_quota", nsMap, tc.quotaCount)
-		metricstest.CheckLastValueData(t, "running_taskruns_throttled_by_node_count", map[string]string{}, tc.nodeCount)
 		metricstest.CheckLastValueData(t, "running_taskruns_throttled_by_node", nsMap, tc.nodeCount)
 		metricstest.CheckLastValueData(t, "running_taskruns_waiting_on_task_resolution_count", map[string]string{}, tc.waitCount)
 	}
@@ -928,7 +923,7 @@ func TestTaskRunIsOfPipelinerun(t *testing.T) {
 }
 
 func unregisterMetrics() {
-	metricstest.Unregister("taskrun_duration_seconds", "pipelinerun_taskrun_duration_seconds", "taskrun_count", "running_taskruns_count", "running_taskruns_throttled_by_quota_count", "running_taskruns_throttled_by_node_count", "running_taskruns_waiting_on_task_resolution_count", "taskruns_pod_latency_milliseconds", "taskrun_total", "running_taskruns", "running_taskruns_throttled_by_quota", "running_taskruns_throttled_by_node", "running_taskruns_waiting_on_task_resolution")
+	metricstest.Unregister("taskrun_duration_seconds", "pipelinerun_taskrun_duration_seconds", "running_taskruns_waiting_on_task_resolution_count", "taskruns_pod_latency_milliseconds", "taskrun_total", "running_taskruns", "running_taskruns_throttled_by_quota", "running_taskruns_throttled_by_node")
 
 	// Allow the recorder singleton to be recreated.
 	once = sync.Once{}


### PR DESCRIPTION
This commit removes the following deprecated metrics that have been replaced with corresponding metrics.
We have given sufficient time to user to migrate to newer metrics.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
BREAKING CHANGE:

This commit removes the following deprecated metrics that have been replaced
by newer, more descriptive metrics:

PipelineRun Metrics:
- pipelinerun_count → replaced by pipelinerun_total
- running_pipelineruns_count → replaced by running_pipelineruns  
- running_pipelineruns_waiting_on_pipeline_resolution_count → replaced by running_pipelineruns_waiting_on_pipeline_resolution
- running_pipelineruns_waiting_on_task_resolution_count → replaced by running_pipelineruns_waiting_on_task_resolution

TaskRun Metrics:
- taskrun_count → replaced by taskrun_total
- running_taskruns_count → replaced by running_taskruns
- running_taskruns_throttled_by_quota_count → replaced by running_taskruns_throttled_by_quota
- running_taskruns_throttled_by_node_count → replaced by running_taskruns_throttled_by_node

The replacement metrics provide the same functionality with improved naming
conventions and are already being recorded in the codebase.

```
