### PR TITLE
Remove all reference to gcr.io tekton projects

### DIFF
--- a/config/300-crds/300-pipelinerun.yaml
+++ b/config/300-crds/300-pipelinerun.yaml
@@ -2162,7 +2162,7 @@ spec:
                           description: |-
                             EntryPoint identifies the entry point into the build. This is often a path to a
                             build definition file and/or a target label within that file.
-                            Example: "task/git-clone/0.8/git-clone.yaml"
+                            Example: "task/git-clone/0.10/git-clone.yaml"
                           type: string
                         uri:
                           description: |-
@@ -2239,7 +2239,7 @@ spec:
                           description: |-
                             EntryPoint identifies the entry point into the build. This is often a path to a
                             build definition file and/or a target label within that file.
-                            Example: "task/git-clone/0.8/git-clone.yaml"
+                            Example: "task/git-clone/0.10/git-clone.yaml"
                           type: string
                         uri:
                           description: |-
@@ -2575,7 +2575,7 @@ spec:
                                     description: |-
                                       EntryPoint identifies the entry point into the build. This is often a path to a
                                       build definition file and/or a target label within that file.
-                                      Example: "task/git-clone/0.8/git-clone.yaml"
+                                      Example: "task/git-clone/0.10/git-clone.yaml"
                                     type: string
                                   uri:
                                     description: |-
@@ -2652,7 +2652,7 @@ spec:
                                     description: |-
                                       EntryPoint identifies the entry point into the build. This is often a path to a
                                       build definition file and/or a target label within that file.
-                                      Example: "task/git-clone/0.8/git-clone.yaml"
+                                      Example: "task/git-clone/0.10/git-clone.yaml"
                                     type: string
                                   uri:
                                     description: |-
@@ -2862,7 +2862,7 @@ spec:
                                           description: |-
                                             EntryPoint identifies the entry point into the build. This is often a path to a
                                             build definition file and/or a target label within that file.
-                                            Example: "task/git-clone/0.8/git-clone.yaml"
+                                            Example: "task/git-clone/0.10/git-clone.yaml"
                                           type: string
                                         uri:
                                           description: |-
@@ -2939,7 +2939,7 @@ spec:
                                           description: |-
                                             EntryPoint identifies the entry point into the build. This is often a path to a
                                             build definition file and/or a target label within that file.
-                                            Example: "task/git-clone/0.8/git-clone.yaml"
+                                            Example: "task/git-clone/0.10/git-clone.yaml"
                                           type: string
                                         uri:
                                           description: |-
@@ -5159,7 +5159,7 @@ spec:
                           description: |-
                             EntryPoint identifies the entry point into the build. This is often a path to a
                             build definition file and/or a target label within that file.
-                            Example: "task/git-clone/0.8/git-clone.yaml"
+                            Example: "task/git-clone/0.10/git-clone.yaml"
                           type: string
                         uri:
                           description: |-

--- a/config/300-crds/300-taskrun.yaml
+++ b/config/300-crds/300-taskrun.yaml
@@ -1738,7 +1738,7 @@ spec:
                           description: |-
                             EntryPoint identifies the entry point into the build. This is often a path to a
                             build definition file and/or a target label within that file.
-                            Example: "task/git-clone/0.8/git-clone.yaml"
+                            Example: "task/git-clone/0.10/git-clone.yaml"
                           type: string
                         uri:
                           description: |-
@@ -1815,7 +1815,7 @@ spec:
                           description: |-
                             EntryPoint identifies the entry point into the build. This is often a path to a
                             build definition file and/or a target label within that file.
-                            Example: "task/git-clone/0.8/git-clone.yaml"
+                            Example: "task/git-clone/0.10/git-clone.yaml"
                           type: string
                         uri:
                           description: |-
@@ -2025,7 +2025,7 @@ spec:
                                 description: |-
                                   EntryPoint identifies the entry point into the build. This is often a path to a
                                   build definition file and/or a target label within that file.
-                                  Example: "task/git-clone/0.8/git-clone.yaml"
+                                  Example: "task/git-clone/0.10/git-clone.yaml"
                                 type: string
                               uri:
                                 description: |-
@@ -2102,7 +2102,7 @@ spec:
                                 description: |-
                                   EntryPoint identifies the entry point into the build. This is often a path to a
                                   build definition file and/or a target label within that file.
-                                  Example: "task/git-clone/0.8/git-clone.yaml"
+                                  Example: "task/git-clone/0.10/git-clone.yaml"
                                 type: string
                               uri:
                                 description: |-
@@ -3806,7 +3806,7 @@ spec:
                           description: |-
                             EntryPoint identifies the entry point into the build. This is often a path to a
                             build definition file and/or a target label within that file.
-                            Example: "task/git-clone/0.8/git-clone.yaml"
+                            Example: "task/git-clone/0.10/git-clone.yaml"
                           type: string
                         uri:
                           description: |-
@@ -4059,7 +4059,7 @@ spec:
                                 description: |-
                                   EntryPoint identifies the entry point into the build. This is often a path to a
                                   build definition file and/or a target label within that file.
-                                  Example: "task/git-clone/0.8/git-clone.yaml"
+                                  Example: "task/git-clone/0.10/git-clone.yaml"
                                 type: string
                               uri:
                                 description: |-

--- a/examples/v1/pipelineruns/beta/git-resolver.yaml
+++ b/examples/v1/pipelineruns/beta/git-resolver.yaml
@@ -25,7 +25,7 @@ spec:
             - name: url
               value: https://github.com/tektoncd/catalog.git
             - name: pathInRepo
-              value: /task/git-clone/0.7/git-clone.yaml
+              value: /task/git-clone/0.10/git-clone.yaml
             - name: revision
               value: main
         params:

--- a/examples/v1/pipelineruns/beta/http-resolver-credentials.yaml
+++ b/examples/v1/pipelineruns/beta/http-resolver-credentials.yaml
@@ -16,14 +16,19 @@ kind: PipelineRun
 metadata:
   generateName: http-resolver-
 spec:
+  workspaces:
+  - name: output
+    emptyDir: {}
   pipelineSpec:
+    workspaces:
+    - name: output
     tasks:
       - name: http-resolver
         taskRef:
           resolver: http
           params:
             - name: url
-              value: https://api.hub.tekton.dev/v1/resource/tekton/task/tkn/0.4/raw
+              value: https://api.hub.tekton.dev/v1/resource/tekton/task/git-clone/0.10/raw
             - name: http-username
               value: git
             - name: http-password-secret
@@ -31,5 +36,8 @@ spec:
             - name: http-password-secret-key
               value: token
         params:
-          - name: ARGS
-            value: ["version"]
+          - name: url
+            value: "https://github.com/kelseyhightower/nocode"
+        workspaces:
+          - name: output
+            workspace: output

--- a/examples/v1/pipelineruns/beta/http-resolver.yaml
+++ b/examples/v1/pipelineruns/beta/http-resolver.yaml
@@ -4,14 +4,22 @@ kind: PipelineRun
 metadata:
   generateName: http-resolver-
 spec:
+  workspaces:
+  - name: output
+    emptyDir: {}
   pipelineSpec:
+    workspaces:
+    - name: output
     tasks:
       - name: http-resolver
         taskRef:
           resolver: http
           params:
             - name: url
-              value: https://api.hub.tekton.dev/v1/resource/tekton/task/tkn/0.4/raw
+              value: https://api.hub.tekton.dev/v1/resource/tekton/task/git-clone/0.10/raw
         params:
-          - name: ARGS
-            value: ["version"]
+          - name: url
+            value: "https://github.com/kelseyhightower/nocode"
+        workspaces:
+          - name: output
+            workspace: output

--- a/examples/v1/pipelineruns/no-ci/git-resolver-custom-apiurl.yaml
+++ b/examples/v1/pipelineruns/no-ci/git-resolver-custom-apiurl.yaml
@@ -25,7 +25,7 @@ spec:
             - name: url
               value: https://github.com/tektoncd/catalog.git
             - name: pathInRepo
-              value: /task/git-clone/0.7/git-clone.yaml
+              value: /task/git-clone/0.10/git-clone.yaml
             - name: revision
               value: main
             # my-secret-token should be created in the namespace where the

--- a/examples/v1/pipelineruns/no-ci/git-resolver-custom-secret.yaml
+++ b/examples/v1/pipelineruns/no-ci/git-resolver-custom-secret.yaml
@@ -25,7 +25,7 @@ spec:
             - name: url
               value: https://github.com/tektoncd/catalog.git
             - name: pathInRepo
-              value: /task/git-clone/0.7/git-clone.yaml
+              value: /task/git-clone/0.10/git-clone.yaml
             - name: revision
               value: main
             # my-secret-token should be created in the namespace where the

--- a/examples/v1/pipelineruns/pipelinerun-with-final-tasks.yaml
+++ b/examples/v1/pipelineruns/pipelinerun-with-final-tasks.yaml
@@ -57,7 +57,7 @@ spec:
       description: The precise commit SHA that was fetched by this Task
   steps:
     - name: clone
-      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:latest
+      image: ghcr.io/tektoncd-catalog/git-clone:v1.1.0
       securityContext:
         runAsUser: 0  # This needs root, and git-init is nonroot by default
       script: |

--- a/examples/v1/pipelineruns/pipelinerun.yaml
+++ b/examples/v1/pipelineruns/pipelinerun.yaml
@@ -58,7 +58,7 @@ spec:
     description: The precise commit SHA that was fetched by this Task
   steps:
   - name: clone
-    image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:latest
+    image: ghcr.io/tektoncd-catalog/git-clone:v1.1.0
     securityContext:
       runAsUser: 0  # This needs root, and git-init is nonroot by default
     script: |

--- a/examples/v1/taskruns/authenticating-git-commands.yaml
+++ b/examples/v1/taskruns/authenticating-git-commands.yaml
@@ -166,7 +166,7 @@ spec:
         git commit -m "Test commit!"
         git push origin master
     - name: git-clone-and-check
-      image: gcr.io/tekton-releases/dogfooding/alpine-git-nonroot:latest
+      image: ghcr.io/tektoncd/plumbing/alpine-git-nonroot:latest
       # Because this Step runs with a non-root security context, the creds-init
       # credentials will fail to copy into /tekton/home. This happens because
       # our previous step _already_ wrote to /tekton/home and ran as a root

--- a/examples/v1/taskruns/beta/authenticating-git-commands.yaml
+++ b/examples/v1/taskruns/beta/authenticating-git-commands.yaml
@@ -161,7 +161,7 @@ spec:
         git commit -m "Test commit!"
         git push origin master
     - name: git-clone-and-check
-      image: gcr.io/tekton-releases/dogfooding/alpine-git-nonroot:latest
+      image: ghcr.io/tektoncd/plumbing/alpine-git-nonroot:latest
       # Because this Step runs with a non-root security context, the creds-init
       # credentials will fail to copy into /tekton/home. This happens because
       # our previous step _already_ wrote to /tekton/home and ran as a root

--- a/examples/v1/taskruns/beta/bundles-resolver.yaml
+++ b/examples/v1/taskruns/beta/bundles-resolver.yaml
@@ -13,7 +13,7 @@ spec:
     resolver: bundles
     params:
       - name: bundle
-        value: gcr.io/tekton-releases/catalog/upstream/git-clone@sha256:8e2c3fb0f719d6463e950f3e44965aa314e69b800833e29e68ba2616bb82deeb
+        value: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone@sha256:65e61544c5870c8828233406689d812391735fd4100cb444bbd81531cb958bb3 # 0.10 bundle
       - name: name
         value: git-clone
       - name: kind

--- a/examples/v1/taskruns/beta/git-resolver.yaml
+++ b/examples/v1/taskruns/beta/git-resolver.yaml
@@ -22,4 +22,4 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: task/git-clone/0.8/git-clone.yaml
+        value: task/git-clone/0.10/git-clone.yaml

--- a/examples/v1/taskruns/beta/hub-resolver.yaml
+++ b/examples/v1/taskruns/beta/hub-resolver.yaml
@@ -24,7 +24,7 @@ spec:
       - name: name
         value: git-clone
       - name: version
-        value: "0.6"
+        value: "0.10"
 ---
 apiVersion: tekton.dev/v1
 kind: TaskRun
@@ -48,4 +48,4 @@ spec:
       - name: name
         value: git-clone
       - name: version
-        value: "0.6.0"
+        value: "0.10"

--- a/examples/v1/taskruns/entrypoint-resolution.yaml
+++ b/examples/v1/taskruns/entrypoint-resolution.yaml
@@ -8,7 +8,7 @@ spec:
     # Multi-arch image with no command defined. We should look up the command
     # for each platform-specific image and pass it to the Pod, which selects
     # the right command at runtime based on the node's runtime platform.
-    - image: gcr.io/tekton-nightly/github.com/tektoncd/pipeline/cmd/nop
+    - image: ghcr.io/tektoncd/pipeline/nop-8eac7c133edad5df719dc37b36b62482:latest
 
     # Multi-arch image with no command defined, but with args. We'll look
     # up the commands and pass it to the entrypoint binary via env var, then

--- a/examples/v1/taskruns/no-ci/docker-creds.yaml
+++ b/examples/v1/taskruns/no-ci/docker-creds.yaml
@@ -37,6 +37,6 @@ spec:
   taskSpec:
     steps:
     - name: test
-      image: gcr.io/tekton-releases/dogfooding/skopeo:latest
+      image: ghcr.io/tektoncd/catalog/upstream/tasks/skopeo-copy:latest
       # Test pulling a private builder container.
       script: skopeo copy docker://gcr.io/build-crd-testing/secret-sauce dir:///tmp/

--- a/examples/v1/taskruns/no-ci/pull-private-image.yaml
+++ b/examples/v1/taskruns/no-ci/pull-private-image.yaml
@@ -47,5 +47,5 @@ spec:
     steps:
     - name: pull
       # Private image is just Ubuntu
-      image: gcr.io/tekton-releases/dogfooding/skopeo:latest
+      image: ghcr.io/tektoncd/catalog/upstream/tasks/skopeo-copy:latest
       script: skopeo copy docker://gcr.io/build-crd-testing/secret-sauce dir:///tmp/

--- a/pkg/apis/pipeline/v1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1/openapi_generated.go
@@ -2359,7 +2359,7 @@ func schema_pkg_apis_pipeline_v1_RefSource(ref common.ReferenceCallback) common.
 					},
 					"entryPoint": {
 						SchemaProps: spec.SchemaProps{
-							Description: "EntryPoint identifies the entry point into the build. This is often a path to a build definition file and/or a target label within that file. Example: \"task/git-clone/0.8/git-clone.yaml\"",
+							Description: "EntryPoint identifies the entry point into the build. This is often a path to a build definition file and/or a target label within that file. Example: \"task/git-clone/0.10/git-clone.yaml\"",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/apis/pipeline/v1/provenance.go
+++ b/pkg/apis/pipeline/v1/provenance.go
@@ -41,6 +41,6 @@ type RefSource struct {
 
 	// EntryPoint identifies the entry point into the build. This is often a path to a
 	// build definition file and/or a target label within that file.
-	// Example: "task/git-clone/0.8/git-clone.yaml"
+	// Example: "task/git-clone/0.10/git-clone.yaml"
 	EntryPoint string `json:"entryPoint,omitempty"`
 }

--- a/pkg/apis/pipeline/v1/swagger.json
+++ b/pkg/apis/pipeline/v1/swagger.json
@@ -1185,7 +1185,7 @@
           }
         },
         "entryPoint": {
-          "description": "EntryPoint identifies the entry point into the build. This is often a path to a build definition file and/or a target label within that file. Example: \"task/git-clone/0.8/git-clone.yaml\"",
+          "description": "EntryPoint identifies the entry point into the build. This is often a path to a build definition file and/or a target label within that file. Example: \"task/git-clone/0.10/git-clone.yaml\"",
           "type": "string"
         },
         "uri": {

--- a/pkg/apis/pipeline/v1beta1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1beta1/openapi_generated.go
@@ -712,7 +712,7 @@ func schema_pkg_apis_pipeline_v1beta1_ConfigSource(ref common.ReferenceCallback)
 					},
 					"entryPoint": {
 						SchemaProps: spec.SchemaProps{
-							Description: "EntryPoint identifies the entry point into the build. This is often a path to a build definition file and/or a target label within that file. Example: \"task/git-clone/0.8/git-clone.yaml\"",
+							Description: "EntryPoint identifies the entry point into the build. This is often a path to a build definition file and/or a target label within that file. Example: \"task/git-clone/0.10/git-clone.yaml\"",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -3122,7 +3122,7 @@ func schema_pkg_apis_pipeline_v1beta1_RefSource(ref common.ReferenceCallback) co
 					},
 					"entryPoint": {
 						SchemaProps: spec.SchemaProps{
-							Description: "EntryPoint identifies the entry point into the build. This is often a path to a build definition file and/or a target label within that file. Example: \"task/git-clone/0.8/git-clone.yaml\"",
+							Description: "EntryPoint identifies the entry point into the build. This is often a path to a build definition file and/or a target label within that file. Example: \"task/git-clone/0.10/git-clone.yaml\"",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/apis/pipeline/v1beta1/provenance.go
+++ b/pkg/apis/pipeline/v1beta1/provenance.go
@@ -44,7 +44,7 @@ type RefSource struct {
 
 	// EntryPoint identifies the entry point into the build. This is often a path to a
 	// build definition file and/or a target label within that file.
-	// Example: "task/git-clone/0.8/git-clone.yaml"
+	// Example: "task/git-clone/0.10/git-clone.yaml"
 	EntryPoint string `json:"entryPoint,omitempty"`
 }
 
@@ -62,6 +62,6 @@ type ConfigSource struct {
 
 	// EntryPoint identifies the entry point into the build. This is often a path to a
 	// build definition file and/or a target label within that file.
-	// Example: "task/git-clone/0.8/git-clone.yaml"
+	// Example: "task/git-clone/0.10/git-clone.yaml"
 	EntryPoint string `json:"entryPoint,omitempty"`
 }

--- a/pkg/apis/pipeline/v1beta1/swagger.json
+++ b/pkg/apis/pipeline/v1beta1/swagger.json
@@ -306,7 +306,7 @@
           }
         },
         "entryPoint": {
-          "description": "EntryPoint identifies the entry point into the build. This is often a path to a build definition file and/or a target label within that file. Example: \"task/git-clone/0.8/git-clone.yaml\"",
+          "description": "EntryPoint identifies the entry point into the build. This is often a path to a build definition file and/or a target label within that file. Example: \"task/git-clone/0.10/git-clone.yaml\"",
           "type": "string"
         },
         "uri": {
@@ -1592,7 +1592,7 @@
           }
         },
         "entryPoint": {
-          "description": "EntryPoint identifies the entry point into the build. This is often a path to a build definition file and/or a target label within that file. Example: \"task/git-clone/0.8/git-clone.yaml\"",
+          "description": "EntryPoint identifies the entry point into the build. This is often a path to a build definition file and/or a target label within that file. Example: \"task/git-clone/0.10/git-clone.yaml\"",
           "type": "string"
         },
         "uri": {

--- a/tekton/release-pipeline.yaml
+++ b/tekton/release-pipeline.yaml
@@ -74,7 +74,7 @@ spec:
           - name: name
             value: git-clone
           - name: version
-            value: "0.7"
+            value: "0.10"
       workspaces:
         - name: output
           workspace: workarea

--- a/test/resolvers_test.go
+++ b/test/resolvers_test.go
@@ -118,7 +118,7 @@ spec:
           - name: name
             value: git-clone
           - name: version
-            value: "0.7"
+            value: "0.10"
         params:
           - name: url
             value: https://github.com/tektoncd/pipeline
@@ -238,7 +238,7 @@ spec:
           - name: url
             value: https://github.com/tektoncd/catalog.git
           - name: pathInRepo
-            value: /task/git-clone/0.7/git-clone.yaml
+            value: /task/git-clone/0.10/git-clone.yaml
           - name: revision
             value: main
         params:
@@ -261,7 +261,7 @@ spec:
 
 func TestGitResolver_Clone_Failure(t *testing.T) {
 	defaultURL := "https://github.com/tektoncd/catalog.git"
-	defaultPathInRepo := "/task/git-clone/0.7/git-clone.yaml"
+	defaultPathInRepo := "/task/git-clone/0.10/git-clone.yaml"
 	defaultCommit := "783b4fe7d21148f3b1a93bfa49b0024d8c6c2955"
 
 	testCases := []struct {

--- a/test/tektonbundles_test.go
+++ b/test/tektonbundles_test.go
@@ -260,7 +260,7 @@ func publishImg(ctx context.Context, t *testing.T, c *clients, namespace string,
 			}},
 			Containers: []corev1.Container{{
 				Name:       "skopeo",
-				Image:      "gcr.io/tekton-releases/dogfooding/skopeo:latest",
+				Image:      "ghcr.io/tektoncd/catalog/upstream/tasks/skopeo-copy:latest",
 				WorkingDir: "/var",
 				Command:    []string{"/bin/sh", "-c"},
 				Args:       []string{"skopeo copy --dest-tls-verify=false oci:image docker://" + ref.String()},


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

There was still a few references that makes the CI fail. This should fix it.

/cc @afrittoli @twoGiants @waveywaves 

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
