### PR TITLE
Feature: Allow THREADS_PER_CONTROLLER env var to override default threads-per-controller value

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -21,6 +21,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strconv"
 
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -43,6 +44,13 @@ const (
 )
 
 func main() {
+	if val, ok := os.LookupEnv("THREADS_PER_CONTROLLER"); ok {
+		threadsPerController, err := strconv.Atoi(val)
+		if err != nil {
+			log.Fatalf("failed to parse value %q of THREADS_PER_CONTROLLER: %v\n", val, err)
+		}
+		controller.DefaultThreadsPerController = threadsPerController
+	}
 	flag.IntVar(&controller.DefaultThreadsPerController, "threads-per-controller", controller.DefaultThreadsPerController, "Threads (goroutines) to create per controller")
 	namespace := flag.String("namespace", corev1.NamespaceAll, "Namespace to restrict informer to. Optional, defaults to all namespaces.")
 	disableHighAvailability := flag.Bool("disable-ha", false, "Whether to disable high-availability functionality for this component.  This flag will be deprecated "+

--- a/cmd/resolvers/main.go
+++ b/cmd/resolvers/main.go
@@ -18,7 +18,9 @@ package main
 
 import (
 	"flag"
+	"log"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/tektoncd/pipeline/pkg/apis/resolution/v1alpha1"
@@ -38,6 +40,13 @@ import (
 )
 
 func main() {
+	if val, ok := os.LookupEnv("THREADS_PER_CONTROLLER"); ok {
+		threadsPerController, err := strconv.Atoi(val)
+		if err != nil {
+			log.Fatalf("failed to parse value %q of THREADS_PER_CONTROLLER: %v\n", val, err)
+		}
+		controller.DefaultThreadsPerController = threadsPerController
+	}
 	flag.IntVar(&controller.DefaultThreadsPerController, "threads-per-controller", controller.DefaultThreadsPerController, "Threads (goroutines) to create per controller")
 
 	ctx := filteredinformerfactory.WithSelectors(signals.NewContext(), v1alpha1.ManagedByLabelKey)

--- a/docs/tekton-controller-performance-configuration.md
+++ b/docs/tekton-controller-performance-configuration.md
@@ -49,6 +49,9 @@ spec:
 
 Now, the ThreadsPerController, QPS and Burst have been changed to be `32`, `50` and `50`.
 
+You can also set `THREADS_PER_CONTROLLER`, `KUBE_API_QPS` and `KUBE_API_BURST` environment variables to overwrite default values.
+If flags and environment variables are set, command line args will take precedence.
+
 **Note**:
 <!-- wokeignore:rule=master -->
 Although in above example, you set QPS and Burst to be `50` and `50`. However, the actual values of them are [multiplied by `2`](https://github.com/pierretasci/pipeline/blob/master/cmd/controller/main.go#L83-L84), so the actual QPS and Burst is `100` and `100`.


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Linked issue : https://github.com/tektoncd/pipeline/discussions/8886

In order to use [helm charts from cdfoundation](https://github.com/cdfoundation/tekton-helm-chart/blob/main/charts/tekton-pipeline/templates/tekton-pipelines-controller-deploy.yaml) to deploy tekton controller, it could be easier to add the possibility to configure `threads-per-controller`, `kube-api-qps` and `kube-api-burst` by environment variables rather than by args.

`KUBE_API_BURST` and `KUBE_API_QPS` env vars can already override `kube-api-qps` and `kube-api-burst` default value :
- [KUBE_API_BURST](https://github.com/knative/pkg/blob/main/environment/client_config.go#L50)
- [KUBE_API_QPS](https://github.com/knative/pkg/blob/main/environment/client_config.go#L52C57-L52C69)

We just need to allow `THREADS_PER_CONTROLLER` env var to override default `threads-per-controller` value.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Default `threads-per-controller` value can be override by `THREADS_PER_CONTROLLER` env var
```
