### PR TITLE
Use tini-git image for the resolvers deployment

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,2 +1,2 @@
 baseImageOverrides:
-  github.com/tektoncd/pipeline/cmd/resolvers: cgr.dev/chainguard/git@sha256:566235a8ef752f37d285042ee05fc37dbb04293e50f116a231984080fb835693
+  github.com/tektoncd/pipeline/cmd/resolvers: ghcr.io/tektoncd/plumbing/tini-git@sha256:3d56865f83236872b0986c6c0716f5de56a1ca8eb3a86f37a46ce6202a6d4a66

--- a/config/resolvers/resolvers-deployment.yaml
+++ b/config/resolvers/resolvers-deployment.yaml
@@ -72,6 +72,11 @@ spec:
       containers:
       - name: controller
         image: ko://github.com/tektoncd/pipeline/cmd/resolvers
+        command:
+        - /sbin/tini
+        - --
+        - /ko-app/resolvers
+        args: []
         resources:
           requests:
             cpu: 100m
@@ -120,6 +125,7 @@ spec:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
           runAsNonRoot: true
+          runAsUser: 65532
           capabilities:
             drop:
             - "ALL"

--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -130,7 +130,7 @@ spec:
         $(params.package)/cmd/entrypoint: ${COMBINED_BASE_IMAGE}
         $(params.package)/cmd/nop: ${COMBINED_BASE_IMAGE}
         $(params.package)/cmd/workingdirinit: ${COMBINED_BASE_IMAGE}
-        $(params.package)/cmd/resolvers: cgr.dev/chainguard/git@sha256:566235a8ef752f37d285042ee05fc37dbb04293e50f116a231984080fb835693
+        $(params.package)/cmd/resolvers: ghcr.io/tektoncd/plumbing/tini-git@sha256:3d56865f83236872b0986c6c0716f5de56a1ca8eb3a86f37a46ce6202a6d4a66
       EOF
 
       cat /workspace/.ko.yaml

--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -55,7 +55,7 @@ function ko_resolve() {
       github.com/tektoncd/pipeline/cmd/nop: ghcr.io/tektoncd/pipeline/github.com/tektoncd/pipeline/combined-base-image:latest
       github.com/tektoncd/pipeline/cmd/workingdirinit: ghcr.io/tektoncd/pipeline/github.com/tektoncd/pipeline/combined-base-image:latest
 
-      github.com/tektoncd/pipeline/cmd/resolvers: cgr.dev/chainguard/git@sha256:566235a8ef752f37d285042ee05fc37dbb04293e50f116a231984080fb835693
+      github.com/tektoncd/pipeline/cmd/resolvers: ghcr.io/tektoncd/plumbing/tini-git@sha256:3d56865f83236872b0986c6c0716f5de56a1ca8eb3a86f37a46ce6202a6d4a66
 EOF
 
   KO_DOCKER_REPO=example.com ko resolve -l 'app.kubernetes.io/component!=resolvers' --platform=all --push=false -R -f config 1>/dev/null


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

And make sure the entrypoint (command) is tini.

Closes #8830
/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
The resolvers deployment now uses the `tini` init system to make sure we don't end up with a lot of git process zombies.
```
