### PR TITLE
efficient polling in `waitForStepsToFinish`

### DIFF
--- a/config/config-defaults.yaml
+++ b/config/config-defaults.yaml
@@ -149,3 +149,11 @@ data:
     #     limits:
     #       memory: "256Mi"
     #       cpu: "500m"
+
+    # default-sidecar-log-polling-interval specifies the polling interval for the Tekton sidecar log results container.
+    # This controls how frequently the sidecar checks for step completion files written by steps in a TaskRun.
+    # Lower values (e.g., "10ms") make the sidecar more responsive but may increase CPU usage; higher values (e.g., "1s")
+    # reduce resource usage but may delay result collection.
+    # This value is used by the sidecar-tekton-log-results container and can be tuned for performance or test scenarios.
+    # Example values: "100ms", "500ms", "1s"
+    default-sidecar-log-polling-interval: "100ms"

--- a/docs/additional-configs.md
+++ b/docs/additional-configs.md
@@ -243,6 +243,7 @@ The example below customizes the following:
 - the default maximum combinations of `Parameters` in a `Matrix` that can be used to fan out a `PipelineTask`. For
 more information, see [`Matrix`](matrix.md).
 - the default resolver type to `git`.
+- the default polling interval for the sidecar log results container via `default-sidecar-log-polling-interval`.
 
 ```yaml
 apiVersion: v1
@@ -260,7 +261,25 @@ data:
     emptyDir: {}
   default-max-matrix-combinations-count: "1024"
   default-resolver-type: "git"
+  default-sidecar-log-polling-interval: "100ms"
 ```
+
+### `default-sidecar-log-polling-interval`
+
+The `default-sidecar-log-polling-interval` key in the `config-defaults` ConfigMap specifies how frequently the Tekton
+sidecar log results container polls for step completion files written by steps in a TaskRun. Lower values (e.g., `10ms`)
+make the sidecar more responsive but may increase CPU usage; higher values (e.g., `1s`) reduce resource usage but may
+delay result collection. This value is used by the `sidecar-tekton-log-results` container and can be tuned for performance
+or test scenarios.
+
+**Example values:**
+- `100ms` (default)
+- `500ms`
+- `1s`
+- `10ms` (for fast polling in tests)
+
+**Note:** The `default-sidecar-log-polling-interval` setting is only applicable when results are created using the
+[sidecar approach](#enabling-larger-results-using-sidecar-logs).
 
 **Note:** The `_example` key in the provided [config-defaults.yaml](./../config/config-defaults.yaml)
 file lists the keys you can customize along with their default values.

--- a/internal/sidecarlogresults/sidecarlogresults_test.go
+++ b/internal/sidecarlogresults/sidecarlogresults_test.go
@@ -23,9 +23,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime/pprof"
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
@@ -605,6 +607,66 @@ func TestExtractStepAndResultFromSidecarResultName_Error(t *testing.T) {
 	wantErr := errors.New("invalid string step-foo-resultName : expected somtthing that looks like <stepName>.<resultName>")
 	if d := cmp.Diff(wantErr.Error(), err.Error()); d != "" {
 		t.Fatal(diff.PrintWantGot(d))
+	}
+}
+
+// TestWaitForStepsToFinish_Profile ensures that waitForStepsToFinish correctly waits for all step output files to appear before returning
+// The test creates a file called cpu.prof and starts Go's CPU profiler
+// A temporary directory is created to simulate the Tekton step run directory.
+// The test creates a large number of subdirectories e.g. step0, step1, ..., each representing a step in a TaskRun
+// A goroutine is started that, one by one, writes an out file in each step directory, with a small delay between each
+// The test calls the function and waits for it to complete and the profile is saved for later analysis
+// This is helpful to compare the impact of code changes, provides a reproducible way to profile and optimize the function waitForStepsToFinish
+func TestWaitForStepsToFinish_Profile(t *testing.T) {
+	f, err := os.Create("cpu.prof")
+	if err != nil {
+		t.Fatalf("could not create CPU profile: %v", err)
+	}
+	defer func(f *os.File) {
+		err := f.Close()
+		if err != nil {
+			return
+		}
+	}(f)
+	err = pprof.StartCPUProfile(f)
+	if err != nil {
+		return
+	}
+	defer pprof.StopCPUProfile()
+
+	// Setup: create a temp runDir with many fake step files
+	runDir := t.TempDir()
+	stepCount := 100
+	for i := range stepCount {
+		dir := filepath.Join(runDir, fmt.Sprintf("step%d", i))
+		err := os.MkdirAll(dir, 0755)
+		if err != nil {
+			return
+		}
+	}
+
+	// Simulate steps finishing one by one with a delay
+	go func() {
+		for i := range stepCount {
+			file := filepath.Join(runDir, fmt.Sprintf("step%d", i), "out")
+			err := os.WriteFile(file, []byte("done"), 0644)
+			if err != nil {
+				return
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	}()
+
+	intervalStr := os.Getenv("SIDECAR_LOG_POLLING_INTERVAL")
+	if intervalStr == "" {
+		intervalStr = "100ms"
+	}
+	interval, err := time.ParseDuration(intervalStr)
+	if err != nil {
+		interval = 100 * time.Millisecond
+	}
+	if err := waitForStepsToFinish(runDir, interval); err != nil {
+		t.Fatalf("waitForStepsToFinish failed: %v", err)
 	}
 }
 

--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -2006,6 +2006,7 @@ _EOF_
 						{Name: "tekton-internal-bin", ReadOnly: true, MountPath: "/tekton/bin"},
 						{Name: "tekton-internal-run-0", ReadOnly: true, MountPath: "/tekton/run/0"},
 					}, implicitVolumeMounts...),
+					Env: []corev1.EnvVar{{Name: "SIDECAR_LOG_POLLING_INTERVAL", Value: "100ms"}},
 				}},
 				Volumes: append(implicitVolumes, binVolume, runVolume(0), downwardVolume, corev1.Volume{
 					Name:         "tekton-creds-init-home-0",
@@ -2087,6 +2088,7 @@ _EOF_
 						{Name: "tekton-internal-bin", ReadOnly: true, MountPath: "/tekton/bin"},
 						{Name: "tekton-internal-run-0", ReadOnly: true, MountPath: "/tekton/run/0"},
 					}, implicitVolumeMounts...),
+					Env: []corev1.EnvVar{{Name: "SIDECAR_LOG_POLLING_INTERVAL", Value: "100ms"}},
 				}},
 				Volumes: append(implicitVolumes, binVolume, runVolume(0), downwardVolume, corev1.Volume{
 					Name:         "tekton-creds-init-home-0",
@@ -2163,6 +2165,7 @@ _EOF_
 						{Name: "tekton-internal-run-0", ReadOnly: true, MountPath: "/tekton/run/0"},
 					}, implicitVolumeMounts...),
 					SecurityContext: SecurityContextConfig{SetSecurityContext: true, SetReadOnlyRootFilesystem: true}.GetSecurityContext(false),
+					Env:             []corev1.EnvVar{{Name: "SIDECAR_LOG_POLLING_INTERVAL", Value: "100ms"}},
 				}},
 				Volumes: append(implicitVolumes, binVolume, runVolume(0), downwardVolume, corev1.Volume{
 					Name:         "tekton-creds-init-home-0",
@@ -2241,6 +2244,7 @@ _EOF_
 						{Name: "tekton-internal-bin", ReadOnly: true, MountPath: "/tekton/bin"},
 						{Name: "tekton-internal-run-0", ReadOnly: true, MountPath: "/tekton/run/0"},
 					}, implicitVolumeMounts...),
+					Env: []corev1.EnvVar{{Name: "SIDECAR_LOG_POLLING_INTERVAL", Value: "100ms"}},
 				}},
 				Volumes: append(implicitVolumes, binVolume, runVolume(0), downwardVolume, corev1.Volume{
 					Name:         "tekton-creds-init-home-0",
@@ -2325,6 +2329,7 @@ _EOF_
 						{Name: "tekton-internal-bin", ReadOnly: true, MountPath: "/tekton/bin"},
 						{Name: "tekton-internal-run-0", ReadOnly: true, MountPath: "/tekton/run/0"},
 					}, implicitVolumeMounts...),
+					Env: []corev1.EnvVar{{Name: "SIDECAR_LOG_POLLING_INTERVAL", Value: "100ms"}},
 				}},
 				Volumes: append(implicitVolumes, binVolume, runVolume(0), downwardVolume, corev1.Volume{
 					Name:         "tekton-creds-init-home-0",
@@ -2404,6 +2409,7 @@ _EOF_
 						{Name: "tekton-internal-run-0", ReadOnly: true, MountPath: "/tekton/run/0"},
 					}, implicitVolumeMounts...),
 					SecurityContext: SecurityContextConfig{SetSecurityContext: true, SetReadOnlyRootFilesystem: true}.GetSecurityContext(false),
+					Env:             []corev1.EnvVar{{Name: "SIDECAR_LOG_POLLING_INTERVAL", Value: "100ms"}},
 				}},
 				Volumes: append(implicitVolumes, binVolume, runVolume(0), downwardVolume, corev1.Volume{
 					Name:         "tekton-creds-init-home-0",

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -158,6 +158,13 @@ function set_enable_kubernetes_sidecar() {
   kubectl patch configmap feature-flags -n tekton-pipelines -p "$jsonpatch"
 }
 
+function set_default_sidecar_log_polling_interval() {
+  # Sets the default-sidecar-log-polling-interval in the config-defaults ConfigMap to 0ms for e2e tests
+  echo "Patching config-defaults ConfigMap: setting default-sidecar-log-polling-interval to 0ms"
+  jsonpatch='{"data": {"default-sidecar-log-polling-interval": "0ms"}}'
+  kubectl patch configmap config-defaults -n tekton-pipelines -p "$jsonpatch"
+}
+
 function run_e2e() {
   # Run the integration tests
   header "Running Go e2e tests"
@@ -187,6 +194,7 @@ set_enable_param_enum "$ENABLE_PARAM_ENUM"
 set_enable_artifacts "$ENABLE_ARTIFACTS"
 set_enable_concise_resolver_syntax "$ENABLE_CONCISE_RESOLVER_SYNTAX"
 set_enable_kubernetes_sidecar "$ENABLE_KUBERNETES_SIDECAR"
+set_default_sidecar_log_polling_interval
 run_e2e
 
 (( failed )) && fail_test


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

We discovered the `sidecar-tekton-log-results` is consuming significantly more CPU than the task steps. For example:

```
$ k top pod large-result-pipeline-runcf9s8-large-task-pod --containers   
POD                                             NAME                         CPU(cores)   MEMORY(bytes)   
large-result-pipeline-runcf9s8-large-task-pod   sidecar-tekton-log-results   1244m        11Mi            
large-result-pipeline-runcf9s8-large-task-pod   step-step1                   6m           7Mi             
large-result-pipeline-runcf9s8-large-task-pod   step-step10                  5m           7Mi             
large-result-pipeline-runcf9s8-large-task-pod   step-step11                  5m           6Mi             
large-result-pipeline-runcf9s8-large-task-pod   step-step2                   4m           6Mi             
large-result-pipeline-runcf9s8-large-task-pod   step-step3                   5m           7Mi             
large-result-pipeline-runcf9s8-large-task-pod   step-step4                   4m           6Mi             
large-result-pipeline-runcf9s8-large-task-pod   step-step5                   4m           6Mi             
large-result-pipeline-runcf9s8-large-task-pod   step-step6                   4m           6Mi             
large-result-pipeline-runcf9s8-large-task-pod   step-step7                   6m           6Mi             
large-result-pipeline-runcf9s8-large-task-pod   step-step8                   4m           7Mi             
large-result-pipeline-runcf9s8-large-task-pod   step-step9                   4m           7Mi             
```

Analysis:

* sidecar-tekton-log-results: 1244m CPU, 11Mi memory
* All other step containers: 4–6m CPU, 6–7Mi memory

Profiling of the `sidecarlogresults` component revealed excessive CPU usage. The current `waitForStepsToFinish` implementation uses a classic busy-wait strategy—it continuously checks for file existence without any sleep interval, resulting in high CPU consumption.

Profiling using unit test showed that nearly all CPU time was spent in system calls, with a high total sample count. This led to excessive CPU usage by the sidecar, even when it was simply waiting.

To address this, the function now sleeps for `100ms` between checks, significantly reducing the polling frequency. As a result, the sidecar now consumes minimal CPU while waiting.

Current profile:

```
$ go tool pprof -top internal/sidecarlogresults/cpu.prof
File: ___TestWaitForStepsToFinish_Profile_in_github_com_tektoncd_pipeline_internal_sidecarlogresults.test
Type: cpu
Time: 2025-07-21 14:40:00 PDT
Duration: 1.21s, Total samples = 890ms (73.77%)
Showing nodes accounting for 890ms, 100% of 890ms total
      flat  flat%   sum%        cum   cum%
     790ms 88.76% 88.76%      790ms 88.76%  syscall.syscall
```

Profile after adding some sleep:

```
$ go tool pprof -top internal/sidecarlogresults/cpu.prof
File: ___TestWaitForStepsToFinish_Profile_in_github_com_tektoncd_pipeline_internal_sidecarlogresults.test
Type: cpu
Time: 2025-07-21 14:42:28 PDT
Duration: 1.43s, Total samples = 70ms ( 4.90%)
Showing nodes accounting for 70ms, 100% of 70ms total
      flat  flat%   sum%        cum   cum%
      50ms 71.43% 71.43%       50ms 71.43%  syscall.syscall 
```

Total samples reduced down to 70ms compared to 890ms. 

Also, the CPU consumption has significantly reduced:

```
$ k top pod large-result-pipeline-runhgxdc-large-task-pod --containers
POD                                             NAME                         CPU(cores)   MEMORY(bytes)   
large-result-pipeline-runhgxdc-large-task-pod   sidecar-tekton-log-results   6m           7Mi             
large-result-pipeline-runhgxdc-large-task-pod   step-step10                  4m           6Mi             
large-result-pipeline-runhgxdc-large-task-pod   step-step11                  5m           6Mi             
large-result-pipeline-runhgxdc-large-task-pod   step-step2                   4m           7Mi             
large-result-pipeline-runhgxdc-large-task-pod   step-step3                   3m           6Mi             
large-result-pipeline-runhgxdc-large-task-pod   step-step4                   4m           6Mi             
large-result-pipeline-runhgxdc-large-task-pod   step-step5                   4m           7Mi             
large-result-pipeline-runhgxdc-large-task-pod   step-step6                   6m           6Mi             
large-result-pipeline-runhgxdc-large-task-pod   step-step7                   3m           6Mi             
large-result-pipeline-runhgxdc-large-task-pod   step-step8                   4m           6Mi             
large-result-pipeline-runhgxdc-large-task-pod   step-step9                   4m           6Mi         
```

To run the profiling test locally:

```
go test -v ./internal/sidecarlogresults -run TestWaitForStepsToFinish_Profile
```

Update:

The new key `default-sidecar-log-polling-interval` has been introduced to provide configurable control over how frequently the Tekton sidecar log results container polls for step completion files.


/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
The log results sidecar has been optimized to significantly reduce CPU utilization.  Operators can tune the system for their environment—using a higher interval to reduce CPU load in production, or a lower interval for faster feedback in development or testing.
```
