### PR TITLE
fix: ensure git shell-out inherits environment variables

### DIFF
--- a/pkg/resolution/resolver/git/repository.go
+++ b/pkg/resolution/resolver/git/repository.go
@@ -120,7 +120,7 @@ func (repo *repository) execGit(ctx context.Context, subCmd string, args ...stri
 		}
 	}
 	cmd := repo.executor(ctx, "git", append(configArgs, args...)...)
-	cmd.Env = append(cmd.Env, env...)
+	cmd.Env = append(cmd.Environ(), env...)
 
 	out, err := cmd.Output()
 	if err != nil {

--- a/pkg/resolution/resolver/git/repository_test.go
+++ b/pkg/resolution/resolver/git/repository_test.go
@@ -22,6 +22,7 @@ import (
 	"encoding/base64"
 	"os/exec"
 	"reflect"
+	"slices"
 	"testing"
 )
 
@@ -84,8 +85,15 @@ func TestClone(t *testing.T) {
 			if !reflect.DeepEqual(cmdParts, expectedCmd) {
 				t.Fatalf("Expected clone command to be %v but got %v", expectedCmd, cmdParts)
 			}
-			if !reflect.DeepEqual(cmd.Env, expectedEnv) {
-				t.Fatalf("Expected clone command env vars to be %v but got %v", expectedEnv, cmd.Env)
+
+			missingEnvVars := []string{}
+			for _, v := range expectedEnv {
+				if !slices.Contains(cmd.Environ(), v) {
+					missingEnvVars = append(missingEnvVars, v)
+				}
+			}
+			if len(missingEnvVars) > 0 {
+				t.Fatalf("Clone command missing env vars %v. Got: %v", missingEnvVars, cmd.Environ())
 			}
 		})
 	}


### PR DESCRIPTION
# Changes

Custom environment variables such as those used to configure SSL cert need to be inherited by git's processes in order to apply.

`cmd.Env` it not initialized to include the default env vars for the process. In order to properly inherit the variables you have to use `cmd.Environ()` to append to the default variables.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
fix: The git resolver now respects environment variables on the pod
```
/kind bug