### PR TITLE
refactor getSidecarLogPollingInterval()

### DIFF
--- a/internal/sidecarlogresults/sidecarlogresults_test.go
+++ b/internal/sidecarlogresults/sidecarlogresults_test.go
@@ -871,3 +871,32 @@ func mustJSON(data any) string {
 	}
 	return string(marshal)
 }
+
+func TestGetSidecarLogPollingInterval(t *testing.T) {
+	tests := []struct {
+		name      string
+		setEnv    string
+		expect    time.Duration
+		wantError bool
+	}{
+		{"empty env", "", 100 * time.Millisecond, false},
+		{"valid duration", "250ms", 250 * time.Millisecond, false},
+		{"invalid duration", "notaduration", 100 * time.Millisecond, true},
+		{"custom value", "1s", 1 * time.Second, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("SIDECAR_LOG_POLLING_INTERVAL", tc.setEnv)
+			got, err := getSidecarLogPollingInterval()
+			if tc.wantError && err == nil {
+				t.Errorf("expected error, got nil")
+			}
+			if !tc.wantError && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if got != tc.expect {
+				t.Errorf("got %v, want %v", got, tc.expect)
+			}
+		})
+	}
+}


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

Introducing getSidecarLogPollingInterval() to avoid repeating the same logic across two different functions.

Reference: https://github.com/tektoncd/pipeline/pull/8901#discussion_r2225088487

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
