### PR TITLE
[release-v1.2.x] adding efficient polling to waitForStepsToFinish

### DIFF
--- a/config/300-crds/300-pipelinerun.yaml
+++ b/config/300-crds/300-pipelinerun.yaml
@@ -2162,7 +2162,7 @@ spec:
                           description: |-
                             EntryPoint identifies the entry point into the build. This is often a path to a
                             build definition file and/or a target label within that file.
-                            Example: "task/git-clone/0.8/git-clone.yaml"
+                            Example: "task/git-clone/0.10/git-clone.yaml"
                           type: string
                         uri:
                           description: |-
@@ -2239,7 +2239,7 @@ spec:
                           description: |-
                             EntryPoint identifies the entry point into the build. This is often a path to a
                             build definition file and/or a target label within that file.
-                            Example: "task/git-clone/0.8/git-clone.yaml"
+                            Example: "task/git-clone/0.10/git-clone.yaml"
                           type: string
                         uri:
                           description: |-
@@ -2575,7 +2575,7 @@ spec:
                                     description: |-
                                       EntryPoint identifies the entry point into the build. This is often a path to a
                                       build definition file and/or a target label within that file.
-                                      Example: "task/git-clone/0.8/git-clone.yaml"
+                                      Example: "task/git-clone/0.10/git-clone.yaml"
                                     type: string
                                   uri:
                                     description: |-
@@ -2652,7 +2652,7 @@ spec:
                                     description: |-
                                       EntryPoint identifies the entry point into the build. This is often a path to a
                                       build definition file and/or a target label within that file.
-                                      Example: "task/git-clone/0.8/git-clone.yaml"
+                                      Example: "task/git-clone/0.10/git-clone.yaml"
                                     type: string
                                   uri:
                                     description: |-
@@ -2862,7 +2862,7 @@ spec:
                                           description: |-
                                             EntryPoint identifies the entry point into the build. This is often a path to a
                                             build definition file and/or a target label within that file.
-                                            Example: "task/git-clone/0.8/git-clone.yaml"
+                                            Example: "task/git-clone/0.10/git-clone.yaml"
                                           type: string
                                         uri:
                                           description: |-
@@ -2939,7 +2939,7 @@ spec:
                                           description: |-
                                             EntryPoint identifies the entry point into the build. This is often a path to a
                                             build definition file and/or a target label within that file.
-                                            Example: "task/git-clone/0.8/git-clone.yaml"
+                                            Example: "task/git-clone/0.10/git-clone.yaml"
                                           type: string
                                         uri:
                                           description: |-
@@ -5159,7 +5159,7 @@ spec:
                           description: |-
                             EntryPoint identifies the entry point into the build. This is often a path to a
                             build definition file and/or a target label within that file.
-                            Example: "task/git-clone/0.8/git-clone.yaml"
+                            Example: "task/git-clone/0.10/git-clone.yaml"
                           type: string
                         uri:
                           description: |-

--- a/config/300-crds/300-taskrun.yaml
+++ b/config/300-crds/300-taskrun.yaml
@@ -1738,7 +1738,7 @@ spec:
                           description: |-
                             EntryPoint identifies the entry point into the build. This is often a path to a
                             build definition file and/or a target label within that file.
-                            Example: "task/git-clone/0.8/git-clone.yaml"
+                            Example: "task/git-clone/0.10/git-clone.yaml"
                           type: string
                         uri:
                           description: |-
@@ -1815,7 +1815,7 @@ spec:
                           description: |-
                             EntryPoint identifies the entry point into the build. This is often a path to a
                             build definition file and/or a target label within that file.
-                            Example: "task/git-clone/0.8/git-clone.yaml"
+                            Example: "task/git-clone/0.10/git-clone.yaml"
                           type: string
                         uri:
                           description: |-
@@ -2025,7 +2025,7 @@ spec:
                                 description: |-
                                   EntryPoint identifies the entry point into the build. This is often a path to a
                                   build definition file and/or a target label within that file.
-                                  Example: "task/git-clone/0.8/git-clone.yaml"
+                                  Example: "task/git-clone/0.10/git-clone.yaml"
                                 type: string
                               uri:
                                 description: |-
@@ -2102,7 +2102,7 @@ spec:
                                 description: |-
                                   EntryPoint identifies the entry point into the build. This is often a path to a
                                   build definition file and/or a target label within that file.
-                                  Example: "task/git-clone/0.8/git-clone.yaml"
+                                  Example: "task/git-clone/0.10/git-clone.yaml"
                                 type: string
                               uri:
                                 description: |-
@@ -3806,7 +3806,7 @@ spec:
                           description: |-
                             EntryPoint identifies the entry point into the build. This is often a path to a
                             build definition file and/or a target label within that file.
-                            Example: "task/git-clone/0.8/git-clone.yaml"
+                            Example: "task/git-clone/0.10/git-clone.yaml"
                           type: string
                         uri:
                           description: |-
@@ -4059,7 +4059,7 @@ spec:
                                 description: |-
                                   EntryPoint identifies the entry point into the build. This is often a path to a
                                   build definition file and/or a target label within that file.
-                                  Example: "task/git-clone/0.8/git-clone.yaml"
+                                  Example: "task/git-clone/0.10/git-clone.yaml"
                                 type: string
                               uri:
                                 description: |-

--- a/config/config-defaults.yaml
+++ b/config/config-defaults.yaml
@@ -149,3 +149,11 @@ data:
     #     limits:
     #       memory: "256Mi"
     #       cpu: "500m"
+
+    # default-sidecar-log-polling-interval specifies the polling interval for the Tekton sidecar log results container.
+    # This controls how frequently the sidecar checks for step completion files written by steps in a TaskRun.
+    # Lower values (e.g., "10ms") make the sidecar more responsive but may increase CPU usage; higher values (e.g., "1s")
+    # reduce resource usage but may delay result collection.
+    # This value is used by the sidecar-tekton-log-results container and can be tuned for performance or test scenarios.
+    # Example values: "100ms", "500ms", "1s"
+    default-sidecar-log-polling-interval: "100ms"

--- a/docs/additional-configs.md
+++ b/docs/additional-configs.md
@@ -243,6 +243,7 @@ The example below customizes the following:
 - the default maximum combinations of `Parameters` in a `Matrix` that can be used to fan out a `PipelineTask`. For
 more information, see [`Matrix`](matrix.md).
 - the default resolver type to `git`.
+- the default polling interval for the sidecar log results container via `default-sidecar-log-polling-interval`.
 
 ```yaml
 apiVersion: v1
@@ -260,7 +261,25 @@ data:
     emptyDir: {}
   default-max-matrix-combinations-count: "1024"
   default-resolver-type: "git"
+  default-sidecar-log-polling-interval: "100ms"
 ```
+
+### `default-sidecar-log-polling-interval`
+
+The `default-sidecar-log-polling-interval` key in the `config-defaults` ConfigMap specifies how frequently the Tekton
+sidecar log results container polls for step completion files written by steps in a TaskRun. Lower values (e.g., `10ms`)
+make the sidecar more responsive but may increase CPU usage; higher values (e.g., `1s`) reduce resource usage but may
+delay result collection. This value is used by the `sidecar-tekton-log-results` container and can be tuned for performance
+or test scenarios.
+
+**Example values:**
+- `100ms` (default)
+- `500ms`
+- `1s`
+- `10ms` (for fast polling in tests)
+
+**Note:** The `default-sidecar-log-polling-interval` setting is only applicable when results are created using the
+[sidecar approach](#enabling-larger-results-using-sidecar-logs).
 
 **Note:** The `_example` key in the provided [config-defaults.yaml](./../config/config-defaults.yaml)
 file lists the keys you can customize along with their default values.

--- a/examples/v1/pipelineruns/beta/git-resolver.yaml
+++ b/examples/v1/pipelineruns/beta/git-resolver.yaml
@@ -25,7 +25,7 @@ spec:
             - name: url
               value: https://github.com/tektoncd/catalog.git
             - name: pathInRepo
-              value: /task/git-clone/0.7/git-clone.yaml
+              value: /task/git-clone/0.10/git-clone.yaml
             - name: revision
               value: main
         params:

--- a/examples/v1/pipelineruns/beta/http-resolver-credentials.yaml
+++ b/examples/v1/pipelineruns/beta/http-resolver-credentials.yaml
@@ -16,14 +16,19 @@ kind: PipelineRun
 metadata:
   generateName: http-resolver-
 spec:
+  workspaces:
+  - name: output
+    emptyDir: {}
   pipelineSpec:
+    workspaces:
+    - name: output
     tasks:
       - name: http-resolver
         taskRef:
           resolver: http
           params:
             - name: url
-              value: https://api.hub.tekton.dev/v1/resource/tekton/task/tkn/0.4/raw
+              value: https://api.hub.tekton.dev/v1/resource/tekton/task/git-clone/0.10/raw
             - name: http-username
               value: git
             - name: http-password-secret
@@ -31,5 +36,8 @@ spec:
             - name: http-password-secret-key
               value: token
         params:
-          - name: ARGS
-            value: ["version"]
+          - name: url
+            value: "https://github.com/kelseyhightower/nocode"
+        workspaces:
+          - name: output
+            workspace: output

--- a/examples/v1/pipelineruns/beta/http-resolver.yaml
+++ b/examples/v1/pipelineruns/beta/http-resolver.yaml
@@ -4,14 +4,22 @@ kind: PipelineRun
 metadata:
   generateName: http-resolver-
 spec:
+  workspaces:
+  - name: output
+    emptyDir: {}
   pipelineSpec:
+    workspaces:
+    - name: output
     tasks:
       - name: http-resolver
         taskRef:
           resolver: http
           params:
             - name: url
-              value: https://api.hub.tekton.dev/v1/resource/tekton/task/tkn/0.4/raw
+              value: https://api.hub.tekton.dev/v1/resource/tekton/task/git-clone/0.10/raw
         params:
-          - name: ARGS
-            value: ["version"]
+          - name: url
+            value: "https://github.com/kelseyhightower/nocode"
+        workspaces:
+          - name: output
+            workspace: output

--- a/examples/v1/pipelineruns/no-ci/git-resolver-custom-apiurl.yaml
+++ b/examples/v1/pipelineruns/no-ci/git-resolver-custom-apiurl.yaml
@@ -25,7 +25,7 @@ spec:
             - name: url
               value: https://github.com/tektoncd/catalog.git
             - name: pathInRepo
-              value: /task/git-clone/0.7/git-clone.yaml
+              value: /task/git-clone/0.10/git-clone.yaml
             - name: revision
               value: main
             # my-secret-token should be created in the namespace where the

--- a/examples/v1/pipelineruns/no-ci/git-resolver-custom-secret.yaml
+++ b/examples/v1/pipelineruns/no-ci/git-resolver-custom-secret.yaml
@@ -25,7 +25,7 @@ spec:
             - name: url
               value: https://github.com/tektoncd/catalog.git
             - name: pathInRepo
-              value: /task/git-clone/0.7/git-clone.yaml
+              value: /task/git-clone/0.10/git-clone.yaml
             - name: revision
               value: main
             # my-secret-token should be created in the namespace where the

--- a/examples/v1/pipelineruns/pipelinerun-with-final-tasks.yaml
+++ b/examples/v1/pipelineruns/pipelinerun-with-final-tasks.yaml
@@ -57,7 +57,7 @@ spec:
       description: The precise commit SHA that was fetched by this Task
   steps:
     - name: clone
-      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:latest
+      image: ghcr.io/tektoncd-catalog/git-clone:v1.1.0
       securityContext:
         runAsUser: 0  # This needs root, and git-init is nonroot by default
       script: |

--- a/examples/v1/pipelineruns/pipelinerun.yaml
+++ b/examples/v1/pipelineruns/pipelinerun.yaml
@@ -58,7 +58,7 @@ spec:
     description: The precise commit SHA that was fetched by this Task
   steps:
   - name: clone
-    image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:latest
+    image: ghcr.io/tektoncd-catalog/git-clone:v1.1.0
     securityContext:
       runAsUser: 0  # This needs root, and git-init is nonroot by default
     script: |

--- a/examples/v1/taskruns/authenticating-git-commands.yaml
+++ b/examples/v1/taskruns/authenticating-git-commands.yaml
@@ -166,7 +166,7 @@ spec:
         git commit -m "Test commit!"
         git push origin master
     - name: git-clone-and-check
-      image: gcr.io/tekton-releases/dogfooding/alpine-git-nonroot:latest
+      image: ghcr.io/tektoncd/plumbing/alpine-git-nonroot:latest
       # Because this Step runs with a non-root security context, the creds-init
       # credentials will fail to copy into /tekton/home. This happens because
       # our previous step _already_ wrote to /tekton/home and ran as a root

--- a/examples/v1/taskruns/beta/authenticating-git-commands.yaml
+++ b/examples/v1/taskruns/beta/authenticating-git-commands.yaml
@@ -161,7 +161,7 @@ spec:
         git commit -m "Test commit!"
         git push origin master
     - name: git-clone-and-check
-      image: gcr.io/tekton-releases/dogfooding/alpine-git-nonroot:latest
+      image: ghcr.io/tektoncd/plumbing/alpine-git-nonroot:latest
       # Because this Step runs with a non-root security context, the creds-init
       # credentials will fail to copy into /tekton/home. This happens because
       # our previous step _already_ wrote to /tekton/home and ran as a root

--- a/examples/v1/taskruns/beta/bundles-resolver.yaml
+++ b/examples/v1/taskruns/beta/bundles-resolver.yaml
@@ -13,7 +13,7 @@ spec:
     resolver: bundles
     params:
       - name: bundle
-        value: gcr.io/tekton-releases/catalog/upstream/git-clone@sha256:8e2c3fb0f719d6463e950f3e44965aa314e69b800833e29e68ba2616bb82deeb
+        value: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone@sha256:65e61544c5870c8828233406689d812391735fd4100cb444bbd81531cb958bb3 # 0.10 bundle
       - name: name
         value: git-clone
       - name: kind

--- a/examples/v1/taskruns/beta/git-resolver.yaml
+++ b/examples/v1/taskruns/beta/git-resolver.yaml
@@ -22,4 +22,4 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: task/git-clone/0.8/git-clone.yaml
+        value: task/git-clone/0.10/git-clone.yaml

--- a/examples/v1/taskruns/beta/hub-resolver.yaml
+++ b/examples/v1/taskruns/beta/hub-resolver.yaml
@@ -24,7 +24,7 @@ spec:
       - name: name
         value: git-clone
       - name: version
-        value: "0.6"
+        value: "0.10"
 ---
 apiVersion: tekton.dev/v1
 kind: TaskRun
@@ -48,4 +48,4 @@ spec:
       - name: name
         value: git-clone
       - name: version
-        value: "0.6.0"
+        value: "0.10"

--- a/examples/v1/taskruns/entrypoint-resolution.yaml
+++ b/examples/v1/taskruns/entrypoint-resolution.yaml
@@ -8,7 +8,7 @@ spec:
     # Multi-arch image with no command defined. We should look up the command
     # for each platform-specific image and pass it to the Pod, which selects
     # the right command at runtime based on the node's runtime platform.
-    - image: gcr.io/tekton-nightly/github.com/tektoncd/pipeline/cmd/nop
+    - image: ghcr.io/tektoncd/pipeline/nop-8eac7c133edad5df719dc37b36b62482:latest
 
     # Multi-arch image with no command defined, but with args. We'll look
     # up the commands and pass it to the entrypoint binary via env var, then

--- a/examples/v1/taskruns/no-ci/docker-creds.yaml
+++ b/examples/v1/taskruns/no-ci/docker-creds.yaml
@@ -37,6 +37,6 @@ spec:
   taskSpec:
     steps:
     - name: test
-      image: gcr.io/tekton-releases/dogfooding/skopeo:latest
+      image: ghcr.io/tektoncd/catalog/upstream/tasks/skopeo-copy:latest
       # Test pulling a private builder container.
       script: skopeo copy docker://gcr.io/build-crd-testing/secret-sauce dir:///tmp/

--- a/examples/v1/taskruns/no-ci/pull-private-image.yaml
+++ b/examples/v1/taskruns/no-ci/pull-private-image.yaml
@@ -47,5 +47,5 @@ spec:
     steps:
     - name: pull
       # Private image is just Ubuntu
-      image: gcr.io/tekton-releases/dogfooding/skopeo:latest
+      image: ghcr.io/tektoncd/catalog/upstream/tasks/skopeo-copy:latest
       script: skopeo copy docker://gcr.io/build-crd-testing/secret-sauce dir:///tmp/

--- a/internal/sidecarlogresults/sidecarlogresults_test.go
+++ b/internal/sidecarlogresults/sidecarlogresults_test.go
@@ -871,3 +871,32 @@ func mustJSON(data any) string {
 	}
 	return string(marshal)
 }
+
+func TestGetSidecarLogPollingInterval(t *testing.T) {
+	tests := []struct {
+		name      string
+		setEnv    string
+		expect    time.Duration
+		wantError bool
+	}{
+		{"empty env", "", 100 * time.Millisecond, false},
+		{"valid duration", "250ms", 250 * time.Millisecond, false},
+		{"invalid duration", "notaduration", 100 * time.Millisecond, true},
+		{"custom value", "1s", 1 * time.Second, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("SIDECAR_LOG_POLLING_INTERVAL", tc.setEnv)
+			got, err := getSidecarLogPollingInterval()
+			if tc.wantError && err == nil {
+				t.Errorf("expected error, got nil")
+			}
+			if !tc.wantError && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if got != tc.expect {
+				t.Errorf("got %v, want %v", got, tc.expect)
+			}
+		})
+	}
+}

--- a/internal/sidecarlogresults/sidecarlogresults_test.go
+++ b/internal/sidecarlogresults/sidecarlogresults_test.go
@@ -23,9 +23,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime/pprof"
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
@@ -605,6 +607,66 @@ func TestExtractStepAndResultFromSidecarResultName_Error(t *testing.T) {
 	wantErr := errors.New("invalid string step-foo-resultName : expected somtthing that looks like <stepName>.<resultName>")
 	if d := cmp.Diff(wantErr.Error(), err.Error()); d != "" {
 		t.Fatal(diff.PrintWantGot(d))
+	}
+}
+
+// TestWaitForStepsToFinish_Profile ensures that waitForStepsToFinish correctly waits for all step output files to appear before returning
+// The test creates a file called cpu.prof and starts Go's CPU profiler
+// A temporary directory is created to simulate the Tekton step run directory.
+// The test creates a large number of subdirectories e.g. step0, step1, ..., each representing a step in a TaskRun
+// A goroutine is started that, one by one, writes an out file in each step directory, with a small delay between each
+// The test calls the function and waits for it to complete and the profile is saved for later analysis
+// This is helpful to compare the impact of code changes, provides a reproducible way to profile and optimize the function waitForStepsToFinish
+func TestWaitForStepsToFinish_Profile(t *testing.T) {
+	f, err := os.Create("cpu.prof")
+	if err != nil {
+		t.Fatalf("could not create CPU profile: %v", err)
+	}
+	defer func(f *os.File) {
+		err := f.Close()
+		if err != nil {
+			return
+		}
+	}(f)
+	err = pprof.StartCPUProfile(f)
+	if err != nil {
+		return
+	}
+	defer pprof.StopCPUProfile()
+
+	// Setup: create a temp runDir with many fake step files
+	runDir := t.TempDir()
+	stepCount := 100
+	for i := range stepCount {
+		dir := filepath.Join(runDir, fmt.Sprintf("step%d", i))
+		err := os.MkdirAll(dir, 0755)
+		if err != nil {
+			return
+		}
+	}
+
+	// Simulate steps finishing one by one with a delay
+	go func() {
+		for i := range stepCount {
+			file := filepath.Join(runDir, fmt.Sprintf("step%d", i), "out")
+			err := os.WriteFile(file, []byte("done"), 0644)
+			if err != nil {
+				return
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	}()
+
+	intervalStr := os.Getenv("SIDECAR_LOG_POLLING_INTERVAL")
+	if intervalStr == "" {
+		intervalStr = "100ms"
+	}
+	interval, err := time.ParseDuration(intervalStr)
+	if err != nil {
+		interval = 100 * time.Millisecond
+	}
+	if err := waitForStepsToFinish(runDir, interval); err != nil {
+		t.Fatalf("waitForStepsToFinish failed: %v", err)
 	}
 }
 

--- a/pkg/apis/pipeline/v1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1/openapi_generated.go
@@ -2359,7 +2359,7 @@ func schema_pkg_apis_pipeline_v1_RefSource(ref common.ReferenceCallback) common.
 					},
 					"entryPoint": {
 						SchemaProps: spec.SchemaProps{
-							Description: "EntryPoint identifies the entry point into the build. This is often a path to a build definition file and/or a target label within that file. Example: \"task/git-clone/0.8/git-clone.yaml\"",
+							Description: "EntryPoint identifies the entry point into the build. This is often a path to a build definition file and/or a target label within that file. Example: \"task/git-clone/0.10/git-clone.yaml\"",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/apis/pipeline/v1/provenance.go
+++ b/pkg/apis/pipeline/v1/provenance.go
@@ -41,6 +41,6 @@ type RefSource struct {
 
 	// EntryPoint identifies the entry point into the build. This is often a path to a
 	// build definition file and/or a target label within that file.
-	// Example: "task/git-clone/0.8/git-clone.yaml"
+	// Example: "task/git-clone/0.10/git-clone.yaml"
 	EntryPoint string `json:"entryPoint,omitempty"`
 }

--- a/pkg/apis/pipeline/v1/swagger.json
+++ b/pkg/apis/pipeline/v1/swagger.json
@@ -1185,7 +1185,7 @@
           }
         },
         "entryPoint": {
-          "description": "EntryPoint identifies the entry point into the build. This is often a path to a build definition file and/or a target label within that file. Example: \"task/git-clone/0.8/git-clone.yaml\"",
+          "description": "EntryPoint identifies the entry point into the build. This is often a path to a build definition file and/or a target label within that file. Example: \"task/git-clone/0.10/git-clone.yaml\"",
           "type": "string"
         },
         "uri": {

--- a/pkg/apis/pipeline/v1beta1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1beta1/openapi_generated.go
@@ -712,7 +712,7 @@ func schema_pkg_apis_pipeline_v1beta1_ConfigSource(ref common.ReferenceCallback)
 					},
 					"entryPoint": {
 						SchemaProps: spec.SchemaProps{
-							Description: "EntryPoint identifies the entry point into the build. This is often a path to a build definition file and/or a target label within that file. Example: \"task/git-clone/0.8/git-clone.yaml\"",
+							Description: "EntryPoint identifies the entry point into the build. This is often a path to a build definition file and/or a target label within that file. Example: \"task/git-clone/0.10/git-clone.yaml\"",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -3122,7 +3122,7 @@ func schema_pkg_apis_pipeline_v1beta1_RefSource(ref common.ReferenceCallback) co
 					},
 					"entryPoint": {
 						SchemaProps: spec.SchemaProps{
-							Description: "EntryPoint identifies the entry point into the build. This is often a path to a build definition file and/or a target label within that file. Example: \"task/git-clone/0.8/git-clone.yaml\"",
+							Description: "EntryPoint identifies the entry point into the build. This is often a path to a build definition file and/or a target label within that file. Example: \"task/git-clone/0.10/git-clone.yaml\"",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/apis/pipeline/v1beta1/provenance.go
+++ b/pkg/apis/pipeline/v1beta1/provenance.go
@@ -44,7 +44,7 @@ type RefSource struct {
 
 	// EntryPoint identifies the entry point into the build. This is often a path to a
 	// build definition file and/or a target label within that file.
-	// Example: "task/git-clone/0.8/git-clone.yaml"
+	// Example: "task/git-clone/0.10/git-clone.yaml"
 	EntryPoint string `json:"entryPoint,omitempty"`
 }
 
@@ -62,6 +62,6 @@ type ConfigSource struct {
 
 	// EntryPoint identifies the entry point into the build. This is often a path to a
 	// build definition file and/or a target label within that file.
-	// Example: "task/git-clone/0.8/git-clone.yaml"
+	// Example: "task/git-clone/0.10/git-clone.yaml"
 	EntryPoint string `json:"entryPoint,omitempty"`
 }

--- a/pkg/apis/pipeline/v1beta1/swagger.json
+++ b/pkg/apis/pipeline/v1beta1/swagger.json
@@ -306,7 +306,7 @@
           }
         },
         "entryPoint": {
-          "description": "EntryPoint identifies the entry point into the build. This is often a path to a build definition file and/or a target label within that file. Example: \"task/git-clone/0.8/git-clone.yaml\"",
+          "description": "EntryPoint identifies the entry point into the build. This is often a path to a build definition file and/or a target label within that file. Example: \"task/git-clone/0.10/git-clone.yaml\"",
           "type": "string"
         },
         "uri": {
@@ -1592,7 +1592,7 @@
           }
         },
         "entryPoint": {
-          "description": "EntryPoint identifies the entry point into the build. This is often a path to a build definition file and/or a target label within that file. Example: \"task/git-clone/0.8/git-clone.yaml\"",
+          "description": "EntryPoint identifies the entry point into the build. This is often a path to a build definition file and/or a target label within that file. Example: \"task/git-clone/0.10/git-clone.yaml\"",
           "type": "string"
         },
         "uri": {

--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -2006,6 +2006,7 @@ _EOF_
 						{Name: "tekton-internal-bin", ReadOnly: true, MountPath: "/tekton/bin"},
 						{Name: "tekton-internal-run-0", ReadOnly: true, MountPath: "/tekton/run/0"},
 					}, implicitVolumeMounts...),
+					Env: []corev1.EnvVar{{Name: "SIDECAR_LOG_POLLING_INTERVAL", Value: "100ms"}},
 				}},
 				Volumes: append(implicitVolumes, binVolume, runVolume(0), downwardVolume, corev1.Volume{
 					Name:         "tekton-creds-init-home-0",
@@ -2087,6 +2088,7 @@ _EOF_
 						{Name: "tekton-internal-bin", ReadOnly: true, MountPath: "/tekton/bin"},
 						{Name: "tekton-internal-run-0", ReadOnly: true, MountPath: "/tekton/run/0"},
 					}, implicitVolumeMounts...),
+					Env: []corev1.EnvVar{{Name: "SIDECAR_LOG_POLLING_INTERVAL", Value: "100ms"}},
 				}},
 				Volumes: append(implicitVolumes, binVolume, runVolume(0), downwardVolume, corev1.Volume{
 					Name:         "tekton-creds-init-home-0",
@@ -2163,6 +2165,7 @@ _EOF_
 						{Name: "tekton-internal-run-0", ReadOnly: true, MountPath: "/tekton/run/0"},
 					}, implicitVolumeMounts...),
 					SecurityContext: SecurityContextConfig{SetSecurityContext: true, SetReadOnlyRootFilesystem: true}.GetSecurityContext(false),
+					Env:             []corev1.EnvVar{{Name: "SIDECAR_LOG_POLLING_INTERVAL", Value: "100ms"}},
 				}},
 				Volumes: append(implicitVolumes, binVolume, runVolume(0), downwardVolume, corev1.Volume{
 					Name:         "tekton-creds-init-home-0",
@@ -2241,6 +2244,7 @@ _EOF_
 						{Name: "tekton-internal-bin", ReadOnly: true, MountPath: "/tekton/bin"},
 						{Name: "tekton-internal-run-0", ReadOnly: true, MountPath: "/tekton/run/0"},
 					}, implicitVolumeMounts...),
+					Env: []corev1.EnvVar{{Name: "SIDECAR_LOG_POLLING_INTERVAL", Value: "100ms"}},
 				}},
 				Volumes: append(implicitVolumes, binVolume, runVolume(0), downwardVolume, corev1.Volume{
 					Name:         "tekton-creds-init-home-0",
@@ -2325,6 +2329,7 @@ _EOF_
 						{Name: "tekton-internal-bin", ReadOnly: true, MountPath: "/tekton/bin"},
 						{Name: "tekton-internal-run-0", ReadOnly: true, MountPath: "/tekton/run/0"},
 					}, implicitVolumeMounts...),
+					Env: []corev1.EnvVar{{Name: "SIDECAR_LOG_POLLING_INTERVAL", Value: "100ms"}},
 				}},
 				Volumes: append(implicitVolumes, binVolume, runVolume(0), downwardVolume, corev1.Volume{
 					Name:         "tekton-creds-init-home-0",
@@ -2404,6 +2409,7 @@ _EOF_
 						{Name: "tekton-internal-run-0", ReadOnly: true, MountPath: "/tekton/run/0"},
 					}, implicitVolumeMounts...),
 					SecurityContext: SecurityContextConfig{SetSecurityContext: true, SetReadOnlyRootFilesystem: true}.GetSecurityContext(false),
+					Env:             []corev1.EnvVar{{Name: "SIDECAR_LOG_POLLING_INTERVAL", Value: "100ms"}},
 				}},
 				Volumes: append(implicitVolumes, binVolume, runVolume(0), downwardVolume, corev1.Volume{
 					Name:         "tekton-creds-init-home-0",

--- a/tekton/release-pipeline.yaml
+++ b/tekton/release-pipeline.yaml
@@ -74,7 +74,7 @@ spec:
           - name: name
             value: git-clone
           - name: version
-            value: "0.7"
+            value: "0.10"
       workspaces:
         - name: output
           workspace: workarea

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -158,6 +158,13 @@ function set_enable_kubernetes_sidecar() {
   kubectl patch configmap feature-flags -n tekton-pipelines -p "$jsonpatch"
 }
 
+function set_default_sidecar_log_polling_interval() {
+  # Sets the default-sidecar-log-polling-interval in the config-defaults ConfigMap to 0ms for e2e tests
+  echo "Patching config-defaults ConfigMap: setting default-sidecar-log-polling-interval to 0ms"
+  jsonpatch='{"data": {"default-sidecar-log-polling-interval": "0ms"}}'
+  kubectl patch configmap config-defaults -n tekton-pipelines -p "$jsonpatch"
+}
+
 function run_e2e() {
   # Run the integration tests
   header "Running Go e2e tests"
@@ -187,6 +194,7 @@ set_enable_param_enum "$ENABLE_PARAM_ENUM"
 set_enable_artifacts "$ENABLE_ARTIFACTS"
 set_enable_concise_resolver_syntax "$ENABLE_CONCISE_RESOLVER_SYNTAX"
 set_enable_kubernetes_sidecar "$ENABLE_KUBERNETES_SIDECAR"
+set_default_sidecar_log_polling_interval
 run_e2e
 
 (( failed )) && fail_test

--- a/test/resolvers_test.go
+++ b/test/resolvers_test.go
@@ -118,7 +118,7 @@ spec:
           - name: name
             value: git-clone
           - name: version
-            value: "0.7"
+            value: "0.10"
         params:
           - name: url
             value: https://github.com/tektoncd/pipeline
@@ -238,7 +238,7 @@ spec:
           - name: url
             value: https://github.com/tektoncd/catalog.git
           - name: pathInRepo
-            value: /task/git-clone/0.7/git-clone.yaml
+            value: /task/git-clone/0.10/git-clone.yaml
           - name: revision
             value: main
         params:
@@ -261,7 +261,7 @@ spec:
 
 func TestGitResolver_Clone_Failure(t *testing.T) {
 	defaultURL := "https://github.com/tektoncd/catalog.git"
-	defaultPathInRepo := "/task/git-clone/0.7/git-clone.yaml"
+	defaultPathInRepo := "/task/git-clone/0.10/git-clone.yaml"
 	defaultCommit := "783b4fe7d21148f3b1a93bfa49b0024d8c6c2955"
 
 	testCases := []struct {

--- a/test/tektonbundles_test.go
+++ b/test/tektonbundles_test.go
@@ -260,7 +260,7 @@ func publishImg(ctx context.Context, t *testing.T, c *clients, namespace string,
 			}},
 			Containers: []corev1.Container{{
 				Name:       "skopeo",
-				Image:      "gcr.io/tekton-releases/dogfooding/skopeo:latest",
+				Image:      "ghcr.io/tektoncd/catalog/upstream/tasks/skopeo-copy:latest",
 				WorkingDir: "/var",
 				Command:    []string{"/bin/sh", "-c"},
 				Args:       []string{"skopeo copy --dest-tls-verify=false oci:image docker://" + ref.String()},


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Manual Cherry-pick of https://github.com/tektoncd/pipeline/pull/8901

https://github.com/tektoncd/pipeline/pull/8901#issuecomment-3111351221

/kind bug

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
The log results sidecar has been optimized to significantly reduce CPU utilization.  Operators can tune the system for their environment—using a higher interval to reduce CPU load in production, or a lower interval for faster feedback in development or testing.
```
