### PR TITLE
Move ConfigMap helpers to testing framework and cleanup :broom: `pipelinerun_test.go` :broom:.

### DIFF
--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -2628,7 +2628,6 @@ _EOF_
 			} else {
 				trAnnotations = c.trAnnotation
 				trAnnotations[ReleaseAnnotation] = fakeVersion
-
 			}
 			testTaskRunName := taskRunName
 			if c.trName != "" {

--- a/pkg/reconciler/resolutionrequest/resolutionrequest_test.go
+++ b/pkg/reconciler/resolutionrequest/resolutionrequest_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/resolution/v1beta1"
+	th "github.com/tektoncd/pipeline/pkg/reconciler/testing"
 	ttesting "github.com/tektoncd/pipeline/pkg/reconciler/testing"
 	resolutioncommon "github.com/tektoncd/pipeline/pkg/resolution/common"
 	"github.com/tektoncd/pipeline/test"
@@ -169,7 +170,7 @@ func TestReconcile(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			d := test.Data{
 				ResolutionRequests: []*v1beta1.ResolutionRequest{tc.input},
-				ConfigMaps:         []*corev1.ConfigMap{newDefaultsConfigMap()},
+				ConfigMaps:         th.NewDefaultsCofigMapInSlice(),
 			}
 
 			testAssets, cancel := getResolutionRequestController(t, d)
@@ -194,11 +195,4 @@ func TestReconcile(t *testing.T) {
 
 func getRequestName(rr *v1beta1.ResolutionRequest) string {
 	return strings.Join([]string{rr.Namespace, rr.Name}, "/")
-}
-
-func newDefaultsConfigMap() *corev1.ConfigMap {
-	return &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{Name: config.GetDefaultsConfigName(), Namespace: system.Namespace()},
-		Data:       make(map[string]string),
-	}
 }


### PR DESCRIPTION
# Changes

Move `ConfigMap` helper functions and constants to testing framework in `pkg/reconciler/testing/configmap.go`. Add convinience wrappers for repeating ConfigMap helper function combinations to reduce duplications.

Remove unused constants and functions and inline variables to reduce the amount of local variables in `pipelinerun_test.go`.

Issue #8906.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
