### PR TITLE
[release-v0.68.x] Add startedAt field in the terminated step of a taskrun

### DIFF
--- a/examples/v1/pipelineruns/alpha/stepaction-params.yaml
+++ b/examples/v1/pipelineruns/alpha/stepaction-params.yaml
@@ -50,7 +50,7 @@ spec:
     - name: objectparam
       value:
         key2: "pipelinerun key2"
-  PipelineSpec:
+  pipelineSpec:
     tasks:
       - name: run-action
         taskSpec:

--- a/examples/v1/pipelineruns/pipelinerun-with-final-tasks.yaml
+++ b/examples/v1/pipelineruns/pipelinerun-with-final-tasks.yaml
@@ -57,7 +57,7 @@ spec:
       description: The precise commit SHA that was fetched by this Task
   steps:
     - name: clone
-      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:latest
+      image: ghcr.io/tektoncd-catalog/git-clone:v1.1.0
       securityContext:
         runAsUser: 0  # This needs root, and git-init is nonroot by default
       script: |

--- a/examples/v1/pipelineruns/pipelinerun.yaml
+++ b/examples/v1/pipelineruns/pipelinerun.yaml
@@ -58,7 +58,7 @@ spec:
     description: The precise commit SHA that was fetched by this Task
   steps:
   - name: clone
-    image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:latest
+    image: ghcr.io/tektoncd-catalog/git-clone:v1.1.0
     securityContext:
       runAsUser: 0  # This needs root, and git-init is nonroot by default
     script: |

--- a/examples/v1/taskruns/authenticating-git-commands.yaml
+++ b/examples/v1/taskruns/authenticating-git-commands.yaml
@@ -166,7 +166,7 @@ spec:
         git commit -m "Test commit!"
         git push origin master
     - name: git-clone-and-check
-      image: gcr.io/tekton-releases/dogfooding/alpine-git-nonroot:latest
+      image: ghcr.io/tektoncd/plumbing/alpine-git-nonroot:latest
       # Because this Step runs with a non-root security context, the creds-init
       # credentials will fail to copy into /tekton/home. This happens because
       # our previous step _already_ wrote to /tekton/home and ran as a root

--- a/examples/v1/taskruns/beta/authenticating-git-commands.yaml
+++ b/examples/v1/taskruns/beta/authenticating-git-commands.yaml
@@ -161,7 +161,7 @@ spec:
         git commit -m "Test commit!"
         git push origin master
     - name: git-clone-and-check
-      image: gcr.io/tekton-releases/dogfooding/alpine-git-nonroot:latest
+      image: ghcr.io/tektoncd/plumbing/alpine-git-nonroot:latest
       # Because this Step runs with a non-root security context, the creds-init
       # credentials will fail to copy into /tekton/home. This happens because
       # our previous step _already_ wrote to /tekton/home and ran as a root

--- a/examples/v1/taskruns/beta/bundles-resolver.yaml
+++ b/examples/v1/taskruns/beta/bundles-resolver.yaml
@@ -13,7 +13,7 @@ spec:
     resolver: bundles
     params:
       - name: bundle
-        value: gcr.io/tekton-releases/catalog/upstream/git-clone@sha256:8e2c3fb0f719d6463e950f3e44965aa314e69b800833e29e68ba2616bb82deeb
+        value: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone@sha256:65e61544c5870c8828233406689d812391735fd4100cb444bbd81531cb958bb3 # 0.10 bundle
       - name: name
         value: git-clone
       - name: kind

--- a/examples/v1/taskruns/beta/stepaction-git-resolver.yaml
+++ b/examples/v1/taskruns/beta/stepaction-git-resolver.yaml
@@ -11,7 +11,7 @@ spec:
       value: main
     - name: repoUrl
       value: https://github.com/tektoncd/catalog.git
-  TaskSpec:
+  taskSpec:
     steps:
       - name: action-runner
         ref:

--- a/examples/v1/taskruns/beta/stepaction-params.yaml
+++ b/examples/v1/taskruns/beta/stepaction-params.yaml
@@ -73,7 +73,7 @@ spec:
     - name: objectparam
       value:
         key2: "taskrun key2"
-  TaskSpec:
+  taskSpec:
     params:
       - name: objectparam
         properties:

--- a/examples/v1/taskruns/beta/stepaction-passing-results.yaml
+++ b/examples/v1/taskruns/beta/stepaction-passing-results.yaml
@@ -60,7 +60,7 @@ kind: TaskRun
 metadata:
   name: step-action-run
 spec:
-  TaskSpec:
+  taskSpec:
     steps:
       - name: inline-step
         results:

--- a/examples/v1/taskruns/beta/stepaction-results.yaml
+++ b/examples/v1/taskruns/beta/stepaction-results.yaml
@@ -16,7 +16,7 @@ kind: TaskRun
 metadata:
   name: step-action-run
 spec:
-  TaskSpec:
+  taskSpec:
     results:
       - name: step-result
         value: $(steps.action-runner.results.result1)

--- a/examples/v1/taskruns/beta/stepaction.yaml
+++ b/examples/v1/taskruns/beta/stepaction.yaml
@@ -12,7 +12,7 @@ kind: TaskRun
 metadata:
   name: step-action-run
 spec:
-  TaskSpec:
+  taskSpec:
     steps:
       - name: action-runner
         ref:

--- a/examples/v1/taskruns/entrypoint-resolution.yaml
+++ b/examples/v1/taskruns/entrypoint-resolution.yaml
@@ -8,7 +8,7 @@ spec:
     # Multi-arch image with no command defined. We should look up the command
     # for each platform-specific image and pass it to the Pod, which selects
     # the right command at runtime based on the node's runtime platform.
-    - image: gcr.io/tekton-nightly/github.com/tektoncd/pipeline/cmd/nop
+    - image: ghcr.io/tektoncd/pipeline/nop-8eac7c133edad5df719dc37b36b62482:latest
 
     # Multi-arch image with no command defined, but with args. We'll look
     # up the commands and pass it to the entrypoint binary via env var, then

--- a/examples/v1/taskruns/no-ci/docker-creds.yaml
+++ b/examples/v1/taskruns/no-ci/docker-creds.yaml
@@ -37,6 +37,6 @@ spec:
   taskSpec:
     steps:
     - name: test
-      image: gcr.io/tekton-releases/dogfooding/skopeo:latest
+      image: ghcr.io/tektoncd/catalog/upstream/tasks/skopeo-copy:latest
       # Test pulling a private builder container.
       script: skopeo copy docker://gcr.io/build-crd-testing/secret-sauce dir:///tmp/

--- a/examples/v1/taskruns/no-ci/pull-private-image.yaml
+++ b/examples/v1/taskruns/no-ci/pull-private-image.yaml
@@ -47,5 +47,5 @@ spec:
     steps:
     - name: pull
       # Private image is just Ubuntu
-      image: gcr.io/tekton-releases/dogfooding/skopeo:latest
+      image: ghcr.io/tektoncd/catalog/upstream/tasks/skopeo-copy:latest
       script: skopeo copy docker://gcr.io/build-crd-testing/secret-sauce dir:///tmp/

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -841,6 +841,7 @@ func terminateStepsInPod(tr *v1.TaskRun, taskRunReason v1.TaskRunReason) {
 		if step.Waiting != nil {
 			step.Terminated = &corev1.ContainerStateTerminated{
 				ExitCode:   1,
+				StartedAt:  tr.CreationTimestamp,
 				FinishedAt: *tr.Status.CompletionTime,
 				// TODO(#7385): replace with more pod/container termination reason instead of overloading taskRunReason
 				Reason:  taskRunReason.String(),

--- a/test/pipelinerun_test.go
+++ b/test/pipelinerun_test.go
@@ -226,7 +226,7 @@ spec:
     type: string
   steps:
   - name: config-docker
-    image: gcr.io/tekton-releases/dogfooding/skopeo:latest
+    image: ghcr.io/tektoncd/catalog/upstream/tasks/skopeo-copy:latest
     command: ['skopeo']
     args: ['copy', '$(params["the.path"])', '$(params["the.dest"])']
 `, helpers.ObjectNameForTest(t), namespace))
@@ -273,7 +273,7 @@ spec:
     type: string
   steps:
   - name: config-docker
-    image: gcr.io/tekton-releases/dogfooding/skopeo:latest
+    image: ghcr.io/tektoncd/catalog/upstream/tasks/skopeo-copy:latest
     command: ['skopeo']
     args: ['copy', '$(params["the.path"])', '$(params["the.dest"])']
 `, helpers.ObjectNameForTest(t), namespace))

--- a/test/tektonbundles_test.go
+++ b/test/tektonbundles_test.go
@@ -260,7 +260,7 @@ func publishImg(ctx context.Context, t *testing.T, c *clients, namespace string,
 			}},
 			Containers: []corev1.Container{{
 				Name:       "skopeo",
-				Image:      "gcr.io/tekton-releases/dogfooding/skopeo:latest",
+				Image:      "ghcr.io/tektoncd/catalog/upstream/tasks/skopeo-copy:latest",
 				WorkingDir: "/var",
 				Command:    []string{"/bin/sh", "-c"},
 				Args:       []string{"skopeo copy --dest-tls-verify=false oci:image docker://" + ref.String()},


### PR DESCRIPTION
This patch adds startedAt time in the terminated step of a taskrun as this field was missing and reconciler was adding null time.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Add startedAt field in the terminated step of a taskrun
```
