### PR TITLE
exponential backoff in `taskRun` controller

### DIFF
--- a/pkg/controller/errors.go
+++ b/pkg/controller/errors.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2025 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package controller provides helper methods for external controllers for
+// Custom Task types.
+package controller
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+// IsWebhookTimeout checks if the error is due to a mutating admission webhook timeout.
+// This function is used to determine if an error should trigger exponential backoff retry logic.
+func IsWebhookTimeout(err error) bool {
+	var statusErr *apierrors.StatusError
+	if errors.As(err, &statusErr) {
+		return statusErr.ErrStatus.Code == http.StatusInternalServerError &&
+			strings.Contains(statusErr.ErrStatus.Message, "timeout")
+	}
+	return false
+}

--- a/pkg/controller/errors_test.go
+++ b/pkg/controller/errors_test.go
@@ -1,0 +1,164 @@
+/*
+Copyright 2025 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestIsWebhookTimeout(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "non-status error",
+			err:      errors.New("some other error"),
+			expected: false,
+		},
+		{
+			name: "webhook timeout error - exact match",
+			err: &apierrors.StatusError{
+				ErrStatus: metav1.Status{
+					Code:    http.StatusInternalServerError,
+					Message: "timeout",
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "webhook timeout error - contains timeout in message",
+			err: &apierrors.StatusError{
+				ErrStatus: metav1.Status{
+					Code:    http.StatusInternalServerError,
+					Message: "admission webhook timeout occurred",
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "webhook timeout error - case insensitive",
+			err: &apierrors.StatusError{
+				ErrStatus: metav1.Status{
+					Code:    http.StatusInternalServerError,
+					Message: "TIMEOUT",
+				},
+			},
+			expected: false, // Case-sensitive matching, so "TIMEOUT" should not match "timeout"
+		},
+		{
+			name: "non-webhook error - different status code",
+			err: &apierrors.StatusError{
+				ErrStatus: metav1.Status{
+					Code:    http.StatusBadRequest,
+					Message: "timeout",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "non-webhook error - different message",
+			err: &apierrors.StatusError{
+				ErrStatus: metav1.Status{
+					Code:    http.StatusInternalServerError,
+					Message: "server error",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "non-webhook error - forbidden",
+			err: &apierrors.StatusError{
+				ErrStatus: metav1.Status{
+					Code:    http.StatusForbidden,
+					Message: "forbidden",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "non-webhook error - conflict",
+			err: &apierrors.StatusError{
+				ErrStatus: metav1.Status{
+					Code:    http.StatusConflict,
+					Message: "conflict",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "non-webhook error - not found",
+			err: &apierrors.StatusError{
+				ErrStatus: metav1.Status{
+					Code:    http.StatusNotFound,
+					Message: "not found",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "webhook timeout error - with additional context",
+			err: &apierrors.StatusError{
+				ErrStatus: metav1.Status{
+					Code:    http.StatusInternalServerError,
+					Message: "failed calling webhook: timeout",
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "webhook timeout error - with error details",
+			err: &apierrors.StatusError{
+				ErrStatus: metav1.Status{
+					Code:    http.StatusInternalServerError,
+					Message: "admission webhook \"example.com\" failed: timeout",
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "non-webhook error - timeout in different context",
+			err: &apierrors.StatusError{
+				ErrStatus: metav1.Status{
+					Code:    http.StatusInternalServerError,
+					Message: "operation completed successfully, no timeout",
+				},
+			},
+			expected: true, // Contains "timeout" substring, so it should match
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsWebhookTimeout(tt.err)
+			if result != tt.expected {
+				t.Errorf("IsWebhookTimeout() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Add exponential backoff retry logic to the TaskRun controller for pod creation, providing better resilience against transient webhook timeout errors while maintaining immediate failure for permanent errors.

Reference: https://github.com/tektoncd/pipeline/pull/8902#issuecomment-3114629246

/kind feature

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Introduced **exponential backoff retry** mechanism for `createPod` function to improve robustness against transient webhook issues in a heavy cluster during resource creation.
```
