### PR TITLE
fix(#8940): token-authentication header typo in git resolver

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,7 +77,7 @@ jobs:
     - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5  # v5.5.0
       with:
         go-version-file: "go.mod"
-    - name: build
+    - name: unit-test
       run: |
         make test-unit-verbose-and-race
   generated:

--- a/examples/v1/pipelineruns/no-ci/git-resolver-custom-secret.yaml
+++ b/examples/v1/pipelineruns/no-ci/git-resolver-custom-secret.yaml
@@ -31,9 +31,11 @@ spec:
             # my-secret-token should be created in the namespace where the
             # pipelinerun is created and contain a GitHub personal access
             # token in the token key of the secret.
-            - name: token
+            # Can be created with the command:
+            #  kubectl create secret generic my-secret-token --from-literal token=$RAW_TOKEN
+            - name: gitToken
               value: my-secret-token
-            - name: tokenKey
+            - name: gitTokenKey
               value: token
         params:
           - name: url

--- a/pkg/resolution/resolver/git/repository_test.go
+++ b/pkg/resolution/resolver/git/repository_test.go
@@ -71,7 +71,7 @@ func TestClone(t *testing.T) {
 			if test.username != "" {
 				token := base64.URLEncoding.EncodeToString([]byte(test.username + ":" + test.password))
 				expectedCmd = append(expectedCmd, "--config-env", "http.extraHeader=GIT_AUTH_HEADER")
-				expectedEnv = append(expectedEnv, "GIT_AUTH_HEADER=Authorization=Basic "+token)
+				expectedEnv = append(expectedEnv, "GIT_AUTH_HEADER=Authorization: Basic "+token)
 			}
 			expectedCmd = append(expectedCmd, "clone", test.url, repo.directory, "--depth=1", "--no-checkout")
 

--- a/test/resolvers_test.go
+++ b/test/resolvers_test.go
@@ -471,6 +471,59 @@ spec:
 	}
 }
 
+func TestGitResolver_HTTPAuth(t *testing.T) {
+	ctx := t.Context()
+	c, namespace := setup(ctx, t, gitFeatureFlags)
+
+	t.Parallel()
+
+	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
+	defer tearDown(ctx, t, c, namespace)
+
+	giteaClusterHostname, tokenSecretName := setupGitea(ctx, t, c, namespace)
+
+	requestUrl := fmt.Sprintf("http://%s/%s/%s", net.JoinHostPort(giteaClusterHostname, "3000"), scmRemoteOrg, scmRemoteRepo)
+
+	trName := helpers.ObjectNameForTest(t)
+	tr := parse.MustParseV1TaskRun(t, fmt.Sprintf(`
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  taskRef:
+    resolver: git
+    params:
+    - name: url
+      value: %s
+    - name: revision
+      value: %s
+    - name: pathInRepo
+      value: %s
+    - name: gitToken
+      value: %s
+    - name: gitTokenKey
+      value: %s
+`,
+		trName,
+		namespace,
+		requestUrl,
+		scmRemoteBranch,
+		scmRemoteTaskPath,
+		tokenSecretName,
+		scmTokenSecretKey,
+	))
+
+	_, err := c.V1TaskRunClient.Create(ctx, tr, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create TaskRun: %v", err)
+	}
+
+	t.Logf("Waiting for TaskRun %s in namespace %s to complete", trName, namespace)
+	if err := WaitForTaskRunState(ctx, c, trName, TaskRunSucceed(trName), "TaskRunSuccess", v1Version); err != nil {
+		t.Fatalf("Error waiting for TaskRun %s to finish: %s", trName, err)
+	}
+}
+
 func TestGitResolver_API(t *testing.T) {
 	ctx := t.Context()
 	c, namespace := setup(ctx, t, gitFeatureFlags)
@@ -699,7 +752,7 @@ spec:
 		},
 		Type: corev1.SecretTypeOpaque,
 		Data: map[string][]byte{
-			scmTokenSecretKey: []byte(base64.StdEncoding.Strict().EncodeToString([]byte(token))),
+			scmTokenSecretKey: []byte(token),
 		},
 	}, metav1.CreateOptions{})
 
@@ -743,6 +796,7 @@ spec:
 
 		_, _, err = giteaClient.CreateOrgRepo(scmRemoteOrg, gitea.CreateRepoOption{
 			Name:          scmRemoteRepo,
+			Private:       true,
 			AutoInit:      true,
 			DefaultBranch: scmRemoteBranch,
 		})


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

The header specified for the git resolver's http auth contained a typo
leading to authentication tokens not being properly sent to the remote.
This change fixes the typo in the header and also ensures the auth
setting is present for all git operations instead of just `clone`, since other
operations such as `fetch` may require remote authentication.

Additionally, this change fixes the outdated token-authenticated git
resolver example and adds an e2e regression test for authenticated git
cloning.

Resolves: https://github.com/tektoncd/pipeline/issues/8940
Resolves: https://issues.redhat.com/browse/SRVKP-8260

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Bug fix: Before this change, there was a regression in which the git resolver was not authenticating with the provided `gitToken` and `gitTokenKey`, breaking the git resolver's http token-based auth. After this change, all git operations performed by the git resolver use the provided `gitToken` for remote authentication.
```
