### PR TITLE
fix nightly-build workflow to use kind setup action from allowed list

### DIFF
--- a/.github/workflows/nightly-builds.yaml
+++ b/.github/workflows/nightly-builds.yaml
@@ -9,7 +9,7 @@ on:
       kubernetes_version:
         description: 'Kubernetes version to test with'
         required: false
-        default: 'v1.33.0'
+        default: 'v1.33.x'
       nightly_bucket:
         description: 'Nightly bucket for builds'
         required: false
@@ -17,7 +17,7 @@ on:
         type: string
 
 env:
-  KUBERNETES_VERSION: ${{ inputs.kubernetes_version || 'v1.33.0' }}
+  KUBERNETES_VERSION: ${{ inputs.kubernetes_version || 'v1.33.x' }}
   REGISTRY: ghcr.io
   PACKAGE: github.com/${{ github.repository }}
   BUCKET: ${{ inputs.nightly_bucket || 'gs://tekton-releases-nightly/pipeline' }}
@@ -26,7 +26,7 @@ env:
 
 jobs:
   build:
-    name: Nightly Build (K8s ${{ inputs.kubernetes_version || 'v1.33.0' }})
+    name: Nightly Build (K8s ${{ inputs.kubernetes_version || 'v1.33.x' }})
     runs-on: ubuntu-latest
 
     permissions:
@@ -49,10 +49,9 @@ jobs:
           echo "latest_sha=${latest_sha}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Kind cluster
-        uses: helm/kind-action@v1.8.0
+        uses: chainguard-dev/actions/setup-kind@v1.4.6
         with:
-          node_image: kindest/node:${{ env.KUBERNETES_VERSION }}
-          cluster_name: tekton-nightly
+          k8s-version: ${{ env.KUBERNETES_VERSION }}
 
       - name: Set up Tekton
         uses: tektoncd/actions/setup-tektoncd@main


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR updates the `nightly-builds.yaml` workflow to comply with the TektonCD action allowlist policy. 
**Error Info:** https://github.com/tektoncd/pipeline/actions/runs/16665724667

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [X] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [X] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [X] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [X] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [X] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [X] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [X] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [X] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
