### PR TITLE
[release-v1.0.x] fix(#8940): token-authentication header typo in git resolver

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,7 +77,7 @@ jobs:
     - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b  # v5.4.0
       with:
         go-version-file: "go.mod"
-    - name: build
+    - name: unit-test
       run: |
         make test-unit-verbose-and-race
   generated:

--- a/examples/v1/pipelineruns/no-ci/git-resolver-custom-secret.yaml
+++ b/examples/v1/pipelineruns/no-ci/git-resolver-custom-secret.yaml
@@ -31,9 +31,11 @@ spec:
             # my-secret-token should be created in the namespace where the
             # pipelinerun is created and contain a GitHub personal access
             # token in the token key of the secret.
-            - name: token
+            # Can be created with the command:
+            #  kubectl create secret generic my-secret-token --from-literal token=$RAW_TOKEN
+            - name: gitToken
               value: my-secret-token
-            - name: tokenKey
+            - name: gitTokenKey
               value: token
         params:
           - name: url

--- a/pkg/resolution/resolver/git/repository_test.go
+++ b/pkg/resolution/resolver/git/repository_test.go
@@ -71,7 +71,7 @@ func TestClone(t *testing.T) {
 			if test.username != "" {
 				token := base64.URLEncoding.EncodeToString([]byte(test.username + ":" + test.password))
 				expectedCmd = append(expectedCmd, "--config-env", "http.extraHeader=GIT_AUTH_HEADER")
-				expectedEnv = append(expectedEnv, "GIT_AUTH_HEADER=Authorization=Basic "+token)
+				expectedEnv = append(expectedEnv, "GIT_AUTH_HEADER=Authorization: Basic "+token)
 			}
 			expectedCmd = append(expectedCmd, "clone", test.url, repo.directory, "--depth=1", "--no-checkout")
 

--- a/test/resolvers_test.go
+++ b/test/resolvers_test.go
@@ -472,7 +472,7 @@ spec:
 }
 
 func TestGitResolver_HTTPAuth(t *testing.T) {
-	ctx := t.Context()
+	ctx := context.Background()
 	c, namespace := setup(ctx, t, gitFeatureFlags)
 
 	t.Parallel()


### PR DESCRIPTION
This is an ~automated~ cherry-pick of https://github.com/tektoncd/pipeline/pull/8937

/assign waveywaves


---

The automated cherry-pick includes a change which is incompatible with the go version of v1.0 (Go v1.23). This change includes the cherry-pick and a patch commit to resolve the go-version compatibility, since I cannot push to the automated cherry-pick branch in [tekton-robot's fork](https://github.com/tekton-robot/pipeline/tree/cherry-pick-8937-to-release-v1.0.x)
Supersedes #8941

---

```release-note
Bug fix: Before this change, there was a regression in which the git resolver was not authenticating with the provided `gitToken` and `gitTokenKey`, breaking the git resolver's http token-based auth. After this change, all git operations performed by the git resolver use the provided `gitToken` for remote authentication.
```