### PR TITLE
fix: exclude pending PipelineRuns from `tekton_pipelines_controller_running_pipelineruns` metric

### DIFF
--- a/pkg/pipelinerunmetrics/metrics.go
+++ b/pkg/pipelinerunmetrics/metrics.go
@@ -412,7 +412,7 @@ func (r *Recorder) RunningPipelineRuns(lister listers.PipelineRunLister) error {
 		if err_ != nil {
 			return err
 		}
-		if !pr.IsDone() {
+		if !pr.IsDone() && !pr.IsPending() {
 			countMap[pipelineRunKey]++
 			metrics.Record(ctx_, runningPRs.M(float64(countMap[pipelineRunKey])))
 			runningPipelineRuns++

--- a/pkg/pipelinerunmetrics/metrics_test.go
+++ b/pkg/pipelinerunmetrics/metrics_test.go
@@ -544,9 +544,12 @@ func TestRecordPipelineRunDurationCount(t *testing.T) {
 func TestRecordRunningPipelineRunsCount(t *testing.T) {
 	unregisterMetrics()
 
-	newPipelineRun := func(status corev1.ConditionStatus) *v1.PipelineRun {
+	newPipelineRun := func(status corev1.ConditionStatus, specStatus v1.PipelineRunSpecStatus) *v1.PipelineRun {
 		return &v1.PipelineRun{
 			ObjectMeta: metav1.ObjectMeta{Name: names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pipelinerun-")},
+			Spec: v1.PipelineRunSpec{
+				Status: specStatus,
+			},
 			Status: v1.PipelineRunStatus{
 				Status: duckv1.Status{
 					Conditions: duckv1.Conditions{{
@@ -561,13 +564,18 @@ func TestRecordRunningPipelineRunsCount(t *testing.T) {
 	ctx, _ := ttesting.SetupFakeContext(t)
 	informer := fakepipelineruninformer.Get(ctx)
 	// Add N randomly-named PipelineRuns with differently-succeeded statuses.
-	for _, tr := range []*v1.PipelineRun{
-		newPipelineRun(corev1.ConditionTrue),
-		newPipelineRun(corev1.ConditionUnknown),
-		newPipelineRun(corev1.ConditionFalse),
+	for _, pr := range []*v1.PipelineRun{
+		// Completed PipelineRun - should NOT be counted as running
+		newPipelineRun(corev1.ConditionTrue, ""),
+		// Actually running PipelineRun - should be counted as running
+		newPipelineRun(corev1.ConditionUnknown, ""),
+		// Pending PipelineRun - should NOT be counted as running
+		newPipelineRun(corev1.ConditionUnknown, v1.PipelineRunSpecStatusPending),
+		// Failed PipelineRun - should NOT be counted as running
+		newPipelineRun(corev1.ConditionFalse, ""),
 	} {
-		if err := informer.Informer().GetIndexer().Add(tr); err != nil {
-			t.Fatalf("Adding TaskRun to informer: %v", err)
+		if err := informer.Informer().GetIndexer().Add(pr); err != nil {
+			t.Fatalf("Adding PipelineRun to informer: %v", err)
 		}
 	}
 


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The running_pipelineruns metric incorrectly counted pending PipelineRuns as running.
Add `!pr.IsPending()` check to exclude them.

Fixes #8949

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Fixed tekton_pipelines_controller_running_pipelineruns metric to exclude pending PipelineRuns, it now counts only running PipelineRuns
```
