### PR TITLE
refactor(tests): move helpers to new testing framework structure

### DIFF
--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/reconciler/apiserver"
 	"github.com/tektoncd/pipeline/pkg/reconciler/pipeline/dag"
 	"github.com/tektoncd/pipeline/pkg/reconciler/taskrun/resources"
+	testhelpers "github.com/tektoncd/pipeline/pkg/reconciler/testing"
 	"github.com/tektoncd/pipeline/pkg/remote"
 	resolutioncommon "github.com/tektoncd/pipeline/pkg/resolution/common"
 	"github.com/tektoncd/pipeline/pkg/trustedresources"
@@ -48,9 +49,7 @@ import (
 	logtesting "knative.dev/pkg/logging/testing"
 )
 
-func nopGetCustomRun(string) (*v1beta1.CustomRun, error) {
-	return nil, errors.New("GetRun should not be called")
-}
+var nopGetCustomRun = testhelpers.NopGetCustomRun
 
 func nopGetTask(context.Context, string) (*v1.Task, *v1.RefSource, *trustedresources.VerificationResult, error) {
 	return nil, nil, nil, errors.New("GetTask should not be called")
@@ -70,7 +69,7 @@ func nopGetPipeline(context.Context, string) (*v1.Pipeline, *v1.RefSource, *trus
 
 func getTaskFn(vr *trustedresources.VerificationResult, err error) resources.GetTask {
 	return func(_ context.Context, name string) (*v1.Task, *v1.RefSource, *trustedresources.VerificationResult, error) {
-		return task, nil, vr, err
+		return testhelpers.ExampleTask, nil, vr, err
 	}
 }
 
@@ -237,47 +236,6 @@ var pts = []v1.PipelineTask{{
 	},
 }}
 
-var p = &v1.Pipeline{
-	ObjectMeta: metav1.ObjectMeta{
-		Namespace: "namespace",
-		Name:      "pipeline",
-	},
-	Spec: v1.PipelineSpec{
-		Tasks: pts,
-	},
-}
-
-var task = &v1.Task{
-	ObjectMeta: metav1.ObjectMeta{
-		Name: "task",
-	},
-	Spec: v1.TaskSpec{
-		Steps: []v1.Step{{
-			Name: "step1",
-		}},
-	},
-}
-
-var trs = []v1.TaskRun{{
-	ObjectMeta: metav1.ObjectMeta{
-		Namespace: "namespace",
-		Name:      "pipelinerun-mytask1",
-	},
-	Spec: v1.TaskRunSpec{},
-}, {
-	ObjectMeta: metav1.ObjectMeta{
-		Namespace: "namespace",
-		Name:      "pipelinerun-mytask2",
-	},
-	Spec: v1.TaskRunSpec{},
-}, {
-	ObjectMeta: metav1.ObjectMeta{
-		Namespace: "namespace",
-		Name:      "pipelinerun-mytask4",
-	},
-	Spec: v1.TaskRunSpec{},
-}}
-
 var customRuns = []v1beta1.CustomRun{{
 	ObjectMeta: metav1.ObjectMeta{
 		Namespace: "namespace",
@@ -332,11 +290,45 @@ var matrixedPipelineTask = &v1.PipelineTask{
 	},
 }
 
-func makeScheduled(tr v1.TaskRun) *v1.TaskRun {
-	newTr := newTaskRun(tr)
-	newTr.Status = v1.TaskRunStatus{ /* explicitly empty */ }
-	return newTr
-}
+var (
+	makeScheduled = func(tr v1.TaskRun) *v1.TaskRun {
+		return testhelpers.MakeScheduled(tr, testhelpers.NewTaskRun)
+	}
+	makeStarted = func(tr v1.TaskRun) *v1.TaskRun {
+		return testhelpers.MakeStarted(tr, testhelpers.NewTaskRun)
+	}
+	makeCustomRunStarted = func(run v1beta1.CustomRun) *v1beta1.CustomRun {
+		return testhelpers.MakeCustomRunStarted(run, testhelpers.NewCustomRun)
+	}
+	makeSucceeded = func(tr v1.TaskRun) *v1.TaskRun {
+		return testhelpers.MakeSucceeded(tr, testhelpers.NewTaskRun)
+	}
+	makeCustomRunSucceeded = func(run v1beta1.CustomRun) *v1beta1.CustomRun {
+		return testhelpers.MakeCustomRunSucceeded(run, testhelpers.NewCustomRun)
+	}
+	makeFailed = func(tr v1.TaskRun) *v1.TaskRun {
+		return testhelpers.MakeFailed(tr, testhelpers.NewTaskRun)
+	}
+	makeToBeRetried = func(tr v1.TaskRun) *v1.TaskRun {
+		return testhelpers.MakeToBeRetried(tr, testhelpers.NewTaskRun)
+	}
+	makeCustomRunFailed = func(run v1beta1.CustomRun) *v1beta1.CustomRun {
+		return testhelpers.MakeCustomRunFailed(run, testhelpers.NewCustomRun)
+	}
+	withCancelled                    = testhelpers.WithCancelled
+	withCancelledForTimeout          = testhelpers.WithCancelledForTimeout
+	withCustomRunCancelled           = testhelpers.WithCustomRunCancelled
+	withCustomRunCancelledForTimeout = testhelpers.WithCustomRunCancelledForTimeout
+	withCancelledBySpec              = testhelpers.WithCancelledBySpec
+	withCustomRunCancelledBySpec     = testhelpers.WithCustomRunCancelledBySpec
+	makeRetried                      = func(tr v1.TaskRun) *v1.TaskRun {
+		return testhelpers.MakeRetried(tr, testhelpers.NewTaskRun, testhelpers.WithRetries)
+	}
+	withRetries          = testhelpers.WithRetries
+	withCustomRunRetries = testhelpers.WithCustomRunRetries
+	newTaskRun           = testhelpers.NewTaskRun
+	newCustomRun         = testhelpers.NewCustomRun
+)
 
 func makePipelineRunScheduled(pr v1.PipelineRun) *v1.PipelineRun {
 	newPr := newPipelineRun(pr)
@@ -344,36 +336,10 @@ func makePipelineRunScheduled(pr v1.PipelineRun) *v1.PipelineRun {
 	return newPr
 }
 
-func makeStarted(tr v1.TaskRun) *v1.TaskRun {
-	newTr := newTaskRun(tr)
-	newTr.Status.Conditions[0].Status = corev1.ConditionUnknown
-	return newTr
-}
-
-func makeCustomRunStarted(run v1beta1.CustomRun) *v1beta1.CustomRun {
-	newRun := newCustomRun(run)
-	newRun.Status.Conditions[0].Status = corev1.ConditionUnknown
-	return newRun
-}
-
 func makePipelineRunStarted(pr v1.PipelineRun) *v1.PipelineRun {
 	newPr := newPipelineRun(pr)
 	newPr.Status.Conditions[0].Status = corev1.ConditionUnknown
 	return newPr
-}
-
-func makeSucceeded(tr v1.TaskRun) *v1.TaskRun {
-	newTr := newTaskRun(tr)
-	newTr.Status.Conditions[0].Status = corev1.ConditionTrue
-	newTr.Status.Conditions[0].Reason = "Succeeded"
-	return newTr
-}
-
-func makeCustomRunSucceeded(run v1beta1.CustomRun) *v1beta1.CustomRun {
-	newRun := newCustomRun(run)
-	newRun.Status.Conditions[0].Status = corev1.ConditionTrue
-	newRun.Status.Conditions[0].Reason = "Succeeded"
-	return newRun
 }
 
 func makePipelineRunSucceeded(pr v1.PipelineRun) *v1.PipelineRun {
@@ -383,27 +349,6 @@ func makePipelineRunSucceeded(pr v1.PipelineRun) *v1.PipelineRun {
 	return newPr
 }
 
-func makeFailed(tr v1.TaskRun) *v1.TaskRun {
-	newTr := newTaskRun(tr)
-	newTr.Status.Conditions[0].Status = corev1.ConditionFalse
-	newTr.Status.Conditions[0].Reason = "Failed"
-	return newTr
-}
-
-func makeToBeRetried(tr v1.TaskRun) *v1.TaskRun {
-	newTr := newTaskRun(tr)
-	newTr.Status.Conditions[0].Status = corev1.ConditionUnknown
-	newTr.Status.Conditions[0].Reason = v1.TaskRunReasonToBeRetried.String()
-	return newTr
-}
-
-func makeCustomRunFailed(run v1beta1.CustomRun) *v1beta1.CustomRun {
-	newRun := newCustomRun(run)
-	newRun.Status.Conditions[0].Status = corev1.ConditionFalse
-	newRun.Status.Conditions[0].Reason = "Failed"
-	return newRun
-}
-
 func makePipelineRunFailed(pr v1.PipelineRun) *v1.PipelineRun {
 	newPr := newPipelineRun(pr)
 	newPr.Status.Conditions[0].Status = corev1.ConditionFalse
@@ -411,101 +356,9 @@ func makePipelineRunFailed(pr v1.PipelineRun) *v1.PipelineRun {
 	return newPr
 }
 
-func withCancelled(tr *v1.TaskRun) *v1.TaskRun {
-	tr.Status.Conditions[0].Reason = v1.TaskRunSpecStatusCancelled
-	return tr
-}
-
-func withCancelledForTimeout(tr *v1.TaskRun) *v1.TaskRun {
-	tr.Spec.StatusMessage = v1.TaskRunCancelledByPipelineTimeoutMsg
-	tr.Status.Conditions[0].Reason = v1.TaskRunSpecStatusCancelled
-	return tr
-}
-
-func withCustomRunCancelled(run *v1beta1.CustomRun) *v1beta1.CustomRun {
-	run.Status.Conditions[0].Reason = v1beta1.CustomRunReasonCancelled.String()
-	return run
-}
-
-func withCustomRunCancelledForTimeout(run *v1beta1.CustomRun) *v1beta1.CustomRun {
-	run.Spec.StatusMessage = v1beta1.CustomRunCancelledByPipelineTimeoutMsg
-	run.Status.Conditions[0].Reason = v1beta1.CustomRunReasonCancelled.String()
-	return run
-}
-
-func withCancelledBySpec(tr *v1.TaskRun) *v1.TaskRun {
-	tr.Spec.Status = v1.TaskRunSpecStatusCancelled
-	return tr
-}
-
-func withCustomRunCancelledBySpec(run *v1beta1.CustomRun) *v1beta1.CustomRun {
-	run.Spec.Status = v1beta1.CustomRunSpecStatusCancelled
-	return run
-}
-
-func makeRetried(tr v1.TaskRun) (newTr *v1.TaskRun) {
-	newTr = newTaskRun(tr)
-	newTr = withRetries(newTr)
-	return
-}
-
-func withRetries(tr *v1.TaskRun) *v1.TaskRun {
-	tr.Status.RetriesStatus = []v1.TaskRunStatus{{
-		Status: duckv1.Status{
-			Conditions: []apis.Condition{{
-				Type:   apis.ConditionSucceeded,
-				Status: corev1.ConditionFalse,
-			}},
-		},
-	}}
-	return tr
-}
-
-func withCustomRunRetries(r *v1beta1.CustomRun) *v1beta1.CustomRun {
-	r.Status.RetriesStatus = []v1beta1.CustomRunStatus{{
-		Status: duckv1.Status{
-			Conditions: []apis.Condition{{
-				Type:   apis.ConditionSucceeded,
-				Status: corev1.ConditionFalse,
-			}},
-		},
-	}}
-	return r
-}
-
-func newTaskRun(tr v1.TaskRun) *v1.TaskRun {
-	return &v1.TaskRun{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: tr.Namespace,
-			Name:      tr.Name,
-		},
-		Spec: tr.Spec,
-		Status: v1.TaskRunStatus{
-			Status: duckv1.Status{
-				Conditions: []apis.Condition{{Type: apis.ConditionSucceeded}},
-			},
-		},
-	}
-}
-
 func withPipelineTaskRetries(pt v1.PipelineTask, retries int) *v1.PipelineTask {
 	pt.Retries = retries
 	return &pt
-}
-
-func newCustomRun(run v1beta1.CustomRun) *v1beta1.CustomRun {
-	return &v1beta1.CustomRun{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: run.Namespace,
-			Name:      run.Name,
-		},
-		Spec: run.Spec,
-		Status: v1beta1.CustomRunStatus{
-			Status: duckv1.Status{
-				Conditions: []apis.Condition{{Type: apis.ConditionSucceeded}},
-			},
-		},
-	}
 }
 
 func newPipelineRun(pr v1.PipelineRun) *v1.PipelineRun {
@@ -528,94 +381,94 @@ var noneStartedState = PipelineRunState{{
 	TaskRunNames: []string{"pipelinerun-mytask1"},
 	TaskRuns:     nil,
 	ResolvedTask: &resources.ResolvedTask{
-		TaskSpec: &task.Spec,
+		TaskSpec: &testhelpers.ExampleTask.Spec,
 	},
 }, {
 	PipelineTask: &pts[1],
 	TaskRunNames: []string{"pipelinerun-mytask2"},
 	TaskRuns:     nil,
 	ResolvedTask: &resources.ResolvedTask{
-		TaskSpec: &task.Spec,
+		TaskSpec: &testhelpers.ExampleTask.Spec,
 	},
 }}
 
 var oneStartedState = PipelineRunState{{
 	PipelineTask: &pts[0],
 	TaskRunNames: []string{"pipelinerun-mytask1"},
-	TaskRuns:     []*v1.TaskRun{makeStarted(trs[0])},
+	TaskRuns:     []*v1.TaskRun{makeStarted(testhelpers.ExampleTaskRuns[0])},
 	ResolvedTask: &resources.ResolvedTask{
-		TaskSpec: &task.Spec,
+		TaskSpec: &testhelpers.ExampleTask.Spec,
 	},
 }, {
 	PipelineTask: &pts[1],
 	TaskRunNames: []string{"pipelinerun-mytask2"},
 	TaskRuns:     nil,
 	ResolvedTask: &resources.ResolvedTask{
-		TaskSpec: &task.Spec,
+		TaskSpec: &testhelpers.ExampleTask.Spec,
 	},
 }}
 
 var oneFinishedState = PipelineRunState{{
 	PipelineTask: &pts[0],
 	TaskRunNames: []string{"pipelinerun-mytask1"},
-	TaskRuns:     []*v1.TaskRun{makeSucceeded(trs[0])},
+	TaskRuns:     []*v1.TaskRun{makeSucceeded(testhelpers.ExampleTaskRuns[0])},
 	ResolvedTask: &resources.ResolvedTask{
-		TaskSpec: &task.Spec,
+		TaskSpec: &testhelpers.ExampleTask.Spec,
 	},
 }, {
 	PipelineTask: &pts[1],
 	TaskRunNames: []string{"pipelinerun-mytask2"},
 	TaskRuns:     nil,
 	ResolvedTask: &resources.ResolvedTask{
-		TaskSpec: &task.Spec,
+		TaskSpec: &testhelpers.ExampleTask.Spec,
 	},
 }}
 
 var oneFailedState = PipelineRunState{{
 	PipelineTask: &pts[0],
 	TaskRunNames: []string{"pipelinerun-mytask1"},
-	TaskRuns:     []*v1.TaskRun{makeFailed(trs[0])},
+	TaskRuns:     []*v1.TaskRun{makeFailed(testhelpers.ExampleTaskRuns[0])},
 	ResolvedTask: &resources.ResolvedTask{
-		TaskSpec: &task.Spec,
+		TaskSpec: &testhelpers.ExampleTask.Spec,
 	},
 }, {
 	PipelineTask: &pts[1],
 	TaskRunNames: []string{"pipelinerun-mytask2"},
 	TaskRuns:     nil,
 	ResolvedTask: &resources.ResolvedTask{
-		TaskSpec: &task.Spec,
+		TaskSpec: &testhelpers.ExampleTask.Spec,
 	},
 }}
 
 var finalScheduledState = PipelineRunState{{
 	PipelineTask: &pts[0],
 	TaskRunNames: []string{"pipelinerun-mytask1"},
-	TaskRuns:     []*v1.TaskRun{makeSucceeded(trs[0])},
+	TaskRuns:     []*v1.TaskRun{makeSucceeded(testhelpers.ExampleTaskRuns[0])},
 	ResolvedTask: &resources.ResolvedTask{
-		TaskSpec: &task.Spec,
+		TaskSpec: &testhelpers.ExampleTask.Spec,
 	},
 }, {
 	PipelineTask: &pts[1],
 	TaskRunNames: []string{"pipelinerun-mytask2"},
-	TaskRuns:     []*v1.TaskRun{makeScheduled(trs[1])},
+	TaskRuns:     []*v1.TaskRun{makeScheduled(testhelpers.ExampleTaskRuns[1])},
 	ResolvedTask: &resources.ResolvedTask{
-		TaskSpec: &task.Spec,
+		TaskSpec: &testhelpers.ExampleTask.Spec,
 	},
 }}
 
 var allFinishedState = PipelineRunState{{
 	PipelineTask: &pts[0],
 	TaskRunNames: []string{"pipelinerun-mytask1"},
-	TaskRuns:     []*v1.TaskRun{makeSucceeded(trs[0])},
+	TaskRuns:     []*v1.TaskRun{makeSucceeded(testhelpers.ExampleTaskRuns[0])},
 	ResolvedTask: &resources.ResolvedTask{
-		TaskSpec: &task.Spec,
+		TaskSpec: &testhelpers.ExampleTask.Spec,
 	},
 }, {
 	PipelineTask: &pts[1],
 	TaskRunNames: []string{"pipelinerun-mytask2"},
-	TaskRuns:     []*v1.TaskRun{makeSucceeded(trs[0])},
+	TaskRuns:     []*v1.TaskRun{makeSucceeded(testhelpers.ExampleTaskRuns[0])},
 	ResolvedTask: &resources.ResolvedTask{
-		TaskSpec: &task.Spec,
+		TaskSpec: &testhelpers.ExampleTask.Spec,
 	},
 }}
 
@@ -670,9 +523,9 @@ var oneCustomRunFailedState = PipelineRunState{{
 var taskCancelled = PipelineRunState{{
 	PipelineTask: &pts[4],
 	TaskRunNames: []string{"pipelinerun-mytask1"},
-	TaskRuns:     []*v1.TaskRun{withCancelled(makeRetried(trs[0]))},
+	TaskRuns:     []*v1.TaskRun{withCancelled(makeRetried(testhelpers.ExampleTaskRuns[0]))},
 	ResolvedTask: &resources.ResolvedTask{
-		TaskSpec: &task.Spec,
+		TaskSpec: &testhelpers.ExampleTask.Spec,
 	},
 }}
 
@@ -687,94 +540,94 @@ var noneStartedStateMatrix = PipelineRunState{{
 	TaskRunNames: []string{"pipelinerun-mytask1"},
 	TaskRuns:     nil,
 	ResolvedTask: &resources.ResolvedTask{
-		TaskSpec: &task.Spec,
+		TaskSpec: &testhelpers.ExampleTask.Spec,
 	},
 }, {
 	PipelineTask: &pts[16],
 	TaskRunNames: []string{"pipelinerun-mytask3"},
 	TaskRuns:     nil,
 	ResolvedTask: &resources.ResolvedTask{
-		TaskSpec: &task.Spec,
+		TaskSpec: &testhelpers.ExampleTask.Spec,
 	},
 }}
 
 var oneStartedStateMatrix = PipelineRunState{{
 	PipelineTask: &pts[15],
 	TaskRunNames: []string{"pipelinerun-mytask1"},
-	TaskRuns:     []*v1.TaskRun{makeStarted(trs[0])},
+	TaskRuns:     []*v1.TaskRun{makeStarted(testhelpers.ExampleTaskRuns[0])},
 	ResolvedTask: &resources.ResolvedTask{
-		TaskSpec: &task.Spec,
+		TaskSpec: &testhelpers.ExampleTask.Spec,
 	},
 }, {
 	PipelineTask: &pts[16],
 	TaskRunNames: []string{"pipelinerun-mytask2"},
 	TaskRuns:     nil,
 	ResolvedTask: &resources.ResolvedTask{
-		TaskSpec: &task.Spec,
+		TaskSpec: &testhelpers.ExampleTask.Spec,
 	},
 }}
 
 var oneFinishedStateMatrix = PipelineRunState{{
 	PipelineTask: &pts[15],
 	TaskRunNames: []string{"pipelinerun-mytask1"},
-	TaskRuns:     []*v1.TaskRun{makeSucceeded(trs[0])},
+	TaskRuns:     []*v1.TaskRun{makeSucceeded(testhelpers.ExampleTaskRuns[0])},
 	ResolvedTask: &resources.ResolvedTask{
-		TaskSpec: &task.Spec,
+		TaskSpec: &testhelpers.ExampleTask.Spec,
 	},
 }, {
 	PipelineTask: &pts[16],
 	TaskRunNames: []string{"pipelinerun-mytask2"},
 	TaskRuns:     nil,
 	ResolvedTask: &resources.ResolvedTask{
-		TaskSpec: &task.Spec,
+		TaskSpec: &testhelpers.ExampleTask.Spec,
 	},
 }}
 
 var oneFailedStateMatrix = PipelineRunState{{
 	PipelineTask: &pts[15],
 	TaskRunNames: []string{"pipelinerun-mytask1"},
-	TaskRuns:     []*v1.TaskRun{makeFailed(trs[0])},
+	TaskRuns:     []*v1.TaskRun{makeFailed(testhelpers.ExampleTaskRuns[0])},
 	ResolvedTask: &resources.ResolvedTask{
-		TaskSpec: &task.Spec,
+		TaskSpec: &testhelpers.ExampleTask.Spec,
 	},
 }, {
 	PipelineTask: &pts[16],
 	TaskRunNames: []string{"pipelinerun-mytask2"},
 	TaskRuns:     nil,
 	ResolvedTask: &resources.ResolvedTask{
-		TaskSpec: &task.Spec,
+		TaskSpec: &testhelpers.ExampleTask.Spec,
 	},
 }}
 
 var finalScheduledStateMatrix = PipelineRunState{{
 	PipelineTask: &pts[15],
 	TaskRunNames: []string{"pipelinerun-mytask1"},
-	TaskRuns:     []*v1.TaskRun{makeSucceeded(trs[0])},
+	TaskRuns:     []*v1.TaskRun{makeSucceeded(testhelpers.ExampleTaskRuns[0])},
 	ResolvedTask: &resources.ResolvedTask{
-		TaskSpec: &task.Spec,
+		TaskSpec: &testhelpers.ExampleTask.Spec,
 	},
 }, {
 	PipelineTask: &pts[16],
 	TaskRunNames: []string{"pipelinerun-mytask2"},
-	TaskRuns:     []*v1.TaskRun{makeScheduled(trs[1])},
+	TaskRuns:     []*v1.TaskRun{makeScheduled(testhelpers.ExampleTaskRuns[1])},
 	ResolvedTask: &resources.ResolvedTask{
-		TaskSpec: &task.Spec,
+		TaskSpec: &testhelpers.ExampleTask.Spec,
 	},
 }}
 
 var allFinishedStateMatrix = PipelineRunState{{
 	PipelineTask: &pts[15],
 	TaskRunNames: []string{"pipelinerun-mytask1"},
-	TaskRuns:     []*v1.TaskRun{makeSucceeded(trs[0])},
+	TaskRuns:     []*v1.TaskRun{makeSucceeded(testhelpers.ExampleTaskRuns[0])},
 	ResolvedTask: &resources.ResolvedTask{
-		TaskSpec: &task.Spec,
+		TaskSpec: &testhelpers.ExampleTask.Spec,
 	},
 }, {
 	PipelineTask: &pts[16],
 	TaskRunNames: []string{"pipelinerun-mytask2"},
-	TaskRuns:     []*v1.TaskRun{makeSucceeded(trs[0])},
+	TaskRuns:     []*v1.TaskRun{makeSucceeded(testhelpers.ExampleTaskRuns[0])},
 	ResolvedTask: &resources.ResolvedTask{
-		TaskSpec: &task.Spec,
+		TaskSpec: &testhelpers.ExampleTask.Spec,
 	},
 }}
 
@@ -817,9 +670,9 @@ var oneCustomRunFailedStateMatrix = PipelineRunState{{
 var taskCancelledMatrix = PipelineRunState{{
 	PipelineTask: &pts[20],
 	TaskRunNames: []string{"pipelinerun-mytask1"},
-	TaskRuns:     []*v1.TaskRun{withCancelled(makeRetried(trs[0]))},
+	TaskRuns:     []*v1.TaskRun{withCancelled(makeRetried(testhelpers.ExampleTaskRuns[0]))},
 	ResolvedTask: &resources.ResolvedTask{
-		TaskSpec: &task.Spec,
+		TaskSpec: &testhelpers.ExampleTask.Spec,
 	},
 }}
 
@@ -965,16 +818,16 @@ func TestIsSkipped(t *testing.T) {
 		state: PipelineRunState{{
 			PipelineTask: &pts[5],
 			TaskRunNames: []string{"pipelinerun-mytask1"},
-			TaskRuns:     []*v1.TaskRun{makeFailed(trs[0])},
+			TaskRuns:     []*v1.TaskRun{makeFailed(testhelpers.ExampleTaskRuns[0])},
 			ResolvedTask: &resources.ResolvedTask{
-				TaskSpec: &task.Spec,
+				TaskSpec: &testhelpers.ExampleTask.Spec,
 			},
 		}, {
 			PipelineTask: &pts[6], // mytask7 runAfter mytask6
 			TaskRunNames: []string{"pipelinerun-mytask2"},
 			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
-				TaskSpec: &task.Spec,
+				TaskSpec: &testhelpers.ExampleTask.Spec,
 			},
 		}},
 		expected: map[string]bool{
@@ -985,16 +838,16 @@ func TestIsSkipped(t *testing.T) {
 		state: PipelineRunState{{
 			PipelineTask: &pts[5],
 			TaskRunNames: []string{"pipelinerun-mytask1"},
-			TaskRuns:     []*v1.TaskRun{withCancelled(makeFailed(trs[0]))},
+			TaskRuns:     []*v1.TaskRun{withCancelled(makeFailed(testhelpers.ExampleTaskRuns[0]))},
 			ResolvedTask: &resources.ResolvedTask{
-				TaskSpec: &task.Spec,
+				TaskSpec: &testhelpers.ExampleTask.Spec,
 			},
 		}, {
 			PipelineTask: &pts[6], // mytask7 runAfter mytask6
 			TaskRunNames: []string{"pipelinerun-mytask2"},
 			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
-				TaskSpec: &task.Spec,
+				TaskSpec: &testhelpers.ExampleTask.Spec,
 			},
 		}},
 		expected: map[string]bool{
@@ -1005,16 +858,16 @@ func TestIsSkipped(t *testing.T) {
 		state: PipelineRunState{{
 			PipelineTask: &pts[5],
 			TaskRunNames: []string{"pipelinerun-mytask1"},
-			TaskRuns:     []*v1.TaskRun{makeFailed(trs[0])},
+			TaskRuns:     []*v1.TaskRun{makeFailed(testhelpers.ExampleTaskRuns[0])},
 			ResolvedTask: &resources.ResolvedTask{
-				TaskSpec: &task.Spec,
+				TaskSpec: &testhelpers.ExampleTask.Spec,
 			},
 		}, {
 			PipelineTask: &pts[6], // mytask7 runAfter mytask6
 			TaskRunNames: []string{"pipelinerun-mytask2"},
 			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
-				TaskSpec: &task.Spec,
+				TaskSpec: &testhelpers.ExampleTask.Spec,
 			},
 		}, {
 			PipelineTask: &v1.PipelineTask{
@@ -1025,7 +878,7 @@ func TestIsSkipped(t *testing.T) {
 			TaskRunNames: []string{"pipelinerun-mytask3"},
 			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
-				TaskSpec: &task.Spec,
+				TaskSpec: &testhelpers.ExampleTask.Spec,
 			},
 		}},
 		expected: map[string]bool{
@@ -1036,23 +889,23 @@ func TestIsSkipped(t *testing.T) {
 		state: PipelineRunState{{
 			PipelineTask: &pts[5],
 			TaskRunNames: []string{"pipelinerun-mytask1"},
-			TaskRuns:     []*v1.TaskRun{makeSucceeded(trs[0])},
+			TaskRuns:     []*v1.TaskRun{makeSucceeded(testhelpers.ExampleTaskRuns[0])},
 			ResolvedTask: &resources.ResolvedTask{
-				TaskSpec: &task.Spec,
+				TaskSpec: &testhelpers.ExampleTask.Spec,
 			},
 		}, {
 			PipelineTask: &pts[0],
 			TaskRunNames: []string{"pipelinerun-mytask2"},
-			TaskRuns:     []*v1.TaskRun{makeFailed(trs[0])},
+			TaskRuns:     []*v1.TaskRun{makeFailed(testhelpers.ExampleTaskRuns[0])},
 			ResolvedTask: &resources.ResolvedTask{
-				TaskSpec: &task.Spec,
+				TaskSpec: &testhelpers.ExampleTask.Spec,
 			},
 		}, {
 			PipelineTask: &pts[7], // mytask8 runAfter mytask1, mytask6
 			TaskRunNames: []string{"pipelinerun-mytask3"},
 			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
-				TaskSpec: &task.Spec,
+				TaskSpec: &testhelpers.ExampleTask.Spec,
 			},
 		}},
 		expected: map[string]bool{
@@ -1063,23 +916,23 @@ func TestIsSkipped(t *testing.T) {
 		state: PipelineRunState{{
 			PipelineTask: &pts[0],
 			TaskRunNames: []string{"pipelinerun-mytask1"},
-			TaskRuns:     []*v1.TaskRun{makeFailed(trs[0])},
+			TaskRuns:     []*v1.TaskRun{makeFailed(testhelpers.ExampleTaskRuns[0])},
 			ResolvedTask: &resources.ResolvedTask{
-				TaskSpec: &task.Spec,
+				TaskSpec: &testhelpers.ExampleTask.Spec,
 			},
 		}, {
 			PipelineTask: &pts[5],
 			TaskRunNames: []string{"pipelinerun-mytask2"},
-			TaskRuns:     []*v1.TaskRun{makeStarted(trs[1])},
+			TaskRuns:     []*v1.TaskRun{makeStarted(testhelpers.ExampleTaskRuns[1])},
 			ResolvedTask: &resources.ResolvedTask{
-				TaskSpec: &task.Spec,
+				TaskSpec: &testhelpers.ExampleTask.Spec,
 			},
 		}, {
 			PipelineTask: &pts[6], // mytask7 runAfter mytask6
 			TaskRunNames: []string{"pipelinerun-mytask3"},
 			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
-				TaskSpec: &task.Spec,
+				TaskSpec: &testhelpers.ExampleTask.Spec,
 			},
 		}},
 		expected: map[string]bool{
@@ -1092,7 +945,7 @@ func TestIsSkipped(t *testing.T) {
 			TaskRunNames: []string{"pipelinerun-guardedtask"},
 			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
-				TaskSpec: &task.Spec,
+				TaskSpec: &testhelpers.ExampleTask.Spec,
 			},
 		}},
 		expected: map[string]bool{
@@ -1105,7 +958,7 @@ func TestIsSkipped(t *testing.T) {
 			TaskRunNames: []string{"pipelinerun-guardedtask"},
 			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
-				TaskSpec: &task.Spec,
+				TaskSpec: &testhelpers.ExampleTask.Spec,
 			},
 		}},
 		expected: map[string]bool{
@@ -1117,13 +970,13 @@ func TestIsSkipped(t *testing.T) {
 			PipelineTask: &pts[0],
 			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
-				TaskSpec: &task.Spec,
+				TaskSpec: &testhelpers.ExampleTask.Spec,
 			},
 		}, {
 			PipelineTask: &pts[11],
 			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
-				TaskSpec: &task.Spec,
+				TaskSpec: &testhelpers.ExampleTask.Spec,
 			},
 		}},
 		expected: map[string]bool{
@@ -1149,7 +1002,7 @@ func TestIsSkipped(t *testing.T) {
 			TaskRunNames: []string{"pipelinerun-guardedtask"},
 			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
-				TaskSpec: &task.Spec,
+				TaskSpec: &testhelpers.ExampleTask.Spec,
 			},
 		}, {
 			// not skipped regardless of its parent task being skipped because when expressions are scoped to task
@@ -1161,7 +1014,7 @@ func TestIsSkipped(t *testing.T) {
 			TaskRunNames: []string{"pipelinerun-ordering-dependent-task-1"},
 			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
-				TaskSpec: &task.Spec,
+				TaskSpec: &testhelpers.ExampleTask.Spec,
 			},
 		}},
 		expected: map[string]bool{
@@ -1176,7 +1029,7 @@ func TestIsSkipped(t *testing.T) {
 			TaskRunNames: []string{"pipelinerun-guardedtask"},
 			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
-				TaskSpec: &task.Spec,
+				TaskSpec: &testhelpers.ExampleTask.Spec,
 			},
 		}, {
 			// not skipped regardless of its parent task being skipped because when expressions are scoped to task
@@ -1188,7 +1041,7 @@ func TestIsSkipped(t *testing.T) {
 			TaskRunNames: []string{"pipelinerun-ordering-dependent-task-1"},
 			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
-				TaskSpec: &task.Spec,
+				TaskSpec: &testhelpers.ExampleTask.Spec,
 			},
 		}, {
 			// not skipped regardless of its grandparent task being skipped because when expressions are scoped to task
@@ -1200,7 +1053,7 @@ func TestIsSkipped(t *testing.T) {
 			TaskRunNames: []string{"pipelinerun-ordering-dependent-task-2"},
 			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
-				TaskSpec: &task.Spec,
+				TaskSpec: &testhelpers.ExampleTask.Spec,
 			},
 		}},
 		expected: map[string]bool{
@@ -1216,7 +1069,7 @@ func TestIsSkipped(t *testing.T) {
 			TaskRunNames: []string{"pipelinerun-guardedtask"},
 			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
-				TaskSpec: &task.Spec,
+				TaskSpec: &testhelpers.ExampleTask.Spec,
 			},
 		}, {
 			// not skipped regardless of its parent task mytask11 being skipped because when expressions are scoped to task
@@ -1228,7 +1081,7 @@ func TestIsSkipped(t *testing.T) {
 			TaskRunNames: []string{"pipelinerun-ordering-dependent-task-1"},
 			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
-				TaskSpec: &task.Spec,
+				TaskSpec: &testhelpers.ExampleTask.Spec,
 			},
 		}, {
 			// not skipped regardless of its grandparent task mytask11 being skipped because when expressions are scoped to task
@@ -1240,7 +1093,7 @@ func TestIsSkipped(t *testing.T) {
 			TaskRunNames: []string{"pipelinerun-ordering-dependent-task-2"},
 			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
-				TaskSpec: &task.Spec,
+				TaskSpec: &testhelpers.ExampleTask.Spec,
 			},
 		}, {
 			// attempted but skipped because of missing result in params from parent task mytask11 which was skipped
@@ -1255,7 +1108,7 @@ func TestIsSkipped(t *testing.T) {
 			TaskRunNames: []string{"pipelinerun-resource-dependent-task-1"},
 			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
-				TaskSpec: &task.Spec,
+				TaskSpec: &testhelpers.ExampleTask.Spec,
 			},
 		}, {
 			// skipped because of parent task mytask20 was skipped because of missing result from grandparent task
@@ -1268,7 +1121,7 @@ func TestIsSkipped(t *testing.T) {
 			TaskRunNames: []string{"pipelinerun-ordering-dependent-task-3"},
 			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
-				TaskSpec: &task.Spec,
+				TaskSpec: &testhelpers.ExampleTask.Spec,
 			},
 		}, {
 			// attempted but skipped because of missing result from parent task mytask11 which was skipped in when expressions
@@ -1284,7 +1137,7 @@ func TestIsSkipped(t *testing.T) {
 			TaskRunNames: []string{"pipelinerun-resource-dependent-task-2"},
 			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
-				TaskSpec: &task.Spec,
+				TaskSpec: &testhelpers.ExampleTask.Spec,
 			},
 		}, {
 			// not skipped because of parent task mytask22 was skipping because when condition
@@ -1296,7 +1149,7 @@ func TestIsSkipped(t *testing.T) {
 			TaskRunNames: []string{"pipelinerun-ordering-dependent-task-4"},
 			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
-				TaskSpec: &task.Spec,
+				TaskSpec: &testhelpers.ExampleTask.Spec,
 			},
 		}},
 		expected: map[string]bool{
@@ -1364,7 +1217,7 @@ func TestIsSkipped(t *testing.T) {
 			TaskRunNames: []string{"pipelinerun-matrix-empty-params"},
 			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
-				TaskSpec: &task.Spec,
+				TaskSpec: &testhelpers.ExampleTask.Spec,
 			},
 		}, {
 			// skipped empty ArrayVal exist in matrix param
@@ -1384,7 +1237,7 @@ func TestIsSkipped(t *testing.T) {
 			TaskRunNames: []string{"pipelinerun-matrix-empty-params"},
 			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
-				TaskSpec: &task.Spec,
+				TaskSpec: &testhelpers.ExampleTask.Spec,
 			},
 		}, {
 			// skipped empty ArrayVal exist in matrix param
@@ -1410,7 +1263,7 @@ func TestIsSkipped(t *testing.T) {
 			TaskRunNames: []string{"pipelinerun-matrix-empty-params"},
 			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
-				TaskSpec: &task.Spec,
+				TaskSpec: &testhelpers.ExampleTask.Spec,
 			},
 		}},
 		expected: map[string]bool{
@@ -1485,7 +1338,7 @@ func TestIsFailure(t *testing.T) {
 		name: "taskrun running",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1.PipelineTask{Name: "task"},
-			TaskRuns:     []*v1.TaskRun{makeStarted(trs[0])},
+			TaskRuns:     []*v1.TaskRun{makeStarted(testhelpers.ExampleTaskRuns[0])},
 		},
 		want: false,
 	}, {
@@ -1507,7 +1360,7 @@ func TestIsFailure(t *testing.T) {
 		name: "taskrun succeeded",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1.PipelineTask{Name: "task"},
-			TaskRuns:     []*v1.TaskRun{makeSucceeded(trs[0])},
+			TaskRuns:     []*v1.TaskRun{makeSucceeded(testhelpers.ExampleTaskRuns[0])},
 		},
 		want: false,
 	}, {
@@ -1529,7 +1382,7 @@ func TestIsFailure(t *testing.T) {
 		name: "taskrun failed",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1.PipelineTask{Name: "task"},
-			TaskRuns:     []*v1.TaskRun{makeFailed(trs[0])},
+			TaskRuns:     []*v1.TaskRun{makeFailed(testhelpers.ExampleTaskRuns[0])},
 		},
 		want: true,
 	}, {
@@ -1559,7 +1412,7 @@ func TestIsFailure(t *testing.T) {
 		name: "taskrun failed - Retried",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1.PipelineTask{Name: "task", Retries: 1},
-			TaskRuns:     []*v1.TaskRun{withRetries(makeFailed(trs[0]))},
+			TaskRuns:     []*v1.TaskRun{withRetries(makeFailed(testhelpers.ExampleTaskRuns[0]))},
 		},
 		want: true,
 	}, {
@@ -1574,21 +1427,21 @@ func TestIsFailure(t *testing.T) {
 		name: "taskrun cancelled",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1.PipelineTask{Name: "task"},
-			TaskRuns:     []*v1.TaskRun{withCancelled(makeFailed(trs[0]))},
+			TaskRuns:     []*v1.TaskRun{withCancelled(makeFailed(testhelpers.ExampleTaskRuns[0]))},
 		},
 		want: true,
 	}, {
 		name: "taskrun cancelled but not failed",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1.PipelineTask{Name: "task"},
-			TaskRuns:     []*v1.TaskRun{withCancelled(newTaskRun(trs[0]))},
+			TaskRuns:     []*v1.TaskRun{withCancelled(newTaskRun(testhelpers.ExampleTaskRuns[0]))},
 		},
 		want: false,
 	}, {
 		name: "taskrun cancelled for timeout",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1.PipelineTask{Name: "task"},
-			TaskRuns:     []*v1.TaskRun{withCancelledForTimeout(makeFailed(trs[0]))},
+			TaskRuns:     []*v1.TaskRun{withCancelledForTimeout(makeFailed(testhelpers.ExampleTaskRuns[0]))},
 		},
 		want: true,
 	}, {
@@ -1619,7 +1472,7 @@ func TestIsFailure(t *testing.T) {
 		name: "taskrun cancelled: retries remaining",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1.PipelineTask{Name: "task", Retries: 1},
-			TaskRuns:     []*v1.TaskRun{withCancelled(makeFailed(trs[0]))},
+			TaskRuns:     []*v1.TaskRun{withCancelled(makeFailed(testhelpers.ExampleTaskRuns[0]))},
 		},
 		want: true,
 	}, {
@@ -1634,7 +1487,7 @@ func TestIsFailure(t *testing.T) {
 		name: "taskrun cancelled: retried",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1.PipelineTask{Name: "task", Retries: 1},
-			TaskRuns:     []*v1.TaskRun{withCancelled(withRetries(makeFailed(trs[0])))},
+			TaskRuns:     []*v1.TaskRun{withCancelled(withRetries(makeFailed(testhelpers.ExampleTaskRuns[0])))},
 		},
 		want: true,
 	}, {
@@ -1662,7 +1515,7 @@ func TestIsFailure(t *testing.T) {
 		name: "matrixed taskruns running",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: matrixedPipelineTask,
-			TaskRuns:     []*v1.TaskRun{makeStarted(trs[0]), makeStarted(trs[1])},
+			TaskRuns:     []*v1.TaskRun{makeStarted(testhelpers.ExampleTaskRuns[0]), makeStarted(testhelpers.ExampleTaskRuns[1])},
 		},
 		want: false,
 	}, {
@@ -1677,7 +1530,7 @@ func TestIsFailure(t *testing.T) {
 		name: "one matrixed taskrun running",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: matrixedPipelineTask,
-			TaskRuns:     []*v1.TaskRun{makeStarted(trs[0]), makeSucceeded(trs[1])},
+			TaskRuns:     []*v1.TaskRun{makeStarted(testhelpers.ExampleTaskRuns[0]), makeSucceeded(testhelpers.ExampleTaskRuns[1])},
 		},
 		want: false,
 	}, {
@@ -1692,14 +1545,14 @@ func TestIsFailure(t *testing.T) {
 		name: "matrixed taskruns succeeded",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: matrixedPipelineTask,
-			TaskRuns:     []*v1.TaskRun{makeSucceeded(trs[0]), makeSucceeded(trs[1])},
+			TaskRuns:     []*v1.TaskRun{makeSucceeded(testhelpers.ExampleTaskRuns[0]), makeSucceeded(testhelpers.ExampleTaskRuns[1])},
 		},
 		want: false,
 	}, {
 		name: "one matrixed taskrun succeeded",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: matrixedPipelineTask,
-			TaskRuns:     []*v1.TaskRun{makeSucceeded(trs[0]), makeStarted(trs[1])},
+			TaskRuns:     []*v1.TaskRun{makeSucceeded(testhelpers.ExampleTaskRuns[0]), makeStarted(testhelpers.ExampleTaskRuns[1])},
 		},
 		want: false,
 	}, {
@@ -1714,7 +1567,7 @@ func TestIsFailure(t *testing.T) {
 		name: "matrixed taskruns failed",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: matrixedPipelineTask,
-			TaskRuns:     []*v1.TaskRun{makeFailed(trs[0]), makeFailed(trs[1])},
+			TaskRuns:     []*v1.TaskRun{makeFailed(testhelpers.ExampleTaskRuns[0]), makeFailed(testhelpers.ExampleTaskRuns[1])},
 		},
 		want: true,
 	}, {
@@ -1729,7 +1582,7 @@ func TestIsFailure(t *testing.T) {
 		name: "one matrixed taskrun failed, one matrixed taskrun running",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: matrixedPipelineTask,
-			TaskRuns:     []*v1.TaskRun{makeFailed(trs[0]), makeStarted(trs[1])},
+			TaskRuns:     []*v1.TaskRun{makeFailed(testhelpers.ExampleTaskRuns[0]), makeStarted(testhelpers.ExampleTaskRuns[1])},
 		},
 		want: false,
 	}, {
@@ -1744,7 +1597,7 @@ func TestIsFailure(t *testing.T) {
 		name: "matrixed taskruns failed: retried",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: withPipelineTaskRetries(*matrixedPipelineTask, 1),
-			TaskRuns:     []*v1.TaskRun{withRetries(makeFailed(trs[0])), withRetries(makeFailed(trs[1]))},
+			TaskRuns:     []*v1.TaskRun{withRetries(makeFailed(testhelpers.ExampleTaskRuns[0])), withRetries(makeFailed(testhelpers.ExampleTaskRuns[1]))},
 		},
 		want: true,
 	}, {
@@ -1759,7 +1612,7 @@ func TestIsFailure(t *testing.T) {
 		name: "matrixed taskruns failed: one taskrun with retries remaining",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: withPipelineTaskRetries(*matrixedPipelineTask, 1),
-			TaskRuns:     []*v1.TaskRun{withRetries(makeToBeRetried(trs[0])), withRetries(makeFailed(trs[1]))},
+			TaskRuns:     []*v1.TaskRun{withRetries(makeToBeRetried(testhelpers.ExampleTaskRuns[0])), withRetries(makeFailed(testhelpers.ExampleTaskRuns[1]))},
 		},
 		want: false,
 	}, {
@@ -1782,7 +1635,7 @@ func TestIsFailure(t *testing.T) {
 		name: "matrixed taskruns cancelled",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: matrixedPipelineTask,
-			TaskRuns:     []*v1.TaskRun{withCancelled(makeFailed(trs[0])), withCancelled(makeFailed(trs[1]))},
+			TaskRuns:     []*v1.TaskRun{withCancelled(makeFailed(testhelpers.ExampleTaskRuns[0])), withCancelled(makeFailed(testhelpers.ExampleTaskRuns[1]))},
 		},
 		want: true,
 	}, {
@@ -1797,7 +1650,7 @@ func TestIsFailure(t *testing.T) {
 		name: "one matrixed taskrun cancelled, one matrixed taskrun running",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: matrixedPipelineTask,
-			TaskRuns:     []*v1.TaskRun{withCancelled(makeFailed(trs[0])), makeStarted(trs[1])},
+			TaskRuns:     []*v1.TaskRun{withCancelled(makeFailed(testhelpers.ExampleTaskRuns[0])), makeStarted(testhelpers.ExampleTaskRuns[1])},
 		},
 		want: false,
 	}, {
@@ -1812,7 +1665,7 @@ func TestIsFailure(t *testing.T) {
 		name: "matrixed taskruns cancelled but not failed",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: matrixedPipelineTask,
-			TaskRuns:     []*v1.TaskRun{withCancelled(newTaskRun(trs[0])), withCancelled(newTaskRun(trs[1]))},
+			TaskRuns:     []*v1.TaskRun{withCancelled(newTaskRun(testhelpers.ExampleTaskRuns[0])), withCancelled(newTaskRun(testhelpers.ExampleTaskRuns[1]))},
 		},
 		want: false,
 	}, {
@@ -1827,7 +1680,7 @@ func TestIsFailure(t *testing.T) {
 		name: "one matrixed taskrun cancelled but not failed",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: matrixedPipelineTask,
-			TaskRuns:     []*v1.TaskRun{withCancelled(newTaskRun(trs[0])), makeStarted(trs[1])},
+			TaskRuns:     []*v1.TaskRun{withCancelled(newTaskRun(testhelpers.ExampleTaskRuns[0])), makeStarted(testhelpers.ExampleTaskRuns[1])},
 		},
 		want: false,
 	}, {
@@ -1842,7 +1695,7 @@ func TestIsFailure(t *testing.T) {
 		name: "matrixed taskruns cancelled: retries remaining",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: withPipelineTaskRetries(*matrixedPipelineTask, 1),
-			TaskRuns:     []*v1.TaskRun{withCancelled(makeFailed(trs[0])), withCancelled(makeFailed(trs[1]))},
+			TaskRuns:     []*v1.TaskRun{withCancelled(makeFailed(testhelpers.ExampleTaskRuns[0])), withCancelled(makeFailed(testhelpers.ExampleTaskRuns[1]))},
 		},
 		want: true,
 	}, {
@@ -1857,7 +1710,7 @@ func TestIsFailure(t *testing.T) {
 		name: "one matrixed taskrun cancelled: retries remaining, one matrixed taskrun running",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: withPipelineTaskRetries(*matrixedPipelineTask, 1),
-			TaskRuns:     []*v1.TaskRun{withCancelled(makeFailed(trs[0])), makeStarted(trs[1])},
+			TaskRuns:     []*v1.TaskRun{withCancelled(makeFailed(testhelpers.ExampleTaskRuns[0])), makeStarted(testhelpers.ExampleTaskRuns[1])},
 		},
 		want: false,
 	}, {
@@ -1872,7 +1725,7 @@ func TestIsFailure(t *testing.T) {
 		name: "matrixed taskruns cancelled: retried",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: withPipelineTaskRetries(*matrixedPipelineTask, 1),
-			TaskRuns:     []*v1.TaskRun{withCancelled(withRetries(makeFailed(trs[0]))), withCancelled(withRetries(makeFailed(trs[1])))},
+			TaskRuns:     []*v1.TaskRun{withCancelled(withRetries(makeFailed(testhelpers.ExampleTaskRuns[0]))), withCancelled(withRetries(makeFailed(testhelpers.ExampleTaskRuns[1])))},
 		},
 		want: true,
 	}, {
@@ -1887,7 +1740,7 @@ func TestIsFailure(t *testing.T) {
 		name: "one matrixed taskrun cancelled: retried, one matrixed taskrun running",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: withPipelineTaskRetries(*matrixedPipelineTask, 1),
-			TaskRuns:     []*v1.TaskRun{withCancelled(withRetries(makeFailed(trs[0]))), makeStarted(trs[1])},
+			TaskRuns:     []*v1.TaskRun{withCancelled(withRetries(makeFailed(testhelpers.ExampleTaskRuns[0]))), makeStarted(testhelpers.ExampleTaskRuns[1])},
 		},
 		want: false,
 	}, {
@@ -1921,43 +1774,43 @@ func TestIsCancelled(t *testing.T) {
 	}, {
 		name: "taskrun not done",
 		rpt: ResolvedPipelineTask{
-			TaskRuns: []*v1.TaskRun{makeStarted(trs[0])},
+			TaskRuns: []*v1.TaskRun{makeStarted(testhelpers.ExampleTaskRuns[0])},
 		},
 		want: false,
 	}, {
 		name: "taskrun succeeded but not cancelled",
 		rpt: ResolvedPipelineTask{
-			TaskRuns: []*v1.TaskRun{(makeSucceeded(trs[0]))},
+			TaskRuns: []*v1.TaskRun{(makeSucceeded(testhelpers.ExampleTaskRuns[0]))},
 		},
 		want: false,
 	}, {
 		name: "taskrun failed but not cancelled",
 		rpt: ResolvedPipelineTask{
-			TaskRuns: []*v1.TaskRun{(makeFailed(trs[0]))},
+			TaskRuns: []*v1.TaskRun{(makeFailed(testhelpers.ExampleTaskRuns[0]))},
 		},
 		want: false,
 	}, {
 		name: "taskrun cancelled and failed",
 		rpt: ResolvedPipelineTask{
-			TaskRuns: []*v1.TaskRun{withCancelled(makeFailed(trs[0]))},
+			TaskRuns: []*v1.TaskRun{withCancelled(makeFailed(testhelpers.ExampleTaskRuns[0]))},
 		},
 		want: true,
 	}, {
 		name: "taskrun cancelled but still running",
 		rpt: ResolvedPipelineTask{
-			TaskRuns: []*v1.TaskRun{withCancelled(makeStarted(trs[0]))},
+			TaskRuns: []*v1.TaskRun{withCancelled(makeStarted(testhelpers.ExampleTaskRuns[0]))},
 		},
 		want: false,
 	}, {
 		name: "one taskrun cancelled, one not done",
 		rpt: ResolvedPipelineTask{
-			TaskRuns: []*v1.TaskRun{withCancelled(makeFailed(trs[0])), makeStarted(trs[1])},
+			TaskRuns: []*v1.TaskRun{withCancelled(makeFailed(testhelpers.ExampleTaskRuns[0])), makeStarted(testhelpers.ExampleTaskRuns[1])},
 		},
 		want: false,
 	}, {
 		name: "one taskrun cancelled, one done but not cancelled",
 		rpt: ResolvedPipelineTask{
-			TaskRuns: []*v1.TaskRun{withCancelled(makeFailed(trs[0])), makeSucceeded(trs[1])},
+			TaskRuns: []*v1.TaskRun{withCancelled(makeFailed(testhelpers.ExampleTaskRuns[0])), makeSucceeded(testhelpers.ExampleTaskRuns[1])},
 		},
 		want: true,
 	}, {
@@ -2040,49 +1893,49 @@ func TestIsCancelledForTimeout(t *testing.T) {
 	}, {
 		name: "taskrun not done",
 		rpt: ResolvedPipelineTask{
-			TaskRuns: []*v1.TaskRun{makeStarted(trs[0])},
+			TaskRuns: []*v1.TaskRun{makeStarted(testhelpers.ExampleTaskRuns[0])},
 		},
 		want: false,
 	}, {
 		name: "taskrun succeeded but not cancelled",
 		rpt: ResolvedPipelineTask{
-			TaskRuns: []*v1.TaskRun{(makeSucceeded(trs[0]))},
+			TaskRuns: []*v1.TaskRun{(makeSucceeded(testhelpers.ExampleTaskRuns[0]))},
 		},
 		want: false,
 	}, {
 		name: "taskrun failed but not cancelled",
 		rpt: ResolvedPipelineTask{
-			TaskRuns: []*v1.TaskRun{(makeFailed(trs[0]))},
+			TaskRuns: []*v1.TaskRun{(makeFailed(testhelpers.ExampleTaskRuns[0]))},
 		},
 		want: false,
 	}, {
 		name: "taskrun cancelled by spec and failed",
 		rpt: ResolvedPipelineTask{
-			TaskRuns: []*v1.TaskRun{withCancelledBySpec(makeFailed(trs[0]))},
+			TaskRuns: []*v1.TaskRun{withCancelledBySpec(makeFailed(testhelpers.ExampleTaskRuns[0]))},
 		},
 		want: false,
 	}, {
 		name: "taskrun cancelled for timeout and failed",
 		rpt: ResolvedPipelineTask{
-			TaskRuns: []*v1.TaskRun{withCancelledForTimeout(makeFailed(trs[0]))},
+			TaskRuns: []*v1.TaskRun{withCancelledForTimeout(makeFailed(testhelpers.ExampleTaskRuns[0]))},
 		},
 		want: true,
 	}, {
 		name: "taskrun cancelled for timeout but still running",
 		rpt: ResolvedPipelineTask{
-			TaskRuns: []*v1.TaskRun{withCancelledForTimeout(makeStarted(trs[0]))},
+			TaskRuns: []*v1.TaskRun{withCancelledForTimeout(makeStarted(testhelpers.ExampleTaskRuns[0]))},
 		},
 		want: false,
 	}, {
 		name: "one taskrun cancelled for timeout, one not done",
 		rpt: ResolvedPipelineTask{
-			TaskRuns: []*v1.TaskRun{withCancelledForTimeout(makeFailed(trs[0])), makeStarted(trs[1])},
+			TaskRuns: []*v1.TaskRun{withCancelledForTimeout(makeFailed(testhelpers.ExampleTaskRuns[0])), makeStarted(testhelpers.ExampleTaskRuns[1])},
 		},
 		want: false,
 	}, {
 		name: "one taskrun cancelled for timeout, one done but not cancelled",
 		rpt: ResolvedPipelineTask{
-			TaskRuns: []*v1.TaskRun{withCancelledForTimeout(makeFailed(trs[0])), makeSucceeded(trs[1])},
+			TaskRuns: []*v1.TaskRun{withCancelledForTimeout(makeFailed(testhelpers.ExampleTaskRuns[0])), makeSucceeded(testhelpers.ExampleTaskRuns[1])},
 		},
 		want: true,
 	}, {
@@ -2321,42 +2174,42 @@ func TestHaveAnyTaskRunsFailed(t *testing.T) {
 		name: "taskrun running",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1.PipelineTask{Name: "task"},
-			TaskRuns:     []*v1.TaskRun{makeStarted(trs[0])},
+			TaskRuns:     []*v1.TaskRun{makeStarted(testhelpers.ExampleTaskRuns[0])},
 		},
 		want: false,
 	}, {
 		name: "taskrun succeeded",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1.PipelineTask{Name: "task"},
-			TaskRuns:     []*v1.TaskRun{makeSucceeded(trs[0])},
+			TaskRuns:     []*v1.TaskRun{makeSucceeded(testhelpers.ExampleTaskRuns[0])},
 		},
 		want: false,
 	}, {
 		name: "taskrun failed",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1.PipelineTask{Name: "task"},
-			TaskRuns:     []*v1.TaskRun{makeFailed(trs[0])},
+			TaskRuns:     []*v1.TaskRun{makeFailed(testhelpers.ExampleTaskRuns[0])},
 		},
 		want: true,
 	}, {
 		name: "taskrun cancelled",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1.PipelineTask{Name: "task"},
-			TaskRuns:     []*v1.TaskRun{withCancelled(makeFailed(trs[0]))},
+			TaskRuns:     []*v1.TaskRun{withCancelled(makeFailed(testhelpers.ExampleTaskRuns[0]))},
 		},
 		want: true,
 	}, {
 		name: "taskrun cancelled but not failed",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1.PipelineTask{Name: "task"},
-			TaskRuns:     []*v1.TaskRun{withCancelled(newTaskRun(trs[0]))},
+			TaskRuns:     []*v1.TaskRun{withCancelled(newTaskRun(testhelpers.ExampleTaskRuns[0]))},
 		},
 		want: false,
 	}, {
 		name: "taskrun cancelled for timeout",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1.PipelineTask{Name: "task"},
-			TaskRuns:     []*v1.TaskRun{withCancelledForTimeout(makeFailed(trs[0]))},
+			TaskRuns:     []*v1.TaskRun{withCancelledForTimeout(makeFailed(testhelpers.ExampleTaskRuns[0]))},
 		},
 		want: true,
 	}, {
@@ -2369,70 +2222,70 @@ func TestHaveAnyTaskRunsFailed(t *testing.T) {
 		name: "matrixed taskruns running",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: matrixedPipelineTask,
-			TaskRuns:     []*v1.TaskRun{makeStarted(trs[0]), makeStarted(trs[1])},
+			TaskRuns:     []*v1.TaskRun{makeStarted(testhelpers.ExampleTaskRuns[0]), makeStarted(testhelpers.ExampleTaskRuns[1])},
 		},
 		want: false,
 	}, {
 		name: "one matrixed taskrun running",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: matrixedPipelineTask,
-			TaskRuns:     []*v1.TaskRun{makeStarted(trs[0]), makeSucceeded(trs[1])},
+			TaskRuns:     []*v1.TaskRun{makeStarted(testhelpers.ExampleTaskRuns[0]), makeSucceeded(testhelpers.ExampleTaskRuns[1])},
 		},
 		want: false,
 	}, {
 		name: "matrixed taskruns succeeded",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: matrixedPipelineTask,
-			TaskRuns:     []*v1.TaskRun{makeSucceeded(trs[0]), makeSucceeded(trs[1])},
+			TaskRuns:     []*v1.TaskRun{makeSucceeded(testhelpers.ExampleTaskRuns[0]), makeSucceeded(testhelpers.ExampleTaskRuns[1])},
 		},
 		want: false,
 	}, {
 		name: "one matrixed taskrun succeeded",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: matrixedPipelineTask,
-			TaskRuns:     []*v1.TaskRun{makeSucceeded(trs[0]), makeStarted(trs[1])},
+			TaskRuns:     []*v1.TaskRun{makeSucceeded(testhelpers.ExampleTaskRuns[0]), makeStarted(testhelpers.ExampleTaskRuns[1])},
 		},
 		want: false,
 	}, {
 		name: "matrixed taskruns failed",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: matrixedPipelineTask,
-			TaskRuns:     []*v1.TaskRun{makeFailed(trs[0]), makeFailed(trs[1])},
+			TaskRuns:     []*v1.TaskRun{makeFailed(testhelpers.ExampleTaskRuns[0]), makeFailed(testhelpers.ExampleTaskRuns[1])},
 		},
 		want: true,
 	}, {
 		name: "one matrixed taskrun failed, one matrixed taskrun running",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: matrixedPipelineTask,
-			TaskRuns:     []*v1.TaskRun{makeFailed(trs[0]), makeStarted(trs[1])},
+			TaskRuns:     []*v1.TaskRun{makeFailed(testhelpers.ExampleTaskRuns[0]), makeStarted(testhelpers.ExampleTaskRuns[1])},
 		},
 		want: true,
 	}, {
 		name: "matrixed taskruns cancelled",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: matrixedPipelineTask,
-			TaskRuns:     []*v1.TaskRun{withCancelled(makeFailed(trs[0])), withCancelled(makeFailed(trs[1]))},
+			TaskRuns:     []*v1.TaskRun{withCancelled(makeFailed(testhelpers.ExampleTaskRuns[0])), withCancelled(makeFailed(testhelpers.ExampleTaskRuns[1]))},
 		},
 		want: true,
 	}, {
 		name: "one matrixed taskrun cancelled, one matrixed taskrun running",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: matrixedPipelineTask,
-			TaskRuns:     []*v1.TaskRun{withCancelled(makeFailed(trs[0])), makeStarted(trs[1])},
+			TaskRuns:     []*v1.TaskRun{withCancelled(makeFailed(testhelpers.ExampleTaskRuns[0])), makeStarted(testhelpers.ExampleTaskRuns[1])},
 		},
 		want: true,
 	}, {
 		name: "matrixed taskruns cancelled but not failed",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: matrixedPipelineTask,
-			TaskRuns:     []*v1.TaskRun{withCancelled(newTaskRun(trs[0])), withCancelled(newTaskRun(trs[1]))},
+			TaskRuns:     []*v1.TaskRun{withCancelled(newTaskRun(testhelpers.ExampleTaskRuns[0])), withCancelled(newTaskRun(testhelpers.ExampleTaskRuns[1]))},
 		},
 		want: false,
 	}, {
 		name: "one matrixed taskrun cancelled but not failed",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: matrixedPipelineTask,
-			TaskRuns:     []*v1.TaskRun{withCancelled(newTaskRun(trs[0])), makeStarted(trs[1])},
+			TaskRuns:     []*v1.TaskRun{withCancelled(newTaskRun(testhelpers.ExampleTaskRuns[0])), makeStarted(testhelpers.ExampleTaskRuns[1])},
 		},
 		want: false,
 	}} {
@@ -2456,14 +2309,14 @@ func TestSkipBecauseParentTaskWasSkipped(t *testing.T) {
 			PipelineTask: &pts[0],
 			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
-				TaskSpec: &task.Spec,
+				TaskSpec: &testhelpers.ExampleTask.Spec,
 			},
 		}, {
 			// child task not skipped because parent is not yet done
 			PipelineTask: &pts[11],
 			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
-				TaskSpec: &task.Spec,
+				TaskSpec: &testhelpers.ExampleTask.Spec,
 			},
 		}},
 		expected: map[string]bool{
@@ -2477,7 +2330,7 @@ func TestSkipBecauseParentTaskWasSkipped(t *testing.T) {
 			TaskRunNames: []string{"pipelinerun-guardedtask"},
 			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
-				TaskSpec: &task.Spec,
+				TaskSpec: &testhelpers.ExampleTask.Spec,
 			},
 		}, {
 			// child task is not skipped regardless of its parent task being skipped due to when expressions evaluating
@@ -2490,7 +2343,7 @@ func TestSkipBecauseParentTaskWasSkipped(t *testing.T) {
 			TaskRunNames: []string{"pipelinerun-ordering-dependent-task-1"},
 			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
-				TaskSpec: &task.Spec,
+				TaskSpec: &testhelpers.ExampleTask.Spec,
 			},
 		}},
 		expected: map[string]bool{
@@ -2505,7 +2358,7 @@ func TestSkipBecauseParentTaskWasSkipped(t *testing.T) {
 			TaskRunNames: []string{"pipelinerun-guardedtask"},
 			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
-				TaskSpec: &task.Spec,
+				TaskSpec: &testhelpers.ExampleTask.Spec,
 			},
 		}, {
 			// child task is not skipped regardless of its parent task being skipped due to when expressions evaluating
@@ -2518,7 +2371,7 @@ func TestSkipBecauseParentTaskWasSkipped(t *testing.T) {
 			TaskRunNames: []string{"pipelinerun-ordering-dependent-task-1"},
 			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
-				TaskSpec: &task.Spec,
+				TaskSpec: &testhelpers.ExampleTask.Spec,
 			},
 		}, {
 			// child task is not skipped regardless of its parent task being skipped due to when expressions evaluating
@@ -2531,7 +2384,7 @@ func TestSkipBecauseParentTaskWasSkipped(t *testing.T) {
 			TaskRunNames: []string{"pipelinerun-ordering-dependent-task-2"},
 			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
-				TaskSpec: &task.Spec,
+				TaskSpec: &testhelpers.ExampleTask.Spec,
 			},
 		}},
 		expected: map[string]bool{
@@ -2704,7 +2557,7 @@ func TestResolvePipelineRun_PipelineTaskHasNoResources(t *testing.T) {
 	}}
 
 	getTask := getTaskFn(nil, nil)
-	getTaskRun := getTaskRunFn(&trs[0])
+	getTaskRun := getTaskRunFn(&testhelpers.ExampleTaskRuns[0])
 	pr := v1.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "pipelinerun",
@@ -2714,7 +2567,7 @@ func TestResolvePipelineRun_PipelineTaskHasNoResources(t *testing.T) {
 	for _, task := range pts {
 		ps, err := ResolvePipelineTask(t.Context(), pr, nopGetPipelineRun, nopGetPipeline, getTask, getTaskRun, nopGetCustomRun, task, nil)
 		if err != nil {
-			t.Errorf("Error getting tasks for fake pipeline %s: %s", p.ObjectMeta.Name, err)
+			t.Errorf("Error getting tasks for fake pipeline %s: %s", testhelpers.ExamplePipeline.ObjectMeta.Name, err)
 		}
 		pipelineState = append(pipelineState, ps)
 	}
@@ -2722,8 +2575,8 @@ func TestResolvePipelineRun_PipelineTaskHasNoResources(t *testing.T) {
 		t.Fatalf("Expected only 2 resolved PipelineTasks but got %d", len(pipelineState))
 	}
 	expectedTask := &resources.ResolvedTask{
-		TaskName: task.Name,
-		TaskSpec: &task.Spec,
+		TaskName: testhelpers.ExampleTask.Name,
+		TaskSpec: &testhelpers.ExampleTask.Spec,
 	}
 	if d := cmp.Diff(expectedTask, pipelineState[0].ResolvedTask, cmpopts.IgnoreUnexported(v1.TaskRunSpec{})); d != "" {
 		t.Fatalf("Expected resources where only Tasks were resolved but actual differed %s", diff.PrintWantGot(d))
@@ -2821,14 +2674,14 @@ func TestResolvePipelineRun_TaskDoesntExist(t *testing.T) {
 		var tnf *TaskNotFoundError
 		switch {
 		case err == nil:
-			t.Fatalf("Pipeline %s: want error, got nil", p.Name)
+			t.Fatalf("Pipeline %s: want error, got nil", testhelpers.ExamplePipeline.Name)
 		case errors.As(err, &tnf):
 			// expected error
 			if len(tnf.Name) == 0 {
-				t.Fatalf("Pipeline %s: TaskNotFoundError did not have name set: %s", p.Name, tnf.Error())
+				t.Fatalf("Pipeline %s: TaskNotFoundError did not have name set: %s", testhelpers.ExamplePipeline.Name, tnf.Error())
 			}
 		default:
-			t.Fatalf("Pipeline %s: Want %T, got %s of type %T", p.Name, tnf, err, err)
+			t.Fatalf("Pipeline %s: Want %T, got %s of type %T", testhelpers.ExamplePipeline.Name, tnf, err, err)
 		}
 	}
 }
@@ -3130,7 +2983,7 @@ func TestResolvePipeline_WhenExpressions(t *testing.T) {
 		case "pipelinerun-mytask1-always-true-0":
 			return t1, nil
 		case "pipelinerun-mytask1":
-			return &trs[0], nil
+			return &testhelpers.ExampleTaskRuns[0], nil
 		}
 		return nil, fmt.Errorf("getTaskRun called with unexpected name %s", name)
 	}
@@ -4032,7 +3885,7 @@ func TestIsMatrixed(t *testing.T) {
 		},
 	}
 	getTask := getTaskFn(nil, nil)
-	getTaskRun := getTaskRunFn(&trs[0])
+	getTaskRun := getTaskRunFn(&testhelpers.ExampleTaskRuns[0])
 	getRun := getRunFn(&customRuns[0])
 
 	for _, tc := range []struct {
@@ -4356,7 +4209,7 @@ func TestResolvePipelineRunTask_WithMatrixedCustomTask(t *testing.T) {
 	}}
 
 	getTask := getTaskFn(nil, nil)
-	getTaskRun := getTaskRunFn(&trs[0])
+	getTaskRun := getTaskRunFn(&testhelpers.ExampleTaskRuns[0])
 	getRun := func(name string) (*v1beta1.CustomRun, error) { return runsMap[name], nil }
 
 	for _, tc := range []struct {
@@ -4458,7 +4311,7 @@ func TestIsSuccessful(t *testing.T) {
 		name: "taskrun running",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1.PipelineTask{Name: "task"},
-			TaskRuns:     []*v1.TaskRun{makeStarted(trs[0])},
+			TaskRuns:     []*v1.TaskRun{makeStarted(testhelpers.ExampleTaskRuns[0])},
 		},
 		want: false,
 	}, {
@@ -4480,7 +4333,7 @@ func TestIsSuccessful(t *testing.T) {
 		name: "taskrun succeeded",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1.PipelineTask{Name: "task"},
-			TaskRuns:     []*v1.TaskRun{makeSucceeded(trs[0])},
+			TaskRuns:     []*v1.TaskRun{makeSucceeded(testhelpers.ExampleTaskRuns[0])},
 		},
 		want: true,
 	}, {
@@ -4502,7 +4355,7 @@ func TestIsSuccessful(t *testing.T) {
 		name: "taskrun failed",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1.PipelineTask{Name: "task"},
-			TaskRuns:     []*v1.TaskRun{makeFailed(trs[0])},
+			TaskRuns:     []*v1.TaskRun{makeFailed(testhelpers.ExampleTaskRuns[0])},
 		},
 		want: false,
 	}, {
@@ -4524,7 +4377,7 @@ func TestIsSuccessful(t *testing.T) {
 		name: "taskrun failed: retries remaining",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1.PipelineTask{Name: "task", Retries: 1},
-			TaskRuns:     []*v1.TaskRun{withRetries(makeToBeRetried(trs[0]))},
+			TaskRuns:     []*v1.TaskRun{withRetries(makeToBeRetried(testhelpers.ExampleTaskRuns[0]))},
 		},
 		want: false,
 	}, {
@@ -4547,14 +4400,14 @@ func TestIsSuccessful(t *testing.T) {
 		name: "taskrun cancelled",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1.PipelineTask{Name: "task"},
-			TaskRuns:     []*v1.TaskRun{withCancelled(makeFailed(trs[0]))},
+			TaskRuns:     []*v1.TaskRun{withCancelled(makeFailed(testhelpers.ExampleTaskRuns[0]))},
 		},
 		want: false,
 	}, {
 		name: "taskrun cancelled but not failed",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1.PipelineTask{Name: "task"},
-			TaskRuns:     []*v1.TaskRun{withCancelled(newTaskRun(trs[0]))},
+			TaskRuns:     []*v1.TaskRun{withCancelled(newTaskRun(testhelpers.ExampleTaskRuns[0]))},
 		},
 		want: false,
 	}, {
@@ -4577,7 +4430,7 @@ func TestIsSuccessful(t *testing.T) {
 		name: "taskrun cancelled: retries remaining",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1.PipelineTask{Name: "task", Retries: 1},
-			TaskRuns:     []*v1.TaskRun{withCancelled(makeFailed(trs[0]))},
+			TaskRuns:     []*v1.TaskRun{withCancelled(makeFailed(testhelpers.ExampleTaskRuns[0]))},
 		},
 		want: false,
 	}, {
@@ -4592,7 +4445,7 @@ func TestIsSuccessful(t *testing.T) {
 		name: "taskrun cancelled: retried",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1.PipelineTask{Name: "task", Retries: 1},
-			TaskRuns:     []*v1.TaskRun{withCancelled(withRetries(makeFailed(trs[0])))},
+			TaskRuns:     []*v1.TaskRun{withCancelled(withRetries(makeFailed(testhelpers.ExampleTaskRuns[0])))},
 		},
 		want: false,
 	}, {
@@ -4620,7 +4473,7 @@ func TestIsSuccessful(t *testing.T) {
 		name: "matrixed taskruns running",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: matrixedPipelineTask,
-			TaskRuns:     []*v1.TaskRun{makeStarted(trs[0]), makeStarted(trs[1])},
+			TaskRuns:     []*v1.TaskRun{makeStarted(testhelpers.ExampleTaskRuns[0]), makeStarted(testhelpers.ExampleTaskRuns[1])},
 		},
 		want: false,
 	}, {
@@ -4635,7 +4488,7 @@ func TestIsSuccessful(t *testing.T) {
 		name: "one matrixed taskrun running",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: matrixedPipelineTask,
-			TaskRuns:     []*v1.TaskRun{makeStarted(trs[0]), makeSucceeded(trs[1])},
+			TaskRuns:     []*v1.TaskRun{makeStarted(testhelpers.ExampleTaskRuns[0]), makeSucceeded(testhelpers.ExampleTaskRuns[1])},
 		},
 		want: false,
 	}, {
@@ -4650,7 +4503,7 @@ func TestIsSuccessful(t *testing.T) {
 		name: "matrixed taskruns succeeded",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: matrixedPipelineTask,
-			TaskRuns:     []*v1.TaskRun{makeSucceeded(trs[0]), makeSucceeded(trs[1])},
+			TaskRuns:     []*v1.TaskRun{makeSucceeded(testhelpers.ExampleTaskRuns[0]), makeSucceeded(testhelpers.ExampleTaskRuns[1])},
 		},
 		want: true,
 	}, {
@@ -4665,7 +4518,7 @@ func TestIsSuccessful(t *testing.T) {
 		name: "one matrixed taskrun succeeded",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: matrixedPipelineTask,
-			TaskRuns:     []*v1.TaskRun{makeSucceeded(trs[0]), makeStarted(trs[1])},
+			TaskRuns:     []*v1.TaskRun{makeSucceeded(testhelpers.ExampleTaskRuns[0]), makeStarted(testhelpers.ExampleTaskRuns[1])},
 		},
 		want: false,
 	}, {
@@ -4680,7 +4533,7 @@ func TestIsSuccessful(t *testing.T) {
 		name: "matrixed taskruns failed",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: matrixedPipelineTask,
-			TaskRuns:     []*v1.TaskRun{makeFailed(trs[0]), makeFailed(trs[1])},
+			TaskRuns:     []*v1.TaskRun{makeFailed(testhelpers.ExampleTaskRuns[0]), makeFailed(testhelpers.ExampleTaskRuns[1])},
 		},
 		want: false,
 	}, {
@@ -4695,7 +4548,7 @@ func TestIsSuccessful(t *testing.T) {
 		name: "one matrixed taskrun failed, one matrixed taskrun running",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: matrixedPipelineTask,
-			TaskRuns:     []*v1.TaskRun{makeFailed(trs[0]), makeStarted(trs[1])},
+			TaskRuns:     []*v1.TaskRun{makeFailed(testhelpers.ExampleTaskRuns[0]), makeStarted(testhelpers.ExampleTaskRuns[1])},
 		},
 		want: false,
 	}, {
@@ -4710,7 +4563,7 @@ func TestIsSuccessful(t *testing.T) {
 		name: "matrixed taskruns failed: retries remaining",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: withPipelineTaskRetries(*matrixedPipelineTask, 1),
-			TaskRuns:     []*v1.TaskRun{withRetries(makeToBeRetried(trs[0])), withRetries(makeToBeRetried(trs[1]))},
+			TaskRuns:     []*v1.TaskRun{withRetries(makeToBeRetried(testhelpers.ExampleTaskRuns[0])), withRetries(makeToBeRetried(testhelpers.ExampleTaskRuns[1]))},
 		},
 		want: false,
 	}, {
@@ -4725,7 +4578,7 @@ func TestIsSuccessful(t *testing.T) {
 		name: "matrixed taskruns failed: one taskrun with retries remaining",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: withPipelineTaskRetries(*matrixedPipelineTask, 1),
-			TaskRuns:     []*v1.TaskRun{withRetries(makeToBeRetried(trs[0])), withRetries(makeFailed(trs[1]))},
+			TaskRuns:     []*v1.TaskRun{withRetries(makeToBeRetried(testhelpers.ExampleTaskRuns[0])), withRetries(makeFailed(testhelpers.ExampleTaskRuns[1]))},
 		},
 		want: false,
 	}, {
@@ -4748,7 +4601,7 @@ func TestIsSuccessful(t *testing.T) {
 		name: "matrixed taskruns cancelled",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: matrixedPipelineTask,
-			TaskRuns:     []*v1.TaskRun{withCancelled(makeFailed(trs[0])), withCancelled(makeFailed(trs[1]))},
+			TaskRuns:     []*v1.TaskRun{withCancelled(makeFailed(testhelpers.ExampleTaskRuns[0])), withCancelled(makeFailed(testhelpers.ExampleTaskRuns[1]))},
 		},
 		want: false,
 	}, {
@@ -4763,7 +4616,7 @@ func TestIsSuccessful(t *testing.T) {
 		name: "one matrixed taskrun cancelled, one matrixed taskrun running",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: matrixedPipelineTask,
-			TaskRuns:     []*v1.TaskRun{withCancelled(makeFailed(trs[0])), makeStarted(trs[1])},
+			TaskRuns:     []*v1.TaskRun{withCancelled(makeFailed(testhelpers.ExampleTaskRuns[0])), makeStarted(testhelpers.ExampleTaskRuns[1])},
 		},
 		want: false,
 	}, {
@@ -4778,7 +4631,7 @@ func TestIsSuccessful(t *testing.T) {
 		name: "matrixed taskruns cancelled but not failed",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: matrixedPipelineTask,
-			TaskRuns:     []*v1.TaskRun{withCancelled(newTaskRun(trs[0])), withCancelled(newTaskRun(trs[1]))},
+			TaskRuns:     []*v1.TaskRun{withCancelled(newTaskRun(testhelpers.ExampleTaskRuns[0])), withCancelled(newTaskRun(testhelpers.ExampleTaskRuns[1]))},
 		},
 		want: false,
 	}, {
@@ -4793,7 +4646,7 @@ func TestIsSuccessful(t *testing.T) {
 		name: "one matrixed taskrun cancelled but not failed",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: matrixedPipelineTask,
-			TaskRuns:     []*v1.TaskRun{withCancelled(newTaskRun(trs[0])), makeStarted(trs[1])},
+			TaskRuns:     []*v1.TaskRun{withCancelled(newTaskRun(testhelpers.ExampleTaskRuns[0])), makeStarted(testhelpers.ExampleTaskRuns[1])},
 		},
 		want: false,
 	}, {
@@ -4808,7 +4661,7 @@ func TestIsSuccessful(t *testing.T) {
 		name: "matrixed taskruns cancelled: retries remaining",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: withPipelineTaskRetries(*matrixedPipelineTask, 1),
-			TaskRuns:     []*v1.TaskRun{withCancelled(makeFailed(trs[0])), withCancelled(makeFailed(trs[1]))},
+			TaskRuns:     []*v1.TaskRun{withCancelled(makeFailed(testhelpers.ExampleTaskRuns[0])), withCancelled(makeFailed(testhelpers.ExampleTaskRuns[1]))},
 		},
 		want: false,
 	}, {
@@ -4823,7 +4676,7 @@ func TestIsSuccessful(t *testing.T) {
 		name: "one matrixed taskrun cancelled: retries remaining, one matrixed taskrun running",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: withPipelineTaskRetries(*matrixedPipelineTask, 1),
-			TaskRuns:     []*v1.TaskRun{withCancelled(makeFailed(trs[0])), makeStarted(trs[1])},
+			TaskRuns:     []*v1.TaskRun{withCancelled(makeFailed(testhelpers.ExampleTaskRuns[0])), makeStarted(testhelpers.ExampleTaskRuns[1])},
 		},
 		want: false,
 	}, {
@@ -4838,7 +4691,7 @@ func TestIsSuccessful(t *testing.T) {
 		name: "matrixed taskruns cancelled: retried",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: withPipelineTaskRetries(*matrixedPipelineTask, 1),
-			TaskRuns:     []*v1.TaskRun{withCancelled(withRetries(makeFailed(trs[0]))), withCancelled(withRetries(makeFailed(trs[1])))},
+			TaskRuns:     []*v1.TaskRun{withCancelled(withRetries(makeFailed(testhelpers.ExampleTaskRuns[0]))), withCancelled(withRetries(makeFailed(testhelpers.ExampleTaskRuns[1])))},
 		},
 		want: false,
 	}, {
@@ -4853,7 +4706,7 @@ func TestIsSuccessful(t *testing.T) {
 		name: "one matrixed taskrun cancelled: retried, one matrixed taskrun running",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: withPipelineTaskRetries(*matrixedPipelineTask, 1),
-			TaskRuns:     []*v1.TaskRun{withCancelled(withRetries(makeFailed(trs[0]))), makeStarted(trs[1])},
+			TaskRuns:     []*v1.TaskRun{withCancelled(withRetries(makeFailed(testhelpers.ExampleTaskRuns[0]))), makeStarted(testhelpers.ExampleTaskRuns[1])},
 		},
 		want: false,
 	}, {
@@ -4895,7 +4748,7 @@ func TestIsRunning(t *testing.T) {
 		name: "taskrun running",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1.PipelineTask{Name: "task"},
-			TaskRuns:     []*v1.TaskRun{makeStarted(trs[0])},
+			TaskRuns:     []*v1.TaskRun{makeStarted(testhelpers.ExampleTaskRuns[0])},
 		},
 		want: true,
 	}, {
@@ -4910,7 +4763,7 @@ func TestIsRunning(t *testing.T) {
 		name: "taskrun succeeded",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1.PipelineTask{Name: "task"},
-			TaskRuns:     []*v1.TaskRun{makeSucceeded(trs[0])},
+			TaskRuns:     []*v1.TaskRun{makeSucceeded(testhelpers.ExampleTaskRuns[0])},
 		},
 		want: false,
 	}, {
@@ -4925,7 +4778,7 @@ func TestIsRunning(t *testing.T) {
 		name: "taskrun failed",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1.PipelineTask{Name: "task"},
-			TaskRuns:     []*v1.TaskRun{makeFailed(trs[0])},
+			TaskRuns:     []*v1.TaskRun{makeFailed(testhelpers.ExampleTaskRuns[0])},
 		},
 		want: false,
 	}, {
@@ -4940,7 +4793,7 @@ func TestIsRunning(t *testing.T) {
 		name: "taskrun failed: retried",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1.PipelineTask{Name: "task", Retries: 1},
-			TaskRuns:     []*v1.TaskRun{withRetries(makeFailed(trs[0]))},
+			TaskRuns:     []*v1.TaskRun{withRetries(makeFailed(testhelpers.ExampleTaskRuns[0]))},
 		},
 		want: false,
 	}, {
@@ -4963,14 +4816,14 @@ func TestIsRunning(t *testing.T) {
 		name: "taskrun cancelled",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1.PipelineTask{Name: "task"},
-			TaskRuns:     []*v1.TaskRun{withCancelled(makeFailed(trs[0]))},
+			TaskRuns:     []*v1.TaskRun{withCancelled(makeFailed(testhelpers.ExampleTaskRuns[0]))},
 		},
 		want: false,
 	}, {
 		name: "taskrun cancelled but not failed",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1.PipelineTask{Name: "task"},
-			TaskRuns:     []*v1.TaskRun{withCancelled(newTaskRun(trs[0]))},
+			TaskRuns:     []*v1.TaskRun{withCancelled(newTaskRun(testhelpers.ExampleTaskRuns[0]))},
 		},
 		want: true,
 	}, {
@@ -4993,7 +4846,7 @@ func TestIsRunning(t *testing.T) {
 		name: "taskrun cancelled: retries remaining",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1.PipelineTask{Name: "task", Retries: 1},
-			TaskRuns:     []*v1.TaskRun{withCancelled(makeFailed(trs[0]))},
+			TaskRuns:     []*v1.TaskRun{withCancelled(makeFailed(testhelpers.ExampleTaskRuns[0]))},
 		},
 		want: false,
 	}, {
@@ -5008,7 +4861,7 @@ func TestIsRunning(t *testing.T) {
 		name: "taskrun cancelled: retried",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: &v1.PipelineTask{Name: "task", Retries: 1},
-			TaskRuns:     []*v1.TaskRun{withCancelled(withRetries(makeFailed(trs[0])))},
+			TaskRuns:     []*v1.TaskRun{withCancelled(withRetries(makeFailed(testhelpers.ExampleTaskRuns[0])))},
 		},
 		want: false,
 	}, {
@@ -5036,7 +4889,7 @@ func TestIsRunning(t *testing.T) {
 		name: "matrixed taskruns running",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: matrixedPipelineTask,
-			TaskRuns:     []*v1.TaskRun{makeStarted(trs[0]), makeStarted(trs[1])},
+			TaskRuns:     []*v1.TaskRun{makeStarted(testhelpers.ExampleTaskRuns[0]), makeStarted(testhelpers.ExampleTaskRuns[1])},
 		},
 		want: true,
 	}, {
@@ -5051,7 +4904,7 @@ func TestIsRunning(t *testing.T) {
 		name: "one matrixed taskrun running",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: matrixedPipelineTask,
-			TaskRuns:     []*v1.TaskRun{makeStarted(trs[0]), makeSucceeded(trs[1])},
+			TaskRuns:     []*v1.TaskRun{makeStarted(testhelpers.ExampleTaskRuns[0]), makeSucceeded(testhelpers.ExampleTaskRuns[1])},
 		},
 		want: true,
 	}, {
@@ -5066,7 +4919,7 @@ func TestIsRunning(t *testing.T) {
 		name: "matrixed taskruns succeeded",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: matrixedPipelineTask,
-			TaskRuns:     []*v1.TaskRun{makeSucceeded(trs[0]), makeSucceeded(trs[1])},
+			TaskRuns:     []*v1.TaskRun{makeSucceeded(testhelpers.ExampleTaskRuns[0]), makeSucceeded(testhelpers.ExampleTaskRuns[1])},
 		},
 		want: false,
 	}, {
@@ -5081,7 +4934,7 @@ func TestIsRunning(t *testing.T) {
 		name: "matrixed taskruns failed",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: matrixedPipelineTask,
-			TaskRuns:     []*v1.TaskRun{makeFailed(trs[0]), makeFailed(trs[1])},
+			TaskRuns:     []*v1.TaskRun{makeFailed(testhelpers.ExampleTaskRuns[0]), makeFailed(testhelpers.ExampleTaskRuns[1])},
 		},
 		want: false,
 	}, {
@@ -5096,7 +4949,7 @@ func TestIsRunning(t *testing.T) {
 		name: "one matrixed taskrun failed, one matrixed taskrun running",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: matrixedPipelineTask,
-			TaskRuns:     []*v1.TaskRun{makeFailed(trs[0]), makeStarted(trs[1])},
+			TaskRuns:     []*v1.TaskRun{makeFailed(testhelpers.ExampleTaskRuns[0]), makeStarted(testhelpers.ExampleTaskRuns[1])},
 		},
 		want: true,
 	}, {
@@ -5111,7 +4964,7 @@ func TestIsRunning(t *testing.T) {
 		name: "matrixed taskruns failed: retries remaining",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: withPipelineTaskRetries(*matrixedPipelineTask, 1),
-			TaskRuns:     []*v1.TaskRun{withRetries(makeToBeRetried(trs[0])), withRetries(makeToBeRetried(trs[1]))},
+			TaskRuns:     []*v1.TaskRun{withRetries(makeToBeRetried(testhelpers.ExampleTaskRuns[0])), withRetries(makeToBeRetried(testhelpers.ExampleTaskRuns[1]))},
 		},
 		want: true,
 	}, {
@@ -5126,7 +4979,7 @@ func TestIsRunning(t *testing.T) {
 		name: "matrixed taskruns failed: one taskrun with retries remaining",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: withPipelineTaskRetries(*matrixedPipelineTask, 1),
-			TaskRuns:     []*v1.TaskRun{withRetries(makeToBeRetried(trs[0])), withRetries(makeFailed(trs[1]))},
+			TaskRuns:     []*v1.TaskRun{withRetries(makeToBeRetried(testhelpers.ExampleTaskRuns[0])), withRetries(makeFailed(testhelpers.ExampleTaskRuns[1]))},
 		},
 		want: true,
 	}, {
@@ -5149,7 +5002,7 @@ func TestIsRunning(t *testing.T) {
 		name: "matrixed taskruns cancelled",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: matrixedPipelineTask,
-			TaskRuns:     []*v1.TaskRun{withCancelled(makeFailed(trs[0])), withCancelled(makeFailed(trs[1]))},
+			TaskRuns:     []*v1.TaskRun{withCancelled(makeFailed(testhelpers.ExampleTaskRuns[0])), withCancelled(makeFailed(testhelpers.ExampleTaskRuns[1]))},
 		},
 		want: false,
 	}, {
@@ -5164,7 +5017,7 @@ func TestIsRunning(t *testing.T) {
 		name: "one matrixed taskrun cancelled, one matrixed taskrun running",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: matrixedPipelineTask,
-			TaskRuns:     []*v1.TaskRun{withCancelled(makeFailed(trs[0])), makeStarted(trs[1])},
+			TaskRuns:     []*v1.TaskRun{withCancelled(makeFailed(testhelpers.ExampleTaskRuns[0])), makeStarted(testhelpers.ExampleTaskRuns[1])},
 		},
 		want: true,
 	}, {
@@ -5179,7 +5032,7 @@ func TestIsRunning(t *testing.T) {
 		name: "matrixed taskruns cancelled but not failed",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: matrixedPipelineTask,
-			TaskRuns:     []*v1.TaskRun{withCancelled(newTaskRun(trs[0])), withCancelled(newTaskRun(trs[1]))},
+			TaskRuns:     []*v1.TaskRun{withCancelled(newTaskRun(testhelpers.ExampleTaskRuns[0])), withCancelled(newTaskRun(testhelpers.ExampleTaskRuns[1]))},
 		},
 		want: true,
 	}, {
@@ -5194,7 +5047,7 @@ func TestIsRunning(t *testing.T) {
 		name: "one matrixed taskrun cancelled but not failed",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: matrixedPipelineTask,
-			TaskRuns:     []*v1.TaskRun{withCancelled(newTaskRun(trs[0])), makeStarted(trs[1])},
+			TaskRuns:     []*v1.TaskRun{withCancelled(newTaskRun(testhelpers.ExampleTaskRuns[0])), makeStarted(testhelpers.ExampleTaskRuns[1])},
 		},
 		want: true,
 	}, {
@@ -5209,7 +5062,7 @@ func TestIsRunning(t *testing.T) {
 		name: "matrixed taskruns cancelled: retries remaining",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: withPipelineTaskRetries(*matrixedPipelineTask, 1),
-			TaskRuns:     []*v1.TaskRun{withCancelled(makeFailed(trs[0])), withCancelled(makeFailed(trs[1]))},
+			TaskRuns:     []*v1.TaskRun{withCancelled(makeFailed(testhelpers.ExampleTaskRuns[0])), withCancelled(makeFailed(testhelpers.ExampleTaskRuns[1]))},
 		},
 		want: false,
 	}, {
@@ -5224,7 +5077,7 @@ func TestIsRunning(t *testing.T) {
 		name: "one matrixed taskrun cancelled: retries remaining, one matrixed taskrun running",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: withPipelineTaskRetries(*matrixedPipelineTask, 1),
-			TaskRuns:     []*v1.TaskRun{withCancelled(makeFailed(trs[0])), makeStarted(trs[1])},
+			TaskRuns:     []*v1.TaskRun{withCancelled(makeFailed(testhelpers.ExampleTaskRuns[0])), makeStarted(testhelpers.ExampleTaskRuns[1])},
 		},
 		want: true,
 	}, {
@@ -5239,7 +5092,7 @@ func TestIsRunning(t *testing.T) {
 		name: "matrixed taskruns cancelled: retried",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: withPipelineTaskRetries(*matrixedPipelineTask, 1),
-			TaskRuns:     []*v1.TaskRun{withCancelled(withRetries(makeFailed(trs[0]))), withCancelled(withRetries(makeFailed(trs[1])))},
+			TaskRuns:     []*v1.TaskRun{withCancelled(withRetries(makeFailed(testhelpers.ExampleTaskRuns[0]))), withCancelled(withRetries(makeFailed(testhelpers.ExampleTaskRuns[1])))},
 		},
 		want: false,
 	}, {
@@ -5254,7 +5107,7 @@ func TestIsRunning(t *testing.T) {
 		name: "one matrixed taskrun cancelled: retried, one matrixed taskrun running",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: withPipelineTaskRetries(*matrixedPipelineTask, 1),
-			TaskRuns:     []*v1.TaskRun{withCancelled(withRetries(makeFailed(trs[0]))), makeStarted(trs[1])},
+			TaskRuns:     []*v1.TaskRun{withCancelled(withRetries(makeFailed(testhelpers.ExampleTaskRuns[0]))), makeStarted(testhelpers.ExampleTaskRuns[1])},
 		},
 		want: true,
 	}, {
@@ -5371,7 +5224,7 @@ func TestGetReason(t *testing.T) {
 			name: "taskrun running",
 			rpt: ResolvedPipelineTask{
 				PipelineTask: &v1.PipelineTask{Name: "task"},
-				TaskRuns:     []*v1.TaskRun{makeStarted(trs[0])},
+				TaskRuns:     []*v1.TaskRun{makeStarted(testhelpers.ExampleTaskRuns[0])},
 			},
 		},
 		{
@@ -5393,7 +5246,7 @@ func TestGetReason(t *testing.T) {
 			name: "taskrun succeeded",
 			rpt: ResolvedPipelineTask{
 				PipelineTask: &v1.PipelineTask{Name: "task"},
-				TaskRuns:     []*v1.TaskRun{makeSucceeded(trs[0])},
+				TaskRuns:     []*v1.TaskRun{makeSucceeded(testhelpers.ExampleTaskRuns[0])},
 			},
 			want: "Succeeded",
 		},
@@ -5418,7 +5271,7 @@ func TestGetReason(t *testing.T) {
 			name: "taskrun failed",
 			rpt: ResolvedPipelineTask{
 				PipelineTask: &v1.PipelineTask{Name: "task"},
-				TaskRuns:     []*v1.TaskRun{makeFailed(trs[0])},
+				TaskRuns:     []*v1.TaskRun{makeFailed(testhelpers.ExampleTaskRuns[0])},
 			},
 			want: "Failed",
 		},
@@ -5443,7 +5296,7 @@ func TestGetReason(t *testing.T) {
 			name: "taskrun failed: retried",
 			rpt: ResolvedPipelineTask{
 				PipelineTask: &v1.PipelineTask{Name: "task", Retries: 1},
-				TaskRuns:     []*v1.TaskRun{withRetries(makeFailed(trs[0]))},
+				TaskRuns:     []*v1.TaskRun{withRetries(makeFailed(testhelpers.ExampleTaskRuns[0]))},
 			},
 			want: "Failed",
 		},
@@ -5460,7 +5313,7 @@ func TestGetReason(t *testing.T) {
 			name: "taskrun cancelled",
 			rpt: ResolvedPipelineTask{
 				PipelineTask: &v1.PipelineTask{Name: "task"},
-				TaskRuns:     []*v1.TaskRun{withCancelled(makeFailed(trs[0]))},
+				TaskRuns:     []*v1.TaskRun{withCancelled(makeFailed(testhelpers.ExampleTaskRuns[0]))},
 			},
 			want: v1.TaskRunReasonCancelled.String(),
 		},
@@ -5468,7 +5321,7 @@ func TestGetReason(t *testing.T) {
 			name: "taskrun cancelled but not failed",
 			rpt: ResolvedPipelineTask{
 				PipelineTask: &v1.PipelineTask{Name: "task"},
-				TaskRuns:     []*v1.TaskRun{withCancelled(newTaskRun(trs[0]))},
+				TaskRuns:     []*v1.TaskRun{withCancelled(newTaskRun(testhelpers.ExampleTaskRuns[0]))},
 			},
 			want: v1.TaskRunReasonCancelled.String(),
 		},
@@ -5494,7 +5347,7 @@ func TestGetReason(t *testing.T) {
 			name: "matrixed taskruns succeeded",
 			rpt: ResolvedPipelineTask{
 				PipelineTask: matrixedPipelineTask,
-				TaskRuns:     []*v1.TaskRun{makeSucceeded(trs[0]), makeSucceeded(trs[1])},
+				TaskRuns:     []*v1.TaskRun{makeSucceeded(testhelpers.ExampleTaskRuns[0]), makeSucceeded(testhelpers.ExampleTaskRuns[1])},
 			},
 			want: "Succeeded",
 		},
@@ -5511,7 +5364,7 @@ func TestGetReason(t *testing.T) {
 			name: "matrixed taskruns failed",
 			rpt: ResolvedPipelineTask{
 				PipelineTask: matrixedPipelineTask,
-				TaskRuns:     []*v1.TaskRun{makeFailed(trs[0]), makeFailed(trs[1])},
+				TaskRuns:     []*v1.TaskRun{makeFailed(testhelpers.ExampleTaskRuns[0]), makeFailed(testhelpers.ExampleTaskRuns[1])},
 			},
 			want: "Failed",
 		},
@@ -5528,7 +5381,7 @@ func TestGetReason(t *testing.T) {
 			name: "matrixed taskruns cancelled",
 			rpt: ResolvedPipelineTask{
 				PipelineTask: matrixedPipelineTask,
-				TaskRuns:     []*v1.TaskRun{withCancelled(makeFailed(trs[0])), withCancelled(makeFailed(trs[1]))},
+				TaskRuns:     []*v1.TaskRun{withCancelled(makeFailed(testhelpers.ExampleTaskRuns[0])), withCancelled(makeFailed(testhelpers.ExampleTaskRuns[1]))},
 			},
 			want: v1.TaskRunReasonCancelled.String(),
 		},

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/reconciler/pipeline/dag"
 	"github.com/tektoncd/pipeline/pkg/reconciler/taskrun/resources"
+	testhelpers "github.com/tektoncd/pipeline/pkg/reconciler/testing"
 	"github.com/tektoncd/pipeline/test/diff"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
@@ -45,95 +46,95 @@ var testClock = clock.NewFakePassiveClock(now)
 
 func TestPipelineRunFacts_CheckDAGTasksDoneDone(t *testing.T) {
 	var taskCancelledByStatusState = PipelineRunState{{
-		PipelineTask: &pts[4], // 2 retries needed
+		PipelineTask: &testhelpers.PipelineTasks[4], // 2 retries needed
 		TaskRunNames: []string{"pipelinerun-mytask1"},
-		TaskRuns:     []*v1.TaskRun{withCancelled(makeRetried(trs[0]))},
+		TaskRuns:     []*v1.TaskRun{withCancelled(makeRetried(testhelpers.ExampleTaskRuns[0]))},
 		ResolvedTask: &resources.ResolvedTask{
-			TaskSpec: &task.Spec,
+			TaskSpec: &testhelpers.ExampleTask.Spec,
 		},
 	}}
 
 	var taskCancelledBySpecState = PipelineRunState{{
-		PipelineTask: &pts[4],
+		PipelineTask: &testhelpers.PipelineTasks[4],
 		TaskRunNames: []string{"pipelinerun-mytask1"},
-		TaskRuns:     []*v1.TaskRun{withCancelledBySpec(makeRetried(trs[0]))},
+		TaskRuns:     []*v1.TaskRun{withCancelledBySpec(makeRetried(testhelpers.ExampleTaskRuns[0]))},
 		ResolvedTask: &resources.ResolvedTask{
-			TaskSpec: &task.Spec,
+			TaskSpec: &testhelpers.ExampleTask.Spec,
 		},
 	}}
 
 	var taskRunningState = PipelineRunState{{
-		PipelineTask: &pts[4],
+		PipelineTask: &testhelpers.PipelineTasks[4],
 		TaskRunNames: []string{"pipelinerun-mytask1"},
-		TaskRuns:     []*v1.TaskRun{makeStarted(trs[0])},
+		TaskRuns:     []*v1.TaskRun{makeStarted(testhelpers.ExampleTaskRuns[0])},
 		ResolvedTask: &resources.ResolvedTask{
-			TaskSpec: &task.Spec,
+			TaskSpec: &testhelpers.ExampleTask.Spec,
 		},
 	}}
 
 	var taskSucceededState = PipelineRunState{{
-		PipelineTask: &pts[4],
+		PipelineTask: &testhelpers.PipelineTasks[4],
 		TaskRunNames: []string{"pipelinerun-mytask1"},
-		TaskRuns:     []*v1.TaskRun{makeSucceeded(trs[0])},
+		TaskRuns:     []*v1.TaskRun{makeSucceeded(testhelpers.ExampleTaskRuns[0])},
 		ResolvedTask: &resources.ResolvedTask{
-			TaskSpec: &task.Spec,
+			TaskSpec: &testhelpers.ExampleTask.Spec,
 		},
 	}}
 
 	var taskRetriedState = PipelineRunState{{
-		PipelineTask: &pts[3], // 1 retry needed
+		PipelineTask: &testhelpers.PipelineTasks[3], // 1 retry needed
 		TaskRunNames: []string{"pipelinerun-mytask1"},
-		TaskRuns:     []*v1.TaskRun{withCancelled(makeRetried(trs[0]))},
+		TaskRuns:     []*v1.TaskRun{withCancelled(makeRetried(testhelpers.ExampleTaskRuns[0]))},
 		ResolvedTask: &resources.ResolvedTask{
-			TaskSpec: &task.Spec,
+			TaskSpec: &testhelpers.ExampleTask.Spec,
 		},
 	}}
 
 	var taskExpectedState = PipelineRunState{{
-		PipelineTask: &pts[4], // 2 retries needed
+		PipelineTask: &testhelpers.PipelineTasks[4], // 2 retries needed
 		TaskRunNames: []string{"pipelinerun-mytask1"},
-		TaskRuns:     []*v1.TaskRun{withRetries(makeToBeRetried(trs[0]))},
+		TaskRuns:     []*v1.TaskRun{withRetries(makeToBeRetried(testhelpers.ExampleTaskRuns[0]))},
 		ResolvedTask: &resources.ResolvedTask{
-			TaskSpec: &task.Spec,
+			TaskSpec: &testhelpers.ExampleTask.Spec,
 		},
 	}}
 
 	var noTaskRunState = PipelineRunState{{
-		PipelineTask: &pts[4], // 2 retries needed
+		PipelineTask: &testhelpers.PipelineTasks[4], // 2 retries needed
 		TaskRunNames: []string{"pipelinerun-mytask1"},
 		TaskRuns:     nil,
 		ResolvedTask: &resources.ResolvedTask{
-			TaskSpec: &task.Spec,
+			TaskSpec: &testhelpers.ExampleTask.Spec,
 		},
 	}}
 
 	var customRunRunningState = PipelineRunState{{
-		PipelineTask:   &pts[12],
+		PipelineTask:   &testhelpers.PipelineTasks[12],
 		CustomTask:     true,
 		CustomRunNames: []string{"pipelinerun-mytask13"},
 		CustomRuns:     []*v1beta1.CustomRun{makeCustomRunStarted(customRuns[0])},
 	}}
 
 	var customRunSucceededState = PipelineRunState{{
-		PipelineTask:   &pts[12],
+		PipelineTask:   &testhelpers.PipelineTasks[12],
 		CustomTask:     true,
 		CustomRunNames: []string{"pipelinerun-mytask13"},
 		CustomRuns:     []*v1beta1.CustomRun{makeCustomRunSucceeded(customRuns[0])},
 	}}
 
 	var customRunFailedState = PipelineRunState{{
-		PipelineTask:   &pts[12],
+		PipelineTask:   &testhelpers.PipelineTasks[12],
 		CustomTask:     true,
 		CustomRunNames: []string{"pipelinerun-mytask13"},
 		CustomRuns:     []*v1beta1.CustomRun{makeCustomRunFailed(customRuns[0])},
 	}}
 
 	var taskCancelledFailedWithRetries = PipelineRunState{{
-		PipelineTask: &pts[4], // 2 retries needed
+		PipelineTask: &testhelpers.PipelineTasks[4], // 2 retries needed
 		TaskRunNames: []string{"pipelinerun-mytask1"},
-		TaskRuns:     []*v1.TaskRun{withCancelled(makeFailed(trs[0]))},
+		TaskRuns:     []*v1.TaskRun{withCancelled(makeFailed(testhelpers.ExampleTaskRuns[0]))},
 		ResolvedTask: &resources.ResolvedTask{
-			TaskSpec: &task.Spec,
+			TaskSpec: &testhelpers.ExampleTask.Spec,
 		},
 	}}
 
@@ -613,182 +614,182 @@ func TestGetNextTasks(t *testing.T) {
 
 func TestGetNextTaskWithRetries(t *testing.T) {
 	var taskCancelledByStatusState = PipelineRunState{{
-		PipelineTask: &pts[4], // 2 retries needed
+		PipelineTask: &testhelpers.PipelineTasks[4], // 2 retries needed
 		TaskRunNames: []string{"pipelinerun-mytask1"},
-		TaskRuns:     []*v1.TaskRun{withCancelled(makeRetried(trs[0]))},
+		TaskRuns:     []*v1.TaskRun{withCancelled(makeRetried(testhelpers.ExampleTaskRuns[0]))},
 		ResolvedTask: &resources.ResolvedTask{
-			TaskSpec: &task.Spec,
+			TaskSpec: &testhelpers.ExampleTask.Spec,
 		},
 	}}
 
 	var taskCancelledBySpecState = PipelineRunState{{
-		PipelineTask: &pts[4],
+		PipelineTask: &testhelpers.PipelineTasks[4],
 		TaskRunNames: []string{"pipelinerun-mytask1"},
-		TaskRuns:     []*v1.TaskRun{withCancelledBySpec(makeRetried(trs[0]))},
+		TaskRuns:     []*v1.TaskRun{withCancelledBySpec(makeRetried(testhelpers.ExampleTaskRuns[0]))},
 		ResolvedTask: &resources.ResolvedTask{
-			TaskSpec: &task.Spec,
+			TaskSpec: &testhelpers.ExampleTask.Spec,
 		},
 	}}
 
 	var taskRunningState = PipelineRunState{{
-		PipelineTask: &pts[4],
+		PipelineTask: &testhelpers.PipelineTasks[4],
 		TaskRunNames: []string{"pipelinerun-mytask1"},
-		TaskRuns:     []*v1.TaskRun{makeStarted(trs[0])},
+		TaskRuns:     []*v1.TaskRun{makeStarted(testhelpers.ExampleTaskRuns[0])},
 		ResolvedTask: &resources.ResolvedTask{
-			TaskSpec: &task.Spec,
+			TaskSpec: &testhelpers.ExampleTask.Spec,
 		},
 	}}
 
 	var taskSucceededState = PipelineRunState{{
-		PipelineTask: &pts[4],
+		PipelineTask: &testhelpers.PipelineTasks[4],
 		TaskRunNames: []string{"pipelinerun-mytask1"},
-		TaskRuns:     []*v1.TaskRun{makeSucceeded(trs[0])},
+		TaskRuns:     []*v1.TaskRun{makeSucceeded(testhelpers.ExampleTaskRuns[0])},
 		ResolvedTask: &resources.ResolvedTask{
-			TaskSpec: &task.Spec,
+			TaskSpec: &testhelpers.ExampleTask.Spec,
 		},
 	}}
 
 	var taskRetriedState = PipelineRunState{{
-		PipelineTask: &pts[3], // 1 retry needed
+		PipelineTask: &testhelpers.PipelineTasks[3], // 1 retry needed
 		TaskRunNames: []string{"pipelinerun-mytask1"},
-		TaskRuns:     []*v1.TaskRun{withCancelled(makeRetried(trs[0]))},
+		TaskRuns:     []*v1.TaskRun{withCancelled(makeRetried(testhelpers.ExampleTaskRuns[0]))},
 		ResolvedTask: &resources.ResolvedTask{
-			TaskSpec: &task.Spec,
+			TaskSpec: &testhelpers.ExampleTask.Spec,
 		},
 	}}
 
 	var customRunCancelledByStatusState = PipelineRunState{{
-		PipelineTask:   &pts[4], // 2 retries needed
+		PipelineTask:   &testhelpers.PipelineTasks[4], // 2 retries needed
 		CustomRunNames: []string{"pipelinerun-mytask1"},
 		CustomRuns:     []*v1beta1.CustomRun{withCustomRunCancelled(withCustomRunRetries(newCustomRun(customRuns[0])))},
 		CustomTask:     true,
 		ResolvedTask: &resources.ResolvedTask{
-			TaskSpec: &task.Spec,
+			TaskSpec: &testhelpers.ExampleTask.Spec,
 		},
 	}}
 
 	var customRunCancelledBySpecState = PipelineRunState{{
-		PipelineTask:   &pts[4],
+		PipelineTask:   &testhelpers.PipelineTasks[4],
 		CustomRunNames: []string{"pipelinerun-mytask1"},
 		CustomRuns:     []*v1beta1.CustomRun{withCustomRunCancelledBySpec(withCustomRunRetries(newCustomRun(customRuns[0])))},
 		CustomTask:     true,
 		ResolvedTask: &resources.ResolvedTask{
-			TaskSpec: &task.Spec,
+			TaskSpec: &testhelpers.ExampleTask.Spec,
 		},
 	}}
 
 	var customRunRunningState = PipelineRunState{{
-		PipelineTask:   &pts[4],
+		PipelineTask:   &testhelpers.PipelineTasks[4],
 		CustomRunNames: []string{"pipelinerun-mytask1"},
 		CustomRuns:     []*v1beta1.CustomRun{makeCustomRunStarted(customRuns[0])},
 		CustomTask:     true,
 		ResolvedTask: &resources.ResolvedTask{
-			TaskSpec: &task.Spec,
+			TaskSpec: &testhelpers.ExampleTask.Spec,
 		},
 	}}
 
 	var customRunSucceededState = PipelineRunState{{
-		PipelineTask:   &pts[4],
+		PipelineTask:   &testhelpers.PipelineTasks[4],
 		CustomRunNames: []string{"pipelinerun-mytask1"},
 		CustomRuns:     []*v1beta1.CustomRun{makeCustomRunSucceeded(customRuns[0])},
 		CustomTask:     true,
 		ResolvedTask: &resources.ResolvedTask{
-			TaskSpec: &task.Spec,
+			TaskSpec: &testhelpers.ExampleTask.Spec,
 		},
 	}}
 
 	var taskCancelledByStatusStateMatrix = PipelineRunState{{
-		PipelineTask: &pts[20], // 2 retries needed
+		PipelineTask: &testhelpers.PipelineTasks[20], // 2 retries needed
 		TaskRunNames: []string{"pipelinerun-mytask1"},
-		TaskRuns:     []*v1.TaskRun{withCancelled(makeRetried(trs[0]))},
+		TaskRuns:     []*v1.TaskRun{withCancelled(makeRetried(testhelpers.ExampleTaskRuns[0]))},
 		ResolvedTask: &resources.ResolvedTask{
-			TaskSpec: &task.Spec,
+			TaskSpec: &testhelpers.ExampleTask.Spec,
 		},
 	}}
 
 	var taskCancelledBySpecStateMatrix = PipelineRunState{{
-		PipelineTask: &pts[20], // 2 retries needed
+		PipelineTask: &testhelpers.PipelineTasks[20], // 2 retries needed
 		TaskRunNames: []string{"pipelinerun-mytask1"},
-		TaskRuns:     []*v1.TaskRun{withCancelledBySpec(makeRetried(trs[0]))},
+		TaskRuns:     []*v1.TaskRun{withCancelledBySpec(makeRetried(testhelpers.ExampleTaskRuns[0]))},
 		ResolvedTask: &resources.ResolvedTask{
-			TaskSpec: &task.Spec,
+			TaskSpec: &testhelpers.ExampleTask.Spec,
 		},
 	}}
 
 	var taskRunningStateMatrix = PipelineRunState{{
-		PipelineTask: &pts[20], // 2 retries needed
+		PipelineTask: &testhelpers.PipelineTasks[20], // 2 retries needed
 		TaskRunNames: []string{"pipelinerun-mytask1"},
-		TaskRuns:     []*v1.TaskRun{makeStarted(trs[0])},
+		TaskRuns:     []*v1.TaskRun{makeStarted(testhelpers.ExampleTaskRuns[0])},
 		ResolvedTask: &resources.ResolvedTask{
-			TaskSpec: &task.Spec,
+			TaskSpec: &testhelpers.ExampleTask.Spec,
 		},
 	}}
 
 	var taskSucceededStateMatrix = PipelineRunState{{
-		PipelineTask: &pts[20], // 2 retries needed
+		PipelineTask: &testhelpers.PipelineTasks[20], // 2 retries needed
 		TaskRunNames: []string{"pipelinerun-mytask1"},
-		TaskRuns:     []*v1.TaskRun{makeSucceeded(trs[0])},
+		TaskRuns:     []*v1.TaskRun{makeSucceeded(testhelpers.ExampleTaskRuns[0])},
 		ResolvedTask: &resources.ResolvedTask{
-			TaskSpec: &task.Spec,
+			TaskSpec: &testhelpers.ExampleTask.Spec,
 		},
 	}}
 
 	var taskRetriedStateMatrix = PipelineRunState{{
-		PipelineTask: &pts[17], // 1 retry needed
+		PipelineTask: &testhelpers.PipelineTasks[17], // 1 retry needed
 		TaskRunNames: []string{"pipelinerun-mytask1"},
-		TaskRuns:     []*v1.TaskRun{withCancelled(makeRetried(trs[0]))},
+		TaskRuns:     []*v1.TaskRun{withCancelled(makeRetried(testhelpers.ExampleTaskRuns[0]))},
 		ResolvedTask: &resources.ResolvedTask{
-			TaskSpec: &task.Spec,
+			TaskSpec: &testhelpers.ExampleTask.Spec,
 		},
 	}}
 
 	var runCancelledByStatusStateMatrix = PipelineRunState{{
-		PipelineTask:   &pts[20], // 2 retries needed
+		PipelineTask:   &testhelpers.PipelineTasks[20], // 2 retries needed
 		CustomRunNames: []string{"pipelinerun-mytask1"},
 		CustomRuns:     []*v1beta1.CustomRun{withCustomRunCancelled(withCustomRunRetries(newCustomRun(customRuns[0])))},
 		CustomTask:     true,
 		ResolvedTask: &resources.ResolvedTask{
-			TaskSpec: &task.Spec,
+			TaskSpec: &testhelpers.ExampleTask.Spec,
 		},
 	}}
 
 	var runCancelledBySpecStateMatrix = PipelineRunState{{
-		PipelineTask:   &pts[20], // 2 retries needed
+		PipelineTask:   &testhelpers.PipelineTasks[20], // 2 retries needed
 		CustomRunNames: []string{"pipelinerun-mytask1"},
 		CustomRuns:     []*v1beta1.CustomRun{withCustomRunCancelledBySpec(withCustomRunRetries(newCustomRun(customRuns[0])))},
 		CustomTask:     true,
 		ResolvedTask: &resources.ResolvedTask{
-			TaskSpec: &task.Spec,
+			TaskSpec: &testhelpers.ExampleTask.Spec,
 		},
 	}}
 
 	var runRunningStateMatrix = PipelineRunState{{
-		PipelineTask:   &pts[20], // 2 retries needed
+		PipelineTask:   &testhelpers.PipelineTasks[20], // 2 retries needed
 		CustomRunNames: []string{"pipelinerun-mytask1"},
 		CustomRuns:     []*v1beta1.CustomRun{makeCustomRunStarted(customRuns[0])},
 		CustomTask:     true,
 		ResolvedTask: &resources.ResolvedTask{
-			TaskSpec: &task.Spec,
+			TaskSpec: &testhelpers.ExampleTask.Spec,
 		},
 	}}
 
 	var customRunSucceededStateMatrix = PipelineRunState{{
-		PipelineTask:   &pts[20], // 2 retries needed
+		PipelineTask:   &testhelpers.PipelineTasks[20], // 2 retries needed
 		CustomRunNames: []string{"pipelinerun-mytask1"},
 		CustomRuns:     []*v1beta1.CustomRun{makeCustomRunSucceeded(customRuns[0])},
 		CustomTask:     true,
 		ResolvedTask: &resources.ResolvedTask{
-			TaskSpec: &task.Spec,
+			TaskSpec: &testhelpers.ExampleTask.Spec,
 		},
 	}}
 
 	var customRunRetriedStateMatrix = PipelineRunState{{
-		PipelineTask:   &pts[17], // 1 retry needed
+		PipelineTask:   &testhelpers.PipelineTasks[17], // 1 retry needed
 		CustomRunNames: []string{"pipelinerun-mytask1"},
 		CustomRuns:     []*v1beta1.CustomRun{withCustomRunCancelled(withCustomRunRetries(newCustomRun(customRuns[0])))},
 		CustomTask:     true,
 		ResolvedTask: &resources.ResolvedTask{
-			TaskSpec: &task.Spec,
+			TaskSpec: &testhelpers.ExampleTask.Spec,
 		},
 	}}
 
@@ -917,7 +918,7 @@ func TestDAGExecutionQueue(t *testing.T) {
 		},
 		TaskRunNames: []string{"createdtask"},
 		ResolvedTask: &resources.ResolvedTask{
-			TaskSpec: &task.Spec,
+			TaskSpec: &testhelpers.ExampleTask.Spec,
 		},
 	}
 	createdRun := ResolvedPipelineTask{
@@ -935,7 +936,7 @@ func TestDAGExecutionQueue(t *testing.T) {
 		},
 		ChildPipelineRunNames: []string{"createdchildpipeline"},
 		ResolvedPipeline: ResolvedPipeline{
-			PipelineSpec: p.Spec.Tasks[21].PipelineSpec,
+			PipelineSpec: pts[21].PipelineSpec,
 		},
 	}
 	runningTask := ResolvedPipelineTask{
@@ -944,9 +945,9 @@ func TestDAGExecutionQueue(t *testing.T) {
 			TaskRef: &v1.TaskRef{Name: "task"},
 		},
 		TaskRunNames: []string{"runningtask"},
-		TaskRuns:     []*v1.TaskRun{newTaskRun(trs[0])},
+		TaskRuns:     []*v1.TaskRun{newTaskRun(testhelpers.ExampleTaskRuns[0])},
 		ResolvedTask: &resources.ResolvedTask{
-			TaskSpec: &task.Spec,
+			TaskSpec: &testhelpers.ExampleTask.Spec,
 		},
 	}
 	runningRun := ResolvedPipelineTask{
@@ -966,7 +967,7 @@ func TestDAGExecutionQueue(t *testing.T) {
 		ChildPipelineRunNames: []string{"runningchildpipeline"},
 		ChildPipelineRuns:     []*v1.PipelineRun{newPipelineRun(prs[0])},
 		ResolvedPipeline: ResolvedPipeline{
-			PipelineSpec: p.Spec.Tasks[21].PipelineSpec,
+			PipelineSpec: pts[21].PipelineSpec,
 		},
 	}
 	successfulTask := ResolvedPipelineTask{
@@ -975,9 +976,9 @@ func TestDAGExecutionQueue(t *testing.T) {
 			TaskRef: &v1.TaskRef{Name: "task"},
 		},
 		TaskRunNames: []string{"successfultask"},
-		TaskRuns:     []*v1.TaskRun{makeSucceeded(trs[0])},
+		TaskRuns:     []*v1.TaskRun{makeSucceeded(testhelpers.ExampleTaskRuns[0])},
 		ResolvedTask: &resources.ResolvedTask{
-			TaskSpec: &task.Spec,
+			TaskSpec: &testhelpers.ExampleTask.Spec,
 		},
 	}
 	successfulRun := ResolvedPipelineTask{
@@ -997,7 +998,7 @@ func TestDAGExecutionQueue(t *testing.T) {
 		ChildPipelineRunNames: []string{"successfulchildpipeline"},
 		ChildPipelineRuns:     []*v1.PipelineRun{makePipelineRunSucceeded(prs[0])},
 		ResolvedPipeline: ResolvedPipeline{
-			PipelineSpec: p.Spec.Tasks[21].PipelineSpec,
+			PipelineSpec: pts[21].PipelineSpec,
 		},
 	}
 	failedTask := ResolvedPipelineTask{
@@ -1006,9 +1007,9 @@ func TestDAGExecutionQueue(t *testing.T) {
 			TaskRef: &v1.TaskRef{Name: "task"},
 		},
 		TaskRunNames: []string{"failedtask"},
-		TaskRuns:     []*v1.TaskRun{makeFailed(trs[0])},
+		TaskRuns:     []*v1.TaskRun{makeFailed(testhelpers.ExampleTaskRuns[0])},
 		ResolvedTask: &resources.ResolvedTask{
-			TaskSpec: &task.Spec,
+			TaskSpec: &testhelpers.ExampleTask.Spec,
 		},
 	}
 	failedCustomRun := ResolvedPipelineTask{
@@ -1028,7 +1029,7 @@ func TestDAGExecutionQueue(t *testing.T) {
 		ChildPipelineRunNames: []string{"failedchildpipeline"},
 		ChildPipelineRuns:     []*v1.PipelineRun{makePipelineRunFailed(prs[0])},
 		ResolvedPipeline: ResolvedPipeline{
-			PipelineSpec: p.Spec.Tasks[21].PipelineSpec,
+			PipelineSpec: pts[21].PipelineSpec,
 		},
 	}
 	tcs := []struct {
@@ -1124,26 +1125,26 @@ func TestDAGExecutionQueueSequentialTasks(t *testing.T) {
 		wantFirst: true,
 	}, {
 		name:         "first task running",
-		firstTaskRun: newTaskRun(trs[0]),
+		firstTaskRun: newTaskRun(testhelpers.ExampleTaskRuns[0]),
 	}, {
 		name:         "first task succeeded",
-		firstTaskRun: makeSucceeded(trs[0]),
+		firstTaskRun: makeSucceeded(testhelpers.ExampleTaskRuns[0]),
 		wantSecond:   true,
 	}, {
 		name:         "first task failed",
-		firstTaskRun: makeFailed(trs[0]),
+		firstTaskRun: makeFailed(testhelpers.ExampleTaskRuns[0]),
 	}, {
 		name:          "first task succeeded, second task running",
-		firstTaskRun:  makeSucceeded(trs[0]),
-		secondTaskRun: newTaskRun(trs[1]),
+		firstTaskRun:  makeSucceeded(testhelpers.ExampleTaskRuns[0]),
+		secondTaskRun: newTaskRun(testhelpers.ExampleTaskRuns[1]),
 	}, {
 		name:          "first task succeeded, second task succeeded",
-		firstTaskRun:  makeSucceeded(trs[0]),
-		secondTaskRun: makeSucceeded(trs[1]),
+		firstTaskRun:  makeSucceeded(testhelpers.ExampleTaskRuns[0]),
+		secondTaskRun: makeSucceeded(testhelpers.ExampleTaskRuns[1]),
 	}, {
 		name:          "first task succeeded, second task failed",
-		firstTaskRun:  makeSucceeded(trs[0]),
-		secondTaskRun: makeFailed(trs[1]),
+		firstTaskRun:  makeSucceeded(testhelpers.ExampleTaskRuns[0]),
+		secondTaskRun: makeFailed(testhelpers.ExampleTaskRuns[1]),
 	}}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1154,7 +1155,7 @@ func TestDAGExecutionQueueSequentialTasks(t *testing.T) {
 				},
 				TaskRunNames: []string{"task-1"},
 				ResolvedTask: &resources.ResolvedTask{
-					TaskSpec: &task.Spec,
+					TaskSpec: &testhelpers.ExampleTask.Spec,
 				},
 			}
 			secondTask := ResolvedPipelineTask{
@@ -1165,7 +1166,7 @@ func TestDAGExecutionQueueSequentialTasks(t *testing.T) {
 				},
 				TaskRunNames: []string{"task-2"},
 				ResolvedTask: &resources.ResolvedTask{
-					TaskSpec: &task.Spec,
+					TaskSpec: &testhelpers.ExampleTask.Spec,
 				},
 			}
 			if tc.firstTaskRun != nil {
@@ -1344,7 +1345,7 @@ func TestDAGExecutionQueueSequentialChildPipelines(t *testing.T) {
 				},
 				ChildPipelineRunNames: []string{"pip-child-1"},
 				ResolvedPipeline: ResolvedPipeline{
-					PipelineSpec: p.Spec.Tasks[21].PipelineSpec,
+					PipelineSpec: pts[21].PipelineSpec,
 				},
 			}
 
@@ -1356,7 +1357,7 @@ func TestDAGExecutionQueueSequentialChildPipelines(t *testing.T) {
 				},
 				ChildPipelineRunNames: []string{"pip-child-2"},
 				ResolvedPipeline: ResolvedPipeline{
-					PipelineSpec: p.Spec.Tasks[22].PipelineSpec,
+					PipelineSpec: pts[22].PipelineSpec,
 				},
 			}
 
@@ -1413,7 +1414,7 @@ func TestPipelineRunState_CompletedOrSkippedDAGTasks(t *testing.T) {
 		name:          "no-tasks-started-run-cancelled-gracefully",
 		state:         noneStartedState,
 		specStatus:    v1.PipelineRunSpecStatusCancelledRunFinally,
-		expectedNames: []string{pts[0].Name, pts[1].Name},
+		expectedNames: []string{testhelpers.PipelineTasks[0].Name, testhelpers.PipelineTasks[1].Name},
 	}, {
 		name:          "one-task-started",
 		state:         oneStartedState,
@@ -1422,24 +1423,24 @@ func TestPipelineRunState_CompletedOrSkippedDAGTasks(t *testing.T) {
 		name:          "one-task-started-run-stopped-gracefully",
 		state:         oneStartedState,
 		specStatus:    v1.PipelineRunSpecStatusStoppedRunFinally,
-		expectedNames: []string{pts[1].Name},
+		expectedNames: []string{testhelpers.PipelineTasks[1].Name},
 	}, {
 		name:          "one-task-finished",
 		state:         oneFinishedState,
-		expectedNames: []string{pts[0].Name},
+		expectedNames: []string{testhelpers.PipelineTasks[0].Name},
 	}, {
 		name:          "one-task-finished-run-cancelled-forcefully",
 		state:         oneFinishedState,
 		specStatus:    v1.PipelineRunSpecStatusCancelled,
-		expectedNames: []string{pts[0].Name},
+		expectedNames: []string{testhelpers.PipelineTasks[0].Name},
 	}, {
 		name:          "one-task-failed",
 		state:         oneFailedState,
-		expectedNames: []string{pts[0].Name, pts[1].Name},
+		expectedNames: []string{testhelpers.PipelineTasks[0].Name, testhelpers.PipelineTasks[1].Name},
 	}, {
 		name:          "all-finished",
 		state:         allFinishedState,
-		expectedNames: []string{pts[0].Name, pts[1].Name},
+		expectedNames: []string{testhelpers.PipelineTasks[0].Name, testhelpers.PipelineTasks[1].Name},
 	}, {
 		name:          "large deps, not started",
 		state:         largePipelineState,
@@ -1459,11 +1460,11 @@ func TestPipelineRunState_CompletedOrSkippedDAGTasks(t *testing.T) {
 	}, {
 		name:          "one-run-finished",
 		state:         oneCustomRunFinishedState,
-		expectedNames: []string{pts[12].Name},
+		expectedNames: []string{testhelpers.PipelineTasks[12].Name},
 	}, {
 		name:          "one-run-failed",
 		state:         oneCustomRunFailedState,
-		expectedNames: []string{pts[12].Name, pts[13].Name},
+		expectedNames: []string{testhelpers.PipelineTasks[12].Name, testhelpers.PipelineTasks[13].Name},
 	}}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1632,66 +1633,66 @@ func TestPipelineRunState_GetFinalTasksAndNames(t *testing.T) {
 		desc: "DAG tasks (mytask1 and mytask2) finished successfully -" +
 			" do not schedule final tasks since pipeline didnt have any",
 		state:              oneStartedState,
-		DAGTasks:           []v1.PipelineTask{pts[0], pts[1]},
+		DAGTasks:           []v1.PipelineTask{testhelpers.PipelineTasks[0], testhelpers.PipelineTasks[1]},
 		finalTasks:         []v1.PipelineTask{},
 		expectedFinalTasks: PipelineRunState{},
 		expectedFinalNames: nil,
-		expectedTaskNames:  sets.NewString(pts[0].Name, pts[1].Name),
+		expectedTaskNames:  sets.NewString(testhelpers.PipelineTasks[0].Name, testhelpers.PipelineTasks[1].Name),
 	}, {
 		// tasks: [ mytask1]
 		// finally: [mytask2]
 		name:               "02 - DAG task not started, no final tasks",
 		desc:               "DAG tasks (mytask1) not started yet - do not schedule final tasks (mytask2)",
 		state:              noneStartedState,
-		DAGTasks:           []v1.PipelineTask{pts[0]},
-		finalTasks:         []v1.PipelineTask{pts[1]},
+		DAGTasks:           []v1.PipelineTask{testhelpers.PipelineTasks[0]},
+		finalTasks:         []v1.PipelineTask{testhelpers.PipelineTasks[1]},
 		expectedFinalTasks: PipelineRunState{},
-		expectedFinalNames: sets.NewString(pts[1].Name),
-		expectedTaskNames:  sets.NewString(pts[0].Name),
+		expectedFinalNames: sets.NewString(testhelpers.PipelineTasks[1].Name),
+		expectedTaskNames:  sets.NewString(testhelpers.PipelineTasks[0].Name),
 	}, {
 		// tasks: [ mytask1]
 		// finally: [mytask2]
 		name:               "03 - DAG task not finished, no final tasks",
 		desc:               "DAG tasks (mytask1) started but not finished - do not schedule final tasks (mytask2)",
 		state:              oneStartedState,
-		DAGTasks:           []v1.PipelineTask{pts[0]},
-		finalTasks:         []v1.PipelineTask{pts[1]},
+		DAGTasks:           []v1.PipelineTask{testhelpers.PipelineTasks[0]},
+		finalTasks:         []v1.PipelineTask{testhelpers.PipelineTasks[1]},
 		expectedFinalTasks: PipelineRunState{},
-		expectedFinalNames: sets.NewString(pts[1].Name),
-		expectedTaskNames:  sets.NewString(pts[0].Name),
+		expectedFinalNames: sets.NewString(testhelpers.PipelineTasks[1].Name),
+		expectedTaskNames:  sets.NewString(testhelpers.PipelineTasks[0].Name),
 	}, {
 		// tasks: [ mytask1]
 		// finally: [mytask2]
 		name:               "04 - DAG task done, return final tasks",
 		desc:               "DAG tasks (mytask1) done - schedule final tasks (mytask2)",
 		state:              oneFinishedState,
-		DAGTasks:           []v1.PipelineTask{pts[0]},
-		finalTasks:         []v1.PipelineTask{pts[1]},
+		DAGTasks:           []v1.PipelineTask{testhelpers.PipelineTasks[0]},
+		finalTasks:         []v1.PipelineTask{testhelpers.PipelineTasks[1]},
 		expectedFinalTasks: PipelineRunState{oneFinishedState[1]},
-		expectedFinalNames: sets.NewString(pts[1].Name),
-		expectedTaskNames:  sets.NewString(pts[0].Name),
+		expectedFinalNames: sets.NewString(testhelpers.PipelineTasks[1].Name),
+		expectedTaskNames:  sets.NewString(testhelpers.PipelineTasks[0].Name),
 	}, {
 		// tasks: [ mytask1]
 		// finally: [mytask2]
 		name:               "05 - DAG task failed, return final tasks",
 		desc:               "DAG task (mytask1) failed - schedule final tasks (mytask2)",
 		state:              oneFailedState,
-		DAGTasks:           []v1.PipelineTask{pts[0]},
-		finalTasks:         []v1.PipelineTask{pts[1]},
+		DAGTasks:           []v1.PipelineTask{testhelpers.PipelineTasks[0]},
+		finalTasks:         []v1.PipelineTask{testhelpers.PipelineTasks[1]},
 		expectedFinalTasks: PipelineRunState{oneFinishedState[1]},
-		expectedFinalNames: sets.NewString(pts[1].Name),
-		expectedTaskNames:  sets.NewString(pts[0].Name),
+		expectedFinalNames: sets.NewString(testhelpers.PipelineTasks[1].Name),
+		expectedTaskNames:  sets.NewString(testhelpers.PipelineTasks[0].Name),
 	}, {
 		// tasks: [ mytask1]
 		// finally: [mytask2]
 		name:               "06 - DAG tasks succeeded, final tasks scheduled - no final tasks",
 		desc:               "DAG task (mytask1) finished successfully - final task (mytask2) scheduled - no final tasks",
 		state:              finalScheduledState,
-		DAGTasks:           []v1.PipelineTask{pts[0]},
-		finalTasks:         []v1.PipelineTask{pts[1]},
+		DAGTasks:           []v1.PipelineTask{testhelpers.PipelineTasks[0]},
+		finalTasks:         []v1.PipelineTask{testhelpers.PipelineTasks[1]},
 		expectedFinalTasks: PipelineRunState{},
-		expectedFinalNames: sets.NewString(pts[1].Name),
-		expectedTaskNames:  sets.NewString(pts[0].Name),
+		expectedFinalNames: sets.NewString(testhelpers.PipelineTasks[1].Name),
+		expectedTaskNames:  sets.NewString(testhelpers.PipelineTasks[0].Name),
 	}}
 	for _, tc := range tcs {
 		dagGraph, err := dag.Build(v1.PipelineTaskList(tc.DAGTasks), v1.PipelineTaskList(tc.DAGTasks).Deps())
@@ -1743,8 +1744,8 @@ func TestPipelineRunState_IsFinalTaskStarted(t *testing.T) {
 		name:                     "01 - DAG task started, final task not created",
 		desc:                     "DAG tasks (mytask1) started yet - do not schedule final tasks (mytask2)",
 		state:                    oneStartedState,
-		DAGTasks:                 []v1.PipelineTask{pts[0]},
-		finalTasks:               []v1.PipelineTask{pts[1]},
+		DAGTasks:                 []v1.PipelineTask{testhelpers.PipelineTasks[0]},
+		finalTasks:               []v1.PipelineTask{testhelpers.PipelineTasks[1]},
 		expectedFinalTaskStarted: false,
 	}, {
 		// tasks: [ mytask1(done)]
@@ -1752,8 +1753,8 @@ func TestPipelineRunState_IsFinalTaskStarted(t *testing.T) {
 		name:                     "02 - DAG task succeeded, final task not created",
 		desc:                     "DAG tasks (mytask1) finished successfully - do not schedule final tasks (mytask2)",
 		state:                    oneFinishedState,
-		DAGTasks:                 []v1.PipelineTask{pts[0]},
-		finalTasks:               []v1.PipelineTask{pts[1]},
+		DAGTasks:                 []v1.PipelineTask{testhelpers.PipelineTasks[0]},
+		finalTasks:               []v1.PipelineTask{testhelpers.PipelineTasks[1]},
 		expectedFinalTaskStarted: false,
 	}, {
 		// tasks: [ mytask1(done)]
@@ -1761,7 +1762,7 @@ func TestPipelineRunState_IsFinalTaskStarted(t *testing.T) {
 		name:                     "03 - DAG task succeeded, no final tasks",
 		desc:                     "DAG tasks (mytask1) finished successfully - no final tasks",
 		state:                    oneStartedState,
-		DAGTasks:                 []v1.PipelineTask{pts[0]},
+		DAGTasks:                 []v1.PipelineTask{testhelpers.PipelineTasks[0]},
 		finalTasks:               []v1.PipelineTask{},
 		expectedFinalTaskStarted: false,
 	}, {
@@ -1770,8 +1771,8 @@ func TestPipelineRunState_IsFinalTaskStarted(t *testing.T) {
 		name:                     "04 - DAG task succeeded, final tasks (mytask2) succeeded",
 		desc:                     "DAG tasks (mytask1) finished successfully - final tasks (mytask2) finished successfully",
 		state:                    allFinishedState,
-		DAGTasks:                 []v1.PipelineTask{pts[0]},
-		finalTasks:               []v1.PipelineTask{pts[1]},
+		DAGTasks:                 []v1.PipelineTask{testhelpers.PipelineTasks[0]},
+		finalTasks:               []v1.PipelineTask{testhelpers.PipelineTasks[1]},
 		expectedFinalTaskStarted: true,
 	}}
 	for _, tc := range tcs {
@@ -1802,29 +1803,29 @@ func TestPipelineRunState_IsFinalTaskStarted(t *testing.T) {
 
 func TestGetPipelineConditionStatus(t *testing.T) {
 	var taskRetriedState = PipelineRunState{{
-		PipelineTask: &pts[3], // 1 retry needed
-		TaskRunNames: []string{"pipelinerun-mytask4"},
-		TaskRuns:     []*v1.TaskRun{withCancelled(makeRetried(trs[0]))},
+		PipelineTask: &testhelpers.PipelineTasks[3], // 1 retry needed
+		TaskRunNames: []string{"pipelinerun-mytask1"},
+		TaskRuns:     []*v1.TaskRun{withCancelled(makeRetried(testhelpers.ExampleTaskRuns[0]))},
 		ResolvedTask: &resources.ResolvedTask{
-			TaskSpec: &task.Spec,
+			TaskSpec: &testhelpers.ExampleTask.Spec,
 		},
 	}}
 
 	var taskCancelledFailed = PipelineRunState{{
-		PipelineTask: &pts[4],
-		TaskRunNames: []string{"pipelinerun-mytask5"},
-		TaskRuns:     []*v1.TaskRun{withCancelled(makeFailed(trs[0]))},
+		PipelineTask: &testhelpers.PipelineTasks[4],
+		TaskRunNames: []string{"pipelinerun-mytask1"},
+		TaskRuns:     []*v1.TaskRun{withCancelled(makeFailed(testhelpers.ExampleTaskRuns[0]))},
 	}}
 
 	var taskCancelledFailedTimedOut = PipelineRunState{{
-		PipelineTask: &pts[4],
-		TaskRunNames: []string{"pipelinerun-mytask5"},
-		TaskRuns:     []*v1.TaskRun{withCancelledForTimeout(makeFailed(trs[0]))},
+		PipelineTask: &testhelpers.PipelineTasks[4],
+		TaskRunNames: []string{"pipelinerun-mytask1"},
+		TaskRuns:     []*v1.TaskRun{withCancelledForTimeout(makeFailed(testhelpers.ExampleTaskRuns[0]))},
 	}}
 
 	var cancelledTask = PipelineRunState{{
-		PipelineTask: &pts[3],
-		TaskRunNames: []string{"pipelinerun-mytask4"},
+		PipelineTask: &testhelpers.PipelineTasks[3], // 1 retry needed
+		TaskRunNames: []string{"pipelinerun-mytask1"},
 		TaskRuns: []*v1.TaskRun{{
 			Status: v1.TaskRunStatus{
 				Status: duckv1.Status{Conditions: []apis.Condition{{
@@ -1835,12 +1836,12 @@ func TestGetPipelineConditionStatus(t *testing.T) {
 			},
 		}},
 		ResolvedTask: &resources.ResolvedTask{
-			TaskSpec: &task.Spec,
+			TaskSpec: &testhelpers.ExampleTask.Spec,
 		},
 	}}
 
 	var cancelledRun = PipelineRunState{{
-		PipelineTask:   &pts[12],
+		PipelineTask:   &testhelpers.PipelineTasks[12],
 		CustomTask:     true,
 		CustomRunNames: []string{"pipelinerun-mytask13"},
 		CustomRuns: []*v1beta1.CustomRun{
@@ -1856,7 +1857,7 @@ func TestGetPipelineConditionStatus(t *testing.T) {
 	}}
 
 	var timedOutRun = PipelineRunState{{
-		PipelineTask:   &pts[12],
+		PipelineTask:   &testhelpers.PipelineTasks[12],
 		CustomTask:     true,
 		CustomRunNames: []string{"pipelinerun-mytask13"},
 		CustomRuns: []*v1beta1.CustomRun{
@@ -1875,41 +1876,44 @@ func TestGetPipelineConditionStatus(t *testing.T) {
 	}}
 
 	var notRunningRun = PipelineRunState{{
-		PipelineTask:   &pts[12],
+		PipelineTask:   &testhelpers.PipelineTasks[12],
 		CustomTask:     true,
 		CustomRunNames: []string{"pipelinerun-mytask13"},
 	}}
 
-	// 3 Tasks, 1 successful, 1 running, 1 failed
+	// 6 Tasks, 4 that run in parallel in the beginning
+	// Of the 4, 1 passed, 1 cancelled, 2 failed
+	// 1 runAfter the passed one, currently running
+	// 1 runAfter the failed one, which is marked as incomplete
 	var tasksWithOneFailureSkipRunning = PipelineRunState{{
-		TaskRunNames: []string{"successfulTaskRun"},
-		PipelineTask: &pts[5],
-		TaskRuns:     []*v1.TaskRun{makeSucceeded(trs[0])},
+		TaskRunNames: []string{"task0taskrun"},
+		PipelineTask: &testhelpers.PipelineTasks[5],
+		TaskRuns:     []*v1.TaskRun{makeSucceeded(testhelpers.ExampleTaskRuns[0])},
 	}, {
 		TaskRunNames: []string{"runningTaskRun"}, // this is running
-		PipelineTask: &pts[6],
-		TaskRuns:     []*v1.TaskRun{makeStarted(trs[1])},
+		PipelineTask: &testhelpers.PipelineTasks[6],
+		TaskRuns:     []*v1.TaskRun{makeStarted(testhelpers.ExampleTaskRuns[1])},
 	}, {
 		TaskRunNames: []string{"failedTaskRun"}, // this failed
-		PipelineTask: &pts[0],
-		TaskRuns:     []*v1.TaskRun{makeFailed(trs[0])},
+		PipelineTask: &testhelpers.PipelineTasks[0],
+		TaskRuns:     []*v1.TaskRun{makeFailed(testhelpers.ExampleTaskRuns[0])},
 	}}
 
 	var tasksWithOneFailureOneCancel = tasksWithOneFailureSkipRunning
 	tasksWithOneFailureOneCancel = append(tasksWithOneFailureOneCancel, cancelledTask[0])
 
-	var taskNotRunningWithSuccessfulParentsOneFailed = PipelineRunState{{
-		TaskRunNames: []string{"successfulTaskRun"},
-		PipelineTask: &pts[5],
-		TaskRuns:     []*v1.TaskRun{makeSucceeded(trs[0])},
+	var taskNotRunningWithSuccesfulParentsOneFailed = PipelineRunState{{
+		TaskRunNames: []string{"task0taskrun"},
+		PipelineTask: &testhelpers.PipelineTasks[5],
+		TaskRuns:     []*v1.TaskRun{makeSucceeded(testhelpers.ExampleTaskRuns[0])},
 	}, {
-		TaskRunNames: []string{"notRunningTaskRun"}, // runAfter pts[5], not started yet
-		PipelineTask: &pts[6],
+		TaskRunNames: []string{"notRunningTaskRun"}, // runAfter testhelpers.PipelineTasks[5], not started yet
+		PipelineTask: &testhelpers.PipelineTasks[6],
 		TaskRuns:     nil,
 	}, {
 		TaskRunNames: []string{"failedTaskRun"}, // this failed
-		PipelineTask: &pts[0],
-		TaskRuns:     []*v1.TaskRun{makeFailed(trs[0])},
+		PipelineTask: &testhelpers.PipelineTasks[0],
+		TaskRuns:     []*v1.TaskRun{makeFailed(testhelpers.ExampleTaskRuns[0])},
 	}}
 
 	tenMinutesAgo := now.Add(-10 * time.Minute)
@@ -2031,7 +2035,7 @@ func TestGetPipelineConditionStatus(t *testing.T) {
 		expectedSkipped:    0,
 	}, {
 		name:              "task not started with passed parent; one failed",
-		state:             taskNotRunningWithSuccessfulParentsOneFailed,
+		state:             taskNotRunningWithSuccesfulParentsOneFailed,
 		expectedReason:    v1.PipelineRunReasonFailed.String(),
 		expectedStatus:    corev1.ConditionFalse,
 		expectedSucceeded: 1,
@@ -2148,43 +2152,43 @@ func TestGetPipelineConditionStatus_WithFinalTasks(t *testing.T) {
 	// pipeline state with one DAG successful, one final task failed
 	dagSucceededFinalFailed := PipelineRunState{{
 		TaskRunNames: []string{"task0taskrun"},
-		PipelineTask: &pts[0],
-		TaskRuns:     []*v1.TaskRun{makeSucceeded(trs[0])},
+		PipelineTask: &testhelpers.PipelineTasks[0],
+		TaskRuns:     []*v1.TaskRun{makeSucceeded(testhelpers.ExampleTaskRuns[0])},
 	}, {
 		TaskRunNames: []string{"failedTaskRun"},
-		PipelineTask: &pts[1],
-		TaskRuns:     []*v1.TaskRun{makeFailed(trs[0])},
+		PipelineTask: &testhelpers.PipelineTasks[1],
+		TaskRuns:     []*v1.TaskRun{makeFailed(testhelpers.ExampleTaskRuns[0])},
 	}}
 
 	// pipeline state with one DAG failed, no final started
 	dagFailedFinalNotStarted := PipelineRunState{{
 		TaskRunNames: []string{"task0taskrun"},
-		PipelineTask: &pts[0],
-		TaskRuns:     []*v1.TaskRun{makeFailed(trs[0])},
+		PipelineTask: &testhelpers.PipelineTasks[0],
+		TaskRuns:     []*v1.TaskRun{makeFailed(testhelpers.ExampleTaskRuns[0])},
 	}, {
 		TaskRunNames: []string{"notRunningTaskRun"},
-		PipelineTask: &pts[1],
+		PipelineTask: &testhelpers.PipelineTasks[1],
 		TaskRuns:     nil,
 	}}
 
 	// pipeline state with one DAG failed, one final task failed
 	dagFailedFinalFailed := PipelineRunState{{
 		TaskRunNames: []string{"task0taskrun"},
-		PipelineTask: &pts[0],
-		TaskRuns:     []*v1.TaskRun{makeFailed(trs[0])},
+		PipelineTask: &testhelpers.PipelineTasks[0],
+		TaskRuns:     []*v1.TaskRun{makeFailed(testhelpers.ExampleTaskRuns[0])},
 	}, {
 		TaskRunNames: []string{"failedTaskRun"},
-		PipelineTask: &pts[1],
-		TaskRuns:     []*v1.TaskRun{makeFailed(trs[0])},
+		PipelineTask: &testhelpers.PipelineTasks[1],
+		TaskRuns:     []*v1.TaskRun{makeFailed(testhelpers.ExampleTaskRuns[0])},
 	}}
 
 	// pipeline state with one DAG failed, one final task skipped
 	dagFailedFinalSkipped := PipelineRunState{{
 		TaskRunNames: []string{"task0taskrun"},
-		PipelineTask: &pts[0],
-		TaskRuns:     []*v1.TaskRun{makeFailed(trs[0])},
+		PipelineTask: &testhelpers.PipelineTasks[0],
+		TaskRuns:     []*v1.TaskRun{makeFailed(testhelpers.ExampleTaskRuns[0])},
 	}, {
-		PipelineTask: &pts[14],
+		PipelineTask: &testhelpers.PipelineTasks[14],
 	}}
 
 	tcs := []struct {
@@ -2202,8 +2206,8 @@ func TestGetPipelineConditionStatus_WithFinalTasks(t *testing.T) {
 	}{{
 		name:               "pipeline with one successful DAG task and failed final task",
 		state:              dagSucceededFinalFailed,
-		dagTasks:           []v1.PipelineTask{pts[0]},
-		finalTasks:         []v1.PipelineTask{pts[1]},
+		dagTasks:           []v1.PipelineTask{testhelpers.PipelineTasks[0]},
+		finalTasks:         []v1.PipelineTask{testhelpers.PipelineTasks[1]},
 		expectedStatus:     corev1.ConditionFalse,
 		expectedReason:     v1.PipelineRunReasonFailed.String(),
 		expectedSucceeded:  1,
@@ -2214,8 +2218,8 @@ func TestGetPipelineConditionStatus_WithFinalTasks(t *testing.T) {
 	}, {
 		name:               "pipeline with one failed DAG task and not started final task",
 		state:              dagFailedFinalNotStarted,
-		dagTasks:           []v1.PipelineTask{pts[0]},
-		finalTasks:         []v1.PipelineTask{pts[1]},
+		dagTasks:           []v1.PipelineTask{testhelpers.PipelineTasks[0]},
+		finalTasks:         []v1.PipelineTask{testhelpers.PipelineTasks[1]},
 		expectedStatus:     corev1.ConditionUnknown,
 		expectedReason:     v1.PipelineRunReasonRunning.String(),
 		expectedSucceeded:  0,
@@ -2226,8 +2230,8 @@ func TestGetPipelineConditionStatus_WithFinalTasks(t *testing.T) {
 	}, {
 		name:               "pipeline with one failed DAG task and failed final task",
 		state:              dagFailedFinalFailed,
-		dagTasks:           []v1.PipelineTask{pts[0]},
-		finalTasks:         []v1.PipelineTask{pts[1]},
+		dagTasks:           []v1.PipelineTask{testhelpers.PipelineTasks[0]},
+		finalTasks:         []v1.PipelineTask{testhelpers.PipelineTasks[1]},
 		expectedStatus:     corev1.ConditionFalse,
 		expectedReason:     v1.PipelineRunReasonFailed.String(),
 		expectedSucceeded:  0,
@@ -2238,8 +2242,8 @@ func TestGetPipelineConditionStatus_WithFinalTasks(t *testing.T) {
 	}, {
 		name:               "pipeline with one failed DAG task and skipped final task",
 		state:              dagFailedFinalSkipped,
-		dagTasks:           []v1.PipelineTask{pts[0]},
-		finalTasks:         []v1.PipelineTask{pts[14]},
+		dagTasks:           []v1.PipelineTask{testhelpers.PipelineTasks[0]},
+		finalTasks:         []v1.PipelineTask{testhelpers.PipelineTasks[14]},
 		expectedStatus:     corev1.ConditionFalse,
 		expectedReason:     v1.PipelineRunReasonFailed.String(),
 		expectedSucceeded:  0,
@@ -2387,163 +2391,6 @@ func TestGetPipelineConditionStatus_PipelineTasksTimeouts(t *testing.T) {
 	}
 }
 
-func TestGetPipelineConditionStatus_TasksTimedOutRunningFinally(t *testing.T) {
-	// DAG task that is running (will be timed out)
-	dagRunning := PipelineRunState{{
-		TaskRunNames: []string{"task0taskrun"},
-		PipelineTask: &pts[0],
-		TaskRuns:     []*v1.TaskRun{makeStarted(trs[0])},
-	}}
-
-	// DAG task that has timed out (cancelled) and finally task not started
-	dagTimedOutFinalNotStarted := PipelineRunState{{
-		TaskRunNames: []string{"task0taskrun"},
-		PipelineTask: &pts[0],
-		TaskRuns:     []*v1.TaskRun{withCancelled(makeFailed(trs[0]))},
-	}, {
-		TaskRunNames: []string{"finaltask"},
-		PipelineTask: &pts[1],
-		TaskRuns:     nil,
-	}}
-
-	// DAG task that has timed out (cancelled) and finally task succeeded
-	dagTimedOutFinalDone := PipelineRunState{{
-		TaskRunNames: []string{"task0taskrun"},
-		PipelineTask: &pts[0],
-		TaskRuns:     []*v1.TaskRun{withCancelled(makeFailed(trs[0]))},
-	}, {
-		TaskRunNames: []string{"finaltask"},
-		PipelineTask: &pts[1],
-		TaskRuns:     []*v1.TaskRun{makeSucceeded(trs[1])},
-	}}
-
-	tcs := []struct {
-		name           string
-		state          PipelineRunState
-		dagTasks       []v1.PipelineTask
-		finalTasks     []v1.PipelineTask
-		expectedStatus corev1.ConditionStatus
-		expectedReason string
-	}{{
-		name:           "tasks timed out with finally tasks not started - should keep running",
-		state:          dagTimedOutFinalNotStarted,
-		dagTasks:       []v1.PipelineTask{pts[0]},
-		finalTasks:     []v1.PipelineTask{pts[1]},
-		expectedStatus: corev1.ConditionUnknown,
-		expectedReason: v1.PipelineRunReasonTimedOutRunningFinally.String(),
-	}, {
-		name:           "tasks timed out with finally tasks completed - should fail",
-		state:          dagTimedOutFinalDone,
-		dagTasks:       []v1.PipelineTask{pts[0]},
-		finalTasks:     []v1.PipelineTask{pts[1]},
-		expectedStatus: corev1.ConditionFalse,
-		expectedReason: v1.PipelineRunReasonTimedOut.String(),
-	}, {
-		name:           "tasks timed out with no finally tasks - should fail",
-		state:          dagRunning,
-		dagTasks:       []v1.PipelineTask{pts[0]},
-		finalTasks:     []v1.PipelineTask{},
-		expectedStatus: corev1.ConditionFalse,
-		expectedReason: v1.PipelineRunReasonTimedOut.String(),
-	}}
-
-	for _, tc := range tcs {
-		t.Run(tc.name, func(t *testing.T) {
-			pr := &v1.PipelineRun{
-				ObjectMeta: metav1.ObjectMeta{Name: "pipelinerun-tasks-timeout-finally"},
-				Spec: v1.PipelineRunSpec{
-					Timeouts: &v1.TimeoutFields{
-						Pipeline: &metav1.Duration{Duration: 2 * time.Minute},
-						Finally:  &metav1.Duration{Duration: 1 * time.Minute},
-						// tasks timeout is calculated: pipeline - finally = 1 minute
-					},
-				},
-				Status: v1.PipelineRunStatus{
-					PipelineRunStatusFields: v1.PipelineRunStatusFields{
-						StartTime: &metav1.Time{Time: now.Add(-90 * time.Second)},
-					},
-				},
-			}
-			d, err := dag.Build(v1.PipelineTaskList(tc.dagTasks), v1.PipelineTaskList(tc.dagTasks).Deps())
-			if err != nil {
-				t.Fatalf("Unexpected error while building graph for DAG tasks %v: %v", tc.dagTasks, err)
-			}
-			df, err := dag.Build(v1.PipelineTaskList(tc.finalTasks), map[string][]string{})
-			if err != nil {
-				t.Fatalf("Unexpected error while building graph for final tasks %v: %v", tc.finalTasks, err)
-			}
-			facts := PipelineRunFacts{
-				State:           tc.state,
-				TasksGraph:      d,
-				FinalTasksGraph: df,
-				TimeoutsState: PipelineRunTimeoutsState{
-					Clock: testClock,
-				},
-			}
-			c := facts.GetPipelineConditionStatus(t.Context(), pr, zap.NewNop().Sugar(), testClock)
-			if c.Status != tc.expectedStatus {
-				t.Errorf("Expected status %s but got %s for test %s", tc.expectedStatus, c.Status, tc.name)
-			}
-			if c.Reason != tc.expectedReason {
-				t.Errorf("Expected reason %s but got %s for test %s", tc.expectedReason, c.Reason, tc.name)
-			}
-		})
-	}
-}
-
-func TestGetPipelineConditionStatus_TasksTimedOutExplicitWithFinally(t *testing.T) {
-	// Same as above but with explicit tasks timeout instead of calculated
-	dagTimedOutFinalNotStarted := PipelineRunState{{
-		TaskRunNames: []string{"task0taskrun"},
-		PipelineTask: &pts[0],
-		TaskRuns:     []*v1.TaskRun{withCancelled(makeFailed(trs[0]))},
-	}, {
-		TaskRunNames: []string{"finaltask"},
-		PipelineTask: &pts[1],
-		TaskRuns:     nil,
-	}}
-
-	pr := &v1.PipelineRun{
-		ObjectMeta: metav1.ObjectMeta{Name: "pipelinerun-explicit-tasks-timeout-finally"},
-		Spec: v1.PipelineRunSpec{
-			Timeouts: &v1.TimeoutFields{
-				Pipeline: &metav1.Duration{Duration: 2 * time.Minute},
-				Tasks:    &metav1.Duration{Duration: 1 * time.Minute},
-			},
-		},
-		Status: v1.PipelineRunStatus{
-			PipelineRunStatusFields: v1.PipelineRunStatusFields{
-				StartTime: &metav1.Time{Time: now.Add(-90 * time.Second)},
-			},
-		},
-	}
-
-	d, err := dag.Build(v1.PipelineTaskList([]v1.PipelineTask{pts[0]}), v1.PipelineTaskList([]v1.PipelineTask{pts[0]}).Deps())
-	if err != nil {
-		t.Fatalf("Unexpected error while building graph for DAG tasks: %v", err)
-	}
-	df, err := dag.Build(v1.PipelineTaskList([]v1.PipelineTask{pts[1]}), map[string][]string{})
-	if err != nil {
-		t.Fatalf("Unexpected error while building graph for final tasks: %v", err)
-	}
-
-	facts := PipelineRunFacts{
-		State:           dagTimedOutFinalNotStarted,
-		TasksGraph:      d,
-		FinalTasksGraph: df,
-		TimeoutsState: PipelineRunTimeoutsState{
-			Clock: testClock,
-		},
-	}
-	c := facts.GetPipelineConditionStatus(t.Context(), pr, zap.NewNop().Sugar(), testClock)
-	if c.Status != corev1.ConditionUnknown {
-		t.Errorf("Expected status %s but got %s", corev1.ConditionUnknown, c.Status)
-	}
-	if c.Reason != v1.PipelineRunReasonTimedOutRunningFinally.String() {
-		t.Errorf("Expected reason %s but got %s", v1.PipelineRunReasonTimedOutRunningFinally.String(), c.Reason)
-	}
-}
-
 func TestGetPipelineConditionStatus_OnError(t *testing.T) {
 	var oneFailedStateOnError = PipelineRunState{{
 		PipelineTask: &v1.PipelineTask{
@@ -2552,16 +2399,16 @@ func TestGetPipelineConditionStatus_OnError(t *testing.T) {
 			OnError: v1.PipelineTaskContinue,
 		},
 		TaskRunNames: []string{"pipelinerun-mytask1"},
-		TaskRuns:     []*v1.TaskRun{makeFailed(trs[0])},
+		TaskRuns:     []*v1.TaskRun{makeFailed(testhelpers.ExampleTaskRuns[0])},
 		ResolvedTask: &resources.ResolvedTask{
-			TaskSpec: &task.Spec,
+			TaskSpec: &testhelpers.ExampleTask.Spec,
 		},
 	}, {
-		PipelineTask: &pts[0],
+		PipelineTask: &testhelpers.PipelineTasks[0],
 		TaskRunNames: []string{"pipelinerun-mytask2"},
-		TaskRuns:     []*v1.TaskRun{makeSucceeded(trs[0])},
+		TaskRuns:     []*v1.TaskRun{makeSucceeded(testhelpers.ExampleTaskRuns[0])},
 		ResolvedTask: &resources.ResolvedTask{
-			TaskSpec: &task.Spec,
+			TaskSpec: &testhelpers.ExampleTask.Spec,
 		},
 	}}
 	d, err := dagFromState(oneFailedStateOnError)
@@ -2798,199 +2645,144 @@ func TestPipelineRunFacts_GetPipelineTaskStatus(t *testing.T) {
 	}{{
 		name:     "no-tasks-started",
 		state:    noneStartedState,
-		dagTasks: []v1.PipelineTask{pts[0], pts[1]},
+		dagTasks: []v1.PipelineTask{testhelpers.PipelineTasks[0], testhelpers.PipelineTasks[1]},
 		expectedStatus: map[string]string{
-			PipelineTaskStatusPrefix + pts[0].Name + PipelineTaskStatusSuffix: PipelineTaskStateNone,
-			PipelineTaskStatusPrefix + pts[0].Name + PipelineTaskReasonSuffix: "",
-			PipelineTaskStatusPrefix + pts[1].Name + PipelineTaskStatusSuffix: PipelineTaskStateNone,
-			PipelineTaskStatusPrefix + pts[1].Name + PipelineTaskReasonSuffix: "",
-			v1.PipelineTasksAggregateStatus:                                   PipelineTaskStateNone,
+			PipelineTaskStatusPrefix + testhelpers.PipelineTasks[0].Name + PipelineTaskStatusSuffix: PipelineTaskStateNone,
+			PipelineTaskStatusPrefix + testhelpers.PipelineTasks[0].Name + PipelineTaskReasonSuffix: "",
+			PipelineTaskStatusPrefix + testhelpers.PipelineTasks[1].Name + PipelineTaskStatusSuffix: PipelineTaskStateNone,
+			PipelineTaskStatusPrefix + testhelpers.PipelineTasks[1].Name + PipelineTaskReasonSuffix: "",
+			v1.PipelineTasksAggregateStatus: PipelineTaskStateNone,
 		},
 	}, {
 		name:     "one-task-started",
 		state:    oneStartedState,
-		dagTasks: []v1.PipelineTask{pts[0], pts[1]},
+		dagTasks: []v1.PipelineTask{testhelpers.PipelineTasks[0], testhelpers.PipelineTasks[1]},
 		expectedStatus: map[string]string{
-			PipelineTaskStatusPrefix + pts[0].Name + PipelineTaskStatusSuffix: PipelineTaskStateNone,
-			PipelineTaskStatusPrefix + pts[0].Name + PipelineTaskReasonSuffix: "",
-			PipelineTaskStatusPrefix + pts[1].Name + PipelineTaskStatusSuffix: PipelineTaskStateNone,
-			PipelineTaskStatusPrefix + pts[1].Name + PipelineTaskReasonSuffix: "",
-			v1.PipelineTasksAggregateStatus:                                   PipelineTaskStateNone,
+			PipelineTaskStatusPrefix + testhelpers.PipelineTasks[0].Name + PipelineTaskStatusSuffix: PipelineTaskStateNone,
+			PipelineTaskStatusPrefix + testhelpers.PipelineTasks[0].Name + PipelineTaskReasonSuffix: "",
+			PipelineTaskStatusPrefix + testhelpers.PipelineTasks[1].Name + PipelineTaskStatusSuffix: PipelineTaskStateNone,
+			PipelineTaskStatusPrefix + testhelpers.PipelineTasks[1].Name + PipelineTaskReasonSuffix: "",
+			v1.PipelineTasksAggregateStatus: PipelineTaskStateNone,
 		},
 	}, {
 		name:     "one-task-finished",
 		state:    oneFinishedState,
-		dagTasks: []v1.PipelineTask{pts[0], pts[1]},
+		dagTasks: []v1.PipelineTask{testhelpers.PipelineTasks[0], testhelpers.PipelineTasks[1]},
 		expectedStatus: map[string]string{
-			PipelineTaskStatusPrefix + pts[0].Name + PipelineTaskStatusSuffix: v1.TaskRunReasonSuccessful.String(),
-			PipelineTaskStatusPrefix + pts[0].Name + PipelineTaskReasonSuffix: "Succeeded",
-			PipelineTaskStatusPrefix + pts[1].Name + PipelineTaskStatusSuffix: PipelineTaskStateNone,
-			PipelineTaskStatusPrefix + pts[1].Name + PipelineTaskReasonSuffix: "",
-			v1.PipelineTasksAggregateStatus:                                   PipelineTaskStateNone,
+			PipelineTaskStatusPrefix + testhelpers.PipelineTasks[0].Name + PipelineTaskStatusSuffix: v1.TaskRunReasonSuccessful.String(),
+			PipelineTaskStatusPrefix + testhelpers.PipelineTasks[0].Name + PipelineTaskReasonSuffix: "Succeeded",
+			PipelineTaskStatusPrefix + testhelpers.PipelineTasks[1].Name + PipelineTaskStatusSuffix: PipelineTaskStateNone,
+			PipelineTaskStatusPrefix + testhelpers.PipelineTasks[1].Name + PipelineTaskReasonSuffix: "",
+			v1.PipelineTasksAggregateStatus: PipelineTaskStateNone,
 		},
 	}, {
 		name:     "one-task-failed",
 		state:    oneFailedState,
-		dagTasks: []v1.PipelineTask{pts[0], pts[1]},
+		dagTasks: []v1.PipelineTask{testhelpers.PipelineTasks[0], testhelpers.PipelineTasks[1]},
 		expectedStatus: map[string]string{
-			PipelineTaskStatusPrefix + pts[0].Name + PipelineTaskStatusSuffix: v1.TaskRunReasonFailed.String(),
-			PipelineTaskStatusPrefix + pts[0].Name + PipelineTaskReasonSuffix: "Failed",
-			PipelineTaskStatusPrefix + pts[1].Name + PipelineTaskStatusSuffix: PipelineTaskStateNone,
-			PipelineTaskStatusPrefix + pts[1].Name + PipelineTaskReasonSuffix: "",
-			v1.PipelineTasksAggregateStatus:                                   v1.PipelineRunReasonFailed.String(),
+			PipelineTaskStatusPrefix + testhelpers.PipelineTasks[0].Name + PipelineTaskStatusSuffix: v1.TaskRunReasonFailed.String(),
+			PipelineTaskStatusPrefix + testhelpers.PipelineTasks[0].Name + PipelineTaskReasonSuffix: "Failed",
+			PipelineTaskStatusPrefix + testhelpers.PipelineTasks[1].Name + PipelineTaskStatusSuffix: PipelineTaskStateNone,
+			PipelineTaskStatusPrefix + testhelpers.PipelineTasks[1].Name + PipelineTaskReasonSuffix: "",
+			v1.PipelineTasksAggregateStatus: v1.PipelineRunReasonFailed.String(),
 		},
 	}, {
 		name:     "all-finished",
 		state:    allFinishedState,
-		dagTasks: []v1.PipelineTask{pts[0], pts[1]},
+		dagTasks: []v1.PipelineTask{testhelpers.PipelineTasks[0], testhelpers.PipelineTasks[1]},
 		expectedStatus: map[string]string{
-			PipelineTaskStatusPrefix + pts[0].Name + PipelineTaskStatusSuffix: v1.TaskRunReasonSuccessful.String(),
-			PipelineTaskStatusPrefix + pts[0].Name + PipelineTaskReasonSuffix: "Succeeded",
-			PipelineTaskStatusPrefix + pts[1].Name + PipelineTaskStatusSuffix: v1.TaskRunReasonSuccessful.String(),
-			PipelineTaskStatusPrefix + pts[1].Name + PipelineTaskReasonSuffix: "Succeeded",
-			v1.PipelineTasksAggregateStatus:                                   v1.PipelineRunReasonSuccessful.String(),
+			PipelineTaskStatusPrefix + testhelpers.PipelineTasks[0].Name + PipelineTaskStatusSuffix: v1.TaskRunReasonSuccessful.String(),
+			PipelineTaskStatusPrefix + testhelpers.PipelineTasks[0].Name + PipelineTaskReasonSuffix: "Succeeded",
+			PipelineTaskStatusPrefix + testhelpers.PipelineTasks[1].Name + PipelineTaskStatusSuffix: v1.TaskRunReasonSuccessful.String(),
+			PipelineTaskStatusPrefix + testhelpers.PipelineTasks[1].Name + PipelineTaskReasonSuffix: "Succeeded",
+			v1.PipelineTasksAggregateStatus: v1.PipelineRunReasonSuccessful.String(),
 		},
 	}, {
 		name: "task-with-when-expressions-passed",
 		state: PipelineRunState{{
-			PipelineTask: &pts[9],
+			PipelineTask: &testhelpers.PipelineTasks[9],
 			TaskRunNames: []string{"pr-guard-succeeded-task-not-started"},
 			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
-				TaskSpec: &task.Spec,
+				TaskSpec: &testhelpers.ExampleTask.Spec,
 			},
 		}},
-		dagTasks: []v1.PipelineTask{pts[9]},
+		dagTasks: []v1.PipelineTask{testhelpers.PipelineTasks[9]},
 		expectedStatus: map[string]string{
-			PipelineTaskStatusPrefix + pts[9].Name + PipelineTaskStatusSuffix: PipelineTaskStateNone,
-			PipelineTaskStatusPrefix + pts[9].Name + PipelineTaskReasonSuffix: "",
-			v1.PipelineTasksAggregateStatus:                                   PipelineTaskStateNone,
+			PipelineTaskStatusPrefix + testhelpers.PipelineTasks[9].Name + PipelineTaskStatusSuffix: PipelineTaskStateNone,
+			PipelineTaskStatusPrefix + testhelpers.PipelineTasks[9].Name + PipelineTaskReasonSuffix: "",
+			v1.PipelineTasksAggregateStatus: PipelineTaskStateNone,
 		},
 	}, {
 		name: "tasks-when-expression-failed-and-task-skipped",
 		state: PipelineRunState{{
-			PipelineTask: &pts[10],
+			PipelineTask: &testhelpers.PipelineTasks[10],
 			TaskRunNames: []string{"pr-guardedtask-skipped"},
 			ResolvedTask: &resources.ResolvedTask{
-				TaskSpec: &task.Spec,
+				TaskSpec: &testhelpers.ExampleTask.Spec,
 			},
 		}},
-		dagTasks: []v1.PipelineTask{pts[10]},
+		dagTasks: []v1.PipelineTask{testhelpers.PipelineTasks[10]},
 		expectedStatus: map[string]string{
-			PipelineTaskStatusPrefix + pts[10].Name + PipelineTaskStatusSuffix: PipelineTaskStateNone,
-			PipelineTaskStatusPrefix + pts[10].Name + PipelineTaskReasonSuffix: "",
-			v1.PipelineTasksAggregateStatus:                                    v1.PipelineRunReasonCompleted.String(),
+			PipelineTaskStatusPrefix + testhelpers.PipelineTasks[10].Name + PipelineTaskStatusSuffix: PipelineTaskStateNone,
+			PipelineTaskStatusPrefix + testhelpers.PipelineTasks[10].Name + PipelineTaskReasonSuffix: "",
+			v1.PipelineTasksAggregateStatus: v1.PipelineRunReasonCompleted.String(),
 		},
 	}, {
 		name: "when-expression-task-with-parent-started",
 		state: PipelineRunState{{
-			PipelineTask: &pts[0],
-			TaskRuns:     []*v1.TaskRun{makeStarted(trs[0])},
+			PipelineTask: &testhelpers.PipelineTasks[0],
+			TaskRuns:     []*v1.TaskRun{makeStarted(testhelpers.ExampleTaskRuns[0])},
 			ResolvedTask: &resources.ResolvedTask{
-				TaskSpec: &task.Spec,
+				TaskSpec: &testhelpers.ExampleTask.Spec,
 			},
 		}, {
-			PipelineTask: &pts[11],
+			PipelineTask: &testhelpers.PipelineTasks[11],
 			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
-				TaskSpec: &task.Spec,
+				TaskSpec: &testhelpers.ExampleTask.Spec,
 			},
 		}},
-		dagTasks: []v1.PipelineTask{pts[0], pts[11]},
+		dagTasks: []v1.PipelineTask{testhelpers.PipelineTasks[0], testhelpers.PipelineTasks[11]},
 		expectedStatus: map[string]string{
-			PipelineTaskStatusPrefix + pts[0].Name + PipelineTaskStatusSuffix:  PipelineTaskStateNone,
-			PipelineTaskStatusPrefix + pts[0].Name + PipelineTaskReasonSuffix:  "",
-			PipelineTaskStatusPrefix + pts[11].Name + PipelineTaskStatusSuffix: PipelineTaskStateNone,
-			PipelineTaskStatusPrefix + pts[11].Name + PipelineTaskReasonSuffix: "",
-			v1.PipelineTasksAggregateStatus:                                    PipelineTaskStateNone,
+			PipelineTaskStatusPrefix + testhelpers.PipelineTasks[0].Name + PipelineTaskStatusSuffix:  PipelineTaskStateNone,
+			PipelineTaskStatusPrefix + testhelpers.PipelineTasks[0].Name + PipelineTaskReasonSuffix:  "",
+			PipelineTaskStatusPrefix + testhelpers.PipelineTasks[11].Name + PipelineTaskStatusSuffix: PipelineTaskStateNone,
+			PipelineTaskStatusPrefix + testhelpers.PipelineTasks[11].Name + PipelineTaskReasonSuffix: "",
+			v1.PipelineTasksAggregateStatus: PipelineTaskStateNone,
 		},
 	}, {
 		name:     "task-cancelled",
 		state:    taskCancelled,
-		dagTasks: []v1.PipelineTask{pts[4]},
+		dagTasks: []v1.PipelineTask{testhelpers.PipelineTasks[4]},
 		expectedStatus: map[string]string{
-			PipelineTaskStatusPrefix + pts[4].Name + PipelineTaskStatusSuffix: PipelineTaskStateNone,
-			PipelineTaskStatusPrefix + pts[4].Name + PipelineTaskReasonSuffix: v1.TaskRunReasonCancelled.String(),
-			v1.PipelineTasksAggregateStatus:                                   PipelineTaskStateNone,
+			PipelineTaskStatusPrefix + testhelpers.PipelineTasks[4].Name + PipelineTaskStatusSuffix: PipelineTaskStateNone,
+			PipelineTaskStatusPrefix + testhelpers.PipelineTasks[4].Name + PipelineTaskReasonSuffix: v1.TaskRunReasonCancelled.String(),
+			v1.PipelineTasksAggregateStatus: PipelineTaskStateNone,
 		},
 	}, {
 		name: "one-skipped-one-failed-aggregate-status-must-be-failed",
 		state: PipelineRunState{{
-			PipelineTask: &pts[10],
+			PipelineTask: &testhelpers.PipelineTasks[10],
 			TaskRunNames: []string{"pr-guardedtask-skipped"},
 			ResolvedTask: &resources.ResolvedTask{
-				TaskSpec: &task.Spec,
+				TaskSpec: &testhelpers.ExampleTask.Spec,
 			},
 		}, {
-			PipelineTask: &pts[0],
+			PipelineTask: &testhelpers.PipelineTasks[0],
 			TaskRunNames: []string{"pipelinerun-mytask1"},
-			TaskRuns:     []*v1.TaskRun{makeFailed(trs[0])},
+			TaskRuns:     []*v1.TaskRun{makeFailed(testhelpers.ExampleTaskRuns[0])},
 			ResolvedTask: &resources.ResolvedTask{
-				TaskSpec: &task.Spec,
+				TaskSpec: &testhelpers.ExampleTask.Spec,
 			},
 		}},
-		dagTasks: []v1.PipelineTask{pts[0], pts[10]},
+		dagTasks: []v1.PipelineTask{testhelpers.PipelineTasks[0], testhelpers.PipelineTasks[10]},
 		expectedStatus: map[string]string{
-			PipelineTaskStatusPrefix + pts[0].Name + PipelineTaskStatusSuffix:  v1.PipelineRunReasonFailed.String(),
-			PipelineTaskStatusPrefix + pts[0].Name + PipelineTaskReasonSuffix:  v1.PipelineRunReasonFailed.String(),
-			PipelineTaskStatusPrefix + pts[10].Name + PipelineTaskStatusSuffix: PipelineTaskStateNone,
-			PipelineTaskStatusPrefix + pts[10].Name + PipelineTaskReasonSuffix: "",
-			v1.PipelineTasksAggregateStatus:                                    v1.PipelineRunReasonFailed.String(),
-		},
-	}, {
-		name:     "no-child-pipelines-started",
-		state:    noneStartedChildPipelineRunState,
-		dagTasks: []v1.PipelineTask{pts[21], pts[22]},
-		expectedStatus: map[string]string{
-			PipelineTaskStatusPrefix + pts[21].Name + PipelineTaskStatusSuffix: PipelineTaskStateNone,
-			PipelineTaskStatusPrefix + pts[21].Name + PipelineTaskReasonSuffix: "",
-			PipelineTaskStatusPrefix + pts[22].Name + PipelineTaskStatusSuffix: PipelineTaskStateNone,
-			PipelineTaskStatusPrefix + pts[22].Name + PipelineTaskReasonSuffix: "",
-			v1.PipelineTasksAggregateStatus:                                    PipelineTaskStateNone,
-		},
-	}, {
-		name:     "one-child-pipeline-started",
-		state:    oneChildPipelineRunStartedState,
-		dagTasks: []v1.PipelineTask{pts[21], pts[22]},
-		expectedStatus: map[string]string{
-			PipelineTaskStatusPrefix + pts[21].Name + PipelineTaskStatusSuffix: PipelineTaskStateNone,
-			PipelineTaskStatusPrefix + pts[21].Name + PipelineTaskReasonSuffix: "",
-			PipelineTaskStatusPrefix + pts[22].Name + PipelineTaskStatusSuffix: PipelineTaskStateNone,
-			PipelineTaskStatusPrefix + pts[22].Name + PipelineTaskReasonSuffix: "",
-			v1.PipelineTasksAggregateStatus:                                    PipelineTaskStateNone,
-		},
-	}, {
-		name:     "one-child-pipeline-finished",
-		state:    oneChildPipelineRunFinishedState,
-		dagTasks: []v1.PipelineTask{pts[21], pts[22]},
-		expectedStatus: map[string]string{
-			PipelineTaskStatusPrefix + pts[21].Name + PipelineTaskStatusSuffix: v1.PipelineRunReasonSuccessful.String(),
-			PipelineTaskStatusPrefix + pts[21].Name + PipelineTaskReasonSuffix: "Succeeded",
-			PipelineTaskStatusPrefix + pts[22].Name + PipelineTaskStatusSuffix: PipelineTaskStateNone,
-			PipelineTaskStatusPrefix + pts[22].Name + PipelineTaskReasonSuffix: "",
-			v1.PipelineTasksAggregateStatus:                                    PipelineTaskStateNone,
-		},
-	}, {
-		name:     "one-child-pipeline-failed",
-		state:    oneChildPipelineRunFailedState,
-		dagTasks: []v1.PipelineTask{pts[21], pts[22]},
-		expectedStatus: map[string]string{
-			PipelineTaskStatusPrefix + pts[21].Name + PipelineTaskStatusSuffix: v1.PipelineRunReasonFailed.String(),
-			PipelineTaskStatusPrefix + pts[21].Name + PipelineTaskReasonSuffix: "Failed",
-			PipelineTaskStatusPrefix + pts[22].Name + PipelineTaskStatusSuffix: PipelineTaskStateNone,
-			PipelineTaskStatusPrefix + pts[22].Name + PipelineTaskReasonSuffix: "",
-			v1.PipelineTasksAggregateStatus:                                    v1.PipelineRunReasonFailed.String(),
-		},
-	}, {
-		name:     "all-child-pipelines-finished",
-		state:    allChildPipelineRunsFinishedState,
-		dagTasks: []v1.PipelineTask{pts[21], pts[22]},
-		expectedStatus: map[string]string{
-			PipelineTaskStatusPrefix + pts[21].Name + PipelineTaskStatusSuffix: v1.PipelineRunReasonSuccessful.String(),
-			PipelineTaskStatusPrefix + pts[21].Name + PipelineTaskReasonSuffix: "Succeeded",
-			PipelineTaskStatusPrefix + pts[22].Name + PipelineTaskStatusSuffix: v1.PipelineRunReasonSuccessful.String(),
-			PipelineTaskStatusPrefix + pts[22].Name + PipelineTaskReasonSuffix: "Succeeded",
-			v1.PipelineTasksAggregateStatus:                                    v1.PipelineRunReasonSuccessful.String(),
+			PipelineTaskStatusPrefix + testhelpers.PipelineTasks[0].Name + PipelineTaskStatusSuffix:  v1.PipelineRunReasonFailed.String(),
+			PipelineTaskStatusPrefix + testhelpers.PipelineTasks[0].Name + PipelineTaskReasonSuffix:  v1.PipelineRunReasonFailed.String(),
+			PipelineTaskStatusPrefix + testhelpers.PipelineTasks[10].Name + PipelineTaskStatusSuffix: PipelineTaskStateNone,
+			PipelineTaskStatusPrefix + testhelpers.PipelineTasks[10].Name + PipelineTaskReasonSuffix: "",
+			v1.PipelineTasksAggregateStatus: v1.PipelineRunReasonFailed.String(),
 		},
 	}}
 	for _, tc := range tcs {
@@ -3024,117 +2816,117 @@ func TestPipelineRunFacts_GetPipelineFinalTaskStatus(t *testing.T) {
 	}{{
 		name:       "no-tasks-started",
 		state:      noneStartedState,
-		finalTasks: []v1.PipelineTask{pts[0], pts[1]},
+		finalTasks: []v1.PipelineTask{testhelpers.PipelineTasks[0], testhelpers.PipelineTasks[1]},
 		expectedStatus: map[string]string{
-			PipelineTaskStatusPrefix + pts[0].Name + PipelineTaskStatusSuffix: PipelineTaskStateNone,
-			PipelineTaskStatusPrefix + pts[1].Name + PipelineTaskStatusSuffix: PipelineTaskStateNone,
+			PipelineTaskStatusPrefix + testhelpers.PipelineTasks[0].Name + PipelineTaskStatusSuffix: PipelineTaskStateNone,
+			PipelineTaskStatusPrefix + testhelpers.PipelineTasks[1].Name + PipelineTaskStatusSuffix: PipelineTaskStateNone,
 		},
 	}, {
 		name:       "one-task-started",
 		state:      oneStartedState,
-		finalTasks: []v1.PipelineTask{pts[0], pts[1]},
+		finalTasks: []v1.PipelineTask{testhelpers.PipelineTasks[0], testhelpers.PipelineTasks[1]},
 		expectedStatus: map[string]string{
-			PipelineTaskStatusPrefix + pts[0].Name + PipelineTaskStatusSuffix: PipelineTaskStateNone,
-			PipelineTaskStatusPrefix + pts[1].Name + PipelineTaskStatusSuffix: PipelineTaskStateNone,
+			PipelineTaskStatusPrefix + testhelpers.PipelineTasks[0].Name + PipelineTaskStatusSuffix: PipelineTaskStateNone,
+			PipelineTaskStatusPrefix + testhelpers.PipelineTasks[1].Name + PipelineTaskStatusSuffix: PipelineTaskStateNone,
 		},
 	}, {
 		name:       "one-task-finished",
 		state:      oneFinishedState,
-		finalTasks: []v1.PipelineTask{pts[0], pts[1]},
+		finalTasks: []v1.PipelineTask{testhelpers.PipelineTasks[0], testhelpers.PipelineTasks[1]},
 		expectedStatus: map[string]string{
-			PipelineTaskStatusPrefix + pts[0].Name + PipelineTaskStatusSuffix: v1.TaskRunReasonSuccessful.String(),
-			PipelineTaskStatusPrefix + pts[1].Name + PipelineTaskStatusSuffix: PipelineTaskStateNone,
+			PipelineTaskStatusPrefix + testhelpers.PipelineTasks[0].Name + PipelineTaskStatusSuffix: v1.TaskRunReasonSuccessful.String(),
+			PipelineTaskStatusPrefix + testhelpers.PipelineTasks[1].Name + PipelineTaskStatusSuffix: PipelineTaskStateNone,
 		},
 	}, {
 		name:       "one-task-failed",
 		state:      oneFailedState,
-		finalTasks: []v1.PipelineTask{pts[0], pts[1]},
+		finalTasks: []v1.PipelineTask{testhelpers.PipelineTasks[0], testhelpers.PipelineTasks[1]},
 		expectedStatus: map[string]string{
-			PipelineTaskStatusPrefix + pts[0].Name + PipelineTaskStatusSuffix: v1.TaskRunReasonFailed.String(),
-			PipelineTaskStatusPrefix + pts[1].Name + PipelineTaskStatusSuffix: PipelineTaskStateNone,
+			PipelineTaskStatusPrefix + testhelpers.PipelineTasks[0].Name + PipelineTaskStatusSuffix: v1.TaskRunReasonFailed.String(),
+			PipelineTaskStatusPrefix + testhelpers.PipelineTasks[1].Name + PipelineTaskStatusSuffix: PipelineTaskStateNone,
 		},
 	}, {
 		name:       "all-finished",
 		state:      allFinishedState,
-		finalTasks: []v1.PipelineTask{pts[0], pts[1]},
+		finalTasks: []v1.PipelineTask{testhelpers.PipelineTasks[0], testhelpers.PipelineTasks[1]},
 		expectedStatus: map[string]string{
-			PipelineTaskStatusPrefix + pts[0].Name + PipelineTaskStatusSuffix: v1.TaskRunReasonSuccessful.String(),
-			PipelineTaskStatusPrefix + pts[1].Name + PipelineTaskStatusSuffix: v1.TaskRunReasonSuccessful.String(),
+			PipelineTaskStatusPrefix + testhelpers.PipelineTasks[0].Name + PipelineTaskStatusSuffix: v1.TaskRunReasonSuccessful.String(),
+			PipelineTaskStatusPrefix + testhelpers.PipelineTasks[1].Name + PipelineTaskStatusSuffix: v1.TaskRunReasonSuccessful.String(),
 		},
 	}, {
 		name: "task-with-when-expressions-passed",
 		state: PipelineRunState{{
-			PipelineTask: &pts[9],
+			PipelineTask: &testhelpers.PipelineTasks[9],
 			TaskRunNames: []string{"pr-guard-succeeded-task-not-started"},
 			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
-				TaskSpec: &task.Spec,
+				TaskSpec: &testhelpers.ExampleTask.Spec,
 			},
 		}},
-		finalTasks: []v1.PipelineTask{pts[9]},
+		finalTasks: []v1.PipelineTask{testhelpers.PipelineTasks[9]},
 		expectedStatus: map[string]string{
-			PipelineTaskStatusPrefix + pts[9].Name + PipelineTaskStatusSuffix: PipelineTaskStateNone,
+			PipelineTaskStatusPrefix + testhelpers.PipelineTasks[9].Name + PipelineTaskStatusSuffix: PipelineTaskStateNone,
 		},
 	}, {
 		name: "tasks-when-expression-failed-and-task-skipped",
 		state: PipelineRunState{{
-			PipelineTask: &pts[10],
+			PipelineTask: &testhelpers.PipelineTasks[10],
 			TaskRunNames: []string{"pr-guardedtask-skipped"},
 			ResolvedTask: &resources.ResolvedTask{
-				TaskSpec: &task.Spec,
+				TaskSpec: &testhelpers.ExampleTask.Spec,
 			},
 		}},
-		finalTasks: []v1.PipelineTask{pts[10]},
+		finalTasks: []v1.PipelineTask{testhelpers.PipelineTasks[10]},
 		expectedStatus: map[string]string{
-			PipelineTaskStatusPrefix + pts[10].Name + PipelineTaskStatusSuffix: PipelineTaskStateNone,
+			PipelineTaskStatusPrefix + testhelpers.PipelineTasks[10].Name + PipelineTaskStatusSuffix: PipelineTaskStateNone,
 		},
 	}, {
 		name: "when-expression-task-with-parent-started",
 		state: PipelineRunState{{
-			PipelineTask: &pts[0],
-			TaskRuns:     []*v1.TaskRun{makeStarted(trs[0])},
+			PipelineTask: &testhelpers.PipelineTasks[0],
+			TaskRuns:     []*v1.TaskRun{makeStarted(testhelpers.ExampleTaskRuns[0])},
 			ResolvedTask: &resources.ResolvedTask{
-				TaskSpec: &task.Spec,
+				TaskSpec: &testhelpers.ExampleTask.Spec,
 			},
 		}, {
-			PipelineTask: &pts[11],
+			PipelineTask: &testhelpers.PipelineTasks[11],
 			TaskRuns:     nil,
 			ResolvedTask: &resources.ResolvedTask{
-				TaskSpec: &task.Spec,
+				TaskSpec: &testhelpers.ExampleTask.Spec,
 			},
 		}},
-		finalTasks: []v1.PipelineTask{pts[0], pts[11]},
+		finalTasks: []v1.PipelineTask{testhelpers.PipelineTasks[0], testhelpers.PipelineTasks[11]},
 		expectedStatus: map[string]string{
-			PipelineTaskStatusPrefix + pts[0].Name + PipelineTaskStatusSuffix:  PipelineTaskStateNone,
-			PipelineTaskStatusPrefix + pts[11].Name + PipelineTaskStatusSuffix: PipelineTaskStateNone,
+			PipelineTaskStatusPrefix + testhelpers.PipelineTasks[0].Name + PipelineTaskStatusSuffix:  PipelineTaskStateNone,
+			PipelineTaskStatusPrefix + testhelpers.PipelineTasks[11].Name + PipelineTaskStatusSuffix: PipelineTaskStateNone,
 		},
 	}, {
 		name:       "task-cancelled",
 		state:      taskCancelled,
-		finalTasks: []v1.PipelineTask{pts[4]},
+		finalTasks: []v1.PipelineTask{testhelpers.PipelineTasks[4]},
 		expectedStatus: map[string]string{
-			PipelineTaskStatusPrefix + pts[4].Name + PipelineTaskStatusSuffix: PipelineTaskStateNone,
+			PipelineTaskStatusPrefix + testhelpers.PipelineTasks[4].Name + PipelineTaskStatusSuffix: PipelineTaskStateNone,
 		},
 	}, {
 		name: "one-skipped-one-failed-aggregate-status-must-be-failed",
 		state: PipelineRunState{{
-			PipelineTask: &pts[10],
+			PipelineTask: &testhelpers.PipelineTasks[10],
 			TaskRunNames: []string{"pr-guardedtask-skipped"},
 			ResolvedTask: &resources.ResolvedTask{
-				TaskSpec: &task.Spec,
+				TaskSpec: &testhelpers.ExampleTask.Spec,
 			},
 		}, {
-			PipelineTask: &pts[0],
+			PipelineTask: &testhelpers.PipelineTasks[0],
 			TaskRunNames: []string{"pipelinerun-mytask1"},
-			TaskRuns:     []*v1.TaskRun{makeFailed(trs[0])},
+			TaskRuns:     []*v1.TaskRun{makeFailed(testhelpers.ExampleTaskRuns[0])},
 			ResolvedTask: &resources.ResolvedTask{
-				TaskSpec: &task.Spec,
+				TaskSpec: &testhelpers.ExampleTask.Spec,
 			},
 		}},
-		finalTasks: []v1.PipelineTask{pts[0], pts[10]},
+		finalTasks: []v1.PipelineTask{testhelpers.PipelineTasks[0], testhelpers.PipelineTasks[10]},
 		expectedStatus: map[string]string{
-			PipelineTaskStatusPrefix + pts[0].Name + PipelineTaskStatusSuffix:  v1.PipelineRunReasonFailed.String(),
-			PipelineTaskStatusPrefix + pts[10].Name + PipelineTaskStatusSuffix: PipelineTaskStateNone,
+			PipelineTaskStatusPrefix + testhelpers.PipelineTasks[0].Name + PipelineTaskStatusSuffix:  v1.PipelineRunReasonFailed.String(),
+			PipelineTaskStatusPrefix + testhelpers.PipelineTasks[10].Name + PipelineTaskStatusSuffix: PipelineTaskStateNone,
 		},
 	}}
 	for _, tc := range tcs {
@@ -3168,39 +2960,39 @@ func TestPipelineRunFacts_GetSkippedTasks(t *testing.T) {
 	}{{
 		name: "stopping-skip-taskruns",
 		state: PipelineRunState{{
-			PipelineTask: &pts[0],
-			TaskRuns:     []*v1.TaskRun{makeFailed(trs[0])},
+			PipelineTask: &testhelpers.PipelineTasks[0],
+			TaskRuns:     []*v1.TaskRun{makeFailed(testhelpers.ExampleTaskRuns[0])},
 		}, {
-			PipelineTask: &pts[14],
+			PipelineTask: &testhelpers.PipelineTasks[14],
 		}},
-		dagTasks: []v1.PipelineTask{pts[0], pts[14]},
+		dagTasks: []v1.PipelineTask{testhelpers.PipelineTasks[0], testhelpers.PipelineTasks[14]},
 		expectedSkippedTasks: []v1.SkippedTask{{
-			Name:   pts[14].Name,
+			Name:   testhelpers.PipelineTasks[14].Name,
 			Reason: v1.StoppingSkip,
 		}},
 	}, {
 		name: "missing-results-skip-finally",
 		state: PipelineRunState{{
 			TaskRunNames: []string{"task0taskrun"},
-			PipelineTask: &pts[0],
-			TaskRuns:     []*v1.TaskRun{makeFailed(trs[0])},
+			PipelineTask: &testhelpers.PipelineTasks[0],
+			TaskRuns:     []*v1.TaskRun{makeFailed(testhelpers.ExampleTaskRuns[0])},
 		}, {
-			PipelineTask: &pts[14],
+			PipelineTask: &testhelpers.PipelineTasks[14],
 		}},
-		dagTasks:     []v1.PipelineTask{pts[0]},
-		finallyTasks: []v1.PipelineTask{pts[14]},
+		dagTasks:     []v1.PipelineTask{testhelpers.PipelineTasks[0]},
+		finallyTasks: []v1.PipelineTask{testhelpers.PipelineTasks[14]},
 		expectedSkippedTasks: []v1.SkippedTask{{
-			Name:   pts[14].Name,
+			Name:   testhelpers.PipelineTasks[14].Name,
 			Reason: v1.MissingResultsSkip,
 		}},
 	}, {
 		name: "when-expressions-skip-finally",
 		state: PipelineRunState{{
-			PipelineTask: &pts[10],
+			PipelineTask: &testhelpers.PipelineTasks[10],
 		}},
-		finallyTasks: []v1.PipelineTask{pts[10]},
+		finallyTasks: []v1.PipelineTask{testhelpers.PipelineTasks[10]},
 		expectedSkippedTasks: []v1.SkippedTask{{
-			Name:   pts[10].Name,
+			Name:   testhelpers.PipelineTasks[10].Name,
 			Reason: v1.WhenExpressionsSkip,
 			WhenExpressions: []v1.WhenExpression{{
 				Input:    "foo",
@@ -3212,11 +3004,11 @@ func TestPipelineRunFacts_GetSkippedTasks(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			d, err := dag.Build(v1.PipelineTaskList(tc.dagTasks), v1.PipelineTaskList(tc.dagTasks).Deps())
 			if err != nil {
-				t.Fatalf("Unexpected error while building graph for DAG tasks %v: %v", v1.PipelineTaskList{pts[0]}, err)
+				t.Fatalf("Unexpected error while building graph for DAG tasks %v: %v", v1.PipelineTaskList{testhelpers.PipelineTasks[0]}, err)
 			}
 			df, err := dag.Build(v1.PipelineTaskList(tc.finallyTasks), map[string][]string{})
 			if err != nil {
-				t.Fatalf("Unexpected error while building graph for final tasks %v: %v", v1.PipelineTaskList{pts[14]}, err)
+				t.Fatalf("Unexpected error while building graph for final tasks %v: %v", v1.PipelineTaskList{testhelpers.PipelineTasks[14]}, err)
 			}
 			facts := PipelineRunFacts{
 				State:           tc.state,

--- a/pkg/reconciler/testing/factory.go
+++ b/pkg/reconciler/testing/factory.go
@@ -1,3 +1,4 @@
+// Package testing provides test helpers for the reconciler.
 package testing
 
 import (
@@ -6,11 +7,261 @@ import (
 
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	v1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/test/parse"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
+	apis "knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/kmeta"
 )
+
+// PipelineTasks is a set of example PipelineTasks for testing.
+var PipelineTasks = []v1.PipelineTask{{
+	Name:    "mytask1",
+	TaskRef: &v1.TaskRef{Name: "task"},
+}, {
+	Name:    "mytask2",
+	TaskRef: &v1.TaskRef{Name: "task"},
+}, {
+	Name:    "mytask3",
+	TaskRef: &v1.TaskRef{Name: "task"},
+}, {
+	Name:    "mytask4",
+	TaskRef: &v1.TaskRef{Name: "task"},
+	Retries: 1,
+}, {
+	Name:    "mytask5",
+	TaskRef: &v1.TaskRef{Name: "cancelledTask"},
+	Retries: 2,
+}, {
+	Name:    "mytask6",
+	TaskRef: &v1.TaskRef{Name: "task"},
+}, {
+	Name:     "mytask7",
+	TaskRef:  &v1.TaskRef{Name: "taskWithOneParent"},
+	RunAfter: []string{"mytask6"},
+}, {
+	Name:     "mytask8",
+	TaskRef:  &v1.TaskRef{Name: "taskWithTwoParents"},
+	RunAfter: []string{"mytask1", "mytask6"},
+}, {
+	Name:     "mytask9",
+	TaskRef:  &v1.TaskRef{Name: "taskHasParentWithRunAfter"},
+	RunAfter: []string{"mytask8"},
+}, {
+	Name:    "mytask10",
+	TaskRef: &v1.TaskRef{Name: "taskWithWhenExpressions"},
+	When: []v1.WhenExpression{{
+		Input:    "foo",
+		Operator: selection.In,
+		Values:   []string{"foo", "bar"},
+	}},
+}, {
+	Name:    "mytask11",
+	TaskRef: &v1.TaskRef{Name: "taskWithWhenExpressions"},
+	When: []v1.WhenExpression{{
+		Input:    "foo",
+		Operator: selection.NotIn,
+		Values:   []string{"foo", "bar"},
+	}},
+}, {
+	Name:    "mytask12",
+	TaskRef: &v1.TaskRef{Name: "taskWithWhenExpressions"},
+	When: []v1.WhenExpression{{
+		Input:    "foo",
+		Operator: selection.In,
+		Values:   []string{"foo", "bar"},
+	}},
+	RunAfter: []string{"mytask1"},
+}, {
+	Name:    "mytask13",
+	TaskRef: &v1.TaskRef{APIVersion: "example.dev/v0", Kind: "Example", Name: "customtask"},
+}, {
+	Name:    "mytask14",
+	TaskRef: &v1.TaskRef{APIVersion: "example.dev/v0", Kind: "Example", Name: "customtask"},
+}, {
+	Name:    "mytask15",
+	TaskRef: &v1.TaskRef{Name: "taskWithReferenceToTaskResult"},
+	Params:  v1.Params{{Name: "param1", Value: *v1.NewStructuredValues("$(tasks.mytask1.results.result1)")}},
+}, {
+	Name: "mytask16",
+	Matrix: &v1.Matrix{
+		Params: v1.Params{{
+			Name:  "browser",
+			Value: v1.ParamValue{ArrayVal: []string{"safari", "chrome"}},
+		}},
+	},
+}, {
+	Name: "mytask17",
+	Matrix: &v1.Matrix{
+		Params: v1.Params{{
+			Name:  "browser",
+			Value: v1.ParamValue{ArrayVal: []string{"safari", "chrome"}},
+		}},
+	},
+}, {
+	Name:    "mytask18",
+	TaskRef: &v1.TaskRef{Name: "task"},
+	Retries: 1,
+	Matrix: &v1.Matrix{
+		Params: v1.Params{{
+			Name:  "browser",
+			Value: v1.ParamValue{ArrayVal: []string{"safari", "chrome"}},
+		}},
+	},
+}, {
+	Name:    "mytask19",
+	TaskRef: &v1.TaskRef{APIVersion: "example.dev/v0", Kind: "Example", Name: "customtask"},
+	Matrix: &v1.Matrix{
+		Params: v1.Params{{
+			Name:  "browser",
+			Value: v1.ParamValue{ArrayVal: []string{"safari", "chrome"}},
+		}},
+	},
+}, {
+	Name:    "mytask20",
+	TaskRef: &v1.TaskRef{APIVersion: "example.dev/v0", Kind: "Example", Name: "customtask"},
+	Matrix: &v1.Matrix{
+		Params: v1.Params{{
+			Name:  "browser",
+			Value: v1.ParamValue{ArrayVal: []string{"safari", "chrome"}},
+		}},
+	},
+}, {
+	Name:    "mytask21",
+	TaskRef: &v1.TaskRef{Name: "task"},
+	Retries: 2,
+	Matrix: &v1.Matrix{
+		Params: v1.Params{{
+			Name:  "browser",
+			Value: v1.ParamValue{ArrayVal: []string{"safari", "chrome"}},
+		}},
+	},
+}}
+
+// ExamplePipeline is a sample Pipeline for testing.
+var ExamplePipeline = &v1.Pipeline{
+	ObjectMeta: metav1.ObjectMeta{
+		Namespace: "namespace",
+		Name:      "pipeline",
+	},
+	Spec: v1.PipelineSpec{
+		Tasks: PipelineTasks,
+	},
+}
+
+// ExampleTask is a sample Task for testing.
+var ExampleTask = &v1.Task{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "task",
+	},
+	Spec: v1.TaskSpec{
+		Steps: []v1.Step{{
+			Name: "step1",
+		}},
+	},
+}
+
+// ExampleTaskRuns is a set of TaskRuns for testing.
+var ExampleTaskRuns = []v1.TaskRun{{
+	ObjectMeta: metav1.ObjectMeta{
+		Namespace: "namespace",
+		Name:      "pipelinerun-mytask1",
+	},
+	Spec: v1.TaskRunSpec{},
+}, {
+	ObjectMeta: metav1.ObjectMeta{
+		Namespace: "namespace",
+		Name:      "pipelinerun-mytask2",
+	},
+	Spec: v1.TaskRunSpec{},
+}, {
+	ObjectMeta: metav1.ObjectMeta{
+		Namespace: "namespace",
+		Name:      "pipelinerun-mytask4",
+	},
+	Spec: v1.TaskRunSpec{},
+}}
+
+// ExampleCustomRuns is a set of CustomRuns for testing.
+var ExampleCustomRuns = []v1beta1.CustomRun{{
+	ObjectMeta: metav1.ObjectMeta{
+		Namespace: "namespace",
+		Name:      "pipelinerun-mytask13",
+	},
+	Spec: v1beta1.CustomRunSpec{},
+}, {
+	ObjectMeta: metav1.ObjectMeta{
+		Namespace: "namespace",
+		Name:      "pipelinerun-mytask14",
+	},
+	Spec: v1beta1.CustomRunSpec{},
+}}
+
+// ExampleMatrixedPipelineTask is a sample matrixed PipelineTask for testing.
+var ExampleMatrixedPipelineTask = &v1.PipelineTask{
+	Name: "task",
+	TaskSpec: &v1.EmbeddedTask{
+		TaskSpec: v1.TaskSpec{
+			Params: []v1.ParamSpec{{
+				Name: "browser",
+				Type: v1.ParamTypeString,
+			}},
+			Results: []v1.TaskResult{{
+				Name: "BROWSER",
+			}},
+			Steps: []v1.Step{{
+				Name:   "produce-results",
+				Image:  "bash:latest",
+				Script: `#!/usr/bin/env bash\necho -n "$(params.browser)" | sha256sum | tee $(results.BROWSER.path)"`,
+			}},
+		},
+	},
+	Matrix: &v1.Matrix{
+		Params: v1.Params{{
+			Name:  "browser",
+			Value: v1.ParamValue{ArrayVal: []string{"safari", "chrome"}},
+		}},
+	},
+}
+
+// NewTaskRun returns a new TaskRun for testing.
+func NewTaskRun(tr v1.TaskRun) *v1.TaskRun {
+	return &v1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: tr.Namespace,
+			Name:      tr.Name,
+		},
+		Spec: tr.Spec,
+		Status: v1.TaskRunStatus{
+			Status: duckv1.Status{
+				Conditions: []apis.Condition{{
+					Type: apis.ConditionSucceeded,
+				}},
+			},
+		},
+	}
+}
+
+// NewCustomRun returns a new CustomRun for testing.
+func NewCustomRun(run v1beta1.CustomRun) *v1beta1.CustomRun {
+	return &v1beta1.CustomRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: run.Namespace,
+			Name:      run.Name,
+		},
+		Spec: run.Spec,
+		Status: v1beta1.CustomRunStatus{
+			Status: duckv1.Status{
+				Conditions: []apis.Condition{{
+					Type: apis.ConditionSucceeded,
+				}},
+			},
+		},
+	}
+}
 
 var (
 	trueb = true

--- a/pkg/reconciler/testing/selectors.go
+++ b/pkg/reconciler/testing/selectors.go
@@ -1,0 +1,12 @@
+package testing
+
+import (
+	"errors"
+
+	v1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+)
+
+// NopGetCustomRun returns an error for CustomRun lookup (used in tests where CustomRun should not be called)
+func NopGetCustomRun(string) (*v1beta1.CustomRun, error) {
+	return nil, errors.New("GetCustomRun should not be called")
+}

--- a/pkg/reconciler/testing/status_transformers.go
+++ b/pkg/reconciler/testing/status_transformers.go
@@ -1,0 +1,125 @@
+package testing
+
+import (
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	v1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	apis "knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+)
+
+// Status transformer helpers for testing
+func MakeScheduled(taskRun v1.TaskRun, newTaskRun func(v1.TaskRun) *v1.TaskRun) *v1.TaskRun {
+	tr := newTaskRun(taskRun)
+	tr.Status = v1.TaskRunStatus{}
+	return tr
+}
+
+func MakeStarted(taskRun v1.TaskRun, newTaskRun func(v1.TaskRun) *v1.TaskRun) *v1.TaskRun {
+	tr := newTaskRun(taskRun)
+	tr.Status.Conditions[0].Status = corev1.ConditionUnknown
+	return tr
+}
+
+func MakeSucceeded(taskRun v1.TaskRun, newTaskRun func(v1.TaskRun) *v1.TaskRun) *v1.TaskRun {
+	tr := newTaskRun(taskRun)
+	tr.Status.Conditions[0].Status = corev1.ConditionTrue
+	tr.Status.Conditions[0].Reason = "Succeeded"
+	return tr
+}
+
+func MakeFailed(taskRun v1.TaskRun, newTaskRun func(v1.TaskRun) *v1.TaskRun) *v1.TaskRun {
+	tr := newTaskRun(taskRun)
+	tr.Status.Conditions[0].Status = corev1.ConditionFalse
+	tr.Status.Conditions[0].Reason = "Failed"
+	return tr
+}
+
+func MakeToBeRetried(taskRun v1.TaskRun, newTaskRun func(v1.TaskRun) *v1.TaskRun) *v1.TaskRun {
+	tr := newTaskRun(taskRun)
+	tr.Status.Conditions[0].Status = corev1.ConditionUnknown
+	tr.Status.Conditions[0].Reason = v1.TaskRunReasonToBeRetried.String()
+	return tr
+}
+
+func MakeRetried(taskRun v1.TaskRun, newTaskRun func(v1.TaskRun) *v1.TaskRun, withRetries func(*v1.TaskRun) *v1.TaskRun) *v1.TaskRun {
+	tr := newTaskRun(taskRun)
+	return withRetries(tr)
+}
+
+func WithRetries(taskRun *v1.TaskRun) *v1.TaskRun {
+	taskRun.Status.RetriesStatus = []v1.TaskRunStatus{{
+		Status: duckv1.Status{
+			Conditions: []apis.Condition{{
+				Type:   apis.ConditionSucceeded,
+				Status: corev1.ConditionFalse,
+			}},
+		},
+	}}
+	return taskRun
+}
+
+func WithCancelled(taskRun *v1.TaskRun) *v1.TaskRun {
+	taskRun.Status.Conditions[0].Reason = v1.TaskRunSpecStatusCancelled
+	return taskRun
+}
+
+func WithCancelledForTimeout(taskRun *v1.TaskRun) *v1.TaskRun {
+	taskRun.Spec.StatusMessage = v1.TaskRunCancelledByPipelineTimeoutMsg
+	taskRun.Status.Conditions[0].Reason = v1.TaskRunSpecStatusCancelled
+	return taskRun
+}
+
+func WithCancelledBySpec(taskRun *v1.TaskRun) *v1.TaskRun {
+	taskRun.Spec.Status = v1.TaskRunSpecStatusCancelled
+	return taskRun
+}
+
+// CustomRun status helpers
+func MakeCustomRunStarted(customRun v1beta1.CustomRun, newCustomRun func(v1beta1.CustomRun) *v1beta1.CustomRun) *v1beta1.CustomRun {
+	run := newCustomRun(customRun)
+	run.Status.Conditions[0].Status = corev1.ConditionUnknown
+	return run
+}
+
+func MakeCustomRunSucceeded(customRun v1beta1.CustomRun, newCustomRun func(v1beta1.CustomRun) *v1beta1.CustomRun) *v1beta1.CustomRun {
+	run := newCustomRun(customRun)
+	run.Status.Conditions[0].Status = corev1.ConditionTrue
+	run.Status.Conditions[0].Reason = "Succeeded"
+	return run
+}
+
+func MakeCustomRunFailed(customRun v1beta1.CustomRun, newCustomRun func(v1beta1.CustomRun) *v1beta1.CustomRun) *v1beta1.CustomRun {
+	run := newCustomRun(customRun)
+	run.Status.Conditions[0].Status = corev1.ConditionFalse
+	run.Status.Conditions[0].Reason = "Failed"
+	return run
+}
+
+func WithCustomRunRetries(customRun *v1beta1.CustomRun) *v1beta1.CustomRun {
+	customRun.Status.RetriesStatus = []v1beta1.CustomRunStatus{{
+		Status: duckv1.Status{
+			Conditions: []apis.Condition{{
+				Type:   apis.ConditionSucceeded,
+				Status: corev1.ConditionFalse,
+			}},
+		},
+	}}
+	return customRun
+}
+
+func WithCustomRunCancelled(customRun *v1beta1.CustomRun) *v1beta1.CustomRun {
+	customRun.Status.Conditions[0].Reason = v1beta1.CustomRunReasonCancelled.String()
+	return customRun
+}
+
+func WithCustomRunCancelledForTimeout(customRun *v1beta1.CustomRun) *v1beta1.CustomRun {
+	customRun.Spec.StatusMessage = v1beta1.CustomRunCancelledByPipelineTimeoutMsg
+	customRun.Status.Conditions[0].Reason = v1beta1.CustomRunReasonCancelled.String()
+	return customRun
+}
+
+func WithCustomRunCancelledBySpec(customRun *v1beta1.CustomRun) *v1beta1.CustomRun {
+	customRun.Spec.Status = v1beta1.CustomRunSpecStatusCancelled
+	return customRun
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

- Moved mock data creation from pipelinerunresolution_test.go to
  pkg/reconciler/testing/factory.go, including:
  - `p` → `pipeline`
  - `pts` → `pipelineTasks`
  - `newTaskRun()` and related setup helpers
- Moved status transformers to pkg/reconciler/testing/status_transformers.go:
  - `makeSucceed()`, `withCanceled()`, etc.
- Moved selectors to pkg/reconciler/testing/selectors.go:
  - `nopGetCustomRun`, etc.
- Renamed single-letter variables to descriptive names for clarity


# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```

Resolves https://github.com/tektoncd/pipeline/issues/8921
