### PR TITLE
[release-v1.3.x]  Do not fail PipelineRun if pvc creation error is because of exceeded quotas

### DIFF
--- a/pkg/reconciler/pipelinerun/affinity_assistant.go
+++ b/pkg/reconciler/pipelinerun/affinity_assistant.go
@@ -50,7 +50,9 @@ const (
 )
 
 var (
-	ErrPvcCreationFailed               = volumeclaim.ErrPvcCreationFailed
+	// Deprecated: use volumeclain.ErrPvcCreationFailed instead
+	ErrPvcCreationFailed = volumeclaim.ErrPvcCreationFailed
+	// Deprecated: use volumeclaim.ErrAffinityAssistantCreationFailed instead
 	ErrPvcCreationFailedRetryable      = volumeclaim.ErrPvcCreationFailedRetryable
 	ErrAffinityAssistantCreationFailed = errors.New("Affinity Assistant creation error")
 )

--- a/pkg/reconciler/pipelinerun/affinity_assistant_test.go
+++ b/pkg/reconciler/pipelinerun/affinity_assistant_test.go
@@ -577,54 +577,56 @@ func TestCreateOrUpdateAffinityAssistantsAndPVCs_Failure(t *testing.T) {
 		name:        "pvc creation failed - per workspace",
 		failureType: "pvc",
 		aaBehavior:  aa.AffinityAssistantPerWorkspace,
-		expectedErr: fmt.Errorf("%w: failed to create PVC pvc-b9eea16dce: error creating persistentvolumeclaims", ErrPvcCreationFailed),
+		expectedErr: fmt.Errorf("%w for pvc-b9eea16dce: error creating persistentvolumeclaims", ErrPvcCreationFailed),
 	}, {
 		name:        "pvc creation failed - disabled",
 		failureType: "pvc",
 		aaBehavior:  aa.AffinityAssistantDisabled,
-		expectedErr: fmt.Errorf("%w: failed to create PVC pvc-b9eea16dce: error creating persistentvolumeclaims", ErrPvcCreationFailed),
+		expectedErr: fmt.Errorf("%w for pvc-b9eea16dce: error creating persistentvolumeclaims", ErrPvcCreationFailed),
 	}}
 
 	for _, tc := range testCases {
-		ctx := t.Context()
-		kubeClientSet := fakek8s.NewSimpleClientset()
-		c := Reconciler{
-			KubeClientSet: kubeClientSet,
-			pvcHandler:    volumeclaim.NewPVCHandler(kubeClientSet, zap.NewExample().Sugar()),
-		}
-
-		switch tc.failureType {
-		case "pvc":
-			c.KubeClientSet.CoreV1().(*fake.FakeCoreV1).PrependReactor("create", "persistentvolumeclaims",
-				func(action testing2.Action) (handled bool, ret runtime.Object, err error) {
-					return true, &corev1.PersistentVolumeClaim{}, errors.New("error creating persistentvolumeclaims")
-				})
-		case "statefulset":
-			c.KubeClientSet.CoreV1().(*fake.FakeCoreV1).PrependReactor("create", "statefulsets",
-				func(action testing2.Action) (handled bool, ret runtime.Object, err error) {
-					return true, &appsv1.StatefulSet{}, errors.New("error creating statefulsets")
-				})
-		}
-
-		err := c.createOrUpdateAffinityAssistantsAndPVCs(ctx, testPRWithVolumeClaimTemplate, tc.aaBehavior)
-
-		if err == nil {
-			t.Errorf("expect error from createOrUpdateAffinityAssistantsAndPVCs but got nil")
-		}
-
-		switch tc.failureType {
-		case "pvc":
-			if !errors.Is(err, ErrPvcCreationFailed) {
-				t.Errorf("expected err type mismatching, expecting %v but got: %v", ErrPvcCreationFailed, err)
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := t.Context()
+			kubeClientSet := fakek8s.NewSimpleClientset()
+			c := Reconciler{
+				KubeClientSet: kubeClientSet,
+				pvcHandler:    volumeclaim.NewPVCHandler(kubeClientSet, zap.NewExample().Sugar()),
 			}
-		case "statefulset":
-			if !errors.Is(err, ErrAffinityAssistantCreationFailed) {
-				t.Errorf("expected err type mismatching, expecting %v but got: %v", ErrAffinityAssistantCreationFailed, err)
+
+			switch tc.failureType {
+			case "pvc":
+				c.KubeClientSet.CoreV1().(*fake.FakeCoreV1).PrependReactor("create", "persistentvolumeclaims",
+					func(action testing2.Action) (handled bool, ret runtime.Object, err error) {
+						return true, &corev1.PersistentVolumeClaim{}, errors.New("error creating persistentvolumeclaims")
+					})
+			case "statefulset":
+				c.KubeClientSet.CoreV1().(*fake.FakeCoreV1).PrependReactor("create", "statefulsets",
+					func(action testing2.Action) (handled bool, ret runtime.Object, err error) {
+						return true, &appsv1.StatefulSet{}, errors.New("error creating statefulsets")
+					})
 			}
-		}
-		if d := cmp.Diff(tc.expectedErr.Error(), err.Error()); d != "" {
-			t.Errorf("expected err mismatching: %v", diff.PrintWantGot(d))
-		}
+
+			err := c.createOrUpdateAffinityAssistantsAndPVCs(ctx, testPRWithVolumeClaimTemplate, tc.aaBehavior)
+
+			if err == nil {
+				t.Errorf("expect error from createOrUpdateAffinityAssistantsAndPVCs but got nil")
+			}
+
+			switch tc.failureType {
+			case "pvc":
+				if !errors.Is(err, ErrPvcCreationFailed) {
+					t.Errorf("expected err type mismatching, expecting %v but got: %v", ErrPvcCreationFailed, err)
+				}
+			case "statefulset":
+				if !errors.Is(err, ErrAffinityAssistantCreationFailed) {
+					t.Errorf("expected err type mismatching, expecting %v but got: %v", ErrAffinityAssistantCreationFailed, err)
+				}
+			}
+			if d := cmp.Diff(tc.expectedErr.Error(), err.Error()); d != "" {
+				t.Errorf("expected err mismatching: %v", diff.PrintWantGot(d))
+			}
+		})
 	}
 }
 

--- a/pkg/reconciler/pipelinerun/affinity_assistant_test.go
+++ b/pkg/reconciler/pipelinerun/affinity_assistant_test.go
@@ -613,12 +613,7 @@ func TestCreateOrUpdateAffinityAssistantsAndPVCs_Failure(t *testing.T) {
 				t.Errorf("expect error from createOrUpdateAffinityAssistantsAndPVCs but got nil")
 			}
 
-			switch tc.failureType {
-			case "pvc":
-				if !errors.Is(err, ErrPvcCreationFailed) {
-					t.Errorf("expected err type mismatching, expecting %v but got: %v", ErrPvcCreationFailed, err)
-				}
-			case "statefulset":
+			if tc.failureType == "statefulset" {
 				if !errors.Is(err, ErrAffinityAssistantCreationFailed) {
 					t.Errorf("expected err type mismatching, expecting %v but got: %v", ErrAffinityAssistantCreationFailed, err)
 				}

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -758,6 +758,10 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1.PipelineRun, getPipel
 				pr.Status.MarkFailed(volumeclaim.ReasonCouldntCreateWorkspacePVC,
 					"Failed to create PVC for PipelineRun %s/%s correctly: %s",
 					pr.Namespace, pr.Name, err)
+			case errors.Is(err, ErrPvcCreationFailedRetryable):
+				logger.Errorf("Failed to create PVC for PipelineRun %s: %v", pr.Name, err)
+				pr.Status.MarkRunning(ReasonPending, "Waiting for PVC creation to succeed: %v", err)
+				return err // not a permanent error, will requeue
 			case errors.Is(err, ErrAffinityAssistantCreationFailed):
 				logger.Errorf("Failed to create affinity assistant StatefulSet for PipelineRun %s: %v", pr.Name, err)
 				pr.Status.MarkFailed(ReasonCouldntCreateOrUpdateAffinityAssistantStatefulSet,

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -753,12 +753,12 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1.PipelineRun, getPipel
 		}
 		if err := c.createOrUpdateAffinityAssistantsAndPVCs(ctx, pr, aaBehavior); err != nil {
 			switch {
-			case errors.Is(err, ErrPvcCreationFailed):
+			case errors.Is(err, volumeclaim.ErrPvcCreationFailed):
 				logger.Errorf("Failed to create PVC for PipelineRun %s: %v", pr.Name, err)
 				pr.Status.MarkFailed(volumeclaim.ReasonCouldntCreateWorkspacePVC,
 					"Failed to create PVC for PipelineRun %s/%s correctly: %s",
 					pr.Namespace, pr.Name, err)
-			case errors.Is(err, ErrPvcCreationFailedRetryable):
+			case errors.Is(err, volumeclaim.ErrPvcCreationFailedRetryable):
 				logger.Errorf("Failed to create PVC for PipelineRun %s: %v", pr.Name, err)
 				pr.Status.MarkRunning(ReasonPending, "Waiting for PVC creation to succeed: %v", err)
 				return err // not a permanent error, will requeue
@@ -768,6 +768,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1.PipelineRun, getPipel
 					"Failed to create StatefulSet for PipelineRun %s/%s correctly: %s",
 					pr.Namespace, pr.Name, err)
 			default:
+				logger.Errorf("default error handling for PipelineRun %s: %v", pr.Name, err)
 			}
 			return controller.NewPermanentError(err)
 		}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
Cherry-pick of [#8903](https://github.com/tektoncd/pipeline/pull/8903)

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
