### PR TITLE
fix(validation): apply SetDefaults to both specs before comparison

### DIFF
--- a/pkg/apis/pipeline/v1beta1/pipelinerun_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_validation.go
@@ -159,6 +159,13 @@ func (ps *PipelineRunSpec) ValidateUpdate(ctx context.Context) (errs *apis.Field
 		return
 	}
 	old := &oldObj.Spec
+	// Apply defaults to both old and new specs before comparison to handle
+	// cases where default field values have changed between API versions.
+	// This prevents upgrade scenarios from being incorrectly flagged as
+	// user modifications when only default values have changed.
+	old.SetDefaults(ctx)
+	psCopy := ps.DeepCopy()
+	psCopy.SetDefaults(ctx)
 
 	// If already in the done state, the spec cannot be modified. Otherwise, only the status field can be modified.
 	tips := "Once the PipelineRun is complete, no updates are allowed"
@@ -167,7 +174,7 @@ func (ps *PipelineRunSpec) ValidateUpdate(ctx context.Context) (errs *apis.Field
 		old.Status = ps.Status
 		tips = "Once the PipelineRun has started, only status updates are allowed"
 	}
-	if !equality.Semantic.DeepEqual(old, ps) {
+	if !equality.Semantic.DeepEqual(old, psCopy) {
 		errs = errs.Also(apis.ErrInvalidValue(tips, ""))
 	}
 


### PR DESCRIPTION
Apply SetDefaults to both old and new specs in ValidateUpdate methods to handle cases where default field values have changed between API versions. This prevents upgrade scenarios from being incorrectly flagged as user modifications when only default values have changed.

Fixes issue where v1beta1 PipelineRun/TaskRun resources in production fail validation after Tekton upgrade due to timeout field structure differences between old and new default values.

- Apply SetDefaults to old spec copy before comparison
- Apply SetDefaults to new spec copy before comparison
- Add comprehensive test cases for upgrade scenarios
- Ensure actual user modifications are still caught correctly

Affects both v1 and v1beta1 API versions for PipelineRun and TaskRun validation methods.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<hr>
I encountered this problem when upgrading Pipelines in my environment from version `0.56` to `0.65`.<br><br>

Previously completed `v1beta1 PipelineRuns` in the cluster were unable to have their finalizers removed, with the error message `Once the PipelineRun is complete, no updates are allowed` This prevented these resources from being properly cleaned up. I wasn't actually modifying any Spec fields.

After applying this fix, the issue was resolved.

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
fix: avoid validation errors during API version upgrades where SetDefaults changes were incorrectly flagged as user modifications for PipelineRun and TaskRun resources.
```
