### PR TITLE
[release-v1.0.x] fix: allow finalizer updates on completed TaskRun and PipelineRuns

### DIFF
--- a/pkg/apis/pipeline/v1/pipelinerun_validation.go
+++ b/pkg/apis/pipeline/v1/pipelinerun_validation.go
@@ -137,17 +137,32 @@ func (ps *PipelineRunSpec) ValidateUpdate(ctx context.Context) (errs *apis.Field
 	if !ok || oldObj == nil {
 		return
 	}
-	old := &oldObj.Spec
+	if oldObj.IsDone() {
+		// try comparing without any copying first
+		// this handles the common case where only finalizers changed
+		if equality.Semantic.DeepEqual(&oldObj.Spec, ps) {
+			return nil // Specs identical, allow update
+		}
 
-	// If already in the done state, the spec cannot be modified. Otherwise, only the status field can be modified.
-	tips := "Once the PipelineRun is complete, no updates are allowed"
-	if !oldObj.IsDone() {
-		old = old.DeepCopy()
-		old.Status = ps.Status
-		tips = "Once the PipelineRun has started, only status updates are allowed"
+		// Specs differ, this could be due to different defaults after upgrade
+		// Apply current defaults to old spec to normalize
+		oldCopy := oldObj.Spec.DeepCopy()
+		oldCopy.SetDefaults(ctx)
+
+		if equality.Semantic.DeepEqual(oldCopy, ps) {
+			return nil // Difference was only defaults, allow update
+		}
+
+		// Real spec changes detected, reject update
+		errs = errs.Also(apis.ErrInvalidValue("Once the PipelineRun is complete, no updates are allowed", ""))
+		return errs
 	}
+
+	// Handle started but not done case
+	old := oldObj.Spec.DeepCopy()
+	old.Status = ps.Status
 	if !equality.Semantic.DeepEqual(old, ps) {
-		errs = errs.Also(apis.ErrInvalidValue(tips, ""))
+		errs = errs.Also(apis.ErrInvalidValue("Once the PipelineRun has started, only status updates are allowed", ""))
 	}
 
 	return

--- a/pkg/apis/pipeline/v1/pipelinerun_validation.go
+++ b/pkg/apis/pipeline/v1/pipelinerun_validation.go
@@ -131,11 +131,11 @@ func (ps *PipelineRunSpec) Validate(ctx context.Context) (errs *apis.FieldError)
 // ValidateUpdate validates the update of a PipelineRunSpec
 func (ps *PipelineRunSpec) ValidateUpdate(ctx context.Context) (errs *apis.FieldError) {
 	if !apis.IsInUpdate(ctx) {
-		return
+		return errs
 	}
 	oldObj, ok := apis.GetBaseline(ctx).(*PipelineRun)
 	if !ok || oldObj == nil {
-		return
+		return errs
 	}
 	if oldObj.IsDone() {
 		// try comparing without any copying first
@@ -165,7 +165,7 @@ func (ps *PipelineRunSpec) ValidateUpdate(ctx context.Context) (errs *apis.Field
 		errs = errs.Also(apis.ErrInvalidValue("Once the PipelineRun has started, only status updates are allowed", ""))
 	}
 
-	return
+	return errs
 }
 
 func (ps *PipelineRunSpec) validatePipelineRunParameters(ctx context.Context) (errs *apis.FieldError) {

--- a/pkg/apis/pipeline/v1/pipelinerun_validation_test.go
+++ b/pkg/apis/pipeline/v1/pipelinerun_validation_test.go
@@ -1779,7 +1779,7 @@ func TestPipelineRunSpec_ValidateUpdate_FinalizerChanges(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := config.ToContext(t.Context(), &config.Config{
+			ctx := config.ToContext(context.Background(), &config.Config{
 				Defaults: &config.Defaults{
 					DefaultResolverType:   "bundles",
 					DefaultTimeoutMinutes: 60,

--- a/pkg/apis/pipeline/v1/pipelinerun_validation_test.go
+++ b/pkg/apis/pipeline/v1/pipelinerun_validation_test.go
@@ -1690,3 +1690,222 @@ func TestPipelineRunSpec_ValidateUpdate(t *testing.T) {
 		})
 	}
 }
+
+func TestPipelineRunSpec_ValidateUpdate_FinalizerChanges(t *testing.T) {
+	tests := []struct {
+		name                string
+		baselinePipelineRun *v1.PipelineRun
+		pipelineRun         *v1.PipelineRun
+		expectedError       string
+	}{
+		{
+			name: "allow finalizer update when specs are identical",
+			baselinePipelineRun: &v1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pr",
+				},
+				Spec: v1.PipelineRunSpec{
+					PipelineRef: &v1.PipelineRef{
+						Name: "test-pipeline",
+						ResolverRef: v1.ResolverRef{
+							Resolver: "bundles",
+						},
+					},
+					Timeouts: &v1.TimeoutFields{
+						Pipeline: &metav1.Duration{Duration: 60 * time.Minute},
+					},
+				},
+				Status: v1.PipelineRunStatus{
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{
+							{Type: apis.ConditionSucceeded, Status: corev1.ConditionTrue},
+						},
+					},
+				},
+			},
+			pipelineRun: &v1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-pr",
+					Finalizers: []string{"chains.tekton.dev/finalizer"},
+				},
+				Spec: v1.PipelineRunSpec{
+					PipelineRef: &v1.PipelineRef{
+						Name: "test-pipeline",
+						ResolverRef: v1.ResolverRef{
+							Resolver: "bundles",
+						},
+					},
+					Timeouts: &v1.TimeoutFields{
+						Pipeline: &metav1.Duration{Duration: 60 * time.Minute},
+					},
+				},
+			},
+			expectedError: "",
+		},
+		{
+			name: "block actual spec changes on completed PipelineRun",
+			baselinePipelineRun: &v1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pr",
+				},
+				Spec: v1.PipelineRunSpec{
+					PipelineRef: &v1.PipelineRef{
+						Name: "test-pipeline",
+					},
+				},
+				Status: v1.PipelineRunStatus{
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{
+							{Type: apis.ConditionSucceeded, Status: corev1.ConditionTrue},
+						},
+					},
+				},
+			},
+			pipelineRun: &v1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-pr",
+					Finalizers: []string{"chains.tekton.dev/finalizer"},
+				},
+				Spec: v1.PipelineRunSpec{
+					PipelineRef: &v1.PipelineRef{
+						Name: "different-pipeline",
+					},
+				},
+			},
+			expectedError: "invalid value: Once the PipelineRun is complete, no updates are allowed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := config.ToContext(t.Context(), &config.Config{
+				Defaults: &config.Defaults{
+					DefaultResolverType:   "bundles",
+					DefaultTimeoutMinutes: 60,
+					DefaultServiceAccount: "default",
+				},
+			})
+			ctx = apis.WithinUpdate(ctx, tt.baselinePipelineRun)
+
+			err := tt.pipelineRun.Spec.ValidateUpdate(ctx)
+
+			if tt.expectedError == "" {
+				if err != nil {
+					t.Errorf("Expected no error, but got: %v", err)
+				}
+			} else {
+				if err == nil {
+					t.Errorf("Expected error containing %q, but got none", tt.expectedError)
+				} else if !strings.Contains(err.Error(), tt.expectedError) {
+					t.Errorf("Expected error containing %q, but got: %v", tt.expectedError, err)
+				}
+			}
+		})
+	}
+}
+
+func TestPipelineRunTaskRunSpecTimeout_Validate(t *testing.T) {
+	tests := []struct {
+		name        string
+		spec        v1.PipelineRunSpec
+		wantErr     bool
+		expectedErr string
+	}{{
+		name: "taskRunSpec timeout within pipeline timeout",
+		spec: v1.PipelineRunSpec{
+			PipelineRef: &v1.PipelineRef{Name: "test"},
+			Timeouts: &v1.TimeoutFields{
+				Pipeline: &metav1.Duration{Duration: 1 * time.Hour},
+			},
+			TaskRunSpecs: []v1.PipelineTaskRunSpec{{
+				PipelineTaskName: "task1",
+				Timeout:          &metav1.Duration{Duration: 30 * time.Minute},
+			}},
+		},
+		wantErr: false,
+	}, {
+		name: "taskRunSpec timeout exceeds pipeline timeout",
+		spec: v1.PipelineRunSpec{
+			PipelineRef: &v1.PipelineRef{Name: "test"},
+			Timeouts: &v1.TimeoutFields{
+				Pipeline: &metav1.Duration{Duration: 30 * time.Minute},
+			},
+			TaskRunSpecs: []v1.PipelineTaskRunSpec{{
+				PipelineTaskName: "task1",
+				Timeout:          &metav1.Duration{Duration: 1 * time.Hour},
+			}},
+		},
+		wantErr:     true,
+		expectedErr: "taskRunSpecs[0].timeout",
+	}, {
+		name: "no pipeline timeout uses default",
+		spec: v1.PipelineRunSpec{
+			PipelineRef: &v1.PipelineRef{Name: "test"},
+			TaskRunSpecs: []v1.PipelineTaskRunSpec{{
+				PipelineTaskName: "task1",
+				Timeout:          &metav1.Duration{Duration: 30 * time.Minute},
+			}},
+		},
+		wantErr: false,
+	}, {
+		name: "taskRunSpec timeout exceeds tasks timeout",
+		spec: v1.PipelineRunSpec{
+			PipelineRef: &v1.PipelineRef{Name: "test"},
+			Timeouts: &v1.TimeoutFields{
+				Tasks: &metav1.Duration{Duration: 30 * time.Minute}, // Key: tasks timeout
+			},
+			TaskRunSpecs: []v1.PipelineTaskRunSpec{{
+				PipelineTaskName: "task1",
+				Timeout:          &metav1.Duration{Duration: 45 * time.Minute}, // Exceeds tasks timeout
+			}},
+		},
+		wantErr:     true,
+		expectedErr: "taskRunSpecs[0].timeout",
+	}, {
+		name: "taskRunSpec timeout within tasks timeout",
+		spec: v1.PipelineRunSpec{
+			PipelineRef: &v1.PipelineRef{Name: "test"},
+			Timeouts: &v1.TimeoutFields{
+				Pipeline: &metav1.Duration{Duration: 2 * time.Hour}, // Pipeline timeout must be >= tasks timeout
+				Tasks:    &metav1.Duration{Duration: 1 * time.Hour},
+			},
+			TaskRunSpecs: []v1.PipelineTaskRunSpec{{
+				PipelineTaskName: "task1",
+				Timeout:          &metav1.Duration{Duration: 30 * time.Minute}, // Within tasks timeout
+			}},
+		},
+		wantErr: false,
+	}, {
+		name: "taskRunSpec timeout exceeds default pipeline timeout",
+		spec: v1.PipelineRunSpec{
+			PipelineRef: &v1.PipelineRef{Name: "test"},
+			// No timeouts field set - should use default 60 minutes
+			TaskRunSpecs: []v1.PipelineTaskRunSpec{{
+				PipelineTaskName: "task1",
+				Timeout:          &metav1.Duration{Duration: 90 * time.Minute}, // Exceeds 60m default
+			}},
+		},
+		wantErr:     true,
+		expectedErr: "taskRunSpecs[0].timeout",
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := config.ToContext(t.Context(), &config.Config{
+				Defaults: &config.Defaults{
+					DefaultTimeoutMinutes: 60,
+				},
+			})
+			err := tt.spec.Validate(ctx)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("Expected error but got none")
+				} else if !strings.Contains(err.Error(), tt.expectedErr) {
+					t.Errorf("Expected error containing %q but got %q", tt.expectedErr, err.Error())
+				}
+			} else if err != nil {
+				t.Errorf("Expected no error but got: %v", err)
+			}
+		})
+	}
+}

--- a/pkg/apis/pipeline/v1/pipelinerun_validation_test.go
+++ b/pkg/apis/pipeline/v1/pipelinerun_validation_test.go
@@ -18,6 +18,7 @@ package v1_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -1799,112 +1800,6 @@ func TestPipelineRunSpec_ValidateUpdate_FinalizerChanges(t *testing.T) {
 				} else if !strings.Contains(err.Error(), tt.expectedError) {
 					t.Errorf("Expected error containing %q, but got: %v", tt.expectedError, err)
 				}
-			}
-		})
-	}
-}
-
-func TestPipelineRunTaskRunSpecTimeout_Validate(t *testing.T) {
-	tests := []struct {
-		name        string
-		spec        v1.PipelineRunSpec
-		wantErr     bool
-		expectedErr string
-	}{{
-		name: "taskRunSpec timeout within pipeline timeout",
-		spec: v1.PipelineRunSpec{
-			PipelineRef: &v1.PipelineRef{Name: "test"},
-			Timeouts: &v1.TimeoutFields{
-				Pipeline: &metav1.Duration{Duration: 1 * time.Hour},
-			},
-			TaskRunSpecs: []v1.PipelineTaskRunSpec{{
-				PipelineTaskName: "task1",
-				Timeout:          &metav1.Duration{Duration: 30 * time.Minute},
-			}},
-		},
-		wantErr: false,
-	}, {
-		name: "taskRunSpec timeout exceeds pipeline timeout",
-		spec: v1.PipelineRunSpec{
-			PipelineRef: &v1.PipelineRef{Name: "test"},
-			Timeouts: &v1.TimeoutFields{
-				Pipeline: &metav1.Duration{Duration: 30 * time.Minute},
-			},
-			TaskRunSpecs: []v1.PipelineTaskRunSpec{{
-				PipelineTaskName: "task1",
-				Timeout:          &metav1.Duration{Duration: 1 * time.Hour},
-			}},
-		},
-		wantErr:     true,
-		expectedErr: "taskRunSpecs[0].timeout",
-	}, {
-		name: "no pipeline timeout uses default",
-		spec: v1.PipelineRunSpec{
-			PipelineRef: &v1.PipelineRef{Name: "test"},
-			TaskRunSpecs: []v1.PipelineTaskRunSpec{{
-				PipelineTaskName: "task1",
-				Timeout:          &metav1.Duration{Duration: 30 * time.Minute},
-			}},
-		},
-		wantErr: false,
-	}, {
-		name: "taskRunSpec timeout exceeds tasks timeout",
-		spec: v1.PipelineRunSpec{
-			PipelineRef: &v1.PipelineRef{Name: "test"},
-			Timeouts: &v1.TimeoutFields{
-				Tasks: &metav1.Duration{Duration: 30 * time.Minute}, // Key: tasks timeout
-			},
-			TaskRunSpecs: []v1.PipelineTaskRunSpec{{
-				PipelineTaskName: "task1",
-				Timeout:          &metav1.Duration{Duration: 45 * time.Minute}, // Exceeds tasks timeout
-			}},
-		},
-		wantErr:     true,
-		expectedErr: "taskRunSpecs[0].timeout",
-	}, {
-		name: "taskRunSpec timeout within tasks timeout",
-		spec: v1.PipelineRunSpec{
-			PipelineRef: &v1.PipelineRef{Name: "test"},
-			Timeouts: &v1.TimeoutFields{
-				Pipeline: &metav1.Duration{Duration: 2 * time.Hour}, // Pipeline timeout must be >= tasks timeout
-				Tasks:    &metav1.Duration{Duration: 1 * time.Hour},
-			},
-			TaskRunSpecs: []v1.PipelineTaskRunSpec{{
-				PipelineTaskName: "task1",
-				Timeout:          &metav1.Duration{Duration: 30 * time.Minute}, // Within tasks timeout
-			}},
-		},
-		wantErr: false,
-	}, {
-		name: "taskRunSpec timeout exceeds default pipeline timeout",
-		spec: v1.PipelineRunSpec{
-			PipelineRef: &v1.PipelineRef{Name: "test"},
-			// No timeouts field set - should use default 60 minutes
-			TaskRunSpecs: []v1.PipelineTaskRunSpec{{
-				PipelineTaskName: "task1",
-				Timeout:          &metav1.Duration{Duration: 90 * time.Minute}, // Exceeds 60m default
-			}},
-		},
-		wantErr:     true,
-		expectedErr: "taskRunSpecs[0].timeout",
-	}}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ctx := config.ToContext(t.Context(), &config.Config{
-				Defaults: &config.Defaults{
-					DefaultTimeoutMinutes: 60,
-				},
-			})
-			err := tt.spec.Validate(ctx)
-			if tt.wantErr {
-				if err == nil {
-					t.Errorf("Expected error but got none")
-				} else if !strings.Contains(err.Error(), tt.expectedErr) {
-					t.Errorf("Expected error containing %q but got %q", tt.expectedErr, err.Error())
-				}
-			} else if err != nil {
-				t.Errorf("Expected no error but got: %v", err)
 			}
 		})
 	}

--- a/pkg/apis/pipeline/v1/taskrun_validation.go
+++ b/pkg/apis/pipeline/v1/taskrun_validation.go
@@ -125,11 +125,11 @@ func (ts *TaskRunSpec) Validate(ctx context.Context) (errs *apis.FieldError) {
 // ValidateUpdate validates the update of a TaskRunSpec
 func (ts *TaskRunSpec) ValidateUpdate(ctx context.Context) (errs *apis.FieldError) {
 	if !apis.IsInUpdate(ctx) {
-		return
+		return errs
 	}
 	oldObj, ok := apis.GetBaseline(ctx).(*TaskRun)
 	if !ok || oldObj == nil {
-		return
+		return errs
 	}
 	if oldObj.IsDone() {
 		// try comparing without any copying first
@@ -160,7 +160,7 @@ func (ts *TaskRunSpec) ValidateUpdate(ctx context.Context) (errs *apis.FieldErro
 		errs = errs.Also(apis.ErrInvalidValue("Once the TaskRun has started, only status and statusMessage updates are allowed", ""))
 	}
 
-	return
+	return errs
 }
 
 // validateInlineParameters validates that any parameters called in the

--- a/pkg/apis/pipeline/v1/taskrun_validation_test.go
+++ b/pkg/apis/pipeline/v1/taskrun_validation_test.go
@@ -18,6 +18,7 @@ package v1_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -1126,6 +1127,115 @@ func TestTaskRunSpec_ValidateUpdate(t *testing.T) {
 			err := tr.Spec.ValidateUpdate(ctx)
 			if d := cmp.Diff(tt.expectedError.Error(), err.Error(), cmpopts.IgnoreUnexported(apis.FieldError{})); d != "" {
 				t.Errorf("TaskRunSpec.ValidateUpdate() errors diff %s", diff.PrintWantGot(d))
+			}
+		})
+	}
+}
+
+func TestTaskRunSpec_ValidateUpdate_FinalizerChanges(t *testing.T) {
+	tests := []struct {
+		name            string
+		baselineTaskRun *v1.TaskRun
+		taskRun         *v1.TaskRun
+		expectedError   string
+	}{
+		{
+			name: "allow finalizer update when specs are identical",
+			baselineTaskRun: &v1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-tr",
+				},
+				Spec: v1.TaskRunSpec{
+					TaskRef: &v1.TaskRef{
+						Name: "test-task",
+						ResolverRef: v1.ResolverRef{
+							Resolver: "bundles",
+						},
+					},
+					Timeout: &metav1.Duration{Duration: 60 * time.Minute},
+				},
+				Status: v1.TaskRunStatus{
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{
+							{Type: apis.ConditionSucceeded, Status: corev1.ConditionTrue},
+						},
+					},
+				},
+			},
+			taskRun: &v1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-tr",
+					Finalizers: []string{"chains.tekton.dev/finalizer"},
+				},
+				Spec: v1.TaskRunSpec{
+					TaskRef: &v1.TaskRef{
+						Name: "test-task",
+						ResolverRef: v1.ResolverRef{
+							Resolver: "bundles",
+						},
+					},
+					Timeout: &metav1.Duration{Duration: 60 * time.Minute},
+				},
+			},
+			expectedError: "",
+		},
+		{
+			name: "block actual spec changes on completed TaskRun",
+			baselineTaskRun: &v1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-tr",
+				},
+				Spec: v1.TaskRunSpec{
+					TaskRef: &v1.TaskRef{
+						Name: "test-task",
+					},
+				},
+				Status: v1.TaskRunStatus{
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{
+							{Type: apis.ConditionSucceeded, Status: corev1.ConditionTrue},
+						},
+					},
+				},
+			},
+			taskRun: &v1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-tr",
+					Finalizers: []string{"chains.tekton.dev/finalizer"},
+				},
+				Spec: v1.TaskRunSpec{
+					TaskRef: &v1.TaskRef{
+						Name: "different-task",
+					},
+				},
+			},
+			expectedError: "invalid value: Once the TaskRun is complete, no updates are allowed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := config.ToContext(t.Context(), &config.Config{
+				Defaults: &config.Defaults{
+					DefaultResolverType:   "bundles",
+					DefaultTimeoutMinutes: 60,
+					DefaultServiceAccount: "default",
+				},
+			})
+			ctx = apis.WithinUpdate(ctx, tt.baselineTaskRun)
+
+			err := tt.taskRun.Spec.ValidateUpdate(ctx)
+
+			if tt.expectedError == "" {
+				if err != nil {
+					t.Errorf("Expected no error, but got: %v", err)
+				}
+			} else {
+				if err == nil {
+					t.Errorf("Expected error containing %q, but got none", tt.expectedError)
+				} else if !strings.Contains(err.Error(), tt.expectedError) {
+					t.Errorf("Expected error containing %q, but got: %v", tt.expectedError, err)
+				}
 			}
 		})
 	}

--- a/pkg/apis/pipeline/v1/taskrun_validation_test.go
+++ b/pkg/apis/pipeline/v1/taskrun_validation_test.go
@@ -1215,7 +1215,7 @@ func TestTaskRunSpec_ValidateUpdate_FinalizerChanges(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := config.ToContext(t.Context(), &config.Config{
+			ctx := config.ToContext(context.Background(), &config.Config{
 				Defaults: &config.Defaults{
 					DefaultResolverType:   "bundles",
 					DefaultTimeoutMinutes: 60,

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_validation.go
@@ -152,11 +152,11 @@ func (ps *PipelineRunSpec) Validate(ctx context.Context) (errs *apis.FieldError)
 // ValidateUpdate validates the update of a PipelineRunSpec
 func (ps *PipelineRunSpec) ValidateUpdate(ctx context.Context) (errs *apis.FieldError) {
 	if !apis.IsInUpdate(ctx) {
-		return
+		return errs
 	}
 	oldObj, ok := apis.GetBaseline(ctx).(*PipelineRun)
 	if !ok || oldObj == nil {
-		return
+		return errs
 	}
 	if oldObj.IsDone() {
 		// try comparing without any copying first
@@ -186,7 +186,7 @@ func (ps *PipelineRunSpec) ValidateUpdate(ctx context.Context) (errs *apis.Field
 		errs = errs.Also(apis.ErrInvalidValue("Once the PipelineRun has started, only status updates are allowed", ""))
 	}
 
-	return
+	return errs
 }
 
 func (ps *PipelineRunSpec) validatePipelineRunParameters(ctx context.Context) (errs *apis.FieldError) {

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_validation.go
@@ -158,17 +158,32 @@ func (ps *PipelineRunSpec) ValidateUpdate(ctx context.Context) (errs *apis.Field
 	if !ok || oldObj == nil {
 		return
 	}
-	old := &oldObj.Spec
+	if oldObj.IsDone() {
+		// try comparing without any copying first
+		// this handles the common case where only finalizers changed
+		if equality.Semantic.DeepEqual(&oldObj.Spec, ps) {
+			return nil // Specs identical, allow update
+		}
 
-	// If already in the done state, the spec cannot be modified. Otherwise, only the status field can be modified.
-	tips := "Once the PipelineRun is complete, no updates are allowed"
-	if !oldObj.IsDone() {
-		old = old.DeepCopy()
-		old.Status = ps.Status
-		tips = "Once the PipelineRun has started, only status updates are allowed"
+		// Specs differ, this could be due to different defaults after upgrade
+		// Apply current defaults to old spec to normalize
+		oldCopy := oldObj.Spec.DeepCopy()
+		oldCopy.SetDefaults(ctx)
+
+		if equality.Semantic.DeepEqual(oldCopy, ps) {
+			return nil // Difference was only defaults, allow update
+		}
+
+		// Real spec changes detected, reject update
+		errs = errs.Also(apis.ErrInvalidValue("Once the PipelineRun is complete, no updates are allowed", ""))
+		return errs
 	}
+
+	// Handle started but not done case
+	old := oldObj.Spec.DeepCopy()
+	old.Status = ps.Status
 	if !equality.Semantic.DeepEqual(old, ps) {
-		errs = errs.Also(apis.ErrInvalidValue(tips, ""))
+		errs = errs.Also(apis.ErrInvalidValue("Once the PipelineRun has started, only status updates are allowed", ""))
 	}
 
 	return

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_validation_test.go
@@ -1953,7 +1953,7 @@ func TestPipelineRunSpec_ValidateUpdate_FinalizerChanges(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := config.ToContext(t.Context(), &config.Config{
+			ctx := config.ToContext(context.Background(), &config.Config{
 				Defaults: &config.Defaults{
 					DefaultResolverType:   "bundles",
 					DefaultTimeoutMinutes: 60,

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_validation_test.go
@@ -1870,3 +1870,215 @@ func TestPipelineRunSpec_ValidateUpdate(t *testing.T) {
 		})
 	}
 }
+
+func TestPipelineRunSpec_ValidateUpdate_FinalizerChanges(t *testing.T) {
+	tests := []struct {
+		name                string
+		baselinePipelineRun *v1beta1.PipelineRun
+		pipelineRun         *v1beta1.PipelineRun
+		expectedError       string
+	}{
+		{
+			name: "allow finalizer update when specs are identical",
+			baselinePipelineRun: &v1beta1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pr",
+				},
+				Spec: v1beta1.PipelineRunSpec{
+					PipelineRef: &v1beta1.PipelineRef{
+						Name: "test-pipeline",
+					},
+					Timeouts: &v1beta1.TimeoutFields{
+						Pipeline: &metav1.Duration{Duration: 60 * time.Minute},
+					},
+				},
+				Status: v1beta1.PipelineRunStatus{
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{
+							{Type: apis.ConditionSucceeded, Status: corev1.ConditionTrue},
+						},
+					},
+				},
+			},
+			pipelineRun: &v1beta1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-pr",
+					Finalizers: []string{"chains.tekton.dev/finalizer"},
+				},
+				Spec: v1beta1.PipelineRunSpec{
+					PipelineRef: &v1beta1.PipelineRef{
+						Name: "test-pipeline",
+					},
+					Timeouts: &v1beta1.TimeoutFields{
+						Pipeline: &metav1.Duration{Duration: 60 * time.Minute},
+					},
+				},
+			},
+			expectedError: "",
+		},
+		{
+			name: "block actual spec changes on completed PipelineRun",
+			baselinePipelineRun: &v1beta1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pr",
+				},
+				Spec: v1beta1.PipelineRunSpec{
+					PipelineRef: &v1beta1.PipelineRef{
+						Name: "test-pipeline",
+					},
+				},
+				Status: v1beta1.PipelineRunStatus{
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{
+							{Type: apis.ConditionSucceeded, Status: corev1.ConditionTrue},
+						},
+					},
+				},
+			},
+			pipelineRun: &v1beta1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-pr",
+					Finalizers: []string{"chains.tekton.dev/finalizer"},
+				},
+				Spec: v1beta1.PipelineRunSpec{
+					PipelineRef: &v1beta1.PipelineRef{
+						Name: "different-pipeline",
+					},
+				},
+			},
+			expectedError: "invalid value: Once the PipelineRun is complete, no updates are allowed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := config.ToContext(t.Context(), &config.Config{
+				Defaults: &config.Defaults{
+					DefaultResolverType:   "bundles",
+					DefaultTimeoutMinutes: 60,
+				},
+			})
+			ctx = apis.WithinUpdate(ctx, tt.baselinePipelineRun)
+
+			err := tt.pipelineRun.Spec.ValidateUpdate(ctx)
+
+			if tt.expectedError == "" {
+				if err != nil {
+					t.Errorf("Expected no error, but got: %v", err)
+				}
+			} else {
+				if err == nil {
+					t.Errorf("Expected error containing %q, but got none", tt.expectedError)
+				} else if !strings.Contains(err.Error(), tt.expectedError) {
+					t.Errorf("Expected error containing %q, but got: %v", tt.expectedError, err)
+				}
+			}
+		})
+	}
+}
+
+func TestPipelineRunTaskRunSpecTimeout_Validate(t *testing.T) {
+	tests := []struct {
+		name        string
+		spec        v1beta1.PipelineRunSpec
+		wantErr     bool
+		expectedErr string
+	}{{
+		name: "taskRunSpec timeout within pipeline timeout",
+		spec: v1beta1.PipelineRunSpec{
+			PipelineRef: &v1beta1.PipelineRef{Name: "test"},
+			Timeouts: &v1beta1.TimeoutFields{
+				Pipeline: &metav1.Duration{Duration: 1 * time.Hour},
+			},
+			TaskRunSpecs: []v1beta1.PipelineTaskRunSpec{{
+				PipelineTaskName: "task1",
+				Timeout:          &metav1.Duration{Duration: 30 * time.Minute},
+			}},
+		},
+		wantErr: false,
+	}, {
+		name: "taskRunSpec timeout exceeds pipeline timeout",
+		spec: v1beta1.PipelineRunSpec{
+			PipelineRef: &v1beta1.PipelineRef{Name: "test"},
+			Timeouts: &v1beta1.TimeoutFields{
+				Pipeline: &metav1.Duration{Duration: 30 * time.Minute},
+			},
+			TaskRunSpecs: []v1beta1.PipelineTaskRunSpec{{
+				PipelineTaskName: "task1",
+				Timeout:          &metav1.Duration{Duration: 1 * time.Hour},
+			}},
+		},
+		wantErr:     true,
+		expectedErr: "taskRunSpecs[0].timeout",
+	}, {
+		name: "no pipeline timeout uses default",
+		spec: v1beta1.PipelineRunSpec{
+			PipelineRef: &v1beta1.PipelineRef{Name: "test"},
+			TaskRunSpecs: []v1beta1.PipelineTaskRunSpec{{
+				PipelineTaskName: "task1",
+				Timeout:          &metav1.Duration{Duration: 30 * time.Minute},
+			}},
+		},
+		wantErr: false,
+	}, {
+		name: "taskRunSpec timeout exceeds tasks timeout",
+		spec: v1beta1.PipelineRunSpec{
+			PipelineRef: &v1beta1.PipelineRef{Name: "test"},
+			Timeouts: &v1beta1.TimeoutFields{
+				Tasks: &metav1.Duration{Duration: 30 * time.Minute}, // Key: tasks timeout
+			},
+			TaskRunSpecs: []v1beta1.PipelineTaskRunSpec{{
+				PipelineTaskName: "task1",
+				Timeout:          &metav1.Duration{Duration: 45 * time.Minute}, // Exceeds tasks timeout
+			}},
+		},
+		wantErr:     true,
+		expectedErr: "taskRunSpecs[0].timeout",
+	}, {
+		name: "taskRunSpec timeout within tasks timeout",
+		spec: v1beta1.PipelineRunSpec{
+			PipelineRef: &v1beta1.PipelineRef{Name: "test"},
+			Timeouts: &v1beta1.TimeoutFields{
+				Pipeline: &metav1.Duration{Duration: 2 * time.Hour}, // Pipeline timeout must be >= tasks timeout
+				Tasks:    &metav1.Duration{Duration: 1 * time.Hour},
+			},
+			TaskRunSpecs: []v1beta1.PipelineTaskRunSpec{{
+				PipelineTaskName: "task1",
+				Timeout:          &metav1.Duration{Duration: 30 * time.Minute}, // Within tasks timeout
+			}},
+		},
+		wantErr: false,
+	}, {
+		name: "taskRunSpec timeout exceeds default pipeline timeout",
+		spec: v1beta1.PipelineRunSpec{
+			PipelineRef: &v1beta1.PipelineRef{Name: "test"},
+			// No timeouts field set - should use default 60 minutes
+			TaskRunSpecs: []v1beta1.PipelineTaskRunSpec{{
+				PipelineTaskName: "task1",
+				Timeout:          &metav1.Duration{Duration: 90 * time.Minute}, // Exceeds 60m default
+			}},
+		},
+		wantErr:     true,
+		expectedErr: "taskRunSpecs[0].timeout",
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := config.ToContext(t.Context(), &config.Config{
+				Defaults: &config.Defaults{
+					DefaultTimeoutMinutes: 60,
+				},
+			})
+			err := tt.spec.Validate(ctx)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("Expected error but got none")
+				} else if !strings.Contains(err.Error(), tt.expectedErr) {
+					t.Errorf("Expected error containing %q but got %q", tt.expectedErr, err.Error())
+				}
+			} else if err != nil {
+				t.Errorf("Expected no error but got: %v", err)
+			}
+		})
+	}
+}

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_validation_test.go
@@ -18,6 +18,7 @@ package v1beta1_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -1972,112 +1973,6 @@ func TestPipelineRunSpec_ValidateUpdate_FinalizerChanges(t *testing.T) {
 				} else if !strings.Contains(err.Error(), tt.expectedError) {
 					t.Errorf("Expected error containing %q, but got: %v", tt.expectedError, err)
 				}
-			}
-		})
-	}
-}
-
-func TestPipelineRunTaskRunSpecTimeout_Validate(t *testing.T) {
-	tests := []struct {
-		name        string
-		spec        v1beta1.PipelineRunSpec
-		wantErr     bool
-		expectedErr string
-	}{{
-		name: "taskRunSpec timeout within pipeline timeout",
-		spec: v1beta1.PipelineRunSpec{
-			PipelineRef: &v1beta1.PipelineRef{Name: "test"},
-			Timeouts: &v1beta1.TimeoutFields{
-				Pipeline: &metav1.Duration{Duration: 1 * time.Hour},
-			},
-			TaskRunSpecs: []v1beta1.PipelineTaskRunSpec{{
-				PipelineTaskName: "task1",
-				Timeout:          &metav1.Duration{Duration: 30 * time.Minute},
-			}},
-		},
-		wantErr: false,
-	}, {
-		name: "taskRunSpec timeout exceeds pipeline timeout",
-		spec: v1beta1.PipelineRunSpec{
-			PipelineRef: &v1beta1.PipelineRef{Name: "test"},
-			Timeouts: &v1beta1.TimeoutFields{
-				Pipeline: &metav1.Duration{Duration: 30 * time.Minute},
-			},
-			TaskRunSpecs: []v1beta1.PipelineTaskRunSpec{{
-				PipelineTaskName: "task1",
-				Timeout:          &metav1.Duration{Duration: 1 * time.Hour},
-			}},
-		},
-		wantErr:     true,
-		expectedErr: "taskRunSpecs[0].timeout",
-	}, {
-		name: "no pipeline timeout uses default",
-		spec: v1beta1.PipelineRunSpec{
-			PipelineRef: &v1beta1.PipelineRef{Name: "test"},
-			TaskRunSpecs: []v1beta1.PipelineTaskRunSpec{{
-				PipelineTaskName: "task1",
-				Timeout:          &metav1.Duration{Duration: 30 * time.Minute},
-			}},
-		},
-		wantErr: false,
-	}, {
-		name: "taskRunSpec timeout exceeds tasks timeout",
-		spec: v1beta1.PipelineRunSpec{
-			PipelineRef: &v1beta1.PipelineRef{Name: "test"},
-			Timeouts: &v1beta1.TimeoutFields{
-				Tasks: &metav1.Duration{Duration: 30 * time.Minute}, // Key: tasks timeout
-			},
-			TaskRunSpecs: []v1beta1.PipelineTaskRunSpec{{
-				PipelineTaskName: "task1",
-				Timeout:          &metav1.Duration{Duration: 45 * time.Minute}, // Exceeds tasks timeout
-			}},
-		},
-		wantErr:     true,
-		expectedErr: "taskRunSpecs[0].timeout",
-	}, {
-		name: "taskRunSpec timeout within tasks timeout",
-		spec: v1beta1.PipelineRunSpec{
-			PipelineRef: &v1beta1.PipelineRef{Name: "test"},
-			Timeouts: &v1beta1.TimeoutFields{
-				Pipeline: &metav1.Duration{Duration: 2 * time.Hour}, // Pipeline timeout must be >= tasks timeout
-				Tasks:    &metav1.Duration{Duration: 1 * time.Hour},
-			},
-			TaskRunSpecs: []v1beta1.PipelineTaskRunSpec{{
-				PipelineTaskName: "task1",
-				Timeout:          &metav1.Duration{Duration: 30 * time.Minute}, // Within tasks timeout
-			}},
-		},
-		wantErr: false,
-	}, {
-		name: "taskRunSpec timeout exceeds default pipeline timeout",
-		spec: v1beta1.PipelineRunSpec{
-			PipelineRef: &v1beta1.PipelineRef{Name: "test"},
-			// No timeouts field set - should use default 60 minutes
-			TaskRunSpecs: []v1beta1.PipelineTaskRunSpec{{
-				PipelineTaskName: "task1",
-				Timeout:          &metav1.Duration{Duration: 90 * time.Minute}, // Exceeds 60m default
-			}},
-		},
-		wantErr:     true,
-		expectedErr: "taskRunSpecs[0].timeout",
-	}}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ctx := config.ToContext(t.Context(), &config.Config{
-				Defaults: &config.Defaults{
-					DefaultTimeoutMinutes: 60,
-				},
-			})
-			err := tt.spec.Validate(ctx)
-			if tt.wantErr {
-				if err == nil {
-					t.Errorf("Expected error but got none")
-				} else if !strings.Contains(err.Error(), tt.expectedErr) {
-					t.Errorf("Expected error containing %q but got %q", tt.expectedErr, err.Error())
-				}
-			} else if err != nil {
-				t.Errorf("Expected no error but got: %v", err)
 			}
 		})
 	}

--- a/pkg/apis/pipeline/v1beta1/taskrun_validation.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_validation.go
@@ -125,11 +125,11 @@ func (ts *TaskRunSpec) Validate(ctx context.Context) (errs *apis.FieldError) {
 // ValidateUpdate validates the update of a TaskRunSpec
 func (ts *TaskRunSpec) ValidateUpdate(ctx context.Context) (errs *apis.FieldError) {
 	if !apis.IsInUpdate(ctx) {
-		return
+		return errs
 	}
 	oldObj, ok := apis.GetBaseline(ctx).(*TaskRun)
 	if !ok || oldObj == nil {
-		return
+		return errs
 	}
 	if oldObj.IsDone() {
 		// try comparing without any copying first
@@ -160,7 +160,7 @@ func (ts *TaskRunSpec) ValidateUpdate(ctx context.Context) (errs *apis.FieldErro
 		errs = errs.Also(apis.ErrInvalidValue("Once the TaskRun has started, only status and statusMessage updates are allowed", ""))
 	}
 
-	return
+	return errs
 }
 
 // validateInlineParameters validates that any parameters called in the

--- a/pkg/apis/pipeline/v1beta1/taskrun_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_validation_test.go
@@ -18,6 +18,7 @@ package v1beta1_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -1097,6 +1098,115 @@ func TestTaskRunSpec_ValidateUpdate(t *testing.T) {
 			err := tr.Spec.ValidateUpdate(ctx)
 			if d := cmp.Diff(tt.expectedError.Error(), err.Error(), cmpopts.IgnoreUnexported(apis.FieldError{})); d != "" {
 				t.Errorf("TaskRunSpec.ValidateUpdate() errors diff %s", diff.PrintWantGot(d))
+			}
+		})
+	}
+}
+
+func TestTaskRunSpec_ValidateUpdate_FinalizerChanges(t *testing.T) {
+	tests := []struct {
+		name            string
+		baselineTaskRun *v1beta1.TaskRun
+		taskRun         *v1beta1.TaskRun
+		expectedError   string
+	}{
+		{
+			name: "allow finalizer update when specs are identical",
+			baselineTaskRun: &v1beta1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-tr",
+				},
+				Spec: v1beta1.TaskRunSpec{
+					TaskRef: &v1beta1.TaskRef{
+						Name: "test-task",
+						ResolverRef: v1beta1.ResolverRef{
+							Resolver: "bundles",
+						},
+					},
+					Timeout: &metav1.Duration{Duration: 60 * time.Minute},
+				},
+				Status: v1beta1.TaskRunStatus{
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{
+							{Type: apis.ConditionSucceeded, Status: corev1.ConditionTrue},
+						},
+					},
+				},
+			},
+			taskRun: &v1beta1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-tr",
+					Finalizers: []string{"chains.tekton.dev/finalizer"},
+				},
+				Spec: v1beta1.TaskRunSpec{
+					TaskRef: &v1beta1.TaskRef{
+						Name: "test-task",
+						ResolverRef: v1beta1.ResolverRef{
+							Resolver: "bundles",
+						},
+					},
+					Timeout: &metav1.Duration{Duration: 60 * time.Minute},
+				},
+			},
+			expectedError: "",
+		},
+		{
+			name: "block actual spec changes on completed TaskRun",
+			baselineTaskRun: &v1beta1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-tr",
+				},
+				Spec: v1beta1.TaskRunSpec{
+					TaskRef: &v1beta1.TaskRef{
+						Name: "test-task",
+					},
+				},
+				Status: v1beta1.TaskRunStatus{
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{
+							{Type: apis.ConditionSucceeded, Status: corev1.ConditionTrue},
+						},
+					},
+				},
+			},
+			taskRun: &v1beta1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-tr",
+					Finalizers: []string{"chains.tekton.dev/finalizer"},
+				},
+				Spec: v1beta1.TaskRunSpec{
+					TaskRef: &v1beta1.TaskRef{
+						Name: "different-task",
+					},
+				},
+			},
+			expectedError: "invalid value: Once the TaskRun is complete, no updates are allowed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := config.ToContext(t.Context(), &config.Config{
+				Defaults: &config.Defaults{
+					DefaultResolverType:   "bundles",
+					DefaultTimeoutMinutes: 60,
+					DefaultServiceAccount: "default",
+				},
+			})
+			ctx = apis.WithinUpdate(ctx, tt.baselineTaskRun)
+
+			err := tt.taskRun.Spec.ValidateUpdate(ctx)
+
+			if tt.expectedError == "" {
+				if err != nil {
+					t.Errorf("Expected no error, but got: %v", err)
+				}
+			} else {
+				if err == nil {
+					t.Errorf("Expected error containing %q, but got none", tt.expectedError)
+				} else if !strings.Contains(err.Error(), tt.expectedError) {
+					t.Errorf("Expected error containing %q, but got: %v", tt.expectedError, err)
+				}
 			}
 		})
 	}

--- a/pkg/apis/pipeline/v1beta1/taskrun_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_validation_test.go
@@ -1186,7 +1186,7 @@ func TestTaskRunSpec_ValidateUpdate_FinalizerChanges(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := config.ToContext(t.Context(), &config.Config{
+			ctx := config.ToContext(context.Background(), &config.Config{
 				Defaults: &config.Defaults{
 					DefaultResolverType:   "bundles",
 					DefaultTimeoutMinutes: 60,


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Manual cherry pick of https://github.com/tektoncd/pipeline/pull/9011

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
