### PR TITLE
feat: resolve array values in Input of When expressions

### DIFF
--- a/pkg/apis/pipeline/v1/when_types_test.go
+++ b/pkg/apis/pipeline/v1/when_types_test.go
@@ -371,7 +371,69 @@ func TestApplyReplacements(t *testing.T) {
 			Operator: selection.In,
 			Values:   []string{"dev", "stage", "foo.txt", "readme.md", "test.go"},
 		},
-	}}
+	}, {
+		name: "replace input with empty results array",
+		original: &WhenExpression{
+			Input:    "$(tasks.foo.results.bar[*])",
+			Operator: selection.In,
+			Values:   []string{"main"},
+		},
+		arrayReplacements: map[string][]string{
+			"tasks.foo.results.bar": {},
+		},
+		expected: &WhenExpression{
+			Input:    "[]",
+			Operator: selection.In,
+			Values:   []string{"main"},
+		},
+	}, {
+		name: "replace input with non-empty results array",
+		original: &WhenExpression{
+			Input:    "$(tasks.foo.results.bar[*])",
+			Operator: selection.In,
+			Values:   []string{"main"},
+		},
+		arrayReplacements: map[string][]string{
+			"tasks.foo.results.bar": {"main", "devel"},
+		},
+		expected: &WhenExpression{
+			Input:    `["main","devel"]`,
+			Operator: selection.In,
+			Values:   []string{"main"},
+		},
+	},
+		{
+			name: "replace input with empty params array",
+			original: &WhenExpression{
+				Input:    "$(params.branches[*])",
+				Operator: selection.In,
+				Values:   []string{"main"},
+			},
+			arrayReplacements: map[string][]string{
+				"params.branches": {},
+			},
+			expected: &WhenExpression{
+				Input:    "[]",
+				Operator: selection.In,
+				Values:   []string{"main"},
+			},
+		},
+		{
+			name: "replace input with non-empty params array",
+			original: &WhenExpression{
+				Input:    "$(params.branches[*])",
+				Operator: selection.In,
+				Values:   []string{"main"},
+			},
+			arrayReplacements: map[string][]string{
+				"params.branches": {"main", "devel"},
+			},
+			expected: &WhenExpression{
+				Input:    `["main","devel"]`,
+				Operator: selection.In,
+				Values:   []string{"main"},
+			},
+		}}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			got := tc.original.applyReplacements(tc.replacements, tc.arrayReplacements)


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
This commits adds support for resolving the Input of When expression from array values, either from params or results. The replacement is the JSON marshaled version of the array value.
# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Array values can now be resolved in the `Input` attribute of `When` expressions
```
