### PR TITLE
fix(taskrun): ensure status steps are ordered correctly when using StepAction

### DIFF
--- a/pkg/pod/status.go
+++ b/pkg/pod/status.go
@@ -269,7 +269,8 @@ func setTaskRunStatusBasedOnStepStatus(ctx context.Context, logger *zap.SugaredL
 	}
 
 	// Continue with extraction of termination messages
-	for _, s := range stepStatuses {
+	orderedStepStates := make([]v1.StepState, len(stepStatuses))
+	for i, s := range stepStatuses {
 		// Avoid changing the original value by modifying the pointer value.
 		state := s.State.DeepCopy()
 		taskRunStepResults := []v1.TaskRunStepResult{}
@@ -378,18 +379,16 @@ func setTaskRunStatusBasedOnStepStatus(ctx context.Context, logger *zap.SugaredL
 			Inputs:            sas.Inputs,
 			Outputs:           sas.Outputs,
 		}
-		foundStep := false
-		for i, ss := range trs.Steps {
+		for _, ss := range trs.Steps {
 			if ss.Name == stepState.Name {
 				stepState.Provenance = ss.Provenance
-				trs.Steps[i] = stepState
-				foundStep = true
 				break
 			}
 		}
-		if !foundStep {
-			trs.Steps = append(trs.Steps, stepState)
-		}
+		orderedStepStates[i] = stepState
+	}
+	if len(orderedStepStates) > 0 {
+		trs.Steps = orderedStepStates
 	}
 
 	return errors.Join(errs...)

--- a/pkg/reconciler/taskrun/resources/taskspec.go
+++ b/pkg/reconciler/taskrun/resources/taskspec.go
@@ -174,19 +174,25 @@ func resolveStepRef(ctx context.Context, taskSpec v1.TaskSpec, taskRun *v1.TaskR
 
 // updateTaskRunProvenance update the TaskRun's status with source provenance information for a given step
 func updateTaskRunProvenance(taskRun *v1.TaskRun, stepName string, stepIndex int, source *v1.RefSource, stepStatusIndex map[string]int) {
-	// The StepState already exists. Update it in place
-	if index, found := stepStatusIndex[stepName]; found {
-		if taskRun.Status.Steps[index].Provenance == nil {
-			taskRun.Status.Steps[index].Provenance = &v1.Provenance{}
+	var provenance *v1.Provenance
+
+	if source != nil {
+		// The StepState already exists. Update it in place
+		if index, found := stepStatusIndex[stepName]; found {
+			if taskRun.Status.Steps[index].Provenance == nil {
+				taskRun.Status.Steps[index].Provenance = &v1.Provenance{}
+			}
+			taskRun.Status.Steps[index].Provenance.RefSource = source
+			return
 		}
-		taskRun.Status.Steps[index].Provenance.RefSource = source
-		return
+
+		provenance = &v1.Provenance{RefSource: source}
 	}
 
 	// No existing StepState found. Create and append a new one
 	newState := v1.StepState{
 		Name:       pod.TrimStepPrefix(pod.StepName(stepName, stepIndex)),
-		Provenance: &v1.Provenance{RefSource: source},
+		Provenance: provenance,
 	}
 	taskRun.Status.Steps = append(taskRun.Status.Steps, newState)
 }
@@ -237,15 +243,13 @@ func GetStepActionsData(ctx context.Context, taskSpec v1.TaskSpec, taskRun *v1.T
 	for i, step := range taskSpec.Steps {
 		if step.Ref == nil {
 			steps[i] = step
+			updateTaskRunProvenance(taskRun, step.Name, i, nil, stepStatusIndex)
 			continue
 		}
 
 		stepRefResolution := stepRefResolutions[i]
 		steps[i] = *stepRefResolution.resolvedStep
-
-		if stepRefResolution.source != nil {
-			updateTaskRunProvenance(taskRun, stepRefResolution.resolvedStep.Name, i, stepRefResolution.source, stepStatusIndex)
-		}
+		updateTaskRunProvenance(taskRun, stepRefResolution.resolvedStep.Name, i, stepRefResolution.source, stepStatusIndex)
 	}
 
 	return steps, nil

--- a/pkg/reconciler/taskrun/resources/taskspec_test.go
+++ b/pkg/reconciler/taskrun/resources/taskspec_test.go
@@ -756,6 +756,212 @@ spec:
 	}
 }
 
+func TestGetStepActionsData_Status(t *testing.T) {
+	firstStepAction := parse.MustParseV1beta1StepAction(t, `
+metadata:
+  name: first-stepaction
+  namespace: default
+spec:
+  image: myImage
+`)
+	firstStepActionSource := v1.RefSource{
+		URI:    "ref-source",
+		Digest: map[string]string{"sha256": "abcd123456"},
+	}
+
+	firstStepActionBytes, err := yaml.Marshal(firstStepAction)
+	if err != nil {
+		t.Fatal("failed to marshal StepAction", err)
+	}
+	rr := test.NewResolvedResource(firstStepActionBytes, map[string]string{}, &firstStepActionSource, nil)
+	requester := test.NewRequester(rr, nil, resource.ResolverPayload{})
+
+	tests := []struct {
+		name        string
+		tr          *v1.TaskRun
+		stepActions []*v1beta1.StepAction
+		want        v1.TaskRunStatus
+	}{
+		{
+			name: "inline only",
+			tr: &v1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "mytaskrun",
+					Namespace: "default",
+				},
+				Spec: v1.TaskRunSpec{
+					TaskSpec: &v1.TaskSpec{
+						Steps: []v1.Step{
+							{
+								Name:  "first-inline",
+								Image: "ubuntu",
+							},
+							{
+								Name:  "second-inline",
+								Image: "ubuntu",
+							},
+						},
+					},
+				},
+			},
+			want: v1.TaskRunStatus{},
+		}, {
+			name: "StepAction only",
+			tr: &v1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "mytaskrun",
+					Namespace: "default",
+				},
+				Spec: v1.TaskRunSpec{
+					TaskSpec: &v1.TaskSpec{
+						Steps: []v1.Step{
+							{
+								Name: "first-remote",
+								Ref: &v1.Ref{
+									Name: "first-stepaction",
+									ResolverRef: v1.ResolverRef{
+										Resolver: "foobar",
+									},
+								},
+							},
+							{
+								Name: "second-remote",
+								Ref: &v1.Ref{
+									Name: "second-stepaction",
+								},
+							},
+						},
+					},
+				},
+			},
+			stepActions: []*v1beta1.StepAction{
+				firstStepAction,
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "second-stepaction",
+						Namespace: "default",
+					},
+					Spec: v1beta1.StepActionSpec{
+						Image: "myimage",
+					},
+				},
+			},
+			want: v1.TaskRunStatus{
+				TaskRunStatusFields: v1.TaskRunStatusFields{
+					Steps: []v1.StepState{
+						{
+							Name: "first-remote",
+							Provenance: &v1.Provenance{
+								RefSource: &v1.RefSource{
+									URI:    "ref-source",
+									Digest: map[string]string{"sha256": "abcd123456"},
+								},
+							},
+						},
+						{
+							Name: "second-remote",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "mixed inline and StepAction",
+			tr: &v1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "mytaskrun",
+					Namespace: "default",
+				},
+				Spec: v1.TaskRunSpec{
+					TaskSpec: &v1.TaskSpec{
+						Steps: []v1.Step{
+							{
+								Name:  "first-inline",
+								Image: "ubuntu",
+							},
+							{
+								Name: "second-remote",
+								Ref: &v1.Ref{
+									Name: "first-stepaction",
+									ResolverRef: v1.ResolverRef{
+										Resolver: "foobar",
+									},
+								},
+							},
+							{
+								Name:  "third-inline",
+								Image: "ubuntu",
+							},
+							{
+								Name: "fourth-remote",
+								Ref: &v1.Ref{
+									Name: "second-stepaction",
+								},
+							},
+						},
+					},
+				},
+			},
+			stepActions: []*v1beta1.StepAction{
+				firstStepAction,
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "second-stepaction",
+						Namespace: "default",
+					},
+					Spec: v1beta1.StepActionSpec{
+						Image: "myimage",
+					},
+				},
+			},
+			want: v1.TaskRunStatus{
+				TaskRunStatusFields: v1.TaskRunStatusFields{
+					Steps: []v1.StepState{
+						{
+							Name: "first-inline",
+						},
+						{
+							Name: "second-remote",
+							Provenance: &v1.Provenance{
+								RefSource: &v1.RefSource{
+									URI:    "ref-source",
+									Digest: map[string]string{"sha256": "abcd123456"},
+								},
+							},
+						},
+						{
+							Name: "third-inline",
+						},
+						{
+							Name: "fourth-remote",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := t.Context()
+			tektonclient := fake.NewSimpleClientset()
+			for _, sa := range tt.stepActions {
+				if err := tektonclient.Tracker().Add(sa); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			_, err := GetStepActionsData(ctx, *tt.tr.Spec.TaskSpec, tt.tr, tektonclient, nil, requester)
+			if err != nil {
+				t.Fatalf("Did not expect an error but got : %s", err)
+			}
+			if d := cmp.Diff(tt.want, tt.tr.Status); d != "" {
+				t.Errorf("the taskrun status did not match what was expected diff: %s", diff.PrintWantGot(d))
+			}
+		})
+	}
+}
+
 func TestGetStepActionsData(t *testing.T) {
 	taskRunUser := int64(1001)
 	stepActionUser := int64(1000)


### PR DESCRIPTION
# Context

When a `TaskRun` references `StepActions`, `TaskRun.Status.Steps` is partially populated during resolution (to capture provenance). Later, pod-based status processing appends inline steps, which can result in `StepAction` steps being shown first and inline steps last, regardless of the real pod order.

This breaks dashboards and tools that assume `Status.Steps` reflects the true execution order:
- **Incorrect ordering**: `StepAction` steps appear first and inline steps are appended, regardless of their real execution order in the pod.
- **UI "popping"**: In the Tekton Dashboard, StepAction-backed steps show up immediately (post-resolution) while inline steps only appear later (after pod creation and status reconciliation). This causes steps to "pop" into view and reshuffle, which is confusing.

Fixes #9037

# Changes

This PR includes two complementary commits that address both completeness and ordering of Status.Steps.
- **Commit n°1**:
   - `setTaskRunStatusBasedOnStepStatus` now constructs a new ordered slice the size of the step container list and replaces `trs.Steps` in one shot.
   - The input `stepStatuses` were already sorted to match `pod.Spec.Containers`; we leverage that to ensure strict pod-order.
   - Provenance for matching steps (by name) is preserved.
- **Commit n°2**:
   - During `GetStepActionsData`, if at least one `StepAction` is present in the `Task`, create a `StepState` for every step:
      - `StepAction` steps get `Provenance.RefSource` when available.
      - Inline steps get `nil` provenance.
   - This makes `Status.Steps` complete earlier in the lifecycle, removing the Dashboard "popping" effect where `StepAction` steps appear first and inline steps arrive later.

# Release Notes

```release-note
- `TaskRun.Status.Steps` now strictly follows the pod’s step container order.
- When `StepActions` are used, inline steps are also included in `TaskRun.Status.Steps` (with nil provenance) early, preventing steps from "popping" into view later and improving dashboard stability.
```