### PR TITLE
test/e2e: remove data race on global variable requireAlphaFeatureFlag

### DIFF
--- a/test/matrix_test.go
+++ b/test/matrix_test.go
@@ -37,10 +37,6 @@ import (
 	"knative.dev/pkg/test/helpers"
 )
 
-var requireAlphaFeatureFlag = requireAnyGate(map[string]string{
-	"enable-api-fields": "alpha",
-})
-
 // TestPipelineRunMatrixed is an integration test that verifies that a Matrixed PipelineRun
 // succeeds with both `matrix params` and `matrix include params`. It also tests array indexing
 // and whole array replacements by consuming results produced by other PipelineTasks.
@@ -49,7 +45,9 @@ func TestPipelineRunMatrixed(t *testing.T) {
 	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	c, namespace := setup(ctx, t, requireAlphaFeatureFlag)
+	c, namespace := setup(ctx, t, requireAnyGate(map[string]string{
+		"enable-api-fields": "alpha",
+	}))
 	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
 	defer tearDown(ctx, t, c, namespace)
 	t.Logf("Creating Tasks in namespace %s", namespace)
@@ -587,7 +585,9 @@ func TestPipelineRunMatrixedFailed(t *testing.T) {
 	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	c, namespace := setup(ctx, t, requireAlphaFeatureFlag)
+	c, namespace := setup(ctx, t, requireAnyGate(map[string]string{
+		"enable-api-fields": "alpha",
+	}))
 	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
 	defer tearDown(ctx, t, c, namespace)
 	t.Logf("Creating Task in namespace %s", namespace)

--- a/test/pipelinefinally_test.go
+++ b/test/pipelinefinally_test.go
@@ -36,10 +36,6 @@ import (
 	"knative.dev/pkg/test/helpers"
 )
 
-var requireAlphaFeatureFlags = requireAnyGate(map[string]string{
-	"enable-api-fields": "alpha",
-})
-
 func TestPipelineLevelFinally_OneDAGTaskFailed_InvalidTaskResult_Failure(t *testing.T) {
 	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
@@ -462,7 +458,9 @@ func TestPipelineLevelFinally_OneFinalTask_CancelledRunFinally(t *testing.T) {
 	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	c, namespace := setup(ctx, t, requireAlphaFeatureFlags)
+	c, namespace := setup(ctx, t, requireAnyGate(map[string]string{
+		"enable-api-fields": "alpha",
+	}))
 	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
 	defer tearDown(ctx, t, c, namespace)
 
@@ -577,7 +575,9 @@ func TestPipelineLevelFinally_OneFinalTask_StoppedRunFinally(t *testing.T) {
 	ctx := t.Context()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	c, namespace := setup(ctx, t, requireAlphaFeatureFlags)
+	c, namespace := setup(ctx, t, requireAnyGate(map[string]string{
+		"enable-api-fields": "alpha",
+	}))
 	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
 	defer tearDown(ctx, t, c, namespace)
 

--- a/test/propagated_results_test.go
+++ b/test/propagated_results_test.go
@@ -42,9 +42,6 @@ func TestPropagatedResults(t *testing.T) {
 
 	ignorePipelineRunStatusFields := cmpopts.IgnoreFields(v1.PipelineRunStatusFields{}, "Provenance")
 	ignoreTaskRunStatus := cmpopts.IgnoreFields(v1.TaskRunStatusFields{}, "StartTime", "CompletionTime", "Sidecars", "Provenance")
-	requireAlphaFeatureFlag = requireAnyGate(map[string]string{
-		"enable-api-fields": "alpha",
-	})
 
 	type tests struct {
 		name            string
@@ -65,7 +62,9 @@ func TestPropagatedResults(t *testing.T) {
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 
-			c, namespace := setup(ctx, t, requireAlphaFeatureFlag)
+			c, namespace := setup(ctx, t, requireAnyGate(map[string]string{
+				"enable-api-fields": "alpha",
+			}))
 
 			knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
 			defer tearDown(ctx, t, c, namespace)


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This variable was set at different places by different tests that may run in parallel. The fix is to remove the variable altogether and just inline the function.


Closes #9065

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
