### PR TITLE
Pods for timed out TaskRuns should not be deleted when  "keep-pod-on-cancel" feature flag is true

### DIFF
--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -807,8 +807,8 @@ func (c *Reconciler) failTaskRun(ctx context.Context, tr *v1.TaskRun, reason v1.
 	terminateStepsInPod(tr, reason)
 
 	var err error
-	if reason == v1.TaskRunReasonCancelled && (config.FromContextOrDefaults(ctx).FeatureFlags.EnableKeepPodOnCancel) {
-		logger.Infof("Canceling task run %q by entrypoint", tr.Name)
+	if (reason == v1.TaskRunReasonCancelled || reason == v1.TaskRunReasonTimedOut) && (config.FromContextOrDefaults(ctx).FeatureFlags.EnableKeepPodOnCancel) {
+		logger.Infof("Canceling task run %q by entrypoint, Reason: %s", tr.Name, reason)
 		err = podconvert.CancelPod(ctx, c.KubeClientSet, tr.Namespace, tr.Status.PodName)
 	} else {
 		err = c.KubeClientSet.CoreV1().Pods(tr.Namespace).Delete(ctx, tr.Status.PodName, metav1.DeleteOptions{})

--- a/pkg/reconciler/taskrun/taskrun_timeout_test.go
+++ b/pkg/reconciler/taskrun/taskrun_timeout_test.go
@@ -1,0 +1,196 @@
+/*
+Copyright 2025 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package taskrun
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/pipeline/pkg/apis/config"
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"github.com/tektoncd/pipeline/pkg/reconciler/volumeclaim"
+	"go.opentelemetry.io/otel/trace"
+
+	_ "github.com/tektoncd/pipeline/pkg/taskrunmetrics/fake"
+	"github.com/tektoncd/pipeline/test"
+	"github.com/tektoncd/pipeline/test/diff"
+	"github.com/tektoncd/pipeline/test/parse"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
+	"knative.dev/pkg/system"
+	_ "knative.dev/pkg/system/testing" // Setup system.Namespace()
+)
+
+func TestFailTaskRun_Timeout(t *testing.T) {
+	testCases := []struct {
+		name           string
+		taskRun        *v1.TaskRun
+		pod            *corev1.Pod
+		reason         v1.TaskRunReason
+		message        string
+		featureFlags   map[string]string
+		expectedStatus apis.Condition
+		expectedPods   []corev1.Pod
+	}{
+		{
+			name: "taskrun-timeout-keep-pod-on-cancel",
+			taskRun: parse.MustParseV1TaskRun(t, `
+metadata:
+  name: test-taskrun-run-timeout
+  namespace: foo
+spec:
+  taskRef:
+    name: test-task
+  timeout: 10s
+status:
+  startTime: "2000-01-01T01:01:01Z"
+  conditions:
+  - status: Unknown
+    type: Succeeded
+  podName: foo-is-bar
+  steps:
+  - running:
+      startedAt: "2022-01-01T00:00:00Z"
+`),
+			pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+				Namespace: "foo",
+				Name:      "foo-is-bar",
+				Annotations: map[string]string{
+					"test": "test value",
+				},
+			}},
+			featureFlags: map[string]string{
+				config.KeepPodOnCancel: "true",
+			},
+			reason:  v1.TaskRunReasonTimedOut,
+			message: "TaskRun test-taskrun-run-timeout failed to finish within 10s",
+			expectedStatus: apis.Condition{
+				Type:    apis.ConditionSucceeded,
+				Status:  corev1.ConditionFalse,
+				Reason:  v1.TaskRunReasonTimedOut.String(),
+				Message: "TaskRun test-taskrun-run-timeout failed to finish within 10s",
+			},
+			expectedPods: []corev1.Pod{{ObjectMeta: metav1.ObjectMeta{
+				Namespace: "foo",
+				Name:      "foo-is-bar",
+				Annotations: map[string]string{
+					"test":              "test value",
+					"tekton.dev/cancel": "CANCEL",
+				},
+			}}},
+		},
+		{
+			name: "taskrun-timeout-keep-pod-on-cancel-false",
+			taskRun: parse.MustParseV1TaskRun(t, `
+metadata:
+  name: test-taskrun-run-timeout
+  namespace: foo
+spec:
+  taskRef:
+    name: test-task
+  timeout: 10s
+status:
+  startTime: "2000-01-01T01:01:01Z"
+  conditions:
+  - status: Unknown
+    type: Succeeded
+  podName: foo-is-bar
+  steps:
+  - running:
+      startedAt: "2022-01-01T00:00:00Z"
+`),
+			pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+				Namespace: "foo",
+				Name:      "foo-is-bar",
+				Annotations: map[string]string{
+					"test": "test value",
+				},
+			}},
+			featureFlags: map[string]string{
+				config.KeepPodOnCancel: "false",
+			},
+			reason:  v1.TaskRunReasonTimedOut,
+			message: "TaskRun test-taskrun-run-timeout failed to finish within 10s",
+			expectedStatus: apis.Condition{
+				Type:    apis.ConditionSucceeded,
+				Status:  corev1.ConditionFalse,
+				Reason:  v1.TaskRunReasonTimedOut.String(),
+				Message: "TaskRun test-taskrun-run-timeout failed to finish within 10s",
+			},
+		}}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := test.Data{
+				TaskRuns: []*v1.TaskRun{tc.taskRun},
+				ConfigMaps: []*corev1.ConfigMap{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      config.GetFeatureFlagsConfigName(),
+							Namespace: system.Namespace(),
+						},
+						Data: tc.featureFlags,
+					},
+				},
+				Pods: []*corev1.Pod{
+					tc.pod,
+				},
+			}
+
+			testAssets, cancel := getTaskRunController(t, d)
+			defer cancel()
+
+			c := &Reconciler{
+				KubeClientSet:     testAssets.Clients.Kube,
+				PipelineClientSet: testAssets.Clients.Pipeline,
+				Clock:             testClock,
+				taskRunLister:     testAssets.Informers.TaskRun.Lister(),
+				limitrangeLister:  testAssets.Informers.LimitRange.Lister(),
+				cloudEventClient:  testAssets.Clients.CloudEvents,
+				metrics:           nil, // Not used
+				entrypointCache:   nil, // Not used
+				pvcHandler:        volumeclaim.NewPVCHandler(testAssets.Clients.Kube, testAssets.Logger),
+				tracerProvider:    trace.NewNoopTracerProvider(),
+			}
+			ctx := testAssets.Ctx
+
+			ff, _ := config.NewFeatureFlagsFromMap(tc.featureFlags)
+
+			ctx = config.ToContext(ctx, &config.Config{
+				FeatureFlags: ff,
+			})
+
+			if err := c.failTaskRun(ctx, tc.taskRun, tc.reason, tc.message); err != nil {
+				t.Errorf("fail timeout test: %v", err)
+			}
+
+			if d := cmp.Diff(&tc.expectedStatus, tc.taskRun.Status.GetCondition(apis.ConditionSucceeded), ignoreLastTransitionTime); d != "" {
+				t.Fatal(diff.PrintWantGot(d))
+			}
+
+			pods, err := c.KubeClientSet.CoreV1().Pods(tc.pod.Namespace).List(ctx, metav1.ListOptions{})
+			if err != nil {
+				t.Fatal("Error while fetching pod: "+tc.pod.Name, err.Error())
+			}
+			if d := cmp.Diff(tc.expectedPods, pods.Items); d != "" {
+				t.Fatal(diff.PrintWantGot(d))
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This PR is for the Fixes #9059

When a TaskRun is timed out then default behavior is to delete the corresponding pod and there is no way to debug the pod later

With this fix, POD will not be deleted when task-run is timed out and feature flag 'keep-pod-on-cancel' is set to true.  
This is same behavior as it was with cancelled task runs.



<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note

If Feature flag "keep-pod-on-cancel" is set to true then pods corresponding  to TaskRun will be not be deleted  when TaskRun Times Out. Earlier pod was retained only if it taskrun was canceled.

```
