### PR TITLE
ci: Ensure e2e setup errors fail tests, add retries during e2e setup

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -18,6 +18,26 @@
 
 source $(git rev-parse --show-toplevel)/vendor/github.com/tektoncd/plumbing/scripts/e2e-tests.sh
 
+# Run the given five times or until it succeeds.
+# Sleeps 5 seconds after earch retry.
+# example usage: `with_retries ping fakeserver.com`
+function with_retries() (
+  set +eo pipefail
+
+  success=""
+  for retry in 1 2 3 4 5; do
+    "$@"
+    success="$?"
+    if [ "${success}" -eq "0" ]; then
+      break
+    fi
+    sleep 5
+    [[ "${retry}" !=  "5" ]] && echo "Retrying..."
+  done
+
+  return "${success}"
+)
+
 function install_pipeline_crd() {
   echo ">> Deploying Tekton Pipelines"
   local ko_target="$(mktemp)"


### PR DESCRIPTION
# Changes
- Add retries to e2e test setup-config functions
- Ensure failures during e2e setup cause the test to fail before executing the golang tests

Setting up the correct configuration values like `enable-api-fields` is not optional since many tests depend on these values at runtime. If a test requires non-default config values which failed to be set, the failure may not cause an e2e test to fail for some time and the test failure message will cause confusion; the configuration being correct during setup is a given. By ensuring a failure in any of the configuration setup functions results in the test suite failing, we ensure the tests will only run against the expected configuration. This change ensures that if the e2e test configuration fails, the tests will not continue.

Fixing that improves the clarity of some flaky failures, but it doesn't reduce the flakiness itself. To reduce failures during e2e environment configuration, this change also implements a retry mechanism to each of the set configuration functions. This reduces flakiness due to network connectivity or race conditions during environment setup. If all config retries are exhausted with failure, then the tests will fail as above.


# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
