### PR TITLE
e2e: tests against 1.34 as well

### DIFF
--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -19,11 +19,12 @@ jobs:
       matrix:
         k8s-name:
         - k8s-oldest             # 1.28
-        - k8s-latest-minus-four  # 1.29
-        - k8s-latest-minus-three # 1.30
-        - k8s-latest-minus-two   # 1.31
-        - k8s-latest-minus-one   # 1.32
-        - k8s-latest             # 1.33
+        - k8s-latest-minus-five  # 1.29
+        - k8s-latest-minus-four  # 1.30
+        - k8s-latest-minus-three # 1.31
+        - k8s-latest-minus-two   # 1.32
+        - k8s-latest-minus-one   # 1.33
+        - k8s-latest             # 1.34
 
         feature-flags:
         - stable
@@ -33,19 +34,25 @@ jobs:
         include:
         - k8s-name: k8s-oldest
           k8s-version: v1.28.x
-        - k8s-name: k8s-latest-minus-four
+        - k8s-name: k8s-latest-minus-five
           k8s-version: v1.29.x
-        - k8s-name: k8s-latest-minus-three
+        - k8s-name: k8s-latest-minus-four
           k8s-version: v1.30.x
-        - k8s-name: k8s-latest-minus-two
+        - k8s-name: k8s-latest-minus-three
           k8s-version: v1.31.x
-        - k8s-name: k8s-latest-minus-one
+        - k8s-name: k8s-latest-minus-two
           k8s-version: v1.32.x
-        - k8s-name: k8s-latest
+        - k8s-name: k8s-latest-minus-one
           k8s-version: v1.33.x
+        - k8s-name: k8s-latest
+          k8s-version: v1.34.x
 
         # Run beta and alpha only on latest and oldest
         exclude:
+        - k8s-name: k8s-latest-minus-five
+          feature-flags: beta
+        - k8s-name: k8s-latest-minus-five
+          feature-flags: alpha
         - k8s-name: k8s-latest-minus-four
           feature-flags: beta
         - k8s-name: k8s-latest-minus-four


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

It is the latest kubernetes version.

/kind misc
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
