### PR TITLE
wip: Rebase against pull-request base-ref

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+    - name: Rebase against ${{ github.base_ref}}
+      if: github.event_name == 'pull_request'
+      run: |
+        # The base branch (e.g., 'main') is available via the github context
+        BASE_REF="${{ github.event.pull_request.base.ref }}"
+
+        echo "Starting rebase onto '$GITHUB_BASE_REF'"
+        git show
+        git show "origin/$GITHUB_BASE_REF"
+        git fetch origin "$GITHUB_BASE_REF"
+        git rebase "origin/$GITHUB_BASE_REF" || {
+          echo "::warning::Rebase failed due to conflicts. Tests will run against the conflicting state to highlight the issue."
+          # Resetting to HEAD after a failed rebase is optional,
+          # but sometimes prevents unexpected issues in later steps.
+          git rebase --abort
+          exit 0
+        }
+        echo "Rebase successful. Running tests against the merged state."
     - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00  # v6.0.0
       with:
         go-version-file: "go.mod"
@@ -32,6 +50,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+    - name: Rebase against ${{ github.base_ref}}
+      if: github.event_name == 'pull_request'
+      run: |
+        # The base branch (e.g., 'main') is available via the github context
+        BASE_REF="${{ github.event.pull_request.base.ref }}"
+
+        echo "Starting rebase onto '$GITHUB_BASE_REF'"
+        git fetch origin "$GITHUB_BASE_REF"
+        git rebase "origin/$GITHUB_BASE_REF" || {
+          echo "::warning::Rebase failed due to conflicts. Tests will run against the conflicting state to highlight the issue."
+          # Resetting to HEAD after a failed rebase is optional,
+          # but sometimes prevents unexpected issues in later steps.
+          git rebase --abort
+          exit 0
+        }
+        echo "Rebase successful. Running tests against the merged state."
     - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00  # v6.0.0
       with:
         go-version-file: "go.mod"
@@ -45,6 +79,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+    - name: Rebase against ${{ github.base_ref}}
+      if: github.event_name == 'pull_request'
+      run: |
+        # The base branch (e.g., 'main') is available via the github context
+        BASE_REF="${{ github.event.pull_request.base.ref }}"
+
+        echo "Starting rebase onto '$GITHUB_BASE_REF'"
+        git fetch origin "$GITHUB_BASE_REF"
+        git rebase "origin/$GITHUB_BASE_REF" || {
+          echo "::warning::Rebase failed due to conflicts. Tests will run against the conflicting state to highlight the issue."
+          # Resetting to HEAD after a failed rebase is optional,
+          # but sometimes prevents unexpected issues in later steps.
+          git rebase --abort
+          exit 0
+        }
+        echo "Rebase successful. Running tests against the merged state."
     - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00  # v6.0.0
       with:
         go-version-file: "go.mod"
@@ -99,6 +149,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+    - name: Rebase against ${{ github.base_ref}}
+      if: github.event_name == 'pull_request'
+      run: |
+        # The base branch (e.g., 'main') is available via the github context
+        BASE_REF="${{ github.event.pull_request.base.ref }}"
+
+        echo "Starting rebase onto '$GITHUB_BASE_REF'"
+        git fetch origin "$GITHUB_BASE_REF"
+        git rebase "origin/$GITHUB_BASE_REF" || {
+          echo "::warning::Rebase failed due to conflicts. Tests will run against the conflicting state to highlight the issue."
+          # Resetting to HEAD after a failed rebase is optional,
+          # but sometimes prevents unexpected issues in later steps.
+          git rebase --abort
+          exit 0
+        }
+        echo "Rebase successful. Running tests against the merged state."
     - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00  # v6.0.0
       with:
         go-version-file: "go.mod"

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -111,6 +111,22 @@ jobs:
         echo "--- Disk space after cleanup ---"
         df -h
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+    - name: Rebase against ${{ github.base_ref}}
+      if: github.event_name == 'pull_request'
+      run: |
+        # The base branch (e.g., 'main') is available via the github context
+        BASE_REF="${{ github.event.pull_request.base.ref }}"
+
+        echo "Starting rebase onto '$GITHUB_BASE_REF'"
+        git fetch origin "$GITHUB_BASE_REF"
+        git rebase "origin/$GITHUB_BASE_REF" || {
+          echo "::warning::Rebase failed due to conflicts. Tests will run against the conflicting state to highlight the issue."
+          # Resetting to HEAD after a failed rebase is optional,
+          # but sometimes prevents unexpected issues in later steps.
+          git rebase --abort
+          exit 0
+        }
+        echo "Rebase successful. Running tests against the merged state."
     - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00  # v6.0.0
       with:
         go-version-file: "go.mod"


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The idea is to ensure we are testing what would be merged, and can anticipate conflicts as well. This would also help not requiring to rebase pull-requests to fix the CI.

/kind misc
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
