### PR TITLE
entrypoint: handle linux in pkgs/platforms

### DIFF
--- a/pkg/platforms/platforms.go
+++ b/pkg/platforms/platforms.go
@@ -36,6 +36,7 @@ const (
 	Windows = "windows"
 	Darwin  = "darwin"
 	FreeBSD = "freebsd"
+	Linux   = "linux"
 )
 
 // Platform describes the platform which the image in the manifest runs on.
@@ -121,7 +122,7 @@ func getCPUVariant() (string, error) {
 		default:
 			variant = Unknown
 		}
-	case FreeBSD:
+	case Linux, FreeBSD:
 		// FreeBSD supports ARMv6 and ARMv7 as well as ARMv4 and ARMv5 (though deprecated)
 		// detecting those variants is currently unimplemented
 		switch runtime.GOARCH {


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Without this, we can errors such as the following

    ERROR failed to get CPU variant os=linux error="getCPUVariant for OS linux: not implemented"
    could not find command for platform "linux/arm64"

The main reason for this is because we are missing the variant when getting the platform, but the oci images for arm64 have it, and thus `TEKTON_PLATFORM_COMMANDS` as well. It creates a mismatch, and the entrypoint cannot find the command it looks for.

Essentially it means that anyone running arm64 cluster and not using `script` or specifying `command` won't be able to run a TaskRun 😅 .

Closes #9094 

/kind bug

@tektoncd/core-maintainers this will need to be cherry-pick to all LTS after 0.68.
Note: This is extracted from https://github.com/tektoncd/pipeline/pull/9090 (which runs e2e tests on arm64 to catch things like that) so that we get it merged more quickly.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
