### PR TITLE
fix: do not fail PipelineRun when TaskRef reconciles with retryable err

### DIFF
--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -54,11 +54,15 @@ type TaskSkipStatus struct {
 // TaskNotFoundError indicates that the resolution failed because a referenced Task couldn't be retrieved
 type TaskNotFoundError struct {
 	Name string
-	Msg  string
+	Err  error
 }
 
 func (e *TaskNotFoundError) Error() string {
-	return fmt.Sprintf("Couldn't retrieve Task %q: %s", e.Name, e.Msg)
+	return fmt.Sprintf("Couldn't retrieve Task %q: %s", e.Name, e.Err.Error())
+}
+
+func (e *TaskNotFoundError) Unwrap() error {
+	return e.Err
 }
 
 // ResolvedPipelineTask contains a PipelineTask and its associated child PipelineRun(s) (Pipelines-in-Pipelines), TaskRun(s) or CustomRuns, if they exist.
@@ -820,7 +824,7 @@ func resolveTask(
 				}
 				return rt, &TaskNotFoundError{
 					Name: name,
-					Msg:  err.Error(),
+					Err:  err,
 				}
 			default:
 				spec := t.Spec

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/pkg/reconciler/apiserver"
 	"github.com/tektoncd/pipeline/pkg/reconciler/pipeline/dag"
 	"github.com/tektoncd/pipeline/pkg/reconciler/taskrun/resources"
 	resolutioncommon "github.com/tektoncd/pipeline/pkg/resolution/common"
@@ -2746,16 +2747,32 @@ func TestResolvePipelineRun_TransientError(t *testing.T) {
 		TaskRef: &v1.TaskRef{Name: "task"},
 	}
 
-	getTask := getTaskFn(nil, apierrors.NewTimeoutError("some dang ol' timeout", 5))
-	getTaskRun := getTaskRunFn(nil)
-	pr := v1.PipelineRun{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "pipelinerun",
-		},
+	testCases := []struct {
+		name         string
+		transientErr error
+	}{
+		{"kubeapi timeout error", apierrors.NewTimeoutError("some dang ol' timeout", 5)},
+		{"retryable resolution error", apiserver.ErrCouldntValidateObjectRetryable},
+		{"any knonw-retryable validation error", apiserver.ErrCouldntValidateObjectRetryable},
 	}
-	_, err := ResolvePipelineTask(t.Context(), pr, nopGetPipelineRun, getTask, getTaskRun, nopGetCustomRun, pt, nil)
-	if !resolutioncommon.IsErrTransient(err) {
-		t.Error("Transient error while getting Task did not result in a transient error")
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			getTask := getTaskFn(nil, testCase.transientErr)
+			getTaskRun := getTaskRunFn(nil)
+			pr := v1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pipelinerun",
+				},
+			}
+			_, err := ResolvePipelineTask(t.Context(), pr, nopGetPipelineRun, getTask, getTaskRun, nopGetCustomRun, pt, nil)
+
+			// This is really testing is that if the getTask function give ResolvePipelineTask a transient error,
+			// ResolvePipielineTask does not swallow that error
+			if !resolutioncommon.IsErrTransient(err) {
+				t.Error("Transient error while getting Task did not result in a transient error")
+			}
+		})
 	}
 }
 

--- a/pkg/resolution/common/errors.go
+++ b/pkg/resolution/common/errors.go
@@ -23,6 +23,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/tektoncd/pipeline/pkg/reconciler/apiserver"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
@@ -153,7 +154,7 @@ func ReasonError(err error) (string, error) {
 // IsErrTransient returns true if an error returned by GetTask/GetStepAction is retryable.
 func IsErrTransient(err error) bool {
 	switch {
-	case apierrors.IsConflict(err), apierrors.IsServerTimeout(err), apierrors.IsTimeout(err), apierrors.IsTooManyRequests(err):
+	case apierrors.IsConflict(err), apierrors.IsServerTimeout(err), apierrors.IsTimeout(err), apierrors.IsTooManyRequests(err), errors.Is(err, apiserver.ErrCouldntValidateObjectRetryable):
 		return true
 	default:
 		return slices.ContainsFunc([]string{errEtcdLeaderChange, context.DeadlineExceeded.Error()}, func(s string) bool {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

With this change, no `ErrCouldntValidateObjectRetryable` returned by DryRunValidate results in a PipelineRun being marked as failed. Previously, the only errors which were actually retried were naming conflicts, server-timeouts, timeouts, and too-many-requests. Unknown errors were still marked as Retryable, but they still caused the pipelinerun to fail. 

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
With this change, unknown DryRunValidation errors during TaskRef and PipelineRef resolution no longer cause PipelineRuns and TaskRuns to fail. Explicit Validation errors will still cause the Run to fail.
```
