### PR TITLE
Run less e2e matrix by default

### DIFF
--- a/.github/workflows/chatops_retest.yaml
+++ b/.github/workflows/chatops_retest.yaml
@@ -60,7 +60,7 @@ jobs:
         GITHUB_PULL_URL: ${{ github.event.client_payload.github.payload.issue.pull_request.url }}
 
     - name: Create comment
-      if: ${{ failure() && steps.landStack.outcome == 'failure' }}
+      if: ${{ failure() }}
       uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
       with:
         token: ${{ secrets.CHATOPS_TOKEN }}

--- a/.github/workflows/e2e-matrix-extras.yaml
+++ b/.github/workflows/e2e-matrix-extras.yaml
@@ -1,0 +1,187 @@
+name: Tekton Extra end-to-end tests
+
+on:
+  repository_dispatch:
+    types: [e2e-extras]
+
+permissions:
+  contents: read
+  pull-requests: read
+  checks: write
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  run-if-requested:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Show Github Object
+      run: |
+        cat <<'EOF'
+        ${{ toJson(github) }}
+        EOF
+    - name: Show Github Event Path Json
+      run: 'cat $GITHUB_EVENT_PATH || true'
+    - name: Set PR variables
+      id: pr
+      uses: actions/github-script@60a0d83039c74a4aee5e5cbf49f72e2045aa4292 # v7.0.1
+      with:
+        script: |
+          const pr = await github.rest.pulls.get({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pull_number: context.issue.number
+          });
+          core.setOutput('sha', pr.data.head.sha);
+
+    - name: Create comment
+      if: ${{ failure() }}
+      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
+      with:
+        token: ${{ secrets.CHATOPS_TOKEN }}
+        repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+        issue-number: ${{ github.event.client_payload.github.payload.issue.number }}
+        body: |
+          Something went wrong with your `/${{ github.event.client_payload.slash_command.command }}` command: [please check the logs][1].
+
+          [1]: ${{ steps.vars.outputs.run-url }}
+
+    - name: Add reaction
+      if: ${{ success() }}
+      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
+      with:
+        token: ${{ secrets.CHATOPS_TOKEN }}
+        repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+        comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+        reactions: hooray
+    outputs:
+      sha: ${{ steps.pr.outputs.sha }}
+
+  e2e-extras:
+    needs: [run-if-requested]
+    if: ${{ needs.run-if-requested.result == 'success' }}
+    concurrency:
+      group: ${{ github.workflow }}-${{ matrix.os }}-${{ matrix.k8s-name }}-${{ matrix.feature-flags }}-${{ github.event.issue.number }}
+      cancel-in-progress: true
+    name: e2e tests (extras)
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+        - ubuntu-latest
+        k8s-name:
+        - k8s-latest-minus-five  # 1.29
+        - k8s-latest-minus-four  # 1.30
+        - k8s-latest-minus-three # 1.31
+        - k8s-latest-minus-two   # 1.32
+        - k8s-latest-minus-one   # 1.33
+        feature-flags: [stable]
+        include:
+        - k8s-name: k8s-latest-minus-five
+          k8s-version: v1.29.x
+        - k8s-name: k8s-latest-minus-four
+          k8s-version: v1.30.x
+        - k8s-name: k8s-latest-minus-three
+          k8s-version: v1.31.x
+        - k8s-name: k8s-latest-minus-two
+          k8s-version: v1.32.x
+        - k8s-name: k8s-latest-minus-one
+          k8s-version: v1.33.x
+    env:
+      KO_DOCKER_REPO: registry.local:5000/tekton
+      CLUSTER_DOMAIN: c${{ github.run_id }}.local
+      ARTIFACTS: ${{ github.workspace }}/artifacts
+    steps:
+    - name: Report tests check
+      uses: actions/github-script@60a0d83039c74a4aee5e5cbf49f72e2045aa4292 # v7.0.1
+      id: check-run
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          const check = await github.rest.checks.create({
+            name: 'run tests',
+            head_sha: '${{ needs.run-if-requested.outputs.sha }}',
+            status: 'in_progress',
+            details_url: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}',
+            ...context.repo
+          })
+          return { id: check.data.id }
+
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+      with:
+        ref: ${{ needs.run-if-requested.outputs.sha }}
+    - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00  # v6.0.0
+      with:
+        go-version-file: "go.mod"
+    - uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d # v0.9
+
+    - name: Install Dependencies
+      run: |
+        echo '::group:: install go-junit-report'
+        go install github.com/jstemmer/go-junit-report@v0.9.1
+        echo '::endgroup::'
+        echo '::group:: created required folders'
+        mkdir -p "${ARTIFACTS}"
+        echo '::endgroup::'
+        echo "${GOPATH}/bin" >> "$GITHUB_PATH"
+
+    - name: Run tests
+      run: |
+        export PATH="$(echo "$PATH" | sed -e 's/^\/bin://'):/bin"
+        export KO_DEFAULTPLATFORMS=linux/$(go env GOARCH)
+        ./hack/setup-kind.sh \
+          --registry-url $(echo ${KO_DOCKER_REPO} | cut -d'/' -f 1) \
+          --cluster-suffix c${{ github.run_id }}.local \
+          --nodes 3 \
+          --k8s-version ${{ matrix.k8s-version }} \
+          --e2e-script ./test/e2e-tests.sh \
+          --e2e-env ./test/e2e-tests-kind-${{ matrix.feature-flags }}.env
+
+    - name: Upload test results
+      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+      with:
+        name: extra-tests-${{ matrix.k8s-version }}-${{ matrix.feature-flags }}-${{ matrix.os }}
+        path: ${{ env.ARTIFACTS }}
+
+    - uses: chainguard-dev/actions/kind-diag@6f4f4de7549514e7b659741b30f6476f245600dd # v1.5.3
+      if: ${{ failure() }}
+      with:
+        artifact-name: extra-tests-${{ matrix.k8s-version }}-${{ matrix.feature-flags }}-${{ matrix.os }}-logs
+
+    - name: Report tests check
+      if: success() || failure()
+      uses: actions/github-script@60a0d83039c74a4aee5e5cbf49f72e2045aa4292 # v7.0.1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          const resp = await github.rest.checks.update({
+            name: 'run tests',
+            check_run_id: ${{ fromJSON(steps.check-run.outputs.result).id }},
+            head_sha: '${{ needs.run-if-requested.outputs.sha }}',
+            status: 'completed',
+            conclusion: '${{ steps.tests-step.outcome }}',
+            details_url: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}',
+            output: {
+              title: 'Run tests',
+              summary: 'Results: ${{ steps.tests-step.outcome }}\n\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+            },
+            ...context.repo
+          })
+          console.log(`Check run create response: ${resp.status}`)
+          console.log(`Check run URL: ${resp.data.url}`)
+          console.log(`Check run HTML: ${resp.data.html_url}`)
+
+    - name: Dump Artifacts
+      if: ${{ failure() }}
+      run: |
+        if [[ -d ${{ env.ARTIFACTS }} ]]; then
+          cd ${{ env.ARTIFACTS }}
+          for x in $(find . -type f); do
+            echo "::group:: artifact $x"
+            cat $x
+            echo '::endgroup::'
+          done
+        fi

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -23,11 +23,6 @@ jobs:
 
         k8s-name:
         - k8s-oldest             # 1.28
-        - k8s-latest-minus-five  # 1.29
-        - k8s-latest-minus-four  # 1.30
-        - k8s-latest-minus-three # 1.31
-        - k8s-latest-minus-two   # 1.32
-        - k8s-latest-minus-one   # 1.33
         - k8s-latest             # 1.34
 
         feature-flags:
@@ -38,60 +33,19 @@ jobs:
         include:
         - k8s-name: k8s-oldest
           k8s-version: v1.28.x
-        - k8s-name: k8s-latest-minus-five
-          k8s-version: v1.29.x
-        - k8s-name: k8s-latest-minus-four
-          k8s-version: v1.30.x
-        - k8s-name: k8s-latest-minus-three
-          k8s-version: v1.31.x
-        - k8s-name: k8s-latest-minus-two
-          k8s-version: v1.32.x
-        - k8s-name: k8s-latest-minus-one
-          k8s-version: v1.33.x
         - k8s-name: k8s-latest
           k8s-version: v1.34.x
 
-        # Run beta and alpha only on latest and oldest
+        # Limit arm64: only run k8s-latest on arm64 (alpha and beta), skip oldest on arm64
         exclude:
-        - k8s-name: k8s-latest-minus-five
-          feature-flags: beta
-        - k8s-name: k8s-latest-minus-five
-          feature-flags: alpha
-        - k8s-name: k8s-latest-minus-four
-          feature-flags: beta
-        - k8s-name: k8s-latest-minus-four
-          feature-flags: alpha
-        - k8s-name: k8s-latest-minus-three
-          feature-flags: beta
-        - k8s-name: k8s-latest-minus-three
-          feature-flags: alpha
-        - k8s-name: k8s-latest-minus-two
-          feature-flags: beta
-        - k8s-name: k8s-latest-minus-two
-          feature-flags: alpha
-        - k8s-name: k8s-latest-minus-one
-          feature-flags: beta
-        - k8s-name: k8s-latest-minus-one
-          feature-flags: alpha
-        # Only run latest on arm64
         - k8s-name: k8s-oldest
           os: ubuntu-24.04-arm
-        - k8s-name: k8s-latest-minus-five
-          os: ubuntu-24.04-arm
-        - k8s-name: k8s-latest-minus-four
-          os: ubuntu-24.04-arm
-        - k8s-name: k8s-latest-minus-three
-          os: ubuntu-24.04-arm
-        - k8s-name: k8s-latest-minus-two
-          os: ubuntu-24.04-arm
-        - k8s-name: k8s-latest-minus-one
-          os: ubuntu-24.04-arm
         - k8s-name: k8s-latest
-          feature-flags: alpha
           os: ubuntu-24.04-arm
-        - k8s-name: k8s-latest
           feature-flags: beta
+        - k8s-name: k8s-latest
           os: ubuntu-24.04-arm
+          feature-flags: alpha
     env:
       KO_DOCKER_REPO: registry.local:5000/tekton
       CLUSTER_DOMAIN: c${{ github.run_id }}.local
@@ -146,13 +100,13 @@ jobs:
     - name: Upload test results
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
       with:
-        name: ${{ matrix.k8s-version }}-${{ matrix.feature-flags }}
+        name: ${{ matrix.k8s-version }}-${{ matrix.feature-flags }}-${{ matrix.os }}
         path: ${{ env.ARTIFACTS }}
 
     - uses: chainguard-dev/actions/kind-diag@abcc11e1cf9073eff6c69e91c49756c1430b094c # v1.5.8
       if: ${{ failure() }}
       with:
-        artifact-name: ${{ matrix.k8s-version }}-${{ matrix.feature-flags }}-logs
+        artifact-name: ${{ matrix.k8s-version }}-${{ matrix.feature-flags }}-${{ matrix.os }}-logs
 
     - name: Dump Artifacts
       if: ${{ failure() }}

--- a/.github/workflows/slash.yml
+++ b/.github/workflows/slash.yml
@@ -38,4 +38,10 @@ jobs:
               "issue_type": "pull-request",
               "repository": "tektoncd/pipeline"
             }
+            {
+              "command": "e2e-extras",
+              "permission": "write",
+              "issue_type": "pull-request",
+              "repository": "tektoncd/pipeline"
+            }
           ]


### PR DESCRIPTION


# Changes

But add a way to run all of them with a comment.

I wonder if this is going to work 🤔 

/kind misc

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
