### PR TITLE
Remove deprecated `// +build` directive from most files

### DIFF
--- a/cmd/entrypoint/namespaces.go
+++ b/cmd/entrypoint/namespaces.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 /*
 Copyright 2023 The Tekton Authors

--- a/cmd/entrypoint/namespaces_test.go
+++ b/cmd/entrypoint/namespaces_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
 Copyright 2022 The Tekton Authors

--- a/cmd/entrypoint/runner.go
+++ b/cmd/entrypoint/runner.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
 Copyright 2021 The Tekton Authors

--- a/cmd/entrypoint/runner_windows.go
+++ b/cmd/entrypoint/runner_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 /*
 Copyright 2021 The Tekton Authors

--- a/cmd/workingdirinit/main_test.go
+++ b/cmd/workingdirinit/main_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
 Copyright 2023 The Tekton Authors

--- a/cmd/workingdirinit/main_windows_test.go
+++ b/cmd/workingdirinit/main_windows_test.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 /*
 Copyright 2023 The Tekton Authors

--- a/test/affinity_assistant_test.go
+++ b/test/affinity_assistant_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2023 The Tekton Authors

--- a/test/artifacts_test.go
+++ b/test/artifacts_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 // /*
 // Copyright 2024 The Tekton Authors

--- a/test/cancel_test.go
+++ b/test/cancel_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2019 The Tekton Authors

--- a/test/conformance_test.go
+++ b/test/conformance_test.go
@@ -1,5 +1,4 @@
 //go:build conformance
-// +build conformance
 
 /*
 Copyright 2020 The Tekton Authors

--- a/test/conversion_test.go
+++ b/test/conversion_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2022 The Tekton Authors

--- a/test/custom_task_test.go
+++ b/test/custom_task_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2019 The Tekton Authors

--- a/test/dag_test.go
+++ b/test/dag_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2019 The Tekton Authors

--- a/test/duplicate_test.go
+++ b/test/duplicate_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2019 The Tekton Authors

--- a/test/entrypoint_test.go
+++ b/test/entrypoint_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2019 The Tekton Authors

--- a/test/examples_test.go
+++ b/test/examples_test.go
@@ -1,5 +1,4 @@
 //go:build examples
-// +build examples
 
 /*
 Copyright 2020 The Tekton Authors

--- a/test/hermetic_taskrun_test.go
+++ b/test/hermetic_taskrun_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2021 The Tekton Authors

--- a/test/ignore_step_error_test.go
+++ b/test/ignore_step_error_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2021 The Tekton Authors

--- a/test/ignore_task_error_test.go
+++ b/test/ignore_task_error_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2023 The Tekton Authors

--- a/test/init_test.go
+++ b/test/init_test.go
@@ -1,5 +1,4 @@
 //go:build conformance || e2e || examples
-// +build conformance e2e examples
 
 /*
 Copyright 2019 The Tekton Authors

--- a/test/larger_results_sidecar_logs_test.go
+++ b/test/larger_results_sidecar_logs_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2022 The Tekton Authors

--- a/test/matrix_test.go
+++ b/test/matrix_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2023 The Tekton Authors

--- a/test/path_filtering.go
+++ b/test/path_filtering.go
@@ -1,5 +1,4 @@
 //go:build examples
-// +build examples
 
 /*
 Copyright 2021 The Tekton Authors

--- a/test/path_filtering_test.go
+++ b/test/path_filtering_test.go
@@ -1,5 +1,4 @@
 //go:build examples
-// +build examples
 
 /*
 Copyright 2021 The Tekton Authors

--- a/test/per_feature_flags_test.go
+++ b/test/per_feature_flags_test.go
@@ -1,5 +1,4 @@
 //go:build featureflags
-// +build featureflags
 
 /*
 Copyright 2023 The Tekton Authors

--- a/test/pipelinefinally_test.go
+++ b/test/pipelinefinally_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2019 The Tekton Authors

--- a/test/pipelinerun_pinp_test.go
+++ b/test/pipelinerun_pinp_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2025 The Tekton Authors

--- a/test/pipelinerun_test.go
+++ b/test/pipelinerun_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2019 The Tekton Authors

--- a/test/preemption_test.go
+++ b/test/preemption_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2023 The Tekton Authors

--- a/test/propagated_params_test.go
+++ b/test/propagated_params_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2022 The Tekton Authors

--- a/test/propagated_results_test.go
+++ b/test/propagated_results_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2023 The Tekton Authors

--- a/test/registry_test.go
+++ b/test/registry_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2019 The Tekton Authors

--- a/test/resolver_cache_test.go
+++ b/test/resolver_cache_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2025 The Tekton Authors

--- a/test/resolvers_gitea_test.go
+++ b/test/resolvers_gitea_test.go
@@ -1,5 +1,4 @@
 //go:build e2e && gitea
-// +build e2e,gitea
 
 /*
  Copyright 2025 The Tekton Authors

--- a/test/resolvers_test.go
+++ b/test/resolvers_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
  Copyright 2022 The Tekton Authors

--- a/test/retry_test.go
+++ b/test/retry_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2019 The Tekton Authors

--- a/test/secret.go
+++ b/test/secret.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2019 The Tekton Authors

--- a/test/serviceaccount_test.go
+++ b/test/serviceaccount_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2019 The Tekton Authors

--- a/test/sidecar_test.go
+++ b/test/sidecar_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2019 The Tekton Authors

--- a/test/start_time_test.go
+++ b/test/start_time_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2019 The Tekton Authors

--- a/test/status_test.go
+++ b/test/status_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2019 The Tekton Authors

--- a/test/step_output_test.go
+++ b/test/step_output_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2019 The Tekton Authors

--- a/test/step_when_test.go
+++ b/test/step_when_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 // /*
 // Copyright 2024 The Tekton Authors

--- a/test/stepaction_results_test.go
+++ b/test/stepaction_results_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2022 The Tekton Authors

--- a/test/task_results_from_failed_tasks_test.go
+++ b/test/task_results_from_failed_tasks_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2023 The Tekton Authors

--- a/test/taskrun_test.go
+++ b/test/taskrun_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2019 The Tekton Authors

--- a/test/tektonbundles_test.go
+++ b/test/tektonbundles_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2020 The Tekton Authors

--- a/test/timeout_test.go
+++ b/test/timeout_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2021 The Tekton Authors

--- a/test/trusted_resources_test.go
+++ b/test/trusted_resources_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2022 The Tekton Authors

--- a/test/upgrade_test.go
+++ b/test/upgrade_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2023 The Tekton Authors

--- a/test/util.go
+++ b/test/util.go
@@ -1,5 +1,4 @@
 //go:build conformance || e2e || examples || featureflags
-// +build conformance e2e examples featureflags
 
 /*
 Copyright 2023 The Tekton Authors

--- a/test/wait_example_test.go
+++ b/test/wait_example_test.go
@@ -1,5 +1,4 @@
 //go:build examples
-// +build examples
 
 /*
 Copyright 2019 The Tekton Authors

--- a/test/windows_script_test.go
+++ b/test/windows_script_test.go
@@ -1,5 +1,4 @@
 //go:build e2e && windows_e2e
-// +build e2e,windows_e2e
 
 /*
 Copyright 2021 The Tekton Authors

--- a/test/windows_test.go
+++ b/test/windows_test.go
@@ -1,5 +1,4 @@
 //go:build e2e && windows_e2e
-// +build e2e,windows_e2e
 
 /*
 Copyright 2021 The Tekton Authors

--- a/test/workingdir_test.go
+++ b/test/workingdir_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2019 The Tekton Authors

--- a/test/workspace_test.go
+++ b/test/workspace_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2019 The Tekton Authors


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

- It will soon error out, and we already use the `//go:build` directive.
- It doesn't touch generated files (need to be fixed upstream)

/cc @waveywaves @aThorp96 

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
