### PR TITLE
feat: upload release manifests to oracle cloud

### DIFF
--- a/.github/workflows/nightly-builds.yaml
+++ b/.github/workflows/nightly-builds.yaml
@@ -1,6 +1,6 @@
 name: Tekton Nightly Build
 
-on:
+"on":
   schedule:
     # Run at 03:00 UTC daily
     - cron: "0 3 * * *"
@@ -11,16 +11,17 @@ on:
         required: false
         default: 'v1.33.x'
       nightly_bucket:
-        description: 'Nightly bucket for builds'
+        description: 'Oracle Cloud bucket name for builds'
         required: false
-        default: 'gs://tekton-releases-nightly/pipeline'
+        default: 'tekton-nightly'
         type: string
 
 env:
   KUBERNETES_VERSION: ${{ inputs.kubernetes_version || 'v1.33.x' }}
   REGISTRY: ghcr.io
   PACKAGE: github.com/${{ github.repository }}
-  BUCKET: ${{ inputs.nightly_bucket || 'gs://tekton-releases-nightly/pipeline' }}
+  BUCKET: ${{ inputs.nightly_bucket || 'tekton-nightly' }}
+  REPO_NAME: ${{ github.event.repository.name }}
   IMAGE_REGISTRY_PATH: ${{ github.repository }}
   IMAGE_REGISTRY_USER: tekton-robot
 
@@ -37,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
         with:
           fetch-depth: 0
 
@@ -50,12 +51,12 @@ jobs:
           echo "latest_sha=${latest_sha}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Kind cluster
-        uses: chainguard-dev/actions/setup-kind@1b32103f5aa389c31ab0be75a8edc38d7e4750d8 # v1.5.7
+        uses: chainguard-dev/actions/setup-kind@1b32103f5aa389c31ab0be75a8edc38d7e4750d8  # v1.5.7
         with:
           k8s-version: ${{ env.KUBERNETES_VERSION }}
 
       - name: Set up Tekton
-        uses: tektoncd/actions/setup-tektoncd@0986bcdfbaf4f83a8a7b19bc2fa360c44ee55929 # main
+        uses: tektoncd/actions/setup-tektoncd@0986bcdfbaf4f83a8a7b19bc2fa360c44ee55929  # main
         with:
           pipeline_version: latest
           setup_registry: "true"
@@ -65,27 +66,27 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GHCR_TOKEN || github.token }}
         run: |
-          # Create Git authentication secret with proper Tekton annotations
+          # Create Git authentication secret as basic-auth type for Git resolver
           kubectl create secret generic git-resolver-secret \
-            --from-literal=token="${GITHUB_TOKEN}" \
+            --type=kubernetes.io/basic-auth \
+            --from-literal=username=git \
+            --from-literal=password="${GITHUB_TOKEN}" \
             -n tekton-pipelines-resolvers || true
 
           kubectl annotate secret git-resolver-secret \
             tekton.dev/git-0=github.com \
-            -n tekton-pipelines-resolvers || true
+            -n tekton-pipelines-resolvers --overwrite || true
 
-          kubectl create secret generic git-resolver-secret \
-            --from-literal=token="${GITHUB_TOKEN}" \
-            -n default || true
-
-          kubectl annotate secret git-resolver-secret \
-            tekton.dev/git-0=github.com \
-            -n default || true
-
-          kubectl patch configmap git-resolver-config -n tekton-pipelines-resolvers --patch='
+          # Configure Git resolver to use the secret
+          kubectl patch configmap git-resolver-config -n tekton-pipelines-resolvers --type=merge --patch='
           data:
-            api-token-secret-name: "git-resolver-secret"
-            api-token-secret-key: "token"
+            default-url: "https://github.com"
+            fetch-timeout: "1m"
+            scm-type: "github"
+            server-url: "https://api.github.com"
+            api-secret-name: "git-resolver-secret"
+            api-secret-key: "password"
+            api-secret-namespace: "tekton-pipelines-resolvers"
           ' || true
 
           kubectl patch configmap feature-flags -n tekton-pipelines --patch='
@@ -94,7 +95,7 @@ jobs:
           ' || true
 
       - name: Install tkn CLI
-        uses: tektoncd/actions/setup-tektoncd-cli@0986bcdfbaf4f83a8a7b19bc2fa360c44ee55929 # main
+        uses: tektoncd/actions/setup-tektoncd-cli@0986bcdfbaf4f83a8a7b19bc2fa360c44ee55929  # main
         with:
           version: latest
 
@@ -104,15 +105,29 @@ jobs:
 
       - name: Create secrets, service account and PVC template
         env:
-          GCS_SERVICE_ACCOUNT_KEY: ${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}
+          OCI_API_KEY: ${{ secrets.OCI_API_KEY }}
+          OCI_FINGERPRINT: ${{ secrets.OCI_FINGERPRINT }}
+          OCI_TENANCY_OCID: ${{ secrets.OCI_TENANCY_OCID }}
+          OCI_USER_OCID: ${{ secrets.OCI_USER_OCID }}
+          OCI_REGION: ${{ secrets.OCI_REGION }}
           GHCR_TOKEN: ${{ secrets.GHCR_TOKEN || github.token }}
           IMAGE_REGISTRY_USER: ${{ env.IMAGE_REGISTRY_USER }}
         run: |
-          # Create GCS service account secret for release bucket access
-          echo "${GCS_SERVICE_ACCOUNT_KEY}" > /tmp/gcs-key.json
+          # Create Oracle Cloud credentials secret for release bucket access
+          echo "${OCI_API_KEY}" > /tmp/oci_api_key.pem
+          echo "${OCI_FINGERPRINT}" > /tmp/fingerprint
+          echo "${OCI_TENANCY_OCID}" > /tmp/tenancy_ocid
+          echo "${OCI_USER_OCID}" > /tmp/user_ocid
+          echo "${OCI_REGION}" > /tmp/region
+
           kubectl create secret generic release-secret \
-            --from-file=release.json=/tmp/gcs-key.json
-          rm -f /tmp/gcs-key.json
+            --from-file=oci_api_key.pem=/tmp/oci_api_key.pem \
+            --from-file=fingerprint=/tmp/fingerprint \
+            --from-file=tenancy_ocid=/tmp/tenancy_ocid \
+            --from-file=user_ocid=/tmp/user_ocid \
+            --from-file=region=/tmp/region
+
+          rm -f /tmp/oci_api_key.pem /tmp/fingerprint /tmp/tenancy_ocid /tmp/user_ocid /tmp/region
 
           # Create a Kubernetes secret for GHCR authentication.
           # This version creates the secret with a custom key name `docker-config.json`
@@ -143,6 +158,7 @@ jobs:
           PIPELINE_RUN=$(tkn pipeline start pipeline-release \
             --serviceaccount=release-right-meow \
             --param package="${{ env.PACKAGE }}" \
+            --param repoName="${{ env.REPO_NAME }}" \
             --param gitRevision="${{ steps.version.outputs.latest_sha }}" \
             --param versionTag="${{ steps.version.outputs.version_tag }}" \
             --param releaseBucket="${{ env.BUCKET }}" \
@@ -153,7 +169,6 @@ jobs:
             --param buildPlatforms="linux/amd64,linux/arm64,linux/s390x,linux/ppc64le" \
             --param publishPlatforms="linux/amd64,linux/arm64,linux/s390x,linux/ppc64le,windows/amd64" \
             --param koExtraArgs="" \
-            --param serviceAccountPath=release.json \
             --param serviceAccountImagesPath=docker-config.json \
             --param releaseAsLatest="true" \
             --param runTests="false" \

--- a/tekton/release-pipeline.yaml
+++ b/tekton/release-pipeline.yaml
@@ -8,6 +8,9 @@ spec:
     - name: package
       description: package to release
       default: github.com/tektoncd/pipeline
+    - name: repoName
+      description: repository name (e.g., pipeline, triggers, etc.)
+      default: pipeline
     - name: gitRevision
       description: the git revision to release
     - name: imageRegistry
@@ -26,7 +29,7 @@ spec:
       description: Version tag (vX.Y.Z for stable, vYYYYMMDD-abc1234 for nightly)
     - name: releaseBucket
       description: bucket where the release is stored. The bucket must be project specific.
-      default: "gs://tekton-releases-nightly/pipeline"  # Will be overridden based on releaseMode
+      default: "tekton-nightly"  # Will be overridden based on releaseMode
     - name: releaseAsLatest
       description: Whether to tag and publish this release as latest
       default: "false"  # Will be overridden based on releaseMode
@@ -42,8 +45,6 @@ spec:
     - name: koExtraArgs
       description: Extra args to be passed to ko
       default: "--preserve-import-paths"
-    - name: serviceAccountPath
-      description: The path to the service account file within the release-secret workspace
     - name: serviceAccountImagesPath
       description: The path to the service account file or credentials within the release-images-secret workspace
     - name: runTests
@@ -53,7 +54,7 @@ spec:
     - name: workarea
       description: The workspace where the repo will be cloned.
     - name: release-secret
-      description: The secret that contains a service account authorized to push to the output bucket
+      description: The secret that contains auth credentials to push to the output bucket
     - name: release-images-secret
       description: The secret that contains a service account authorized to push to the imageRegistry
   results:
@@ -202,15 +203,16 @@ spec:
         - name: release-secret
           workspace: release-images-secret
       timeout: 3h
+
     - name: publish-to-bucket
       runAfter: [publish-images]
       taskRef:
         resolver: bundles
         params:
           - name: bundle
-            value: ghcr.io/tektoncd/catalog/upstream/tasks/gcs-upload:0.3
+            value: ghcr.io/tektoncd/catalog/upstream/tasks/oracle-cloud-storage-upload:0.1
           - name: name
-            value: gcs-upload
+            value: oracle-cloud-storage-upload
           - name: kind
             value: task
       workspaces:
@@ -220,12 +222,17 @@ spec:
           workspace: workarea
           subPath: bucket
       params:
-        - name: location
-          value: $(params.releaseBucket)/previous/$(params.versionTag)
         - name: path
           value: $(params.versionTag)
-        - name: serviceAccountPath
-          value: $(params.serviceAccountPath)
+        - name: bucketName
+          value: $(params.releaseBucket)
+        - name: objectPrefix
+          value: $(params.repoName)/previous/$(params.versionTag)/
+        - name: replaceExistingFiles
+          value: "true"
+        - name: recursive
+          value: "true"
+
     - name: publish-to-bucket-latest
       runAfter: [publish-images]
       when:
@@ -236,9 +243,9 @@ spec:
         resolver: bundles
         params:
           - name: bundle
-            value: ghcr.io/tektoncd/catalog/upstream/tasks/gcs-upload:0.3
+            value: ghcr.io/tektoncd/catalog/upstream/tasks/oracle-cloud-storage-upload:0.1
           - name: name
-            value: gcs-upload
+            value: oracle-cloud-storage-upload
           - name: kind
             value: task
       workspaces:
@@ -248,14 +255,19 @@ spec:
           workspace: workarea
           subPath: bucket
       params:
-        - name: location
-          value: $(params.releaseBucket)/latest
         - name: path
           value: $(params.versionTag)
-        - name: serviceAccountPath
-          value: $(params.serviceAccountPath)
+        - name: bucketName
+          value: $(params.releaseBucket)
+        - name: objectPrefix
+          value: $(params.repoName)/latest/
+        - name: replaceExistingFiles
+          value: "true"
+        - name: recursive
+          value: "true"
         - name: deleteExtraFiles
-          value: "true" # Uses rsync to copy content into latest
+          value: "true"  # Uses sync to copy content into latest
+
     - name: report-bucket
       runAfter: [publish-to-bucket]
       params:
@@ -263,10 +275,13 @@ spec:
           value: $(params.releaseBucket)
         - name: versionTag
           value: $(params.versionTag)
+        - name: repoName
+          value: $(params.repoName)
       taskSpec:
         params:
           - name: releaseBucket
           - name: versionTag
+          - name: repoName
         results:
           - name: release
             description: The full URL of the release file in the bucket
@@ -280,9 +295,12 @@ spec:
                 value: $(params.releaseBucket)
               - name: VERSION_TAG
                 value: $(params.versionTag)
+              - name: REPO_NAME
+                value: $(params.repoName)
             script: |
-              BASE_URL=$(echo "${RELEASE_BUCKET}/previous/${VERSION_TAG}")
-              # If the bucket is in the gs:// return the corresponding public https URL
-              BASE_URL=$(echo ${BASE_URL} | sed 's,gs://,https://storage.googleapis.com/,g')
+              # Oracle Cloud Storage: Construct public URL
+              # Format: https://infra.tekton.dev/<releaseBucket>/<repoName>/previous/<versionTag>
+              BASE_URL="https://infra.tekton.dev/${RELEASE_BUCKET}/${REPO_NAME}/previous/${VERSION_TAG}"
+
               echo "${BASE_URL}/release.yaml" > $(results.release.path)
               echo "${BASE_URL}/release.notag.yaml" > $(results.release-no-tag.path)


### PR DESCRIPTION
# Changes

This PR incorporates the listed changes to ensure  Tekton's nightly release artifacts are stored and published using Oracle Cloud for future releases.
* Switched release artifact storage from GCS (`gs://...`) to Oracle Cloud (`tekton-nightly`), updating default bucket names and related descriptions in both `.github/workflows/nightly-builds.yaml` and `tekton/release-pipeline.yaml`. 
* Updated workflow to use oracle cloud credentials (`OCI_API_KEY`, `OCI_FINGERPRINT`, etc.) from workflow secrets instead of GCS service account keys, and changed secret creation logic accordingly.
* Changed Git authentication secret to use basic-auth type for compatibility with the Git resolver.
* Added a new `repoName` parameter to both the workflow and pipeline for improved artifact organization, and passed 

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [X] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [X] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [X] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [X] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [X] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
/kind feat