### PR TITLE
Use patch instead of update to replace sidecars with nop image

### DIFF
--- a/examples/v1/pipelineruns/pipelinerun-with-task-timeout-override.yaml
+++ b/examples/v1/pipelineruns/pipelinerun-with-task-timeout-override.yaml
@@ -21,8 +21,8 @@ spec:
     script: |
       #!/bin/sh
       echo "- Pipeline task timeout: 60s (defined in pipeline spec)"
-      echo "- TaskRunSpecs override: 20s (defined in pipelinerun spec)"
-      echo "- Actual task duration: 10s (within 20s override timeout)"
+      echo "- TaskRunSpecs override: 40s (defined in pipelinerun spec)"
+      echo "- Actual task duration: 10s (within 40s override timeout)"
 ---
 apiVersion: tekton.dev/v1
 kind: Pipeline
@@ -50,4 +50,4 @@ spec:
     name: taskrun-timeout-override
   taskRunSpecs:
   - pipelineTaskName: long-running-task
-    timeout: "20s"      # 20s timeout (can't actually test with a timeout lesser than  10s else the task fails)
+    timeout: "40s"      # 40s timeout (accounts for image pull time + 10s sleep)


### PR DESCRIPTION
## What
Changed StopSidecars() to use Patch() instead of Update() when stopping sidecar containers by replacing their images with the nop image.

## Why
The original implementation used Update(), which requires an exact resourceVersion match. This causes 409 conflicts when the kubelet updates the pod status between our GET and UPDATE calls (which happens frequently as containers terminate).

This causes the below errors on the pod.
```
error stopping sidecars of Pod: Operation cannot be fulfilled on pods "...": 
the object has been modified; please apply your changes to the latest version
```

And the task runs fail with TaskRunResolutionFailed

<img width="1674" height="287" alt="image" src="https://github.com/user-attachments/assets/6c28d3b9-e6de-42cd-88ba-cd174dc0b495" />

Even though the task succeeded and sidecars eventually stop, the TaskRun gets marked as failed due to this race condition. 
The fix uses JSON Patch (same pattern as UpdateReady() and CancelPod() in this file), which only patches the specific container image fields


## Release Notes
**Does this PR introduce a user-facing change?**

```release-note
Fixed race condition causing TaskRuns to fail with 409 conflict error when stopping sidecars. 
StopSidecars now uses Patch instead of Update to avoid conflicts with concurrent kubelet pod status updates.

```