### PR TITLE
examples: make sure we use the same image for sidecar and step

### DIFF
--- a/examples/v1/taskruns/dind-sidecar.yaml
+++ b/examples/v1/taskruns/dind-sidecar.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   taskSpec:
     steps:
-    - image: docker
+    - image: docker@sha256:0752ca4e936da012c173c119217c0f9599b3b191c1557e53206d5d06d2627580
       name: client
       env:
       # Connect to the sidecar over TCP, with TLS.


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

We should run the same version of docker for both the sidecar (daemon) and the task (client). Otherwise we could get a mismatch version error like the following

    2025-11-12T09:41:13.7066287Z         docker: Error response from daemon: client version 1.52 is too new. Maximum supported API version is 1.43


Fixes #9138
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

/kind misc
/cc @waveywaves @afrittoli @twoGiants 

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
