### PR TITLE
fix: update default tracing endpoint to http protobuf endpoint

### DIFF
--- a/config/config-tracing.yaml
+++ b/config/config-tracing.yaml
@@ -41,6 +41,6 @@ data:
     #
     # API endpoint to send the traces to
     # (optional): The default value is given below
-    endpoint: "http://jaeger-collector.jaeger.svc.cluster.local:14268/api/traces"
+    endpoint: "http://jaeger-collector.jaeger.svc.cluster.local:4318/v1/traces"
     # (optional) Name of the k8s secret which contains basic auth credentials
     credentialsSecret: "jaeger-creds"

--- a/docs/developers/tracing.md
+++ b/docs/developers/tracing.md
@@ -29,5 +29,5 @@ Check the official [Jaeger docs](https://www.jaegertracing.io/docs/) on how to w
 The configmap `config/config-tracing.yaml` contains the configuration for tracing. It contains the following fields:
 
 * enabled: Set this to true to enable tracing
-* endpoint: API endpoint for jaeger collector to send the traces. By default the endpoint is configured to be `http://jaeger-collector.jaeger.svc.cluster.local:14268/api/traces`.
+* endpoint: API endpoint for jaeger collector to send the traces. By default the endpoint is configured to be `http://jaeger-collector.jaeger.svc.cluster.local:4318/v1/traces`.
 * credentialsSecret: Name of the secret which contains `username` and `password` to authenticate against the endpoint

--- a/pkg/apis/config/tracing.go
+++ b/pkg/apis/config/tracing.go
@@ -34,7 +34,7 @@ const (
 	tracingCredentialsSecretKey = "credentialsSecret"
 
 	// DefaultEndpoint is the default destination for sending traces
-	DefaultEndpoint = "http://jaeger-collector.jaeger.svc.cluster.local:14268/api/traces"
+	DefaultEndpoint = "http://jaeger-collector.jaeger.svc.cluster.local:4318/v1/traces"
 )
 
 // DefaultTracing holds all the default configurations for tracing

--- a/pkg/apis/config/tracing_test.go
+++ b/pkg/apis/config/tracing_test.go
@@ -35,7 +35,7 @@ func TestNewTracingFromConfigMap(t *testing.T) {
 			name: "empty",
 			want: &config.Tracing{
 				Enabled:  false,
-				Endpoint: "http://jaeger-collector.jaeger.svc.cluster.local:14268/api/traces",
+				Endpoint: "http://jaeger-collector.jaeger.svc.cluster.local:4318/v1/traces",
 			},
 			fileName: "config-tracing-empty",
 		},


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

currently the otel sdk is used to export metrics in the protobuf format, for the sake of consistency this commit makes sure that we use 4318 with /v1/traces as the default jaegar tracing endpoint use port 4318 with /v1/traces for the default jaegar tracing endpoint instead of port 14268 with /api/traces endpoint.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
