### PR TITLE
refactor: add clock injection to cache for testing

### DIFF
--- a/pkg/remoteresolution/resolver/framework/cache/annotated_resource.go
+++ b/pkg/remoteresolution/resolver/framework/cache/annotated_resource.go
@@ -17,8 +17,6 @@ limitations under the License.
 package cache
 
 import (
-	"time"
-
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	resolutionframework "github.com/tektoncd/pipeline/pkg/resolution/resolver/framework"
 )
@@ -46,23 +44,23 @@ type annotatedResource struct {
 	annotations map[string]string
 }
 
-// newAnnotatedResource creates a new annotatedResource with cache annotations
-func newAnnotatedResource(resource resolutionframework.ResolvedResource, resolverType, operation string, clock Clock) *annotatedResource {
+func newAnnotatedResource(
+	resource resolutionframework.ResolvedResource,
+	resolverType,
+	operation string,
+	timestamp string,
+) *annotatedResource {
 	// Create a new map to avoid concurrent map writes when the same resource
 	// is being annotated from multiple goroutines
 	existingAnnotations := resource.Annotations()
 	annotations := make(map[string]string)
 
-	// Copy existing annotations to new map
-	if existingAnnotations != nil {
-		for k, v := range existingAnnotations {
-			annotations[k] = v
-		}
+	for k, v := range existingAnnotations {
+		annotations[k] = v
 	}
 
-	// Add cache annotations
 	annotations[cacheAnnotationKey] = cacheValueTrue
-	annotations[cacheTimestampKey] = clock.Now().Format(time.RFC3339)
+	annotations[cacheTimestampKey] = timestamp
 	annotations[cacheResolverTypeKey] = resolverType
 	annotations[cacheOperationKey] = operation
 

--- a/pkg/remoteresolution/resolver/framework/cache/clock.go
+++ b/pkg/remoteresolution/resolver/framework/cache/clock.go
@@ -18,14 +18,6 @@ package cache
 
 import "time"
 
-// Clock is an interface for getting the current time.
-// This allows for testing without relying on actual time for timestamp generation.
-// Note: The underlying k8s LRUExpireCache uses real time for TTL expiration checks,
-// so we cannot use a fake clock to control cache expiration in tests.
-type Clock interface {
-	Now() time.Time
-}
-
 // realClock implements Clock using the actual system time.
 type realClock struct{}
 

--- a/test/timeout_test.go
+++ b/test/timeout_test.go
@@ -308,7 +308,7 @@ spec:
 
 	for _, step := range tr.Status.Steps {
 		if step.Terminated == nil {
-			t.Errorf("TaskRun %s step %s does not have a terminated state but should", taskRun.Name, step.Name)
+			t.Fatalf("TaskRun %s step %s does not have a terminated state but should", taskRun.Name, step.Name)
 		}
 		if d := cmp.Diff(step.Terminated.Reason, v1.TaskRunReasonTimedOut.String()); d != "" {
 			t.Fatalf("-got, +want: %v", d)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Small firs cleanup follow up to #9051. (not really `size/L`)

This PR refactors the cache implementation to support deterministic testing of TTL expiration behavior.

**Key changes:**
- Replace custom `Clock` interface with `k8s.io/apimachinery/pkg/util/cache.Clock` for better integration with `LRUExpireCacheWithClock`
- Add `newResolverCacheWithClock` constructor to enable clock injection for testing
- Move timestamp formatting from `newAnnotatedResource` to the cache layer, passing pre-formatted strings instead of Clock instances
- Refactor `TestCacheTTLExpiration` to verify cache entries expire correctly after TTL using `fakeClock`
- Refactor `TestNewAnnotatedResource` to use explicit timestamp values
- Fix failing e2e test  `TestTaskRunTimeout` on k8 v1.33.0

This improves testability without changing runtime behavior - the cache continues to use real system time in production.

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```