### PR TITLE
feat: Add digest validation support to HTTP resolver

### DIFF
--- a/config/resolvers/config-feature-flags.yaml
+++ b/config/resolvers/config-feature-flags.yaml
@@ -30,3 +30,5 @@ data:
   enable-git-resolver: "true"
   # Setting this flag to "true" enables remote resolution of tasks and pipelines from other namespaces within the cluster.
   enable-cluster-resolver: "true"
+  # Setting this flag to "true" enables remote resolution of tasks and pipelines from HTTP URLs.
+  enable-http-resolver: "true"

--- a/docs/http-resolver.md
+++ b/docs/http-resolver.md
@@ -12,12 +12,26 @@ This resolver responds to type `http`.
 
 ## Parameters
 
-| Param Name                 | Description                                                                                                                                                                | Example Value                                                                                   |   |
-|----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------|---|
-| `url`                      | The URL to fetch from                                                                                                                                                      | <https://raw.githubusercontent.com/tektoncd-catalog/git-clone/main/task/git-clone/git-clone.yaml> |   |
-| `http-username`            | An optional username when fetching a task with credentials (need to be used in conjunction with `http-password-secret`)                                                    | `git`                                                                                           |   |
-| `http-password-secret`     | An optional secret in the PipelineRun namespace with a reference to a password when fetching a task with credentials (need to be used in conjunction with `http-username`) | `http-password`                                                                                 |   |
-| `http-password-secret-key` | An optional key in the `http-password-secret` to be used when fetching a task with credentials                                                                             | Default: `password`                                                                             |   |
+| Param Name                 | Description                                                                                                                                                                        | Example Value                                                                                     |     |
+| -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- | --- |
+| `url`                      | The URL to fetch from                                                                                                                                                              | <https://raw.githubusercontent.com/tektoncd-catalog/git-clone/main/task/git-clone/git-clone.yaml> |     |
+| `http-username`            | An optional username when fetching a task with credentials (need to be used in conjunction with `http-password-secret`)                                                            | `git`                                                                                             |     |
+| `http-password-secret`     | An optional secret in the PipelineRun namespace with a reference to a password when fetching a task with credentials (need to be used in conjunction with `http-username`)         | `http-password`                                                                                   |     |
+| `http-password-secret-key` | An optional key in the `http-password-secret` to be used when fetching a task with credentials                                                                                     | Default: `password`                                                                               |     |
+| `digest`                   | An optional digest to verify the integrity of the fetched content. The value must be in the format `<algorithm>:<hash>`, where the supported algorithms are `sha256` and `sha512`. | `sha256:f37cdd0e86...`                                                                            |     |
+
+You can calculate the hash of your Tekton resource using the following command:
+
+```
+# Calculate sha256 digest
+curl -sL https://raw.githubusercontent.com/owner/private-repo/main/task/task.yaml | sha256sum
+
+# Calculate sha512 digest
+curl -sL https://raw.githubusercontent.com/owner/private-repo/main/task/task.yaml | sha512sum
+
+
+`sha265sum` and `sha512sum` are available on all major Linux distributions and macOS
+```
 
 A valid URL must be provided. Only HTTP or HTTPS URLs are supported.
 
@@ -92,6 +106,23 @@ spec:
     params:
     - name: url
       value: https://raw.githubusercontent.com/tektoncd/catalog/main/pipeline/build-push-gke-deploy/0.1/build-push-gke-deploy.yaml
+```
+
+### Pipeline Resolution with Digest
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: http-demo
+spec:
+  pipelineRef:
+    resolver: http
+    params:
+      - name: url
+        value: https://raw.githubusercontent.com/tektoncd/catalog/main/pipeline/build-push-gke-deploy/0.1/build-push-gke-deploy.yaml
+      - name: digest
+        value: sha256:e1a86b942e85ce5558fc737a3b4a82d7425ca392741d20afa3b7fb426e96c66b
 ```
 
 ---


### PR DESCRIPTION
This commit introduces content hash verification for the HTTP resolver by adding support for optional digest validation using SHA256 and SHA512 algorithms.

Changes:
- Add new 'digest' parameter accepting '<algorithm>:<hash>' format where algorithm can be 'sha256' or 'sha512'
- Implement digest validation logic using constant-time comparison to prevent timing-based side-channel attacks
- Add comprehensive unit tests covering valid matches, mismatches, invalid formats, and unsupported algorithms
- Add E2E tests to verify digest validation in real cluster scenarios
- Enable 'enable-http-resolver' feature flag in default configuration
- Update documentation with digest parameter description, usage examples, and commands to calculate SHA256/SHA512 hashes

Security considerations:
- Uses constant-time comparison to prevent timing attacks
- Digest validation is optional to maintain backward compatibility
- Digest values are logged for debugging

Fixes: #8759

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
The HTTP resolver now supports optional content integrity verification through a new `digest` parameter. Users can provide a cryptographic hash in the format `<algorithm>:<hash>` (where algorithm is either `sha256` or `sha512`) to verify that the fetched content matches the expected value. For example, `digest: sha256:f37cdd0e8611932bca52eed219c2b273161501510b37218fb79ca0a6a4487cff`. This parameter is optional and currently enabled by default, ensuring backward compatibility with existing HTTP resolver configurations.
```
