### PR TITLE
.github/workflows: make sure changes in workflow do not generate skips

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,7 @@ jobs:
         # should be true. Skipping output on an empty set of changes eliminates the false positive
         if [[ -n "${CHANGED_FILES}" ]]; then
           echo "non-docs=$(echo \"${CHANGED_FILES}\" | grep -qv '**\.md' && echo 'true' )" | tee -a $GITHUB_OUTPUT
-          echo "yaml=$(echo \"${CHANGED_FILES}\" | grep -q '**\.ya\?ml' && echo 'true' )" | tee -a $GITHUB_OUTPUT
+          echo "yaml=$(echo \"${CHANGED_FILES}\" | grep -v '^\.github/workflows/' | grep -q '**\.ya\?ml' && echo 'true' )" | tee -a $GITHUB_OUTPUT
         fi
 
   build:


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

If we change something on github workflows, we should make sure we run
them. Before this change, it would be considered as just yaml changes
and could end up skipping builds and tests.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/kind misc
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
