### PR TITLE
.github/workflows: fix detect-changes regular expression

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,8 +40,8 @@ jobs:
         # If no files are changed at all, then `grep -v` will match even though no change outputs
         # should be true. Skipping output on an empty set of changes eliminates the false positive
         if [[ -n "${CHANGED_FILES}" ]]; then
-          echo "non-docs=$(echo \"${CHANGED_FILES}\" | grep -qv '**\.md' && echo 'true' )" | tee -a $GITHUB_OUTPUT
-          echo "yaml=$(echo \"${CHANGED_FILES}\" | grep -q '**\.ya\?ml' && echo 'true' )" | tee -a $GITHUB_OUTPUT
+          echo "non-docs=$(echo \"${CHANGED_FILES}\" | grep -qv '\.md$' && echo 'true' )" | tee -a $GITHUB_OUTPUT
+          echo "yaml=$(echo \"${CHANGED_FILES}\" | grep -q '\.ya\?ml$' && echo 'true' )" | tee -a $GITHUB_OUTPUT
         fi
 
   build:


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

- Removed ** which is a glob pattern, not valid in grep regex
- Added $ to anchor the match to the end of the filename
- Escaped the . to match a literal dot (not any character)

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

This should remove some false positive like on https://github.com/tektoncd/pipeline/pull/9164.
Tested with this : https://gist.github.com/vdemeester/0e0c639a827a4b64d7446d947ff9ad40

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
