### PR TITLE
fix: Populate step statuses before TaskRun timeout handling

### DIFF
--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -1345,6 +1345,9 @@ spec:
     name: test-task
 status:
   podName: the-pod
+  taskSpec:
+    steps:
+    - image: foo
 `)
 	taskRun.Status.StartTime = &metav1.Time{Time: startTime}
 	d := test.Data{

--- a/pkg/reconciler/taskrun/taskrun_timeout_test.go
+++ b/pkg/reconciler/taskrun/taskrun_timeout_test.go
@@ -18,6 +18,7 @@ package taskrun
 
 import (
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
@@ -36,6 +37,125 @@ import (
 	"knative.dev/pkg/system"
 	_ "knative.dev/pkg/system/testing" // Setup system.Namespace()
 )
+
+// TestReconcileTimeoutWithEmptyStepStatus tests that when a TaskRun times out
+// and tr.Status.Steps is empty (race condition), the reconciler populates
+// step statuses from the pod before terminating them.
+func TestReconcileTimeoutWithEmptyStepStatus(t *testing.T) {
+	task := parse.MustParseV1Task(t, `
+metadata:
+  name: test-task
+  namespace: foo
+spec:
+  steps:
+  - name: step1
+    image: busybox
+  - name: step2
+    image: busybox
+`)
+
+	taskRun := parse.MustParseV1TaskRun(t, `
+metadata:
+  name: test-taskrun-timeout-empty-steps
+  namespace: foo
+spec:
+  taskRef:
+    name: test-task
+  timeout: 1s
+status:
+  conditions:
+  - status: Unknown
+    type: Succeeded
+  startTime: "2021-12-31T23:59:58Z"
+  podName: test-taskrun-timeout-empty-steps-pod
+`)
+	// In a real scenario, TaskSpec would have been set during pod creation in a previous reconcile
+	taskRun.Status.TaskSpec = &task.Spec
+
+	// Create a pod with running step containers
+	// This simulates a pod that exists but hasn't had its status synced to the TaskRun yet
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "foo",
+			Name:      "test-taskrun-timeout-empty-steps-pod",
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name: "step-step1",
+					State: corev1.ContainerState{
+						Running: &corev1.ContainerStateRunning{
+							StartedAt: metav1.Time{Time: testClock.Now().Add(-30 * time.Second)},
+						},
+					},
+				},
+				{
+					Name: "step-step2",
+					State: corev1.ContainerState{
+						Waiting: &corev1.ContainerStateWaiting{
+							Reason: "PodInitializing",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	d := test.Data{
+		TaskRuns: []*v1.TaskRun{taskRun},
+		Tasks:    []*v1.Task{task},
+		Pods:     []*corev1.Pod{pod},
+	}
+
+	testAssets, cancel := getTaskRunController(t, d)
+	defer cancel()
+	c := testAssets.Controller
+	clients := testAssets.Clients
+
+	if err := c.Reconciler.Reconcile(testAssets.Ctx, getRunName(taskRun)); err != nil {
+		t.Fatalf("Unexpected error when reconciling timed out TaskRun: %v", err)
+	}
+
+	reconciledRun, err := clients.Pipeline.TektonV1().TaskRuns("foo").Get(testAssets.Ctx, "test-taskrun-timeout-empty-steps", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Error getting reconciled TaskRun: %v", err)
+	}
+
+	// Verify the TaskRun is marked as timed out
+	condition := reconciledRun.Status.GetCondition(apis.ConditionSucceeded)
+	if condition == nil || condition.Status != corev1.ConditionFalse {
+		t.Errorf("Expected TaskRun to be failed, got condition: %v", condition)
+	}
+	if condition != nil && condition.Reason != v1.TaskRunReasonTimedOut.String() {
+		t.Errorf("Expected TaskRun reason to be %s, got %s", v1.TaskRunReasonTimedOut.String(), condition.Reason)
+	}
+
+	// Verify that step statuses are populated and terminated
+	if len(reconciledRun.Status.Steps) == 0 {
+		t.Fatal("Expected step statuses to be populated, but got empty Steps array")
+	}
+
+	if len(reconciledRun.Status.Steps) != 2 {
+		t.Fatalf("Expected 2 steps, got %d", len(reconciledRun.Status.Steps))
+	}
+
+	// Verify all steps are terminated with TimedOut reason
+	for i, step := range reconciledRun.Status.Steps {
+		if step.Terminated == nil {
+			t.Errorf("Step %d (%s) should have Terminated status, but it's nil", i, step.Name)
+			continue
+		}
+		if step.Terminated.Reason != v1.TaskRunReasonTimedOut.String() {
+			t.Errorf("Step %d (%s) should have reason %s, got %s",
+				i, step.Name, v1.TaskRunReasonTimedOut.String(), step.Terminated.Reason)
+		}
+		if step.TerminationReason != v1.TaskRunReasonTimedOut.String() {
+			t.Errorf("Step %d (%s) should have TerminationReason %s, got %s",
+				i, step.Name, v1.TaskRunReasonTimedOut.String(), step.TerminationReason)
+		}
+	}
+}
 
 func TestFailTaskRun_Timeout(t *testing.T) {
 	testCases := []struct {


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This prevent some race condition where timeout fires before pod status
fetch. TestTaskRunTimeout validates that steps are terminated, but it
can be not populated from time to time (in my test 4/5 times out of 25).

Fixes #731
This should reduce *a lot* flakes on timeout tests.

I am not sure if we need a release note or not. It does fix a bug though.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Fix a race condition on timeout that would result in a TaskRun status without steps statuses.
```
