### PR TITLE
.github/workflows: fix e2e-matrix-extras

### DIFF
--- a/.github/workflows/e2e-matrix-extras.yaml
+++ b/.github/workflows/e2e-matrix-extras.yaml
@@ -32,7 +32,7 @@ jobs:
           const pr = await github.rest.pulls.get({
             owner: context.repo.owner,
             repo: context.repo.repo,
-            pull_number: context.issue.number
+            pull_number: ${{ github.event.client_payload.github.payload.issue.number }}
           });
           core.setOutput('sha', pr.data.head.sha);
 
@@ -63,7 +63,7 @@ jobs:
     needs: [run-if-requested]
     if: ${{ needs.run-if-requested.result == 'success' }}
     concurrency:
-      group: ${{ github.workflow }}-${{ matrix.os }}-${{ matrix.k8s-name }}-${{ matrix.feature-flags }}-${{ github.event.issue.number }}
+      group: ${{ github.workflow }}-${{ matrix.os }}-${{ matrix.k8s-name }}-${{ matrix.feature-flags }}-${{ github.event.client_payload.github.payload.issue.number }}
       cancel-in-progress: true
     name: e2e tests (extras)
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The problem was that the workflow was trying to use
context.issue.number and github.event.issue.number, which aren't
available in repository_dispatch events.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/kind misc

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
