### PR TITLE
Fix parameter substitution for defaults referencing other params

### DIFF
--- a/pkg/reconciler/pipelinerun/resources/apply_test.go
+++ b/pkg/reconciler/pipelinerun/resources/apply_test.go
@@ -1791,6 +1791,84 @@ func TestApplyParameters(t *testing.T) {
 				}},
 			},
 		},
+		{
+			name: "parameter default value inherited from another parameter",
+			original: v1.PipelineSpec{
+				Params: []v1.ParamSpec{
+					{Name: "fallback-param", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("pipeline fallback value")},
+					{Name: "param", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("$(params.fallback-param)")},
+				},
+				Tasks: []v1.PipelineTask{{
+					Params: v1.Params{
+						{Name: "task-param", Value: *v1.NewStructuredValues("$(params.param)")},
+					},
+				}},
+			},
+			params: v1.Params{{Name: "fallback-param", Value: *v1.NewStructuredValues("override fallback param value")}},
+			expected: v1.PipelineSpec{
+				Params: []v1.ParamSpec{
+					{Name: "fallback-param", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("pipeline fallback value")},
+					{Name: "param", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("$(params.fallback-param)")},
+				},
+				Tasks: []v1.PipelineTask{{
+					Params: v1.Params{
+						{Name: "task-param", Value: *v1.NewStructuredValues("override fallback param value")},
+					},
+				}},
+			},
+		},
+		{
+			name: "parameter default value inherited from another parameter - no override",
+			original: v1.PipelineSpec{
+				Params: []v1.ParamSpec{
+					{Name: "fallback-param", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("pipeline fallback value")},
+					{Name: "param", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("$(params.fallback-param)")},
+				},
+				Tasks: []v1.PipelineTask{{
+					Params: v1.Params{
+						{Name: "task-param", Value: *v1.NewStructuredValues("$(params.param)")},
+					},
+				}},
+			},
+			params: v1.Params{},
+			expected: v1.PipelineSpec{
+				Params: []v1.ParamSpec{
+					{Name: "fallback-param", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("pipeline fallback value")},
+					{Name: "param", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("$(params.fallback-param)")},
+				},
+				Tasks: []v1.PipelineTask{{
+					Params: v1.Params{
+						{Name: "task-param", Value: *v1.NewStructuredValues("pipeline fallback value")},
+					},
+				}},
+			},
+		},
+		{
+			name: "parameter default value inherited from another parameter - override param",
+			original: v1.PipelineSpec{
+				Params: []v1.ParamSpec{
+					{Name: "fallback-param", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("pipeline fallback value")},
+					{Name: "param", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("$(params.fallback-param)")},
+				},
+				Tasks: []v1.PipelineTask{{
+					Params: v1.Params{
+						{Name: "task-param", Value: *v1.NewStructuredValues("$(params.param)")},
+					},
+				}},
+			},
+			params: v1.Params{{Name: "param", Value: *v1.NewStructuredValues("override param value")}},
+			expected: v1.PipelineSpec{
+				Params: []v1.ParamSpec{
+					{Name: "fallback-param", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("pipeline fallback value")},
+					{Name: "param", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("$(params.fallback-param)")},
+				},
+				Tasks: []v1.PipelineTask{{
+					Params: v1.Params{
+						{Name: "task-param", Value: *v1.NewStructuredValues("override param value")},
+					},
+				}},
+			},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This fixes issue #8862 where parameter default values that reference
other parameters (e.g., default: $(params.fallback-param)) were not
being properly substituted when using local pipeline resolution.

- Added logic to handle parameter dependency chains by resolving in
  multiple passes until no more substitutions are needed
- Added three test cases covering all scenarios from issue #8862

Co-Authored-By: Claude <noreply@anthropic.com>
Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

Fixes #8862

/kind bug
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Fixes parameters referencing other parameters through defaults.
```
