### PR TITLE
chore(release-pipeline): update references to oci bucket

### DIFF
--- a/tekton/README.md
+++ b/tekton/README.md
@@ -131,37 +131,70 @@ release and generate the `release.yaml`
   [`tektoncd/catalog`](https://github.com/tektoncd/catalog) and
   [`publish.yaml`](publish.yaml)'s `Task`.
 
-### Service account and secrets
+### Dogfooding Cluster connectivity and secrets
 
-In order to release, these Pipelines use the `release-right-meow` service account,
-which uses `release-secret` and has
-[`Storage Admin`](https://cloud.google.com/container-registry/docs/access-control)
-access to
-[`tekton-releases`]((https://github.com/tektoncd/plumbing/blob/main/gcp.md))
-and
-[`tekton-releases-nightly`]((https://github.com/tektoncd/plumbing/blob/main/gcp.md)).
+1. To connect to the cloud instance and OKE cluster we need the Oracle Cloud CLI client. Install Oracle Cloud CLI from https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/cliinstall.htm
 
-After creating these service accounts in GCP, the kubernetes service account and
-secret were created with:
+1. The next step is to establish connection from the local client to the cloud instance. Login to the Oracle Cloud Console and create a new `API key` from the user profile.
+Follow the steps here: https://docs.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm#two
+Download a Private Key and Add a new API key as mentioned in the doc. Copy the config file to `~/.oci/config` and update the path to the private key file in config.
+With this the config is ready for usage by the CLI.
 
-```bash
-KEY_FILE=release.json
-GENERIC_SECRET=release-secret
-ACCOUNT=release-right-meow
+1. Test the connection by doing a get of the OKE cluster id.
+Refer here https://docs.oracle.com/en-us/iaas/tools/oci-cli/3.70.0/oci_cli_docs/cmdref/ce.html for the CLI options.
+Command to create a kubeconfig in your local could be obtained from console navigating to the OKE > Actions > Access Cluster. Run the command pointing to the PUBLIC_ENDPOINT and we should be connected to the cluster.
 
-# Connected to the `prow` in the `tekton-releases` GCP project
-GCP_ACCOUNT="$ACCOUNT@tekton-releases.iam.gserviceaccount.com"
+1. [Setup a context to connect to the dogfooding cluster](./release-cheat-sheet.md#setup-dogfooding-context) 
 
-# 1. Create a private key for the service account
-gcloud iam service-accounts keys create $KEY_FILE --iam-account $GCP_ACCOUNT
+1. When executing release pipelines, some tasks require `oci cli` commands. The CLI requires credentials which should be created as a Kubernetes secret and mounted to the respective task's workspace. For example refer the precheck definition.
+```
+    - name: precheck
+      runAfter: [git-clone]
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/tektoncd/plumbing
+          - name: revision
+            value: 8d3152d3d39982ce1768325b373d321efaa83031
+          - name: pathInRepo
+            value: tekton/resources/release/base/prerelease_checks_oci.yaml
+      params:
+        - name: package
+          value: $(params.package)
+        - name: versionTag
+          value: $(params.versionTag)
+        - name: releaseBucket
+          value: $(params.releaseBucket)/$(params.repoName)
+      workspaces:
+        - name: source-to-release
+          workspace: workarea
+          subPath: git
+        - name: oci-credentials
+          workspace: release-secret
+```
+Sample secret template for reference:
+```
+apiVersion: v1
+kind: Secret
+metadata:
+  name: oci-credentials
+type: Opaque
+stringData:
+  # REQUIRED: OCI API Private Key (PEM format)
+  oci_api_key.pem: |
+    -----BEGIN RSA PRIVATE KEY-----
+    YOUR_ACTUAL_PRIVATE_KEY_CONTENT_HERE
+    -----END RSA PRIVATE KEY-----
 
-# 2. Create kubernetes secret, which we will use via a service account and directly mounting
-kubectl create secret generic $GENERIC_SECRET --from-file=./$KEY_FILE
+  # REQUIRED: API Key Fingerprint
+  fingerprint: "YOUR_API_KEY_FINGERPRINT_HERE"
 
-# 3. Add the docker secret to the service account
-kubectl apply -f tekton/account.yaml
-kubectl patch serviceaccount $ACCOUNT \
-  -p "{\"secrets\": [{\"name\": \"$GENERIC_SECRET\"}]}"
+  # OPTIONAL: These can be provided as task parameters instead
+  tenancy_ocid: "ocid1.tenancy.oc1..example_tenancy_id"
+  user_ocid: "ocid1.user.oc1..example_user_id"
+  region: "us-ashburn-1"
+  namespace: "your-namespace-here"  # Will be auto-detected if not provided
 ```
 
 ### Setup post processing

--- a/tekton/release-cheat-sheet.md
+++ b/tekton/release-cheat-sheet.md
@@ -58,6 +58,7 @@ the pipelines repo, a terminal window and a text editor.
     TEKTON_OLD_VERSION= # Example: v0.68.0
     TEKTON_RELEASE_NAME="Oriental Longhair Omnibot" # Name of the release
     TEKTON_PACKAGE=tektoncd/pipeline
+    TEKTON_REPO_NAME=pipeline
     EOF
     . ./release.env
     ```
@@ -89,17 +90,16 @@ the pipelines repo, a terminal window and a text editor.
 
    ```bash
     tkn --context dogfooding pipeline start pipeline-release \
-      --serviceaccount=release-right-meow \
       --param package=github.com/tektoncd/pipeline \
+      --param repoName="${TEKTON_REPO_NAME}" \
       --param gitRevision="${TEKTON_RELEASE_GIT_SHA}" \
       --param imageRegistry=ghcr.io \
       --param imageRegistryPath=tektoncd/pipeline \
       --param imageRegistryRegions="" \
       --param imageRegistryUser=tekton-robot \
-      --param serviceAccountPath=release.json \
       --param serviceAccountImagesPath=credentials \
       --param versionTag="${TEKTON_VERSION}" \
-      --param releaseBucket=gs://tekton-releases/pipeline \
+      --param releaseBucket=tekton-releases \
       --param koExtraArgs="" \
       --workspace name=release-secret,secret=release-secret \
       --workspace name=release-images-secret,secret=ghcr-creds \
@@ -122,8 +122,8 @@ the pipelines repo, a terminal window and a text editor.
 
     NAME                    VALUE
     ∙ commit-sha            ff6d7abebde12460aecd061ab0f6fd21053ba8a7
-    ∙ release-file           https://storage.googleapis.com/tekton-releases-nightly/pipeline/previous/v20210223-xyzxyz/release.yaml
-    ∙ release-file-no-tag    https://storage.googleapis.com/tekton-releases-nightly/pipeline/previous/v20210223-xyzxyz/release.notag.yaml
+    ∙ release-file           https://infra.tekton.dev/tekton-releases/pipeline/previous/v0.13.0/release.yaml
+    ∙ release-file-no-tag    https://infra.tekton.dev/tekton-releases/pipeline/previous/v0.13.0/release.notag.yaml
 
     (...)
     ```
@@ -136,29 +136,42 @@ the pipelines repo, a terminal window and a text editor.
     1. Find the Rekor UUID for the release
 
     ```bash
-    RELEASE_FILE=https://storage.googleapis.com/tekton-releases/pipeline/previous/${TEKTON_VERSION}/release.yaml
-    CONTROLLER_IMAGE_SHA=$(curl $RELEASE_FILE | egrep 'ghcr.io.*controller' | cut -d'@' -f2)
+    RELEASE_FILE=https://infra.tekton.dev/tekton-releases/triggers/previous/${VERSION_TAG}/release.yaml
+    CONTROLLER_IMAGE_SHA=$(curl -L $RELEASE_FILE | sed -n 's/"//g;s/.*ghcr\.io.*controller.*@//p;')
     REKOR_UUID=$(rekor-cli search --sha $CONTROLLER_IMAGE_SHA | grep -v Found | head -1)
     echo -e "CONTROLLER_IMAGE_SHA: ${CONTROLLER_IMAGE_SHA}\nREKOR_UUID: ${REKOR_UUID}"
     ```
 
     1. Execute the Draft Release Pipeline.
 
-    ```bash
-    tkn --context dogfooding pipeline start \
-      --workspace name=shared,volumeClaimTemplateFile=workspace-template.yaml \
-      --workspace name=credentials,secret=release-secret \
-      -p package="tektoncd/pipeline" \
-      -p git-revision="$TEKTON_RELEASE_GIT_SHA" \
-      -p release-tag="${TEKTON_VERSION}" \
-      -p previous-release-tag="${TEKTON_OLD_VERSION}" \
-      -p release-name="${TEKTON_RELEASE_NAME}" \
-      -p bucket="gs://tekton-releases/pipeline" \
-      -p rekor-uuid="$REKOR_UUID" \
-      release-draft
-    ```
+        Create a pod template file:
 
-    1. Watch logs of create-draft-release
+        ```shell
+        cat <<EOF > tekton/pod-template.yaml
+        securityContext:
+          fsGroup: 65532
+          runAsUser: 65532
+          runAsNonRoot: true
+        EOF
+        ```
+        ```shell
+
+        tkn pipeline start \
+          --workspace name=shared,volumeClaimTemplateFile=workspace-template.yaml \
+          --workspace name=credentials,secret=oci-release-secret \
+          --pod-template pod-template.yaml \
+          -p package="${TEKTON_PACKAGE}" \
+          -p git-revision="$TEKTON_RELEASE_GIT_SHA" \
+          -p release-tag="${TEKTON_VERSION}" \
+          -p previous-release-tag="${TEKTON_OLD_VERSION}" \
+          -p release-name="${TEKTON_RELEASE_NAME}" \
+          -p repo-name="${TEKTON_REPO_NAME}" \
+          -p bucket="tekton-releases" \
+          -p rekor-uuid="$REKOR_UUID" \
+          release-draft-oci
+        ```
+
+    1. Watch logs of resulting pipeline run on pipeline `release-draft-oci`
 
     1. On successful completion, a URL will be logged. Visit that URL and look through the release notes.
       1. Manually add upgrade and deprecation notices based on the generated release notes
@@ -195,12 +208,12 @@ the pipelines repo, a terminal window and a text editor.
 
     ```bash
     # Test latest
-    kubectl --context my-dev-cluster apply --filename https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml
+    kubectl --context my-dev-cluster apply --filename https://infra.tekton.dev/tekton-releases/pipeline/latest/release.yaml
     ```
 
     ```bash
     # Test backport
-    kubectl --context my-dev-cluster apply --filename https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.11.2/release.yaml
+    kubectl --context my-dev-cluster apply --filename https://infra.tekton.dev/tekton-releases/pipeline/previous/v0.11.2/release.yaml
     ```
 
 1. Announce the release in Slack channels #general, #announcements and #pipelines.
@@ -221,15 +234,22 @@ Congratulations, you're done!
 1. Configure `kubectl` to connect to
    [the dogfooding cluster](https://github.com/tektoncd/plumbing/blob/main/docs/dogfooding.md):
 
+   The dogfooding cluster is currently an OKE cluster in oracle cloud. we need the Oracle Cloud CLI client. Install oracle cloud cli (https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/cliinstall.htm) 
+
     ```bash
-    gcloud container clusters get-credentials dogfooding --zone us-central1-a --project tekton-releases
+    oci ce cluster create-kubeconfig --cluster-id <CLUSTER-OCID> --file $HOME/.kube/config --region <CLUSTER-REGION> --token-version 2.0.0  --kube-endpoint PUBLIC_ENDPOINT
     ```
 
 1. Give [the context](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/)
    a short memorable name such as `dogfooding`:
 
    ```bash
-   kubectl config rename-context gke_tekton-releases_us-central1-a_dogfooding dogfooding
+   kubectl config current-context
+   ```
+   get the context name and replace with current_context_name
+
+   ```bash
+   kubectl config rename-context <current_context_name> dogfooding
    ```
 
 1. **Important: Switch `kubectl` back to your own cluster by default.**

--- a/tekton/release-pipeline.yaml
+++ b/tekton/release-pipeline.yaml
@@ -96,20 +96,22 @@ spec:
           - name: url
             value: https://github.com/tektoncd/plumbing
           - name: revision
-            value: aeed19e5a36f335ebfdc4b96fa78d1ce5bb4f7b8
+            value: 8d3152d3d39982ce1768325b373d321efaa83031
           - name: pathInRepo
-            value: tekton/resources/release/base/prerelease_checks.yaml
+            value: tekton/resources/release/base/prerelease_checks_oci.yaml
       params:
         - name: package
           value: $(params.package)
         - name: versionTag
           value: $(params.versionTag)
         - name: releaseBucket
-          value: $(params.releaseBucket)
+          value: $(params.releaseBucket)/$(params.repoName)
       workspaces:
         - name: source-to-release
           workspace: workarea
           subPath: git
+        - name: oci-credentials
+          workspace: release-secret
 
     - name: unit-tests
       runAfter: [precheck]
@@ -210,7 +212,7 @@ spec:
         resolver: bundles
         params:
           - name: bundle
-            value: ghcr.io/tektoncd/catalog/upstream/tasks/oracle-cloud-storage-upload:0.1
+            value: ghcr.io/tektoncd/catalog/upstream/tasks/oracle-cloud-storage-upload:0.2
           - name: name
             value: oracle-cloud-storage-upload
           - name: kind
@@ -243,7 +245,7 @@ spec:
         resolver: bundles
         params:
           - name: bundle
-            value: ghcr.io/tektoncd/catalog/upstream/tasks/oracle-cloud-storage-upload:0.1
+            value: ghcr.io/tektoncd/catalog/upstream/tasks/oracle-cloud-storage-upload:0.2
           - name: name
             value: oracle-cloud-storage-upload
           - name: kind


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This pull request updates the Tekton release cheat sheet and release pipeline to reflect new infrastructure and workflow changes, primarily switching from Google Cloud (GCP) to Oracle Cloud Infrastructure (OCI) and updating release URLs. The changes standardize release parameters, update secret and bucket references, and revise instructions for interacting with clusters and release files.

**Infrastructure and URL updates:**

* Changed all release file and bucket URLs from `storage.googleapis.com` to `infra.tekton.dev`, ensuring consistency with the new hosting location.
* Updated cluster authentication instructions from using `gcloud` (GCP) to OCI CLI commands, reflecting the migration to Oracle Cloud.

**Parameter and secret updates:**

* Adjusted pipeline start parameters by removing obsolete ones (e.g., `serviceaccount`, `serviceAccountPath`), adding `repoName`, and updating secret references from `release-secret` to `oci-release-secret` where appropriate.

**Release workflow improvements:**

* Updated instructions for fetching controller image SHA and Rekor UUID to use the new release file URLs and improved parsing commands for compatibility.
* Added guidance for renaming the Kubernetes context using the current context name, making it easier to follow for users unfamiliar with GCP context naming.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [X] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [X] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [X] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [X] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [X] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [X] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
/kind misc