### PR TITLE
.github/workflows: use plumbing workflow for chatops_retest

### DIFF
--- a/.github/workflows/chatops_retest.yaml
+++ b/.github/workflows/chatops_retest.yaml
@@ -1,4 +1,4 @@
-# The _chatops_retest workflow reruns failed GHA for a PR
+# The chatops_retest workflow reruns failed GHA for a PR
 #
 # This workflow is triggered by leaving a "/retest" comment on
 # a pull request. If the required preconditions are met, it will
@@ -7,8 +7,11 @@
 # Condition for the "/retest" command are:
 # - either the issuer is a maintainer
 # - or the issuer is the owner the PR
-
 name: Rerun Failed Actions
+
+permissions:
+  contents: read
+
 on:
   repository_dispatch:
     types: [retest-command]
@@ -16,66 +19,5 @@ on:
 jobs:
   retest:
     name: Rerun Failed Actions
-    runs-on: ubuntu-latest
-    steps:
-    - name: Show Environment Variables
-      run: env
-    - name: Show Github Object
-      run: |
-        cat <<'EOF'
-        ${{ toJson(github) }}
-        EOF
-    - name: Show Github Event Path Json
-      run: 'cat $GITHUB_EVENT_PATH || true'
-    - name: Rerun Failed Actions
-      run: |
-        echo '::group:: Get the PR commit sha'
-        # Get the sha of the HEAD commit in the PR
-        GITHUB_COMMIT_SHA=$(gh api $(echo ${GITHUB_PULL_URL#https://api.github.com/}) | \
-            jq -r .head.sha)
-        echo GITHUB_COMMIT_SHA=${GITHUB_COMMIT_SHA}
-        echo '::endgroup::'
-
-        echo '::group:: Get the list of run IDs'
-        # Get a list of run IDs
-        RUN_IDS=$(gh api repos/${GITHUB_REPO}/commits/${GITHUB_COMMIT_SHA}/check-runs | \
-            jq -r '.check_runs[] | select(.name != "Rerun Failed Actions") | .html_url | capture("/runs/(?<number>[0-9]+)/job") | .number' | \
-            sort -u)
-        echo RUN_IDS=${RUN_IDS}
-        echo '::endgroup::'
-
-        echo '::group:: Rerun failed runs'
-        # For each run, retrigger faild jobs
-        for runid in ${RUN_IDS}; do
-            echo Restarting run ${runid} for commit ${GITHUB_COMMIT_SHA}
-            gh run \
-                --repo ${GITHUB_REPO} \
-                rerun ${runid} \
-                --failed || true
-        done
-        echo '::endgroup::'
-      env:
-        GITHUB_TOKEN: ${{ secrets.CHATOPS_TOKEN }}
-        GITHUB_REPO: ${{ github.event.client_payload.github.payload.repository.full_name }}
-        GITHUB_PULL_URL: ${{ github.event.client_payload.github.payload.issue.pull_request.url }}
-
-    - name: Create comment
-      if: ${{ failure() }}
-      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
-      with:
-        token: ${{ secrets.CHATOPS_TOKEN }}
-        repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
-        issue-number: ${{ github.event.client_payload.github.payload.issue.number }}
-        body: |
-          Something went wrong with your `/${{ github.event.client_payload.slash_command.command }}` command: [please check the logs][1].
-
-          [1]: ${{ steps.vars.outputs.run-url }}
-
-    - name: Add reaction
-      if: ${{ success() }}
-      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
-      with:
-        token: ${{ secrets.CHATOPS_TOKEN }}
-        repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
-        comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
-        reactions: hooray
+    uses: tektoncd/plumbing/.github/workflows/_chatops_retest.yml@48c53b4e7f1e0bb206575b80eb9fcf07b5854907
+    secrets: inherit


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The workflow is defined in plumbing and meant to be shared from
there. This migrates the current copy/pasted to using it instead.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/kind misc
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
