### PR TITLE
.github/workflows: use CHATOPS_TOKEN for coverage comments

### DIFF
--- a/.github/workflows/go-coverage.yml
+++ b/.github/workflows/go-coverage.yml
@@ -61,5 +61,6 @@ jobs:
         uses: fgrosse/go-coverage-report@8c1d1a09864211d258937b1b1a5b849f7e4f2682 # v1.2.0
         continue-on-error: true # This may fail if artifact on main branch does not exist (first run or expired)
         with:
+          token: ${{ secrets.CHATOPS_TOKEN }}
           coverage-artifact-name: "code-coverage"
           coverage-file-name: "coverage.txt"


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The default GITHUB_TOKEN has restricted permissions on fork PRs and cannot post comments even with pull-requests: write permission. This causes the coverage workflow to fail with "Resource not accessible by integration" when trying to comment on PRs from forks.

Use CHATOPS_TOKEN instead, following the same pattern used in slash.yml for fork PR interactions.

Fixes the error: GraphQL: Resource not accessible by integration (addComment)

/cc @AlanGreene @afrittoli 
/kind misc
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
