### PR TITLE
test: limit examples test parallelism to 2 to prevent timeouts

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -174,7 +174,7 @@ function run_e2e() {
   # and they cause a lot of noise in the logs, making it harder to debug integration
   # test failures.
   if [ "${RUN_YAML_TESTS}" == "true" ]; then
-    go_test_e2e -mod=readonly -parallel=6 -tags=examples -timeout=${E2E_GO_TEST_TIMEOUT} ./test/
+    go_test_e2e -mod=readonly -parallel=2 -tags=examples -timeout=${E2E_GO_TEST_TIMEOUT} ./test/
   fi
 
   if [ "${RUN_FEATUREFLAG_TESTS}" == "true" ]; then


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Reduced parallel test execution from 6 to 2 concurrent tests to mitigate
resource contention and API rate limiting issues that were causing timeouts
in alpha test runs.

Alpha tests run 125 examples (all tests), which with high parallelism (6)
was causing Kubernetes API rate limiting and timeout failures. Sequential
execution (parallel=1) works but takes ~49 minutes. This change aims to
balance speed (~25-30 min expected) with reliability.

Related to #9062

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/kind misc
/cc @afrittoli @waveywaves @twoGiants @aThorp96 
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
