### PR TITLE
Fix commit SHA of github-script action

### DIFF
--- a/.github/workflows/e2e-matrix-extras.yaml
+++ b/.github/workflows/e2e-matrix-extras.yaml
@@ -96,7 +96,7 @@ jobs:
       ARTIFACTS: ${{ github.workspace }}/artifacts
     steps:
     - name: Report tests check
-      uses: actions/github-script@60a0d83039c74a4aee5e5cbf49f72e2045aa4292 # v7.0.1
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
       id: check-run
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -153,7 +153,7 @@ jobs:
 
     - name: Report tests check
       if: success() || failure()
-      uses: actions/github-script@60a0d83039c74a4aee5e5cbf49f72e2045aa4292 # v7.0.1
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Follow-up to https://github.com/tektoncd/pipeline/pull/9161
2 uses of the github-script action were referencing an invalid SHA. Update to point to the correct value for the 7.0.1 release.

Not sure why I thought they had already been updated as mentioned in the original PR, I must have been working from a different branch.
/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
