### PR TITLE
Propagate service account to affinity assistant

### DIFF
--- a/pkg/reconciler/pipelinerun/affinity_assistant.go
+++ b/pkg/reconciler/pipelinerun/affinity_assistant.go
@@ -382,13 +382,13 @@ func affinityAssistantStatefulSet(aaBehavior aa.AffinityAssistantBehavior, name 
 					Labels: getStatefulSetLabels(pr, name),
 				},
 				Spec: corev1.PodSpec{
-					Containers: containers,
-
-					Tolerations:       tpl.Tolerations,
-					NodeSelector:      tpl.NodeSelector,
-					ImagePullSecrets:  tpl.ImagePullSecrets,
-					SecurityContext:   tpl.SecurityContext,
-					PriorityClassName: priorityClassName,
+					Containers:         containers,
+					ServiceAccountName: pr.Spec.TaskRunTemplate.ServiceAccountName,
+					Tolerations:        tpl.Tolerations,
+					NodeSelector:       tpl.NodeSelector,
+					ImagePullSecrets:   tpl.ImagePullSecrets,
+					SecurityContext:    tpl.SecurityContext,
+					PriorityClassName:  priorityClassName,
 
 					Affinity: getAssistantAffinityMergedWithPodTemplateAffinity(pr, aaBehavior),
 					Volumes:  volumes,

--- a/pkg/reconciler/pipelinerun/affinity_assistant_test.go
+++ b/pkg/reconciler/pipelinerun/affinity_assistant_test.go
@@ -945,6 +945,24 @@ func TestOnlySelectPodTemplateFieldsArePropagatedToAffinityAssistant(t *testing.
 	}
 }
 
+func TestServiceAccountIsPropagatedToAffinityAssistant(t *testing.T) {
+	prWithServiceAccount := &v1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pipelinerun-with-sa",
+		},
+		Spec: v1.PipelineRunSpec{
+			TaskRunTemplate: v1.PipelineTaskRunTemplate{
+				ServiceAccountName: "test-service-account",
+			},
+		},
+	}
+
+	sts := affinityAssistantStatefulSet(aa.AffinityAssistantPerWorkspace, "test-assistant", prWithServiceAccount, []corev1.PersistentVolumeClaim{}, []string{}, containerConfigWithoutSecurityContext, nil)
+	if sts.Spec.Template.Spec.ServiceAccountName != "test-service-account" {
+		t.Fatalf("expected ServiceAccountName %q in StatefulSet, got %q", "test-service-account", sts.Spec.Template.Spec.ServiceAccountName)
+	}
+}
+
 func TestThatTheAffinityAssistantIsWithoutNodeSelectorAndTolerations(t *testing.T) {
 	prWithoutCustomPodTemplate := &v1.PipelineRun{
 		TypeMeta: metav1.TypeMeta{Kind: "PipelineRun"},


### PR DESCRIPTION
  <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

Fixes #3748 and picks up #3751

# Changes

  - Propagate the PipelineRun `taskRunTemplate.serviceAccountName` to the affinity-assistant StatefulSet so the assistant pod uses the same service account as the TaskRuns.
  - Added a unit test to verify the service account is copied onto the assistant pod template.

# Submitter Checklist

  - [ ] Has Docs if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
  - [x] Has Tests included if any functionality added or changed
  - [ ] pre-commit Passed
  - [x] Follows the commit message standard
  - [x] Meets the Tekton contributor standards (including functionality, content, code)
  - [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake,
  misc, question, tep
  - [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some
  examples of good release notes.
  - [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Fix affinity assistant pods to use the PipelineRun’s taskRunTemplate.serviceAccountName so they align with TaskRuns.