### PR TITLE
Remove beta note from projected workspaces and csi as they are stable

### DIFF
--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -509,7 +509,6 @@ workspaces:
 ##### `projected`
 
 The `projected` field references a [`projected` volume](https://kubernetes.io/docs/concepts/storage/projected-volumes).
-`projected` volume workspaces are a [beta feature](./additional-configs.md#beta-features).
 Using a `projected` volume has the following limitations:
 
 - `projected` volume sources are always mounted as read-only. `Steps` cannot write to them and will error out if they try.
@@ -530,7 +529,6 @@ workspaces:
 ##### `csi`
 
 The `csi` field references a [`csi` volume](https://kubernetes.io/docs/concepts/storage/volumes/#csi).
-`csi` workspaces are a [beta feature](./additional-configs.md#beta-features).
 Using a `csi` volume has the following limitations:
 <!-- wokeignore:rule=master --> 
 - `csi` volume sources require a volume driver to use, which must correspond to the value by the CSI driver as defined in the [CSI spec](https://github.com/container-storage-interface/spec/blob/master/spec.md#getplugininfo).


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

In the documentation csi and projected volume workspaces still have a note saying it is a beta feature.
This is incorrect as both features were promoted to stable a while ago. 

See the following PR: https://github.com/tektoncd/pipeline/pull/6954

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
