### PR TITLE
chore: enhance cherry-pick PR format with original context

### DIFF
--- a/.github/workflows/cherry-pick-command.yaml
+++ b/.github/workflows/cherry-pick-command.yaml
@@ -111,7 +111,7 @@ jobs:
 
             # Get PR information
             echo "Fetching PR #$PR_NUMBER information..."
-            PR_DATA=$(gh pr view $PR_NUMBER --repo ${{ github.repository }} --json state,mergeCommit,mergedAt)
+            PR_DATA=$(gh pr view $PR_NUMBER --repo ${{ github.repository }} --json state,mergeCommit,mergedAt,title,body)
 
             # Check if PR is merged
             PR_STATE=$(echo "$PR_DATA" | jq -r '.state')
@@ -122,7 +122,10 @@ jobs:
             fi
 
             MERGE_COMMIT=$(echo "$PR_DATA" | jq -r '.mergeCommit.oid')
+            PR_TITLE=$(echo "$PR_DATA" | jq -r '.title')
+            PR_BODY=$(echo "$PR_DATA" | jq -r '.body')
             echo "Found merge commit: $MERGE_COMMIT"
+            echo "PR title: $PR_TITLE"
 
             # Fetch target branch
             echo "Fetching target branch: $TARGET_BRANCH..."
@@ -169,12 +172,23 @@ jobs:
 
             # Create pull request
             echo "Creating pull request..."
+
+            # Prepare PR body file
+            {
+              echo "This is a cherry-pick of #$PR_NUMBER"
+              echo ""
+              echo "---"
+              echo ""
+              echo "$PR_BODY"
+            } > /tmp/pr-body.md
+
+            # Create pull request with original PR content
             gh pr create \
               --repo ${{ github.repository }} \
               --base "$TARGET_BRANCH" \
               --head "$CHERRY_PICK_BRANCH" \
-              --title "Cherry-pick #$PR_NUMBER to $TARGET_BRANCH" \
-              --body "Automatic cherry-pick of #$PR_NUMBER to \`$TARGET_BRANCH\`"
+              --title "[cherry-pick: $TARGET_BRANCH] $PR_TITLE" \
+              --body-file /tmp/pr-body.md
 
             echo "✅ Cherry-pick completed successfully!"
           } 2>&1 | tee "$OUTPUT_FILE"


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

- Make cherry-pick PRs easier to understand with descriptive titles
- Preserve original PR context to maintain decision history
- Improve reviewer experience with linked source PR

/cc @afrittoli 
/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
