### PR TITLE
.github/workflows: fixing go-coverage token issues

### DIFF
--- a/.github/workflows/go-coverage.yml
+++ b/.github/workflows/go-coverage.yml
@@ -60,7 +60,8 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: fgrosse/go-coverage-report@8c1d1a09864211d258937b1b1a5b849f7e4f2682 # v1.2.0
         continue-on-error: true # This may fail if artifact on main branch does not exist (first run or expired)
+        env:
+          GITHUB_TOKEN: ${{ secrets.CHATOPS_TOKEN }}
         with:
-          token: ${{ secrets.CHATOPS_TOKEN }}
           coverage-artifact-name: "code-coverage"
           coverage-file-name: "coverage.txt"


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Current go-coverage workflow doesn't work as it doesn't comment anything. It fails with the following:

  + gh pr comment 9202 --body-file=.github/outputs/coverage-comment.md Creating new coverage report comment GraphQL: Resource not accessible by integration (addComment)

The token parameter we pass doesn't exists:

    Unexpected input(s) 'token', valid inputs are ['version', 'sha256sum', 'coverage-artifact-name', 'coverage-file-name', 'root-package', 'skip-comment', 'trim', 'github-baseline-workflow-ref']

So instead of passing an invalid parameter, this tries to use environment variable to override the GITHUB_TOKEN with one that has addComment rights.

If this doesn't work, we'll have to use something else as this would mean this approach cannot work with forks.

/kind misc
/cc @afrittoli @twoGiants @waveywaves @AlanGreene 

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
