### PR TITLE
fix: Add permissions to cherry-pick workflow

### DIFF
--- a/.github/workflows/cherry-pick-command.yaml
+++ b/.github/workflows/cherry-pick-command.yaml
@@ -19,6 +19,11 @@ on:
   repository_dispatch:
     types: [cherry-pick-command]
 
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
 jobs:
   cherry-pick:
     name: Cherry Pick Actions


### PR DESCRIPTION
# Changes

Added required permissions (contents: write, pull-requests: write, issues: write) to the cherry-pick-command workflow. The reusable workflow from tektoncd/plumbing requires these permissions to push branches, create PRs, and add comments.

Fixes the startup_failure seen in recent cherry-pick workflow runs.

# Submitter Checklist

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```