### PR TITLE
Add hostUsers field support to PodTemplate

### DIFF
--- a/config/300-crds/300-pipelinerun.yaml
+++ b/config/300-crds/300-pipelinerun.yaml
@@ -337,6 +337,18 @@ spec:
                     hostNetwork:
                       description: HostNetwork specifies whether the pod may use the node network namespace
                       type: boolean
+                    hostUsers:
+                      description: |-
+                        HostUsers indicates whether the pod will use the host's user namespace.
+                        Optional: Default to true.
+                        If set to true or not present, the pod will be run in the host user namespace, useful
+                        for when the pod needs a feature only available to the host user namespace, such as
+                        loading a kernel module with CAP_SYS_MODULE.
+                        When set to false, a new user namespace is created for the pod. Setting false
+                        is useful to mitigating container breakout vulnerabilities such as allowing
+                        containers to run as root without their user having root privileges on the host.
+                        This field depends on the kubernetes feature gate UserNamespacesSupport being enabled.
+                      type: boolean
                     imagePullSecrets:
                       description: ImagePullSecrets gives the name of the secret used by the pod to pull the image if specified
                       type: array
@@ -1145,6 +1157,18 @@ spec:
                             x-kubernetes-list-type: atomic
                           hostNetwork:
                             description: HostNetwork specifies whether the pod may use the node network namespace
+                            type: boolean
+                          hostUsers:
+                            description: |-
+                              HostUsers indicates whether the pod will use the host's user namespace.
+                              Optional: Default to true.
+                              If set to true or not present, the pod will be run in the host user namespace, useful
+                              for when the pod needs a feature only available to the host user namespace, such as
+                              loading a kernel module with CAP_SYS_MODULE.
+                              When set to false, a new user namespace is created for the pod. Setting false
+                              is useful to mitigating container breakout vulnerabilities such as allowing
+                              containers to run as root without their user having root privileges on the host.
+                              This field depends on the kubernetes feature gate UserNamespacesSupport being enabled.
                             type: boolean
                           imagePullSecrets:
                             description: ImagePullSecrets gives the name of the secret used by the pod to pull the image if specified
@@ -3496,6 +3520,18 @@ spec:
                           hostNetwork:
                             description: HostNetwork specifies whether the pod may use the node network namespace
                             type: boolean
+                          hostUsers:
+                            description: |-
+                              HostUsers indicates whether the pod will use the host's user namespace.
+                              Optional: Default to true.
+                              If set to true or not present, the pod will be run in the host user namespace, useful
+                              for when the pod needs a feature only available to the host user namespace, such as
+                              loading a kernel module with CAP_SYS_MODULE.
+                              When set to false, a new user namespace is created for the pod. Setting false
+                              is useful to mitigating container breakout vulnerabilities such as allowing
+                              containers to run as root without their user having root privileges on the host.
+                              This field depends on the kubernetes feature gate UserNamespacesSupport being enabled.
+                            type: boolean
                           imagePullSecrets:
                             description: ImagePullSecrets gives the name of the secret used by the pod to pull the image if specified
                             type: array
@@ -4138,6 +4174,18 @@ spec:
                           x-kubernetes-list-type: atomic
                         hostNetwork:
                           description: HostNetwork specifies whether the pod may use the node network namespace
+                          type: boolean
+                        hostUsers:
+                          description: |-
+                            HostUsers indicates whether the pod will use the host's user namespace.
+                            Optional: Default to true.
+                            If set to true or not present, the pod will be run in the host user namespace, useful
+                            for when the pod needs a feature only available to the host user namespace, such as
+                            loading a kernel module with CAP_SYS_MODULE.
+                            When set to false, a new user namespace is created for the pod. Setting false
+                            is useful to mitigating container breakout vulnerabilities such as allowing
+                            containers to run as root without their user having root privileges on the host.
+                            This field depends on the kubernetes feature gate UserNamespacesSupport being enabled.
                           type: boolean
                         imagePullSecrets:
                           description: ImagePullSecrets gives the name of the secret used by the pod to pull the image if specified

--- a/config/300-crds/300-taskrun.yaml
+++ b/config/300-crds/300-taskrun.yaml
@@ -365,6 +365,18 @@ spec:
                     hostNetwork:
                       description: HostNetwork specifies whether the pod may use the node network namespace
                       type: boolean
+                    hostUsers:
+                      description: |-
+                        HostUsers indicates whether the pod will use the host's user namespace.
+                        Optional: Default to true.
+                        If set to true or not present, the pod will be run in the host user namespace, useful
+                        for when the pod needs a feature only available to the host user namespace, such as
+                        loading a kernel module with CAP_SYS_MODULE.
+                        When set to false, a new user namespace is created for the pod. Setting false
+                        is useful to mitigating container breakout vulnerabilities such as allowing
+                        containers to run as root without their user having root privileges on the host.
+                        This field depends on the kubernetes feature gate UserNamespacesSupport being enabled.
+                      type: boolean
                     imagePullSecrets:
                       description: ImagePullSecrets gives the name of the secret used by the pod to pull the image if specified
                       type: array
@@ -2571,6 +2583,18 @@ spec:
                       x-kubernetes-list-type: atomic
                     hostNetwork:
                       description: HostNetwork specifies whether the pod may use the node network namespace
+                      type: boolean
+                    hostUsers:
+                      description: |-
+                        HostUsers indicates whether the pod will use the host's user namespace.
+                        Optional: Default to true.
+                        If set to true or not present, the pod will be run in the host user namespace, useful
+                        for when the pod needs a feature only available to the host user namespace, such as
+                        loading a kernel module with CAP_SYS_MODULE.
+                        When set to false, a new user namespace is created for the pod. Setting false
+                        is useful to mitigating container breakout vulnerabilities such as allowing
+                        containers to run as root without their user having root privileges on the host.
+                        This field depends on the kubernetes feature gate UserNamespacesSupport being enabled.
                       type: boolean
                     imagePullSecrets:
                       description: ImagePullSecrets gives the name of the secret used by the pod to pull the image if specified

--- a/docs/podtemplates.md
+++ b/docs/podtemplates.md
@@ -117,12 +117,16 @@ Pod templates support fields listed in the table below.
                 pulling a container image</a>.</td>
 		</tr>
 		<tr>
-			<td><code>hostNetwork</code></td>
-			<td><b>Default:</b> <code>false</code>. Determines whether to use the host network namespace.</td>
-		</tr>
-		<tr>
-			<td><code>hostAliases</code></td>
-			<td>Adds entries to a Pod's `/etc/hosts` to provide Pod-level overrides of hostnames. For further info see [Kubernetes' docs for this field](https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/).</td>
+            <td><code>hostNetwork</code></td>
+            <td><b>Default:</b> <code>false</code>. Determines whether to use the host network namespace.</td>
+        </tr>
+        <tr>
+            <td><code>hostUsers</code></td>
+            <td><b>Default:</b> <code>true</code>. Determines whether to use the host's user namespace. When set to <code>false</code>, a new user namespace is created for the pod, providing better security isolation. This is useful for mitigating container breakout vulnerabilities. This field is alpha-level and requires the <code>UserNamespacesSupport</code> feature gate to be enabled on the Kubernetes cluster (available in Kubernetes 1.25+).</td>
+        </tr>
+        <tr>
+            <td><code>hostAliases</code></td>
+            <td>Adds entries to a Pod's `/etc/hosts` to provide Pod-level overrides of hostnames. For further info see [Kubernetes' docs for this field](https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/).</td>
 		</tr>
         <tr>
             <td><code>topologySpreadConstraints</code></td>

--- a/pkg/apis/pipeline/pod/template.go
+++ b/pkg/apis/pipeline/pod/template.go
@@ -132,6 +132,18 @@ type Template struct {
 	// +optional
 	HostNetwork bool `json:"hostNetwork,omitempty"`
 
+	// HostUsers indicates whether the pod will use the host's user namespace.
+	// Optional: Default to true.
+	// If set to true or not present, the pod will be run in the host user namespace, useful
+	// for when the pod needs a feature only available to the host user namespace, such as
+	// loading a kernel module with CAP_SYS_MODULE.
+	// When set to false, a new user namespace is created for the pod. Setting false
+	// is useful to mitigating container breakout vulnerabilities such as allowing
+	// containers to run as root without their user having root privileges on the host.
+	// This field depends on the kubernetes feature gate UserNamespacesSupport being enabled.
+	// +optional
+	HostUsers *bool `json:"hostUsers,omitempty"`
+
 	// TopologySpreadConstraints controls how Pods are spread across your cluster among
 	// failure-domains such as regions, zones, nodes, and other user-defined topology domains.
 	// +optional
@@ -228,6 +240,9 @@ func MergePodTemplateWithDefault(tpl, defaultTpl *PodTemplate) *PodTemplate {
 		}
 		if !tpl.HostNetwork && defaultTpl.HostNetwork {
 			tpl.HostNetwork = true
+		}
+		if tpl.HostUsers == nil {
+			tpl.HostUsers = defaultTpl.HostUsers
 		}
 		if tpl.TopologySpreadConstraints == nil {
 			tpl.TopologySpreadConstraints = defaultTpl.TopologySpreadConstraints

--- a/pkg/apis/pipeline/pod/zz_generated.deepcopy.go
+++ b/pkg/apis/pipeline/pod/zz_generated.deepcopy.go
@@ -153,6 +153,11 @@ func (in *Template) DeepCopyInto(out *Template) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.HostUsers != nil {
+		in, out := &in.HostUsers, &out.HostUsers
+		*out = new(bool)
+		**out = **in
+	}
 	if in.TopologySpreadConstraints != nil {
 		in, out := &in.TopologySpreadConstraints, &out.TopologySpreadConstraints
 		*out = make([]v1.TopologySpreadConstraint, len(*in))

--- a/pkg/apis/pipeline/v1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1/openapi_generated.go
@@ -369,6 +369,13 @@ func schema_pkg_apis_pipeline_pod_Template(ref common.ReferenceCallback) common.
 							Format:      "",
 						},
 					},
+					"hostUsers": {
+						SchemaProps: spec.SchemaProps{
+							Description: "HostUsers indicates whether the pod will use the host's user namespace. Optional: Default to true. If set to true or not present, the pod will be run in the host user namespace, useful for when the pod needs a feature only available to the host user namespace, such as loading a kernel module with CAP_SYS_MODULE. When set to false, a new user namespace is created for the pod. Setting false is useful to mitigating container breakout vulnerabilities such as allowing containers to run as root without their user having root privileges on the host. This field depends on the kubernetes feature gate UserNamespacesSupport being enabled.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 					"topologySpreadConstraints": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{

--- a/pkg/apis/pipeline/v1/swagger.json
+++ b/pkg/apis/pipeline/v1/swagger.json
@@ -95,6 +95,10 @@
           "description": "HostNetwork specifies whether the pod may use the node network namespace",
           "type": "boolean"
         },
+        "hostUsers": {
+          "description": "HostUsers indicates whether the pod will use the host's user namespace. Optional: Default to true. If set to true or not present, the pod will be run in the host user namespace, useful for when the pod needs a feature only available to the host user namespace, such as loading a kernel module with CAP_SYS_MODULE. When set to false, a new user namespace is created for the pod. Setting false is useful to mitigating container breakout vulnerabilities such as allowing containers to run as root without their user having root privileges on the host. This field depends on the kubernetes feature gate UserNamespacesSupport being enabled.",
+          "type": "boolean"
+        },
         "imagePullSecrets": {
           "description": "ImagePullSecrets gives the name of the secret used by the pod to pull the image if specified",
           "type": "array",

--- a/pkg/apis/pipeline/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1alpha1/openapi_generated.go
@@ -316,6 +316,13 @@ func schema_pkg_apis_pipeline_pod_Template(ref common.ReferenceCallback) common.
 							Format:      "",
 						},
 					},
+					"hostUsers": {
+						SchemaProps: spec.SchemaProps{
+							Description: "HostUsers indicates whether the pod will use the host's user namespace. Optional: Default to true. If set to true or not present, the pod will be run in the host user namespace, useful for when the pod needs a feature only available to the host user namespace, such as loading a kernel module with CAP_SYS_MODULE. When set to false, a new user namespace is created for the pod. Setting false is useful to mitigating container breakout vulnerabilities such as allowing containers to run as root without their user having root privileges on the host. This field depends on the kubernetes feature gate UserNamespacesSupport being enabled.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 					"topologySpreadConstraints": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{

--- a/pkg/apis/pipeline/v1alpha1/swagger.json
+++ b/pkg/apis/pipeline/v1alpha1/swagger.json
@@ -95,6 +95,10 @@
           "description": "HostNetwork specifies whether the pod may use the node network namespace",
           "type": "boolean"
         },
+        "hostUsers": {
+          "description": "HostUsers indicates whether the pod will use the host's user namespace. Optional: Default to true. If set to true or not present, the pod will be run in the host user namespace, useful for when the pod needs a feature only available to the host user namespace, such as loading a kernel module with CAP_SYS_MODULE. When set to false, a new user namespace is created for the pod. Setting false is useful to mitigating container breakout vulnerabilities such as allowing containers to run as root without their user having root privileges on the host. This field depends on the kubernetes feature gate UserNamespacesSupport being enabled.",
+          "type": "boolean"
+        },
         "imagePullSecrets": {
           "description": "ImagePullSecrets gives the name of the secret used by the pod to pull the image if specified",
           "type": "array",

--- a/pkg/apis/pipeline/v1beta1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1beta1/openapi_generated.go
@@ -394,6 +394,13 @@ func schema_pkg_apis_pipeline_pod_Template(ref common.ReferenceCallback) common.
 							Format:      "",
 						},
 					},
+					"hostUsers": {
+						SchemaProps: spec.SchemaProps{
+							Description: "HostUsers indicates whether the pod will use the host's user namespace. Optional: Default to true. If set to true or not present, the pod will be run in the host user namespace, useful for when the pod needs a feature only available to the host user namespace, such as loading a kernel module with CAP_SYS_MODULE. When set to false, a new user namespace is created for the pod. Setting false is useful to mitigating container breakout vulnerabilities such as allowing containers to run as root without their user having root privileges on the host. This field depends on the kubernetes feature gate UserNamespacesSupport being enabled.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 					"topologySpreadConstraints": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{

--- a/pkg/apis/pipeline/v1beta1/swagger.json
+++ b/pkg/apis/pipeline/v1beta1/swagger.json
@@ -95,6 +95,10 @@
           "description": "HostNetwork specifies whether the pod may use the node network namespace",
           "type": "boolean"
         },
+        "hostUsers": {
+          "description": "HostUsers indicates whether the pod will use the host's user namespace. Optional: Default to true. If set to true or not present, the pod will be run in the host user namespace, useful for when the pod needs a feature only available to the host user namespace, such as loading a kernel module with CAP_SYS_MODULE. When set to false, a new user namespace is created for the pod. Setting false is useful to mitigating container breakout vulnerabilities such as allowing containers to run as root without their user having root privileges on the host. This field depends on the kubernetes feature gate UserNamespacesSupport being enabled.",
+          "type": "boolean"
+        },
         "imagePullSecrets": {
           "description": "ImagePullSecrets gives the name of the secret used by the pod to pull the image if specified",
           "type": "array",

--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -528,6 +528,7 @@ func (b *Builder) Build(ctx context.Context, taskRun *v1.TaskRun, taskSpec v1.Ta
 			AutomountServiceAccountToken: podTemplate.AutomountServiceAccountToken,
 			SchedulerName:                podTemplate.SchedulerName,
 			HostNetwork:                  podTemplate.HostNetwork,
+			HostUsers:                    podTemplate.HostUsers,
 			DNSPolicy:                    dnsPolicy,
 			DNSConfig:                    podTemplate.DNSConfig,
 			EnableServiceLinks:           podTemplate.EnableServiceLinks,


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
This PR adds support for the Kubernetes `hostUsers` field in Tekton's `PodTemplate`, enabling users to control whether TaskRun/PipelineRun pods run in the host's user namespace or in an isolated user namespace.

- Added `HostUsers *bool` field to `pkg/apis/pipeline/pod/Template` struct
- Added merge logic in `MergePodTemplateWithDefault()` to handle default values
- Field is propagated from PodTemplate to Kubernetes PodSpec

### Code Generation
- Updated CRDs: `config/300-crds/300-taskrun.yaml` and `config/300-crds/300-pipelinerun.yaml`
- Generated OpenAPI schemas for all API versions (v1, v1beta1, v1alpha1)
- Generated deepcopy code for the new field

### Tests
- Added unit test case `"using hostUsers false"` in `pkg/pod/pod_test.go`
- Verified field propagation from TaskRunSpec to PodSpec

Closes #9190.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Add support for `hostUsers` field in PodTemplate to control user namespace isolation
```
