### PR TITLE
Fix duplicated protobuf tag in pod.Template struct

### DIFF
--- a/pkg/apis/pipeline/pod/template.go
+++ b/pkg/apis/pipeline/pod/template.go
@@ -112,7 +112,7 @@ type Template struct {
 	// If not specified, the pod priority will be default or zero if there is no
 	// default.
 	// +optional
-	PriorityClassName *string `json:"priorityClassName,omitempty" protobuf:"bytes,7,opt,name=priorityClassName"`
+	PriorityClassName *string `json:"priorityClassName,omitempty" protobuf:"bytes,8,opt,name=priorityClassName"`
 	// SchedulerName specifies the scheduler to be used to dispatch the Pod
 	// +optional
 	SchedulerName string `json:"schedulerName,omitempty"`


### PR DESCRIPTION
# Summary
Fixes duplicate protobuf tag number in `pkg/apis/pipeline/pod/template.go`.

# Changes
- Changed `PriorityClassName` protobuf tag from 7 to 8
- Tag 7 was already used by `Env` field
- Tag 8 is the next available sequential number

## Issue
Fixes #8345

## Testing
Verified tag 8 is not used elsewhere in the Template struct.

# Release Notes

```release-note
fix duplicate protobuf tag for PriorityClassName in pod.Template struct
```