### PR TITLE
Fix: CI job incorrectly skipped by file change detection

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,11 +37,26 @@ jobs:
 
         echo -e "Changed files:\n${CHANGED_FILES}"
 
-        # If no files are changed at all, then `grep -v` will match even though no change outputs
-        # should be true. Skipping output on an empty set of changes eliminates the false positive
+        # If there are no changed files, non-docs and yaml are not set and remain false by default.
+        # This ensures that jobs depending on these outputs do not run when there are no changes.
         if [[ -n "${CHANGED_FILES}" ]]; then
-          NON_DOCS=$(echo "${CHANGED_FILES}" | grep -Eqv '\.md$' && echo 'true' || echo 'false')
-          YAML=$(echo "${CHANGED_FILES}" | grep -Eq '\.ya?ml$' && echo 'true' || echo 'false')
+          NON_DOCS='false'
+          YAML='false'
+
+          while read -r file; do
+            if [[ "$file" != *.md ]]; then
+              NON_DOCS='true'
+              break
+            fi
+          done <<< "${CHANGED_FILES}"
+
+          while read -r file; do
+            if [[ "$file" == *.yaml || "$file" == *.yml ]]; then
+              YAML='true'
+              break
+            fi
+          done <<< "${CHANGED_FILES}"
+
           echo "non-docs=${NON_DOCS}" | tee -a $GITHUB_OUTPUT
           echo "yaml=${YAML}" | tee -a $GITHUB_OUTPUT
         fi


### PR DESCRIPTION
# Changes

Updated the CI workflow to correctly detect changes in non-documentation and YAML files, preventing accidental skips of the CI job.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
