### PR TITLE
fix(e2e): improve dind-sidecar probe configuration for reliability

### DIFF
--- a/examples/v1/taskruns/dind-sidecar.yaml
+++ b/examples/v1/taskruns/dind-sidecar.yaml
@@ -59,12 +59,19 @@ spec:
       - mountPath: /certs/client
         name: dind-certs
       # Wait for the dind daemon to generate the certs it will share with the
-      # client.
-      readinessProbe:
-        initialDelaySeconds: 3
-        periodSeconds: 2
+      # client. StartupProbe handles slow Docker daemon initialization.
+      startupProbe:
+        periodSeconds: 1
+        failureThreshold: 30  # Allow up to 30 seconds for Docker daemon to start
         exec:
           command: ['ls', '/certs/client/ca.pem']
+      # ReadinessProbe verifies Docker daemon is actually ready to accept commands.
+      # Note: With k8s native sidecar support, startupProbe is honored but
+      # readinessProbe may not be.
+      readinessProbe:
+        periodSeconds: 2
+        exec:
+          command: ['docker', 'info']
 
     volumes:
     - name: dind-certs


### PR DESCRIPTION
# Changes

Improves the `dind-sidecar.yaml` example test reliability by adding a `startupProbe` and enhancing the `readinessProbe`:

- **Added startupProbe**: Allows up to 30 seconds for Docker daemon initialization before marking the sidecar as failed, addressing slow startup in CI environments
- **Enhanced readinessProbe**: Changed from checking cert file existence to running `docker info` to verify the daemon is actually ready to accept commands
- **Better k8s native sidecar support**: StartupProbe is properly honored with `enableKubernetesSidecar: true`, while readinessProbe may not be

This addresses flaky test failures seen in CI, particularly in alpha mode with k8s native sidecar support enabled.

Related analysis: `dind-sidecar-failure-analysis.md` (Nov 28, 2025)

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```