### PR TITLE
fix(e2e): wait for SSH key and config in git auth test

### DIFF
--- a/examples/v1/taskruns/authenticating-git-commands.yaml
+++ b/examples/v1/taskruns/authenticating-git-commands.yaml
@@ -154,6 +154,25 @@ spec:
           # When disable-home-env-overwrite is "true", creds-init credentials
           # will be copied to /root/.ssh by the entrypoint. We just need to
           # overwrite the known_hosts file with that of our test git server.
+
+          # Wait for credentials to be fully copied by the entrypoint.
+          # With native sidecars, there can be a timing race where the script
+          # starts executing before the entrypoint finishes copying credentials.
+          # We need both the private key AND the SSH config file that tells SSH to use it.
+          timeout=30
+          elapsed=0
+          while [ ! -f /root/.ssh/id_ssh-key-for-git ] || [ ! -f /root/.ssh/config ]; do
+            if [ $elapsed -ge $timeout ]; then
+              echo "ERROR: Timed out waiting for credentials to be copied to /root/.ssh/"
+              echo "Expected files: id_ssh-key-for-git and config"
+              echo "Contents of /root/.ssh/:"
+              ls -la /root/.ssh/ || echo "Directory does not exist"
+              exit 1
+            fi
+            sleep 1
+            elapsed=$((elapsed + 1))
+          done
+
           cp /messages/known_hosts /root/.ssh/known_hosts
         fi
 

--- a/examples/v1/taskruns/beta/authenticating-git-commands.yaml
+++ b/examples/v1/taskruns/beta/authenticating-git-commands.yaml
@@ -149,6 +149,25 @@ spec:
           # When disable-home-env-overwrite is "true", creds-init credentials
           # will be copied to /root/.ssh by the entrypoint. We just need to
           # overwrite the known_hosts file with that of our test git server.
+
+          # Wait for credentials to be fully copied by the entrypoint.
+          # With native sidecars, there can be a timing race where the script
+          # starts executing before the entrypoint finishes copying credentials.
+          # We need both the private key AND the SSH config file that tells SSH to use it.
+          timeout=30
+          elapsed=0
+          while [ ! -f /root/.ssh/id_ssh-key-for-git ] || [ ! -f /root/.ssh/config ]; do
+            if [ $elapsed -ge $timeout ]; then
+              echo "ERROR: Timed out waiting for credentials to be copied to /root/.ssh/"
+              echo "Expected files: id_ssh-key-for-git and config"
+              echo "Contents of /root/.ssh/:"
+              ls -la /root/.ssh/ || echo "Directory does not exist"
+              exit 1
+            fi
+            sleep 1
+            elapsed=$((elapsed + 1))
+          done
+
           cp /messages/known_hosts /root/.ssh/known_hosts
         fi
 


### PR DESCRIPTION
# Changes

This PR fixes an intermittent flake in the `authenticating-git-commands` e2e test that occurs with Kubernetes native sidecar support.

## Problem

The test was experiencing intermittent "Permission denied (publickey)" failures when attempting git clone operations. Analysis of the failure logs revealed:

- SSH client attempted password authentication (not publickey)
- Server logs showed "Failed password" errors
- This indicated SSH wasn't finding/using the expected private key

## Root Cause

The entrypoint's `CopyCredsToHome()` function recursively copies credentials from `/tekton/creds/.ssh/` to `$HOME/.ssh/` file-by-file:
1. `id_ssh-key-for-git` (private key)
2. `config` (SSH config pointing to the key)
3. `known_hosts` (if present in secret)

**The race condition:** The script started executing while the file-by-file copy was still in progress. When the script ran `git clone`, SSH couldn't find the `config` file that tells it to use the non-standard key name `id_ssh-key-for-git`. Without this config, SSH tried default key names, found nothing, and fell back to password authentication, which failed.

## Solution

Add a wait loop that explicitly checks for both required files (`id_ssh-key-for-git` AND `config`) before proceeding with git operations:

```bash
while [ ! -f /root/.ssh/id_ssh-key-for-git ] || [ ! -f /root/.ssh/config ]; do
  # wait up to 30 seconds with diagnostic output on timeout
done
```

This ensures SSH has everything it needs for authentication before attempting git clone.

## Testing

- The fix applies to both v1 and beta versions of the test for consistency
- Added detailed error messages showing expected files and directory contents if timeout occurs
- 30-second timeout is generous for normal operation (credentials copy in < 1 second) while catching genuine issues

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
  - N/A - internal test fix only
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
  - N/A - this IS the test fix
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
  - Will add `/kind flake` after creation
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release
  - N/A - no user-facing changes

# Release Notes

```release-note
NONE
```