### PR TITLE
feat: Add self-contained JSON Schema generation for Tekton CRDs

### DIFF
--- a/hack/jsonschema-gen/main.go
+++ b/hack/jsonschema-gen/main.go
@@ -1,0 +1,222 @@
+/*
+Copyright 2025 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// CRD represents a Kubernetes CustomResourceDefinition
+type CRD struct {
+	APIVersion string `yaml:"apiVersion"`
+	Kind       string `yaml:"kind"`
+	Metadata   struct {
+		Name string `yaml:"name"`
+	} `yaml:"metadata"`
+	Spec struct {
+		Group    string `yaml:"group"`
+		Versions []struct {
+			Name    string `yaml:"name"`
+			Served  bool   `yaml:"served"`
+			Storage bool   `yaml:"storage"`
+			Schema  struct {
+				OpenAPIV3Schema map[string]interface{} `yaml:"openAPIV3Schema"`
+			} `yaml:"schema"`
+		} `yaml:"versions"`
+		Names struct {
+			Kind     string `yaml:"kind"`
+			Singular string `yaml:"singular"`
+			Plural   string `yaml:"plural"`
+		} `yaml:"names"`
+	} `yaml:"spec"`
+}
+
+// JSONSchema represents a JSON Schema document
+type JSONSchema struct {
+	Schema      string                 `json:"$schema"`
+	ID          string                 `json:"$id"`
+	Title       string                 `json:"title"`
+	Description string                 `json:"description,omitempty"`
+	Type        interface{}            `json:"type,omitempty"`
+	Properties  map[string]interface{} `json:"properties,omitempty"`
+	Required    []string               `json:"required,omitempty"`
+	// Additional fields from OpenAPIV3Schema
+	AdditionalProperties interface{} `json:"additionalProperties,omitempty"`
+	Items                interface{} `json:"items,omitempty"`
+	Enum                 []string    `json:"enum,omitempty"`
+	Default              interface{} `json:"default,omitempty"`
+	Format               string      `json:"format,omitempty"`
+	Pattern              string      `json:"pattern,omitempty"`
+	Minimum              interface{} `json:"minimum,omitempty"`
+	Maximum              interface{} `json:"maximum,omitempty"`
+	MinLength            interface{} `json:"minLength,omitempty"`
+	MaxLength            interface{} `json:"maxLength,omitempty"`
+	MinItems             interface{} `json:"minItems,omitempty"`
+	MaxItems             interface{} `json:"maxItems,omitempty"`
+	UniqueItems          bool        `json:"uniqueItems,omitempty"`
+	OneOf                interface{} `json:"oneOf,omitempty"`
+	AnyOf                interface{} `json:"anyOf,omitempty"`
+	AllOf                interface{} `json:"allOf,omitempty"`
+	Not                  interface{} `json:"not,omitempty"`
+}
+
+func main() {
+	crdDir := flag.String("crd-dir", "config/300-crds", "Directory containing CRD YAML files")
+	outputDir := flag.String("output-dir", "schema", "Output directory for JSON Schema files")
+	apiVersion := flag.String("api-version", "", "API version to generate (empty for all)")
+	flag.Parse()
+
+	// Create output directory if it doesn't exist
+	if err := os.MkdirAll(*outputDir, 0755); err != nil {
+		fmt.Fprintf(os.Stderr, "Error creating output directory: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Find all CRD files
+	files, err := filepath.Glob(filepath.Join(*crdDir, "*.yaml"))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error finding CRD files: %v\n", err)
+		os.Exit(1)
+	}
+
+	for _, file := range files {
+		if err := processCRDFile(file, *outputDir, *apiVersion); err != nil {
+			fmt.Fprintf(os.Stderr, "Error processing %s: %v\n", file, err)
+			os.Exit(1)
+		}
+	}
+
+	fmt.Println("JSON Schema generation complete.")
+}
+
+func processCRDFile(filePath, outputDir, targetAPIVersion string) error {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return fmt.Errorf("reading file: %w", err)
+	}
+
+	var crd CRD
+	if err := yaml.Unmarshal(data, &crd); err != nil {
+		return fmt.Errorf("parsing YAML: %w", err)
+	}
+
+	// Skip non-CRD files
+	if crd.Kind != "CustomResourceDefinition" {
+		return nil
+	}
+
+	group := crd.Spec.Group
+	kind := crd.Spec.Names.Kind
+
+	for _, version := range crd.Spec.Versions {
+		// Skip if specific version requested and this isn't it
+		if targetAPIVersion != "" && version.Name != targetAPIVersion {
+			continue
+		}
+
+		// Skip versions without schema
+		if version.Schema.OpenAPIV3Schema == nil {
+			continue
+		}
+
+		// Create version-specific output directory
+		versionDir := filepath.Join(outputDir, version.Name)
+		if err := os.MkdirAll(versionDir, 0755); err != nil {
+			return fmt.Errorf("creating version directory: %w", err)
+		}
+
+		schema := convertToJSONSchema(version.Schema.OpenAPIV3Schema, group, version.Name, kind)
+
+		// Write JSON Schema file
+		outputFile := filepath.Join(versionDir, strings.ToLower(kind)+".json")
+		jsonData, err := json.MarshalIndent(schema, "", "  ")
+		if err != nil {
+			return fmt.Errorf("marshaling JSON: %w", err)
+		}
+
+		if err := os.WriteFile(outputFile, jsonData, 0644); err != nil {
+			return fmt.Errorf("writing file: %w", err)
+		}
+
+		fmt.Printf("Generated %s\n", outputFile)
+	}
+
+	return nil
+}
+
+func convertToJSONSchema(openAPISchema map[string]interface{}, group, version, kind string) map[string]interface{} {
+	schema := make(map[string]interface{})
+
+	// Add JSON Schema meta fields
+	schema["$schema"] = "https://json-schema.org/draft/2020-12/schema"
+	schema["$id"] = fmt.Sprintf("https://tekton.dev/schemas/%s/%s.json", version, strings.ToLower(kind))
+	schema["title"] = fmt.Sprintf("Tekton %s %s", kind, version)
+
+	// Copy and convert OpenAPI schema properties
+	convertOpenAPIToJSONSchema(openAPISchema, schema)
+
+	return schema
+}
+
+func convertOpenAPIToJSONSchema(src map[string]interface{}, dst map[string]interface{}) {
+	for key, value := range src {
+		switch key {
+		// Skip OpenAPI-specific fields that don't apply to JSON Schema
+		case "x-kubernetes-preserve-unknown-fields",
+			"x-kubernetes-list-type",
+			"x-kubernetes-list-map-keys",
+			"x-kubernetes-map-type",
+			"x-kubernetes-patch-strategy",
+			"x-kubernetes-patch-merge-key",
+			"x-kubernetes-embedded-resource",
+			"x-kubernetes-int-or-string",
+			"x-kubernetes-group-version-kind",
+			"x-kubernetes-validations":
+			// These are Kubernetes-specific extensions, skip them
+			continue
+		default:
+			// For nested objects, recursively convert
+			if mapValue, ok := value.(map[string]interface{}); ok {
+				newMap := make(map[string]interface{})
+				convertOpenAPIToJSONSchema(mapValue, newMap)
+				dst[key] = newMap
+			} else if sliceValue, ok := value.([]interface{}); ok {
+				// Handle arrays of objects
+				newSlice := make([]interface{}, len(sliceValue))
+				for i, item := range sliceValue {
+					if itemMap, ok := item.(map[string]interface{}); ok {
+						newItem := make(map[string]interface{})
+						convertOpenAPIToJSONSchema(itemMap, newItem)
+						newSlice[i] = newItem
+					} else {
+						newSlice[i] = item
+					}
+				}
+				dst[key] = newSlice
+			} else {
+				dst[key] = value
+			}
+		}
+	}
+}

--- a/hack/jsonschema-gen/main_test.go
+++ b/hack/jsonschema-gen/main_test.go
@@ -1,0 +1,199 @@
+/*
+Copyright 2025 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestConvertOpenAPIToJSONSchema(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    map[string]interface{}
+		expected map[string]interface{}
+	}{
+		{
+			name: "basic type conversion",
+			input: map[string]interface{}{
+				"type":        "object",
+				"description": "Test object",
+			},
+			expected: map[string]interface{}{
+				"type":        "object",
+				"description": "Test object",
+			},
+		},
+		{
+			name: "filters kubernetes extensions",
+			input: map[string]interface{}{
+				"type":                                 "string",
+				"x-kubernetes-preserve-unknown-fields": true,
+				"x-kubernetes-list-type":               "atomic",
+			},
+			expected: map[string]interface{}{
+				"type": "string",
+			},
+		},
+		{
+			name: "handles nested properties",
+			input: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"name": map[string]interface{}{
+						"type":                                 "string",
+						"x-kubernetes-preserve-unknown-fields": true,
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"name": map[string]interface{}{
+						"type": "string",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := make(map[string]interface{})
+			convertOpenAPIToJSONSchema(tt.input, result)
+
+			// Compare using JSON marshaling for deep equality
+			expectedJSON, _ := json.Marshal(tt.expected)
+			resultJSON, _ := json.Marshal(result)
+
+			if string(expectedJSON) != string(resultJSON) {
+				t.Errorf("convertOpenAPIToJSONSchema() = %s, want %s", resultJSON, expectedJSON)
+			}
+		})
+	}
+}
+
+func TestConvertToJSONSchema(t *testing.T) {
+	input := map[string]interface{}{
+		"type":        "object",
+		"description": "Test Task",
+		"properties": map[string]interface{}{
+			"apiVersion": map[string]interface{}{
+				"type": "string",
+			},
+			"kind": map[string]interface{}{
+				"type": "string",
+			},
+		},
+	}
+
+	result := convertToJSONSchema(input, "tekton.dev", "v1", "Task")
+
+	// Verify JSON Schema meta fields
+	if result["$schema"] != "https://json-schema.org/draft/2020-12/schema" {
+		t.Errorf("Expected $schema to be set, got %v", result["$schema"])
+	}
+
+	if result["$id"] != "https://tekton.dev/schemas/v1/task.json" {
+		t.Errorf("Expected $id to be set correctly, got %v", result["$id"])
+	}
+
+	if result["title"] != "Tekton Task v1" {
+		t.Errorf("Expected title to be set correctly, got %v", result["title"])
+	}
+
+	// Verify properties are preserved
+	props, ok := result["properties"].(map[string]interface{})
+	if !ok {
+		t.Error("Expected properties to be a map")
+	}
+
+	if _, ok := props["apiVersion"]; !ok {
+		t.Error("Expected apiVersion property to be preserved")
+	}
+}
+
+func TestProcessCRDFile(t *testing.T) {
+	// Create a temporary directory for test output
+	tmpDir, err := os.MkdirTemp("", "jsonschema-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Create a simple test CRD file
+	testCRD := `apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: tasks.tekton.dev
+spec:
+  group: tekton.dev
+  names:
+    kind: Task
+    plural: tasks
+    singular: task
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          description: Test Task
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+`
+	crdFile := filepath.Join(tmpDir, "test-task.yaml")
+	if err := os.WriteFile(crdFile, []byte(testCRD), 0644); err != nil {
+		t.Fatalf("Failed to write test CRD: %v", err)
+	}
+
+	outputDir := filepath.Join(tmpDir, "output")
+	if err := processCRDFile(crdFile, outputDir, ""); err != nil {
+		t.Fatalf("processCRDFile failed: %v", err)
+	}
+
+	// Verify output file was created
+	outputFile := filepath.Join(outputDir, "v1", "task.json")
+	if _, err := os.Stat(outputFile); os.IsNotExist(err) {
+		t.Errorf("Expected output file %s to exist", outputFile)
+	}
+
+	// Verify output is valid JSON
+	data, err := os.ReadFile(outputFile)
+	if err != nil {
+		t.Fatalf("Failed to read output file: %v", err)
+	}
+
+	var schema map[string]interface{}
+	if err := json.Unmarshal(data, &schema); err != nil {
+		t.Errorf("Output is not valid JSON: %v", err)
+	}
+
+	// Verify schema has required fields
+	if schema["$schema"] == nil {
+		t.Error("Expected $schema field in output")
+	}
+	if schema["$id"] == nil {
+		t.Error("Expected $id field in output")
+	}
+}

--- a/hack/update-jsonschema.sh
+++ b/hack/update-jsonschema.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# Copyright 2025 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT_DIR="$(git rev-parse --show-toplevel)"
+CRD_DIR="${REPO_ROOT_DIR}/config/300-crds"
+OUTPUT_DIR="${REPO_ROOT_DIR}/schema"
+
+echo "Generating JSON Schema files from CRDs..."
+
+# Create output directory
+mkdir -p "${OUTPUT_DIR}"
+
+# Run the JSON Schema generator
+go run "${REPO_ROOT_DIR}/hack/jsonschema-gen/main.go" \
+  -crd-dir="${CRD_DIR}" \
+  -output-dir="${OUTPUT_DIR}"
+
+echo "JSON Schema generation complete."
+echo "Generated schemas are in: ${OUTPUT_DIR}"

--- a/schema/v1/pipeline.json
+++ b/schema/v1/pipeline.json
@@ -1,0 +1,639 @@
+{
+  "$id": "https://tekton.dev/schemas/v1/pipeline.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Pipeline describes a list of Tasks to execute. It expresses how outputs\nof tasks feed into inputs of subsequent tasks.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Spec holds the desired state of the Pipeline from the client",
+      "properties": {
+        "description": {
+          "description": "Description is a user-facing description of the pipeline that may be\nused to populate a UI.",
+          "type": "string"
+        },
+        "displayName": {
+          "description": "DisplayName is a user-facing name of the pipeline that may be\nused to populate a UI.",
+          "type": "string"
+        },
+        "finally": {
+          "description": "Finally declares the list of Tasks that execute just before leaving the Pipeline\ni.e. either after all Tasks are finished executing successfully\nor after a failure which would result in ending the Pipeline",
+          "items": {
+            "description": "PipelineTask defines a task in a Pipeline, passing inputs from both\nParams and from the output of previous tasks.",
+            "properties": {
+              "description": {
+                "description": "Description is the description of this task within the context of a Pipeline.\nThis description may be used to populate a UI.",
+                "type": "string"
+              },
+              "displayName": {
+                "description": "DisplayName is the display name of this task within the context of a Pipeline.\nThis display name may be used to populate a UI.",
+                "type": "string"
+              },
+              "matrix": {
+                "description": "Matrix declares parameters used to fan out this task.",
+                "properties": {
+                  "include": {
+                    "description": "Include is a list of IncludeParams which allows passing in specific combinations of Parameters into the Matrix.",
+                    "items": {
+                      "description": "IncludeParams allows passing in a specific combinations of Parameters into the Matrix.",
+                      "properties": {
+                        "name": {
+                          "description": "Name the specified combination",
+                          "type": "string"
+                        },
+                        "params": {
+                          "description": "Params takes only `Parameters` of type `\"string\"`\nThe names of the `params` must match the names of the `params` in the underlying `Task`",
+                          "items": {
+                            "description": "Param declares an ParamValues to use for the parameter called name.",
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "value": {}
+                            },
+                            "required": [
+                              "name",
+                              "value"
+                            ],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "params": {
+                    "description": "Params is a list of parameters used to fan out the pipelineTask\nParams takes only `Parameters` of type `\"array\"`\nEach array element is supplied to the `PipelineTask` by substituting `params` of type `\"string\"` in the underlying `Task`.\nThe names of the `params` in the `Matrix` must match the names of the `params` in the underlying `Task` that they will be substituting.",
+                    "items": {
+                      "description": "Param declares an ParamValues to use for the parameter called name.",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "value": {}
+                      },
+                      "required": [
+                        "name",
+                        "value"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              },
+              "name": {
+                "description": "Name is the name of this task within the context of a Pipeline. Name is\nused as a coordinate with the `from` and `runAfter` fields to establish\nthe execution order of tasks relative to one another.",
+                "type": "string"
+              },
+              "onError": {
+                "description": "OnError defines the exiting behavior of a PipelineRun on error\ncan be set to [ continue | stopAndFail ]",
+                "type": "string"
+              },
+              "params": {
+                "description": "Parameters declares parameters passed to this task.",
+                "items": {
+                  "description": "Param declares an ParamValues to use for the parameter called name.",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "value": {}
+                  },
+                  "required": [
+                    "name",
+                    "value"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "pipelineRef": {
+                "description": "PipelineRef is a reference to a pipeline definition\nNote: PipelineRef is in preview mode and not yet supported",
+                "properties": {
+                  "apiVersion": {
+                    "description": "API version of the referent",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+                    "type": "string"
+                  },
+                  "params": {
+                    "description": "Params contains the parameters used to identify the\nreferenced Tekton resource. Example entries might include\n\"repo\" or \"path\" but the set of params ultimately depends on\nthe chosen resolver.",
+                    "items": {
+                      "description": "Param declares an ParamValues to use for the parameter called name.",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "value": {}
+                      },
+                      "required": [
+                        "name",
+                        "value"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "resolver": {
+                    "description": "Resolver is the name of the resolver that should perform\nresolution of the referenced Tekton resource, such as \"git\".",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "pipelineSpec": {
+                "description": "PipelineSpec is a specification of a pipeline\nNote: PipelineSpec is in preview mode and not yet supported\nSpecifying PipelineSpec can be disabled by setting\n`disable-inline-spec` feature flag.\nSee Pipeline.spec (API version: tekton.dev/v1)"
+              },
+              "retries": {
+                "description": "Retries represents how many times this task should be retried in case of task failure: ConditionSucceeded set to False",
+                "type": "integer"
+              },
+              "runAfter": {
+                "description": "RunAfter is the list of PipelineTask names that should be executed before\nthis Task executes. (Used to force a specific ordering in graph execution.)",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "taskRef": {
+                "description": "TaskRef is a reference to a task definition.",
+                "properties": {
+                  "apiVersion": {
+                    "description": "API version of the referent\nNote: A Task with non-empty APIVersion and Kind is considered a Custom Task",
+                    "type": "string"
+                  },
+                  "kind": {
+                    "description": "TaskKind indicates the Kind of the Task:\n1. Namespaced Task when Kind is set to \"Task\". If Kind is \"\", it defaults to \"Task\".\n2. Custom Task when Kind is non-empty and APIVersion is non-empty",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+                    "type": "string"
+                  },
+                  "params": {
+                    "description": "Params contains the parameters used to identify the\nreferenced Tekton resource. Example entries might include\n\"repo\" or \"path\" but the set of params ultimately depends on\nthe chosen resolver.",
+                    "items": {
+                      "description": "Param declares an ParamValues to use for the parameter called name.",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "value": {}
+                      },
+                      "required": [
+                        "name",
+                        "value"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "resolver": {
+                    "description": "Resolver is the name of the resolver that should perform\nresolution of the referenced Tekton resource, such as \"git\".",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "taskSpec": {
+                "description": "TaskSpec is a specification of a task\nSpecifying TaskSpec can be disabled by setting\n`disable-inline-spec` feature flag.\nSee Task.spec (API version: tekton.dev/v1)"
+              },
+              "timeout": {
+                "description": "Duration after which the TaskRun times out. Defaults to 1 hour.\nRefer Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration",
+                "type": "string"
+              },
+              "when": {
+                "description": "When is a list of when expressions that need to be true for the task to run",
+                "items": {
+                  "description": "WhenExpression allows a PipelineTask to declare expressions to be evaluated before the Task is run\nto determine whether the Task should be executed or skipped",
+                  "properties": {
+                    "cel": {
+                      "description": "CEL is a string of Common Language Expression, which can be used to conditionally execute\nthe task based on the result of the expression evaluation\nMore info about CEL syntax: https://github.com/google/cel-spec/blob/master/doc/langdef.md",
+                      "type": "string"
+                    },
+                    "input": {
+                      "description": "Input is the string for guard checking which can be a static input or an output from a parent Task",
+                      "type": "string"
+                    },
+                    "operator": {
+                      "description": "Operator that represents an Input's relationship to the values",
+                      "type": "string"
+                    },
+                    "values": {
+                      "description": "Values is an array of strings, which is compared against the input, for guard checking\nIt must be non-empty",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "workspaces": {
+                "description": "Workspaces maps workspaces from the pipeline spec to the workspaces\ndeclared in the Task.",
+                "items": {
+                  "description": "WorkspacePipelineTaskBinding describes how a workspace passed into the pipeline should be\nmapped to a task's declared workspace.",
+                  "properties": {
+                    "name": {
+                      "description": "Name is the name of the workspace as declared by the task",
+                      "type": "string"
+                    },
+                    "subPath": {
+                      "description": "SubPath is optionally a directory on the volume which should be used\nfor this binding (i.e. the volume will be mounted at this sub directory).",
+                      "type": "string"
+                    },
+                    "workspace": {
+                      "description": "Workspace is the name of the workspace declared by the pipeline",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "params": {
+          "description": "Params declares a list of input parameters that must be supplied when\nthis Pipeline is run.",
+          "items": {
+            "description": "ParamSpec defines arbitrary parameters needed beyond typed inputs (such as\nresources). Parameter values are provided by users as inputs on a TaskRun\nor PipelineRun.",
+            "properties": {
+              "default": {
+                "description": "Default is the value a parameter takes if no input value is supplied. If\ndefault is set, a Task may be executed without a supplied value for the\nparameter."
+              },
+              "description": {
+                "description": "Description is a user-facing description of the parameter that may be\nused to populate a UI.",
+                "type": "string"
+              },
+              "enum": {
+                "description": "Enum declares a set of allowed param input values for tasks/pipelines that can be validated.\nIf Enum is not set, no input validation is performed for the param.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "name": {
+                "description": "Name declares the name by which a parameter is referenced.",
+                "type": "string"
+              },
+              "properties": {
+                "additionalProperties": {
+                  "description": "PropertySpec defines the struct for object keys",
+                  "properties": {
+                    "type": {
+                      "description": "ParamType indicates the type of an input parameter;\nUsed to distinguish between a single string and an array of strings.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "description": "Properties is the JSON Schema properties to support key-value pairs parameter.",
+                "type": "object"
+              },
+              "type": {
+                "description": "Type is the user-specified type of the parameter. The possible types\nare currently \"string\", \"array\" and \"object\", and \"string\" is the default.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "results": {
+          "description": "Results are values that this pipeline can output once run",
+          "items": {
+            "description": "PipelineResult used to describe the results of a pipeline",
+            "properties": {
+              "description": {
+                "description": "Description is a human-readable description of the result",
+                "type": "string"
+              },
+              "name": {
+                "description": "Name the given name",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type is the user-specified type of the result.\nThe possible types are 'string', 'array', and 'object', with 'string' as the default.\n'array' and 'object' types are alpha features.",
+                "type": "string"
+              },
+              "value": {
+                "description": "Value the expression used to retrieve the value"
+              }
+            },
+            "required": [
+              "name",
+              "value"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "tasks": {
+          "description": "Tasks declares the graph of Tasks that execute when this Pipeline is run.",
+          "items": {
+            "description": "PipelineTask defines a task in a Pipeline, passing inputs from both\nParams and from the output of previous tasks.",
+            "properties": {
+              "description": {
+                "description": "Description is the description of this task within the context of a Pipeline.\nThis description may be used to populate a UI.",
+                "type": "string"
+              },
+              "displayName": {
+                "description": "DisplayName is the display name of this task within the context of a Pipeline.\nThis display name may be used to populate a UI.",
+                "type": "string"
+              },
+              "matrix": {
+                "description": "Matrix declares parameters used to fan out this task.",
+                "properties": {
+                  "include": {
+                    "description": "Include is a list of IncludeParams which allows passing in specific combinations of Parameters into the Matrix.",
+                    "items": {
+                      "description": "IncludeParams allows passing in a specific combinations of Parameters into the Matrix.",
+                      "properties": {
+                        "name": {
+                          "description": "Name the specified combination",
+                          "type": "string"
+                        },
+                        "params": {
+                          "description": "Params takes only `Parameters` of type `\"string\"`\nThe names of the `params` must match the names of the `params` in the underlying `Task`",
+                          "items": {
+                            "description": "Param declares an ParamValues to use for the parameter called name.",
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "value": {}
+                            },
+                            "required": [
+                              "name",
+                              "value"
+                            ],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "params": {
+                    "description": "Params is a list of parameters used to fan out the pipelineTask\nParams takes only `Parameters` of type `\"array\"`\nEach array element is supplied to the `PipelineTask` by substituting `params` of type `\"string\"` in the underlying `Task`.\nThe names of the `params` in the `Matrix` must match the names of the `params` in the underlying `Task` that they will be substituting.",
+                    "items": {
+                      "description": "Param declares an ParamValues to use for the parameter called name.",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "value": {}
+                      },
+                      "required": [
+                        "name",
+                        "value"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              },
+              "name": {
+                "description": "Name is the name of this task within the context of a Pipeline. Name is\nused as a coordinate with the `from` and `runAfter` fields to establish\nthe execution order of tasks relative to one another.",
+                "type": "string"
+              },
+              "onError": {
+                "description": "OnError defines the exiting behavior of a PipelineRun on error\ncan be set to [ continue | stopAndFail ]",
+                "type": "string"
+              },
+              "params": {
+                "description": "Parameters declares parameters passed to this task.",
+                "items": {
+                  "description": "Param declares an ParamValues to use for the parameter called name.",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "value": {}
+                  },
+                  "required": [
+                    "name",
+                    "value"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "pipelineRef": {
+                "description": "PipelineRef is a reference to a pipeline definition\nNote: PipelineRef is in preview mode and not yet supported",
+                "properties": {
+                  "apiVersion": {
+                    "description": "API version of the referent",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+                    "type": "string"
+                  },
+                  "params": {
+                    "description": "Params contains the parameters used to identify the\nreferenced Tekton resource. Example entries might include\n\"repo\" or \"path\" but the set of params ultimately depends on\nthe chosen resolver.",
+                    "items": {
+                      "description": "Param declares an ParamValues to use for the parameter called name.",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "value": {}
+                      },
+                      "required": [
+                        "name",
+                        "value"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "resolver": {
+                    "description": "Resolver is the name of the resolver that should perform\nresolution of the referenced Tekton resource, such as \"git\".",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "pipelineSpec": {
+                "description": "PipelineSpec is a specification of a pipeline\nNote: PipelineSpec is in preview mode and not yet supported\nSpecifying PipelineSpec can be disabled by setting\n`disable-inline-spec` feature flag.\nSee Pipeline.spec (API version: tekton.dev/v1)"
+              },
+              "retries": {
+                "description": "Retries represents how many times this task should be retried in case of task failure: ConditionSucceeded set to False",
+                "type": "integer"
+              },
+              "runAfter": {
+                "description": "RunAfter is the list of PipelineTask names that should be executed before\nthis Task executes. (Used to force a specific ordering in graph execution.)",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "taskRef": {
+                "description": "TaskRef is a reference to a task definition.",
+                "properties": {
+                  "apiVersion": {
+                    "description": "API version of the referent\nNote: A Task with non-empty APIVersion and Kind is considered a Custom Task",
+                    "type": "string"
+                  },
+                  "kind": {
+                    "description": "TaskKind indicates the Kind of the Task:\n1. Namespaced Task when Kind is set to \"Task\". If Kind is \"\", it defaults to \"Task\".\n2. Custom Task when Kind is non-empty and APIVersion is non-empty",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+                    "type": "string"
+                  },
+                  "params": {
+                    "description": "Params contains the parameters used to identify the\nreferenced Tekton resource. Example entries might include\n\"repo\" or \"path\" but the set of params ultimately depends on\nthe chosen resolver.",
+                    "items": {
+                      "description": "Param declares an ParamValues to use for the parameter called name.",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "value": {}
+                      },
+                      "required": [
+                        "name",
+                        "value"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "resolver": {
+                    "description": "Resolver is the name of the resolver that should perform\nresolution of the referenced Tekton resource, such as \"git\".",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "taskSpec": {
+                "description": "TaskSpec is a specification of a task\nSpecifying TaskSpec can be disabled by setting\n`disable-inline-spec` feature flag.\nSee Task.spec (API version: tekton.dev/v1)"
+              },
+              "timeout": {
+                "description": "Duration after which the TaskRun times out. Defaults to 1 hour.\nRefer Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration",
+                "type": "string"
+              },
+              "when": {
+                "description": "When is a list of when expressions that need to be true for the task to run",
+                "items": {
+                  "description": "WhenExpression allows a PipelineTask to declare expressions to be evaluated before the Task is run\nto determine whether the Task should be executed or skipped",
+                  "properties": {
+                    "cel": {
+                      "description": "CEL is a string of Common Language Expression, which can be used to conditionally execute\nthe task based on the result of the expression evaluation\nMore info about CEL syntax: https://github.com/google/cel-spec/blob/master/doc/langdef.md",
+                      "type": "string"
+                    },
+                    "input": {
+                      "description": "Input is the string for guard checking which can be a static input or an output from a parent Task",
+                      "type": "string"
+                    },
+                    "operator": {
+                      "description": "Operator that represents an Input's relationship to the values",
+                      "type": "string"
+                    },
+                    "values": {
+                      "description": "Values is an array of strings, which is compared against the input, for guard checking\nIt must be non-empty",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "workspaces": {
+                "description": "Workspaces maps workspaces from the pipeline spec to the workspaces\ndeclared in the Task.",
+                "items": {
+                  "description": "WorkspacePipelineTaskBinding describes how a workspace passed into the pipeline should be\nmapped to a task's declared workspace.",
+                  "properties": {
+                    "name": {
+                      "description": "Name is the name of the workspace as declared by the task",
+                      "type": "string"
+                    },
+                    "subPath": {
+                      "description": "SubPath is optionally a directory on the volume which should be used\nfor this binding (i.e. the volume will be mounted at this sub directory).",
+                      "type": "string"
+                    },
+                    "workspace": {
+                      "description": "Workspace is the name of the workspace declared by the pipeline",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "workspaces": {
+          "description": "Workspaces declares a set of named workspaces that are expected to be\nprovided by a PipelineRun.",
+          "items": {
+            "description": "PipelineWorkspaceDeclaration creates a named slot in a Pipeline that a PipelineRun\nis expected to populate with a workspace binding.",
+            "properties": {
+              "description": {
+                "description": "Description is a human readable string describing how the workspace will be\nused in the Pipeline. It can be useful to include a bit of detail about which\ntasks are intended to have access to the data on the workspace.",
+                "type": "string"
+              },
+              "name": {
+                "description": "Name is the name of a workspace to be provided by a PipelineRun.",
+                "type": "string"
+              },
+              "optional": {
+                "description": "Optional marks a Workspace as not being required in PipelineRuns. By default\nthis field is false and so declared workspaces are required.",
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "title": "Tekton Pipeline v1",
+  "type": "object"
+}

--- a/schema/v1/pipelinerun.json
+++ b/schema/v1/pipelinerun.json
@@ -1,0 +1,1876 @@
+{
+  "$id": "https://tekton.dev/schemas/v1/pipelinerun.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "PipelineRun represents a single execution of a Pipeline. PipelineRuns are how\nthe graph of Tasks declared in a Pipeline are executed; they specify inputs\nto Pipelines such as parameter values and capture operational aspects of the\nTasks execution such as service account and tolerations. Creating a\nPipelineRun creates TaskRuns for Tasks in the referenced Pipeline.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "PipelineRunSpec defines the desired state of PipelineRun",
+      "properties": {
+        "managedBy": {
+          "description": "ManagedBy indicates which controller is responsible for reconciling\nthis resource. If unset or set to \"tekton.dev/pipeline\", the default\nTekton controller will manage this resource.\nThis field is immutable.",
+          "type": "string"
+        },
+        "params": {
+          "description": "Params is a list of parameter names and values.",
+          "items": {
+            "description": "Param declares an ParamValues to use for the parameter called name.",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "value": {}
+            },
+            "required": [
+              "name",
+              "value"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "pipelineRef": {
+          "description": "PipelineRef can be used to refer to a specific instance of a Pipeline.",
+          "properties": {
+            "apiVersion": {
+              "description": "API version of the referent",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+              "type": "string"
+            },
+            "params": {
+              "description": "Params contains the parameters used to identify the\nreferenced Tekton resource. Example entries might include\n\"repo\" or \"path\" but the set of params ultimately depends on\nthe chosen resolver.",
+              "items": {
+                "description": "Param declares an ParamValues to use for the parameter called name.",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "value": {}
+                },
+                "required": [
+                  "name",
+                  "value"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "resolver": {
+              "description": "Resolver is the name of the resolver that should perform\nresolution of the referenced Tekton resource, such as \"git\".",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "pipelineSpec": {
+          "description": "Specifying PipelineSpec can be disabled by setting\n`disable-inline-spec` feature flag.\nSee Pipeline.spec (API version: tekton.dev/v1)"
+        },
+        "status": {
+          "description": "Used for cancelling a pipelinerun (and maybe more later on)",
+          "type": "string"
+        },
+        "taskRunSpecs": {
+          "description": "TaskRunSpecs holds a set of runtime specs",
+          "items": {
+            "description": "PipelineTaskRunSpec  can be used to configure specific\nspecs for a concrete Task",
+            "properties": {
+              "computeResources": {
+                "description": "Compute resources to use for this TaskRun",
+                "properties": {
+                  "claims": {
+                    "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                    "items": {
+                      "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                      "properties": {
+                        "name": {
+                          "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                          "type": "string"
+                        },
+                        "request": {
+                          "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "limits": {
+                    "additionalProperties": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                    },
+                    "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                    "type": "object"
+                  },
+                  "requests": {
+                    "additionalProperties": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                    },
+                    "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                    "type": "object"
+                  }
+                },
+                "type": "object"
+              },
+              "metadata": {
+                "description": "PipelineTaskMetadata contains the labels or annotations for an EmbeddedTask",
+                "properties": {
+                  "annotations": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "type": "object"
+                  },
+                  "labels": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "type": "object"
+                  }
+                },
+                "type": "object"
+              },
+              "pipelineTaskName": {
+                "type": "string"
+              },
+              "podTemplate": {
+                "description": "PodTemplate holds pod specific configuration",
+                "properties": {
+                  "affinity": {
+                    "description": "If specified, the pod's scheduling constraints.\nSee Pod.spec.affinity (API version: v1)"
+                  },
+                  "automountServiceAccountToken": {
+                    "description": "AutomountServiceAccountToken indicates whether pods running as this\nservice account should have an API token automatically mounted.",
+                    "type": "boolean"
+                  },
+                  "dnsConfig": {
+                    "description": "Specifies the DNS parameters of a pod.\nParameters specified here will be merged to the generated DNS\nconfiguration based on DNSPolicy.",
+                    "properties": {
+                      "nameservers": {
+                        "description": "A list of DNS name server IP addresses.\nThis will be appended to the base nameservers generated from DNSPolicy.\nDuplicated nameservers will be removed.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "options": {
+                        "description": "A list of DNS resolver options.\nThis will be merged with the base options generated from DNSPolicy.\nDuplicated entries will be removed. Resolution options given in Options\nwill override those that appear in the base DNSPolicy.",
+                        "items": {
+                          "description": "PodDNSConfigOption defines DNS resolver options of a pod.",
+                          "properties": {
+                            "name": {
+                              "description": "Name is this DNS resolver option's name.\nRequired.",
+                              "type": "string"
+                            },
+                            "value": {
+                              "description": "Value is this DNS resolver option's value.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "searches": {
+                        "description": "A list of DNS search domains for host-name lookup.\nThis will be appended to the base search paths generated from DNSPolicy.\nDuplicated search paths will be removed.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "dnsPolicy": {
+                    "description": "Set DNS policy for the pod. Defaults to \"ClusterFirst\". Valid values are\n'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig\nwill be merged with the policy selected with DNSPolicy.",
+                    "type": "string"
+                  },
+                  "enableServiceLinks": {
+                    "description": "EnableServiceLinks indicates whether information about services should be injected into pod's\nenvironment variables, matching the syntax of Docker links.\nOptional: Defaults to true.",
+                    "type": "boolean"
+                  },
+                  "env": {
+                    "description": "List of environment variables that can be provided to the containers belonging to the pod.",
+                    "items": {
+                      "description": "EnvVar represents an environment variable present in a Container.",
+                      "properties": {
+                        "name": {
+                          "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                          "type": "string"
+                        },
+                        "value": {
+                          "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
+                          "type": "string"
+                        },
+                        "valueFrom": {
+                          "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                          "properties": {
+                            "configMapKeyRef": {
+                              "description": "Selects a key of a ConfigMap.",
+                              "properties": {
+                                "key": {
+                                  "description": "The key to select.",
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "default": "",
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "description": "Specify whether the ConfigMap or its key must be defined",
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object"
+                            },
+                            "fieldRef": {
+                              "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['\u003cKEY\u003e']`, `metadata.annotations['\u003cKEY\u003e']`,\nspec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                              "properties": {
+                                "apiVersion": {
+                                  "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                  "type": "string"
+                                },
+                                "fieldPath": {
+                                  "description": "Path of the field to select in the specified API version.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "fieldPath"
+                              ],
+                              "type": "object"
+                            },
+                            "resourceFieldRef": {
+                              "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                              "properties": {
+                                "containerName": {
+                                  "description": "Container name: required for volumes, optional for env vars",
+                                  "type": "string"
+                                },
+                                "divisor": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                                },
+                                "resource": {
+                                  "description": "Required: resource to select",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "resource"
+                              ],
+                              "type": "object"
+                            },
+                            "secretKeyRef": {
+                              "description": "Selects a key of a secret in the pod's namespace",
+                              "properties": {
+                                "key": {
+                                  "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "default": "",
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "description": "Specify whether the Secret or its key must be defined",
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "hostAliases": {
+                    "description": "HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts\nfile if specified. This is only valid for non-hostNetwork pods.",
+                    "items": {
+                      "description": "HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the\npod's hosts file.",
+                      "properties": {
+                        "hostnames": {
+                          "description": "Hostnames for the above IP address.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "ip": {
+                          "description": "IP address of the host file entry.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "ip"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "hostNetwork": {
+                    "description": "HostNetwork specifies whether the pod may use the node network namespace",
+                    "type": "boolean"
+                  },
+                  "hostUsers": {
+                    "description": "HostUsers indicates whether the pod will use the host's user namespace.\nOptional: Default to true.\nIf set to true or not present, the pod will be run in the host user namespace, useful\nfor when the pod needs a feature only available to the host user namespace, such as\nloading a kernel module with CAP_SYS_MODULE.\nWhen set to false, a new user namespace is created for the pod. Setting false\nis useful to mitigating container breakout vulnerabilities such as allowing\ncontainers to run as root without their user having root privileges on the host.\nThis field depends on the kubernetes feature gate UserNamespacesSupport being enabled.",
+                    "type": "boolean"
+                  },
+                  "imagePullSecrets": {
+                    "description": "ImagePullSecrets gives the name of the secret used by the pod to pull the image if specified",
+                    "items": {
+                      "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                      "properties": {
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "nodeSelector": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "NodeSelector is a selector which must be true for the pod to fit on a node.\nSelector which must match a node's labels for the pod to be scheduled on that node.\nMore info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/",
+                    "type": "object"
+                  },
+                  "priorityClassName": {
+                    "description": "If specified, indicates the pod's priority. \"system-node-critical\" and\n\"system-cluster-critical\" are two special keywords which indicate the\nhighest priorities with the former being the highest priority. Any other\nname must be defined by creating a PriorityClass object with that name.\nIf not specified, the pod priority will be default or zero if there is no\ndefault.",
+                    "type": "string"
+                  },
+                  "runtimeClassName": {
+                    "description": "RuntimeClassName refers to a RuntimeClass object in the node.k8s.io\ngroup, which should be used to run this pod. If no RuntimeClass resource\nmatches the named class, the pod will not be run. If unset or empty, the\n\"legacy\" RuntimeClass will be used, which is an implicit class with an\nempty definition that uses the default runtime handler.\nMore info: https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md\nThis is a beta feature as of Kubernetes v1.14.",
+                    "type": "string"
+                  },
+                  "schedulerName": {
+                    "description": "SchedulerName specifies the scheduler to be used to dispatch the Pod",
+                    "type": "string"
+                  },
+                  "securityContext": {
+                    "description": "SecurityContext holds pod-level security attributes and common container settings.\nOptional: Defaults to empty.  See type description for default values of each field.\nSee Pod.spec.securityContext (API version: v1)"
+                  },
+                  "tolerations": {
+                    "description": "If specified, the pod's tolerations.",
+                    "items": {
+                      "description": "The pod this Toleration is attached to tolerates any taint that matches\nthe triple \u003ckey,value,effect\u003e using the matching operator \u003coperator\u003e.",
+                      "properties": {
+                        "effect": {
+                          "description": "Effect indicates the taint effect to match. Empty means match all taint effects.\nWhen specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                          "type": "string"
+                        },
+                        "key": {
+                          "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys.\nIf the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                          "type": "string"
+                        },
+                        "operator": {
+                          "description": "Operator represents a key's relationship to the value.\nValid operators are Exists and Equal. Defaults to Equal.\nExists is equivalent to wildcard for value, so that a pod can\ntolerate all taints of a particular category.",
+                          "type": "string"
+                        },
+                        "tolerationSeconds": {
+                          "description": "TolerationSeconds represents the period of time the toleration (which must be\nof effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,\nit is not set, which means tolerate the taint forever (do not evict). Zero and\nnegative values will be treated as 0 (evict immediately) by the system.",
+                          "format": "int64",
+                          "type": "integer"
+                        },
+                        "value": {
+                          "description": "Value is the taint value the toleration matches to.\nIf the operator is Exists, the value should be empty, otherwise just a regular string.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "topologySpreadConstraints": {
+                    "description": "TopologySpreadConstraints controls how Pods are spread across your cluster among\nfailure-domains such as regions, zones, nodes, and other user-defined topology domains.",
+                    "items": {
+                      "description": "TopologySpreadConstraint specifies how to spread matching pods among the given topology.",
+                      "properties": {
+                        "labelSelector": {
+                          "description": "LabelSelector is used to find matching pods.\nPods that match this label selector are counted to determine the number of pods\nin their corresponding topology domain.",
+                          "properties": {
+                            "matchExpressions": {
+                              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                              "items": {
+                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                "properties": {
+                                  "key": {
+                                    "description": "key is the label key that the selector applies to.",
+                                    "type": "string"
+                                  },
+                                  "operator": {
+                                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                    "type": "string"
+                                  },
+                                  "values": {
+                                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "operator"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "matchLabels": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "matchLabelKeys": {
+                          "description": "MatchLabelKeys is a set of pod label keys to select the pods over which\nspreading will be calculated. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are ANDed with labelSelector\nto select the group of existing pods over which spreading will be calculated\nfor the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.\nMatchLabelKeys cannot be set when LabelSelector isn't set.\nKeys that don't exist in the incoming pod labels will\nbe ignored. A null or empty list means only match against labelSelector.\n\nThis is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "maxSkew": {
+                          "description": "MaxSkew describes the degree to which pods may be unevenly distributed.\nWhen `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference\nbetween the number of matching pods in the target topology and the global minimum.\nThe global minimum is the minimum number of matching pods in an eligible domain\nor zero if the number of eligible domains is less than MinDomains.\nFor example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same\nlabelSelector spread as 2/2/1:\nIn this case, the global minimum is 1.\n| zone1 | zone2 | zone3 |\n|  P P  |  P P  |   P   |\n- if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;\nscheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)\nviolate MaxSkew(1).\n- if MaxSkew is 2, incoming pod can be scheduled onto any zone.\nWhen `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence\nto topologies that satisfy it.\nIt's a required field. Default value is 1 and 0 is not allowed.",
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "minDomains": {
+                          "description": "MinDomains indicates a minimum number of eligible domains.\nWhen the number of eligible domains with matching topology keys is less than minDomains,\nPod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed.\nAnd when the number of eligible domains with matching topology keys equals or greater than minDomains,\nthis value has no effect on scheduling.\nAs a result, when the number of eligible domains is less than minDomains,\nscheduler won't schedule more than maxSkew Pods to those domains.\nIf value is nil, the constraint behaves as if MinDomains is equal to 1.\nValid values are integers greater than 0.\nWhen value is not nil, WhenUnsatisfiable must be DoNotSchedule.\n\nFor example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same\nlabelSelector spread as 2/2/2:\n| zone1 | zone2 | zone3 |\n|  P P  |  P P  |  P P  |\nThe number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0.\nIn this situation, new pod with the same labelSelector cannot be scheduled,\nbecause computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,\nit will violate MaxSkew.",
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "nodeAffinityPolicy": {
+                          "description": "NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector\nwhen calculating pod topology spread skew. Options are:\n- Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.\n- Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.\n\nIf this value is nil, the behavior is equivalent to the Honor policy.\nThis is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.",
+                          "type": "string"
+                        },
+                        "nodeTaintsPolicy": {
+                          "description": "NodeTaintsPolicy indicates how we will treat node taints when calculating\npod topology spread skew. Options are:\n- Honor: nodes without taints, along with tainted nodes for which the incoming pod\nhas a toleration, are included.\n- Ignore: node taints are ignored. All nodes are included.\n\nIf this value is nil, the behavior is equivalent to the Ignore policy.\nThis is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.",
+                          "type": "string"
+                        },
+                        "topologyKey": {
+                          "description": "TopologyKey is the key of node labels. Nodes that have a label with this key\nand identical values are considered to be in the same topology.\nWe consider each \u003ckey, value\u003e as a \"bucket\", and try to put balanced number\nof pods into each bucket.\nWe define a domain as a particular instance of a topology.\nAlso, we define an eligible domain as a domain whose nodes meet the requirements of\nnodeAffinityPolicy and nodeTaintsPolicy.\ne.g. If TopologyKey is \"kubernetes.io/hostname\", each Node is a domain of that topology.\nAnd, if TopologyKey is \"topology.kubernetes.io/zone\", each zone is a domain of that topology.\nIt's a required field.",
+                          "type": "string"
+                        },
+                        "whenUnsatisfiable": {
+                          "description": "WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy\nthe spread constraint.\n- DoNotSchedule (default) tells the scheduler not to schedule it.\n- ScheduleAnyway tells the scheduler to schedule the pod in any location,\n  but giving higher precedence to topologies that would help reduce the\n  skew.\nA constraint is considered \"Unsatisfiable\" for an incoming pod\nif and only if every possible node assignment for that pod would violate\n\"MaxSkew\" on some topology.\nFor example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same\nlabelSelector spread as 3/1/1:\n| zone1 | zone2 | zone3 |\n| P P P |   P   |   P   |\nIf WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled\nto zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies\nMaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler\nwon't make it *more* imbalanced.\nIt's a required field.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "maxSkew",
+                        "topologyKey",
+                        "whenUnsatisfiable"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "volumes": {
+                    "description": "List of volumes that can be mounted by containers belonging to the pod.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes\nSee Pod.spec.volumes (API version: v1)"
+                  }
+                },
+                "type": "object"
+              },
+              "serviceAccountName": {
+                "type": "string"
+              },
+              "sidecarSpecs": {
+                "items": {
+                  "description": "TaskRunSidecarSpec is used to override the values of a Sidecar in the corresponding Task.",
+                  "properties": {
+                    "computeResources": {
+                      "description": "The resource requirements to apply to the Sidecar.",
+                      "properties": {
+                        "claims": {
+                          "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                          "items": {
+                            "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                            "properties": {
+                              "name": {
+                                "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                                "type": "string"
+                              },
+                              "request": {
+                                "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "limits": {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                          },
+                          "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                          "type": "object"
+                        },
+                        "requests": {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                          },
+                          "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "name": {
+                      "description": "The name of the Sidecar to override.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "computeResources",
+                    "name"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "stepSpecs": {
+                "items": {
+                  "description": "TaskRunStepSpec is used to override the values of a Step in the corresponding Task.",
+                  "properties": {
+                    "computeResources": {
+                      "description": "The resource requirements to apply to the Step.",
+                      "properties": {
+                        "claims": {
+                          "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                          "items": {
+                            "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                            "properties": {
+                              "name": {
+                                "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                                "type": "string"
+                              },
+                              "request": {
+                                "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "limits": {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                          },
+                          "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                          "type": "object"
+                        },
+                        "requests": {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                          },
+                          "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "name": {
+                      "description": "The name of the Step to override.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "computeResources",
+                    "name"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "timeout": {
+                "description": "Duration after which the TaskRun times out. Overrides the timeout specified\non the Task's spec if specified. Takes lower precedence to PipelineRun's\n`spec.timeouts.tasks`\nRefer Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "taskRunTemplate": {
+          "description": "TaskRunTemplate represent template of taskrun",
+          "properties": {
+            "podTemplate": {
+              "description": "PodTemplate holds pod specific configuration",
+              "properties": {
+                "affinity": {
+                  "description": "If specified, the pod's scheduling constraints.\nSee Pod.spec.affinity (API version: v1)"
+                },
+                "automountServiceAccountToken": {
+                  "description": "AutomountServiceAccountToken indicates whether pods running as this\nservice account should have an API token automatically mounted.",
+                  "type": "boolean"
+                },
+                "dnsConfig": {
+                  "description": "Specifies the DNS parameters of a pod.\nParameters specified here will be merged to the generated DNS\nconfiguration based on DNSPolicy.",
+                  "properties": {
+                    "nameservers": {
+                      "description": "A list of DNS name server IP addresses.\nThis will be appended to the base nameservers generated from DNSPolicy.\nDuplicated nameservers will be removed.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "options": {
+                      "description": "A list of DNS resolver options.\nThis will be merged with the base options generated from DNSPolicy.\nDuplicated entries will be removed. Resolution options given in Options\nwill override those that appear in the base DNSPolicy.",
+                      "items": {
+                        "description": "PodDNSConfigOption defines DNS resolver options of a pod.",
+                        "properties": {
+                          "name": {
+                            "description": "Name is this DNS resolver option's name.\nRequired.",
+                            "type": "string"
+                          },
+                          "value": {
+                            "description": "Value is this DNS resolver option's value.",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "searches": {
+                      "description": "A list of DNS search domains for host-name lookup.\nThis will be appended to the base search paths generated from DNSPolicy.\nDuplicated search paths will be removed.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                },
+                "dnsPolicy": {
+                  "description": "Set DNS policy for the pod. Defaults to \"ClusterFirst\". Valid values are\n'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig\nwill be merged with the policy selected with DNSPolicy.",
+                  "type": "string"
+                },
+                "enableServiceLinks": {
+                  "description": "EnableServiceLinks indicates whether information about services should be injected into pod's\nenvironment variables, matching the syntax of Docker links.\nOptional: Defaults to true.",
+                  "type": "boolean"
+                },
+                "env": {
+                  "description": "List of environment variables that can be provided to the containers belonging to the pod.",
+                  "items": {
+                    "description": "EnvVar represents an environment variable present in a Container.",
+                    "properties": {
+                      "name": {
+                        "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
+                        "type": "string"
+                      },
+                      "valueFrom": {
+                        "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                        "properties": {
+                          "configMapKeyRef": {
+                            "description": "Selects a key of a ConfigMap.",
+                            "properties": {
+                              "key": {
+                                "description": "The key to select.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "default": "",
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the ConfigMap or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object"
+                          },
+                          "fieldRef": {
+                            "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['\u003cKEY\u003e']`, `metadata.annotations['\u003cKEY\u003e']`,\nspec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                            "properties": {
+                              "apiVersion": {
+                                "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                "type": "string"
+                              },
+                              "fieldPath": {
+                                "description": "Path of the field to select in the specified API version.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "fieldPath"
+                            ],
+                            "type": "object"
+                          },
+                          "resourceFieldRef": {
+                            "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                            "properties": {
+                              "containerName": {
+                                "description": "Container name: required for volumes, optional for env vars",
+                                "type": "string"
+                              },
+                              "divisor": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                              },
+                              "resource": {
+                                "description": "Required: resource to select",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "resource"
+                            ],
+                            "type": "object"
+                          },
+                          "secretKeyRef": {
+                            "description": "Selects a key of a secret in the pod's namespace",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "default": "",
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "hostAliases": {
+                  "description": "HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts\nfile if specified. This is only valid for non-hostNetwork pods.",
+                  "items": {
+                    "description": "HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the\npod's hosts file.",
+                    "properties": {
+                      "hostnames": {
+                        "description": "Hostnames for the above IP address.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "ip": {
+                        "description": "IP address of the host file entry.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "ip"
+                    ],
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "hostNetwork": {
+                  "description": "HostNetwork specifies whether the pod may use the node network namespace",
+                  "type": "boolean"
+                },
+                "hostUsers": {
+                  "description": "HostUsers indicates whether the pod will use the host's user namespace.\nOptional: Default to true.\nIf set to true or not present, the pod will be run in the host user namespace, useful\nfor when the pod needs a feature only available to the host user namespace, such as\nloading a kernel module with CAP_SYS_MODULE.\nWhen set to false, a new user namespace is created for the pod. Setting false\nis useful to mitigating container breakout vulnerabilities such as allowing\ncontainers to run as root without their user having root privileges on the host.\nThis field depends on the kubernetes feature gate UserNamespacesSupport being enabled.",
+                  "type": "boolean"
+                },
+                "imagePullSecrets": {
+                  "description": "ImagePullSecrets gives the name of the secret used by the pod to pull the image if specified",
+                  "items": {
+                    "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                    "properties": {
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "nodeSelector": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "NodeSelector is a selector which must be true for the pod to fit on a node.\nSelector which must match a node's labels for the pod to be scheduled on that node.\nMore info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/",
+                  "type": "object"
+                },
+                "priorityClassName": {
+                  "description": "If specified, indicates the pod's priority. \"system-node-critical\" and\n\"system-cluster-critical\" are two special keywords which indicate the\nhighest priorities with the former being the highest priority. Any other\nname must be defined by creating a PriorityClass object with that name.\nIf not specified, the pod priority will be default or zero if there is no\ndefault.",
+                  "type": "string"
+                },
+                "runtimeClassName": {
+                  "description": "RuntimeClassName refers to a RuntimeClass object in the node.k8s.io\ngroup, which should be used to run this pod. If no RuntimeClass resource\nmatches the named class, the pod will not be run. If unset or empty, the\n\"legacy\" RuntimeClass will be used, which is an implicit class with an\nempty definition that uses the default runtime handler.\nMore info: https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md\nThis is a beta feature as of Kubernetes v1.14.",
+                  "type": "string"
+                },
+                "schedulerName": {
+                  "description": "SchedulerName specifies the scheduler to be used to dispatch the Pod",
+                  "type": "string"
+                },
+                "securityContext": {
+                  "description": "SecurityContext holds pod-level security attributes and common container settings.\nOptional: Defaults to empty.  See type description for default values of each field.\nSee Pod.spec.securityContext (API version: v1)"
+                },
+                "tolerations": {
+                  "description": "If specified, the pod's tolerations.",
+                  "items": {
+                    "description": "The pod this Toleration is attached to tolerates any taint that matches\nthe triple \u003ckey,value,effect\u003e using the matching operator \u003coperator\u003e.",
+                    "properties": {
+                      "effect": {
+                        "description": "Effect indicates the taint effect to match. Empty means match all taint effects.\nWhen specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                        "type": "string"
+                      },
+                      "key": {
+                        "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys.\nIf the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                        "type": "string"
+                      },
+                      "operator": {
+                        "description": "Operator represents a key's relationship to the value.\nValid operators are Exists and Equal. Defaults to Equal.\nExists is equivalent to wildcard for value, so that a pod can\ntolerate all taints of a particular category.",
+                        "type": "string"
+                      },
+                      "tolerationSeconds": {
+                        "description": "TolerationSeconds represents the period of time the toleration (which must be\nof effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,\nit is not set, which means tolerate the taint forever (do not evict). Zero and\nnegative values will be treated as 0 (evict immediately) by the system.",
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "value": {
+                        "description": "Value is the taint value the toleration matches to.\nIf the operator is Exists, the value should be empty, otherwise just a regular string.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "topologySpreadConstraints": {
+                  "description": "TopologySpreadConstraints controls how Pods are spread across your cluster among\nfailure-domains such as regions, zones, nodes, and other user-defined topology domains.",
+                  "items": {
+                    "description": "TopologySpreadConstraint specifies how to spread matching pods among the given topology.",
+                    "properties": {
+                      "labelSelector": {
+                        "description": "LabelSelector is used to find matching pods.\nPods that match this label selector are counted to determine the number of pods\nin their corresponding topology domain.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "matchLabelKeys": {
+                        "description": "MatchLabelKeys is a set of pod label keys to select the pods over which\nspreading will be calculated. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are ANDed with labelSelector\nto select the group of existing pods over which spreading will be calculated\nfor the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.\nMatchLabelKeys cannot be set when LabelSelector isn't set.\nKeys that don't exist in the incoming pod labels will\nbe ignored. A null or empty list means only match against labelSelector.\n\nThis is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "maxSkew": {
+                        "description": "MaxSkew describes the degree to which pods may be unevenly distributed.\nWhen `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference\nbetween the number of matching pods in the target topology and the global minimum.\nThe global minimum is the minimum number of matching pods in an eligible domain\nor zero if the number of eligible domains is less than MinDomains.\nFor example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same\nlabelSelector spread as 2/2/1:\nIn this case, the global minimum is 1.\n| zone1 | zone2 | zone3 |\n|  P P  |  P P  |   P   |\n- if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;\nscheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)\nviolate MaxSkew(1).\n- if MaxSkew is 2, incoming pod can be scheduled onto any zone.\nWhen `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence\nto topologies that satisfy it.\nIt's a required field. Default value is 1 and 0 is not allowed.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "minDomains": {
+                        "description": "MinDomains indicates a minimum number of eligible domains.\nWhen the number of eligible domains with matching topology keys is less than minDomains,\nPod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed.\nAnd when the number of eligible domains with matching topology keys equals or greater than minDomains,\nthis value has no effect on scheduling.\nAs a result, when the number of eligible domains is less than minDomains,\nscheduler won't schedule more than maxSkew Pods to those domains.\nIf value is nil, the constraint behaves as if MinDomains is equal to 1.\nValid values are integers greater than 0.\nWhen value is not nil, WhenUnsatisfiable must be DoNotSchedule.\n\nFor example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same\nlabelSelector spread as 2/2/2:\n| zone1 | zone2 | zone3 |\n|  P P  |  P P  |  P P  |\nThe number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0.\nIn this situation, new pod with the same labelSelector cannot be scheduled,\nbecause computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,\nit will violate MaxSkew.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "nodeAffinityPolicy": {
+                        "description": "NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector\nwhen calculating pod topology spread skew. Options are:\n- Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.\n- Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.\n\nIf this value is nil, the behavior is equivalent to the Honor policy.\nThis is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.",
+                        "type": "string"
+                      },
+                      "nodeTaintsPolicy": {
+                        "description": "NodeTaintsPolicy indicates how we will treat node taints when calculating\npod topology spread skew. Options are:\n- Honor: nodes without taints, along with tainted nodes for which the incoming pod\nhas a toleration, are included.\n- Ignore: node taints are ignored. All nodes are included.\n\nIf this value is nil, the behavior is equivalent to the Ignore policy.\nThis is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.",
+                        "type": "string"
+                      },
+                      "topologyKey": {
+                        "description": "TopologyKey is the key of node labels. Nodes that have a label with this key\nand identical values are considered to be in the same topology.\nWe consider each \u003ckey, value\u003e as a \"bucket\", and try to put balanced number\nof pods into each bucket.\nWe define a domain as a particular instance of a topology.\nAlso, we define an eligible domain as a domain whose nodes meet the requirements of\nnodeAffinityPolicy and nodeTaintsPolicy.\ne.g. If TopologyKey is \"kubernetes.io/hostname\", each Node is a domain of that topology.\nAnd, if TopologyKey is \"topology.kubernetes.io/zone\", each zone is a domain of that topology.\nIt's a required field.",
+                        "type": "string"
+                      },
+                      "whenUnsatisfiable": {
+                        "description": "WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy\nthe spread constraint.\n- DoNotSchedule (default) tells the scheduler not to schedule it.\n- ScheduleAnyway tells the scheduler to schedule the pod in any location,\n  but giving higher precedence to topologies that would help reduce the\n  skew.\nA constraint is considered \"Unsatisfiable\" for an incoming pod\nif and only if every possible node assignment for that pod would violate\n\"MaxSkew\" on some topology.\nFor example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same\nlabelSelector spread as 3/1/1:\n| zone1 | zone2 | zone3 |\n| P P P |   P   |   P   |\nIf WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled\nto zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies\nMaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler\nwon't make it *more* imbalanced.\nIt's a required field.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "maxSkew",
+                      "topologyKey",
+                      "whenUnsatisfiable"
+                    ],
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "volumes": {
+                  "description": "List of volumes that can be mounted by containers belonging to the pod.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes\nSee Pod.spec.volumes (API version: v1)"
+                }
+              },
+              "type": "object"
+            },
+            "serviceAccountName": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "timeouts": {
+          "description": "Time after which the Pipeline times out.\nCurrently three keys are accepted in the map\npipeline, tasks and finally\nwith Timeouts.pipeline \u003e= Timeouts.tasks + Timeouts.finally",
+          "properties": {
+            "finally": {
+              "description": "Finally sets the maximum allowed duration of this pipeline's finally",
+              "type": "string"
+            },
+            "pipeline": {
+              "description": "Pipeline sets the maximum allowed duration for execution of the entire pipeline. The sum of individual timeouts for tasks and finally must not exceed this value.",
+              "type": "string"
+            },
+            "tasks": {
+              "description": "Tasks sets the maximum allowed duration of this pipeline's tasks",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "workspaces": {
+          "description": "Workspaces holds a set of workspace bindings that must match names\nwith those declared in the pipeline.",
+          "items": {
+            "description": "WorkspaceBinding maps a Task's declared workspace to a Volume.",
+            "properties": {
+              "configMap": {
+                "description": "ConfigMap represents a configMap that should populate this workspace.",
+                "properties": {
+                  "defaultMode": {
+                    "description": "defaultMode is optional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDefaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "items": {
+                    "description": "items if unspecified, each key-value pair in the Data field of the referenced\nConfigMap will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the ConfigMap,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                    "items": {
+                      "description": "Maps a string key to a path within a volume.",
+                      "properties": {
+                        "key": {
+                          "description": "key is the key to project.",
+                          "type": "string"
+                        },
+                        "mode": {
+                          "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "path": {
+                          "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "key",
+                        "path"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "name": {
+                    "default": "",
+                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                    "type": "string"
+                  },
+                  "optional": {
+                    "description": "optional specify whether the ConfigMap or its keys must be defined",
+                    "type": "boolean"
+                  }
+                },
+                "type": "object"
+              },
+              "csi": {
+                "description": "CSI (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers.",
+                "properties": {
+                  "driver": {
+                    "description": "driver is the name of the CSI driver that handles this volume.\nConsult with your admin for the correct name as registered in the cluster.",
+                    "type": "string"
+                  },
+                  "fsType": {
+                    "description": "fsType to mount. Ex. \"ext4\", \"xfs\", \"ntfs\".\nIf not provided, the empty value is passed to the associated CSI driver\nwhich will determine the default filesystem to apply.",
+                    "type": "string"
+                  },
+                  "nodePublishSecretRef": {
+                    "description": "nodePublishSecretRef is a reference to the secret object containing\nsensitive information to pass to the CSI driver to complete the CSI\nNodePublishVolume and NodeUnpublishVolume calls.\nThis field is optional, and  may be empty if no secret is required. If the\nsecret object contains more than one secret, all secret references are passed.",
+                    "properties": {
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "readOnly": {
+                    "description": "readOnly specifies a read-only configuration for the volume.\nDefaults to false (read/write).",
+                    "type": "boolean"
+                  },
+                  "volumeAttributes": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "volumeAttributes stores driver-specific properties that are passed to the CSI\ndriver. Consult your driver's documentation for supported values.",
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "driver"
+                ],
+                "type": "object"
+              },
+              "emptyDir": {
+                "description": "EmptyDir represents a temporary directory that shares a Task's lifetime.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir\nEither this OR PersistentVolumeClaim can be used.",
+                "properties": {
+                  "medium": {
+                    "description": "medium represents what type of storage medium should back this directory.\nThe default is \"\" which means to use the node's default medium.\nMust be an empty string (default) or Memory.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                    "type": "string"
+                  },
+                  "sizeLimit": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "description": "sizeLimit is the total amount of local storage required for this EmptyDir volume.\nThe size limit is also applicable for memory medium.\nThe maximum usage on memory medium EmptyDir would be the minimum value between\nthe SizeLimit specified here and the sum of memory limits of all containers in a pod.\nThe default is nil which means that the limit is undefined.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                  }
+                },
+                "type": "object"
+              },
+              "name": {
+                "description": "Name is the name of the workspace populated by the volume.",
+                "type": "string"
+              },
+              "persistentVolumeClaim": {
+                "description": "PersistentVolumeClaimVolumeSource represents a reference to a\nPersistentVolumeClaim in the same namespace. Either this OR EmptyDir can be used.",
+                "properties": {
+                  "claimName": {
+                    "description": "claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "readOnly Will force the ReadOnly setting in VolumeMounts.\nDefault false.",
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "claimName"
+                ],
+                "type": "object"
+              },
+              "projected": {
+                "description": "Projected represents a projected volume that should populate this workspace.",
+                "properties": {
+                  "defaultMode": {
+                    "description": "defaultMode are the mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "sources": {
+                    "description": "sources is the list of volume projections. Each entry in this list\nhandles one source.",
+                    "items": {
+                      "description": "Projection that may be projected along with other supported volume types.\nExactly one of these fields must be set.",
+                      "properties": {
+                        "clusterTrustBundle": {
+                          "description": "ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field\nof ClusterTrustBundle objects in an auto-updating file.\n\nAlpha, gated by the ClusterTrustBundleProjection feature gate.\n\nClusterTrustBundle objects can either be selected by name, or by the\ncombination of signer name and a label selector.\n\nKubelet performs aggressive normalization of the PEM contents written\ninto the pod filesystem.  Esoteric PEM features such as inter-block\ncomments and block headers are stripped.  Certificates are deduplicated.\nThe ordering of certificates within the file is arbitrary, and Kubelet\nmay change the order over time.",
+                          "properties": {
+                            "labelSelector": {
+                              "description": "Select all ClusterTrustBundles that match this label selector.  Only has\neffect if signerName is set.  Mutually-exclusive with name.  If unset,\ninterpreted as \"match nothing\".  If set but empty, interpreted as \"match\neverything\".",
+                              "properties": {
+                                "matchExpressions": {
+                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                  "items": {
+                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "key is the label key that the selector applies to.",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "operator"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "matchLabels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "name": {
+                              "description": "Select a single ClusterTrustBundle by object name.  Mutually-exclusive\nwith signerName and labelSelector.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "If true, don't block pod startup if the referenced ClusterTrustBundle(s)\naren't available.  If using name, then the named ClusterTrustBundle is\nallowed not to exist.  If using signerName, then the combination of\nsignerName and labelSelector is allowed to match zero\nClusterTrustBundles.",
+                              "type": "boolean"
+                            },
+                            "path": {
+                              "description": "Relative path from the volume root to write the bundle.",
+                              "type": "string"
+                            },
+                            "signerName": {
+                              "description": "Select all ClusterTrustBundles that match this signer name.\nMutually-exclusive with name.  The contents of all selected\nClusterTrustBundles will be unified and deduplicated.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "path"
+                          ],
+                          "type": "object"
+                        },
+                        "configMap": {
+                          "description": "configMap information about the configMap data to project",
+                          "properties": {
+                            "items": {
+                              "description": "items if unspecified, each key-value pair in the Data field of the referenced\nConfigMap will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the ConfigMap,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                              "items": {
+                                "description": "Maps a string key to a path within a volume.",
+                                "properties": {
+                                  "key": {
+                                    "description": "key is the key to project.",
+                                    "type": "string"
+                                  },
+                                  "mode": {
+                                    "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "path": {
+                                    "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "path"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "optional specify whether the ConfigMap or its keys must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "downwardAPI": {
+                          "description": "downwardAPI information about the downwardAPI data to project",
+                          "properties": {
+                            "items": {
+                              "description": "Items is a list of DownwardAPIVolume file",
+                              "items": {
+                                "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                                "properties": {
+                                  "fieldRef": {
+                                    "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.",
+                                    "properties": {
+                                      "apiVersion": {
+                                        "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                        "type": "string"
+                                      },
+                                      "fieldPath": {
+                                        "description": "Path of the field to select in the specified API version.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "fieldPath"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "mode": {
+                                    "description": "Optional: mode bits used to set permissions on this file, must be an octal value\nbetween 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "path": {
+                                    "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                                    "type": "string"
+                                  },
+                                  "resourceFieldRef": {
+                                    "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                                    "properties": {
+                                      "containerName": {
+                                        "description": "Container name: required for volumes, optional for env vars",
+                                        "type": "string"
+                                      },
+                                      "divisor": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                                      },
+                                      "resource": {
+                                        "description": "Required: resource to select",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "resource"
+                                    ],
+                                    "type": "object"
+                                  }
+                                },
+                                "required": [
+                                  "path"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "secret": {
+                          "description": "secret information about the secret data to project",
+                          "properties": {
+                            "items": {
+                              "description": "items if unspecified, each key-value pair in the Data field of the referenced\nSecret will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the Secret,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                              "items": {
+                                "description": "Maps a string key to a path within a volume.",
+                                "properties": {
+                                  "key": {
+                                    "description": "key is the key to project.",
+                                    "type": "string"
+                                  },
+                                  "mode": {
+                                    "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "path": {
+                                    "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "path"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "optional field specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "serviceAccountToken": {
+                          "description": "serviceAccountToken is information about the serviceAccountToken data to project",
+                          "properties": {
+                            "audience": {
+                              "description": "audience is the intended audience of the token. A recipient of a token\nmust identify itself with an identifier specified in the audience of the\ntoken, and otherwise should reject the token. The audience defaults to the\nidentifier of the apiserver.",
+                              "type": "string"
+                            },
+                            "expirationSeconds": {
+                              "description": "expirationSeconds is the requested duration of validity of the service\naccount token. As the token approaches expiration, the kubelet volume\nplugin will proactively rotate the service account token. The kubelet will\nstart trying to rotate the token if the token is older than 80 percent of\nits time to live or if the token is older than 24 hours.Defaults to 1 hour\nand must be at least 10 minutes.",
+                              "format": "int64",
+                              "type": "integer"
+                            },
+                            "path": {
+                              "description": "path is the path relative to the mount point of the file to project the\ntoken into.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "path"
+                          ],
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              },
+              "secret": {
+                "description": "Secret represents a secret that should populate this workspace.",
+                "properties": {
+                  "defaultMode": {
+                    "description": "defaultMode is Optional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values\nfor mode bits. Defaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "items": {
+                    "description": "items If unspecified, each key-value pair in the Data field of the referenced\nSecret will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the Secret,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                    "items": {
+                      "description": "Maps a string key to a path within a volume.",
+                      "properties": {
+                        "key": {
+                          "description": "key is the key to project.",
+                          "type": "string"
+                        },
+                        "mode": {
+                          "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "path": {
+                          "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "key",
+                        "path"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "optional": {
+                    "description": "optional field specify whether the Secret or its keys must be defined",
+                    "type": "boolean"
+                  },
+                  "secretName": {
+                    "description": "secretName is the name of the secret in the pod's namespace to use.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "subPath": {
+                "description": "SubPath is optionally a directory on the volume which should be used\nfor this binding (i.e. the volume will be mounted at this sub directory).",
+                "type": "string"
+              },
+              "volumeClaimTemplate": {
+                "description": "VolumeClaimTemplate is a template for a claim that will be created in the same namespace.\nThe PipelineRun controller is responsible for creating a unique claim for each instance of PipelineRun.\nSee PersistentVolumeClaim (API version: v1)"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "status": {
+      "description": "PipelineRunStatus defines the observed state of PipelineRun",
+      "properties": {
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Annotations is additional Status fields for the Resource to save some\nadditional State as well as convey more information to the user. This is\nroughly akin to Annotations on any k8s resource, just the reconciler conveying\nricher information outwards.",
+          "type": "object"
+        },
+        "childReferences": {
+          "description": "list of TaskRun and Run names, PipelineTask names, and API versions/kinds for children of this PipelineRun.",
+          "items": {
+            "description": "ChildStatusReference is used to point to the statuses of individual TaskRuns and Runs within this PipelineRun.",
+            "properties": {
+              "apiVersion": {
+                "type": "string"
+              },
+              "displayName": {
+                "description": "DisplayName is a user-facing name of the pipelineTask that may be\nused to populate a UI.",
+                "type": "string"
+              },
+              "kind": {
+                "type": "string"
+              },
+              "name": {
+                "description": "Name is the name of the TaskRun or Run this is referencing.",
+                "type": "string"
+              },
+              "pipelineTaskName": {
+                "description": "PipelineTaskName is the name of the PipelineTask this is referencing.",
+                "type": "string"
+              },
+              "whenExpressions": {
+                "description": "WhenExpressions is the list of checks guarding the execution of the PipelineTask",
+                "items": {
+                  "description": "WhenExpression allows a PipelineTask to declare expressions to be evaluated before the Task is run\nto determine whether the Task should be executed or skipped",
+                  "properties": {
+                    "cel": {
+                      "description": "CEL is a string of Common Language Expression, which can be used to conditionally execute\nthe task based on the result of the expression evaluation\nMore info about CEL syntax: https://github.com/google/cel-spec/blob/master/doc/langdef.md",
+                      "type": "string"
+                    },
+                    "input": {
+                      "description": "Input is the string for guard checking which can be a static input or an output from a parent Task",
+                      "type": "string"
+                    },
+                    "operator": {
+                      "description": "Operator that represents an Input's relationship to the values",
+                      "type": "string"
+                    },
+                    "values": {
+                      "description": "Values is an array of strings, which is compared against the input, for guard checking\nIt must be non-empty",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "completionTime": {
+          "description": "CompletionTime is the time the PipelineRun completed.",
+          "format": "date-time",
+          "type": "string"
+        },
+        "conditions": {
+          "description": "Conditions the latest available observations of a resource's current state.",
+          "items": {
+            "description": "Condition defines a readiness condition for a Knative resource.\nSee: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "LastTransitionTime is the last time the condition transitioned from one status to another.\nWe use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic\ndifferences (all other things held constant).",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity with which to treat failures of this type of condition.\nWhen this is not specified, it defaults to Error.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "finallyStartTime": {
+          "description": "FinallyStartTime is when all non-finally tasks have been completed and only finally tasks are being executed.",
+          "format": "date-time",
+          "type": "string"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the 'Generation' of the Service that\nwas last processed by the controller.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "pipelineSpec": {
+          "description": "PipelineSpec contains the exact spec used to instantiate the run.\nSee Pipeline.spec (API version: tekton.dev/v1)"
+        },
+        "provenance": {
+          "description": "Provenance contains some key authenticated metadata about how a software artifact was built (what sources, what inputs/outputs, etc.).",
+          "properties": {
+            "featureFlags": {
+              "description": "FeatureFlags identifies the feature flags that were used during the task/pipeline run",
+              "properties": {
+                "awaitSidecarReadiness": {
+                  "type": "boolean"
+                },
+                "coschedule": {
+                  "type": "string"
+                },
+                "disableCredsInit": {
+                  "type": "boolean"
+                },
+                "disableInlineSpec": {
+                  "type": "string"
+                },
+                "enableAPIFields": {
+                  "type": "string"
+                },
+                "enableArtifacts": {
+                  "type": "boolean"
+                },
+                "enableCELInWhenExpression": {
+                  "type": "boolean"
+                },
+                "enableConciseResolverSyntax": {
+                  "type": "boolean"
+                },
+                "enableKeepPodOnCancel": {
+                  "type": "boolean"
+                },
+                "enableKubernetesSidecar": {
+                  "type": "boolean"
+                },
+                "enableParamEnum": {
+                  "type": "boolean"
+                },
+                "enableProvenanceInStatus": {
+                  "type": "boolean"
+                },
+                "enableStepActions": {
+                  "description": "EnableStepActions is a no-op flag since StepActions are stable",
+                  "type": "boolean"
+                },
+                "enableWaitExponentialBackoff": {
+                  "type": "boolean"
+                },
+                "enforceNonfalsifiability": {
+                  "type": "string"
+                },
+                "maxResultSize": {
+                  "type": "integer"
+                },
+                "requireGitSSHSecretKnownHosts": {
+                  "type": "boolean"
+                },
+                "resultExtractionMethod": {
+                  "type": "string"
+                },
+                "runningInEnvWithInjectedSidecars": {
+                  "type": "boolean"
+                },
+                "sendCloudEventsForRuns": {
+                  "type": "boolean"
+                },
+                "setSecurityContext": {
+                  "type": "boolean"
+                },
+                "setSecurityContextReadOnlyRootFilesystem": {
+                  "type": "boolean"
+                },
+                "verificationNoMatchPolicy": {
+                  "description": "VerificationNoMatchPolicy is the feature flag for \"trusted-resources-verification-no-match-policy\"\nVerificationNoMatchPolicy can be set to \"ignore\", \"warn\" and \"fail\" values.\nignore: skip trusted resources verification when no matching verification policies found\nwarn: skip trusted resources verification when no matching verification policies found and log a warning\nfail: fail the taskrun or pipelines run if no matching verification policies found",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "refSource": {
+              "description": "RefSource identifies the source where a remote task/pipeline came from.",
+              "properties": {
+                "digest": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Digest is a collection of cryptographic digests for the contents of the artifact specified by URI.\nExample: {\"sha1\": \"f99d13e554ffcb696dee719fa85b695cb5b0f428\"}",
+                  "type": "object"
+                },
+                "entryPoint": {
+                  "description": "EntryPoint identifies the entry point into the build. This is often a path to a\nbuild definition file and/or a target label within that file.\nExample: \"task/git-clone/0.10/git-clone.yaml\"",
+                  "type": "string"
+                },
+                "uri": {
+                  "description": "URI indicates the identity of the source of the build definition.\nExample: \"https://github.com/tektoncd/catalog\"",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "results": {
+          "description": "Results are the list of results written out by the pipeline task's containers",
+          "items": {
+            "description": "PipelineRunResult used to describe the results of a pipeline",
+            "properties": {
+              "name": {
+                "description": "Name is the result's name as declared by the Pipeline",
+                "type": "string"
+              },
+              "value": {
+                "description": "Value is the result returned from the execution of this PipelineRun"
+              }
+            },
+            "required": [
+              "name",
+              "value"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "skippedTasks": {
+          "description": "list of tasks that were skipped due to when expressions evaluating to false",
+          "items": {
+            "description": "SkippedTask is used to describe the Tasks that were skipped due to their When Expressions\nevaluating to False. This is a struct because we are looking into including more details\nabout the When Expressions that caused this Task to be skipped.",
+            "properties": {
+              "name": {
+                "description": "Name is the Pipeline Task name",
+                "type": "string"
+              },
+              "reason": {
+                "description": "Reason is the cause of the PipelineTask being skipped.",
+                "type": "string"
+              },
+              "whenExpressions": {
+                "description": "WhenExpressions is the list of checks guarding the execution of the PipelineTask",
+                "items": {
+                  "description": "WhenExpression allows a PipelineTask to declare expressions to be evaluated before the Task is run\nto determine whether the Task should be executed or skipped",
+                  "properties": {
+                    "cel": {
+                      "description": "CEL is a string of Common Language Expression, which can be used to conditionally execute\nthe task based on the result of the expression evaluation\nMore info about CEL syntax: https://github.com/google/cel-spec/blob/master/doc/langdef.md",
+                      "type": "string"
+                    },
+                    "input": {
+                      "description": "Input is the string for guard checking which can be a static input or an output from a parent Task",
+                      "type": "string"
+                    },
+                    "operator": {
+                      "description": "Operator that represents an Input's relationship to the values",
+                      "type": "string"
+                    },
+                    "values": {
+                      "description": "Values is an array of strings, which is compared against the input, for guard checking\nIt must be non-empty",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "name",
+              "reason"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "spanContext": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "SpanContext contains tracing span context fields",
+          "type": "object"
+        },
+        "startTime": {
+          "description": "StartTime is the time the PipelineRun is actually started.",
+          "format": "date-time",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "title": "Tekton PipelineRun v1",
+  "type": "object"
+}

--- a/schema/v1/task.json
+++ b/schema/v1/task.json
@@ -1,0 +1,2461 @@
+{
+  "$id": "https://tekton.dev/schemas/v1/task.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Task represents a collection of sequential steps that are run as part of a\nPipeline using a set of inputs and producing a set of outputs. Tasks execute\nwhen TaskRuns are created that provide the input parameters and resources and\noutput resources the Task requires.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Spec holds the desired state of the Task from the client",
+      "properties": {
+        "description": {
+          "description": "Description is a user-facing description of the task that may be\nused to populate a UI.",
+          "type": "string"
+        },
+        "displayName": {
+          "description": "DisplayName is a user-facing name of the task that may be\nused to populate a UI.",
+          "type": "string"
+        },
+        "params": {
+          "description": "Params is a list of input parameters required to run the task. Params\nmust be supplied as inputs in TaskRuns unless they declare a default\nvalue.",
+          "items": {
+            "description": "ParamSpec defines arbitrary parameters needed beyond typed inputs (such as\nresources). Parameter values are provided by users as inputs on a TaskRun\nor PipelineRun.",
+            "properties": {
+              "default": {
+                "description": "Default is the value a parameter takes if no input value is supplied. If\ndefault is set, a Task may be executed without a supplied value for the\nparameter."
+              },
+              "description": {
+                "description": "Description is a user-facing description of the parameter that may be\nused to populate a UI.",
+                "type": "string"
+              },
+              "enum": {
+                "description": "Enum declares a set of allowed param input values for tasks/pipelines that can be validated.\nIf Enum is not set, no input validation is performed for the param.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "name": {
+                "description": "Name declares the name by which a parameter is referenced.",
+                "type": "string"
+              },
+              "properties": {
+                "additionalProperties": {
+                  "description": "PropertySpec defines the struct for object keys",
+                  "properties": {
+                    "type": {
+                      "description": "ParamType indicates the type of an input parameter;\nUsed to distinguish between a single string and an array of strings.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "description": "Properties is the JSON Schema properties to support key-value pairs parameter.",
+                "type": "object"
+              },
+              "type": {
+                "description": "Type is the user-specified type of the parameter. The possible types\nare currently \"string\", \"array\" and \"object\", and \"string\" is the default.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "results": {
+          "description": "Results are values that this Task can output",
+          "items": {
+            "description": "TaskResult used to describe the results of a task",
+            "properties": {
+              "description": {
+                "description": "Description is a human-readable description of the result",
+                "type": "string"
+              },
+              "name": {
+                "description": "Name the given name",
+                "type": "string"
+              },
+              "properties": {
+                "additionalProperties": {
+                  "description": "PropertySpec defines the struct for object keys",
+                  "properties": {
+                    "type": {
+                      "description": "ParamType indicates the type of an input parameter;\nUsed to distinguish between a single string and an array of strings.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "description": "Properties is the JSON Schema properties to support key-value pairs results.",
+                "type": "object"
+              },
+              "type": {
+                "description": "Type is the user-specified type of the result. The possible type\nis currently \"string\" and will support \"array\" in following work.",
+                "type": "string"
+              },
+              "value": {
+                "description": "Value the expression used to retrieve the value of the result from an underlying Step."
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "sidecars": {
+          "description": "Sidecars are run alongside the Task's step containers. They begin before\nthe steps start and end after the steps complete.",
+          "items": {
+            "description": "Sidecar has nearly the same data structure as Step but does not have the ability to timeout.",
+            "properties": {
+              "args": {
+                "description": "Arguments to the entrypoint.\nThe image's CMD is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the Sidecar's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will\nproduce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless\nof whether the variable exists or not. Cannot be updated.\nMore info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "command": {
+                "description": "Entrypoint array. Not executed within a shell.\nThe image's ENTRYPOINT is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the Sidecar's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will\nproduce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless\nof whether the variable exists or not. Cannot be updated.\nMore info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "computeResources": {
+                "description": "ComputeResources required by this Sidecar.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                "properties": {
+                  "claims": {
+                    "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                    "items": {
+                      "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                      "properties": {
+                        "name": {
+                          "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                          "type": "string"
+                        },
+                        "request": {
+                          "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "limits": {
+                    "additionalProperties": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                    },
+                    "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                    "type": "object"
+                  },
+                  "requests": {
+                    "additionalProperties": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                    },
+                    "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                    "type": "object"
+                  }
+                },
+                "type": "object"
+              },
+              "env": {
+                "description": "List of environment variables to set in the Sidecar.\nCannot be updated.",
+                "items": {
+                  "description": "EnvVar represents an environment variable present in a Container.",
+                  "properties": {
+                    "name": {
+                      "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                      "type": "string"
+                    },
+                    "value": {
+                      "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
+                      "type": "string"
+                    },
+                    "valueFrom": {
+                      "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                      "properties": {
+                        "configMapKeyRef": {
+                          "description": "Selects a key of a ConfigMap.",
+                          "properties": {
+                            "key": {
+                              "description": "The key to select.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the ConfigMap or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object"
+                        },
+                        "fieldRef": {
+                          "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['\u003cKEY\u003e']`, `metadata.annotations['\u003cKEY\u003e']`,\nspec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                          "properties": {
+                            "apiVersion": {
+                              "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                              "type": "string"
+                            },
+                            "fieldPath": {
+                              "description": "Path of the field to select in the specified API version.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "fieldPath"
+                          ],
+                          "type": "object"
+                        },
+                        "resourceFieldRef": {
+                          "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                          "properties": {
+                            "containerName": {
+                              "description": "Container name: required for volumes, optional for env vars",
+                              "type": "string"
+                            },
+                            "divisor": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                            },
+                            "resource": {
+                              "description": "Required: resource to select",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "resource"
+                          ],
+                          "type": "object"
+                        },
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "envFrom": {
+                "description": "List of sources to populate environment variables in the Sidecar.\nThe keys defined within a source must be a C_IDENTIFIER. All invalid keys\nwill be reported as an event when the container is starting. When a key exists in multiple\nsources, the value associated with the last source will take precedence.\nValues defined by an Env with a duplicate key will take precedence.\nCannot be updated.",
+                "items": {
+                  "description": "EnvFromSource represents the source of a set of ConfigMaps",
+                  "properties": {
+                    "configMapRef": {
+                      "description": "The ConfigMap to select from",
+                      "properties": {
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the ConfigMap must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "prefix": {
+                      "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
+                      "type": "string"
+                    },
+                    "secretRef": {
+                      "description": "The Secret to select from",
+                      "properties": {
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "image": {
+                "description": "Image reference name.\nMore info: https://kubernetes.io/docs/concepts/containers/images",
+                "type": "string"
+              },
+              "imagePullPolicy": {
+                "description": "Image pull policy.\nOne of Always, Never, IfNotPresent.\nDefaults to Always if :latest tag is specified, or IfNotPresent otherwise.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+                "type": "string"
+              },
+              "lifecycle": {
+                "description": "Actions that the management system should take in response to Sidecar lifecycle events.\nCannot be updated.",
+                "properties": {
+                  "postStart": {
+                    "description": "PostStart is called immediately after a container is created. If the handler fails,\nthe container is terminated and restarted according to its restart policy.\nOther management of the container blocks until the hook completes.\nMore info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+                    "properties": {
+                      "exec": {
+                        "description": "Exec specifies a command to execute in the container.",
+                        "properties": {
+                          "command": {
+                            "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "httpGet": {
+                        "description": "HTTPGet specifies an HTTP GET request to perform.",
+                        "properties": {
+                          "host": {
+                            "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                            "type": "string"
+                          },
+                          "httpHeaders": {
+                            "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                            "items": {
+                              "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                              "properties": {
+                                "name": {
+                                  "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "description": "The header field value",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "value"
+                              ],
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "path": {
+                            "description": "Path to access on the HTTP server.",
+                            "type": "string"
+                          },
+                          "port": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
+                          },
+                          "scheme": {
+                            "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object"
+                      },
+                      "sleep": {
+                        "description": "Sleep represents a duration that the container should sleep.",
+                        "properties": {
+                          "seconds": {
+                            "description": "Seconds is the number of seconds to sleep.",
+                            "format": "int64",
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "seconds"
+                        ],
+                        "type": "object"
+                      },
+                      "tcpSocket": {
+                        "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept\nfor backward compatibility. There is no validation of this field and\nlifecycle hooks will fail at runtime when it is specified.",
+                        "properties": {
+                          "host": {
+                            "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                            "type": "string"
+                          },
+                          "port": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "preStop": {
+                    "description": "PreStop is called immediately before a container is terminated due to an\nAPI request or management event such as liveness/startup probe failure,\npreemption, resource contention, etc. The handler is not called if the\ncontainer crashes or exits. The Pod's termination grace period countdown begins before the\nPreStop hook is executed. Regardless of the outcome of the handler, the\ncontainer will eventually terminate within the Pod's termination grace\nperiod (unless delayed by finalizers). Other management of the container blocks until the hook completes\nor until the termination grace period is reached.\nMore info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+                    "properties": {
+                      "exec": {
+                        "description": "Exec specifies a command to execute in the container.",
+                        "properties": {
+                          "command": {
+                            "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "httpGet": {
+                        "description": "HTTPGet specifies an HTTP GET request to perform.",
+                        "properties": {
+                          "host": {
+                            "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                            "type": "string"
+                          },
+                          "httpHeaders": {
+                            "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                            "items": {
+                              "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                              "properties": {
+                                "name": {
+                                  "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "description": "The header field value",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "value"
+                              ],
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "path": {
+                            "description": "Path to access on the HTTP server.",
+                            "type": "string"
+                          },
+                          "port": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
+                          },
+                          "scheme": {
+                            "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object"
+                      },
+                      "sleep": {
+                        "description": "Sleep represents a duration that the container should sleep.",
+                        "properties": {
+                          "seconds": {
+                            "description": "Seconds is the number of seconds to sleep.",
+                            "format": "int64",
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "seconds"
+                        ],
+                        "type": "object"
+                      },
+                      "tcpSocket": {
+                        "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept\nfor backward compatibility. There is no validation of this field and\nlifecycle hooks will fail at runtime when it is specified.",
+                        "properties": {
+                          "host": {
+                            "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                            "type": "string"
+                          },
+                          "port": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "type": "object"
+              },
+              "livenessProbe": {
+                "description": "Periodic probe of Sidecar liveness.\nContainer will be restarted if the probe fails.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                "properties": {
+                  "exec": {
+                    "description": "Exec specifies a command to execute in the container.",
+                    "properties": {
+                      "command": {
+                        "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "failureThreshold": {
+                    "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "grpc": {
+                    "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                    "properties": {
+                      "port": {
+                        "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "service": {
+                        "default": "",
+                        "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object"
+                  },
+                  "httpGet": {
+                    "description": "HTTPGet specifies an HTTP GET request to perform.",
+                    "properties": {
+                      "host": {
+                        "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                        "type": "string"
+                      },
+                      "httpHeaders": {
+                        "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                        "items": {
+                          "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                          "properties": {
+                            "name": {
+                              "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                              "type": "string"
+                            },
+                            "value": {
+                              "description": "The header field value",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "value"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "path": {
+                        "description": "Path to access on the HTTP server.",
+                        "type": "string"
+                      },
+                      "port": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
+                      },
+                      "scheme": {
+                        "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object"
+                  },
+                  "initialDelaySeconds": {
+                    "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "periodSeconds": {
+                    "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "successThreshold": {
+                    "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "tcpSocket": {
+                    "description": "TCPSocket specifies a connection to a TCP port.",
+                    "properties": {
+                      "host": {
+                        "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                        "type": "string"
+                      },
+                      "port": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object"
+                  },
+                  "terminationGracePeriodSeconds": {
+                    "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "timeoutSeconds": {
+                    "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                    "format": "int32",
+                    "type": "integer"
+                  }
+                },
+                "type": "object"
+              },
+              "name": {
+                "description": "Name of the Sidecar specified as a DNS_LABEL.\nEach Sidecar in a Task must have a unique name (DNS_LABEL).\nCannot be updated.",
+                "type": "string"
+              },
+              "ports": {
+                "description": "List of ports to expose from the Sidecar. Exposing a port here gives\nthe system additional information about the network connections a\ncontainer uses, but is primarily informational. Not specifying a port here\nDOES NOT prevent that port from being exposed. Any port which is\nlistening on the default \"0.0.0.0\" address inside a container will be\naccessible from the network.\nCannot be updated.",
+                "items": {
+                  "description": "ContainerPort represents a network port in a single container.",
+                  "properties": {
+                    "containerPort": {
+                      "description": "Number of port to expose on the pod's IP address.\nThis must be a valid port number, 0 \u003c x \u003c 65536.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "hostIP": {
+                      "description": "What host IP to bind the external port to.",
+                      "type": "string"
+                    },
+                    "hostPort": {
+                      "description": "Number of port to expose on the host.\nIf specified, this must be a valid port number, 0 \u003c x \u003c 65536.\nIf HostNetwork is specified, this must match ContainerPort.\nMost containers do not need this.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "name": {
+                      "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each\nnamed port in a pod must have a unique name. Name for the port that can be\nreferred to by services.",
+                      "type": "string"
+                    },
+                    "protocol": {
+                      "default": "TCP",
+                      "description": "Protocol for port. Must be UDP, TCP, or SCTP.\nDefaults to \"TCP\".",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "containerPort"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "readinessProbe": {
+                "description": "Periodic probe of Sidecar service readiness.\nContainer will be removed from service endpoints if the probe fails.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                "properties": {
+                  "exec": {
+                    "description": "Exec specifies a command to execute in the container.",
+                    "properties": {
+                      "command": {
+                        "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "failureThreshold": {
+                    "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "grpc": {
+                    "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                    "properties": {
+                      "port": {
+                        "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "service": {
+                        "default": "",
+                        "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object"
+                  },
+                  "httpGet": {
+                    "description": "HTTPGet specifies an HTTP GET request to perform.",
+                    "properties": {
+                      "host": {
+                        "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                        "type": "string"
+                      },
+                      "httpHeaders": {
+                        "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                        "items": {
+                          "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                          "properties": {
+                            "name": {
+                              "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                              "type": "string"
+                            },
+                            "value": {
+                              "description": "The header field value",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "value"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "path": {
+                        "description": "Path to access on the HTTP server.",
+                        "type": "string"
+                      },
+                      "port": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
+                      },
+                      "scheme": {
+                        "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object"
+                  },
+                  "initialDelaySeconds": {
+                    "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "periodSeconds": {
+                    "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "successThreshold": {
+                    "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "tcpSocket": {
+                    "description": "TCPSocket specifies a connection to a TCP port.",
+                    "properties": {
+                      "host": {
+                        "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                        "type": "string"
+                      },
+                      "port": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object"
+                  },
+                  "terminationGracePeriodSeconds": {
+                    "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "timeoutSeconds": {
+                    "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                    "format": "int32",
+                    "type": "integer"
+                  }
+                },
+                "type": "object"
+              },
+              "restartPolicy": {
+                "description": "RestartPolicy refers to kubernetes RestartPolicy. It can only be set for an\ninitContainer and must have it's policy set to \"Always\". It is currently\nleft optional to help support Kubernetes versions prior to 1.29 when this feature\nwas introduced.",
+                "type": "string"
+              },
+              "script": {
+                "description": "Script is the contents of an executable file to execute.\n\nIf Script is not empty, the Step cannot have an Command or Args.",
+                "type": "string"
+              },
+              "securityContext": {
+                "description": "SecurityContext defines the security options the Sidecar should be run with.\nIf set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.\nMore info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/",
+                "properties": {
+                  "allowPrivilegeEscalation": {
+                    "description": "AllowPrivilegeEscalation controls whether a process can gain more\nprivileges than its parent process. This bool directly controls if\nthe no_new_privs flag will be set on the container process.\nAllowPrivilegeEscalation is true always when the container is:\n1) run as Privileged\n2) has CAP_SYS_ADMIN\nNote that this field cannot be set when spec.os.name is windows.",
+                    "type": "boolean"
+                  },
+                  "appArmorProfile": {
+                    "description": "appArmorProfile is the AppArmor options to use by this container. If set, this profile\noverrides the pod's appArmorProfile.\nNote that this field cannot be set when spec.os.name is windows.",
+                    "properties": {
+                      "localhostProfile": {
+                        "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                        "type": "string"
+                      },
+                      "type": {
+                        "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "type"
+                    ],
+                    "type": "object"
+                  },
+                  "capabilities": {
+                    "description": "The capabilities to add/drop when running containers.\nDefaults to the default set of capabilities granted by the container runtime.\nNote that this field cannot be set when spec.os.name is windows.",
+                    "properties": {
+                      "add": {
+                        "description": "Added capabilities",
+                        "items": {
+                          "description": "Capability represent POSIX capabilities type",
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "drop": {
+                        "description": "Removed capabilities",
+                        "items": {
+                          "description": "Capability represent POSIX capabilities type",
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "privileged": {
+                    "description": "Run container in privileged mode.\nProcesses in privileged containers are essentially equivalent to root on the host.\nDefaults to false.\nNote that this field cannot be set when spec.os.name is windows.",
+                    "type": "boolean"
+                  },
+                  "procMount": {
+                    "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
+                    "type": "string"
+                  },
+                  "readOnlyRootFilesystem": {
+                    "description": "Whether this container has a read-only root filesystem.\nDefault is false.\nNote that this field cannot be set when spec.os.name is windows.",
+                    "type": "boolean"
+                  },
+                  "runAsGroup": {
+                    "description": "The GID to run the entrypoint of the container process.\nUses runtime default if unset.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "runAsNonRoot": {
+                    "description": "Indicates that the container must run as a non-root user.\nIf true, the Kubelet will validate the image at runtime to ensure that it\ndoes not run as UID 0 (root) and fail to start the container if it does.\nIf unset or false, no such validation will be performed.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
+                    "type": "boolean"
+                  },
+                  "runAsUser": {
+                    "description": "The UID to run the entrypoint of the container process.\nDefaults to user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "seLinuxOptions": {
+                    "description": "The SELinux context to be applied to the container.\nIf unspecified, the container runtime will allocate a random SELinux context for each\ncontainer.  May also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+                    "properties": {
+                      "level": {
+                        "description": "Level is SELinux level label that applies to the container.",
+                        "type": "string"
+                      },
+                      "role": {
+                        "description": "Role is a SELinux role label that applies to the container.",
+                        "type": "string"
+                      },
+                      "type": {
+                        "description": "Type is a SELinux type label that applies to the container.",
+                        "type": "string"
+                      },
+                      "user": {
+                        "description": "User is a SELinux user label that applies to the container.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "seccompProfile": {
+                    "description": "The seccomp options to use by this container. If seccomp options are\nprovided at both the pod \u0026 container level, the container options\noverride the pod options.\nNote that this field cannot be set when spec.os.name is windows.",
+                    "properties": {
+                      "localhostProfile": {
+                        "description": "localhostProfile indicates a profile defined in a file on the node should be used.\nThe profile must be preconfigured on the node to work.\nMust be a descending path, relative to the kubelet's configured seccomp profile location.\nMust be set if type is \"Localhost\". Must NOT be set for any other type.",
+                        "type": "string"
+                      },
+                      "type": {
+                        "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "type"
+                    ],
+                    "type": "object"
+                  },
+                  "windowsOptions": {
+                    "description": "The Windows specific settings applied to all containers.\nIf unspecified, the options from the PodSecurityContext will be used.\nIf set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is linux.",
+                    "properties": {
+                      "gmsaCredentialSpec": {
+                        "description": "GMSACredentialSpec is where the GMSA admission webhook\n(https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the\nGMSA credential spec named by the GMSACredentialSpecName field.",
+                        "type": "string"
+                      },
+                      "gmsaCredentialSpecName": {
+                        "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                        "type": "string"
+                      },
+                      "hostProcess": {
+                        "description": "HostProcess determines if a container should be run as a 'Host Process' container.\nAll of a Pod's containers must have the same effective HostProcess value\n(it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).\nIn addition, if HostProcess is true then HostNetwork must also be set to true.",
+                        "type": "boolean"
+                      },
+                      "runAsUserName": {
+                        "description": "The UserName in Windows to run the entrypoint of the container process.\nDefaults to the user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext. If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "type": "object"
+              },
+              "startupProbe": {
+                "description": "StartupProbe indicates that the Pod the Sidecar is running in has successfully initialized.\nIf specified, no other probes are executed until this completes successfully.\nIf this probe fails, the Pod will be restarted, just as if the livenessProbe failed.\nThis can be used to provide different probe parameters at the beginning of a Pod's lifecycle,\nwhen it might take a long time to load data or warm a cache, than during steady-state operation.\nThis cannot be updated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                "properties": {
+                  "exec": {
+                    "description": "Exec specifies a command to execute in the container.",
+                    "properties": {
+                      "command": {
+                        "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "failureThreshold": {
+                    "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "grpc": {
+                    "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                    "properties": {
+                      "port": {
+                        "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "service": {
+                        "default": "",
+                        "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object"
+                  },
+                  "httpGet": {
+                    "description": "HTTPGet specifies an HTTP GET request to perform.",
+                    "properties": {
+                      "host": {
+                        "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                        "type": "string"
+                      },
+                      "httpHeaders": {
+                        "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                        "items": {
+                          "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                          "properties": {
+                            "name": {
+                              "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                              "type": "string"
+                            },
+                            "value": {
+                              "description": "The header field value",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "value"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "path": {
+                        "description": "Path to access on the HTTP server.",
+                        "type": "string"
+                      },
+                      "port": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
+                      },
+                      "scheme": {
+                        "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object"
+                  },
+                  "initialDelaySeconds": {
+                    "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "periodSeconds": {
+                    "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "successThreshold": {
+                    "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "tcpSocket": {
+                    "description": "TCPSocket specifies a connection to a TCP port.",
+                    "properties": {
+                      "host": {
+                        "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                        "type": "string"
+                      },
+                      "port": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object"
+                  },
+                  "terminationGracePeriodSeconds": {
+                    "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "timeoutSeconds": {
+                    "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                    "format": "int32",
+                    "type": "integer"
+                  }
+                },
+                "type": "object"
+              },
+              "stdin": {
+                "description": "Whether this Sidecar should allocate a buffer for stdin in the container runtime. If this\nis not set, reads from stdin in the Sidecar will always result in EOF.\nDefault is false.",
+                "type": "boolean"
+              },
+              "stdinOnce": {
+                "description": "Whether the container runtime should close the stdin channel after it has been opened by\na single attach. When stdin is true the stdin stream will remain open across multiple attach\nsessions. If stdinOnce is set to true, stdin is opened on Sidecar start, is empty until the\nfirst client attaches to stdin, and then remains open and accepts data until the client disconnects,\nat which time stdin is closed and remains closed until the Sidecar is restarted. If this\nflag is false, a container processes that reads from stdin will never receive an EOF.\nDefault is false",
+                "type": "boolean"
+              },
+              "terminationMessagePath": {
+                "description": "Optional: Path at which the file to which the Sidecar's termination message\nwill be written is mounted into the Sidecar's filesystem.\nMessage written is intended to be brief final status, such as an assertion failure message.\nWill be truncated by the node if greater than 4096 bytes. The total message length across\nall containers will be limited to 12kb.\nDefaults to /dev/termination-log.\nCannot be updated.",
+                "type": "string"
+              },
+              "terminationMessagePolicy": {
+                "description": "Indicate how the termination message should be populated. File will use the contents of\nterminationMessagePath to populate the Sidecar status message on both success and failure.\nFallbackToLogsOnError will use the last chunk of Sidecar log output if the termination\nmessage file is empty and the Sidecar exited with an error.\nThe log output is limited to 2048 bytes or 80 lines, whichever is smaller.\nDefaults to File.\nCannot be updated.",
+                "type": "string"
+              },
+              "tty": {
+                "description": "Whether this Sidecar should allocate a TTY for itself, also requires 'stdin' to be true.\nDefault is false.",
+                "type": "boolean"
+              },
+              "volumeDevices": {
+                "description": "volumeDevices is the list of block devices to be used by the Sidecar.",
+                "items": {
+                  "description": "volumeDevice describes a mapping of a raw block device within a container.",
+                  "properties": {
+                    "devicePath": {
+                      "description": "devicePath is the path inside of the container that the device will be mapped to.",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "name must match the name of a persistentVolumeClaim in the pod",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "devicePath",
+                    "name"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "volumeMounts": {
+                "description": "Volumes to mount into the Sidecar's filesystem.\nCannot be updated.",
+                "items": {
+                  "description": "VolumeMount describes a mounting of a Volume within a container.",
+                  "properties": {
+                    "mountPath": {
+                      "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
+                      "type": "string"
+                    },
+                    "mountPropagation": {
+                      "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "This must match the Name of a Volume.",
+                      "type": "string"
+                    },
+                    "readOnly": {
+                      "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
+                      "type": "boolean"
+                    },
+                    "recursiveReadOnly": {
+                      "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
+                      "type": "string"
+                    },
+                    "subPath": {
+                      "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
+                      "type": "string"
+                    },
+                    "subPathExpr": {
+                      "description": "Expanded path within the volume from which the container's volume should be mounted.\nBehaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.\nDefaults to \"\" (volume's root).\nSubPathExpr and SubPath are mutually exclusive.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "mountPath",
+                    "name"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "workingDir": {
+                "description": "Sidecar's working directory.\nIf not specified, the container runtime's default will be used, which\nmight be configured in the container image.\nCannot be updated.",
+                "type": "string"
+              },
+              "workspaces": {
+                "description": "This is an alpha field. You must set the \"enable-api-fields\" feature flag to \"alpha\"\nfor this field to be supported.\n\nWorkspaces is a list of workspaces from the Task that this Sidecar wants\nexclusive access to. Adding a workspace to this list means that any\nother Step or Sidecar that does not also request this Workspace will\nnot have access to it.",
+                "items": {
+                  "description": "WorkspaceUsage is used by a Step or Sidecar to declare that it wants isolated access\nto a Workspace defined in a Task.",
+                  "properties": {
+                    "mountPath": {
+                      "description": "MountPath is the path that the workspace should be mounted to inside the Step or Sidecar,\noverriding any MountPath specified in the Task's WorkspaceDeclaration.",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name is the name of the workspace this Step or Sidecar wants access to.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "mountPath",
+                    "name"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "stepTemplate": {
+          "description": "StepTemplate can be used as the basis for all step containers within the\nTask, so that the steps inherit settings on the base container.",
+          "properties": {
+            "args": {
+              "description": "Arguments to the entrypoint.\nThe image's CMD is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the Step's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will\nproduce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless\nof whether the variable exists or not. Cannot be updated.\nMore info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "command": {
+              "description": "Entrypoint array. Not executed within a shell.\nThe image's ENTRYPOINT is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the Step's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will\nproduce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless\nof whether the variable exists or not. Cannot be updated.\nMore info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "computeResources": {
+              "description": "ComputeResources required by this Step.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+              "properties": {
+                "claims": {
+                  "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                  "items": {
+                    "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                    "properties": {
+                      "name": {
+                        "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                        "type": "string"
+                      },
+                      "request": {
+                        "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "limits": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                  },
+                  "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                  "type": "object"
+                },
+                "requests": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                  },
+                  "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "env": {
+              "description": "List of environment variables to set in the Step.\nCannot be updated.",
+              "items": {
+                "description": "EnvVar represents an environment variable present in a Container.",
+                "properties": {
+                  "name": {
+                    "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                    "type": "string"
+                  },
+                  "value": {
+                    "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
+                    "type": "string"
+                  },
+                  "valueFrom": {
+                    "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                    "properties": {
+                      "configMapKeyRef": {
+                        "description": "Selects a key of a ConfigMap.",
+                        "properties": {
+                          "key": {
+                            "description": "The key to select.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "default": "",
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the ConfigMap or its key must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object"
+                      },
+                      "fieldRef": {
+                        "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['\u003cKEY\u003e']`, `metadata.annotations['\u003cKEY\u003e']`,\nspec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                        "properties": {
+                          "apiVersion": {
+                            "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                            "type": "string"
+                          },
+                          "fieldPath": {
+                            "description": "Path of the field to select in the specified API version.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "fieldPath"
+                        ],
+                        "type": "object"
+                      },
+                      "resourceFieldRef": {
+                        "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                        "properties": {
+                          "containerName": {
+                            "description": "Container name: required for volumes, optional for env vars",
+                            "type": "string"
+                          },
+                          "divisor": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                          },
+                          "resource": {
+                            "description": "Required: resource to select",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "resource"
+                        ],
+                        "type": "object"
+                      },
+                      "secretKeyRef": {
+                        "description": "Selects a key of a secret in the pod's namespace",
+                        "properties": {
+                          "key": {
+                            "description": "The key of the secret to select from.  Must be a valid secret key.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "default": "",
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the Secret or its key must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "envFrom": {
+              "description": "List of sources to populate environment variables in the Step.\nThe keys defined within a source must be a C_IDENTIFIER. All invalid keys\nwill be reported as an event when the Step is starting. When a key exists in multiple\nsources, the value associated with the last source will take precedence.\nValues defined by an Env with a duplicate key will take precedence.\nCannot be updated.",
+              "items": {
+                "description": "EnvFromSource represents the source of a set of ConfigMaps",
+                "properties": {
+                  "configMapRef": {
+                    "description": "The ConfigMap to select from",
+                    "properties": {
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string"
+                      },
+                      "optional": {
+                        "description": "Specify whether the ConfigMap must be defined",
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "prefix": {
+                    "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
+                    "type": "string"
+                  },
+                  "secretRef": {
+                    "description": "The Secret to select from",
+                    "properties": {
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string"
+                      },
+                      "optional": {
+                        "description": "Specify whether the Secret must be defined",
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "image": {
+              "description": "Image reference name.\nMore info: https://kubernetes.io/docs/concepts/containers/images",
+              "type": "string"
+            },
+            "imagePullPolicy": {
+              "description": "Image pull policy.\nOne of Always, Never, IfNotPresent.\nDefaults to Always if :latest tag is specified, or IfNotPresent otherwise.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+              "type": "string"
+            },
+            "securityContext": {
+              "description": "SecurityContext defines the security options the Step should be run with.\nIf set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.\nMore info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/",
+              "properties": {
+                "allowPrivilegeEscalation": {
+                  "description": "AllowPrivilegeEscalation controls whether a process can gain more\nprivileges than its parent process. This bool directly controls if\nthe no_new_privs flag will be set on the container process.\nAllowPrivilegeEscalation is true always when the container is:\n1) run as Privileged\n2) has CAP_SYS_ADMIN\nNote that this field cannot be set when spec.os.name is windows.",
+                  "type": "boolean"
+                },
+                "appArmorProfile": {
+                  "description": "appArmorProfile is the AppArmor options to use by this container. If set, this profile\noverrides the pod's appArmorProfile.\nNote that this field cannot be set when spec.os.name is windows.",
+                  "properties": {
+                    "localhostProfile": {
+                      "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object"
+                },
+                "capabilities": {
+                  "description": "The capabilities to add/drop when running containers.\nDefaults to the default set of capabilities granted by the container runtime.\nNote that this field cannot be set when spec.os.name is windows.",
+                  "properties": {
+                    "add": {
+                      "description": "Added capabilities",
+                      "items": {
+                        "description": "Capability represent POSIX capabilities type",
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "drop": {
+                      "description": "Removed capabilities",
+                      "items": {
+                        "description": "Capability represent POSIX capabilities type",
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                },
+                "privileged": {
+                  "description": "Run container in privileged mode.\nProcesses in privileged containers are essentially equivalent to root on the host.\nDefaults to false.\nNote that this field cannot be set when spec.os.name is windows.",
+                  "type": "boolean"
+                },
+                "procMount": {
+                  "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
+                  "type": "string"
+                },
+                "readOnlyRootFilesystem": {
+                  "description": "Whether this container has a read-only root filesystem.\nDefault is false.\nNote that this field cannot be set when spec.os.name is windows.",
+                  "type": "boolean"
+                },
+                "runAsGroup": {
+                  "description": "The GID to run the entrypoint of the container process.\nUses runtime default if unset.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "runAsNonRoot": {
+                  "description": "Indicates that the container must run as a non-root user.\nIf true, the Kubelet will validate the image at runtime to ensure that it\ndoes not run as UID 0 (root) and fail to start the container if it does.\nIf unset or false, no such validation will be performed.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
+                  "type": "boolean"
+                },
+                "runAsUser": {
+                  "description": "The UID to run the entrypoint of the container process.\nDefaults to user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "seLinuxOptions": {
+                  "description": "The SELinux context to be applied to the container.\nIf unspecified, the container runtime will allocate a random SELinux context for each\ncontainer.  May also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+                  "properties": {
+                    "level": {
+                      "description": "Level is SELinux level label that applies to the container.",
+                      "type": "string"
+                    },
+                    "role": {
+                      "description": "Role is a SELinux role label that applies to the container.",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "Type is a SELinux type label that applies to the container.",
+                      "type": "string"
+                    },
+                    "user": {
+                      "description": "User is a SELinux user label that applies to the container.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "seccompProfile": {
+                  "description": "The seccomp options to use by this container. If seccomp options are\nprovided at both the pod \u0026 container level, the container options\noverride the pod options.\nNote that this field cannot be set when spec.os.name is windows.",
+                  "properties": {
+                    "localhostProfile": {
+                      "description": "localhostProfile indicates a profile defined in a file on the node should be used.\nThe profile must be preconfigured on the node to work.\nMust be a descending path, relative to the kubelet's configured seccomp profile location.\nMust be set if type is \"Localhost\". Must NOT be set for any other type.",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object"
+                },
+                "windowsOptions": {
+                  "description": "The Windows specific settings applied to all containers.\nIf unspecified, the options from the PodSecurityContext will be used.\nIf set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is linux.",
+                  "properties": {
+                    "gmsaCredentialSpec": {
+                      "description": "GMSACredentialSpec is where the GMSA admission webhook\n(https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the\nGMSA credential spec named by the GMSACredentialSpecName field.",
+                      "type": "string"
+                    },
+                    "gmsaCredentialSpecName": {
+                      "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                      "type": "string"
+                    },
+                    "hostProcess": {
+                      "description": "HostProcess determines if a container should be run as a 'Host Process' container.\nAll of a Pod's containers must have the same effective HostProcess value\n(it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).\nIn addition, if HostProcess is true then HostNetwork must also be set to true.",
+                      "type": "boolean"
+                    },
+                    "runAsUserName": {
+                      "description": "The UserName in Windows to run the entrypoint of the container process.\nDefaults to the user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext. If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "volumeDevices": {
+              "description": "volumeDevices is the list of block devices to be used by the Step.",
+              "items": {
+                "description": "volumeDevice describes a mapping of a raw block device within a container.",
+                "properties": {
+                  "devicePath": {
+                    "description": "devicePath is the path inside of the container that the device will be mapped to.",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "name must match the name of a persistentVolumeClaim in the pod",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "devicePath",
+                  "name"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "volumeMounts": {
+              "description": "Volumes to mount into the Step's filesystem.\nCannot be updated.",
+              "items": {
+                "description": "VolumeMount describes a mounting of a Volume within a container.",
+                "properties": {
+                  "mountPath": {
+                    "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
+                    "type": "string"
+                  },
+                  "mountPropagation": {
+                    "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "This must match the Name of a Volume.",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
+                    "type": "boolean"
+                  },
+                  "recursiveReadOnly": {
+                    "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
+                    "type": "string"
+                  },
+                  "subPath": {
+                    "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
+                    "type": "string"
+                  },
+                  "subPathExpr": {
+                    "description": "Expanded path within the volume from which the container's volume should be mounted.\nBehaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.\nDefaults to \"\" (volume's root).\nSubPathExpr and SubPath are mutually exclusive.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "mountPath",
+                  "name"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "workingDir": {
+              "description": "Step's working directory.\nIf not specified, the container runtime's default will be used, which\nmight be configured in the container image.\nCannot be updated.",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "steps": {
+          "description": "Steps are the steps of the build; each step is run sequentially with the\nsource mounted into /workspace.",
+          "items": {
+            "description": "Step runs a subcomponent of a Task",
+            "properties": {
+              "args": {
+                "description": "Arguments to the entrypoint.\nThe image's CMD is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the container's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will\nproduce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless\nof whether the variable exists or not. Cannot be updated.\nMore info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "command": {
+                "description": "Entrypoint array. Not executed within a shell.\nThe image's ENTRYPOINT is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the container's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will\nproduce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless\nof whether the variable exists or not. Cannot be updated.\nMore info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "computeResources": {
+                "description": "ComputeResources required by this Step.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                "properties": {
+                  "claims": {
+                    "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                    "items": {
+                      "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                      "properties": {
+                        "name": {
+                          "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                          "type": "string"
+                        },
+                        "request": {
+                          "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "limits": {
+                    "additionalProperties": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                    },
+                    "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                    "type": "object"
+                  },
+                  "requests": {
+                    "additionalProperties": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                    },
+                    "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                    "type": "object"
+                  }
+                },
+                "type": "object"
+              },
+              "displayName": {
+                "description": "DisplayName is a user-facing name of the step that may be\nused to populate a UI.",
+                "type": "string"
+              },
+              "env": {
+                "description": "List of environment variables to set in the Step.\nCannot be updated.",
+                "items": {
+                  "description": "EnvVar represents an environment variable present in a Container.",
+                  "properties": {
+                    "name": {
+                      "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                      "type": "string"
+                    },
+                    "value": {
+                      "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
+                      "type": "string"
+                    },
+                    "valueFrom": {
+                      "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                      "properties": {
+                        "configMapKeyRef": {
+                          "description": "Selects a key of a ConfigMap.",
+                          "properties": {
+                            "key": {
+                              "description": "The key to select.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the ConfigMap or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object"
+                        },
+                        "fieldRef": {
+                          "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['\u003cKEY\u003e']`, `metadata.annotations['\u003cKEY\u003e']`,\nspec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                          "properties": {
+                            "apiVersion": {
+                              "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                              "type": "string"
+                            },
+                            "fieldPath": {
+                              "description": "Path of the field to select in the specified API version.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "fieldPath"
+                          ],
+                          "type": "object"
+                        },
+                        "resourceFieldRef": {
+                          "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                          "properties": {
+                            "containerName": {
+                              "description": "Container name: required for volumes, optional for env vars",
+                              "type": "string"
+                            },
+                            "divisor": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                            },
+                            "resource": {
+                              "description": "Required: resource to select",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "resource"
+                          ],
+                          "type": "object"
+                        },
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "envFrom": {
+                "description": "List of sources to populate environment variables in the Step.\nThe keys defined within a source must be a C_IDENTIFIER. All invalid keys\nwill be reported as an event when the Step is starting. When a key exists in multiple\nsources, the value associated with the last source will take precedence.\nValues defined by an Env with a duplicate key will take precedence.\nCannot be updated.",
+                "items": {
+                  "description": "EnvFromSource represents the source of a set of ConfigMaps",
+                  "properties": {
+                    "configMapRef": {
+                      "description": "The ConfigMap to select from",
+                      "properties": {
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the ConfigMap must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "prefix": {
+                      "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
+                      "type": "string"
+                    },
+                    "secretRef": {
+                      "description": "The Secret to select from",
+                      "properties": {
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "image": {
+                "description": "Docker image name.\nMore info: https://kubernetes.io/docs/concepts/containers/images",
+                "type": "string"
+              },
+              "imagePullPolicy": {
+                "description": "Image pull policy.\nOne of Always, Never, IfNotPresent.\nDefaults to Always if :latest tag is specified, or IfNotPresent otherwise.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+                "type": "string"
+              },
+              "name": {
+                "description": "Name of the Step specified as a DNS_LABEL.\nEach Step in a Task must have a unique name.",
+                "type": "string"
+              },
+              "onError": {
+                "description": "OnError defines the exiting behavior of a container on error\ncan be set to [ continue | stopAndFail ]",
+                "type": "string"
+              },
+              "params": {
+                "description": "Params declares parameters passed to this step action.",
+                "items": {
+                  "description": "Param declares an ParamValues to use for the parameter called name.",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "value": {}
+                  },
+                  "required": [
+                    "name",
+                    "value"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "ref": {
+                "description": "Contains the reference to an existing StepAction.",
+                "properties": {
+                  "name": {
+                    "description": "Name of the referenced step",
+                    "type": "string"
+                  },
+                  "params": {
+                    "description": "Params contains the parameters used to identify the\nreferenced Tekton resource. Example entries might include\n\"repo\" or \"path\" but the set of params ultimately depends on\nthe chosen resolver.",
+                    "items": {
+                      "description": "Param declares an ParamValues to use for the parameter called name.",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "value": {}
+                      },
+                      "required": [
+                        "name",
+                        "value"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "resolver": {
+                    "description": "Resolver is the name of the resolver that should perform\nresolution of the referenced Tekton resource, such as \"git\".",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "results": {
+                "description": "Results declares StepResults produced by the Step.\n\nIt can be used in an inlined Step when used to store Results to $(step.results.resultName.path).\nIt cannot be used when referencing StepActions using [v1.Step.Ref].\nThe Results declared by the StepActions will be stored here instead.",
+                "items": {
+                  "description": "StepResult used to describe the Results of a Step.",
+                  "properties": {
+                    "description": {
+                      "description": "Description is a human-readable description of the result",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name the given name",
+                      "type": "string"
+                    },
+                    "properties": {
+                      "additionalProperties": {
+                        "description": "PropertySpec defines the struct for object keys",
+                        "properties": {
+                          "type": {
+                            "description": "ParamType indicates the type of an input parameter;\nUsed to distinguish between a single string and an array of strings.",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "description": "Properties is the JSON Schema properties to support key-value pairs results.",
+                      "type": "object"
+                    },
+                    "type": {
+                      "description": "The possible types are 'string', 'array', and 'object', with 'string' as the default.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "script": {
+                "description": "Script is the contents of an executable file to execute.\n\nIf Script is not empty, the Step cannot have an Command and the Args will be passed to the Script.",
+                "type": "string"
+              },
+              "securityContext": {
+                "description": "SecurityContext defines the security options the Step should be run with.\nIf set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.\nMore info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/",
+                "properties": {
+                  "allowPrivilegeEscalation": {
+                    "description": "AllowPrivilegeEscalation controls whether a process can gain more\nprivileges than its parent process. This bool directly controls if\nthe no_new_privs flag will be set on the container process.\nAllowPrivilegeEscalation is true always when the container is:\n1) run as Privileged\n2) has CAP_SYS_ADMIN\nNote that this field cannot be set when spec.os.name is windows.",
+                    "type": "boolean"
+                  },
+                  "appArmorProfile": {
+                    "description": "appArmorProfile is the AppArmor options to use by this container. If set, this profile\noverrides the pod's appArmorProfile.\nNote that this field cannot be set when spec.os.name is windows.",
+                    "properties": {
+                      "localhostProfile": {
+                        "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                        "type": "string"
+                      },
+                      "type": {
+                        "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "type"
+                    ],
+                    "type": "object"
+                  },
+                  "capabilities": {
+                    "description": "The capabilities to add/drop when running containers.\nDefaults to the default set of capabilities granted by the container runtime.\nNote that this field cannot be set when spec.os.name is windows.",
+                    "properties": {
+                      "add": {
+                        "description": "Added capabilities",
+                        "items": {
+                          "description": "Capability represent POSIX capabilities type",
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "drop": {
+                        "description": "Removed capabilities",
+                        "items": {
+                          "description": "Capability represent POSIX capabilities type",
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "privileged": {
+                    "description": "Run container in privileged mode.\nProcesses in privileged containers are essentially equivalent to root on the host.\nDefaults to false.\nNote that this field cannot be set when spec.os.name is windows.",
+                    "type": "boolean"
+                  },
+                  "procMount": {
+                    "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
+                    "type": "string"
+                  },
+                  "readOnlyRootFilesystem": {
+                    "description": "Whether this container has a read-only root filesystem.\nDefault is false.\nNote that this field cannot be set when spec.os.name is windows.",
+                    "type": "boolean"
+                  },
+                  "runAsGroup": {
+                    "description": "The GID to run the entrypoint of the container process.\nUses runtime default if unset.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "runAsNonRoot": {
+                    "description": "Indicates that the container must run as a non-root user.\nIf true, the Kubelet will validate the image at runtime to ensure that it\ndoes not run as UID 0 (root) and fail to start the container if it does.\nIf unset or false, no such validation will be performed.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
+                    "type": "boolean"
+                  },
+                  "runAsUser": {
+                    "description": "The UID to run the entrypoint of the container process.\nDefaults to user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "seLinuxOptions": {
+                    "description": "The SELinux context to be applied to the container.\nIf unspecified, the container runtime will allocate a random SELinux context for each\ncontainer.  May also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+                    "properties": {
+                      "level": {
+                        "description": "Level is SELinux level label that applies to the container.",
+                        "type": "string"
+                      },
+                      "role": {
+                        "description": "Role is a SELinux role label that applies to the container.",
+                        "type": "string"
+                      },
+                      "type": {
+                        "description": "Type is a SELinux type label that applies to the container.",
+                        "type": "string"
+                      },
+                      "user": {
+                        "description": "User is a SELinux user label that applies to the container.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "seccompProfile": {
+                    "description": "The seccomp options to use by this container. If seccomp options are\nprovided at both the pod \u0026 container level, the container options\noverride the pod options.\nNote that this field cannot be set when spec.os.name is windows.",
+                    "properties": {
+                      "localhostProfile": {
+                        "description": "localhostProfile indicates a profile defined in a file on the node should be used.\nThe profile must be preconfigured on the node to work.\nMust be a descending path, relative to the kubelet's configured seccomp profile location.\nMust be set if type is \"Localhost\". Must NOT be set for any other type.",
+                        "type": "string"
+                      },
+                      "type": {
+                        "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "type"
+                    ],
+                    "type": "object"
+                  },
+                  "windowsOptions": {
+                    "description": "The Windows specific settings applied to all containers.\nIf unspecified, the options from the PodSecurityContext will be used.\nIf set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is linux.",
+                    "properties": {
+                      "gmsaCredentialSpec": {
+                        "description": "GMSACredentialSpec is where the GMSA admission webhook\n(https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the\nGMSA credential spec named by the GMSACredentialSpecName field.",
+                        "type": "string"
+                      },
+                      "gmsaCredentialSpecName": {
+                        "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                        "type": "string"
+                      },
+                      "hostProcess": {
+                        "description": "HostProcess determines if a container should be run as a 'Host Process' container.\nAll of a Pod's containers must have the same effective HostProcess value\n(it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).\nIn addition, if HostProcess is true then HostNetwork must also be set to true.",
+                        "type": "boolean"
+                      },
+                      "runAsUserName": {
+                        "description": "The UserName in Windows to run the entrypoint of the container process.\nDefaults to the user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext. If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "type": "object"
+              },
+              "stderrConfig": {
+                "description": "Stores configuration for the stderr stream of the step.",
+                "properties": {
+                  "path": {
+                    "description": "Path to duplicate stdout stream to on container's local filesystem.",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "stdoutConfig": {
+                "description": "Stores configuration for the stdout stream of the step.",
+                "properties": {
+                  "path": {
+                    "description": "Path to duplicate stdout stream to on container's local filesystem.",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "timeout": {
+                "description": "Timeout is the time after which the step times out. Defaults to never.\nRefer to Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration",
+                "type": "string"
+              },
+              "volumeDevices": {
+                "description": "volumeDevices is the list of block devices to be used by the Step.",
+                "items": {
+                  "description": "volumeDevice describes a mapping of a raw block device within a container.",
+                  "properties": {
+                    "devicePath": {
+                      "description": "devicePath is the path inside of the container that the device will be mapped to.",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "name must match the name of a persistentVolumeClaim in the pod",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "devicePath",
+                    "name"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "volumeMounts": {
+                "description": "Volumes to mount into the Step's filesystem.\nCannot be updated.",
+                "items": {
+                  "description": "VolumeMount describes a mounting of a Volume within a container.",
+                  "properties": {
+                    "mountPath": {
+                      "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
+                      "type": "string"
+                    },
+                    "mountPropagation": {
+                      "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "This must match the Name of a Volume.",
+                      "type": "string"
+                    },
+                    "readOnly": {
+                      "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
+                      "type": "boolean"
+                    },
+                    "recursiveReadOnly": {
+                      "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
+                      "type": "string"
+                    },
+                    "subPath": {
+                      "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
+                      "type": "string"
+                    },
+                    "subPathExpr": {
+                      "description": "Expanded path within the volume from which the container's volume should be mounted.\nBehaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.\nDefaults to \"\" (volume's root).\nSubPathExpr and SubPath are mutually exclusive.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "mountPath",
+                    "name"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "when": {
+                "description": "When is a list of when expressions that need to be true for the task to run",
+                "items": {
+                  "description": "WhenExpression allows a PipelineTask to declare expressions to be evaluated before the Task is run\nto determine whether the Task should be executed or skipped",
+                  "properties": {
+                    "cel": {
+                      "description": "CEL is a string of Common Language Expression, which can be used to conditionally execute\nthe task based on the result of the expression evaluation\nMore info about CEL syntax: https://github.com/google/cel-spec/blob/master/doc/langdef.md",
+                      "type": "string"
+                    },
+                    "input": {
+                      "description": "Input is the string for guard checking which can be a static input or an output from a parent Task",
+                      "type": "string"
+                    },
+                    "operator": {
+                      "description": "Operator that represents an Input's relationship to the values",
+                      "type": "string"
+                    },
+                    "values": {
+                      "description": "Values is an array of strings, which is compared against the input, for guard checking\nIt must be non-empty",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "workingDir": {
+                "description": "Step's working directory.\nIf not specified, the container runtime's default will be used, which\nmight be configured in the container image.\nCannot be updated.",
+                "type": "string"
+              },
+              "workspaces": {
+                "description": "This is an alpha field. You must set the \"enable-api-fields\" feature flag to \"alpha\"\nfor this field to be supported.\n\nWorkspaces is a list of workspaces from the Task that this Step wants\nexclusive access to. Adding a workspace to this list means that any\nother Step or Sidecar that does not also request this Workspace will\nnot have access to it.",
+                "items": {
+                  "description": "WorkspaceUsage is used by a Step or Sidecar to declare that it wants isolated access\nto a Workspace defined in a Task.",
+                  "properties": {
+                    "mountPath": {
+                      "description": "MountPath is the path that the workspace should be mounted to inside the Step or Sidecar,\noverriding any MountPath specified in the Task's WorkspaceDeclaration.",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name is the name of the workspace this Step or Sidecar wants access to.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "mountPath",
+                    "name"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "volumes": {
+          "description": "Volumes is a collection of volumes that are available to mount into the\nsteps of the build.\nSee Pod.spec.volumes (API version: v1)"
+        },
+        "workspaces": {
+          "description": "Workspaces are the volumes that this Task requires.",
+          "items": {
+            "description": "WorkspaceDeclaration is a declaration of a volume that a Task requires.",
+            "properties": {
+              "description": {
+                "description": "Description is an optional human readable description of this volume.",
+                "type": "string"
+              },
+              "mountPath": {
+                "description": "MountPath overrides the directory that the volume will be made available at.",
+                "type": "string"
+              },
+              "name": {
+                "description": "Name is the name by which you can bind the volume at runtime.",
+                "type": "string"
+              },
+              "optional": {
+                "description": "Optional marks a Workspace as not being required in TaskRuns. By default\nthis field is false and so declared workspaces are required.",
+                "type": "boolean"
+              },
+              "readOnly": {
+                "description": "ReadOnly dictates whether a mounted volume is writable. By default this\nfield is false and so mounted volumes are writable.",
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "title": "Tekton Task v1",
+  "type": "object"
+}

--- a/schema/v1/taskrun.json
+++ b/schema/v1/taskrun.json
@@ -1,0 +1,4275 @@
+{
+  "$id": "https://tekton.dev/schemas/v1/taskrun.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "TaskRun represents a single execution of a Task. TaskRuns are how the steps\nspecified in a Task are executed; they specify the parameters and resources\nused to run the steps in a Task.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "TaskRunSpec defines the desired state of TaskRun",
+      "properties": {
+        "computeResources": {
+          "description": "Compute resources to use for this TaskRun",
+          "properties": {
+            "claims": {
+              "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+              "items": {
+                "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                "properties": {
+                  "name": {
+                    "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                    "type": "string"
+                  },
+                  "request": {
+                    "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "limits": {
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+              },
+              "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+              "type": "object"
+            },
+            "requests": {
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+              },
+              "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "debug": {
+          "description": "TaskRunDebug defines the breakpoint config for a particular TaskRun",
+          "properties": {
+            "breakpoints": {
+              "description": "TaskBreakpoints defines the breakpoint config for a particular Task",
+              "properties": {
+                "beforeSteps": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "onFailure": {
+                  "description": "if enabled, pause TaskRun on failure of a step\nfailed step will not exit",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "managedBy": {
+          "description": "ManagedBy indicates which controller is responsible for reconciling\nthis resource. If unset or set to \"tekton.dev/pipeline\", the default\nTekton controller will manage this resource.\nThis field is immutable.",
+          "type": "string"
+        },
+        "params": {
+          "description": "Params is a list of Param",
+          "items": {
+            "description": "Param declares an ParamValues to use for the parameter called name.",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "value": {}
+            },
+            "required": [
+              "name",
+              "value"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "podTemplate": {
+          "description": "PodTemplate holds pod specific configuration",
+          "properties": {
+            "affinity": {
+              "description": "If specified, the pod's scheduling constraints.\nSee Pod.spec.affinity (API version: v1)"
+            },
+            "automountServiceAccountToken": {
+              "description": "AutomountServiceAccountToken indicates whether pods running as this\nservice account should have an API token automatically mounted.",
+              "type": "boolean"
+            },
+            "dnsConfig": {
+              "description": "Specifies the DNS parameters of a pod.\nParameters specified here will be merged to the generated DNS\nconfiguration based on DNSPolicy.",
+              "properties": {
+                "nameservers": {
+                  "description": "A list of DNS name server IP addresses.\nThis will be appended to the base nameservers generated from DNSPolicy.\nDuplicated nameservers will be removed.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "options": {
+                  "description": "A list of DNS resolver options.\nThis will be merged with the base options generated from DNSPolicy.\nDuplicated entries will be removed. Resolution options given in Options\nwill override those that appear in the base DNSPolicy.",
+                  "items": {
+                    "description": "PodDNSConfigOption defines DNS resolver options of a pod.",
+                    "properties": {
+                      "name": {
+                        "description": "Name is this DNS resolver option's name.\nRequired.",
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "Value is this DNS resolver option's value.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "searches": {
+                  "description": "A list of DNS search domains for host-name lookup.\nThis will be appended to the base search paths generated from DNSPolicy.\nDuplicated search paths will be removed.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            },
+            "dnsPolicy": {
+              "description": "Set DNS policy for the pod. Defaults to \"ClusterFirst\". Valid values are\n'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig\nwill be merged with the policy selected with DNSPolicy.",
+              "type": "string"
+            },
+            "enableServiceLinks": {
+              "description": "EnableServiceLinks indicates whether information about services should be injected into pod's\nenvironment variables, matching the syntax of Docker links.\nOptional: Defaults to true.",
+              "type": "boolean"
+            },
+            "env": {
+              "description": "List of environment variables that can be provided to the containers belonging to the pod.",
+              "items": {
+                "description": "EnvVar represents an environment variable present in a Container.",
+                "properties": {
+                  "name": {
+                    "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                    "type": "string"
+                  },
+                  "value": {
+                    "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
+                    "type": "string"
+                  },
+                  "valueFrom": {
+                    "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                    "properties": {
+                      "configMapKeyRef": {
+                        "description": "Selects a key of a ConfigMap.",
+                        "properties": {
+                          "key": {
+                            "description": "The key to select.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "default": "",
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the ConfigMap or its key must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object"
+                      },
+                      "fieldRef": {
+                        "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['\u003cKEY\u003e']`, `metadata.annotations['\u003cKEY\u003e']`,\nspec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                        "properties": {
+                          "apiVersion": {
+                            "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                            "type": "string"
+                          },
+                          "fieldPath": {
+                            "description": "Path of the field to select in the specified API version.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "fieldPath"
+                        ],
+                        "type": "object"
+                      },
+                      "resourceFieldRef": {
+                        "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                        "properties": {
+                          "containerName": {
+                            "description": "Container name: required for volumes, optional for env vars",
+                            "type": "string"
+                          },
+                          "divisor": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                          },
+                          "resource": {
+                            "description": "Required: resource to select",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "resource"
+                        ],
+                        "type": "object"
+                      },
+                      "secretKeyRef": {
+                        "description": "Selects a key of a secret in the pod's namespace",
+                        "properties": {
+                          "key": {
+                            "description": "The key of the secret to select from.  Must be a valid secret key.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "default": "",
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the Secret or its key must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "hostAliases": {
+              "description": "HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts\nfile if specified. This is only valid for non-hostNetwork pods.",
+              "items": {
+                "description": "HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the\npod's hosts file.",
+                "properties": {
+                  "hostnames": {
+                    "description": "Hostnames for the above IP address.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "ip": {
+                    "description": "IP address of the host file entry.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "ip"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "hostNetwork": {
+              "description": "HostNetwork specifies whether the pod may use the node network namespace",
+              "type": "boolean"
+            },
+            "hostUsers": {
+              "description": "HostUsers indicates whether the pod will use the host's user namespace.\nOptional: Default to true.\nIf set to true or not present, the pod will be run in the host user namespace, useful\nfor when the pod needs a feature only available to the host user namespace, such as\nloading a kernel module with CAP_SYS_MODULE.\nWhen set to false, a new user namespace is created for the pod. Setting false\nis useful to mitigating container breakout vulnerabilities such as allowing\ncontainers to run as root without their user having root privileges on the host.\nThis field depends on the kubernetes feature gate UserNamespacesSupport being enabled.",
+              "type": "boolean"
+            },
+            "imagePullSecrets": {
+              "description": "ImagePullSecrets gives the name of the secret used by the pod to pull the image if specified",
+              "items": {
+                "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                "properties": {
+                  "name": {
+                    "default": "",
+                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "nodeSelector": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "NodeSelector is a selector which must be true for the pod to fit on a node.\nSelector which must match a node's labels for the pod to be scheduled on that node.\nMore info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/",
+              "type": "object"
+            },
+            "priorityClassName": {
+              "description": "If specified, indicates the pod's priority. \"system-node-critical\" and\n\"system-cluster-critical\" are two special keywords which indicate the\nhighest priorities with the former being the highest priority. Any other\nname must be defined by creating a PriorityClass object with that name.\nIf not specified, the pod priority will be default or zero if there is no\ndefault.",
+              "type": "string"
+            },
+            "runtimeClassName": {
+              "description": "RuntimeClassName refers to a RuntimeClass object in the node.k8s.io\ngroup, which should be used to run this pod. If no RuntimeClass resource\nmatches the named class, the pod will not be run. If unset or empty, the\n\"legacy\" RuntimeClass will be used, which is an implicit class with an\nempty definition that uses the default runtime handler.\nMore info: https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md\nThis is a beta feature as of Kubernetes v1.14.",
+              "type": "string"
+            },
+            "schedulerName": {
+              "description": "SchedulerName specifies the scheduler to be used to dispatch the Pod",
+              "type": "string"
+            },
+            "securityContext": {
+              "description": "SecurityContext holds pod-level security attributes and common container settings.\nOptional: Defaults to empty.  See type description for default values of each field.\nSee Pod.spec.securityContext (API version: v1)"
+            },
+            "tolerations": {
+              "description": "If specified, the pod's tolerations.",
+              "items": {
+                "description": "The pod this Toleration is attached to tolerates any taint that matches\nthe triple \u003ckey,value,effect\u003e using the matching operator \u003coperator\u003e.",
+                "properties": {
+                  "effect": {
+                    "description": "Effect indicates the taint effect to match. Empty means match all taint effects.\nWhen specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                    "type": "string"
+                  },
+                  "key": {
+                    "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys.\nIf the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "Operator represents a key's relationship to the value.\nValid operators are Exists and Equal. Defaults to Equal.\nExists is equivalent to wildcard for value, so that a pod can\ntolerate all taints of a particular category.",
+                    "type": "string"
+                  },
+                  "tolerationSeconds": {
+                    "description": "TolerationSeconds represents the period of time the toleration (which must be\nof effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,\nit is not set, which means tolerate the taint forever (do not evict). Zero and\nnegative values will be treated as 0 (evict immediately) by the system.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "value": {
+                    "description": "Value is the taint value the toleration matches to.\nIf the operator is Exists, the value should be empty, otherwise just a regular string.",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "topologySpreadConstraints": {
+              "description": "TopologySpreadConstraints controls how Pods are spread across your cluster among\nfailure-domains such as regions, zones, nodes, and other user-defined topology domains.",
+              "items": {
+                "description": "TopologySpreadConstraint specifies how to spread matching pods among the given topology.",
+                "properties": {
+                  "labelSelector": {
+                    "description": "LabelSelector is used to find matching pods.\nPods that match this label selector are counted to determine the number of pods\nin their corresponding topology domain.",
+                    "properties": {
+                      "matchExpressions": {
+                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                        "items": {
+                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                          "properties": {
+                            "key": {
+                              "description": "key is the label key that the selector applies to.",
+                              "type": "string"
+                            },
+                            "operator": {
+                              "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                              "type": "string"
+                            },
+                            "values": {
+                              "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "required": [
+                            "key",
+                            "operator"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "matchLabels": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                        "type": "object"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "matchLabelKeys": {
+                    "description": "MatchLabelKeys is a set of pod label keys to select the pods over which\nspreading will be calculated. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are ANDed with labelSelector\nto select the group of existing pods over which spreading will be calculated\nfor the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.\nMatchLabelKeys cannot be set when LabelSelector isn't set.\nKeys that don't exist in the incoming pod labels will\nbe ignored. A null or empty list means only match against labelSelector.\n\nThis is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "maxSkew": {
+                    "description": "MaxSkew describes the degree to which pods may be unevenly distributed.\nWhen `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference\nbetween the number of matching pods in the target topology and the global minimum.\nThe global minimum is the minimum number of matching pods in an eligible domain\nor zero if the number of eligible domains is less than MinDomains.\nFor example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same\nlabelSelector spread as 2/2/1:\nIn this case, the global minimum is 1.\n| zone1 | zone2 | zone3 |\n|  P P  |  P P  |   P   |\n- if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;\nscheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)\nviolate MaxSkew(1).\n- if MaxSkew is 2, incoming pod can be scheduled onto any zone.\nWhen `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence\nto topologies that satisfy it.\nIt's a required field. Default value is 1 and 0 is not allowed.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "minDomains": {
+                    "description": "MinDomains indicates a minimum number of eligible domains.\nWhen the number of eligible domains with matching topology keys is less than minDomains,\nPod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed.\nAnd when the number of eligible domains with matching topology keys equals or greater than minDomains,\nthis value has no effect on scheduling.\nAs a result, when the number of eligible domains is less than minDomains,\nscheduler won't schedule more than maxSkew Pods to those domains.\nIf value is nil, the constraint behaves as if MinDomains is equal to 1.\nValid values are integers greater than 0.\nWhen value is not nil, WhenUnsatisfiable must be DoNotSchedule.\n\nFor example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same\nlabelSelector spread as 2/2/2:\n| zone1 | zone2 | zone3 |\n|  P P  |  P P  |  P P  |\nThe number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0.\nIn this situation, new pod with the same labelSelector cannot be scheduled,\nbecause computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,\nit will violate MaxSkew.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "nodeAffinityPolicy": {
+                    "description": "NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector\nwhen calculating pod topology spread skew. Options are:\n- Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.\n- Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.\n\nIf this value is nil, the behavior is equivalent to the Honor policy.\nThis is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.",
+                    "type": "string"
+                  },
+                  "nodeTaintsPolicy": {
+                    "description": "NodeTaintsPolicy indicates how we will treat node taints when calculating\npod topology spread skew. Options are:\n- Honor: nodes without taints, along with tainted nodes for which the incoming pod\nhas a toleration, are included.\n- Ignore: node taints are ignored. All nodes are included.\n\nIf this value is nil, the behavior is equivalent to the Ignore policy.\nThis is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.",
+                    "type": "string"
+                  },
+                  "topologyKey": {
+                    "description": "TopologyKey is the key of node labels. Nodes that have a label with this key\nand identical values are considered to be in the same topology.\nWe consider each \u003ckey, value\u003e as a \"bucket\", and try to put balanced number\nof pods into each bucket.\nWe define a domain as a particular instance of a topology.\nAlso, we define an eligible domain as a domain whose nodes meet the requirements of\nnodeAffinityPolicy and nodeTaintsPolicy.\ne.g. If TopologyKey is \"kubernetes.io/hostname\", each Node is a domain of that topology.\nAnd, if TopologyKey is \"topology.kubernetes.io/zone\", each zone is a domain of that topology.\nIt's a required field.",
+                    "type": "string"
+                  },
+                  "whenUnsatisfiable": {
+                    "description": "WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy\nthe spread constraint.\n- DoNotSchedule (default) tells the scheduler not to schedule it.\n- ScheduleAnyway tells the scheduler to schedule the pod in any location,\n  but giving higher precedence to topologies that would help reduce the\n  skew.\nA constraint is considered \"Unsatisfiable\" for an incoming pod\nif and only if every possible node assignment for that pod would violate\n\"MaxSkew\" on some topology.\nFor example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same\nlabelSelector spread as 3/1/1:\n| zone1 | zone2 | zone3 |\n| P P P |   P   |   P   |\nIf WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled\nto zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies\nMaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler\nwon't make it *more* imbalanced.\nIt's a required field.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "maxSkew",
+                  "topologyKey",
+                  "whenUnsatisfiable"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "volumes": {
+              "description": "List of volumes that can be mounted by containers belonging to the pod.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes\nSee Pod.spec.volumes (API version: v1)"
+            }
+          },
+          "type": "object"
+        },
+        "retries": {
+          "description": "Retries represents how many times this TaskRun should be retried in the event of task failure.",
+          "type": "integer"
+        },
+        "serviceAccountName": {
+          "type": "string"
+        },
+        "sidecarSpecs": {
+          "description": "Specs to apply to Sidecars in this TaskRun.\nIf a field is specified in both a Sidecar and a SidecarSpec,\nthe value from the SidecarSpec will be used.\nThis field is only supported when the alpha feature gate is enabled.",
+          "items": {
+            "description": "TaskRunSidecarSpec is used to override the values of a Sidecar in the corresponding Task.",
+            "properties": {
+              "computeResources": {
+                "description": "The resource requirements to apply to the Sidecar.",
+                "properties": {
+                  "claims": {
+                    "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                    "items": {
+                      "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                      "properties": {
+                        "name": {
+                          "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                          "type": "string"
+                        },
+                        "request": {
+                          "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "limits": {
+                    "additionalProperties": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                    },
+                    "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                    "type": "object"
+                  },
+                  "requests": {
+                    "additionalProperties": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                    },
+                    "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                    "type": "object"
+                  }
+                },
+                "type": "object"
+              },
+              "name": {
+                "description": "The name of the Sidecar to override.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "computeResources",
+              "name"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "status": {
+          "description": "Used for cancelling a TaskRun (and maybe more later on)",
+          "type": "string"
+        },
+        "statusMessage": {
+          "description": "Status message for cancellation.",
+          "type": "string"
+        },
+        "stepSpecs": {
+          "description": "Specs to apply to Steps in this TaskRun.\nIf a field is specified in both a Step and a StepSpec,\nthe value from the StepSpec will be used.\nThis field is only supported when the alpha feature gate is enabled.",
+          "items": {
+            "description": "TaskRunStepSpec is used to override the values of a Step in the corresponding Task.",
+            "properties": {
+              "computeResources": {
+                "description": "The resource requirements to apply to the Step.",
+                "properties": {
+                  "claims": {
+                    "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                    "items": {
+                      "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                      "properties": {
+                        "name": {
+                          "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                          "type": "string"
+                        },
+                        "request": {
+                          "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "limits": {
+                    "additionalProperties": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                    },
+                    "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                    "type": "object"
+                  },
+                  "requests": {
+                    "additionalProperties": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                    },
+                    "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                    "type": "object"
+                  }
+                },
+                "type": "object"
+              },
+              "name": {
+                "description": "The name of the Step to override.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "computeResources",
+              "name"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "taskRef": {
+          "description": "no more than one of the TaskRef and TaskSpec may be specified.",
+          "properties": {
+            "apiVersion": {
+              "description": "API version of the referent\nNote: A Task with non-empty APIVersion and Kind is considered a Custom Task",
+              "type": "string"
+            },
+            "kind": {
+              "description": "TaskKind indicates the Kind of the Task:\n1. Namespaced Task when Kind is set to \"Task\". If Kind is \"\", it defaults to \"Task\".\n2. Custom Task when Kind is non-empty and APIVersion is non-empty",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+              "type": "string"
+            },
+            "params": {
+              "description": "Params contains the parameters used to identify the\nreferenced Tekton resource. Example entries might include\n\"repo\" or \"path\" but the set of params ultimately depends on\nthe chosen resolver.",
+              "items": {
+                "description": "Param declares an ParamValues to use for the parameter called name.",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "value": {}
+                },
+                "required": [
+                  "name",
+                  "value"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "resolver": {
+              "description": "Resolver is the name of the resolver that should perform\nresolution of the referenced Tekton resource, such as \"git\".",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "taskSpec": {
+          "description": "Specifying TaskSpec can be disabled by setting\n`disable-inline-spec` feature flag.\nSee Task.spec (API version: tekton.dev/v1)"
+        },
+        "timeout": {
+          "description": "Time after which one retry attempt times out. Defaults to 1 hour.\nRefer Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration",
+          "type": "string"
+        },
+        "workspaces": {
+          "description": "Workspaces is a list of WorkspaceBindings from volumes to workspaces.",
+          "items": {
+            "description": "WorkspaceBinding maps a Task's declared workspace to a Volume.",
+            "properties": {
+              "configMap": {
+                "description": "ConfigMap represents a configMap that should populate this workspace.",
+                "properties": {
+                  "defaultMode": {
+                    "description": "defaultMode is optional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDefaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "items": {
+                    "description": "items if unspecified, each key-value pair in the Data field of the referenced\nConfigMap will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the ConfigMap,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                    "items": {
+                      "description": "Maps a string key to a path within a volume.",
+                      "properties": {
+                        "key": {
+                          "description": "key is the key to project.",
+                          "type": "string"
+                        },
+                        "mode": {
+                          "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "path": {
+                          "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "key",
+                        "path"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "name": {
+                    "default": "",
+                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                    "type": "string"
+                  },
+                  "optional": {
+                    "description": "optional specify whether the ConfigMap or its keys must be defined",
+                    "type": "boolean"
+                  }
+                },
+                "type": "object"
+              },
+              "csi": {
+                "description": "CSI (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers.",
+                "properties": {
+                  "driver": {
+                    "description": "driver is the name of the CSI driver that handles this volume.\nConsult with your admin for the correct name as registered in the cluster.",
+                    "type": "string"
+                  },
+                  "fsType": {
+                    "description": "fsType to mount. Ex. \"ext4\", \"xfs\", \"ntfs\".\nIf not provided, the empty value is passed to the associated CSI driver\nwhich will determine the default filesystem to apply.",
+                    "type": "string"
+                  },
+                  "nodePublishSecretRef": {
+                    "description": "nodePublishSecretRef is a reference to the secret object containing\nsensitive information to pass to the CSI driver to complete the CSI\nNodePublishVolume and NodeUnpublishVolume calls.\nThis field is optional, and  may be empty if no secret is required. If the\nsecret object contains more than one secret, all secret references are passed.",
+                    "properties": {
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "readOnly": {
+                    "description": "readOnly specifies a read-only configuration for the volume.\nDefaults to false (read/write).",
+                    "type": "boolean"
+                  },
+                  "volumeAttributes": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "volumeAttributes stores driver-specific properties that are passed to the CSI\ndriver. Consult your driver's documentation for supported values.",
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "driver"
+                ],
+                "type": "object"
+              },
+              "emptyDir": {
+                "description": "EmptyDir represents a temporary directory that shares a Task's lifetime.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir\nEither this OR PersistentVolumeClaim can be used.",
+                "properties": {
+                  "medium": {
+                    "description": "medium represents what type of storage medium should back this directory.\nThe default is \"\" which means to use the node's default medium.\nMust be an empty string (default) or Memory.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                    "type": "string"
+                  },
+                  "sizeLimit": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "description": "sizeLimit is the total amount of local storage required for this EmptyDir volume.\nThe size limit is also applicable for memory medium.\nThe maximum usage on memory medium EmptyDir would be the minimum value between\nthe SizeLimit specified here and the sum of memory limits of all containers in a pod.\nThe default is nil which means that the limit is undefined.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                  }
+                },
+                "type": "object"
+              },
+              "name": {
+                "description": "Name is the name of the workspace populated by the volume.",
+                "type": "string"
+              },
+              "persistentVolumeClaim": {
+                "description": "PersistentVolumeClaimVolumeSource represents a reference to a\nPersistentVolumeClaim in the same namespace. Either this OR EmptyDir can be used.",
+                "properties": {
+                  "claimName": {
+                    "description": "claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "readOnly Will force the ReadOnly setting in VolumeMounts.\nDefault false.",
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "claimName"
+                ],
+                "type": "object"
+              },
+              "projected": {
+                "description": "Projected represents a projected volume that should populate this workspace.",
+                "properties": {
+                  "defaultMode": {
+                    "description": "defaultMode are the mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "sources": {
+                    "description": "sources is the list of volume projections. Each entry in this list\nhandles one source.",
+                    "items": {
+                      "description": "Projection that may be projected along with other supported volume types.\nExactly one of these fields must be set.",
+                      "properties": {
+                        "clusterTrustBundle": {
+                          "description": "ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field\nof ClusterTrustBundle objects in an auto-updating file.\n\nAlpha, gated by the ClusterTrustBundleProjection feature gate.\n\nClusterTrustBundle objects can either be selected by name, or by the\ncombination of signer name and a label selector.\n\nKubelet performs aggressive normalization of the PEM contents written\ninto the pod filesystem.  Esoteric PEM features such as inter-block\ncomments and block headers are stripped.  Certificates are deduplicated.\nThe ordering of certificates within the file is arbitrary, and Kubelet\nmay change the order over time.",
+                          "properties": {
+                            "labelSelector": {
+                              "description": "Select all ClusterTrustBundles that match this label selector.  Only has\neffect if signerName is set.  Mutually-exclusive with name.  If unset,\ninterpreted as \"match nothing\".  If set but empty, interpreted as \"match\neverything\".",
+                              "properties": {
+                                "matchExpressions": {
+                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                  "items": {
+                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "key is the label key that the selector applies to.",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "operator"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "matchLabels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "name": {
+                              "description": "Select a single ClusterTrustBundle by object name.  Mutually-exclusive\nwith signerName and labelSelector.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "If true, don't block pod startup if the referenced ClusterTrustBundle(s)\naren't available.  If using name, then the named ClusterTrustBundle is\nallowed not to exist.  If using signerName, then the combination of\nsignerName and labelSelector is allowed to match zero\nClusterTrustBundles.",
+                              "type": "boolean"
+                            },
+                            "path": {
+                              "description": "Relative path from the volume root to write the bundle.",
+                              "type": "string"
+                            },
+                            "signerName": {
+                              "description": "Select all ClusterTrustBundles that match this signer name.\nMutually-exclusive with name.  The contents of all selected\nClusterTrustBundles will be unified and deduplicated.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "path"
+                          ],
+                          "type": "object"
+                        },
+                        "configMap": {
+                          "description": "configMap information about the configMap data to project",
+                          "properties": {
+                            "items": {
+                              "description": "items if unspecified, each key-value pair in the Data field of the referenced\nConfigMap will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the ConfigMap,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                              "items": {
+                                "description": "Maps a string key to a path within a volume.",
+                                "properties": {
+                                  "key": {
+                                    "description": "key is the key to project.",
+                                    "type": "string"
+                                  },
+                                  "mode": {
+                                    "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "path": {
+                                    "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "path"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "optional specify whether the ConfigMap or its keys must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "downwardAPI": {
+                          "description": "downwardAPI information about the downwardAPI data to project",
+                          "properties": {
+                            "items": {
+                              "description": "Items is a list of DownwardAPIVolume file",
+                              "items": {
+                                "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                                "properties": {
+                                  "fieldRef": {
+                                    "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.",
+                                    "properties": {
+                                      "apiVersion": {
+                                        "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                        "type": "string"
+                                      },
+                                      "fieldPath": {
+                                        "description": "Path of the field to select in the specified API version.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "fieldPath"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "mode": {
+                                    "description": "Optional: mode bits used to set permissions on this file, must be an octal value\nbetween 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "path": {
+                                    "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                                    "type": "string"
+                                  },
+                                  "resourceFieldRef": {
+                                    "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                                    "properties": {
+                                      "containerName": {
+                                        "description": "Container name: required for volumes, optional for env vars",
+                                        "type": "string"
+                                      },
+                                      "divisor": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                                      },
+                                      "resource": {
+                                        "description": "Required: resource to select",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "resource"
+                                    ],
+                                    "type": "object"
+                                  }
+                                },
+                                "required": [
+                                  "path"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "secret": {
+                          "description": "secret information about the secret data to project",
+                          "properties": {
+                            "items": {
+                              "description": "items if unspecified, each key-value pair in the Data field of the referenced\nSecret will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the Secret,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                              "items": {
+                                "description": "Maps a string key to a path within a volume.",
+                                "properties": {
+                                  "key": {
+                                    "description": "key is the key to project.",
+                                    "type": "string"
+                                  },
+                                  "mode": {
+                                    "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "path": {
+                                    "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "path"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "optional field specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "serviceAccountToken": {
+                          "description": "serviceAccountToken is information about the serviceAccountToken data to project",
+                          "properties": {
+                            "audience": {
+                              "description": "audience is the intended audience of the token. A recipient of a token\nmust identify itself with an identifier specified in the audience of the\ntoken, and otherwise should reject the token. The audience defaults to the\nidentifier of the apiserver.",
+                              "type": "string"
+                            },
+                            "expirationSeconds": {
+                              "description": "expirationSeconds is the requested duration of validity of the service\naccount token. As the token approaches expiration, the kubelet volume\nplugin will proactively rotate the service account token. The kubelet will\nstart trying to rotate the token if the token is older than 80 percent of\nits time to live or if the token is older than 24 hours.Defaults to 1 hour\nand must be at least 10 minutes.",
+                              "format": "int64",
+                              "type": "integer"
+                            },
+                            "path": {
+                              "description": "path is the path relative to the mount point of the file to project the\ntoken into.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "path"
+                          ],
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              },
+              "secret": {
+                "description": "Secret represents a secret that should populate this workspace.",
+                "properties": {
+                  "defaultMode": {
+                    "description": "defaultMode is Optional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values\nfor mode bits. Defaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "items": {
+                    "description": "items If unspecified, each key-value pair in the Data field of the referenced\nSecret will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the Secret,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                    "items": {
+                      "description": "Maps a string key to a path within a volume.",
+                      "properties": {
+                        "key": {
+                          "description": "key is the key to project.",
+                          "type": "string"
+                        },
+                        "mode": {
+                          "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "path": {
+                          "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "key",
+                        "path"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "optional": {
+                    "description": "optional field specify whether the Secret or its keys must be defined",
+                    "type": "boolean"
+                  },
+                  "secretName": {
+                    "description": "secretName is the name of the secret in the pod's namespace to use.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "subPath": {
+                "description": "SubPath is optionally a directory on the volume which should be used\nfor this binding (i.e. the volume will be mounted at this sub directory).",
+                "type": "string"
+              },
+              "volumeClaimTemplate": {
+                "description": "VolumeClaimTemplate is a template for a claim that will be created in the same namespace.\nThe PipelineRun controller is responsible for creating a unique claim for each instance of PipelineRun.\nSee PersistentVolumeClaim (API version: v1)"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "status": {
+      "description": "TaskRunStatus defines the observed state of TaskRun",
+      "properties": {
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Annotations is additional Status fields for the Resource to save some\nadditional State as well as convey more information to the user. This is\nroughly akin to Annotations on any k8s resource, just the reconciler conveying\nricher information outwards.",
+          "type": "object"
+        },
+        "artifacts": {
+          "description": "Artifacts are the list of artifacts written out by the task's containers",
+          "properties": {
+            "inputs": {
+              "items": {
+                "description": "Artifact represents an artifact within a system, potentially containing multiple values\nassociated with it.",
+                "properties": {
+                  "buildOutput": {
+                    "description": "Indicate if the artifact is a build output or a by-product",
+                    "type": "boolean"
+                  },
+                  "name": {
+                    "description": "The artifact's identifying category name",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "A collection of values related to the artifact",
+                    "items": {
+                      "description": "ArtifactValue represents a specific value or data element within an Artifact.",
+                      "properties": {
+                        "digest": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "uri": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "outputs": {
+              "items": {
+                "description": "Artifact represents an artifact within a system, potentially containing multiple values\nassociated with it.",
+                "properties": {
+                  "buildOutput": {
+                    "description": "Indicate if the artifact is a build output or a by-product",
+                    "type": "boolean"
+                  },
+                  "name": {
+                    "description": "The artifact's identifying category name",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "A collection of values related to the artifact",
+                    "items": {
+                      "description": "ArtifactValue represents a specific value or data element within an Artifact.",
+                      "properties": {
+                        "digest": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "uri": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "completionTime": {
+          "description": "CompletionTime is the time the build completed.",
+          "format": "date-time",
+          "type": "string"
+        },
+        "conditions": {
+          "description": "Conditions the latest available observations of a resource's current state.",
+          "items": {
+            "description": "Condition defines a readiness condition for a Knative resource.\nSee: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "LastTransitionTime is the last time the condition transitioned from one status to another.\nWe use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic\ndifferences (all other things held constant).",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity with which to treat failures of this type of condition.\nWhen this is not specified, it defaults to Error.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the 'Generation' of the Service that\nwas last processed by the controller.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "podName": {
+          "description": "PodName is the name of the pod responsible for executing this task's steps.",
+          "type": "string"
+        },
+        "provenance": {
+          "description": "Provenance contains some key authenticated metadata about how a software artifact was built (what sources, what inputs/outputs, etc.).",
+          "properties": {
+            "featureFlags": {
+              "description": "FeatureFlags identifies the feature flags that were used during the task/pipeline run",
+              "properties": {
+                "awaitSidecarReadiness": {
+                  "type": "boolean"
+                },
+                "coschedule": {
+                  "type": "string"
+                },
+                "disableCredsInit": {
+                  "type": "boolean"
+                },
+                "disableInlineSpec": {
+                  "type": "string"
+                },
+                "enableAPIFields": {
+                  "type": "string"
+                },
+                "enableArtifacts": {
+                  "type": "boolean"
+                },
+                "enableCELInWhenExpression": {
+                  "type": "boolean"
+                },
+                "enableConciseResolverSyntax": {
+                  "type": "boolean"
+                },
+                "enableKeepPodOnCancel": {
+                  "type": "boolean"
+                },
+                "enableKubernetesSidecar": {
+                  "type": "boolean"
+                },
+                "enableParamEnum": {
+                  "type": "boolean"
+                },
+                "enableProvenanceInStatus": {
+                  "type": "boolean"
+                },
+                "enableStepActions": {
+                  "description": "EnableStepActions is a no-op flag since StepActions are stable",
+                  "type": "boolean"
+                },
+                "enableWaitExponentialBackoff": {
+                  "type": "boolean"
+                },
+                "enforceNonfalsifiability": {
+                  "type": "string"
+                },
+                "maxResultSize": {
+                  "type": "integer"
+                },
+                "requireGitSSHSecretKnownHosts": {
+                  "type": "boolean"
+                },
+                "resultExtractionMethod": {
+                  "type": "string"
+                },
+                "runningInEnvWithInjectedSidecars": {
+                  "type": "boolean"
+                },
+                "sendCloudEventsForRuns": {
+                  "type": "boolean"
+                },
+                "setSecurityContext": {
+                  "type": "boolean"
+                },
+                "setSecurityContextReadOnlyRootFilesystem": {
+                  "type": "boolean"
+                },
+                "verificationNoMatchPolicy": {
+                  "description": "VerificationNoMatchPolicy is the feature flag for \"trusted-resources-verification-no-match-policy\"\nVerificationNoMatchPolicy can be set to \"ignore\", \"warn\" and \"fail\" values.\nignore: skip trusted resources verification when no matching verification policies found\nwarn: skip trusted resources verification when no matching verification policies found and log a warning\nfail: fail the taskrun or pipelines run if no matching verification policies found",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "refSource": {
+              "description": "RefSource identifies the source where a remote task/pipeline came from.",
+              "properties": {
+                "digest": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Digest is a collection of cryptographic digests for the contents of the artifact specified by URI.\nExample: {\"sha1\": \"f99d13e554ffcb696dee719fa85b695cb5b0f428\"}",
+                  "type": "object"
+                },
+                "entryPoint": {
+                  "description": "EntryPoint identifies the entry point into the build. This is often a path to a\nbuild definition file and/or a target label within that file.\nExample: \"task/git-clone/0.10/git-clone.yaml\"",
+                  "type": "string"
+                },
+                "uri": {
+                  "description": "URI indicates the identity of the source of the build definition.\nExample: \"https://github.com/tektoncd/catalog\"",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "results": {
+          "description": "Results are the list of results written out by the task's containers",
+          "items": {
+            "description": "TaskRunResult used to describe the results of a task",
+            "properties": {
+              "name": {
+                "description": "Name the given name",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type is the user-specified type of the result. The possible type\nis currently \"string\" and will support \"array\" in following work.",
+                "type": "string"
+              },
+              "value": {
+                "description": "Value the given value of the result"
+              }
+            },
+            "required": [
+              "name",
+              "value"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "retriesStatus": {
+          "description": "RetriesStatus contains the history of TaskRunStatus in case of a retry in order to keep record of failures.\nAll TaskRunStatus stored in RetriesStatus will have no date within the RetriesStatus as is redundant."
+        },
+        "sidecars": {
+          "description": "The list has one entry per sidecar in the manifest. Each entry is\nrepresents the imageid of the corresponding sidecar.",
+          "items": {
+            "description": "SidecarState reports the results of running a sidecar in a Task.",
+            "properties": {
+              "container": {
+                "type": "string"
+              },
+              "imageID": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "running": {
+                "description": "Details about a running container",
+                "properties": {
+                  "startedAt": {
+                    "description": "Time at which the container was last (re-)started",
+                    "format": "date-time",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "terminated": {
+                "description": "Details about a terminated container",
+                "properties": {
+                  "containerID": {
+                    "description": "Container's ID in the format '\u003ctype\u003e://\u003ccontainer_id\u003e'",
+                    "type": "string"
+                  },
+                  "exitCode": {
+                    "description": "Exit status from the last termination of the container",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "finishedAt": {
+                    "description": "Time at which the container last terminated",
+                    "format": "date-time",
+                    "type": "string"
+                  },
+                  "message": {
+                    "description": "Message regarding the last termination of the container",
+                    "type": "string"
+                  },
+                  "reason": {
+                    "description": "(brief) reason from the last termination of the container",
+                    "type": "string"
+                  },
+                  "signal": {
+                    "description": "Signal from the last termination of the container",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "startedAt": {
+                    "description": "Time at which previous execution of the container started",
+                    "format": "date-time",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "exitCode"
+                ],
+                "type": "object"
+              },
+              "waiting": {
+                "description": "Details about a waiting container",
+                "properties": {
+                  "message": {
+                    "description": "Message regarding why the container is not yet running.",
+                    "type": "string"
+                  },
+                  "reason": {
+                    "description": "(brief) reason the container is not yet running.",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "spanContext": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "SpanContext contains tracing span context fields",
+          "type": "object"
+        },
+        "startTime": {
+          "description": "StartTime is the time the build is actually started.",
+          "format": "date-time",
+          "type": "string"
+        },
+        "steps": {
+          "description": "Steps describes the state of each build step container.",
+          "items": {
+            "description": "StepState reports the results of running a step in a Task.",
+            "properties": {
+              "container": {
+                "type": "string"
+              },
+              "imageID": {
+                "type": "string"
+              },
+              "inputs": {
+                "items": {
+                  "description": "Artifact represents an artifact within a system, potentially containing multiple values\nassociated with it.",
+                  "properties": {
+                    "buildOutput": {
+                      "description": "Indicate if the artifact is a build output or a by-product",
+                      "type": "boolean"
+                    },
+                    "name": {
+                      "description": "The artifact's identifying category name",
+                      "type": "string"
+                    },
+                    "values": {
+                      "description": "A collection of values related to the artifact",
+                      "items": {
+                        "description": "ArtifactValue represents a specific value or data element within an Artifact.",
+                        "properties": {
+                          "digest": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "uri": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "name": {
+                "type": "string"
+              },
+              "outputs": {
+                "items": {
+                  "description": "Artifact represents an artifact within a system, potentially containing multiple values\nassociated with it.",
+                  "properties": {
+                    "buildOutput": {
+                      "description": "Indicate if the artifact is a build output or a by-product",
+                      "type": "boolean"
+                    },
+                    "name": {
+                      "description": "The artifact's identifying category name",
+                      "type": "string"
+                    },
+                    "values": {
+                      "description": "A collection of values related to the artifact",
+                      "items": {
+                        "description": "ArtifactValue represents a specific value or data element within an Artifact.",
+                        "properties": {
+                          "digest": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "uri": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "provenance": {
+                "description": "Provenance contains metadata about resources used in the TaskRun/PipelineRun\nsuch as the source from where a remote build definition was fetched.\nThis field aims to carry minimum amoumt of metadata in *Run status so that\nTekton Chains can capture them in the provenance.",
+                "properties": {
+                  "featureFlags": {
+                    "description": "FeatureFlags identifies the feature flags that were used during the task/pipeline run",
+                    "properties": {
+                      "awaitSidecarReadiness": {
+                        "type": "boolean"
+                      },
+                      "coschedule": {
+                        "type": "string"
+                      },
+                      "disableCredsInit": {
+                        "type": "boolean"
+                      },
+                      "disableInlineSpec": {
+                        "type": "string"
+                      },
+                      "enableAPIFields": {
+                        "type": "string"
+                      },
+                      "enableArtifacts": {
+                        "type": "boolean"
+                      },
+                      "enableCELInWhenExpression": {
+                        "type": "boolean"
+                      },
+                      "enableConciseResolverSyntax": {
+                        "type": "boolean"
+                      },
+                      "enableKeepPodOnCancel": {
+                        "type": "boolean"
+                      },
+                      "enableKubernetesSidecar": {
+                        "type": "boolean"
+                      },
+                      "enableParamEnum": {
+                        "type": "boolean"
+                      },
+                      "enableProvenanceInStatus": {
+                        "type": "boolean"
+                      },
+                      "enableStepActions": {
+                        "description": "EnableStepActions is a no-op flag since StepActions are stable",
+                        "type": "boolean"
+                      },
+                      "enableWaitExponentialBackoff": {
+                        "type": "boolean"
+                      },
+                      "enforceNonfalsifiability": {
+                        "type": "string"
+                      },
+                      "maxResultSize": {
+                        "type": "integer"
+                      },
+                      "requireGitSSHSecretKnownHosts": {
+                        "type": "boolean"
+                      },
+                      "resultExtractionMethod": {
+                        "type": "string"
+                      },
+                      "runningInEnvWithInjectedSidecars": {
+                        "type": "boolean"
+                      },
+                      "sendCloudEventsForRuns": {
+                        "type": "boolean"
+                      },
+                      "setSecurityContext": {
+                        "type": "boolean"
+                      },
+                      "setSecurityContextReadOnlyRootFilesystem": {
+                        "type": "boolean"
+                      },
+                      "verificationNoMatchPolicy": {
+                        "description": "VerificationNoMatchPolicy is the feature flag for \"trusted-resources-verification-no-match-policy\"\nVerificationNoMatchPolicy can be set to \"ignore\", \"warn\" and \"fail\" values.\nignore: skip trusted resources verification when no matching verification policies found\nwarn: skip trusted resources verification when no matching verification policies found and log a warning\nfail: fail the taskrun or pipelines run if no matching verification policies found",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "refSource": {
+                    "description": "RefSource identifies the source where a remote task/pipeline came from.",
+                    "properties": {
+                      "digest": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "Digest is a collection of cryptographic digests for the contents of the artifact specified by URI.\nExample: {\"sha1\": \"f99d13e554ffcb696dee719fa85b695cb5b0f428\"}",
+                        "type": "object"
+                      },
+                      "entryPoint": {
+                        "description": "EntryPoint identifies the entry point into the build. This is often a path to a\nbuild definition file and/or a target label within that file.\nExample: \"task/git-clone/0.10/git-clone.yaml\"",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "URI indicates the identity of the source of the build definition.\nExample: \"https://github.com/tektoncd/catalog\"",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "type": "object"
+              },
+              "results": {
+                "items": {
+                  "description": "TaskRunResult used to describe the results of a task",
+                  "properties": {
+                    "name": {
+                      "description": "Name the given name",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "Type is the user-specified type of the result. The possible type\nis currently \"string\" and will support \"array\" in following work.",
+                      "type": "string"
+                    },
+                    "value": {
+                      "description": "Value the given value of the result"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "value"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "running": {
+                "description": "Details about a running container",
+                "properties": {
+                  "startedAt": {
+                    "description": "Time at which the container was last (re-)started",
+                    "format": "date-time",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "terminated": {
+                "description": "Details about a terminated container",
+                "properties": {
+                  "containerID": {
+                    "description": "Container's ID in the format '\u003ctype\u003e://\u003ccontainer_id\u003e'",
+                    "type": "string"
+                  },
+                  "exitCode": {
+                    "description": "Exit status from the last termination of the container",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "finishedAt": {
+                    "description": "Time at which the container last terminated",
+                    "format": "date-time",
+                    "type": "string"
+                  },
+                  "message": {
+                    "description": "Message regarding the last termination of the container",
+                    "type": "string"
+                  },
+                  "reason": {
+                    "description": "(brief) reason from the last termination of the container",
+                    "type": "string"
+                  },
+                  "signal": {
+                    "description": "Signal from the last termination of the container",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "startedAt": {
+                    "description": "Time at which previous execution of the container started",
+                    "format": "date-time",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "exitCode"
+                ],
+                "type": "object"
+              },
+              "terminationReason": {
+                "type": "string"
+              },
+              "waiting": {
+                "description": "Details about a waiting container",
+                "properties": {
+                  "message": {
+                    "description": "Message regarding why the container is not yet running.",
+                    "type": "string"
+                  },
+                  "reason": {
+                    "description": "(brief) reason the container is not yet running.",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "taskSpec": {
+          "description": "TaskSpec contains the Spec from the dereferenced Task definition used to instantiate this TaskRun.",
+          "properties": {
+            "description": {
+              "description": "Description is a user-facing description of the task that may be\nused to populate a UI.",
+              "type": "string"
+            },
+            "displayName": {
+              "description": "DisplayName is a user-facing name of the task that may be\nused to populate a UI.",
+              "type": "string"
+            },
+            "params": {
+              "description": "Params is a list of input parameters required to run the task. Params\nmust be supplied as inputs in TaskRuns unless they declare a default\nvalue.",
+              "items": {
+                "description": "ParamSpec defines arbitrary parameters needed beyond typed inputs (such as\nresources). Parameter values are provided by users as inputs on a TaskRun\nor PipelineRun.",
+                "properties": {
+                  "default": {
+                    "description": "Default is the value a parameter takes if no input value is supplied. If\ndefault is set, a Task may be executed without a supplied value for the\nparameter."
+                  },
+                  "description": {
+                    "description": "Description is a user-facing description of the parameter that may be\nused to populate a UI.",
+                    "type": "string"
+                  },
+                  "enum": {
+                    "description": "Enum declares a set of allowed param input values for tasks/pipelines that can be validated.\nIf Enum is not set, no input validation is performed for the param.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "name": {
+                    "description": "Name declares the name by which a parameter is referenced.",
+                    "type": "string"
+                  },
+                  "properties": {
+                    "additionalProperties": {
+                      "description": "PropertySpec defines the struct for object keys",
+                      "properties": {
+                        "type": {
+                          "description": "ParamType indicates the type of an input parameter;\nUsed to distinguish between a single string and an array of strings.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "description": "Properties is the JSON Schema properties to support key-value pairs parameter.",
+                    "type": "object"
+                  },
+                  "type": {
+                    "description": "Type is the user-specified type of the parameter. The possible types\nare currently \"string\", \"array\" and \"object\", and \"string\" is the default.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "results": {
+              "description": "Results are values that this Task can output",
+              "items": {
+                "description": "TaskResult used to describe the results of a task",
+                "properties": {
+                  "description": {
+                    "description": "Description is a human-readable description of the result",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name the given name",
+                    "type": "string"
+                  },
+                  "properties": {
+                    "additionalProperties": {
+                      "description": "PropertySpec defines the struct for object keys",
+                      "properties": {
+                        "type": {
+                          "description": "ParamType indicates the type of an input parameter;\nUsed to distinguish between a single string and an array of strings.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "description": "Properties is the JSON Schema properties to support key-value pairs results.",
+                    "type": "object"
+                  },
+                  "type": {
+                    "description": "Type is the user-specified type of the result. The possible type\nis currently \"string\" and will support \"array\" in following work.",
+                    "type": "string"
+                  },
+                  "value": {
+                    "description": "Value the expression used to retrieve the value of the result from an underlying Step."
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "sidecars": {
+              "description": "Sidecars are run alongside the Task's step containers. They begin before\nthe steps start and end after the steps complete.",
+              "items": {
+                "description": "Sidecar has nearly the same data structure as Step but does not have the ability to timeout.",
+                "properties": {
+                  "args": {
+                    "description": "Arguments to the entrypoint.\nThe image's CMD is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the Sidecar's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will\nproduce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless\nof whether the variable exists or not. Cannot be updated.\nMore info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "command": {
+                    "description": "Entrypoint array. Not executed within a shell.\nThe image's ENTRYPOINT is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the Sidecar's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will\nproduce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless\nof whether the variable exists or not. Cannot be updated.\nMore info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "computeResources": {
+                    "description": "ComputeResources required by this Sidecar.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                    "properties": {
+                      "claims": {
+                        "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                        "items": {
+                          "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                          "properties": {
+                            "name": {
+                              "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                              "type": "string"
+                            },
+                            "request": {
+                              "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "limits": {
+                        "additionalProperties": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                        },
+                        "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                        "type": "object"
+                      },
+                      "requests": {
+                        "additionalProperties": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                        },
+                        "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                        "type": "object"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "env": {
+                    "description": "List of environment variables to set in the Sidecar.\nCannot be updated.",
+                    "items": {
+                      "description": "EnvVar represents an environment variable present in a Container.",
+                      "properties": {
+                        "name": {
+                          "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                          "type": "string"
+                        },
+                        "value": {
+                          "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
+                          "type": "string"
+                        },
+                        "valueFrom": {
+                          "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                          "properties": {
+                            "configMapKeyRef": {
+                              "description": "Selects a key of a ConfigMap.",
+                              "properties": {
+                                "key": {
+                                  "description": "The key to select.",
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "default": "",
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "description": "Specify whether the ConfigMap or its key must be defined",
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object"
+                            },
+                            "fieldRef": {
+                              "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['\u003cKEY\u003e']`, `metadata.annotations['\u003cKEY\u003e']`,\nspec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                              "properties": {
+                                "apiVersion": {
+                                  "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                  "type": "string"
+                                },
+                                "fieldPath": {
+                                  "description": "Path of the field to select in the specified API version.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "fieldPath"
+                              ],
+                              "type": "object"
+                            },
+                            "resourceFieldRef": {
+                              "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                              "properties": {
+                                "containerName": {
+                                  "description": "Container name: required for volumes, optional for env vars",
+                                  "type": "string"
+                                },
+                                "divisor": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                                },
+                                "resource": {
+                                  "description": "Required: resource to select",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "resource"
+                              ],
+                              "type": "object"
+                            },
+                            "secretKeyRef": {
+                              "description": "Selects a key of a secret in the pod's namespace",
+                              "properties": {
+                                "key": {
+                                  "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "default": "",
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "description": "Specify whether the Secret or its key must be defined",
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "envFrom": {
+                    "description": "List of sources to populate environment variables in the Sidecar.\nThe keys defined within a source must be a C_IDENTIFIER. All invalid keys\nwill be reported as an event when the container is starting. When a key exists in multiple\nsources, the value associated with the last source will take precedence.\nValues defined by an Env with a duplicate key will take precedence.\nCannot be updated.",
+                    "items": {
+                      "description": "EnvFromSource represents the source of a set of ConfigMaps",
+                      "properties": {
+                        "configMapRef": {
+                          "description": "The ConfigMap to select from",
+                          "properties": {
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the ConfigMap must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "prefix": {
+                          "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
+                          "type": "string"
+                        },
+                        "secretRef": {
+                          "description": "The Secret to select from",
+                          "properties": {
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "image": {
+                    "description": "Image reference name.\nMore info: https://kubernetes.io/docs/concepts/containers/images",
+                    "type": "string"
+                  },
+                  "imagePullPolicy": {
+                    "description": "Image pull policy.\nOne of Always, Never, IfNotPresent.\nDefaults to Always if :latest tag is specified, or IfNotPresent otherwise.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+                    "type": "string"
+                  },
+                  "lifecycle": {
+                    "description": "Actions that the management system should take in response to Sidecar lifecycle events.\nCannot be updated.",
+                    "properties": {
+                      "postStart": {
+                        "description": "PostStart is called immediately after a container is created. If the handler fails,\nthe container is terminated and restarted according to its restart policy.\nOther management of the container blocks until the hook completes.\nMore info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+                        "properties": {
+                          "exec": {
+                            "description": "Exec specifies a command to execute in the container.",
+                            "properties": {
+                              "command": {
+                                "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "httpGet": {
+                            "description": "HTTPGet specifies an HTTP GET request to perform.",
+                            "properties": {
+                              "host": {
+                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                "items": {
+                                  "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                  "properties": {
+                                    "name": {
+                                      "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "description": "The header field value",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "description": "Path to access on the HTTP server.",
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
+                              },
+                              "scheme": {
+                                "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object"
+                          },
+                          "sleep": {
+                            "description": "Sleep represents a duration that the container should sleep.",
+                            "properties": {
+                              "seconds": {
+                                "description": "Seconds is the number of seconds to sleep.",
+                                "format": "int64",
+                                "type": "integer"
+                              }
+                            },
+                            "required": [
+                              "seconds"
+                            ],
+                            "type": "object"
+                          },
+                          "tcpSocket": {
+                            "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept\nfor backward compatibility. There is no validation of this field and\nlifecycle hooks will fail at runtime when it is specified.",
+                            "properties": {
+                              "host": {
+                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "preStop": {
+                        "description": "PreStop is called immediately before a container is terminated due to an\nAPI request or management event such as liveness/startup probe failure,\npreemption, resource contention, etc. The handler is not called if the\ncontainer crashes or exits. The Pod's termination grace period countdown begins before the\nPreStop hook is executed. Regardless of the outcome of the handler, the\ncontainer will eventually terminate within the Pod's termination grace\nperiod (unless delayed by finalizers). Other management of the container blocks until the hook completes\nor until the termination grace period is reached.\nMore info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+                        "properties": {
+                          "exec": {
+                            "description": "Exec specifies a command to execute in the container.",
+                            "properties": {
+                              "command": {
+                                "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "httpGet": {
+                            "description": "HTTPGet specifies an HTTP GET request to perform.",
+                            "properties": {
+                              "host": {
+                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                "items": {
+                                  "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                  "properties": {
+                                    "name": {
+                                      "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "description": "The header field value",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "description": "Path to access on the HTTP server.",
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
+                              },
+                              "scheme": {
+                                "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object"
+                          },
+                          "sleep": {
+                            "description": "Sleep represents a duration that the container should sleep.",
+                            "properties": {
+                              "seconds": {
+                                "description": "Seconds is the number of seconds to sleep.",
+                                "format": "int64",
+                                "type": "integer"
+                              }
+                            },
+                            "required": [
+                              "seconds"
+                            ],
+                            "type": "object"
+                          },
+                          "tcpSocket": {
+                            "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept\nfor backward compatibility. There is no validation of this field and\nlifecycle hooks will fail at runtime when it is specified.",
+                            "properties": {
+                              "host": {
+                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "livenessProbe": {
+                    "description": "Periodic probe of Sidecar liveness.\nContainer will be restarted if the probe fails.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                    "properties": {
+                      "exec": {
+                        "description": "Exec specifies a command to execute in the container.",
+                        "properties": {
+                          "command": {
+                            "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "failureThreshold": {
+                        "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "grpc": {
+                        "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                        "properties": {
+                          "port": {
+                            "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "service": {
+                            "default": "",
+                            "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object"
+                      },
+                      "httpGet": {
+                        "description": "HTTPGet specifies an HTTP GET request to perform.",
+                        "properties": {
+                          "host": {
+                            "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                            "type": "string"
+                          },
+                          "httpHeaders": {
+                            "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                            "items": {
+                              "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                              "properties": {
+                                "name": {
+                                  "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "description": "The header field value",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "value"
+                              ],
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "path": {
+                            "description": "Path to access on the HTTP server.",
+                            "type": "string"
+                          },
+                          "port": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
+                          },
+                          "scheme": {
+                            "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object"
+                      },
+                      "initialDelaySeconds": {
+                        "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "periodSeconds": {
+                        "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "successThreshold": {
+                        "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "tcpSocket": {
+                        "description": "TCPSocket specifies a connection to a TCP port.",
+                        "properties": {
+                          "host": {
+                            "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                            "type": "string"
+                          },
+                          "port": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object"
+                      },
+                      "terminationGracePeriodSeconds": {
+                        "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "timeoutSeconds": {
+                        "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                        "format": "int32",
+                        "type": "integer"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "name": {
+                    "description": "Name of the Sidecar specified as a DNS_LABEL.\nEach Sidecar in a Task must have a unique name (DNS_LABEL).\nCannot be updated.",
+                    "type": "string"
+                  },
+                  "ports": {
+                    "description": "List of ports to expose from the Sidecar. Exposing a port here gives\nthe system additional information about the network connections a\ncontainer uses, but is primarily informational. Not specifying a port here\nDOES NOT prevent that port from being exposed. Any port which is\nlistening on the default \"0.0.0.0\" address inside a container will be\naccessible from the network.\nCannot be updated.",
+                    "items": {
+                      "description": "ContainerPort represents a network port in a single container.",
+                      "properties": {
+                        "containerPort": {
+                          "description": "Number of port to expose on the pod's IP address.\nThis must be a valid port number, 0 \u003c x \u003c 65536.",
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "hostIP": {
+                          "description": "What host IP to bind the external port to.",
+                          "type": "string"
+                        },
+                        "hostPort": {
+                          "description": "Number of port to expose on the host.\nIf specified, this must be a valid port number, 0 \u003c x \u003c 65536.\nIf HostNetwork is specified, this must match ContainerPort.\nMost containers do not need this.",
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "name": {
+                          "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each\nnamed port in a pod must have a unique name. Name for the port that can be\nreferred to by services.",
+                          "type": "string"
+                        },
+                        "protocol": {
+                          "default": "TCP",
+                          "description": "Protocol for port. Must be UDP, TCP, or SCTP.\nDefaults to \"TCP\".",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "containerPort"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "readinessProbe": {
+                    "description": "Periodic probe of Sidecar service readiness.\nContainer will be removed from service endpoints if the probe fails.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                    "properties": {
+                      "exec": {
+                        "description": "Exec specifies a command to execute in the container.",
+                        "properties": {
+                          "command": {
+                            "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "failureThreshold": {
+                        "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "grpc": {
+                        "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                        "properties": {
+                          "port": {
+                            "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "service": {
+                            "default": "",
+                            "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object"
+                      },
+                      "httpGet": {
+                        "description": "HTTPGet specifies an HTTP GET request to perform.",
+                        "properties": {
+                          "host": {
+                            "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                            "type": "string"
+                          },
+                          "httpHeaders": {
+                            "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                            "items": {
+                              "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                              "properties": {
+                                "name": {
+                                  "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "description": "The header field value",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "value"
+                              ],
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "path": {
+                            "description": "Path to access on the HTTP server.",
+                            "type": "string"
+                          },
+                          "port": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
+                          },
+                          "scheme": {
+                            "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object"
+                      },
+                      "initialDelaySeconds": {
+                        "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "periodSeconds": {
+                        "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "successThreshold": {
+                        "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "tcpSocket": {
+                        "description": "TCPSocket specifies a connection to a TCP port.",
+                        "properties": {
+                          "host": {
+                            "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                            "type": "string"
+                          },
+                          "port": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object"
+                      },
+                      "terminationGracePeriodSeconds": {
+                        "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "timeoutSeconds": {
+                        "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                        "format": "int32",
+                        "type": "integer"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "restartPolicy": {
+                    "description": "RestartPolicy refers to kubernetes RestartPolicy. It can only be set for an\ninitContainer and must have it's policy set to \"Always\". It is currently\nleft optional to help support Kubernetes versions prior to 1.29 when this feature\nwas introduced.",
+                    "type": "string"
+                  },
+                  "script": {
+                    "description": "Script is the contents of an executable file to execute.\n\nIf Script is not empty, the Step cannot have an Command or Args.",
+                    "type": "string"
+                  },
+                  "securityContext": {
+                    "description": "SecurityContext defines the security options the Sidecar should be run with.\nIf set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.\nMore info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/",
+                    "properties": {
+                      "allowPrivilegeEscalation": {
+                        "description": "AllowPrivilegeEscalation controls whether a process can gain more\nprivileges than its parent process. This bool directly controls if\nthe no_new_privs flag will be set on the container process.\nAllowPrivilegeEscalation is true always when the container is:\n1) run as Privileged\n2) has CAP_SYS_ADMIN\nNote that this field cannot be set when spec.os.name is windows.",
+                        "type": "boolean"
+                      },
+                      "appArmorProfile": {
+                        "description": "appArmorProfile is the AppArmor options to use by this container. If set, this profile\noverrides the pod's appArmorProfile.\nNote that this field cannot be set when spec.os.name is windows.",
+                        "properties": {
+                          "localhostProfile": {
+                            "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                            "type": "string"
+                          },
+                          "type": {
+                            "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ],
+                        "type": "object"
+                      },
+                      "capabilities": {
+                        "description": "The capabilities to add/drop when running containers.\nDefaults to the default set of capabilities granted by the container runtime.\nNote that this field cannot be set when spec.os.name is windows.",
+                        "properties": {
+                          "add": {
+                            "description": "Added capabilities",
+                            "items": {
+                              "description": "Capability represent POSIX capabilities type",
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "drop": {
+                            "description": "Removed capabilities",
+                            "items": {
+                              "description": "Capability represent POSIX capabilities type",
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "privileged": {
+                        "description": "Run container in privileged mode.\nProcesses in privileged containers are essentially equivalent to root on the host.\nDefaults to false.\nNote that this field cannot be set when spec.os.name is windows.",
+                        "type": "boolean"
+                      },
+                      "procMount": {
+                        "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
+                        "type": "string"
+                      },
+                      "readOnlyRootFilesystem": {
+                        "description": "Whether this container has a read-only root filesystem.\nDefault is false.\nNote that this field cannot be set when spec.os.name is windows.",
+                        "type": "boolean"
+                      },
+                      "runAsGroup": {
+                        "description": "The GID to run the entrypoint of the container process.\nUses runtime default if unset.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "runAsNonRoot": {
+                        "description": "Indicates that the container must run as a non-root user.\nIf true, the Kubelet will validate the image at runtime to ensure that it\ndoes not run as UID 0 (root) and fail to start the container if it does.\nIf unset or false, no such validation will be performed.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
+                        "type": "boolean"
+                      },
+                      "runAsUser": {
+                        "description": "The UID to run the entrypoint of the container process.\nDefaults to user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "seLinuxOptions": {
+                        "description": "The SELinux context to be applied to the container.\nIf unspecified, the container runtime will allocate a random SELinux context for each\ncontainer.  May also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+                        "properties": {
+                          "level": {
+                            "description": "Level is SELinux level label that applies to the container.",
+                            "type": "string"
+                          },
+                          "role": {
+                            "description": "Role is a SELinux role label that applies to the container.",
+                            "type": "string"
+                          },
+                          "type": {
+                            "description": "Type is a SELinux type label that applies to the container.",
+                            "type": "string"
+                          },
+                          "user": {
+                            "description": "User is a SELinux user label that applies to the container.",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "seccompProfile": {
+                        "description": "The seccomp options to use by this container. If seccomp options are\nprovided at both the pod \u0026 container level, the container options\noverride the pod options.\nNote that this field cannot be set when spec.os.name is windows.",
+                        "properties": {
+                          "localhostProfile": {
+                            "description": "localhostProfile indicates a profile defined in a file on the node should be used.\nThe profile must be preconfigured on the node to work.\nMust be a descending path, relative to the kubelet's configured seccomp profile location.\nMust be set if type is \"Localhost\". Must NOT be set for any other type.",
+                            "type": "string"
+                          },
+                          "type": {
+                            "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ],
+                        "type": "object"
+                      },
+                      "windowsOptions": {
+                        "description": "The Windows specific settings applied to all containers.\nIf unspecified, the options from the PodSecurityContext will be used.\nIf set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is linux.",
+                        "properties": {
+                          "gmsaCredentialSpec": {
+                            "description": "GMSACredentialSpec is where the GMSA admission webhook\n(https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the\nGMSA credential spec named by the GMSACredentialSpecName field.",
+                            "type": "string"
+                          },
+                          "gmsaCredentialSpecName": {
+                            "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                            "type": "string"
+                          },
+                          "hostProcess": {
+                            "description": "HostProcess determines if a container should be run as a 'Host Process' container.\nAll of a Pod's containers must have the same effective HostProcess value\n(it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).\nIn addition, if HostProcess is true then HostNetwork must also be set to true.",
+                            "type": "boolean"
+                          },
+                          "runAsUserName": {
+                            "description": "The UserName in Windows to run the entrypoint of the container process.\nDefaults to the user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext. If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "startupProbe": {
+                    "description": "StartupProbe indicates that the Pod the Sidecar is running in has successfully initialized.\nIf specified, no other probes are executed until this completes successfully.\nIf this probe fails, the Pod will be restarted, just as if the livenessProbe failed.\nThis can be used to provide different probe parameters at the beginning of a Pod's lifecycle,\nwhen it might take a long time to load data or warm a cache, than during steady-state operation.\nThis cannot be updated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                    "properties": {
+                      "exec": {
+                        "description": "Exec specifies a command to execute in the container.",
+                        "properties": {
+                          "command": {
+                            "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "failureThreshold": {
+                        "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "grpc": {
+                        "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                        "properties": {
+                          "port": {
+                            "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "service": {
+                            "default": "",
+                            "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object"
+                      },
+                      "httpGet": {
+                        "description": "HTTPGet specifies an HTTP GET request to perform.",
+                        "properties": {
+                          "host": {
+                            "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                            "type": "string"
+                          },
+                          "httpHeaders": {
+                            "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                            "items": {
+                              "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                              "properties": {
+                                "name": {
+                                  "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "description": "The header field value",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "value"
+                              ],
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "path": {
+                            "description": "Path to access on the HTTP server.",
+                            "type": "string"
+                          },
+                          "port": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
+                          },
+                          "scheme": {
+                            "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object"
+                      },
+                      "initialDelaySeconds": {
+                        "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "periodSeconds": {
+                        "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "successThreshold": {
+                        "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "tcpSocket": {
+                        "description": "TCPSocket specifies a connection to a TCP port.",
+                        "properties": {
+                          "host": {
+                            "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                            "type": "string"
+                          },
+                          "port": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object"
+                      },
+                      "terminationGracePeriodSeconds": {
+                        "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "timeoutSeconds": {
+                        "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                        "format": "int32",
+                        "type": "integer"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "stdin": {
+                    "description": "Whether this Sidecar should allocate a buffer for stdin in the container runtime. If this\nis not set, reads from stdin in the Sidecar will always result in EOF.\nDefault is false.",
+                    "type": "boolean"
+                  },
+                  "stdinOnce": {
+                    "description": "Whether the container runtime should close the stdin channel after it has been opened by\na single attach. When stdin is true the stdin stream will remain open across multiple attach\nsessions. If stdinOnce is set to true, stdin is opened on Sidecar start, is empty until the\nfirst client attaches to stdin, and then remains open and accepts data until the client disconnects,\nat which time stdin is closed and remains closed until the Sidecar is restarted. If this\nflag is false, a container processes that reads from stdin will never receive an EOF.\nDefault is false",
+                    "type": "boolean"
+                  },
+                  "terminationMessagePath": {
+                    "description": "Optional: Path at which the file to which the Sidecar's termination message\nwill be written is mounted into the Sidecar's filesystem.\nMessage written is intended to be brief final status, such as an assertion failure message.\nWill be truncated by the node if greater than 4096 bytes. The total message length across\nall containers will be limited to 12kb.\nDefaults to /dev/termination-log.\nCannot be updated.",
+                    "type": "string"
+                  },
+                  "terminationMessagePolicy": {
+                    "description": "Indicate how the termination message should be populated. File will use the contents of\nterminationMessagePath to populate the Sidecar status message on both success and failure.\nFallbackToLogsOnError will use the last chunk of Sidecar log output if the termination\nmessage file is empty and the Sidecar exited with an error.\nThe log output is limited to 2048 bytes or 80 lines, whichever is smaller.\nDefaults to File.\nCannot be updated.",
+                    "type": "string"
+                  },
+                  "tty": {
+                    "description": "Whether this Sidecar should allocate a TTY for itself, also requires 'stdin' to be true.\nDefault is false.",
+                    "type": "boolean"
+                  },
+                  "volumeDevices": {
+                    "description": "volumeDevices is the list of block devices to be used by the Sidecar.",
+                    "items": {
+                      "description": "volumeDevice describes a mapping of a raw block device within a container.",
+                      "properties": {
+                        "devicePath": {
+                          "description": "devicePath is the path inside of the container that the device will be mapped to.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "name must match the name of a persistentVolumeClaim in the pod",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "devicePath",
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "volumeMounts": {
+                    "description": "Volumes to mount into the Sidecar's filesystem.\nCannot be updated.",
+                    "items": {
+                      "description": "VolumeMount describes a mounting of a Volume within a container.",
+                      "properties": {
+                        "mountPath": {
+                          "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
+                          "type": "string"
+                        },
+                        "mountPropagation": {
+                          "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "This must match the Name of a Volume.",
+                          "type": "string"
+                        },
+                        "readOnly": {
+                          "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
+                          "type": "boolean"
+                        },
+                        "recursiveReadOnly": {
+                          "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
+                          "type": "string"
+                        },
+                        "subPath": {
+                          "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
+                          "type": "string"
+                        },
+                        "subPathExpr": {
+                          "description": "Expanded path within the volume from which the container's volume should be mounted.\nBehaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.\nDefaults to \"\" (volume's root).\nSubPathExpr and SubPath are mutually exclusive.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "mountPath",
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "workingDir": {
+                    "description": "Sidecar's working directory.\nIf not specified, the container runtime's default will be used, which\nmight be configured in the container image.\nCannot be updated.",
+                    "type": "string"
+                  },
+                  "workspaces": {
+                    "description": "This is an alpha field. You must set the \"enable-api-fields\" feature flag to \"alpha\"\nfor this field to be supported.\n\nWorkspaces is a list of workspaces from the Task that this Sidecar wants\nexclusive access to. Adding a workspace to this list means that any\nother Step or Sidecar that does not also request this Workspace will\nnot have access to it.",
+                    "items": {
+                      "description": "WorkspaceUsage is used by a Step or Sidecar to declare that it wants isolated access\nto a Workspace defined in a Task.",
+                      "properties": {
+                        "mountPath": {
+                          "description": "MountPath is the path that the workspace should be mounted to inside the Step or Sidecar,\noverriding any MountPath specified in the Task's WorkspaceDeclaration.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name is the name of the workspace this Step or Sidecar wants access to.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "mountPath",
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "stepTemplate": {
+              "description": "StepTemplate can be used as the basis for all step containers within the\nTask, so that the steps inherit settings on the base container.",
+              "properties": {
+                "args": {
+                  "description": "Arguments to the entrypoint.\nThe image's CMD is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the Step's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will\nproduce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless\nof whether the variable exists or not. Cannot be updated.\nMore info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "command": {
+                  "description": "Entrypoint array. Not executed within a shell.\nThe image's ENTRYPOINT is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the Step's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will\nproduce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless\nof whether the variable exists or not. Cannot be updated.\nMore info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "computeResources": {
+                  "description": "ComputeResources required by this Step.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                  "properties": {
+                    "claims": {
+                      "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                      "items": {
+                        "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                        "properties": {
+                          "name": {
+                            "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                            "type": "string"
+                          },
+                          "request": {
+                            "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "limits": {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                      },
+                      "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                      "type": "object"
+                    },
+                    "requests": {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                      },
+                      "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "env": {
+                  "description": "List of environment variables to set in the Step.\nCannot be updated.",
+                  "items": {
+                    "description": "EnvVar represents an environment variable present in a Container.",
+                    "properties": {
+                      "name": {
+                        "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
+                        "type": "string"
+                      },
+                      "valueFrom": {
+                        "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                        "properties": {
+                          "configMapKeyRef": {
+                            "description": "Selects a key of a ConfigMap.",
+                            "properties": {
+                              "key": {
+                                "description": "The key to select.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "default": "",
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the ConfigMap or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object"
+                          },
+                          "fieldRef": {
+                            "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['\u003cKEY\u003e']`, `metadata.annotations['\u003cKEY\u003e']`,\nspec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                            "properties": {
+                              "apiVersion": {
+                                "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                "type": "string"
+                              },
+                              "fieldPath": {
+                                "description": "Path of the field to select in the specified API version.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "fieldPath"
+                            ],
+                            "type": "object"
+                          },
+                          "resourceFieldRef": {
+                            "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                            "properties": {
+                              "containerName": {
+                                "description": "Container name: required for volumes, optional for env vars",
+                                "type": "string"
+                              },
+                              "divisor": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                              },
+                              "resource": {
+                                "description": "Required: resource to select",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "resource"
+                            ],
+                            "type": "object"
+                          },
+                          "secretKeyRef": {
+                            "description": "Selects a key of a secret in the pod's namespace",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "default": "",
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "envFrom": {
+                  "description": "List of sources to populate environment variables in the Step.\nThe keys defined within a source must be a C_IDENTIFIER. All invalid keys\nwill be reported as an event when the Step is starting. When a key exists in multiple\nsources, the value associated with the last source will take precedence.\nValues defined by an Env with a duplicate key will take precedence.\nCannot be updated.",
+                  "items": {
+                    "description": "EnvFromSource represents the source of a set of ConfigMaps",
+                    "properties": {
+                      "configMapRef": {
+                        "description": "The ConfigMap to select from",
+                        "properties": {
+                          "name": {
+                            "default": "",
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the ConfigMap must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "prefix": {
+                        "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
+                        "type": "string"
+                      },
+                      "secretRef": {
+                        "description": "The Secret to select from",
+                        "properties": {
+                          "name": {
+                            "default": "",
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the Secret must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "image": {
+                  "description": "Image reference name.\nMore info: https://kubernetes.io/docs/concepts/containers/images",
+                  "type": "string"
+                },
+                "imagePullPolicy": {
+                  "description": "Image pull policy.\nOne of Always, Never, IfNotPresent.\nDefaults to Always if :latest tag is specified, or IfNotPresent otherwise.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+                  "type": "string"
+                },
+                "securityContext": {
+                  "description": "SecurityContext defines the security options the Step should be run with.\nIf set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.\nMore info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/",
+                  "properties": {
+                    "allowPrivilegeEscalation": {
+                      "description": "AllowPrivilegeEscalation controls whether a process can gain more\nprivileges than its parent process. This bool directly controls if\nthe no_new_privs flag will be set on the container process.\nAllowPrivilegeEscalation is true always when the container is:\n1) run as Privileged\n2) has CAP_SYS_ADMIN\nNote that this field cannot be set when spec.os.name is windows.",
+                      "type": "boolean"
+                    },
+                    "appArmorProfile": {
+                      "description": "appArmorProfile is the AppArmor options to use by this container. If set, this profile\noverrides the pod's appArmorProfile.\nNote that this field cannot be set when spec.os.name is windows.",
+                      "properties": {
+                        "localhostProfile": {
+                          "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "type": "object"
+                    },
+                    "capabilities": {
+                      "description": "The capabilities to add/drop when running containers.\nDefaults to the default set of capabilities granted by the container runtime.\nNote that this field cannot be set when spec.os.name is windows.",
+                      "properties": {
+                        "add": {
+                          "description": "Added capabilities",
+                          "items": {
+                            "description": "Capability represent POSIX capabilities type",
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "drop": {
+                          "description": "Removed capabilities",
+                          "items": {
+                            "description": "Capability represent POSIX capabilities type",
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "privileged": {
+                      "description": "Run container in privileged mode.\nProcesses in privileged containers are essentially equivalent to root on the host.\nDefaults to false.\nNote that this field cannot be set when spec.os.name is windows.",
+                      "type": "boolean"
+                    },
+                    "procMount": {
+                      "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
+                      "type": "string"
+                    },
+                    "readOnlyRootFilesystem": {
+                      "description": "Whether this container has a read-only root filesystem.\nDefault is false.\nNote that this field cannot be set when spec.os.name is windows.",
+                      "type": "boolean"
+                    },
+                    "runAsGroup": {
+                      "description": "The GID to run the entrypoint of the container process.\nUses runtime default if unset.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "runAsNonRoot": {
+                      "description": "Indicates that the container must run as a non-root user.\nIf true, the Kubelet will validate the image at runtime to ensure that it\ndoes not run as UID 0 (root) and fail to start the container if it does.\nIf unset or false, no such validation will be performed.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
+                      "type": "boolean"
+                    },
+                    "runAsUser": {
+                      "description": "The UID to run the entrypoint of the container process.\nDefaults to user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "seLinuxOptions": {
+                      "description": "The SELinux context to be applied to the container.\nIf unspecified, the container runtime will allocate a random SELinux context for each\ncontainer.  May also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+                      "properties": {
+                        "level": {
+                          "description": "Level is SELinux level label that applies to the container.",
+                          "type": "string"
+                        },
+                        "role": {
+                          "description": "Role is a SELinux role label that applies to the container.",
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "Type is a SELinux type label that applies to the container.",
+                          "type": "string"
+                        },
+                        "user": {
+                          "description": "User is a SELinux user label that applies to the container.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "seccompProfile": {
+                      "description": "The seccomp options to use by this container. If seccomp options are\nprovided at both the pod \u0026 container level, the container options\noverride the pod options.\nNote that this field cannot be set when spec.os.name is windows.",
+                      "properties": {
+                        "localhostProfile": {
+                          "description": "localhostProfile indicates a profile defined in a file on the node should be used.\nThe profile must be preconfigured on the node to work.\nMust be a descending path, relative to the kubelet's configured seccomp profile location.\nMust be set if type is \"Localhost\". Must NOT be set for any other type.",
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "type": "object"
+                    },
+                    "windowsOptions": {
+                      "description": "The Windows specific settings applied to all containers.\nIf unspecified, the options from the PodSecurityContext will be used.\nIf set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is linux.",
+                      "properties": {
+                        "gmsaCredentialSpec": {
+                          "description": "GMSACredentialSpec is where the GMSA admission webhook\n(https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the\nGMSA credential spec named by the GMSACredentialSpecName field.",
+                          "type": "string"
+                        },
+                        "gmsaCredentialSpecName": {
+                          "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                          "type": "string"
+                        },
+                        "hostProcess": {
+                          "description": "HostProcess determines if a container should be run as a 'Host Process' container.\nAll of a Pod's containers must have the same effective HostProcess value\n(it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).\nIn addition, if HostProcess is true then HostNetwork must also be set to true.",
+                          "type": "boolean"
+                        },
+                        "runAsUserName": {
+                          "description": "The UserName in Windows to run the entrypoint of the container process.\nDefaults to the user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext. If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "volumeDevices": {
+                  "description": "volumeDevices is the list of block devices to be used by the Step.",
+                  "items": {
+                    "description": "volumeDevice describes a mapping of a raw block device within a container.",
+                    "properties": {
+                      "devicePath": {
+                        "description": "devicePath is the path inside of the container that the device will be mapped to.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "name must match the name of a persistentVolumeClaim in the pod",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "devicePath",
+                      "name"
+                    ],
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "volumeMounts": {
+                  "description": "Volumes to mount into the Step's filesystem.\nCannot be updated.",
+                  "items": {
+                    "description": "VolumeMount describes a mounting of a Volume within a container.",
+                    "properties": {
+                      "mountPath": {
+                        "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
+                        "type": "string"
+                      },
+                      "mountPropagation": {
+                        "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "This must match the Name of a Volume.",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
+                        "type": "boolean"
+                      },
+                      "recursiveReadOnly": {
+                        "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
+                        "type": "string"
+                      },
+                      "subPath": {
+                        "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
+                        "type": "string"
+                      },
+                      "subPathExpr": {
+                        "description": "Expanded path within the volume from which the container's volume should be mounted.\nBehaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.\nDefaults to \"\" (volume's root).\nSubPathExpr and SubPath are mutually exclusive.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "mountPath",
+                      "name"
+                    ],
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "workingDir": {
+                  "description": "Step's working directory.\nIf not specified, the container runtime's default will be used, which\nmight be configured in the container image.\nCannot be updated.",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "steps": {
+              "description": "Steps are the steps of the build; each step is run sequentially with the\nsource mounted into /workspace.",
+              "items": {
+                "description": "Step runs a subcomponent of a Task",
+                "properties": {
+                  "args": {
+                    "description": "Arguments to the entrypoint.\nThe image's CMD is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the container's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will\nproduce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless\nof whether the variable exists or not. Cannot be updated.\nMore info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "command": {
+                    "description": "Entrypoint array. Not executed within a shell.\nThe image's ENTRYPOINT is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the container's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will\nproduce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless\nof whether the variable exists or not. Cannot be updated.\nMore info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "computeResources": {
+                    "description": "ComputeResources required by this Step.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                    "properties": {
+                      "claims": {
+                        "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                        "items": {
+                          "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                          "properties": {
+                            "name": {
+                              "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                              "type": "string"
+                            },
+                            "request": {
+                              "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "limits": {
+                        "additionalProperties": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                        },
+                        "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                        "type": "object"
+                      },
+                      "requests": {
+                        "additionalProperties": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                        },
+                        "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                        "type": "object"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "displayName": {
+                    "description": "DisplayName is a user-facing name of the step that may be\nused to populate a UI.",
+                    "type": "string"
+                  },
+                  "env": {
+                    "description": "List of environment variables to set in the Step.\nCannot be updated.",
+                    "items": {
+                      "description": "EnvVar represents an environment variable present in a Container.",
+                      "properties": {
+                        "name": {
+                          "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                          "type": "string"
+                        },
+                        "value": {
+                          "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
+                          "type": "string"
+                        },
+                        "valueFrom": {
+                          "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                          "properties": {
+                            "configMapKeyRef": {
+                              "description": "Selects a key of a ConfigMap.",
+                              "properties": {
+                                "key": {
+                                  "description": "The key to select.",
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "default": "",
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "description": "Specify whether the ConfigMap or its key must be defined",
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object"
+                            },
+                            "fieldRef": {
+                              "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['\u003cKEY\u003e']`, `metadata.annotations['\u003cKEY\u003e']`,\nspec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                              "properties": {
+                                "apiVersion": {
+                                  "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                  "type": "string"
+                                },
+                                "fieldPath": {
+                                  "description": "Path of the field to select in the specified API version.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "fieldPath"
+                              ],
+                              "type": "object"
+                            },
+                            "resourceFieldRef": {
+                              "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                              "properties": {
+                                "containerName": {
+                                  "description": "Container name: required for volumes, optional for env vars",
+                                  "type": "string"
+                                },
+                                "divisor": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                                },
+                                "resource": {
+                                  "description": "Required: resource to select",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "resource"
+                              ],
+                              "type": "object"
+                            },
+                            "secretKeyRef": {
+                              "description": "Selects a key of a secret in the pod's namespace",
+                              "properties": {
+                                "key": {
+                                  "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "default": "",
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "description": "Specify whether the Secret or its key must be defined",
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "envFrom": {
+                    "description": "List of sources to populate environment variables in the Step.\nThe keys defined within a source must be a C_IDENTIFIER. All invalid keys\nwill be reported as an event when the Step is starting. When a key exists in multiple\nsources, the value associated with the last source will take precedence.\nValues defined by an Env with a duplicate key will take precedence.\nCannot be updated.",
+                    "items": {
+                      "description": "EnvFromSource represents the source of a set of ConfigMaps",
+                      "properties": {
+                        "configMapRef": {
+                          "description": "The ConfigMap to select from",
+                          "properties": {
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the ConfigMap must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "prefix": {
+                          "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
+                          "type": "string"
+                        },
+                        "secretRef": {
+                          "description": "The Secret to select from",
+                          "properties": {
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "image": {
+                    "description": "Docker image name.\nMore info: https://kubernetes.io/docs/concepts/containers/images",
+                    "type": "string"
+                  },
+                  "imagePullPolicy": {
+                    "description": "Image pull policy.\nOne of Always, Never, IfNotPresent.\nDefaults to Always if :latest tag is specified, or IfNotPresent otherwise.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name of the Step specified as a DNS_LABEL.\nEach Step in a Task must have a unique name.",
+                    "type": "string"
+                  },
+                  "onError": {
+                    "description": "OnError defines the exiting behavior of a container on error\ncan be set to [ continue | stopAndFail ]",
+                    "type": "string"
+                  },
+                  "params": {
+                    "description": "Params declares parameters passed to this step action.",
+                    "items": {
+                      "description": "Param declares an ParamValues to use for the parameter called name.",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "value": {}
+                      },
+                      "required": [
+                        "name",
+                        "value"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "ref": {
+                    "description": "Contains the reference to an existing StepAction.",
+                    "properties": {
+                      "name": {
+                        "description": "Name of the referenced step",
+                        "type": "string"
+                      },
+                      "params": {
+                        "description": "Params contains the parameters used to identify the\nreferenced Tekton resource. Example entries might include\n\"repo\" or \"path\" but the set of params ultimately depends on\nthe chosen resolver.",
+                        "items": {
+                          "description": "Param declares an ParamValues to use for the parameter called name.",
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "value": {}
+                          },
+                          "required": [
+                            "name",
+                            "value"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "resolver": {
+                        "description": "Resolver is the name of the resolver that should perform\nresolution of the referenced Tekton resource, such as \"git\".",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "results": {
+                    "description": "Results declares StepResults produced by the Step.\n\nIt can be used in an inlined Step when used to store Results to $(step.results.resultName.path).\nIt cannot be used when referencing StepActions using [v1.Step.Ref].\nThe Results declared by the StepActions will be stored here instead.",
+                    "items": {
+                      "description": "StepResult used to describe the Results of a Step.",
+                      "properties": {
+                        "description": {
+                          "description": "Description is a human-readable description of the result",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name the given name",
+                          "type": "string"
+                        },
+                        "properties": {
+                          "additionalProperties": {
+                            "description": "PropertySpec defines the struct for object keys",
+                            "properties": {
+                              "type": {
+                                "description": "ParamType indicates the type of an input parameter;\nUsed to distinguish between a single string and an array of strings.",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "description": "Properties is the JSON Schema properties to support key-value pairs results.",
+                          "type": "object"
+                        },
+                        "type": {
+                          "description": "The possible types are 'string', 'array', and 'object', with 'string' as the default.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "script": {
+                    "description": "Script is the contents of an executable file to execute.\n\nIf Script is not empty, the Step cannot have an Command and the Args will be passed to the Script.",
+                    "type": "string"
+                  },
+                  "securityContext": {
+                    "description": "SecurityContext defines the security options the Step should be run with.\nIf set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.\nMore info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/",
+                    "properties": {
+                      "allowPrivilegeEscalation": {
+                        "description": "AllowPrivilegeEscalation controls whether a process can gain more\nprivileges than its parent process. This bool directly controls if\nthe no_new_privs flag will be set on the container process.\nAllowPrivilegeEscalation is true always when the container is:\n1) run as Privileged\n2) has CAP_SYS_ADMIN\nNote that this field cannot be set when spec.os.name is windows.",
+                        "type": "boolean"
+                      },
+                      "appArmorProfile": {
+                        "description": "appArmorProfile is the AppArmor options to use by this container. If set, this profile\noverrides the pod's appArmorProfile.\nNote that this field cannot be set when spec.os.name is windows.",
+                        "properties": {
+                          "localhostProfile": {
+                            "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                            "type": "string"
+                          },
+                          "type": {
+                            "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ],
+                        "type": "object"
+                      },
+                      "capabilities": {
+                        "description": "The capabilities to add/drop when running containers.\nDefaults to the default set of capabilities granted by the container runtime.\nNote that this field cannot be set when spec.os.name is windows.",
+                        "properties": {
+                          "add": {
+                            "description": "Added capabilities",
+                            "items": {
+                              "description": "Capability represent POSIX capabilities type",
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "drop": {
+                            "description": "Removed capabilities",
+                            "items": {
+                              "description": "Capability represent POSIX capabilities type",
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "privileged": {
+                        "description": "Run container in privileged mode.\nProcesses in privileged containers are essentially equivalent to root on the host.\nDefaults to false.\nNote that this field cannot be set when spec.os.name is windows.",
+                        "type": "boolean"
+                      },
+                      "procMount": {
+                        "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
+                        "type": "string"
+                      },
+                      "readOnlyRootFilesystem": {
+                        "description": "Whether this container has a read-only root filesystem.\nDefault is false.\nNote that this field cannot be set when spec.os.name is windows.",
+                        "type": "boolean"
+                      },
+                      "runAsGroup": {
+                        "description": "The GID to run the entrypoint of the container process.\nUses runtime default if unset.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "runAsNonRoot": {
+                        "description": "Indicates that the container must run as a non-root user.\nIf true, the Kubelet will validate the image at runtime to ensure that it\ndoes not run as UID 0 (root) and fail to start the container if it does.\nIf unset or false, no such validation will be performed.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
+                        "type": "boolean"
+                      },
+                      "runAsUser": {
+                        "description": "The UID to run the entrypoint of the container process.\nDefaults to user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "seLinuxOptions": {
+                        "description": "The SELinux context to be applied to the container.\nIf unspecified, the container runtime will allocate a random SELinux context for each\ncontainer.  May also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+                        "properties": {
+                          "level": {
+                            "description": "Level is SELinux level label that applies to the container.",
+                            "type": "string"
+                          },
+                          "role": {
+                            "description": "Role is a SELinux role label that applies to the container.",
+                            "type": "string"
+                          },
+                          "type": {
+                            "description": "Type is a SELinux type label that applies to the container.",
+                            "type": "string"
+                          },
+                          "user": {
+                            "description": "User is a SELinux user label that applies to the container.",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "seccompProfile": {
+                        "description": "The seccomp options to use by this container. If seccomp options are\nprovided at both the pod \u0026 container level, the container options\noverride the pod options.\nNote that this field cannot be set when spec.os.name is windows.",
+                        "properties": {
+                          "localhostProfile": {
+                            "description": "localhostProfile indicates a profile defined in a file on the node should be used.\nThe profile must be preconfigured on the node to work.\nMust be a descending path, relative to the kubelet's configured seccomp profile location.\nMust be set if type is \"Localhost\". Must NOT be set for any other type.",
+                            "type": "string"
+                          },
+                          "type": {
+                            "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ],
+                        "type": "object"
+                      },
+                      "windowsOptions": {
+                        "description": "The Windows specific settings applied to all containers.\nIf unspecified, the options from the PodSecurityContext will be used.\nIf set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is linux.",
+                        "properties": {
+                          "gmsaCredentialSpec": {
+                            "description": "GMSACredentialSpec is where the GMSA admission webhook\n(https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the\nGMSA credential spec named by the GMSACredentialSpecName field.",
+                            "type": "string"
+                          },
+                          "gmsaCredentialSpecName": {
+                            "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                            "type": "string"
+                          },
+                          "hostProcess": {
+                            "description": "HostProcess determines if a container should be run as a 'Host Process' container.\nAll of a Pod's containers must have the same effective HostProcess value\n(it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).\nIn addition, if HostProcess is true then HostNetwork must also be set to true.",
+                            "type": "boolean"
+                          },
+                          "runAsUserName": {
+                            "description": "The UserName in Windows to run the entrypoint of the container process.\nDefaults to the user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext. If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "stderrConfig": {
+                    "description": "Stores configuration for the stderr stream of the step.",
+                    "properties": {
+                      "path": {
+                        "description": "Path to duplicate stdout stream to on container's local filesystem.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "stdoutConfig": {
+                    "description": "Stores configuration for the stdout stream of the step.",
+                    "properties": {
+                      "path": {
+                        "description": "Path to duplicate stdout stream to on container's local filesystem.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "timeout": {
+                    "description": "Timeout is the time after which the step times out. Defaults to never.\nRefer to Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration",
+                    "type": "string"
+                  },
+                  "volumeDevices": {
+                    "description": "volumeDevices is the list of block devices to be used by the Step.",
+                    "items": {
+                      "description": "volumeDevice describes a mapping of a raw block device within a container.",
+                      "properties": {
+                        "devicePath": {
+                          "description": "devicePath is the path inside of the container that the device will be mapped to.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "name must match the name of a persistentVolumeClaim in the pod",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "devicePath",
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "volumeMounts": {
+                    "description": "Volumes to mount into the Step's filesystem.\nCannot be updated.",
+                    "items": {
+                      "description": "VolumeMount describes a mounting of a Volume within a container.",
+                      "properties": {
+                        "mountPath": {
+                          "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
+                          "type": "string"
+                        },
+                        "mountPropagation": {
+                          "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "This must match the Name of a Volume.",
+                          "type": "string"
+                        },
+                        "readOnly": {
+                          "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
+                          "type": "boolean"
+                        },
+                        "recursiveReadOnly": {
+                          "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
+                          "type": "string"
+                        },
+                        "subPath": {
+                          "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
+                          "type": "string"
+                        },
+                        "subPathExpr": {
+                          "description": "Expanded path within the volume from which the container's volume should be mounted.\nBehaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.\nDefaults to \"\" (volume's root).\nSubPathExpr and SubPath are mutually exclusive.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "mountPath",
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "when": {
+                    "description": "When is a list of when expressions that need to be true for the task to run",
+                    "items": {
+                      "description": "WhenExpression allows a PipelineTask to declare expressions to be evaluated before the Task is run\nto determine whether the Task should be executed or skipped",
+                      "properties": {
+                        "cel": {
+                          "description": "CEL is a string of Common Language Expression, which can be used to conditionally execute\nthe task based on the result of the expression evaluation\nMore info about CEL syntax: https://github.com/google/cel-spec/blob/master/doc/langdef.md",
+                          "type": "string"
+                        },
+                        "input": {
+                          "description": "Input is the string for guard checking which can be a static input or an output from a parent Task",
+                          "type": "string"
+                        },
+                        "operator": {
+                          "description": "Operator that represents an Input's relationship to the values",
+                          "type": "string"
+                        },
+                        "values": {
+                          "description": "Values is an array of strings, which is compared against the input, for guard checking\nIt must be non-empty",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "workingDir": {
+                    "description": "Step's working directory.\nIf not specified, the container runtime's default will be used, which\nmight be configured in the container image.\nCannot be updated.",
+                    "type": "string"
+                  },
+                  "workspaces": {
+                    "description": "This is an alpha field. You must set the \"enable-api-fields\" feature flag to \"alpha\"\nfor this field to be supported.\n\nWorkspaces is a list of workspaces from the Task that this Step wants\nexclusive access to. Adding a workspace to this list means that any\nother Step or Sidecar that does not also request this Workspace will\nnot have access to it.",
+                    "items": {
+                      "description": "WorkspaceUsage is used by a Step or Sidecar to declare that it wants isolated access\nto a Workspace defined in a Task.",
+                      "properties": {
+                        "mountPath": {
+                          "description": "MountPath is the path that the workspace should be mounted to inside the Step or Sidecar,\noverriding any MountPath specified in the Task's WorkspaceDeclaration.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name is the name of the workspace this Step or Sidecar wants access to.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "mountPath",
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "volumes": {
+              "description": "Volumes is a collection of volumes that are available to mount into the\nsteps of the build.\nSee Pod.spec.volumes (API version: v1)"
+            },
+            "workspaces": {
+              "description": "Workspaces are the volumes that this Task requires.",
+              "items": {
+                "description": "WorkspaceDeclaration is a declaration of a volume that a Task requires.",
+                "properties": {
+                  "description": {
+                    "description": "Description is an optional human readable description of this volume.",
+                    "type": "string"
+                  },
+                  "mountPath": {
+                    "description": "MountPath overrides the directory that the volume will be made available at.",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name is the name by which you can bind the volume at runtime.",
+                    "type": "string"
+                  },
+                  "optional": {
+                    "description": "Optional marks a Workspace as not being required in TaskRuns. By default\nthis field is false and so declared workspaces are required.",
+                    "type": "boolean"
+                  },
+                  "readOnly": {
+                    "description": "ReadOnly dictates whether a mounted volume is writable. By default this\nfield is false and so mounted volumes are writable.",
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "required": [
+        "podName"
+      ],
+      "type": "object"
+    }
+  },
+  "title": "Tekton TaskRun v1",
+  "type": "object"
+}

--- a/schema/v1alpha1/resolutionrequest.json
+++ b/schema/v1alpha1/resolutionrequest.json
@@ -1,0 +1,100 @@
+{
+  "$id": "https://tekton.dev/schemas/v1alpha1/resolutionrequest.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "ResolutionRequest is an object for requesting the content of\na Tekton resource like a pipeline.yaml.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Spec holds the information for the request part of the resource request.",
+      "properties": {
+        "params": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Parameters are the runtime attributes passed to\nthe resolver to help it figure out how to resolve the\nresource being requested. For example: repo URL, commit SHA,\npath to file, the kind of authentication to leverage, etc.",
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "status": {
+      "description": "Status communicates the state of the request and, ultimately,\nthe content of the resolved resource.",
+      "properties": {
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Annotations is additional Status fields for the Resource to save some\nadditional State as well as convey more information to the user. This is\nroughly akin to Annotations on any k8s resource, just the reconciler conveying\nricher information outwards.",
+          "type": "object"
+        },
+        "conditions": {
+          "description": "Conditions the latest available observations of a resource's current state.",
+          "items": {
+            "description": "Condition defines a readiness condition for a Knative resource.\nSee: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "LastTransitionTime is the last time the condition transitioned from one status to another.\nWe use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic\ndifferences (all other things held constant).",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity with which to treat failures of this type of condition.\nWhen this is not specified, it defaults to Error.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "data": {
+          "description": "Data is a string representation of the resolved content\nof the requested resource in-lined into the ResolutionRequest\nobject.",
+          "type": "string"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the 'Generation' of the Service that\nwas last processed by the controller.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "refSource": {
+          "description": "RefSource is the source reference of the remote data that records where the remote\nfile came from including the url, digest and the entrypoint."
+        }
+      },
+      "required": [
+        "data",
+        "refSource"
+      ],
+      "type": "object"
+    }
+  },
+  "title": "Tekton ResolutionRequest v1alpha1",
+  "type": "object"
+}

--- a/schema/v1alpha1/stepaction.json
+++ b/schema/v1alpha1/stepaction.json
@@ -1,0 +1,439 @@
+{
+  "$id": "https://tekton.dev/schemas/v1alpha1/stepaction.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "StepAction represents the actionable components of Step.\nThe Step can only reference it from the cluster or using remote resolution.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Spec holds the desired state of the Step from the client",
+      "properties": {
+        "args": {
+          "description": "Arguments to the entrypoint.\nThe image's CMD is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the container's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will\nproduce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless\nof whether the variable exists or not. Cannot be updated.\nMore info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "command": {
+          "description": "Entrypoint array. Not executed within a shell.\nThe image's ENTRYPOINT is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the container's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will\nproduce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless\nof whether the variable exists or not. Cannot be updated.\nMore info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "description": {
+          "description": "Description is a user-facing description of the stepaction that may be\nused to populate a UI.",
+          "type": "string"
+        },
+        "env": {
+          "description": "List of environment variables to set in the container.\nCannot be updated.",
+          "items": {
+            "description": "EnvVar represents an environment variable present in a Container.",
+            "properties": {
+              "name": {
+                "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                "type": "string"
+              },
+              "value": {
+                "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
+                "type": "string"
+              },
+              "valueFrom": {
+                "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                "properties": {
+                  "configMapKeyRef": {
+                    "description": "Selects a key of a ConfigMap.",
+                    "properties": {
+                      "key": {
+                        "description": "The key to select.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string"
+                      },
+                      "optional": {
+                        "description": "Specify whether the ConfigMap or its key must be defined",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "key"
+                    ],
+                    "type": "object"
+                  },
+                  "fieldRef": {
+                    "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['\u003cKEY\u003e']`, `metadata.annotations['\u003cKEY\u003e']`,\nspec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                    "properties": {
+                      "apiVersion": {
+                        "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                        "type": "string"
+                      },
+                      "fieldPath": {
+                        "description": "Path of the field to select in the specified API version.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "fieldPath"
+                    ],
+                    "type": "object"
+                  },
+                  "resourceFieldRef": {
+                    "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                    "properties": {
+                      "containerName": {
+                        "description": "Container name: required for volumes, optional for env vars",
+                        "type": "string"
+                      },
+                      "divisor": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                      },
+                      "resource": {
+                        "description": "Required: resource to select",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "resource"
+                    ],
+                    "type": "object"
+                  },
+                  "secretKeyRef": {
+                    "description": "Selects a key of a secret in the pod's namespace",
+                    "properties": {
+                      "key": {
+                        "description": "The key of the secret to select from.  Must be a valid secret key.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string"
+                      },
+                      "optional": {
+                        "description": "Specify whether the Secret or its key must be defined",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "key"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "image": {
+          "description": "Image reference name to run for this StepAction.\nMore info: https://kubernetes.io/docs/concepts/containers/images",
+          "type": "string"
+        },
+        "params": {
+          "description": "Params is a list of input parameters required to run the stepAction.\nParams must be supplied as inputs in Steps unless they declare a defaultvalue.",
+          "items": {
+            "description": "ParamSpec defines arbitrary parameters needed beyond typed inputs (such as\nresources). Parameter values are provided by users as inputs on a TaskRun\nor PipelineRun.",
+            "properties": {
+              "default": {
+                "description": "Default is the value a parameter takes if no input value is supplied. If\ndefault is set, a Task may be executed without a supplied value for the\nparameter."
+              },
+              "description": {
+                "description": "Description is a user-facing description of the parameter that may be\nused to populate a UI.",
+                "type": "string"
+              },
+              "enum": {
+                "description": "Enum declares a set of allowed param input values for tasks/pipelines that can be validated.\nIf Enum is not set, no input validation is performed for the param.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "name": {
+                "description": "Name declares the name by which a parameter is referenced.",
+                "type": "string"
+              },
+              "properties": {
+                "additionalProperties": {
+                  "description": "PropertySpec defines the struct for object keys",
+                  "properties": {
+                    "type": {
+                      "description": "ParamType indicates the type of an input parameter;\nUsed to distinguish between a single string and an array of strings.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "description": "Properties is the JSON Schema properties to support key-value pairs parameter.",
+                "type": "object"
+              },
+              "type": {
+                "description": "Type is the user-specified type of the parameter. The possible types\nare currently \"string\", \"array\" and \"object\", and \"string\" is the default.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "results": {
+          "description": "Results are values that this StepAction can output",
+          "items": {
+            "description": "StepResult used to describe the Results of a Step.",
+            "properties": {
+              "description": {
+                "description": "Description is a human-readable description of the result",
+                "type": "string"
+              },
+              "name": {
+                "description": "Name the given name",
+                "type": "string"
+              },
+              "properties": {
+                "additionalProperties": {
+                  "description": "PropertySpec defines the struct for object keys",
+                  "properties": {
+                    "type": {
+                      "description": "ParamType indicates the type of an input parameter;\nUsed to distinguish between a single string and an array of strings.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "description": "Properties is the JSON Schema properties to support key-value pairs results.",
+                "type": "object"
+              },
+              "type": {
+                "description": "The possible types are 'string', 'array', and 'object', with 'string' as the default.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "script": {
+          "description": "Script is the contents of an executable file to execute.\n\nIf Script is not empty, the Step cannot have an Command and the Args will be passed to the Script.",
+          "type": "string"
+        },
+        "securityContext": {
+          "description": "SecurityContext defines the security options the Step should be run with.\nIf set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.\nMore info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/\nThe value set in StepAction will take precedence over the value from Task.",
+          "properties": {
+            "allowPrivilegeEscalation": {
+              "description": "AllowPrivilegeEscalation controls whether a process can gain more\nprivileges than its parent process. This bool directly controls if\nthe no_new_privs flag will be set on the container process.\nAllowPrivilegeEscalation is true always when the container is:\n1) run as Privileged\n2) has CAP_SYS_ADMIN\nNote that this field cannot be set when spec.os.name is windows.",
+              "type": "boolean"
+            },
+            "appArmorProfile": {
+              "description": "appArmorProfile is the AppArmor options to use by this container. If set, this profile\noverrides the pod's appArmorProfile.\nNote that this field cannot be set when spec.os.name is windows.",
+              "properties": {
+                "localhostProfile": {
+                  "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                  "type": "string"
+                },
+                "type": {
+                  "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object"
+            },
+            "capabilities": {
+              "description": "The capabilities to add/drop when running containers.\nDefaults to the default set of capabilities granted by the container runtime.\nNote that this field cannot be set when spec.os.name is windows.",
+              "properties": {
+                "add": {
+                  "description": "Added capabilities",
+                  "items": {
+                    "description": "Capability represent POSIX capabilities type",
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "drop": {
+                  "description": "Removed capabilities",
+                  "items": {
+                    "description": "Capability represent POSIX capabilities type",
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            },
+            "privileged": {
+              "description": "Run container in privileged mode.\nProcesses in privileged containers are essentially equivalent to root on the host.\nDefaults to false.\nNote that this field cannot be set when spec.os.name is windows.",
+              "type": "boolean"
+            },
+            "procMount": {
+              "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
+              "type": "string"
+            },
+            "readOnlyRootFilesystem": {
+              "description": "Whether this container has a read-only root filesystem.\nDefault is false.\nNote that this field cannot be set when spec.os.name is windows.",
+              "type": "boolean"
+            },
+            "runAsGroup": {
+              "description": "The GID to run the entrypoint of the container process.\nUses runtime default if unset.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "runAsNonRoot": {
+              "description": "Indicates that the container must run as a non-root user.\nIf true, the Kubelet will validate the image at runtime to ensure that it\ndoes not run as UID 0 (root) and fail to start the container if it does.\nIf unset or false, no such validation will be performed.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
+              "type": "boolean"
+            },
+            "runAsUser": {
+              "description": "The UID to run the entrypoint of the container process.\nDefaults to user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "seLinuxOptions": {
+              "description": "The SELinux context to be applied to the container.\nIf unspecified, the container runtime will allocate a random SELinux context for each\ncontainer.  May also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+              "properties": {
+                "level": {
+                  "description": "Level is SELinux level label that applies to the container.",
+                  "type": "string"
+                },
+                "role": {
+                  "description": "Role is a SELinux role label that applies to the container.",
+                  "type": "string"
+                },
+                "type": {
+                  "description": "Type is a SELinux type label that applies to the container.",
+                  "type": "string"
+                },
+                "user": {
+                  "description": "User is a SELinux user label that applies to the container.",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "seccompProfile": {
+              "description": "The seccomp options to use by this container. If seccomp options are\nprovided at both the pod \u0026 container level, the container options\noverride the pod options.\nNote that this field cannot be set when spec.os.name is windows.",
+              "properties": {
+                "localhostProfile": {
+                  "description": "localhostProfile indicates a profile defined in a file on the node should be used.\nThe profile must be preconfigured on the node to work.\nMust be a descending path, relative to the kubelet's configured seccomp profile location.\nMust be set if type is \"Localhost\". Must NOT be set for any other type.",
+                  "type": "string"
+                },
+                "type": {
+                  "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object"
+            },
+            "windowsOptions": {
+              "description": "The Windows specific settings applied to all containers.\nIf unspecified, the options from the PodSecurityContext will be used.\nIf set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is linux.",
+              "properties": {
+                "gmsaCredentialSpec": {
+                  "description": "GMSACredentialSpec is where the GMSA admission webhook\n(https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the\nGMSA credential spec named by the GMSACredentialSpecName field.",
+                  "type": "string"
+                },
+                "gmsaCredentialSpecName": {
+                  "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                  "type": "string"
+                },
+                "hostProcess": {
+                  "description": "HostProcess determines if a container should be run as a 'Host Process' container.\nAll of a Pod's containers must have the same effective HostProcess value\n(it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).\nIn addition, if HostProcess is true then HostNetwork must also be set to true.",
+                  "type": "boolean"
+                },
+                "runAsUserName": {
+                  "description": "The UserName in Windows to run the entrypoint of the container process.\nDefaults to the user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext. If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "volumeMounts": {
+          "description": "Volumes to mount into the Step's filesystem.\nCannot be updated.",
+          "items": {
+            "description": "VolumeMount describes a mounting of a Volume within a container.",
+            "properties": {
+              "mountPath": {
+                "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
+                "type": "string"
+              },
+              "mountPropagation": {
+                "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
+                "type": "string"
+              },
+              "name": {
+                "description": "This must match the Name of a Volume.",
+                "type": "string"
+              },
+              "readOnly": {
+                "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
+                "type": "boolean"
+              },
+              "recursiveReadOnly": {
+                "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
+                "type": "string"
+              },
+              "subPath": {
+                "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
+                "type": "string"
+              },
+              "subPathExpr": {
+                "description": "Expanded path within the volume from which the container's volume should be mounted.\nBehaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.\nDefaults to \"\" (volume's root).\nSubPathExpr and SubPath are mutually exclusive.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "mountPath",
+              "name"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "workingDir": {
+          "description": "Step's working directory.\nIf not specified, the container runtime's default will be used, which\nmight be configured in the container image.\nCannot be updated.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "title": "Tekton StepAction v1alpha1",
+  "type": "object"
+}

--- a/schema/v1alpha1/verificationpolicy.json
+++ b/schema/v1alpha1/verificationpolicy.json
@@ -1,0 +1,103 @@
+{
+  "$id": "https://tekton.dev/schemas/v1alpha1/verificationpolicy.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "VerificationPolicy defines the rules to verify Tekton resources.\nVerificationPolicy can config the mapping from resources to a list of public\nkeys, so when verifying the resources we can use the corresponding public keys.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Spec holds the desired state of the VerificationPolicy.",
+      "properties": {
+        "authorities": {
+          "description": "Authorities defines the rules for validating signatures.",
+          "items": {
+            "description": "The Authority block defines the keys for validating signatures.",
+            "properties": {
+              "key": {
+                "description": "Key contains the public key to validate the resource.",
+                "properties": {
+                  "data": {
+                    "description": "Data contains the inline public key.",
+                    "type": "string"
+                  },
+                  "hashAlgorithm": {
+                    "description": "HashAlgorithm always defaults to sha256 if the algorithm hasn't been explicitly set",
+                    "type": "string"
+                  },
+                  "kms": {
+                    "description": "KMS contains the KMS url of the public key\nSupported formats differ based on the KMS system used.\nOne example of a KMS url could be:\ngcpkms://projects/[PROJECT]/locations/[LOCATION]\u003e/keyRings/[KEYRING]/cryptoKeys/[KEY]/cryptoKeyVersions/[KEY_VERSION]\nFor more examples please refer https://docs.sigstore.dev/cosign/kms_support.\nNote that the KMS is not supported yet.",
+                    "type": "string"
+                  },
+                  "secretRef": {
+                    "description": "SecretRef sets a reference to a secret with the key.",
+                    "properties": {
+                      "name": {
+                        "description": "name is unique within a namespace to reference a secret resource.",
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "description": "namespace defines the space within which the secret name must be unique.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "type": "object"
+              },
+              "name": {
+                "description": "Name is the name for this authority.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "mode": {
+          "description": "Mode controls whether a failing policy will fail the taskrun/pipelinerun, or only log the warnings\nenforce - fail the taskrun/pipelinerun if verification fails (default)\nwarn - don't fail the taskrun/pipelinerun if verification fails but log warnings",
+          "type": "string"
+        },
+        "resources": {
+          "description": "Resources defines the patterns of resources sources that should be subject to this policy.\nFor example, we may want to apply this Policy from a certain GitHub repo.\nThen the ResourcesPattern should be valid regex. E.g. If using gitresolver, and we want to config keys from a certain git repo.\n`ResourcesPattern` can be `https://github.com/tektoncd/catalog.git`, we will use regex to filter out those resources.",
+          "items": {
+            "description": "ResourcePattern defines the pattern of the resource source",
+            "properties": {
+              "pattern": {
+                "description": "Pattern defines a resource pattern. Regex is created to filter resources based on `Pattern`\nExample patterns:\nGitHub resource: https://github.com/tektoncd/catalog.git, https://github.com/tektoncd/*\nBundle resource: gcr.io/tekton-releases/catalog/upstream/git-clone, gcr.io/tekton-releases/catalog/upstream/*\nHub resource: https://artifacthub.io/*,",
+                "type": "string"
+              }
+            },
+            "required": [
+              "pattern"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "authorities",
+        "resources"
+      ],
+      "type": "object"
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "title": "Tekton VerificationPolicy v1alpha1",
+  "type": "object"
+}

--- a/schema/v1beta1/customrun.json
+++ b/schema/v1beta1/customrun.json
@@ -1,0 +1,698 @@
+{
+  "$id": "https://tekton.dev/schemas/v1beta1/customrun.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "CustomRun represents a single execution of a Custom Task.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "CustomRunSpec defines the desired state of CustomRun",
+      "properties": {
+        "customRef": {
+          "description": "TaskRef can be used to refer to a specific instance of a task.",
+          "properties": {
+            "apiVersion": {
+              "description": "API version of the referent\nNote: A Task with non-empty APIVersion and Kind is considered a Custom Task",
+              "type": "string"
+            },
+            "bundle": {
+              "description": "Bundle url reference to a Tekton Bundle.\n\nDeprecated: Please use ResolverRef with the bundles resolver instead.\nThe field is staying there for go client backward compatibility, but is not used/allowed anymore.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "TaskKind indicates the Kind of the Task:\n1. Namespaced Task when Kind is set to \"Task\". If Kind is \"\", it defaults to \"Task\".\n2. Custom Task when Kind is non-empty and APIVersion is non-empty",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+              "type": "string"
+            },
+            "params": {
+              "description": "Params contains the parameters used to identify the\nreferenced Tekton resource. Example entries might include\n\"repo\" or \"path\" but the set of params ultimately depends on\nthe chosen resolver.",
+              "items": {
+                "description": "Param declares an ParamValues to use for the parameter called name.",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "value": {}
+                },
+                "required": [
+                  "name",
+                  "value"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "resolver": {
+              "description": "Resolver is the name of the resolver that should perform\nresolution of the referenced Tekton resource, such as \"git\".",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "customSpec": {
+          "description": "Spec is a specification of a custom task",
+          "properties": {
+            "apiVersion": {
+              "type": "string"
+            },
+            "kind": {
+              "type": "string"
+            },
+            "metadata": {
+              "description": "PipelineTaskMetadata contains the labels or annotations for an EmbeddedTask",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "spec": {
+              "description": "Spec is a specification of a custom task",
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "params": {
+          "description": "Params is a list of Param",
+          "items": {
+            "description": "Param declares an ParamValues to use for the parameter called name.",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "value": {}
+            },
+            "required": [
+              "name",
+              "value"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "retries": {
+          "description": "Used for propagating retries count to custom tasks",
+          "type": "integer"
+        },
+        "serviceAccountName": {
+          "type": "string"
+        },
+        "status": {
+          "description": "Used for cancelling a customrun (and maybe more later on)",
+          "type": "string"
+        },
+        "statusMessage": {
+          "description": "Status message for cancellation.",
+          "type": "string"
+        },
+        "timeout": {
+          "description": "Time after which the custom-task times out.\nRefer Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration",
+          "type": "string"
+        },
+        "workspaces": {
+          "description": "Workspaces is a list of WorkspaceBindings from volumes to workspaces.",
+          "items": {
+            "description": "WorkspaceBinding maps a Task's declared workspace to a Volume.",
+            "properties": {
+              "configMap": {
+                "description": "ConfigMap represents a configMap that should populate this workspace.",
+                "properties": {
+                  "defaultMode": {
+                    "description": "defaultMode is optional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDefaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "items": {
+                    "description": "items if unspecified, each key-value pair in the Data field of the referenced\nConfigMap will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the ConfigMap,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                    "items": {
+                      "description": "Maps a string key to a path within a volume.",
+                      "properties": {
+                        "key": {
+                          "description": "key is the key to project.",
+                          "type": "string"
+                        },
+                        "mode": {
+                          "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "path": {
+                          "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "key",
+                        "path"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "name": {
+                    "default": "",
+                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                    "type": "string"
+                  },
+                  "optional": {
+                    "description": "optional specify whether the ConfigMap or its keys must be defined",
+                    "type": "boolean"
+                  }
+                },
+                "type": "object"
+              },
+              "csi": {
+                "description": "CSI (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers.",
+                "properties": {
+                  "driver": {
+                    "description": "driver is the name of the CSI driver that handles this volume.\nConsult with your admin for the correct name as registered in the cluster.",
+                    "type": "string"
+                  },
+                  "fsType": {
+                    "description": "fsType to mount. Ex. \"ext4\", \"xfs\", \"ntfs\".\nIf not provided, the empty value is passed to the associated CSI driver\nwhich will determine the default filesystem to apply.",
+                    "type": "string"
+                  },
+                  "nodePublishSecretRef": {
+                    "description": "nodePublishSecretRef is a reference to the secret object containing\nsensitive information to pass to the CSI driver to complete the CSI\nNodePublishVolume and NodeUnpublishVolume calls.\nThis field is optional, and  may be empty if no secret is required. If the\nsecret object contains more than one secret, all secret references are passed.",
+                    "properties": {
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "readOnly": {
+                    "description": "readOnly specifies a read-only configuration for the volume.\nDefaults to false (read/write).",
+                    "type": "boolean"
+                  },
+                  "volumeAttributes": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "volumeAttributes stores driver-specific properties that are passed to the CSI\ndriver. Consult your driver's documentation for supported values.",
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "driver"
+                ],
+                "type": "object"
+              },
+              "emptyDir": {
+                "description": "EmptyDir represents a temporary directory that shares a Task's lifetime.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir\nEither this OR PersistentVolumeClaim can be used.",
+                "properties": {
+                  "medium": {
+                    "description": "medium represents what type of storage medium should back this directory.\nThe default is \"\" which means to use the node's default medium.\nMust be an empty string (default) or Memory.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                    "type": "string"
+                  },
+                  "sizeLimit": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "description": "sizeLimit is the total amount of local storage required for this EmptyDir volume.\nThe size limit is also applicable for memory medium.\nThe maximum usage on memory medium EmptyDir would be the minimum value between\nthe SizeLimit specified here and the sum of memory limits of all containers in a pod.\nThe default is nil which means that the limit is undefined.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                  }
+                },
+                "type": "object"
+              },
+              "name": {
+                "description": "Name is the name of the workspace populated by the volume.",
+                "type": "string"
+              },
+              "persistentVolumeClaim": {
+                "description": "PersistentVolumeClaimVolumeSource represents a reference to a\nPersistentVolumeClaim in the same namespace. Either this OR EmptyDir can be used.",
+                "properties": {
+                  "claimName": {
+                    "description": "claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "readOnly Will force the ReadOnly setting in VolumeMounts.\nDefault false.",
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "claimName"
+                ],
+                "type": "object"
+              },
+              "projected": {
+                "description": "Projected represents a projected volume that should populate this workspace.",
+                "properties": {
+                  "defaultMode": {
+                    "description": "defaultMode are the mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "sources": {
+                    "description": "sources is the list of volume projections. Each entry in this list\nhandles one source.",
+                    "items": {
+                      "description": "Projection that may be projected along with other supported volume types.\nExactly one of these fields must be set.",
+                      "properties": {
+                        "clusterTrustBundle": {
+                          "description": "ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field\nof ClusterTrustBundle objects in an auto-updating file.\n\nAlpha, gated by the ClusterTrustBundleProjection feature gate.\n\nClusterTrustBundle objects can either be selected by name, or by the\ncombination of signer name and a label selector.\n\nKubelet performs aggressive normalization of the PEM contents written\ninto the pod filesystem.  Esoteric PEM features such as inter-block\ncomments and block headers are stripped.  Certificates are deduplicated.\nThe ordering of certificates within the file is arbitrary, and Kubelet\nmay change the order over time.",
+                          "properties": {
+                            "labelSelector": {
+                              "description": "Select all ClusterTrustBundles that match this label selector.  Only has\neffect if signerName is set.  Mutually-exclusive with name.  If unset,\ninterpreted as \"match nothing\".  If set but empty, interpreted as \"match\neverything\".",
+                              "properties": {
+                                "matchExpressions": {
+                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                  "items": {
+                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "key is the label key that the selector applies to.",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "operator"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "matchLabels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "name": {
+                              "description": "Select a single ClusterTrustBundle by object name.  Mutually-exclusive\nwith signerName and labelSelector.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "If true, don't block pod startup if the referenced ClusterTrustBundle(s)\naren't available.  If using name, then the named ClusterTrustBundle is\nallowed not to exist.  If using signerName, then the combination of\nsignerName and labelSelector is allowed to match zero\nClusterTrustBundles.",
+                              "type": "boolean"
+                            },
+                            "path": {
+                              "description": "Relative path from the volume root to write the bundle.",
+                              "type": "string"
+                            },
+                            "signerName": {
+                              "description": "Select all ClusterTrustBundles that match this signer name.\nMutually-exclusive with name.  The contents of all selected\nClusterTrustBundles will be unified and deduplicated.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "path"
+                          ],
+                          "type": "object"
+                        },
+                        "configMap": {
+                          "description": "configMap information about the configMap data to project",
+                          "properties": {
+                            "items": {
+                              "description": "items if unspecified, each key-value pair in the Data field of the referenced\nConfigMap will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the ConfigMap,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                              "items": {
+                                "description": "Maps a string key to a path within a volume.",
+                                "properties": {
+                                  "key": {
+                                    "description": "key is the key to project.",
+                                    "type": "string"
+                                  },
+                                  "mode": {
+                                    "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "path": {
+                                    "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "path"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "optional specify whether the ConfigMap or its keys must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "downwardAPI": {
+                          "description": "downwardAPI information about the downwardAPI data to project",
+                          "properties": {
+                            "items": {
+                              "description": "Items is a list of DownwardAPIVolume file",
+                              "items": {
+                                "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                                "properties": {
+                                  "fieldRef": {
+                                    "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.",
+                                    "properties": {
+                                      "apiVersion": {
+                                        "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                        "type": "string"
+                                      },
+                                      "fieldPath": {
+                                        "description": "Path of the field to select in the specified API version.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "fieldPath"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "mode": {
+                                    "description": "Optional: mode bits used to set permissions on this file, must be an octal value\nbetween 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "path": {
+                                    "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                                    "type": "string"
+                                  },
+                                  "resourceFieldRef": {
+                                    "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                                    "properties": {
+                                      "containerName": {
+                                        "description": "Container name: required for volumes, optional for env vars",
+                                        "type": "string"
+                                      },
+                                      "divisor": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                                      },
+                                      "resource": {
+                                        "description": "Required: resource to select",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "resource"
+                                    ],
+                                    "type": "object"
+                                  }
+                                },
+                                "required": [
+                                  "path"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "secret": {
+                          "description": "secret information about the secret data to project",
+                          "properties": {
+                            "items": {
+                              "description": "items if unspecified, each key-value pair in the Data field of the referenced\nSecret will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the Secret,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                              "items": {
+                                "description": "Maps a string key to a path within a volume.",
+                                "properties": {
+                                  "key": {
+                                    "description": "key is the key to project.",
+                                    "type": "string"
+                                  },
+                                  "mode": {
+                                    "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "path": {
+                                    "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "path"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "optional field specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "serviceAccountToken": {
+                          "description": "serviceAccountToken is information about the serviceAccountToken data to project",
+                          "properties": {
+                            "audience": {
+                              "description": "audience is the intended audience of the token. A recipient of a token\nmust identify itself with an identifier specified in the audience of the\ntoken, and otherwise should reject the token. The audience defaults to the\nidentifier of the apiserver.",
+                              "type": "string"
+                            },
+                            "expirationSeconds": {
+                              "description": "expirationSeconds is the requested duration of validity of the service\naccount token. As the token approaches expiration, the kubelet volume\nplugin will proactively rotate the service account token. The kubelet will\nstart trying to rotate the token if the token is older than 80 percent of\nits time to live or if the token is older than 24 hours.Defaults to 1 hour\nand must be at least 10 minutes.",
+                              "format": "int64",
+                              "type": "integer"
+                            },
+                            "path": {
+                              "description": "path is the path relative to the mount point of the file to project the\ntoken into.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "path"
+                          ],
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              },
+              "secret": {
+                "description": "Secret represents a secret that should populate this workspace.",
+                "properties": {
+                  "defaultMode": {
+                    "description": "defaultMode is Optional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values\nfor mode bits. Defaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "items": {
+                    "description": "items If unspecified, each key-value pair in the Data field of the referenced\nSecret will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the Secret,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                    "items": {
+                      "description": "Maps a string key to a path within a volume.",
+                      "properties": {
+                        "key": {
+                          "description": "key is the key to project.",
+                          "type": "string"
+                        },
+                        "mode": {
+                          "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "path": {
+                          "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "key",
+                        "path"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "optional": {
+                    "description": "optional field specify whether the Secret or its keys must be defined",
+                    "type": "boolean"
+                  },
+                  "secretName": {
+                    "description": "secretName is the name of the secret in the pod's namespace to use.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "subPath": {
+                "description": "SubPath is optionally a directory on the volume which should be used\nfor this binding (i.e. the volume will be mounted at this sub directory).",
+                "type": "string"
+              },
+              "volumeClaimTemplate": {
+                "description": "VolumeClaimTemplate is a template for a claim that will be created in the same namespace.\nThe PipelineRun controller is responsible for creating a unique claim for each instance of PipelineRun.\nSee PersistentVolumeClaim (API version: v1)"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "status": {
+      "description": "CustomRunStatus defines the observed state of CustomRun",
+      "properties": {
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Annotations is additional Status fields for the Resource to save some\nadditional State as well as convey more information to the user. This is\nroughly akin to Annotations on any k8s resource, just the reconciler conveying\nricher information outwards.",
+          "type": "object"
+        },
+        "completionTime": {
+          "description": "CompletionTime is the time the build completed.",
+          "format": "date-time",
+          "type": "string"
+        },
+        "conditions": {
+          "description": "Conditions the latest available observations of a resource's current state.",
+          "items": {
+            "description": "Condition defines a readiness condition for a Knative resource.\nSee: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "LastTransitionTime is the last time the condition transitioned from one status to another.\nWe use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic\ndifferences (all other things held constant).",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity with which to treat failures of this type of condition.\nWhen this is not specified, it defaults to Error.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "extraFields": {
+          "description": "ExtraFields holds arbitrary fields provided by the custom task\ncontroller."
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the 'Generation' of the Service that\nwas last processed by the controller.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "results": {
+          "description": "Results reports any output result values to be consumed by later\ntasks in a pipeline.",
+          "items": {
+            "description": "CustomRunResult used to describe the results of a task",
+            "properties": {
+              "name": {
+                "description": "Name the given name",
+                "type": "string"
+              },
+              "value": {
+                "description": "Value the given value of the result",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "value"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "retriesStatus": {
+          "description": "RetriesStatus contains the history of CustomRunStatus, in case of a retry.\nSee CustomRun.status (API version: tekton.dev/v1beta1)"
+        },
+        "startTime": {
+          "description": "StartTime is the time the build is actually started.",
+          "format": "date-time",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "title": "Tekton CustomRun v1beta1",
+  "type": "object"
+}

--- a/schema/v1beta1/pipeline.json
+++ b/schema/v1beta1/pipeline.json
@@ -1,0 +1,815 @@
+{
+  "$id": "https://tekton.dev/schemas/v1beta1/pipeline.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Pipeline\nDeprecated: Please use v1.Pipeline instead.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Spec",
+      "properties": {
+        "description": {
+          "description": "Description",
+          "type": "string"
+        },
+        "displayName": {
+          "description": "DisplayName",
+          "type": "string"
+        },
+        "finally": {
+          "description": "Finally",
+          "items": {
+            "description": "PipelineTask",
+            "properties": {
+              "description": {
+                "description": "Description",
+                "type": "string"
+              },
+              "displayName": {
+                "description": "DisplayName",
+                "type": "string"
+              },
+              "matrix": {
+                "description": "Matrix",
+                "properties": {
+                  "include": {
+                    "description": "Include",
+                    "items": {
+                      "description": "IncludeParams",
+                      "properties": {
+                        "name": {
+                          "description": "Name",
+                          "type": "string"
+                        },
+                        "params": {
+                          "description": "Params",
+                          "items": {
+                            "description": "Param",
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "description": "Value"
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "value"
+                            ],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "params": {
+                    "description": "Params",
+                    "items": {
+                      "description": "Param",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "description": "Value"
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "value"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              },
+              "name": {
+                "description": "Name",
+                "type": "string"
+              },
+              "onError": {
+                "description": "OnError",
+                "type": "string"
+              },
+              "params": {
+                "description": "Params",
+                "items": {
+                  "description": "Param",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "description": "Value"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "value"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "pipelineRef": {
+                "description": "PipelineRef",
+                "properties": {
+                  "apiVersion": {
+                    "description": "APIVersion",
+                    "type": "string"
+                  },
+                  "bundle": {
+                    "description": "Deprecated: Please use ResolverRef with the bundles resolver instead.\nBundle",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name",
+                    "type": "string"
+                  },
+                  "params": {
+                    "description": "Params",
+                    "items": {
+                      "description": "Param",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "description": "Value"
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "value"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "resolver": {
+                    "description": "Resolver",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "pipelineSpec": {
+                "description": "PipelineSpec"
+              },
+              "resources": {
+                "description": "Resources\nDeprecated: Unused, preserved only for backwards compatibility",
+                "properties": {
+                  "inputs": {
+                    "description": "Inputs",
+                    "items": {
+                      "description": "PipelineTaskInputResource\nDeprecated: Unused, preserved only for backwards compatibility",
+                      "properties": {
+                        "from": {
+                          "description": "From",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "name": {
+                          "description": "Name",
+                          "type": "string"
+                        },
+                        "resource": {
+                          "description": "Resource",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "resource"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "outputs": {
+                    "description": "Outputs",
+                    "items": {
+                      "description": "PipelineTaskOutputResource\nDeprecated: Unused, preserved only for backwards compatibility",
+                      "properties": {
+                        "name": {
+                          "description": "Name",
+                          "type": "string"
+                        },
+                        "resource": {
+                          "description": "Resource",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "resource"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              },
+              "retries": {
+                "description": "Retries",
+                "type": "integer"
+              },
+              "runAfter": {
+                "description": "RunAfter",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "taskRef": {
+                "description": "TaskRef",
+                "properties": {
+                  "apiVersion": {
+                    "description": "APIVersion",
+                    "type": "string"
+                  },
+                  "bundle": {
+                    "description": "Deprecated: Please use ResolverRef with the bundles resolver instead.\nBundle",
+                    "type": "string"
+                  },
+                  "kind": {
+                    "description": "Kind",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name",
+                    "type": "string"
+                  },
+                  "params": {
+                    "description": "Params",
+                    "items": {
+                      "description": "Param",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "description": "Value"
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "value"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "resolver": {
+                    "description": "Resolver",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "taskSpec": {
+                "description": "TaskSpec"
+              },
+              "timeout": {
+                "description": "Timeout",
+                "type": "string"
+              },
+              "when": {
+                "description": "WhenExpressions",
+                "items": {
+                  "description": "WhenExpression",
+                  "properties": {
+                    "cel": {
+                      "description": "CEL",
+                      "type": "string"
+                    },
+                    "input": {
+                      "description": "Input",
+                      "type": "string"
+                    },
+                    "operator": {
+                      "description": "Operator",
+                      "type": "string"
+                    },
+                    "values": {
+                      "description": "Values",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "workspaces": {
+                "description": "Workspaces",
+                "items": {
+                  "description": "WorkspacePipelineTaskBinding",
+                  "properties": {
+                    "name": {
+                      "description": "Name",
+                      "type": "string"
+                    },
+                    "subPath": {
+                      "description": "SubPath",
+                      "type": "string"
+                    },
+                    "workspace": {
+                      "description": "Workspace",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "params": {
+          "description": "Params",
+          "items": {
+            "description": "ParamSpec",
+            "properties": {
+              "default": {
+                "description": "Default"
+              },
+              "description": {
+                "description": "Description",
+                "type": "string"
+              },
+              "enum": {
+                "description": "Enum",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "name": {
+                "description": "Name",
+                "type": "string"
+              },
+              "properties": {
+                "additionalProperties": {
+                  "description": "PropertySpec",
+                  "properties": {
+                    "type": {
+                      "description": "ParamType",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "description": "Properties",
+                "type": "object"
+              },
+              "type": {
+                "description": "Type",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "resources": {
+          "description": "Resources\nDeprecated: Unused, preserved only for backwards compatibility",
+          "items": {
+            "description": "PipelineDeclaredResource\nDeprecated: Unused, preserved only for backwards compatibility",
+            "properties": {
+              "name": {
+                "description": "Name",
+                "type": "string"
+              },
+              "optional": {
+                "description": "Optional",
+                "type": "boolean"
+              },
+              "type": {
+                "description": "Type",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "type"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "results": {
+          "description": "Results",
+          "items": {
+            "description": "PipelineResult",
+            "properties": {
+              "description": {
+                "description": "Description",
+                "type": "string"
+              },
+              "name": {
+                "description": "Name",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type",
+                "type": "string"
+              },
+              "value": {
+                "description": "Value"
+              }
+            },
+            "required": [
+              "name",
+              "value"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "tasks": {
+          "description": "Tasks",
+          "items": {
+            "description": "PipelineTask",
+            "properties": {
+              "description": {
+                "description": "Description",
+                "type": "string"
+              },
+              "displayName": {
+                "description": "DisplayName",
+                "type": "string"
+              },
+              "matrix": {
+                "description": "Matrix",
+                "properties": {
+                  "include": {
+                    "description": "Include",
+                    "items": {
+                      "description": "IncludeParams",
+                      "properties": {
+                        "name": {
+                          "description": "Name",
+                          "type": "string"
+                        },
+                        "params": {
+                          "description": "Params",
+                          "items": {
+                            "description": "Param",
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "description": "Value"
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "value"
+                            ],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "params": {
+                    "description": "Params",
+                    "items": {
+                      "description": "Param",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "description": "Value"
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "value"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              },
+              "name": {
+                "description": "Name",
+                "type": "string"
+              },
+              "onError": {
+                "description": "OnError",
+                "type": "string"
+              },
+              "params": {
+                "description": "Params",
+                "items": {
+                  "description": "Param",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "description": "Value"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "value"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "pipelineRef": {
+                "description": "PipelineRef",
+                "properties": {
+                  "apiVersion": {
+                    "description": "APIVersion",
+                    "type": "string"
+                  },
+                  "bundle": {
+                    "description": "Deprecated: Please use ResolverRef with the bundles resolver instead.\nBundle",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name",
+                    "type": "string"
+                  },
+                  "params": {
+                    "description": "Params",
+                    "items": {
+                      "description": "Param",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "description": "Value"
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "value"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "resolver": {
+                    "description": "Resolver",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "pipelineSpec": {
+                "description": "PipelineSpec"
+              },
+              "resources": {
+                "description": "Resources\nDeprecated: Unused, preserved only for backwards compatibility",
+                "properties": {
+                  "inputs": {
+                    "description": "Inputs",
+                    "items": {
+                      "description": "PipelineTaskInputResource\nDeprecated: Unused, preserved only for backwards compatibility",
+                      "properties": {
+                        "from": {
+                          "description": "From",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "name": {
+                          "description": "Name",
+                          "type": "string"
+                        },
+                        "resource": {
+                          "description": "Resource",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "resource"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "outputs": {
+                    "description": "Outputs",
+                    "items": {
+                      "description": "PipelineTaskOutputResource\nDeprecated: Unused, preserved only for backwards compatibility",
+                      "properties": {
+                        "name": {
+                          "description": "Name",
+                          "type": "string"
+                        },
+                        "resource": {
+                          "description": "Resource",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "resource"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              },
+              "retries": {
+                "description": "Retries",
+                "type": "integer"
+              },
+              "runAfter": {
+                "description": "RunAfter",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "taskRef": {
+                "description": "TaskRef",
+                "properties": {
+                  "apiVersion": {
+                    "description": "APIVersion",
+                    "type": "string"
+                  },
+                  "bundle": {
+                    "description": "Deprecated: Please use ResolverRef with the bundles resolver instead.\nBundle",
+                    "type": "string"
+                  },
+                  "kind": {
+                    "description": "Kind",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name",
+                    "type": "string"
+                  },
+                  "params": {
+                    "description": "Params",
+                    "items": {
+                      "description": "Param",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "description": "Value"
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "value"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "resolver": {
+                    "description": "Resolver",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "taskSpec": {
+                "description": "TaskSpec"
+              },
+              "timeout": {
+                "description": "Timeout",
+                "type": "string"
+              },
+              "when": {
+                "description": "WhenExpressions",
+                "items": {
+                  "description": "WhenExpression",
+                  "properties": {
+                    "cel": {
+                      "description": "CEL",
+                      "type": "string"
+                    },
+                    "input": {
+                      "description": "Input",
+                      "type": "string"
+                    },
+                    "operator": {
+                      "description": "Operator",
+                      "type": "string"
+                    },
+                    "values": {
+                      "description": "Values",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "workspaces": {
+                "description": "Workspaces",
+                "items": {
+                  "description": "WorkspacePipelineTaskBinding",
+                  "properties": {
+                    "name": {
+                      "description": "Name",
+                      "type": "string"
+                    },
+                    "subPath": {
+                      "description": "SubPath",
+                      "type": "string"
+                    },
+                    "workspace": {
+                      "description": "Workspace",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "workspaces": {
+          "description": "Workspaces",
+          "items": {
+            "description": "PipelineWorkspaceDeclaration",
+            "properties": {
+              "description": {
+                "description": "Description",
+                "type": "string"
+              },
+              "name": {
+                "description": "Name",
+                "type": "string"
+              },
+              "optional": {
+                "description": "Optional",
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "title": "Tekton Pipeline v1beta1",
+  "type": "object"
+}

--- a/schema/v1beta1/pipelinerun.json
+++ b/schema/v1beta1/pipelinerun.json
@@ -1,0 +1,2874 @@
+{
+  "$id": "https://tekton.dev/schemas/v1beta1/pipelinerun.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "PipelineRun\nDeprecated: Please use v1.PipelineRun instead.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Spec",
+      "properties": {
+        "managedBy": {
+          "description": "ManagedBy",
+          "type": "string"
+        },
+        "params": {
+          "description": "Params",
+          "items": {
+            "description": "Param",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "value": {
+                "description": "Value"
+              }
+            },
+            "required": [
+              "name",
+              "value"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "pipelineRef": {
+          "description": "PipelineRef",
+          "properties": {
+            "apiVersion": {
+              "description": "APIVersion",
+              "type": "string"
+            },
+            "bundle": {
+              "description": "Deprecated: Please use ResolverRef with the bundles resolver instead.\nBundle",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name",
+              "type": "string"
+            },
+            "params": {
+              "description": "Params",
+              "items": {
+                "description": "Param",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "description": "Value"
+                  }
+                },
+                "required": [
+                  "name",
+                  "value"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "resolver": {
+              "description": "Resolver",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "pipelineSpec": {
+          "description": "PipelineSpec"
+        },
+        "podTemplate": {
+          "description": "PodTemplate",
+          "properties": {
+            "affinity": {
+              "description": "If specified, the pod's scheduling constraints.\nSee Pod.spec.affinity (API version: v1)"
+            },
+            "automountServiceAccountToken": {
+              "description": "AutomountServiceAccountToken indicates whether pods running as this\nservice account should have an API token automatically mounted.",
+              "type": "boolean"
+            },
+            "dnsConfig": {
+              "description": "Specifies the DNS parameters of a pod.\nParameters specified here will be merged to the generated DNS\nconfiguration based on DNSPolicy.",
+              "properties": {
+                "nameservers": {
+                  "description": "A list of DNS name server IP addresses.\nThis will be appended to the base nameservers generated from DNSPolicy.\nDuplicated nameservers will be removed.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "options": {
+                  "description": "A list of DNS resolver options.\nThis will be merged with the base options generated from DNSPolicy.\nDuplicated entries will be removed. Resolution options given in Options\nwill override those that appear in the base DNSPolicy.",
+                  "items": {
+                    "description": "PodDNSConfigOption defines DNS resolver options of a pod.",
+                    "properties": {
+                      "name": {
+                        "description": "Name is this DNS resolver option's name.\nRequired.",
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "Value is this DNS resolver option's value.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "searches": {
+                  "description": "A list of DNS search domains for host-name lookup.\nThis will be appended to the base search paths generated from DNSPolicy.\nDuplicated search paths will be removed.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            },
+            "dnsPolicy": {
+              "description": "Set DNS policy for the pod. Defaults to \"ClusterFirst\". Valid values are\n'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig\nwill be merged with the policy selected with DNSPolicy.",
+              "type": "string"
+            },
+            "enableServiceLinks": {
+              "description": "EnableServiceLinks indicates whether information about services should be injected into pod's\nenvironment variables, matching the syntax of Docker links.\nOptional: Defaults to true.",
+              "type": "boolean"
+            },
+            "env": {
+              "description": "List of environment variables that can be provided to the containers belonging to the pod.",
+              "items": {
+                "description": "EnvVar represents an environment variable present in a Container.",
+                "properties": {
+                  "name": {
+                    "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                    "type": "string"
+                  },
+                  "value": {
+                    "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
+                    "type": "string"
+                  },
+                  "valueFrom": {
+                    "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                    "properties": {
+                      "configMapKeyRef": {
+                        "description": "Selects a key of a ConfigMap.",
+                        "properties": {
+                          "key": {
+                            "description": "The key to select.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "default": "",
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the ConfigMap or its key must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object"
+                      },
+                      "fieldRef": {
+                        "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['\u003cKEY\u003e']`, `metadata.annotations['\u003cKEY\u003e']`,\nspec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                        "properties": {
+                          "apiVersion": {
+                            "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                            "type": "string"
+                          },
+                          "fieldPath": {
+                            "description": "Path of the field to select in the specified API version.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "fieldPath"
+                        ],
+                        "type": "object"
+                      },
+                      "resourceFieldRef": {
+                        "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                        "properties": {
+                          "containerName": {
+                            "description": "Container name: required for volumes, optional for env vars",
+                            "type": "string"
+                          },
+                          "divisor": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                          },
+                          "resource": {
+                            "description": "Required: resource to select",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "resource"
+                        ],
+                        "type": "object"
+                      },
+                      "secretKeyRef": {
+                        "description": "Selects a key of a secret in the pod's namespace",
+                        "properties": {
+                          "key": {
+                            "description": "The key of the secret to select from.  Must be a valid secret key.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "default": "",
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the Secret or its key must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "hostAliases": {
+              "description": "HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts\nfile if specified. This is only valid for non-hostNetwork pods.",
+              "items": {
+                "description": "HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the\npod's hosts file.",
+                "properties": {
+                  "hostnames": {
+                    "description": "Hostnames for the above IP address.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "ip": {
+                    "description": "IP address of the host file entry.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "ip"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "hostNetwork": {
+              "description": "HostNetwork specifies whether the pod may use the node network namespace",
+              "type": "boolean"
+            },
+            "hostUsers": {
+              "description": "HostUsers indicates whether the pod will use the host's user namespace.\nOptional: Default to true.\nIf set to true or not present, the pod will be run in the host user namespace, useful\nfor when the pod needs a feature only available to the host user namespace, such as\nloading a kernel module with CAP_SYS_MODULE.\nWhen set to false, a new user namespace is created for the pod. Setting false\nis useful to mitigating container breakout vulnerabilities such as allowing\ncontainers to run as root without their user having root privileges on the host.\nThis field depends on the kubernetes feature gate UserNamespacesSupport being enabled.",
+              "type": "boolean"
+            },
+            "imagePullSecrets": {
+              "description": "ImagePullSecrets gives the name of the secret used by the pod to pull the image if specified",
+              "items": {
+                "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                "properties": {
+                  "name": {
+                    "default": "",
+                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "nodeSelector": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "NodeSelector is a selector which must be true for the pod to fit on a node.\nSelector which must match a node's labels for the pod to be scheduled on that node.\nMore info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/",
+              "type": "object"
+            },
+            "priorityClassName": {
+              "description": "If specified, indicates the pod's priority. \"system-node-critical\" and\n\"system-cluster-critical\" are two special keywords which indicate the\nhighest priorities with the former being the highest priority. Any other\nname must be defined by creating a PriorityClass object with that name.\nIf not specified, the pod priority will be default or zero if there is no\ndefault.",
+              "type": "string"
+            },
+            "runtimeClassName": {
+              "description": "RuntimeClassName refers to a RuntimeClass object in the node.k8s.io\ngroup, which should be used to run this pod. If no RuntimeClass resource\nmatches the named class, the pod will not be run. If unset or empty, the\n\"legacy\" RuntimeClass will be used, which is an implicit class with an\nempty definition that uses the default runtime handler.\nMore info: https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md\nThis is a beta feature as of Kubernetes v1.14.",
+              "type": "string"
+            },
+            "schedulerName": {
+              "description": "SchedulerName specifies the scheduler to be used to dispatch the Pod",
+              "type": "string"
+            },
+            "securityContext": {
+              "description": "SecurityContext holds pod-level security attributes and common container settings.\nOptional: Defaults to empty.  See type description for default values of each field.\nSee Pod.spec.securityContext (API version: v1)"
+            },
+            "tolerations": {
+              "description": "If specified, the pod's tolerations.",
+              "items": {
+                "description": "The pod this Toleration is attached to tolerates any taint that matches\nthe triple \u003ckey,value,effect\u003e using the matching operator \u003coperator\u003e.",
+                "properties": {
+                  "effect": {
+                    "description": "Effect indicates the taint effect to match. Empty means match all taint effects.\nWhen specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                    "type": "string"
+                  },
+                  "key": {
+                    "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys.\nIf the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "Operator represents a key's relationship to the value.\nValid operators are Exists and Equal. Defaults to Equal.\nExists is equivalent to wildcard for value, so that a pod can\ntolerate all taints of a particular category.",
+                    "type": "string"
+                  },
+                  "tolerationSeconds": {
+                    "description": "TolerationSeconds represents the period of time the toleration (which must be\nof effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,\nit is not set, which means tolerate the taint forever (do not evict). Zero and\nnegative values will be treated as 0 (evict immediately) by the system.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "value": {
+                    "description": "Value is the taint value the toleration matches to.\nIf the operator is Exists, the value should be empty, otherwise just a regular string.",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "topologySpreadConstraints": {
+              "description": "TopologySpreadConstraints controls how Pods are spread across your cluster among\nfailure-domains such as regions, zones, nodes, and other user-defined topology domains.",
+              "items": {
+                "description": "TopologySpreadConstraint specifies how to spread matching pods among the given topology.",
+                "properties": {
+                  "labelSelector": {
+                    "description": "LabelSelector is used to find matching pods.\nPods that match this label selector are counted to determine the number of pods\nin their corresponding topology domain.",
+                    "properties": {
+                      "matchExpressions": {
+                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                        "items": {
+                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                          "properties": {
+                            "key": {
+                              "description": "key is the label key that the selector applies to.",
+                              "type": "string"
+                            },
+                            "operator": {
+                              "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                              "type": "string"
+                            },
+                            "values": {
+                              "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "required": [
+                            "key",
+                            "operator"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "matchLabels": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                        "type": "object"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "matchLabelKeys": {
+                    "description": "MatchLabelKeys is a set of pod label keys to select the pods over which\nspreading will be calculated. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are ANDed with labelSelector\nto select the group of existing pods over which spreading will be calculated\nfor the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.\nMatchLabelKeys cannot be set when LabelSelector isn't set.\nKeys that don't exist in the incoming pod labels will\nbe ignored. A null or empty list means only match against labelSelector.\n\nThis is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "maxSkew": {
+                    "description": "MaxSkew describes the degree to which pods may be unevenly distributed.\nWhen `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference\nbetween the number of matching pods in the target topology and the global minimum.\nThe global minimum is the minimum number of matching pods in an eligible domain\nor zero if the number of eligible domains is less than MinDomains.\nFor example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same\nlabelSelector spread as 2/2/1:\nIn this case, the global minimum is 1.\n| zone1 | zone2 | zone3 |\n|  P P  |  P P  |   P   |\n- if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;\nscheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)\nviolate MaxSkew(1).\n- if MaxSkew is 2, incoming pod can be scheduled onto any zone.\nWhen `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence\nto topologies that satisfy it.\nIt's a required field. Default value is 1 and 0 is not allowed.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "minDomains": {
+                    "description": "MinDomains indicates a minimum number of eligible domains.\nWhen the number of eligible domains with matching topology keys is less than minDomains,\nPod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed.\nAnd when the number of eligible domains with matching topology keys equals or greater than minDomains,\nthis value has no effect on scheduling.\nAs a result, when the number of eligible domains is less than minDomains,\nscheduler won't schedule more than maxSkew Pods to those domains.\nIf value is nil, the constraint behaves as if MinDomains is equal to 1.\nValid values are integers greater than 0.\nWhen value is not nil, WhenUnsatisfiable must be DoNotSchedule.\n\nFor example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same\nlabelSelector spread as 2/2/2:\n| zone1 | zone2 | zone3 |\n|  P P  |  P P  |  P P  |\nThe number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0.\nIn this situation, new pod with the same labelSelector cannot be scheduled,\nbecause computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,\nit will violate MaxSkew.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "nodeAffinityPolicy": {
+                    "description": "NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector\nwhen calculating pod topology spread skew. Options are:\n- Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.\n- Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.\n\nIf this value is nil, the behavior is equivalent to the Honor policy.\nThis is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.",
+                    "type": "string"
+                  },
+                  "nodeTaintsPolicy": {
+                    "description": "NodeTaintsPolicy indicates how we will treat node taints when calculating\npod topology spread skew. Options are:\n- Honor: nodes without taints, along with tainted nodes for which the incoming pod\nhas a toleration, are included.\n- Ignore: node taints are ignored. All nodes are included.\n\nIf this value is nil, the behavior is equivalent to the Ignore policy.\nThis is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.",
+                    "type": "string"
+                  },
+                  "topologyKey": {
+                    "description": "TopologyKey is the key of node labels. Nodes that have a label with this key\nand identical values are considered to be in the same topology.\nWe consider each \u003ckey, value\u003e as a \"bucket\", and try to put balanced number\nof pods into each bucket.\nWe define a domain as a particular instance of a topology.\nAlso, we define an eligible domain as a domain whose nodes meet the requirements of\nnodeAffinityPolicy and nodeTaintsPolicy.\ne.g. If TopologyKey is \"kubernetes.io/hostname\", each Node is a domain of that topology.\nAnd, if TopologyKey is \"topology.kubernetes.io/zone\", each zone is a domain of that topology.\nIt's a required field.",
+                    "type": "string"
+                  },
+                  "whenUnsatisfiable": {
+                    "description": "WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy\nthe spread constraint.\n- DoNotSchedule (default) tells the scheduler not to schedule it.\n- ScheduleAnyway tells the scheduler to schedule the pod in any location,\n  but giving higher precedence to topologies that would help reduce the\n  skew.\nA constraint is considered \"Unsatisfiable\" for an incoming pod\nif and only if every possible node assignment for that pod would violate\n\"MaxSkew\" on some topology.\nFor example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same\nlabelSelector spread as 3/1/1:\n| zone1 | zone2 | zone3 |\n| P P P |   P   |   P   |\nIf WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled\nto zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies\nMaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler\nwon't make it *more* imbalanced.\nIt's a required field.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "maxSkew",
+                  "topologyKey",
+                  "whenUnsatisfiable"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "volumes": {
+              "description": "List of volumes that can be mounted by containers belonging to the pod.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes\nSee Pod.spec.volumes (API version: v1)"
+            }
+          },
+          "type": "object"
+        },
+        "resources": {
+          "description": "Resources\nDeprecated: Unused, preserved only for backwards compatibility",
+          "items": {
+            "description": "PipelineResourceBinding\nDeprecated: Unused, preserved only for backwards compatibility",
+            "properties": {
+              "name": {
+                "description": "Name",
+                "type": "string"
+              },
+              "resourceRef": {
+                "description": "ResourceRef",
+                "properties": {
+                  "apiVersion": {
+                    "description": "APIVersion",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "resourceSpec": {
+                "description": "ResourceSpec",
+                "properties": {
+                  "description": {
+                    "description": "Description is a user-facing description of the resource that may be\nused to populate a UI.",
+                    "type": "string"
+                  },
+                  "params": {
+                    "items": {
+                      "description": "ResourceParam declares a string value to use for the parameter called Name, and is used in\nthe specific context of PipelineResources.\n\nDeprecated: Unused, preserved only for backwards compatibility",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "value"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "secrets": {
+                    "description": "Secrets to fetch to populate some of resource fields",
+                    "items": {
+                      "description": "SecretParam indicates which secret can be used to populate a field of the resource\n\nDeprecated: Unused, preserved only for backwards compatibility",
+                      "properties": {
+                        "fieldName": {
+                          "type": "string"
+                        },
+                        "secretKey": {
+                          "type": "string"
+                        },
+                        "secretName": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "fieldName",
+                        "secretKey",
+                        "secretName"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "type": {
+                    "description": "PipelineResourceType represents the type of endpoint the pipelineResource is, so that the\ncontroller will know this pipelineResource shouldx be fetched and optionally what\nadditional metatdata should be provided for it.\n\nDeprecated: Unused, preserved only for backwards compatibility",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "params",
+                  "type"
+                ],
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "serviceAccountName": {
+          "description": "ServiceAccountName",
+          "type": "string"
+        },
+        "status": {
+          "description": "Status",
+          "type": "string"
+        },
+        "taskRunSpecs": {
+          "description": "TaskRunSpecs",
+          "items": {
+            "description": "PipelineTaskRunSpec",
+            "properties": {
+              "computeResources": {
+                "description": "ComputeResources",
+                "properties": {
+                  "claims": {
+                    "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                    "items": {
+                      "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                      "properties": {
+                        "name": {
+                          "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                          "type": "string"
+                        },
+                        "request": {
+                          "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "limits": {
+                    "additionalProperties": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                    },
+                    "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                    "type": "object"
+                  },
+                  "requests": {
+                    "additionalProperties": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                    },
+                    "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                    "type": "object"
+                  }
+                },
+                "type": "object"
+              },
+              "metadata": {
+                "description": "Metadata",
+                "properties": {
+                  "annotations": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Annotations",
+                    "type": "object"
+                  },
+                  "labels": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Labels",
+                    "type": "object"
+                  }
+                },
+                "type": "object"
+              },
+              "pipelineTaskName": {
+                "type": "string"
+              },
+              "sidecarOverrides": {
+                "description": "SidecarOverrides",
+                "items": {
+                  "description": "TaskRunSidecarOverride",
+                  "properties": {
+                    "name": {
+                      "description": "Name",
+                      "type": "string"
+                    },
+                    "resources": {
+                      "description": "Resources",
+                      "properties": {
+                        "claims": {
+                          "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                          "items": {
+                            "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                            "properties": {
+                              "name": {
+                                "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                                "type": "string"
+                              },
+                              "request": {
+                                "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "limits": {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                          },
+                          "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                          "type": "object"
+                        },
+                        "requests": {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                          },
+                          "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "resources"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "stepOverrides": {
+                "description": "StepOverrides",
+                "items": {
+                  "description": "TaskRunStepOverride",
+                  "properties": {
+                    "name": {
+                      "description": "Name",
+                      "type": "string"
+                    },
+                    "resources": {
+                      "description": "Resources",
+                      "properties": {
+                        "claims": {
+                          "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                          "items": {
+                            "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                            "properties": {
+                              "name": {
+                                "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                                "type": "string"
+                              },
+                              "request": {
+                                "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "limits": {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                          },
+                          "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                          "type": "object"
+                        },
+                        "requests": {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                          },
+                          "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "resources"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "taskPodTemplate": {
+                "description": "PodTemplate holds pod specific configuration",
+                "properties": {
+                  "affinity": {
+                    "description": "If specified, the pod's scheduling constraints.\nSee Pod.spec.affinity (API version: v1)"
+                  },
+                  "automountServiceAccountToken": {
+                    "description": "AutomountServiceAccountToken indicates whether pods running as this\nservice account should have an API token automatically mounted.",
+                    "type": "boolean"
+                  },
+                  "dnsConfig": {
+                    "description": "Specifies the DNS parameters of a pod.\nParameters specified here will be merged to the generated DNS\nconfiguration based on DNSPolicy.",
+                    "properties": {
+                      "nameservers": {
+                        "description": "A list of DNS name server IP addresses.\nThis will be appended to the base nameservers generated from DNSPolicy.\nDuplicated nameservers will be removed.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "options": {
+                        "description": "A list of DNS resolver options.\nThis will be merged with the base options generated from DNSPolicy.\nDuplicated entries will be removed. Resolution options given in Options\nwill override those that appear in the base DNSPolicy.",
+                        "items": {
+                          "description": "PodDNSConfigOption defines DNS resolver options of a pod.",
+                          "properties": {
+                            "name": {
+                              "description": "Name is this DNS resolver option's name.\nRequired.",
+                              "type": "string"
+                            },
+                            "value": {
+                              "description": "Value is this DNS resolver option's value.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "searches": {
+                        "description": "A list of DNS search domains for host-name lookup.\nThis will be appended to the base search paths generated from DNSPolicy.\nDuplicated search paths will be removed.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "dnsPolicy": {
+                    "description": "Set DNS policy for the pod. Defaults to \"ClusterFirst\". Valid values are\n'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig\nwill be merged with the policy selected with DNSPolicy.",
+                    "type": "string"
+                  },
+                  "enableServiceLinks": {
+                    "description": "EnableServiceLinks indicates whether information about services should be injected into pod's\nenvironment variables, matching the syntax of Docker links.\nOptional: Defaults to true.",
+                    "type": "boolean"
+                  },
+                  "env": {
+                    "description": "List of environment variables that can be provided to the containers belonging to the pod.",
+                    "items": {
+                      "description": "EnvVar represents an environment variable present in a Container.",
+                      "properties": {
+                        "name": {
+                          "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                          "type": "string"
+                        },
+                        "value": {
+                          "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
+                          "type": "string"
+                        },
+                        "valueFrom": {
+                          "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                          "properties": {
+                            "configMapKeyRef": {
+                              "description": "Selects a key of a ConfigMap.",
+                              "properties": {
+                                "key": {
+                                  "description": "The key to select.",
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "default": "",
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "description": "Specify whether the ConfigMap or its key must be defined",
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object"
+                            },
+                            "fieldRef": {
+                              "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['\u003cKEY\u003e']`, `metadata.annotations['\u003cKEY\u003e']`,\nspec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                              "properties": {
+                                "apiVersion": {
+                                  "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                  "type": "string"
+                                },
+                                "fieldPath": {
+                                  "description": "Path of the field to select in the specified API version.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "fieldPath"
+                              ],
+                              "type": "object"
+                            },
+                            "resourceFieldRef": {
+                              "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                              "properties": {
+                                "containerName": {
+                                  "description": "Container name: required for volumes, optional for env vars",
+                                  "type": "string"
+                                },
+                                "divisor": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                                },
+                                "resource": {
+                                  "description": "Required: resource to select",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "resource"
+                              ],
+                              "type": "object"
+                            },
+                            "secretKeyRef": {
+                              "description": "Selects a key of a secret in the pod's namespace",
+                              "properties": {
+                                "key": {
+                                  "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "default": "",
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "description": "Specify whether the Secret or its key must be defined",
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "hostAliases": {
+                    "description": "HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts\nfile if specified. This is only valid for non-hostNetwork pods.",
+                    "items": {
+                      "description": "HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the\npod's hosts file.",
+                      "properties": {
+                        "hostnames": {
+                          "description": "Hostnames for the above IP address.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "ip": {
+                          "description": "IP address of the host file entry.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "ip"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "hostNetwork": {
+                    "description": "HostNetwork specifies whether the pod may use the node network namespace",
+                    "type": "boolean"
+                  },
+                  "hostUsers": {
+                    "description": "HostUsers indicates whether the pod will use the host's user namespace.\nOptional: Default to true.\nIf set to true or not present, the pod will be run in the host user namespace, useful\nfor when the pod needs a feature only available to the host user namespace, such as\nloading a kernel module with CAP_SYS_MODULE.\nWhen set to false, a new user namespace is created for the pod. Setting false\nis useful to mitigating container breakout vulnerabilities such as allowing\ncontainers to run as root without their user having root privileges on the host.\nThis field depends on the kubernetes feature gate UserNamespacesSupport being enabled.",
+                    "type": "boolean"
+                  },
+                  "imagePullSecrets": {
+                    "description": "ImagePullSecrets gives the name of the secret used by the pod to pull the image if specified",
+                    "items": {
+                      "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                      "properties": {
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "nodeSelector": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "NodeSelector is a selector which must be true for the pod to fit on a node.\nSelector which must match a node's labels for the pod to be scheduled on that node.\nMore info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/",
+                    "type": "object"
+                  },
+                  "priorityClassName": {
+                    "description": "If specified, indicates the pod's priority. \"system-node-critical\" and\n\"system-cluster-critical\" are two special keywords which indicate the\nhighest priorities with the former being the highest priority. Any other\nname must be defined by creating a PriorityClass object with that name.\nIf not specified, the pod priority will be default or zero if there is no\ndefault.",
+                    "type": "string"
+                  },
+                  "runtimeClassName": {
+                    "description": "RuntimeClassName refers to a RuntimeClass object in the node.k8s.io\ngroup, which should be used to run this pod. If no RuntimeClass resource\nmatches the named class, the pod will not be run. If unset or empty, the\n\"legacy\" RuntimeClass will be used, which is an implicit class with an\nempty definition that uses the default runtime handler.\nMore info: https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md\nThis is a beta feature as of Kubernetes v1.14.",
+                    "type": "string"
+                  },
+                  "schedulerName": {
+                    "description": "SchedulerName specifies the scheduler to be used to dispatch the Pod",
+                    "type": "string"
+                  },
+                  "securityContext": {
+                    "description": "SecurityContext holds pod-level security attributes and common container settings.\nOptional: Defaults to empty.  See type description for default values of each field.\nSee Pod.spec.securityContext (API version: v1)"
+                  },
+                  "tolerations": {
+                    "description": "If specified, the pod's tolerations.",
+                    "items": {
+                      "description": "The pod this Toleration is attached to tolerates any taint that matches\nthe triple \u003ckey,value,effect\u003e using the matching operator \u003coperator\u003e.",
+                      "properties": {
+                        "effect": {
+                          "description": "Effect indicates the taint effect to match. Empty means match all taint effects.\nWhen specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                          "type": "string"
+                        },
+                        "key": {
+                          "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys.\nIf the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                          "type": "string"
+                        },
+                        "operator": {
+                          "description": "Operator represents a key's relationship to the value.\nValid operators are Exists and Equal. Defaults to Equal.\nExists is equivalent to wildcard for value, so that a pod can\ntolerate all taints of a particular category.",
+                          "type": "string"
+                        },
+                        "tolerationSeconds": {
+                          "description": "TolerationSeconds represents the period of time the toleration (which must be\nof effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,\nit is not set, which means tolerate the taint forever (do not evict). Zero and\nnegative values will be treated as 0 (evict immediately) by the system.",
+                          "format": "int64",
+                          "type": "integer"
+                        },
+                        "value": {
+                          "description": "Value is the taint value the toleration matches to.\nIf the operator is Exists, the value should be empty, otherwise just a regular string.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "topologySpreadConstraints": {
+                    "description": "TopologySpreadConstraints controls how Pods are spread across your cluster among\nfailure-domains such as regions, zones, nodes, and other user-defined topology domains.",
+                    "items": {
+                      "description": "TopologySpreadConstraint specifies how to spread matching pods among the given topology.",
+                      "properties": {
+                        "labelSelector": {
+                          "description": "LabelSelector is used to find matching pods.\nPods that match this label selector are counted to determine the number of pods\nin their corresponding topology domain.",
+                          "properties": {
+                            "matchExpressions": {
+                              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                              "items": {
+                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                "properties": {
+                                  "key": {
+                                    "description": "key is the label key that the selector applies to.",
+                                    "type": "string"
+                                  },
+                                  "operator": {
+                                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                    "type": "string"
+                                  },
+                                  "values": {
+                                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "operator"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "matchLabels": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "matchLabelKeys": {
+                          "description": "MatchLabelKeys is a set of pod label keys to select the pods over which\nspreading will be calculated. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are ANDed with labelSelector\nto select the group of existing pods over which spreading will be calculated\nfor the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.\nMatchLabelKeys cannot be set when LabelSelector isn't set.\nKeys that don't exist in the incoming pod labels will\nbe ignored. A null or empty list means only match against labelSelector.\n\nThis is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "maxSkew": {
+                          "description": "MaxSkew describes the degree to which pods may be unevenly distributed.\nWhen `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference\nbetween the number of matching pods in the target topology and the global minimum.\nThe global minimum is the minimum number of matching pods in an eligible domain\nor zero if the number of eligible domains is less than MinDomains.\nFor example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same\nlabelSelector spread as 2/2/1:\nIn this case, the global minimum is 1.\n| zone1 | zone2 | zone3 |\n|  P P  |  P P  |   P   |\n- if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;\nscheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)\nviolate MaxSkew(1).\n- if MaxSkew is 2, incoming pod can be scheduled onto any zone.\nWhen `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence\nto topologies that satisfy it.\nIt's a required field. Default value is 1 and 0 is not allowed.",
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "minDomains": {
+                          "description": "MinDomains indicates a minimum number of eligible domains.\nWhen the number of eligible domains with matching topology keys is less than minDomains,\nPod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed.\nAnd when the number of eligible domains with matching topology keys equals or greater than minDomains,\nthis value has no effect on scheduling.\nAs a result, when the number of eligible domains is less than minDomains,\nscheduler won't schedule more than maxSkew Pods to those domains.\nIf value is nil, the constraint behaves as if MinDomains is equal to 1.\nValid values are integers greater than 0.\nWhen value is not nil, WhenUnsatisfiable must be DoNotSchedule.\n\nFor example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same\nlabelSelector spread as 2/2/2:\n| zone1 | zone2 | zone3 |\n|  P P  |  P P  |  P P  |\nThe number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0.\nIn this situation, new pod with the same labelSelector cannot be scheduled,\nbecause computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,\nit will violate MaxSkew.",
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "nodeAffinityPolicy": {
+                          "description": "NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector\nwhen calculating pod topology spread skew. Options are:\n- Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.\n- Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.\n\nIf this value is nil, the behavior is equivalent to the Honor policy.\nThis is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.",
+                          "type": "string"
+                        },
+                        "nodeTaintsPolicy": {
+                          "description": "NodeTaintsPolicy indicates how we will treat node taints when calculating\npod topology spread skew. Options are:\n- Honor: nodes without taints, along with tainted nodes for which the incoming pod\nhas a toleration, are included.\n- Ignore: node taints are ignored. All nodes are included.\n\nIf this value is nil, the behavior is equivalent to the Ignore policy.\nThis is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.",
+                          "type": "string"
+                        },
+                        "topologyKey": {
+                          "description": "TopologyKey is the key of node labels. Nodes that have a label with this key\nand identical values are considered to be in the same topology.\nWe consider each \u003ckey, value\u003e as a \"bucket\", and try to put balanced number\nof pods into each bucket.\nWe define a domain as a particular instance of a topology.\nAlso, we define an eligible domain as a domain whose nodes meet the requirements of\nnodeAffinityPolicy and nodeTaintsPolicy.\ne.g. If TopologyKey is \"kubernetes.io/hostname\", each Node is a domain of that topology.\nAnd, if TopologyKey is \"topology.kubernetes.io/zone\", each zone is a domain of that topology.\nIt's a required field.",
+                          "type": "string"
+                        },
+                        "whenUnsatisfiable": {
+                          "description": "WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy\nthe spread constraint.\n- DoNotSchedule (default) tells the scheduler not to schedule it.\n- ScheduleAnyway tells the scheduler to schedule the pod in any location,\n  but giving higher precedence to topologies that would help reduce the\n  skew.\nA constraint is considered \"Unsatisfiable\" for an incoming pod\nif and only if every possible node assignment for that pod would violate\n\"MaxSkew\" on some topology.\nFor example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same\nlabelSelector spread as 3/1/1:\n| zone1 | zone2 | zone3 |\n| P P P |   P   |   P   |\nIf WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled\nto zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies\nMaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler\nwon't make it *more* imbalanced.\nIt's a required field.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "maxSkew",
+                        "topologyKey",
+                        "whenUnsatisfiable"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "volumes": {
+                    "description": "List of volumes that can be mounted by containers belonging to the pod.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes\nSee Pod.spec.volumes (API version: v1)"
+                  }
+                },
+                "type": "object"
+              },
+              "taskServiceAccountName": {
+                "type": "string"
+              },
+              "timeout": {
+                "description": "Timeout",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "timeout": {
+          "description": "Deprecated: use pipelineRunSpec.Timeouts.Pipeline instead\nTimeout",
+          "type": "string"
+        },
+        "timeouts": {
+          "description": "Timeouts",
+          "properties": {
+            "finally": {
+              "description": "Finally",
+              "type": "string"
+            },
+            "pipeline": {
+              "description": "Pipeline",
+              "type": "string"
+            },
+            "tasks": {
+              "description": "Tasks",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "workspaces": {
+          "description": "Workspaces",
+          "items": {
+            "description": "WorkspaceBinding",
+            "properties": {
+              "configMap": {
+                "description": "ConfigMap",
+                "properties": {
+                  "defaultMode": {
+                    "description": "defaultMode is optional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDefaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "items": {
+                    "description": "items if unspecified, each key-value pair in the Data field of the referenced\nConfigMap will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the ConfigMap,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                    "items": {
+                      "description": "Maps a string key to a path within a volume.",
+                      "properties": {
+                        "key": {
+                          "description": "key is the key to project.",
+                          "type": "string"
+                        },
+                        "mode": {
+                          "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "path": {
+                          "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "key",
+                        "path"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "name": {
+                    "default": "",
+                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                    "type": "string"
+                  },
+                  "optional": {
+                    "description": "optional specify whether the ConfigMap or its keys must be defined",
+                    "type": "boolean"
+                  }
+                },
+                "type": "object"
+              },
+              "csi": {
+                "description": "CSI",
+                "properties": {
+                  "driver": {
+                    "description": "driver is the name of the CSI driver that handles this volume.\nConsult with your admin for the correct name as registered in the cluster.",
+                    "type": "string"
+                  },
+                  "fsType": {
+                    "description": "fsType to mount. Ex. \"ext4\", \"xfs\", \"ntfs\".\nIf not provided, the empty value is passed to the associated CSI driver\nwhich will determine the default filesystem to apply.",
+                    "type": "string"
+                  },
+                  "nodePublishSecretRef": {
+                    "description": "nodePublishSecretRef is a reference to the secret object containing\nsensitive information to pass to the CSI driver to complete the CSI\nNodePublishVolume and NodeUnpublishVolume calls.\nThis field is optional, and  may be empty if no secret is required. If the\nsecret object contains more than one secret, all secret references are passed.",
+                    "properties": {
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "readOnly": {
+                    "description": "readOnly specifies a read-only configuration for the volume.\nDefaults to false (read/write).",
+                    "type": "boolean"
+                  },
+                  "volumeAttributes": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "volumeAttributes stores driver-specific properties that are passed to the CSI\ndriver. Consult your driver's documentation for supported values.",
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "driver"
+                ],
+                "type": "object"
+              },
+              "emptyDir": {
+                "description": "EmptyDir",
+                "properties": {
+                  "medium": {
+                    "description": "medium represents what type of storage medium should back this directory.\nThe default is \"\" which means to use the node's default medium.\nMust be an empty string (default) or Memory.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                    "type": "string"
+                  },
+                  "sizeLimit": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "description": "sizeLimit is the total amount of local storage required for this EmptyDir volume.\nThe size limit is also applicable for memory medium.\nThe maximum usage on memory medium EmptyDir would be the minimum value between\nthe SizeLimit specified here and the sum of memory limits of all containers in a pod.\nThe default is nil which means that the limit is undefined.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                  }
+                },
+                "type": "object"
+              },
+              "name": {
+                "description": "Name",
+                "type": "string"
+              },
+              "persistentVolumeClaim": {
+                "description": "PersistentVolumeClaim",
+                "properties": {
+                  "claimName": {
+                    "description": "claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "readOnly Will force the ReadOnly setting in VolumeMounts.\nDefault false.",
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "claimName"
+                ],
+                "type": "object"
+              },
+              "projected": {
+                "description": "Projected",
+                "properties": {
+                  "defaultMode": {
+                    "description": "defaultMode are the mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "sources": {
+                    "description": "sources is the list of volume projections. Each entry in this list\nhandles one source.",
+                    "items": {
+                      "description": "Projection that may be projected along with other supported volume types.\nExactly one of these fields must be set.",
+                      "properties": {
+                        "clusterTrustBundle": {
+                          "description": "ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field\nof ClusterTrustBundle objects in an auto-updating file.\n\nAlpha, gated by the ClusterTrustBundleProjection feature gate.\n\nClusterTrustBundle objects can either be selected by name, or by the\ncombination of signer name and a label selector.\n\nKubelet performs aggressive normalization of the PEM contents written\ninto the pod filesystem.  Esoteric PEM features such as inter-block\ncomments and block headers are stripped.  Certificates are deduplicated.\nThe ordering of certificates within the file is arbitrary, and Kubelet\nmay change the order over time.",
+                          "properties": {
+                            "labelSelector": {
+                              "description": "Select all ClusterTrustBundles that match this label selector.  Only has\neffect if signerName is set.  Mutually-exclusive with name.  If unset,\ninterpreted as \"match nothing\".  If set but empty, interpreted as \"match\neverything\".",
+                              "properties": {
+                                "matchExpressions": {
+                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                  "items": {
+                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "key is the label key that the selector applies to.",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "operator"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "matchLabels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "name": {
+                              "description": "Select a single ClusterTrustBundle by object name.  Mutually-exclusive\nwith signerName and labelSelector.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "If true, don't block pod startup if the referenced ClusterTrustBundle(s)\naren't available.  If using name, then the named ClusterTrustBundle is\nallowed not to exist.  If using signerName, then the combination of\nsignerName and labelSelector is allowed to match zero\nClusterTrustBundles.",
+                              "type": "boolean"
+                            },
+                            "path": {
+                              "description": "Relative path from the volume root to write the bundle.",
+                              "type": "string"
+                            },
+                            "signerName": {
+                              "description": "Select all ClusterTrustBundles that match this signer name.\nMutually-exclusive with name.  The contents of all selected\nClusterTrustBundles will be unified and deduplicated.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "path"
+                          ],
+                          "type": "object"
+                        },
+                        "configMap": {
+                          "description": "configMap information about the configMap data to project",
+                          "properties": {
+                            "items": {
+                              "description": "items if unspecified, each key-value pair in the Data field of the referenced\nConfigMap will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the ConfigMap,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                              "items": {
+                                "description": "Maps a string key to a path within a volume.",
+                                "properties": {
+                                  "key": {
+                                    "description": "key is the key to project.",
+                                    "type": "string"
+                                  },
+                                  "mode": {
+                                    "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "path": {
+                                    "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "path"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "optional specify whether the ConfigMap or its keys must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "downwardAPI": {
+                          "description": "downwardAPI information about the downwardAPI data to project",
+                          "properties": {
+                            "items": {
+                              "description": "Items is a list of DownwardAPIVolume file",
+                              "items": {
+                                "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                                "properties": {
+                                  "fieldRef": {
+                                    "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.",
+                                    "properties": {
+                                      "apiVersion": {
+                                        "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                        "type": "string"
+                                      },
+                                      "fieldPath": {
+                                        "description": "Path of the field to select in the specified API version.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "fieldPath"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "mode": {
+                                    "description": "Optional: mode bits used to set permissions on this file, must be an octal value\nbetween 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "path": {
+                                    "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                                    "type": "string"
+                                  },
+                                  "resourceFieldRef": {
+                                    "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                                    "properties": {
+                                      "containerName": {
+                                        "description": "Container name: required for volumes, optional for env vars",
+                                        "type": "string"
+                                      },
+                                      "divisor": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                                      },
+                                      "resource": {
+                                        "description": "Required: resource to select",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "resource"
+                                    ],
+                                    "type": "object"
+                                  }
+                                },
+                                "required": [
+                                  "path"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "secret": {
+                          "description": "secret information about the secret data to project",
+                          "properties": {
+                            "items": {
+                              "description": "items if unspecified, each key-value pair in the Data field of the referenced\nSecret will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the Secret,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                              "items": {
+                                "description": "Maps a string key to a path within a volume.",
+                                "properties": {
+                                  "key": {
+                                    "description": "key is the key to project.",
+                                    "type": "string"
+                                  },
+                                  "mode": {
+                                    "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "path": {
+                                    "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "path"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "optional field specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "serviceAccountToken": {
+                          "description": "serviceAccountToken is information about the serviceAccountToken data to project",
+                          "properties": {
+                            "audience": {
+                              "description": "audience is the intended audience of the token. A recipient of a token\nmust identify itself with an identifier specified in the audience of the\ntoken, and otherwise should reject the token. The audience defaults to the\nidentifier of the apiserver.",
+                              "type": "string"
+                            },
+                            "expirationSeconds": {
+                              "description": "expirationSeconds is the requested duration of validity of the service\naccount token. As the token approaches expiration, the kubelet volume\nplugin will proactively rotate the service account token. The kubelet will\nstart trying to rotate the token if the token is older than 80 percent of\nits time to live or if the token is older than 24 hours.Defaults to 1 hour\nand must be at least 10 minutes.",
+                              "format": "int64",
+                              "type": "integer"
+                            },
+                            "path": {
+                              "description": "path is the path relative to the mount point of the file to project the\ntoken into.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "path"
+                          ],
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              },
+              "secret": {
+                "description": "Secret",
+                "properties": {
+                  "defaultMode": {
+                    "description": "defaultMode is Optional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values\nfor mode bits. Defaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "items": {
+                    "description": "items If unspecified, each key-value pair in the Data field of the referenced\nSecret will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the Secret,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                    "items": {
+                      "description": "Maps a string key to a path within a volume.",
+                      "properties": {
+                        "key": {
+                          "description": "key is the key to project.",
+                          "type": "string"
+                        },
+                        "mode": {
+                          "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "path": {
+                          "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "key",
+                        "path"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "optional": {
+                    "description": "optional field specify whether the Secret or its keys must be defined",
+                    "type": "boolean"
+                  },
+                  "secretName": {
+                    "description": "secretName is the name of the secret in the pod's namespace to use.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "subPath": {
+                "description": "SubPath",
+                "type": "string"
+              },
+              "volumeClaimTemplate": {
+                "description": "VolumeClaimTemplate"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "status": {
+      "description": "Status",
+      "properties": {
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Annotations is additional Status fields for the Resource to save some\nadditional State as well as convey more information to the user. This is\nroughly akin to Annotations on any k8s resource, just the reconciler conveying\nricher information outwards.",
+          "type": "object"
+        },
+        "childReferences": {
+          "description": "ChildReferences",
+          "items": {
+            "description": "ChildStatusReference",
+            "properties": {
+              "apiVersion": {
+                "type": "string"
+              },
+              "displayName": {
+                "description": "DisplayName",
+                "type": "string"
+              },
+              "kind": {
+                "type": "string"
+              },
+              "name": {
+                "description": "Name",
+                "type": "string"
+              },
+              "pipelineTaskName": {
+                "description": "PipelineTaskName",
+                "type": "string"
+              },
+              "whenExpressions": {
+                "description": "WhenExpressions",
+                "items": {
+                  "description": "WhenExpression",
+                  "properties": {
+                    "cel": {
+                      "description": "CEL",
+                      "type": "string"
+                    },
+                    "input": {
+                      "description": "Input",
+                      "type": "string"
+                    },
+                    "operator": {
+                      "description": "Operator",
+                      "type": "string"
+                    },
+                    "values": {
+                      "description": "Values",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "completionTime": {
+          "description": "CompletionTime",
+          "format": "date-time",
+          "type": "string"
+        },
+        "conditions": {
+          "description": "Conditions the latest available observations of a resource's current state.",
+          "items": {
+            "description": "Condition defines a readiness condition for a Knative resource.\nSee: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "LastTransitionTime is the last time the condition transitioned from one status to another.\nWe use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic\ndifferences (all other things held constant).",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity with which to treat failures of this type of condition.\nWhen this is not specified, it defaults to Error.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "finallyStartTime": {
+          "description": "FinallyStartTime",
+          "format": "date-time",
+          "type": "string"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the 'Generation' of the Service that\nwas last processed by the controller.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "pipelineResults": {
+          "description": "PipelineResults",
+          "items": {
+            "description": "PipelineRunResult",
+            "properties": {
+              "name": {
+                "description": "Name",
+                "type": "string"
+              },
+              "value": {
+                "description": "Value"
+              }
+            },
+            "required": [
+              "name",
+              "value"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "pipelineSpec": {
+          "description": "PipelineSpec"
+        },
+        "provenance": {
+          "description": "Provenance",
+          "properties": {
+            "configSource": {
+              "description": "ConfigSource\nDeprecated: Use RefSource instead",
+              "properties": {
+                "digest": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Digest",
+                  "type": "object"
+                },
+                "entryPoint": {
+                  "description": "EntryPoint",
+                  "type": "string"
+                },
+                "uri": {
+                  "description": "URI",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "featureFlags": {
+              "description": "FeatureFlags",
+              "properties": {
+                "awaitSidecarReadiness": {
+                  "type": "boolean"
+                },
+                "coschedule": {
+                  "type": "string"
+                },
+                "disableCredsInit": {
+                  "type": "boolean"
+                },
+                "disableInlineSpec": {
+                  "type": "string"
+                },
+                "enableAPIFields": {
+                  "type": "string"
+                },
+                "enableArtifacts": {
+                  "type": "boolean"
+                },
+                "enableCELInWhenExpression": {
+                  "type": "boolean"
+                },
+                "enableConciseResolverSyntax": {
+                  "type": "boolean"
+                },
+                "enableKeepPodOnCancel": {
+                  "type": "boolean"
+                },
+                "enableKubernetesSidecar": {
+                  "type": "boolean"
+                },
+                "enableParamEnum": {
+                  "type": "boolean"
+                },
+                "enableProvenanceInStatus": {
+                  "type": "boolean"
+                },
+                "enableStepActions": {
+                  "description": "EnableStepActions is a no-op flag since StepActions are stable",
+                  "type": "boolean"
+                },
+                "enableWaitExponentialBackoff": {
+                  "type": "boolean"
+                },
+                "enforceNonfalsifiability": {
+                  "type": "string"
+                },
+                "maxResultSize": {
+                  "type": "integer"
+                },
+                "requireGitSSHSecretKnownHosts": {
+                  "type": "boolean"
+                },
+                "resultExtractionMethod": {
+                  "type": "string"
+                },
+                "runningInEnvWithInjectedSidecars": {
+                  "type": "boolean"
+                },
+                "sendCloudEventsForRuns": {
+                  "type": "boolean"
+                },
+                "setSecurityContext": {
+                  "type": "boolean"
+                },
+                "setSecurityContextReadOnlyRootFilesystem": {
+                  "type": "boolean"
+                },
+                "verificationNoMatchPolicy": {
+                  "description": "VerificationNoMatchPolicy is the feature flag for \"trusted-resources-verification-no-match-policy\"\nVerificationNoMatchPolicy can be set to \"ignore\", \"warn\" and \"fail\" values.\nignore: skip trusted resources verification when no matching verification policies found\nwarn: skip trusted resources verification when no matching verification policies found and log a warning\nfail: fail the taskrun or pipelines run if no matching verification policies found",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "refSource": {
+              "description": "RefSource",
+              "properties": {
+                "digest": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Digest",
+                  "type": "object"
+                },
+                "entryPoint": {
+                  "description": "EntryPoint",
+                  "type": "string"
+                },
+                "uri": {
+                  "description": "URI",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "runs": {
+          "additionalProperties": {
+            "description": "PipelineRunRunStatus",
+            "properties": {
+              "pipelineTaskName": {
+                "description": "PipelineTaskName",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status",
+                "properties": {
+                  "annotations": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Annotations is additional Status fields for the Resource to save some\nadditional State as well as convey more information to the user. This is\nroughly akin to Annotations on any k8s resource, just the reconciler conveying\nricher information outwards.",
+                    "type": "object"
+                  },
+                  "completionTime": {
+                    "description": "CompletionTime is the time the build completed.",
+                    "format": "date-time",
+                    "type": "string"
+                  },
+                  "conditions": {
+                    "description": "Conditions the latest available observations of a resource's current state.",
+                    "items": {
+                      "description": "Condition defines a readiness condition for a Knative resource.\nSee: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties",
+                      "properties": {
+                        "lastTransitionTime": {
+                          "description": "LastTransitionTime is the last time the condition transitioned from one status to another.\nWe use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic\ndifferences (all other things held constant).",
+                          "type": "string"
+                        },
+                        "message": {
+                          "description": "A human readable message indicating details about the transition.",
+                          "type": "string"
+                        },
+                        "reason": {
+                          "description": "The reason for the condition's last transition.",
+                          "type": "string"
+                        },
+                        "severity": {
+                          "description": "Severity with which to treat failures of this type of condition.\nWhen this is not specified, it defaults to Error.",
+                          "type": "string"
+                        },
+                        "status": {
+                          "description": "Status of the condition, one of True, False, Unknown.",
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "Type of condition.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "status",
+                        "type"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "extraFields": {
+                    "description": "ExtraFields holds arbitrary fields provided by the custom task\ncontroller."
+                  },
+                  "observedGeneration": {
+                    "description": "ObservedGeneration is the 'Generation' of the Service that\nwas last processed by the controller.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "results": {
+                    "description": "Results reports any output result values to be consumed by later\ntasks in a pipeline.",
+                    "items": {
+                      "description": "CustomRunResult used to describe the results of a task",
+                      "properties": {
+                        "name": {
+                          "description": "Name the given name",
+                          "type": "string"
+                        },
+                        "value": {
+                          "description": "Value the given value of the result",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "value"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "retriesStatus": {
+                    "description": "RetriesStatus contains the history of CustomRunStatus, in case of a retry.\nSee CustomRun.status (API version: tekton.dev/v1beta1)"
+                  },
+                  "startTime": {
+                    "description": "StartTime is the time the build is actually started.",
+                    "format": "date-time",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "whenExpressions": {
+                "description": "WhenExpressions",
+                "items": {
+                  "description": "WhenExpression",
+                  "properties": {
+                    "cel": {
+                      "description": "CEL",
+                      "type": "string"
+                    },
+                    "input": {
+                      "description": "Input",
+                      "type": "string"
+                    },
+                    "operator": {
+                      "description": "Operator",
+                      "type": "string"
+                    },
+                    "values": {
+                      "description": "Values",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            },
+            "type": "object"
+          },
+          "description": "Runs",
+          "type": "object"
+        },
+        "skippedTasks": {
+          "description": "SkippedTasks",
+          "items": {
+            "description": "SkippedTask",
+            "properties": {
+              "name": {
+                "description": "Name",
+                "type": "string"
+              },
+              "reason": {
+                "description": "Reason",
+                "type": "string"
+              },
+              "whenExpressions": {
+                "description": "WhenExpressions",
+                "items": {
+                  "description": "WhenExpression",
+                  "properties": {
+                    "cel": {
+                      "description": "CEL",
+                      "type": "string"
+                    },
+                    "input": {
+                      "description": "Input",
+                      "type": "string"
+                    },
+                    "operator": {
+                      "description": "Operator",
+                      "type": "string"
+                    },
+                    "values": {
+                      "description": "Values",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "name",
+              "reason"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "spanContext": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "SpanContext",
+          "type": "object"
+        },
+        "startTime": {
+          "description": "StartTime",
+          "format": "date-time",
+          "type": "string"
+        },
+        "taskRuns": {
+          "additionalProperties": {
+            "description": "PipelineRunTaskRunStatus",
+            "properties": {
+              "pipelineTaskName": {
+                "description": "PipelineTaskName",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status",
+                "properties": {
+                  "annotations": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Annotations is additional Status fields for the Resource to save some\nadditional State as well as convey more information to the user. This is\nroughly akin to Annotations on any k8s resource, just the reconciler conveying\nricher information outwards.",
+                    "type": "object"
+                  },
+                  "cloudEvents": {
+                    "description": "Deprecated: Removed in v0.44.0.\nCloudEvents",
+                    "items": {
+                      "description": "CloudEventDelivery",
+                      "properties": {
+                        "status": {
+                          "description": "CloudEventDeliveryState",
+                          "properties": {
+                            "condition": {
+                              "description": "Condition",
+                              "type": "string"
+                            },
+                            "message": {
+                              "description": "Error",
+                              "type": "string"
+                            },
+                            "retryCount": {
+                              "description": "RetryCount",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "sentAt": {
+                              "description": "SentAt",
+                              "format": "date-time",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "message",
+                            "retryCount"
+                          ],
+                          "type": "object"
+                        },
+                        "target": {
+                          "description": "Target",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "completionTime": {
+                    "description": "CompletionTime",
+                    "format": "date-time",
+                    "type": "string"
+                  },
+                  "conditions": {
+                    "description": "Conditions the latest available observations of a resource's current state.",
+                    "items": {
+                      "description": "Condition defines a readiness condition for a Knative resource.\nSee: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties",
+                      "properties": {
+                        "lastTransitionTime": {
+                          "description": "LastTransitionTime is the last time the condition transitioned from one status to another.\nWe use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic\ndifferences (all other things held constant).",
+                          "type": "string"
+                        },
+                        "message": {
+                          "description": "A human readable message indicating details about the transition.",
+                          "type": "string"
+                        },
+                        "reason": {
+                          "description": "The reason for the condition's last transition.",
+                          "type": "string"
+                        },
+                        "severity": {
+                          "description": "Severity with which to treat failures of this type of condition.\nWhen this is not specified, it defaults to Error.",
+                          "type": "string"
+                        },
+                        "status": {
+                          "description": "Status of the condition, one of True, False, Unknown.",
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "Type of condition.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "status",
+                        "type"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "observedGeneration": {
+                    "description": "ObservedGeneration is the 'Generation' of the Service that\nwas last processed by the controller.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "podName": {
+                    "description": "PodName",
+                    "type": "string"
+                  },
+                  "provenance": {
+                    "description": "Provenance",
+                    "properties": {
+                      "configSource": {
+                        "description": "ConfigSource\nDeprecated: Use RefSource instead",
+                        "properties": {
+                          "digest": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "Digest",
+                            "type": "object"
+                          },
+                          "entryPoint": {
+                            "description": "EntryPoint",
+                            "type": "string"
+                          },
+                          "uri": {
+                            "description": "URI",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "featureFlags": {
+                        "description": "FeatureFlags",
+                        "properties": {
+                          "awaitSidecarReadiness": {
+                            "type": "boolean"
+                          },
+                          "coschedule": {
+                            "type": "string"
+                          },
+                          "disableCredsInit": {
+                            "type": "boolean"
+                          },
+                          "disableInlineSpec": {
+                            "type": "string"
+                          },
+                          "enableAPIFields": {
+                            "type": "string"
+                          },
+                          "enableArtifacts": {
+                            "type": "boolean"
+                          },
+                          "enableCELInWhenExpression": {
+                            "type": "boolean"
+                          },
+                          "enableConciseResolverSyntax": {
+                            "type": "boolean"
+                          },
+                          "enableKeepPodOnCancel": {
+                            "type": "boolean"
+                          },
+                          "enableKubernetesSidecar": {
+                            "type": "boolean"
+                          },
+                          "enableParamEnum": {
+                            "type": "boolean"
+                          },
+                          "enableProvenanceInStatus": {
+                            "type": "boolean"
+                          },
+                          "enableStepActions": {
+                            "description": "EnableStepActions is a no-op flag since StepActions are stable",
+                            "type": "boolean"
+                          },
+                          "enableWaitExponentialBackoff": {
+                            "type": "boolean"
+                          },
+                          "enforceNonfalsifiability": {
+                            "type": "string"
+                          },
+                          "maxResultSize": {
+                            "type": "integer"
+                          },
+                          "requireGitSSHSecretKnownHosts": {
+                            "type": "boolean"
+                          },
+                          "resultExtractionMethod": {
+                            "type": "string"
+                          },
+                          "runningInEnvWithInjectedSidecars": {
+                            "type": "boolean"
+                          },
+                          "sendCloudEventsForRuns": {
+                            "type": "boolean"
+                          },
+                          "setSecurityContext": {
+                            "type": "boolean"
+                          },
+                          "setSecurityContextReadOnlyRootFilesystem": {
+                            "type": "boolean"
+                          },
+                          "verificationNoMatchPolicy": {
+                            "description": "VerificationNoMatchPolicy is the feature flag for \"trusted-resources-verification-no-match-policy\"\nVerificationNoMatchPolicy can be set to \"ignore\", \"warn\" and \"fail\" values.\nignore: skip trusted resources verification when no matching verification policies found\nwarn: skip trusted resources verification when no matching verification policies found and log a warning\nfail: fail the taskrun or pipelines run if no matching verification policies found",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "refSource": {
+                        "description": "RefSource",
+                        "properties": {
+                          "digest": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "Digest",
+                            "type": "object"
+                          },
+                          "entryPoint": {
+                            "description": "EntryPoint",
+                            "type": "string"
+                          },
+                          "uri": {
+                            "description": "URI",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "resourcesResult": {
+                    "description": "ResourcesResult\nDeprecated: this field is not populated and is preserved only for backwards compatibility",
+                    "items": {
+                      "description": "RunResult is used to write key/value pairs to TaskRun pod termination messages.\nThe key/value pairs may come from the entrypoint binary, or represent a TaskRunResult.\nIf they represent a TaskRunResult, the key is the name of the result and the value is the\nJSON-serialized value of the result.",
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "resourceName": {
+                          "description": "ResourceName may be used in tests, but it is not populated in termination messages.\nIt is preserved here for backwards compatibility and will not be ported to v1.",
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "ResultType used to find out whether a RunResult is from a task result or not\nNote that ResultsType is another type which is used to define the data type\n(e.g. string, array, etc) we used for Results",
+                          "type": "integer"
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "key",
+                        "value"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "retriesStatus": {
+                    "description": "RetriesStatus"
+                  },
+                  "sidecars": {
+                    "description": "Sidecars",
+                    "items": {
+                      "description": "SidecarState",
+                      "properties": {
+                        "container": {
+                          "type": "string"
+                        },
+                        "imageID": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "running": {
+                          "description": "Details about a running container",
+                          "properties": {
+                            "startedAt": {
+                              "description": "Time at which the container was last (re-)started",
+                              "format": "date-time",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "terminated": {
+                          "description": "Details about a terminated container",
+                          "properties": {
+                            "containerID": {
+                              "description": "Container's ID in the format '\u003ctype\u003e://\u003ccontainer_id\u003e'",
+                              "type": "string"
+                            },
+                            "exitCode": {
+                              "description": "Exit status from the last termination of the container",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "finishedAt": {
+                              "description": "Time at which the container last terminated",
+                              "format": "date-time",
+                              "type": "string"
+                            },
+                            "message": {
+                              "description": "Message regarding the last termination of the container",
+                              "type": "string"
+                            },
+                            "reason": {
+                              "description": "(brief) reason from the last termination of the container",
+                              "type": "string"
+                            },
+                            "signal": {
+                              "description": "Signal from the last termination of the container",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "startedAt": {
+                              "description": "Time at which previous execution of the container started",
+                              "format": "date-time",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "exitCode"
+                          ],
+                          "type": "object"
+                        },
+                        "waiting": {
+                          "description": "Details about a waiting container",
+                          "properties": {
+                            "message": {
+                              "description": "Message regarding why the container is not yet running.",
+                              "type": "string"
+                            },
+                            "reason": {
+                              "description": "(brief) reason the container is not yet running.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "spanContext": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "SpanContext",
+                    "type": "object"
+                  },
+                  "startTime": {
+                    "description": "StartTime",
+                    "format": "date-time",
+                    "type": "string"
+                  },
+                  "steps": {
+                    "description": "Steps",
+                    "items": {
+                      "description": "StepState",
+                      "properties": {
+                        "container": {
+                          "type": "string"
+                        },
+                        "imageID": {
+                          "type": "string"
+                        },
+                        "inputs": {
+                          "items": {
+                            "description": "Artifact",
+                            "properties": {
+                              "buildOutput": {
+                                "description": "BuildOutput",
+                                "type": "boolean"
+                              },
+                              "name": {
+                                "description": "Name",
+                                "type": "string"
+                              },
+                              "values": {
+                                "description": "Values",
+                                "items": {
+                                  "description": "ArtifactValue",
+                                  "properties": {
+                                    "digest": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "uri": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "outputs": {
+                          "items": {
+                            "description": "Artifact",
+                            "properties": {
+                              "buildOutput": {
+                                "description": "BuildOutput",
+                                "type": "boolean"
+                              },
+                              "name": {
+                                "description": "Name",
+                                "type": "string"
+                              },
+                              "values": {
+                                "description": "Values",
+                                "items": {
+                                  "description": "ArtifactValue",
+                                  "properties": {
+                                    "digest": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "uri": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "provenance": {
+                          "description": "Provenance",
+                          "properties": {
+                            "configSource": {
+                              "description": "ConfigSource\nDeprecated: Use RefSource instead",
+                              "properties": {
+                                "digest": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "Digest",
+                                  "type": "object"
+                                },
+                                "entryPoint": {
+                                  "description": "EntryPoint",
+                                  "type": "string"
+                                },
+                                "uri": {
+                                  "description": "URI",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "featureFlags": {
+                              "description": "FeatureFlags",
+                              "properties": {
+                                "awaitSidecarReadiness": {
+                                  "type": "boolean"
+                                },
+                                "coschedule": {
+                                  "type": "string"
+                                },
+                                "disableCredsInit": {
+                                  "type": "boolean"
+                                },
+                                "disableInlineSpec": {
+                                  "type": "string"
+                                },
+                                "enableAPIFields": {
+                                  "type": "string"
+                                },
+                                "enableArtifacts": {
+                                  "type": "boolean"
+                                },
+                                "enableCELInWhenExpression": {
+                                  "type": "boolean"
+                                },
+                                "enableConciseResolverSyntax": {
+                                  "type": "boolean"
+                                },
+                                "enableKeepPodOnCancel": {
+                                  "type": "boolean"
+                                },
+                                "enableKubernetesSidecar": {
+                                  "type": "boolean"
+                                },
+                                "enableParamEnum": {
+                                  "type": "boolean"
+                                },
+                                "enableProvenanceInStatus": {
+                                  "type": "boolean"
+                                },
+                                "enableStepActions": {
+                                  "description": "EnableStepActions is a no-op flag since StepActions are stable",
+                                  "type": "boolean"
+                                },
+                                "enableWaitExponentialBackoff": {
+                                  "type": "boolean"
+                                },
+                                "enforceNonfalsifiability": {
+                                  "type": "string"
+                                },
+                                "maxResultSize": {
+                                  "type": "integer"
+                                },
+                                "requireGitSSHSecretKnownHosts": {
+                                  "type": "boolean"
+                                },
+                                "resultExtractionMethod": {
+                                  "type": "string"
+                                },
+                                "runningInEnvWithInjectedSidecars": {
+                                  "type": "boolean"
+                                },
+                                "sendCloudEventsForRuns": {
+                                  "type": "boolean"
+                                },
+                                "setSecurityContext": {
+                                  "type": "boolean"
+                                },
+                                "setSecurityContextReadOnlyRootFilesystem": {
+                                  "type": "boolean"
+                                },
+                                "verificationNoMatchPolicy": {
+                                  "description": "VerificationNoMatchPolicy is the feature flag for \"trusted-resources-verification-no-match-policy\"\nVerificationNoMatchPolicy can be set to \"ignore\", \"warn\" and \"fail\" values.\nignore: skip trusted resources verification when no matching verification policies found\nwarn: skip trusted resources verification when no matching verification policies found and log a warning\nfail: fail the taskrun or pipelines run if no matching verification policies found",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "refSource": {
+                              "description": "RefSource",
+                              "properties": {
+                                "digest": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "Digest",
+                                  "type": "object"
+                                },
+                                "entryPoint": {
+                                  "description": "EntryPoint",
+                                  "type": "string"
+                                },
+                                "uri": {
+                                  "description": "URI",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "results": {
+                          "items": {
+                            "description": "TaskRunResult",
+                            "properties": {
+                              "name": {
+                                "description": "Name",
+                                "type": "string"
+                              },
+                              "type": {
+                                "description": "Type",
+                                "type": "string"
+                              },
+                              "value": {
+                                "description": "Value"
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "value"
+                            ],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "running": {
+                          "description": "Details about a running container",
+                          "properties": {
+                            "startedAt": {
+                              "description": "Time at which the container was last (re-)started",
+                              "format": "date-time",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "terminated": {
+                          "description": "Details about a terminated container",
+                          "properties": {
+                            "containerID": {
+                              "description": "Container's ID in the format '\u003ctype\u003e://\u003ccontainer_id\u003e'",
+                              "type": "string"
+                            },
+                            "exitCode": {
+                              "description": "Exit status from the last termination of the container",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "finishedAt": {
+                              "description": "Time at which the container last terminated",
+                              "format": "date-time",
+                              "type": "string"
+                            },
+                            "message": {
+                              "description": "Message regarding the last termination of the container",
+                              "type": "string"
+                            },
+                            "reason": {
+                              "description": "(brief) reason from the last termination of the container",
+                              "type": "string"
+                            },
+                            "signal": {
+                              "description": "Signal from the last termination of the container",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "startedAt": {
+                              "description": "Time at which previous execution of the container started",
+                              "format": "date-time",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "exitCode"
+                          ],
+                          "type": "object"
+                        },
+                        "waiting": {
+                          "description": "Details about a waiting container",
+                          "properties": {
+                            "message": {
+                              "description": "Message regarding why the container is not yet running.",
+                              "type": "string"
+                            },
+                            "reason": {
+                              "description": "(brief) reason the container is not yet running.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "taskResults": {
+                    "description": "TaskRunResults",
+                    "items": {
+                      "description": "TaskRunResult",
+                      "properties": {
+                        "name": {
+                          "description": "Name",
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "Type",
+                          "type": "string"
+                        },
+                        "value": {
+                          "description": "Value"
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "value"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "taskSpec": {
+                    "description": "TaskSpec"
+                  }
+                },
+                "required": [
+                  "podName"
+                ],
+                "type": "object"
+              },
+              "whenExpressions": {
+                "description": "WhenExpressions",
+                "items": {
+                  "description": "WhenExpression",
+                  "properties": {
+                    "cel": {
+                      "description": "CEL",
+                      "type": "string"
+                    },
+                    "input": {
+                      "description": "Input",
+                      "type": "string"
+                    },
+                    "operator": {
+                      "description": "Operator",
+                      "type": "string"
+                    },
+                    "values": {
+                      "description": "Values",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            },
+            "type": "object"
+          },
+          "description": "TaskRuns",
+          "type": "object"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "title": "Tekton PipelineRun v1beta1",
+  "type": "object"
+}

--- a/schema/v1beta1/resolutionrequest.json
+++ b/schema/v1beta1/resolutionrequest.json
@@ -1,0 +1,119 @@
+{
+  "$id": "https://tekton.dev/schemas/v1beta1/resolutionrequest.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "ResolutionRequest is an object for requesting the content of\na Tekton resource like a pipeline.yaml.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Spec holds the information for the request part of the resource request.",
+      "properties": {
+        "params": {
+          "description": "Parameters are the runtime attributes passed to\nthe resolver to help it figure out how to resolve the\nresource being requested. For example: repo URL, commit SHA,\npath to file, the kind of authentication to leverage, etc.",
+          "items": {
+            "description": "Param declares an ParamValues to use for the parameter called name.",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "value": {}
+            },
+            "required": [
+              "name",
+              "value"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "url": {
+          "description": "URL is the runtime url passed to the resolver\nto help it figure out how to resolver the resource being\nrequested.\nThis is currently at an ALPHA stability level and subject to\nalpha API compatibility policies.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "status": {
+      "description": "Status communicates the state of the request and, ultimately,\nthe content of the resolved resource.",
+      "properties": {
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Annotations is additional Status fields for the Resource to save some\nadditional State as well as convey more information to the user. This is\nroughly akin to Annotations on any k8s resource, just the reconciler conveying\nricher information outwards.",
+          "type": "object"
+        },
+        "conditions": {
+          "description": "Conditions the latest available observations of a resource's current state.",
+          "items": {
+            "description": "Condition defines a readiness condition for a Knative resource.\nSee: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "LastTransitionTime is the last time the condition transitioned from one status to another.\nWe use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic\ndifferences (all other things held constant).",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity with which to treat failures of this type of condition.\nWhen this is not specified, it defaults to Error.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "data": {
+          "description": "Data is a string representation of the resolved content\nof the requested resource in-lined into the ResolutionRequest\nobject.",
+          "type": "string"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the 'Generation' of the Service that\nwas last processed by the controller.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "refSource": {
+          "description": "RefSource is the source reference of the remote data that records the url, digest\nand the entrypoint."
+        },
+        "source": {
+          "description": "Deprecated: Use RefSource instead"
+        }
+      },
+      "required": [
+        "data",
+        "refSource",
+        "source"
+      ],
+      "type": "object"
+    }
+  },
+  "title": "Tekton ResolutionRequest v1beta1",
+  "type": "object"
+}

--- a/schema/v1beta1/stepaction.json
+++ b/schema/v1beta1/stepaction.json
@@ -1,0 +1,439 @@
+{
+  "$id": "https://tekton.dev/schemas/v1beta1/stepaction.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "StepAction",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Spec",
+      "properties": {
+        "args": {
+          "description": "Args",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "command": {
+          "description": "Command",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "description": {
+          "description": "Description",
+          "type": "string"
+        },
+        "env": {
+          "description": "Env",
+          "items": {
+            "description": "EnvVar represents an environment variable present in a Container.",
+            "properties": {
+              "name": {
+                "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                "type": "string"
+              },
+              "value": {
+                "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
+                "type": "string"
+              },
+              "valueFrom": {
+                "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                "properties": {
+                  "configMapKeyRef": {
+                    "description": "Selects a key of a ConfigMap.",
+                    "properties": {
+                      "key": {
+                        "description": "The key to select.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string"
+                      },
+                      "optional": {
+                        "description": "Specify whether the ConfigMap or its key must be defined",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "key"
+                    ],
+                    "type": "object"
+                  },
+                  "fieldRef": {
+                    "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['\u003cKEY\u003e']`, `metadata.annotations['\u003cKEY\u003e']`,\nspec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                    "properties": {
+                      "apiVersion": {
+                        "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                        "type": "string"
+                      },
+                      "fieldPath": {
+                        "description": "Path of the field to select in the specified API version.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "fieldPath"
+                    ],
+                    "type": "object"
+                  },
+                  "resourceFieldRef": {
+                    "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                    "properties": {
+                      "containerName": {
+                        "description": "Container name: required for volumes, optional for env vars",
+                        "type": "string"
+                      },
+                      "divisor": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                      },
+                      "resource": {
+                        "description": "Required: resource to select",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "resource"
+                    ],
+                    "type": "object"
+                  },
+                  "secretKeyRef": {
+                    "description": "Selects a key of a secret in the pod's namespace",
+                    "properties": {
+                      "key": {
+                        "description": "The key of the secret to select from.  Must be a valid secret key.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string"
+                      },
+                      "optional": {
+                        "description": "Specify whether the Secret or its key must be defined",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "key"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "image": {
+          "description": "Image",
+          "type": "string"
+        },
+        "params": {
+          "description": "Params",
+          "items": {
+            "description": "ParamSpec defines arbitrary parameters needed beyond typed inputs (such as\nresources). Parameter values are provided by users as inputs on a TaskRun\nor PipelineRun.",
+            "properties": {
+              "default": {
+                "description": "Default is the value a parameter takes if no input value is supplied. If\ndefault is set, a Task may be executed without a supplied value for the\nparameter."
+              },
+              "description": {
+                "description": "Description is a user-facing description of the parameter that may be\nused to populate a UI.",
+                "type": "string"
+              },
+              "enum": {
+                "description": "Enum declares a set of allowed param input values for tasks/pipelines that can be validated.\nIf Enum is not set, no input validation is performed for the param.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "name": {
+                "description": "Name declares the name by which a parameter is referenced.",
+                "type": "string"
+              },
+              "properties": {
+                "additionalProperties": {
+                  "description": "PropertySpec defines the struct for object keys",
+                  "properties": {
+                    "type": {
+                      "description": "ParamType indicates the type of an input parameter;\nUsed to distinguish between a single string and an array of strings.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "description": "Properties is the JSON Schema properties to support key-value pairs parameter.",
+                "type": "object"
+              },
+              "type": {
+                "description": "Type is the user-specified type of the parameter. The possible types\nare currently \"string\", \"array\" and \"object\", and \"string\" is the default.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "results": {
+          "description": "Results",
+          "items": {
+            "description": "StepResult used to describe the Results of a Step.",
+            "properties": {
+              "description": {
+                "description": "Description is a human-readable description of the result",
+                "type": "string"
+              },
+              "name": {
+                "description": "Name the given name",
+                "type": "string"
+              },
+              "properties": {
+                "additionalProperties": {
+                  "description": "PropertySpec defines the struct for object keys",
+                  "properties": {
+                    "type": {
+                      "description": "ParamType indicates the type of an input parameter;\nUsed to distinguish between a single string and an array of strings.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "description": "Properties is the JSON Schema properties to support key-value pairs results.",
+                "type": "object"
+              },
+              "type": {
+                "description": "The possible types are 'string', 'array', and 'object', with 'string' as the default.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "script": {
+          "description": "Script",
+          "type": "string"
+        },
+        "securityContext": {
+          "description": "SecurityContext",
+          "properties": {
+            "allowPrivilegeEscalation": {
+              "description": "AllowPrivilegeEscalation controls whether a process can gain more\nprivileges than its parent process. This bool directly controls if\nthe no_new_privs flag will be set on the container process.\nAllowPrivilegeEscalation is true always when the container is:\n1) run as Privileged\n2) has CAP_SYS_ADMIN\nNote that this field cannot be set when spec.os.name is windows.",
+              "type": "boolean"
+            },
+            "appArmorProfile": {
+              "description": "appArmorProfile is the AppArmor options to use by this container. If set, this profile\noverrides the pod's appArmorProfile.\nNote that this field cannot be set when spec.os.name is windows.",
+              "properties": {
+                "localhostProfile": {
+                  "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                  "type": "string"
+                },
+                "type": {
+                  "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object"
+            },
+            "capabilities": {
+              "description": "The capabilities to add/drop when running containers.\nDefaults to the default set of capabilities granted by the container runtime.\nNote that this field cannot be set when spec.os.name is windows.",
+              "properties": {
+                "add": {
+                  "description": "Added capabilities",
+                  "items": {
+                    "description": "Capability represent POSIX capabilities type",
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "drop": {
+                  "description": "Removed capabilities",
+                  "items": {
+                    "description": "Capability represent POSIX capabilities type",
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            },
+            "privileged": {
+              "description": "Run container in privileged mode.\nProcesses in privileged containers are essentially equivalent to root on the host.\nDefaults to false.\nNote that this field cannot be set when spec.os.name is windows.",
+              "type": "boolean"
+            },
+            "procMount": {
+              "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
+              "type": "string"
+            },
+            "readOnlyRootFilesystem": {
+              "description": "Whether this container has a read-only root filesystem.\nDefault is false.\nNote that this field cannot be set when spec.os.name is windows.",
+              "type": "boolean"
+            },
+            "runAsGroup": {
+              "description": "The GID to run the entrypoint of the container process.\nUses runtime default if unset.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "runAsNonRoot": {
+              "description": "Indicates that the container must run as a non-root user.\nIf true, the Kubelet will validate the image at runtime to ensure that it\ndoes not run as UID 0 (root) and fail to start the container if it does.\nIf unset or false, no such validation will be performed.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
+              "type": "boolean"
+            },
+            "runAsUser": {
+              "description": "The UID to run the entrypoint of the container process.\nDefaults to user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "seLinuxOptions": {
+              "description": "The SELinux context to be applied to the container.\nIf unspecified, the container runtime will allocate a random SELinux context for each\ncontainer.  May also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+              "properties": {
+                "level": {
+                  "description": "Level is SELinux level label that applies to the container.",
+                  "type": "string"
+                },
+                "role": {
+                  "description": "Role is a SELinux role label that applies to the container.",
+                  "type": "string"
+                },
+                "type": {
+                  "description": "Type is a SELinux type label that applies to the container.",
+                  "type": "string"
+                },
+                "user": {
+                  "description": "User is a SELinux user label that applies to the container.",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "seccompProfile": {
+              "description": "The seccomp options to use by this container. If seccomp options are\nprovided at both the pod \u0026 container level, the container options\noverride the pod options.\nNote that this field cannot be set when spec.os.name is windows.",
+              "properties": {
+                "localhostProfile": {
+                  "description": "localhostProfile indicates a profile defined in a file on the node should be used.\nThe profile must be preconfigured on the node to work.\nMust be a descending path, relative to the kubelet's configured seccomp profile location.\nMust be set if type is \"Localhost\". Must NOT be set for any other type.",
+                  "type": "string"
+                },
+                "type": {
+                  "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object"
+            },
+            "windowsOptions": {
+              "description": "The Windows specific settings applied to all containers.\nIf unspecified, the options from the PodSecurityContext will be used.\nIf set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is linux.",
+              "properties": {
+                "gmsaCredentialSpec": {
+                  "description": "GMSACredentialSpec is where the GMSA admission webhook\n(https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the\nGMSA credential spec named by the GMSACredentialSpecName field.",
+                  "type": "string"
+                },
+                "gmsaCredentialSpecName": {
+                  "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                  "type": "string"
+                },
+                "hostProcess": {
+                  "description": "HostProcess determines if a container should be run as a 'Host Process' container.\nAll of a Pod's containers must have the same effective HostProcess value\n(it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).\nIn addition, if HostProcess is true then HostNetwork must also be set to true.",
+                  "type": "boolean"
+                },
+                "runAsUserName": {
+                  "description": "The UserName in Windows to run the entrypoint of the container process.\nDefaults to the user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext. If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "volumeMounts": {
+          "description": "VolumeMounts",
+          "items": {
+            "description": "VolumeMount describes a mounting of a Volume within a container.",
+            "properties": {
+              "mountPath": {
+                "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
+                "type": "string"
+              },
+              "mountPropagation": {
+                "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
+                "type": "string"
+              },
+              "name": {
+                "description": "This must match the Name of a Volume.",
+                "type": "string"
+              },
+              "readOnly": {
+                "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
+                "type": "boolean"
+              },
+              "recursiveReadOnly": {
+                "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
+                "type": "string"
+              },
+              "subPath": {
+                "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
+                "type": "string"
+              },
+              "subPathExpr": {
+                "description": "Expanded path within the volume from which the container's volume should be mounted.\nBehaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.\nDefaults to \"\" (volume's root).\nSubPathExpr and SubPath are mutually exclusive.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "mountPath",
+              "name"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "workingDir": {
+          "description": "WorkingDir",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "title": "Tekton StepAction v1beta1",
+  "type": "object"
+}

--- a/schema/v1beta1/task.json
+++ b/schema/v1beta1/task.json
@@ -1,0 +1,3990 @@
+{
+  "$id": "https://tekton.dev/schemas/v1beta1/task.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Task\nDeprecated: Please use v1.Task instead.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Spec",
+      "properties": {
+        "description": {
+          "description": "Description",
+          "type": "string"
+        },
+        "displayName": {
+          "description": "DisplayName",
+          "type": "string"
+        },
+        "params": {
+          "description": "Params",
+          "items": {
+            "description": "ParamSpec",
+            "properties": {
+              "default": {
+                "description": "Default"
+              },
+              "description": {
+                "description": "Description",
+                "type": "string"
+              },
+              "enum": {
+                "description": "Enum",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "name": {
+                "description": "Name",
+                "type": "string"
+              },
+              "properties": {
+                "additionalProperties": {
+                  "description": "PropertySpec",
+                  "properties": {
+                    "type": {
+                      "description": "ParamType",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "description": "Properties",
+                "type": "object"
+              },
+              "type": {
+                "description": "Type",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "resources": {
+          "description": "Resources\nDeprecated: Unused, preserved only for backwards compatibility",
+          "properties": {
+            "inputs": {
+              "description": "Inputs",
+              "items": {
+                "description": "TaskResource\nDeprecated: Unused, preserved only for backwards compatibility",
+                "properties": {
+                  "description": {
+                    "description": "Description is a user-facing description of the declared resource that may be\nused to populate a UI.",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name declares the name by which a resource is referenced in the\ndefinition. Resources may be referenced by name in the definition of a\nTask's steps.",
+                    "type": "string"
+                  },
+                  "optional": {
+                    "description": "Optional declares the resource as optional.\nBy default optional is set to false which makes a resource required.\noptional: true - the resource is considered optional\noptional: false - the resource is considered required (equivalent of not specifying it)",
+                    "type": "boolean"
+                  },
+                  "targetPath": {
+                    "description": "TargetPath is the path in workspace directory where the resource\nwill be copied.",
+                    "type": "string"
+                  },
+                  "type": {
+                    "description": "Type is the type of this resource;",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "type"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "outputs": {
+              "description": "Outputs",
+              "items": {
+                "description": "TaskResource\nDeprecated: Unused, preserved only for backwards compatibility",
+                "properties": {
+                  "description": {
+                    "description": "Description is a user-facing description of the declared resource that may be\nused to populate a UI.",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name declares the name by which a resource is referenced in the\ndefinition. Resources may be referenced by name in the definition of a\nTask's steps.",
+                    "type": "string"
+                  },
+                  "optional": {
+                    "description": "Optional declares the resource as optional.\nBy default optional is set to false which makes a resource required.\noptional: true - the resource is considered optional\noptional: false - the resource is considered required (equivalent of not specifying it)",
+                    "type": "boolean"
+                  },
+                  "targetPath": {
+                    "description": "TargetPath is the path in workspace directory where the resource\nwill be copied.",
+                    "type": "string"
+                  },
+                  "type": {
+                    "description": "Type is the type of this resource;",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "type"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "results": {
+          "description": "Results",
+          "items": {
+            "description": "TaskResult",
+            "properties": {
+              "description": {
+                "description": "Description",
+                "type": "string"
+              },
+              "name": {
+                "description": "Name",
+                "type": "string"
+              },
+              "properties": {
+                "additionalProperties": {
+                  "description": "PropertySpec",
+                  "properties": {
+                    "type": {
+                      "description": "ParamType",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "description": "Properties",
+                "type": "object"
+              },
+              "type": {
+                "description": "Type",
+                "type": "string"
+              },
+              "value": {
+                "description": "Value"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "sidecars": {
+          "description": "Sidecars",
+          "items": {
+            "description": "Sidecar",
+            "properties": {
+              "args": {
+                "description": "Args",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "command": {
+                "description": "Command",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "env": {
+                "description": "Env",
+                "items": {
+                  "description": "EnvVar represents an environment variable present in a Container.",
+                  "properties": {
+                    "name": {
+                      "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                      "type": "string"
+                    },
+                    "value": {
+                      "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
+                      "type": "string"
+                    },
+                    "valueFrom": {
+                      "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                      "properties": {
+                        "configMapKeyRef": {
+                          "description": "Selects a key of a ConfigMap.",
+                          "properties": {
+                            "key": {
+                              "description": "The key to select.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the ConfigMap or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object"
+                        },
+                        "fieldRef": {
+                          "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['\u003cKEY\u003e']`, `metadata.annotations['\u003cKEY\u003e']`,\nspec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                          "properties": {
+                            "apiVersion": {
+                              "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                              "type": "string"
+                            },
+                            "fieldPath": {
+                              "description": "Path of the field to select in the specified API version.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "fieldPath"
+                          ],
+                          "type": "object"
+                        },
+                        "resourceFieldRef": {
+                          "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                          "properties": {
+                            "containerName": {
+                              "description": "Container name: required for volumes, optional for env vars",
+                              "type": "string"
+                            },
+                            "divisor": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                            },
+                            "resource": {
+                              "description": "Required: resource to select",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "resource"
+                          ],
+                          "type": "object"
+                        },
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "envFrom": {
+                "description": "EnvFrom",
+                "items": {
+                  "description": "EnvFromSource represents the source of a set of ConfigMaps",
+                  "properties": {
+                    "configMapRef": {
+                      "description": "The ConfigMap to select from",
+                      "properties": {
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the ConfigMap must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "prefix": {
+                      "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
+                      "type": "string"
+                    },
+                    "secretRef": {
+                      "description": "The Secret to select from",
+                      "properties": {
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "image": {
+                "description": "Image",
+                "type": "string"
+              },
+              "imagePullPolicy": {
+                "description": "ImagePullPolicy",
+                "type": "string"
+              },
+              "lifecycle": {
+                "description": "Lifecycle",
+                "properties": {
+                  "postStart": {
+                    "description": "PostStart is called immediately after a container is created. If the handler fails,\nthe container is terminated and restarted according to its restart policy.\nOther management of the container blocks until the hook completes.\nMore info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+                    "properties": {
+                      "exec": {
+                        "description": "Exec specifies a command to execute in the container.",
+                        "properties": {
+                          "command": {
+                            "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "httpGet": {
+                        "description": "HTTPGet specifies an HTTP GET request to perform.",
+                        "properties": {
+                          "host": {
+                            "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                            "type": "string"
+                          },
+                          "httpHeaders": {
+                            "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                            "items": {
+                              "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                              "properties": {
+                                "name": {
+                                  "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "description": "The header field value",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "value"
+                              ],
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "path": {
+                            "description": "Path to access on the HTTP server.",
+                            "type": "string"
+                          },
+                          "port": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
+                          },
+                          "scheme": {
+                            "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object"
+                      },
+                      "sleep": {
+                        "description": "Sleep represents a duration that the container should sleep.",
+                        "properties": {
+                          "seconds": {
+                            "description": "Seconds is the number of seconds to sleep.",
+                            "format": "int64",
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "seconds"
+                        ],
+                        "type": "object"
+                      },
+                      "tcpSocket": {
+                        "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept\nfor backward compatibility. There is no validation of this field and\nlifecycle hooks will fail at runtime when it is specified.",
+                        "properties": {
+                          "host": {
+                            "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                            "type": "string"
+                          },
+                          "port": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "preStop": {
+                    "description": "PreStop is called immediately before a container is terminated due to an\nAPI request or management event such as liveness/startup probe failure,\npreemption, resource contention, etc. The handler is not called if the\ncontainer crashes or exits. The Pod's termination grace period countdown begins before the\nPreStop hook is executed. Regardless of the outcome of the handler, the\ncontainer will eventually terminate within the Pod's termination grace\nperiod (unless delayed by finalizers). Other management of the container blocks until the hook completes\nor until the termination grace period is reached.\nMore info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+                    "properties": {
+                      "exec": {
+                        "description": "Exec specifies a command to execute in the container.",
+                        "properties": {
+                          "command": {
+                            "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "httpGet": {
+                        "description": "HTTPGet specifies an HTTP GET request to perform.",
+                        "properties": {
+                          "host": {
+                            "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                            "type": "string"
+                          },
+                          "httpHeaders": {
+                            "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                            "items": {
+                              "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                              "properties": {
+                                "name": {
+                                  "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "description": "The header field value",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "value"
+                              ],
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "path": {
+                            "description": "Path to access on the HTTP server.",
+                            "type": "string"
+                          },
+                          "port": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
+                          },
+                          "scheme": {
+                            "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object"
+                      },
+                      "sleep": {
+                        "description": "Sleep represents a duration that the container should sleep.",
+                        "properties": {
+                          "seconds": {
+                            "description": "Seconds is the number of seconds to sleep.",
+                            "format": "int64",
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "seconds"
+                        ],
+                        "type": "object"
+                      },
+                      "tcpSocket": {
+                        "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept\nfor backward compatibility. There is no validation of this field and\nlifecycle hooks will fail at runtime when it is specified.",
+                        "properties": {
+                          "host": {
+                            "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                            "type": "string"
+                          },
+                          "port": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "type": "object"
+              },
+              "livenessProbe": {
+                "description": "LivenessProbe",
+                "properties": {
+                  "exec": {
+                    "description": "Exec specifies a command to execute in the container.",
+                    "properties": {
+                      "command": {
+                        "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "failureThreshold": {
+                    "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "grpc": {
+                    "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                    "properties": {
+                      "port": {
+                        "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "service": {
+                        "default": "",
+                        "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object"
+                  },
+                  "httpGet": {
+                    "description": "HTTPGet specifies an HTTP GET request to perform.",
+                    "properties": {
+                      "host": {
+                        "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                        "type": "string"
+                      },
+                      "httpHeaders": {
+                        "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                        "items": {
+                          "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                          "properties": {
+                            "name": {
+                              "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                              "type": "string"
+                            },
+                            "value": {
+                              "description": "The header field value",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "value"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "path": {
+                        "description": "Path to access on the HTTP server.",
+                        "type": "string"
+                      },
+                      "port": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
+                      },
+                      "scheme": {
+                        "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object"
+                  },
+                  "initialDelaySeconds": {
+                    "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "periodSeconds": {
+                    "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "successThreshold": {
+                    "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "tcpSocket": {
+                    "description": "TCPSocket specifies a connection to a TCP port.",
+                    "properties": {
+                      "host": {
+                        "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                        "type": "string"
+                      },
+                      "port": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object"
+                  },
+                  "terminationGracePeriodSeconds": {
+                    "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "timeoutSeconds": {
+                    "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                    "format": "int32",
+                    "type": "integer"
+                  }
+                },
+                "type": "object"
+              },
+              "name": {
+                "description": "Name",
+                "type": "string"
+              },
+              "ports": {
+                "description": "Ports",
+                "items": {
+                  "description": "ContainerPort represents a network port in a single container.",
+                  "properties": {
+                    "containerPort": {
+                      "description": "Number of port to expose on the pod's IP address.\nThis must be a valid port number, 0 \u003c x \u003c 65536.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "hostIP": {
+                      "description": "What host IP to bind the external port to.",
+                      "type": "string"
+                    },
+                    "hostPort": {
+                      "description": "Number of port to expose on the host.\nIf specified, this must be a valid port number, 0 \u003c x \u003c 65536.\nIf HostNetwork is specified, this must match ContainerPort.\nMost containers do not need this.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "name": {
+                      "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each\nnamed port in a pod must have a unique name. Name for the port that can be\nreferred to by services.",
+                      "type": "string"
+                    },
+                    "protocol": {
+                      "default": "TCP",
+                      "description": "Protocol for port. Must be UDP, TCP, or SCTP.\nDefaults to \"TCP\".",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "containerPort"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "readinessProbe": {
+                "description": "ReadinessProbe",
+                "properties": {
+                  "exec": {
+                    "description": "Exec specifies a command to execute in the container.",
+                    "properties": {
+                      "command": {
+                        "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "failureThreshold": {
+                    "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "grpc": {
+                    "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                    "properties": {
+                      "port": {
+                        "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "service": {
+                        "default": "",
+                        "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object"
+                  },
+                  "httpGet": {
+                    "description": "HTTPGet specifies an HTTP GET request to perform.",
+                    "properties": {
+                      "host": {
+                        "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                        "type": "string"
+                      },
+                      "httpHeaders": {
+                        "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                        "items": {
+                          "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                          "properties": {
+                            "name": {
+                              "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                              "type": "string"
+                            },
+                            "value": {
+                              "description": "The header field value",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "value"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "path": {
+                        "description": "Path to access on the HTTP server.",
+                        "type": "string"
+                      },
+                      "port": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
+                      },
+                      "scheme": {
+                        "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object"
+                  },
+                  "initialDelaySeconds": {
+                    "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "periodSeconds": {
+                    "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "successThreshold": {
+                    "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "tcpSocket": {
+                    "description": "TCPSocket specifies a connection to a TCP port.",
+                    "properties": {
+                      "host": {
+                        "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                        "type": "string"
+                      },
+                      "port": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object"
+                  },
+                  "terminationGracePeriodSeconds": {
+                    "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "timeoutSeconds": {
+                    "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                    "format": "int32",
+                    "type": "integer"
+                  }
+                },
+                "type": "object"
+              },
+              "resources": {
+                "description": "Resources",
+                "properties": {
+                  "claims": {
+                    "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                    "items": {
+                      "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                      "properties": {
+                        "name": {
+                          "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                          "type": "string"
+                        },
+                        "request": {
+                          "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "limits": {
+                    "additionalProperties": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                    },
+                    "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                    "type": "object"
+                  },
+                  "requests": {
+                    "additionalProperties": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                    },
+                    "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                    "type": "object"
+                  }
+                },
+                "type": "object"
+              },
+              "restartPolicy": {
+                "description": "RestartPolicy",
+                "type": "string"
+              },
+              "script": {
+                "description": "Script",
+                "type": "string"
+              },
+              "securityContext": {
+                "description": "SecurityContext",
+                "properties": {
+                  "allowPrivilegeEscalation": {
+                    "description": "AllowPrivilegeEscalation controls whether a process can gain more\nprivileges than its parent process. This bool directly controls if\nthe no_new_privs flag will be set on the container process.\nAllowPrivilegeEscalation is true always when the container is:\n1) run as Privileged\n2) has CAP_SYS_ADMIN\nNote that this field cannot be set when spec.os.name is windows.",
+                    "type": "boolean"
+                  },
+                  "appArmorProfile": {
+                    "description": "appArmorProfile is the AppArmor options to use by this container. If set, this profile\noverrides the pod's appArmorProfile.\nNote that this field cannot be set when spec.os.name is windows.",
+                    "properties": {
+                      "localhostProfile": {
+                        "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                        "type": "string"
+                      },
+                      "type": {
+                        "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "type"
+                    ],
+                    "type": "object"
+                  },
+                  "capabilities": {
+                    "description": "The capabilities to add/drop when running containers.\nDefaults to the default set of capabilities granted by the container runtime.\nNote that this field cannot be set when spec.os.name is windows.",
+                    "properties": {
+                      "add": {
+                        "description": "Added capabilities",
+                        "items": {
+                          "description": "Capability represent POSIX capabilities type",
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "drop": {
+                        "description": "Removed capabilities",
+                        "items": {
+                          "description": "Capability represent POSIX capabilities type",
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "privileged": {
+                    "description": "Run container in privileged mode.\nProcesses in privileged containers are essentially equivalent to root on the host.\nDefaults to false.\nNote that this field cannot be set when spec.os.name is windows.",
+                    "type": "boolean"
+                  },
+                  "procMount": {
+                    "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
+                    "type": "string"
+                  },
+                  "readOnlyRootFilesystem": {
+                    "description": "Whether this container has a read-only root filesystem.\nDefault is false.\nNote that this field cannot be set when spec.os.name is windows.",
+                    "type": "boolean"
+                  },
+                  "runAsGroup": {
+                    "description": "The GID to run the entrypoint of the container process.\nUses runtime default if unset.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "runAsNonRoot": {
+                    "description": "Indicates that the container must run as a non-root user.\nIf true, the Kubelet will validate the image at runtime to ensure that it\ndoes not run as UID 0 (root) and fail to start the container if it does.\nIf unset or false, no such validation will be performed.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
+                    "type": "boolean"
+                  },
+                  "runAsUser": {
+                    "description": "The UID to run the entrypoint of the container process.\nDefaults to user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "seLinuxOptions": {
+                    "description": "The SELinux context to be applied to the container.\nIf unspecified, the container runtime will allocate a random SELinux context for each\ncontainer.  May also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+                    "properties": {
+                      "level": {
+                        "description": "Level is SELinux level label that applies to the container.",
+                        "type": "string"
+                      },
+                      "role": {
+                        "description": "Role is a SELinux role label that applies to the container.",
+                        "type": "string"
+                      },
+                      "type": {
+                        "description": "Type is a SELinux type label that applies to the container.",
+                        "type": "string"
+                      },
+                      "user": {
+                        "description": "User is a SELinux user label that applies to the container.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "seccompProfile": {
+                    "description": "The seccomp options to use by this container. If seccomp options are\nprovided at both the pod \u0026 container level, the container options\noverride the pod options.\nNote that this field cannot be set when spec.os.name is windows.",
+                    "properties": {
+                      "localhostProfile": {
+                        "description": "localhostProfile indicates a profile defined in a file on the node should be used.\nThe profile must be preconfigured on the node to work.\nMust be a descending path, relative to the kubelet's configured seccomp profile location.\nMust be set if type is \"Localhost\". Must NOT be set for any other type.",
+                        "type": "string"
+                      },
+                      "type": {
+                        "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "type"
+                    ],
+                    "type": "object"
+                  },
+                  "windowsOptions": {
+                    "description": "The Windows specific settings applied to all containers.\nIf unspecified, the options from the PodSecurityContext will be used.\nIf set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is linux.",
+                    "properties": {
+                      "gmsaCredentialSpec": {
+                        "description": "GMSACredentialSpec is where the GMSA admission webhook\n(https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the\nGMSA credential spec named by the GMSACredentialSpecName field.",
+                        "type": "string"
+                      },
+                      "gmsaCredentialSpecName": {
+                        "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                        "type": "string"
+                      },
+                      "hostProcess": {
+                        "description": "HostProcess determines if a container should be run as a 'Host Process' container.\nAll of a Pod's containers must have the same effective HostProcess value\n(it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).\nIn addition, if HostProcess is true then HostNetwork must also be set to true.",
+                        "type": "boolean"
+                      },
+                      "runAsUserName": {
+                        "description": "The UserName in Windows to run the entrypoint of the container process.\nDefaults to the user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext. If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "type": "object"
+              },
+              "startupProbe": {
+                "description": "StartupProbe",
+                "properties": {
+                  "exec": {
+                    "description": "Exec specifies a command to execute in the container.",
+                    "properties": {
+                      "command": {
+                        "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "failureThreshold": {
+                    "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "grpc": {
+                    "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                    "properties": {
+                      "port": {
+                        "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "service": {
+                        "default": "",
+                        "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object"
+                  },
+                  "httpGet": {
+                    "description": "HTTPGet specifies an HTTP GET request to perform.",
+                    "properties": {
+                      "host": {
+                        "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                        "type": "string"
+                      },
+                      "httpHeaders": {
+                        "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                        "items": {
+                          "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                          "properties": {
+                            "name": {
+                              "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                              "type": "string"
+                            },
+                            "value": {
+                              "description": "The header field value",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "value"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "path": {
+                        "description": "Path to access on the HTTP server.",
+                        "type": "string"
+                      },
+                      "port": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
+                      },
+                      "scheme": {
+                        "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object"
+                  },
+                  "initialDelaySeconds": {
+                    "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "periodSeconds": {
+                    "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "successThreshold": {
+                    "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "tcpSocket": {
+                    "description": "TCPSocket specifies a connection to a TCP port.",
+                    "properties": {
+                      "host": {
+                        "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                        "type": "string"
+                      },
+                      "port": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object"
+                  },
+                  "terminationGracePeriodSeconds": {
+                    "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "timeoutSeconds": {
+                    "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                    "format": "int32",
+                    "type": "integer"
+                  }
+                },
+                "type": "object"
+              },
+              "stdin": {
+                "description": "Stdin",
+                "type": "boolean"
+              },
+              "stdinOnce": {
+                "description": "StdinOnce",
+                "type": "boolean"
+              },
+              "terminationMessagePath": {
+                "description": "TerminationMessagePath",
+                "type": "string"
+              },
+              "terminationMessagePolicy": {
+                "description": "TerminationMessagePolicy",
+                "type": "string"
+              },
+              "tty": {
+                "description": "TTY",
+                "type": "boolean"
+              },
+              "volumeDevices": {
+                "description": "VolumeDevices",
+                "items": {
+                  "description": "volumeDevice describes a mapping of a raw block device within a container.",
+                  "properties": {
+                    "devicePath": {
+                      "description": "devicePath is the path inside of the container that the device will be mapped to.",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "name must match the name of a persistentVolumeClaim in the pod",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "devicePath",
+                    "name"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "volumeMounts": {
+                "description": "VolumeMounts",
+                "items": {
+                  "description": "VolumeMount describes a mounting of a Volume within a container.",
+                  "properties": {
+                    "mountPath": {
+                      "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
+                      "type": "string"
+                    },
+                    "mountPropagation": {
+                      "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "This must match the Name of a Volume.",
+                      "type": "string"
+                    },
+                    "readOnly": {
+                      "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
+                      "type": "boolean"
+                    },
+                    "recursiveReadOnly": {
+                      "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
+                      "type": "string"
+                    },
+                    "subPath": {
+                      "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
+                      "type": "string"
+                    },
+                    "subPathExpr": {
+                      "description": "Expanded path within the volume from which the container's volume should be mounted.\nBehaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.\nDefaults to \"\" (volume's root).\nSubPathExpr and SubPath are mutually exclusive.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "mountPath",
+                    "name"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "workingDir": {
+                "description": "WorkingDir",
+                "type": "string"
+              },
+              "workspaces": {
+                "description": "Workspaces",
+                "items": {
+                  "description": "WorkspaceUsage",
+                  "properties": {
+                    "mountPath": {
+                      "description": "MountPath",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "mountPath",
+                    "name"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "stepTemplate": {
+          "description": "StepTemplate",
+          "properties": {
+            "args": {
+              "description": "Args",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "command": {
+              "description": "Command",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "env": {
+              "description": "Env",
+              "items": {
+                "description": "EnvVar represents an environment variable present in a Container.",
+                "properties": {
+                  "name": {
+                    "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                    "type": "string"
+                  },
+                  "value": {
+                    "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
+                    "type": "string"
+                  },
+                  "valueFrom": {
+                    "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                    "properties": {
+                      "configMapKeyRef": {
+                        "description": "Selects a key of a ConfigMap.",
+                        "properties": {
+                          "key": {
+                            "description": "The key to select.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "default": "",
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the ConfigMap or its key must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object"
+                      },
+                      "fieldRef": {
+                        "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['\u003cKEY\u003e']`, `metadata.annotations['\u003cKEY\u003e']`,\nspec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                        "properties": {
+                          "apiVersion": {
+                            "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                            "type": "string"
+                          },
+                          "fieldPath": {
+                            "description": "Path of the field to select in the specified API version.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "fieldPath"
+                        ],
+                        "type": "object"
+                      },
+                      "resourceFieldRef": {
+                        "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                        "properties": {
+                          "containerName": {
+                            "description": "Container name: required for volumes, optional for env vars",
+                            "type": "string"
+                          },
+                          "divisor": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                          },
+                          "resource": {
+                            "description": "Required: resource to select",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "resource"
+                        ],
+                        "type": "object"
+                      },
+                      "secretKeyRef": {
+                        "description": "Selects a key of a secret in the pod's namespace",
+                        "properties": {
+                          "key": {
+                            "description": "The key of the secret to select from.  Must be a valid secret key.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "default": "",
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the Secret or its key must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "envFrom": {
+              "description": "EnvFrom",
+              "items": {
+                "description": "EnvFromSource represents the source of a set of ConfigMaps",
+                "properties": {
+                  "configMapRef": {
+                    "description": "The ConfigMap to select from",
+                    "properties": {
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string"
+                      },
+                      "optional": {
+                        "description": "Specify whether the ConfigMap must be defined",
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "prefix": {
+                    "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
+                    "type": "string"
+                  },
+                  "secretRef": {
+                    "description": "The Secret to select from",
+                    "properties": {
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string"
+                      },
+                      "optional": {
+                        "description": "Specify whether the Secret must be defined",
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "image": {
+              "description": "Image",
+              "type": "string"
+            },
+            "imagePullPolicy": {
+              "description": "ImagePullPolicy",
+              "type": "string"
+            },
+            "lifecycle": {
+              "description": "Deprecated: This field will be removed in a future release.\nDeprecatedLifecycle",
+              "properties": {
+                "postStart": {
+                  "description": "PostStart is called immediately after a container is created. If the handler fails,\nthe container is terminated and restarted according to its restart policy.\nOther management of the container blocks until the hook completes.\nMore info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+                  "properties": {
+                    "exec": {
+                      "description": "Exec specifies a command to execute in the container.",
+                      "properties": {
+                        "command": {
+                          "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "httpGet": {
+                      "description": "HTTPGet specifies an HTTP GET request to perform.",
+                      "properties": {
+                        "host": {
+                          "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                          "type": "string"
+                        },
+                        "httpHeaders": {
+                          "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                          "items": {
+                            "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                            "properties": {
+                              "name": {
+                                "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                "type": "string"
+                              },
+                              "value": {
+                                "description": "The header field value",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "value"
+                            ],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "path": {
+                          "description": "Path to access on the HTTP server.",
+                          "type": "string"
+                        },
+                        "port": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
+                        },
+                        "scheme": {
+                          "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "port"
+                      ],
+                      "type": "object"
+                    },
+                    "sleep": {
+                      "description": "Sleep represents a duration that the container should sleep.",
+                      "properties": {
+                        "seconds": {
+                          "description": "Seconds is the number of seconds to sleep.",
+                          "format": "int64",
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "seconds"
+                      ],
+                      "type": "object"
+                    },
+                    "tcpSocket": {
+                      "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept\nfor backward compatibility. There is no validation of this field and\nlifecycle hooks will fail at runtime when it is specified.",
+                      "properties": {
+                        "host": {
+                          "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                          "type": "string"
+                        },
+                        "port": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
+                        }
+                      },
+                      "required": [
+                        "port"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "preStop": {
+                  "description": "PreStop is called immediately before a container is terminated due to an\nAPI request or management event such as liveness/startup probe failure,\npreemption, resource contention, etc. The handler is not called if the\ncontainer crashes or exits. The Pod's termination grace period countdown begins before the\nPreStop hook is executed. Regardless of the outcome of the handler, the\ncontainer will eventually terminate within the Pod's termination grace\nperiod (unless delayed by finalizers). Other management of the container blocks until the hook completes\nor until the termination grace period is reached.\nMore info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+                  "properties": {
+                    "exec": {
+                      "description": "Exec specifies a command to execute in the container.",
+                      "properties": {
+                        "command": {
+                          "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "httpGet": {
+                      "description": "HTTPGet specifies an HTTP GET request to perform.",
+                      "properties": {
+                        "host": {
+                          "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                          "type": "string"
+                        },
+                        "httpHeaders": {
+                          "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                          "items": {
+                            "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                            "properties": {
+                              "name": {
+                                "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                "type": "string"
+                              },
+                              "value": {
+                                "description": "The header field value",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "value"
+                            ],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "path": {
+                          "description": "Path to access on the HTTP server.",
+                          "type": "string"
+                        },
+                        "port": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
+                        },
+                        "scheme": {
+                          "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "port"
+                      ],
+                      "type": "object"
+                    },
+                    "sleep": {
+                      "description": "Sleep represents a duration that the container should sleep.",
+                      "properties": {
+                        "seconds": {
+                          "description": "Seconds is the number of seconds to sleep.",
+                          "format": "int64",
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "seconds"
+                      ],
+                      "type": "object"
+                    },
+                    "tcpSocket": {
+                      "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept\nfor backward compatibility. There is no validation of this field and\nlifecycle hooks will fail at runtime when it is specified.",
+                      "properties": {
+                        "host": {
+                          "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                          "type": "string"
+                        },
+                        "port": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
+                        }
+                      },
+                      "required": [
+                        "port"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "livenessProbe": {
+              "description": "Deprecated: This field will be removed in a future release.\nDeprecatedLivenessProbe",
+              "properties": {
+                "exec": {
+                  "description": "Exec specifies a command to execute in the container.",
+                  "properties": {
+                    "command": {
+                      "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                },
+                "failureThreshold": {
+                  "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "grpc": {
+                  "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                  "properties": {
+                    "port": {
+                      "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "service": {
+                      "default": "",
+                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "port"
+                  ],
+                  "type": "object"
+                },
+                "httpGet": {
+                  "description": "HTTPGet specifies an HTTP GET request to perform.",
+                  "properties": {
+                    "host": {
+                      "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                      "type": "string"
+                    },
+                    "httpHeaders": {
+                      "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                      "items": {
+                        "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                        "properties": {
+                          "name": {
+                            "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                            "type": "string"
+                          },
+                          "value": {
+                            "description": "The header field value",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "path": {
+                      "description": "Path to access on the HTTP server.",
+                      "type": "string"
+                    },
+                    "port": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
+                    },
+                    "scheme": {
+                      "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "port"
+                  ],
+                  "type": "object"
+                },
+                "initialDelaySeconds": {
+                  "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "periodSeconds": {
+                  "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "successThreshold": {
+                  "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "tcpSocket": {
+                  "description": "TCPSocket specifies a connection to a TCP port.",
+                  "properties": {
+                    "host": {
+                      "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                      "type": "string"
+                    },
+                    "port": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
+                    }
+                  },
+                  "required": [
+                    "port"
+                  ],
+                  "type": "object"
+                },
+                "terminationGracePeriodSeconds": {
+                  "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "timeoutSeconds": {
+                  "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                  "format": "int32",
+                  "type": "integer"
+                }
+              },
+              "type": "object"
+            },
+            "name": {
+              "description": "Deprecated: This field will be removed in a future release.\nDeprecatedName",
+              "type": "string"
+            },
+            "ports": {
+              "description": "Deprecated: This field will be removed in a future release.\nDeprecatedPorts",
+              "items": {
+                "description": "ContainerPort represents a network port in a single container.",
+                "properties": {
+                  "containerPort": {
+                    "description": "Number of port to expose on the pod's IP address.\nThis must be a valid port number, 0 \u003c x \u003c 65536.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "hostIP": {
+                    "description": "What host IP to bind the external port to.",
+                    "type": "string"
+                  },
+                  "hostPort": {
+                    "description": "Number of port to expose on the host.\nIf specified, this must be a valid port number, 0 \u003c x \u003c 65536.\nIf HostNetwork is specified, this must match ContainerPort.\nMost containers do not need this.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "name": {
+                    "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each\nnamed port in a pod must have a unique name. Name for the port that can be\nreferred to by services.",
+                    "type": "string"
+                  },
+                  "protocol": {
+                    "default": "TCP",
+                    "description": "Protocol for port. Must be UDP, TCP, or SCTP.\nDefaults to \"TCP\".",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "containerPort"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "readinessProbe": {
+              "description": "Deprecated: This field will be removed in a future release.\nDeprecatedReadinessProbe",
+              "properties": {
+                "exec": {
+                  "description": "Exec specifies a command to execute in the container.",
+                  "properties": {
+                    "command": {
+                      "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                },
+                "failureThreshold": {
+                  "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "grpc": {
+                  "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                  "properties": {
+                    "port": {
+                      "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "service": {
+                      "default": "",
+                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "port"
+                  ],
+                  "type": "object"
+                },
+                "httpGet": {
+                  "description": "HTTPGet specifies an HTTP GET request to perform.",
+                  "properties": {
+                    "host": {
+                      "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                      "type": "string"
+                    },
+                    "httpHeaders": {
+                      "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                      "items": {
+                        "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                        "properties": {
+                          "name": {
+                            "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                            "type": "string"
+                          },
+                          "value": {
+                            "description": "The header field value",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "path": {
+                      "description": "Path to access on the HTTP server.",
+                      "type": "string"
+                    },
+                    "port": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
+                    },
+                    "scheme": {
+                      "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "port"
+                  ],
+                  "type": "object"
+                },
+                "initialDelaySeconds": {
+                  "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "periodSeconds": {
+                  "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "successThreshold": {
+                  "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "tcpSocket": {
+                  "description": "TCPSocket specifies a connection to a TCP port.",
+                  "properties": {
+                    "host": {
+                      "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                      "type": "string"
+                    },
+                    "port": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
+                    }
+                  },
+                  "required": [
+                    "port"
+                  ],
+                  "type": "object"
+                },
+                "terminationGracePeriodSeconds": {
+                  "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "timeoutSeconds": {
+                  "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                  "format": "int32",
+                  "type": "integer"
+                }
+              },
+              "type": "object"
+            },
+            "resources": {
+              "description": "Resources",
+              "properties": {
+                "claims": {
+                  "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                  "items": {
+                    "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                    "properties": {
+                      "name": {
+                        "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                        "type": "string"
+                      },
+                      "request": {
+                        "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "limits": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                  },
+                  "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                  "type": "object"
+                },
+                "requests": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                  },
+                  "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "securityContext": {
+              "description": "SecurityContext",
+              "properties": {
+                "allowPrivilegeEscalation": {
+                  "description": "AllowPrivilegeEscalation controls whether a process can gain more\nprivileges than its parent process. This bool directly controls if\nthe no_new_privs flag will be set on the container process.\nAllowPrivilegeEscalation is true always when the container is:\n1) run as Privileged\n2) has CAP_SYS_ADMIN\nNote that this field cannot be set when spec.os.name is windows.",
+                  "type": "boolean"
+                },
+                "appArmorProfile": {
+                  "description": "appArmorProfile is the AppArmor options to use by this container. If set, this profile\noverrides the pod's appArmorProfile.\nNote that this field cannot be set when spec.os.name is windows.",
+                  "properties": {
+                    "localhostProfile": {
+                      "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object"
+                },
+                "capabilities": {
+                  "description": "The capabilities to add/drop when running containers.\nDefaults to the default set of capabilities granted by the container runtime.\nNote that this field cannot be set when spec.os.name is windows.",
+                  "properties": {
+                    "add": {
+                      "description": "Added capabilities",
+                      "items": {
+                        "description": "Capability represent POSIX capabilities type",
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "drop": {
+                      "description": "Removed capabilities",
+                      "items": {
+                        "description": "Capability represent POSIX capabilities type",
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                },
+                "privileged": {
+                  "description": "Run container in privileged mode.\nProcesses in privileged containers are essentially equivalent to root on the host.\nDefaults to false.\nNote that this field cannot be set when spec.os.name is windows.",
+                  "type": "boolean"
+                },
+                "procMount": {
+                  "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
+                  "type": "string"
+                },
+                "readOnlyRootFilesystem": {
+                  "description": "Whether this container has a read-only root filesystem.\nDefault is false.\nNote that this field cannot be set when spec.os.name is windows.",
+                  "type": "boolean"
+                },
+                "runAsGroup": {
+                  "description": "The GID to run the entrypoint of the container process.\nUses runtime default if unset.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "runAsNonRoot": {
+                  "description": "Indicates that the container must run as a non-root user.\nIf true, the Kubelet will validate the image at runtime to ensure that it\ndoes not run as UID 0 (root) and fail to start the container if it does.\nIf unset or false, no such validation will be performed.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
+                  "type": "boolean"
+                },
+                "runAsUser": {
+                  "description": "The UID to run the entrypoint of the container process.\nDefaults to user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "seLinuxOptions": {
+                  "description": "The SELinux context to be applied to the container.\nIf unspecified, the container runtime will allocate a random SELinux context for each\ncontainer.  May also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+                  "properties": {
+                    "level": {
+                      "description": "Level is SELinux level label that applies to the container.",
+                      "type": "string"
+                    },
+                    "role": {
+                      "description": "Role is a SELinux role label that applies to the container.",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "Type is a SELinux type label that applies to the container.",
+                      "type": "string"
+                    },
+                    "user": {
+                      "description": "User is a SELinux user label that applies to the container.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "seccompProfile": {
+                  "description": "The seccomp options to use by this container. If seccomp options are\nprovided at both the pod \u0026 container level, the container options\noverride the pod options.\nNote that this field cannot be set when spec.os.name is windows.",
+                  "properties": {
+                    "localhostProfile": {
+                      "description": "localhostProfile indicates a profile defined in a file on the node should be used.\nThe profile must be preconfigured on the node to work.\nMust be a descending path, relative to the kubelet's configured seccomp profile location.\nMust be set if type is \"Localhost\". Must NOT be set for any other type.",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object"
+                },
+                "windowsOptions": {
+                  "description": "The Windows specific settings applied to all containers.\nIf unspecified, the options from the PodSecurityContext will be used.\nIf set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is linux.",
+                  "properties": {
+                    "gmsaCredentialSpec": {
+                      "description": "GMSACredentialSpec is where the GMSA admission webhook\n(https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the\nGMSA credential spec named by the GMSACredentialSpecName field.",
+                      "type": "string"
+                    },
+                    "gmsaCredentialSpecName": {
+                      "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                      "type": "string"
+                    },
+                    "hostProcess": {
+                      "description": "HostProcess determines if a container should be run as a 'Host Process' container.\nAll of a Pod's containers must have the same effective HostProcess value\n(it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).\nIn addition, if HostProcess is true then HostNetwork must also be set to true.",
+                      "type": "boolean"
+                    },
+                    "runAsUserName": {
+                      "description": "The UserName in Windows to run the entrypoint of the container process.\nDefaults to the user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext. If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "startupProbe": {
+              "description": "Deprecated: This field will be removed in a future release.\nDeprecatedStartupProbe",
+              "properties": {
+                "exec": {
+                  "description": "Exec specifies a command to execute in the container.",
+                  "properties": {
+                    "command": {
+                      "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                },
+                "failureThreshold": {
+                  "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "grpc": {
+                  "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                  "properties": {
+                    "port": {
+                      "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "service": {
+                      "default": "",
+                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "port"
+                  ],
+                  "type": "object"
+                },
+                "httpGet": {
+                  "description": "HTTPGet specifies an HTTP GET request to perform.",
+                  "properties": {
+                    "host": {
+                      "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                      "type": "string"
+                    },
+                    "httpHeaders": {
+                      "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                      "items": {
+                        "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                        "properties": {
+                          "name": {
+                            "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                            "type": "string"
+                          },
+                          "value": {
+                            "description": "The header field value",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "path": {
+                      "description": "Path to access on the HTTP server.",
+                      "type": "string"
+                    },
+                    "port": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
+                    },
+                    "scheme": {
+                      "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "port"
+                  ],
+                  "type": "object"
+                },
+                "initialDelaySeconds": {
+                  "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "periodSeconds": {
+                  "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "successThreshold": {
+                  "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "tcpSocket": {
+                  "description": "TCPSocket specifies a connection to a TCP port.",
+                  "properties": {
+                    "host": {
+                      "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                      "type": "string"
+                    },
+                    "port": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
+                    }
+                  },
+                  "required": [
+                    "port"
+                  ],
+                  "type": "object"
+                },
+                "terminationGracePeriodSeconds": {
+                  "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "timeoutSeconds": {
+                  "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                  "format": "int32",
+                  "type": "integer"
+                }
+              },
+              "type": "object"
+            },
+            "stdin": {
+              "description": "Deprecated: This field will be removed in a future release.\nDeprecatedStdin",
+              "type": "boolean"
+            },
+            "stdinOnce": {
+              "description": "Deprecated: This field will be removed in a future release.\nDeprecatedStdinOnce",
+              "type": "boolean"
+            },
+            "terminationMessagePath": {
+              "description": "DeprecatedTerminationMessagePath\nDeprecated: This field will be removed in a future release and cannot be meaningfully used.",
+              "type": "string"
+            },
+            "terminationMessagePolicy": {
+              "description": "DeprecatedTerminationMessagePolicy\nDeprecated: This field will be removed in a future release and cannot be meaningfully used.",
+              "type": "string"
+            },
+            "tty": {
+              "description": "Deprecated: This field will be removed in a future release.\nDeprecatedTTY",
+              "type": "boolean"
+            },
+            "volumeDevices": {
+              "description": "VolumeDevices",
+              "items": {
+                "description": "volumeDevice describes a mapping of a raw block device within a container.",
+                "properties": {
+                  "devicePath": {
+                    "description": "devicePath is the path inside of the container that the device will be mapped to.",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "name must match the name of a persistentVolumeClaim in the pod",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "devicePath",
+                  "name"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "volumeMounts": {
+              "description": "VolumeMounts",
+              "items": {
+                "description": "VolumeMount describes a mounting of a Volume within a container.",
+                "properties": {
+                  "mountPath": {
+                    "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
+                    "type": "string"
+                  },
+                  "mountPropagation": {
+                    "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "This must match the Name of a Volume.",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
+                    "type": "boolean"
+                  },
+                  "recursiveReadOnly": {
+                    "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
+                    "type": "string"
+                  },
+                  "subPath": {
+                    "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
+                    "type": "string"
+                  },
+                  "subPathExpr": {
+                    "description": "Expanded path within the volume from which the container's volume should be mounted.\nBehaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.\nDefaults to \"\" (volume's root).\nSubPathExpr and SubPath are mutually exclusive.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "mountPath",
+                  "name"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "workingDir": {
+              "description": "WorkingDir",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object"
+        },
+        "steps": {
+          "description": "Steps",
+          "items": {
+            "description": "Step",
+            "properties": {
+              "args": {
+                "description": "Args",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "command": {
+                "description": "Command",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "displayName": {
+                "description": "DisplayName",
+                "type": "string"
+              },
+              "env": {
+                "description": "Env",
+                "items": {
+                  "description": "EnvVar represents an environment variable present in a Container.",
+                  "properties": {
+                    "name": {
+                      "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                      "type": "string"
+                    },
+                    "value": {
+                      "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
+                      "type": "string"
+                    },
+                    "valueFrom": {
+                      "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                      "properties": {
+                        "configMapKeyRef": {
+                          "description": "Selects a key of a ConfigMap.",
+                          "properties": {
+                            "key": {
+                              "description": "The key to select.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the ConfigMap or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object"
+                        },
+                        "fieldRef": {
+                          "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['\u003cKEY\u003e']`, `metadata.annotations['\u003cKEY\u003e']`,\nspec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                          "properties": {
+                            "apiVersion": {
+                              "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                              "type": "string"
+                            },
+                            "fieldPath": {
+                              "description": "Path of the field to select in the specified API version.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "fieldPath"
+                          ],
+                          "type": "object"
+                        },
+                        "resourceFieldRef": {
+                          "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                          "properties": {
+                            "containerName": {
+                              "description": "Container name: required for volumes, optional for env vars",
+                              "type": "string"
+                            },
+                            "divisor": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                            },
+                            "resource": {
+                              "description": "Required: resource to select",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "resource"
+                          ],
+                          "type": "object"
+                        },
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "envFrom": {
+                "description": "EnvFrom",
+                "items": {
+                  "description": "EnvFromSource represents the source of a set of ConfigMaps",
+                  "properties": {
+                    "configMapRef": {
+                      "description": "The ConfigMap to select from",
+                      "properties": {
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the ConfigMap must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "prefix": {
+                      "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
+                      "type": "string"
+                    },
+                    "secretRef": {
+                      "description": "The Secret to select from",
+                      "properties": {
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "image": {
+                "description": "Image",
+                "type": "string"
+              },
+              "imagePullPolicy": {
+                "description": "ImagePullPolicy",
+                "type": "string"
+              },
+              "lifecycle": {
+                "description": "Deprecated: This field will be removed in a future release.\nDeprecatedLifecycle",
+                "properties": {
+                  "postStart": {
+                    "description": "PostStart is called immediately after a container is created. If the handler fails,\nthe container is terminated and restarted according to its restart policy.\nOther management of the container blocks until the hook completes.\nMore info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+                    "properties": {
+                      "exec": {
+                        "description": "Exec specifies a command to execute in the container.",
+                        "properties": {
+                          "command": {
+                            "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "httpGet": {
+                        "description": "HTTPGet specifies an HTTP GET request to perform.",
+                        "properties": {
+                          "host": {
+                            "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                            "type": "string"
+                          },
+                          "httpHeaders": {
+                            "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                            "items": {
+                              "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                              "properties": {
+                                "name": {
+                                  "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "description": "The header field value",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "value"
+                              ],
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "path": {
+                            "description": "Path to access on the HTTP server.",
+                            "type": "string"
+                          },
+                          "port": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
+                          },
+                          "scheme": {
+                            "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object"
+                      },
+                      "sleep": {
+                        "description": "Sleep represents a duration that the container should sleep.",
+                        "properties": {
+                          "seconds": {
+                            "description": "Seconds is the number of seconds to sleep.",
+                            "format": "int64",
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "seconds"
+                        ],
+                        "type": "object"
+                      },
+                      "tcpSocket": {
+                        "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept\nfor backward compatibility. There is no validation of this field and\nlifecycle hooks will fail at runtime when it is specified.",
+                        "properties": {
+                          "host": {
+                            "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                            "type": "string"
+                          },
+                          "port": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "preStop": {
+                    "description": "PreStop is called immediately before a container is terminated due to an\nAPI request or management event such as liveness/startup probe failure,\npreemption, resource contention, etc. The handler is not called if the\ncontainer crashes or exits. The Pod's termination grace period countdown begins before the\nPreStop hook is executed. Regardless of the outcome of the handler, the\ncontainer will eventually terminate within the Pod's termination grace\nperiod (unless delayed by finalizers). Other management of the container blocks until the hook completes\nor until the termination grace period is reached.\nMore info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+                    "properties": {
+                      "exec": {
+                        "description": "Exec specifies a command to execute in the container.",
+                        "properties": {
+                          "command": {
+                            "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "httpGet": {
+                        "description": "HTTPGet specifies an HTTP GET request to perform.",
+                        "properties": {
+                          "host": {
+                            "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                            "type": "string"
+                          },
+                          "httpHeaders": {
+                            "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                            "items": {
+                              "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                              "properties": {
+                                "name": {
+                                  "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "description": "The header field value",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "value"
+                              ],
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "path": {
+                            "description": "Path to access on the HTTP server.",
+                            "type": "string"
+                          },
+                          "port": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
+                          },
+                          "scheme": {
+                            "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object"
+                      },
+                      "sleep": {
+                        "description": "Sleep represents a duration that the container should sleep.",
+                        "properties": {
+                          "seconds": {
+                            "description": "Seconds is the number of seconds to sleep.",
+                            "format": "int64",
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "seconds"
+                        ],
+                        "type": "object"
+                      },
+                      "tcpSocket": {
+                        "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept\nfor backward compatibility. There is no validation of this field and\nlifecycle hooks will fail at runtime when it is specified.",
+                        "properties": {
+                          "host": {
+                            "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                            "type": "string"
+                          },
+                          "port": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "type": "object"
+              },
+              "livenessProbe": {
+                "description": "Deprecated: This field will be removed in a future release.\nDeprecatedLivenessProbe",
+                "properties": {
+                  "exec": {
+                    "description": "Exec specifies a command to execute in the container.",
+                    "properties": {
+                      "command": {
+                        "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "failureThreshold": {
+                    "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "grpc": {
+                    "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                    "properties": {
+                      "port": {
+                        "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "service": {
+                        "default": "",
+                        "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object"
+                  },
+                  "httpGet": {
+                    "description": "HTTPGet specifies an HTTP GET request to perform.",
+                    "properties": {
+                      "host": {
+                        "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                        "type": "string"
+                      },
+                      "httpHeaders": {
+                        "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                        "items": {
+                          "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                          "properties": {
+                            "name": {
+                              "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                              "type": "string"
+                            },
+                            "value": {
+                              "description": "The header field value",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "value"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "path": {
+                        "description": "Path to access on the HTTP server.",
+                        "type": "string"
+                      },
+                      "port": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
+                      },
+                      "scheme": {
+                        "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object"
+                  },
+                  "initialDelaySeconds": {
+                    "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "periodSeconds": {
+                    "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "successThreshold": {
+                    "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "tcpSocket": {
+                    "description": "TCPSocket specifies a connection to a TCP port.",
+                    "properties": {
+                      "host": {
+                        "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                        "type": "string"
+                      },
+                      "port": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object"
+                  },
+                  "terminationGracePeriodSeconds": {
+                    "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "timeoutSeconds": {
+                    "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                    "format": "int32",
+                    "type": "integer"
+                  }
+                },
+                "type": "object"
+              },
+              "name": {
+                "description": "Name",
+                "type": "string"
+              },
+              "onError": {
+                "description": "OnError",
+                "type": "string"
+              },
+              "params": {
+                "description": "Params",
+                "items": {
+                  "description": "Param",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "description": "Value"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "value"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "ports": {
+                "description": "Deprecated: This field will be removed in a future release.\nDeprecatedPorts",
+                "items": {
+                  "description": "ContainerPort represents a network port in a single container.",
+                  "properties": {
+                    "containerPort": {
+                      "description": "Number of port to expose on the pod's IP address.\nThis must be a valid port number, 0 \u003c x \u003c 65536.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "hostIP": {
+                      "description": "What host IP to bind the external port to.",
+                      "type": "string"
+                    },
+                    "hostPort": {
+                      "description": "Number of port to expose on the host.\nIf specified, this must be a valid port number, 0 \u003c x \u003c 65536.\nIf HostNetwork is specified, this must match ContainerPort.\nMost containers do not need this.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "name": {
+                      "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each\nnamed port in a pod must have a unique name. Name for the port that can be\nreferred to by services.",
+                      "type": "string"
+                    },
+                    "protocol": {
+                      "default": "TCP",
+                      "description": "Protocol for port. Must be UDP, TCP, or SCTP.\nDefaults to \"TCP\".",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "containerPort"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "readinessProbe": {
+                "description": "Deprecated: This field will be removed in a future release.\nDeprecatedReadinessProbe",
+                "properties": {
+                  "exec": {
+                    "description": "Exec specifies a command to execute in the container.",
+                    "properties": {
+                      "command": {
+                        "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "failureThreshold": {
+                    "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "grpc": {
+                    "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                    "properties": {
+                      "port": {
+                        "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "service": {
+                        "default": "",
+                        "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object"
+                  },
+                  "httpGet": {
+                    "description": "HTTPGet specifies an HTTP GET request to perform.",
+                    "properties": {
+                      "host": {
+                        "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                        "type": "string"
+                      },
+                      "httpHeaders": {
+                        "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                        "items": {
+                          "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                          "properties": {
+                            "name": {
+                              "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                              "type": "string"
+                            },
+                            "value": {
+                              "description": "The header field value",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "value"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "path": {
+                        "description": "Path to access on the HTTP server.",
+                        "type": "string"
+                      },
+                      "port": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
+                      },
+                      "scheme": {
+                        "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object"
+                  },
+                  "initialDelaySeconds": {
+                    "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "periodSeconds": {
+                    "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "successThreshold": {
+                    "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "tcpSocket": {
+                    "description": "TCPSocket specifies a connection to a TCP port.",
+                    "properties": {
+                      "host": {
+                        "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                        "type": "string"
+                      },
+                      "port": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object"
+                  },
+                  "terminationGracePeriodSeconds": {
+                    "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "timeoutSeconds": {
+                    "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                    "format": "int32",
+                    "type": "integer"
+                  }
+                },
+                "type": "object"
+              },
+              "ref": {
+                "description": "Ref",
+                "properties": {
+                  "name": {
+                    "description": "Name",
+                    "type": "string"
+                  },
+                  "params": {
+                    "description": "Params",
+                    "items": {
+                      "description": "Param",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "description": "Value"
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "value"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "resolver": {
+                    "description": "Resolver",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "resources": {
+                "description": "Resources",
+                "properties": {
+                  "claims": {
+                    "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                    "items": {
+                      "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                      "properties": {
+                        "name": {
+                          "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                          "type": "string"
+                        },
+                        "request": {
+                          "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "limits": {
+                    "additionalProperties": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                    },
+                    "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                    "type": "object"
+                  },
+                  "requests": {
+                    "additionalProperties": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                    },
+                    "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                    "type": "object"
+                  }
+                },
+                "type": "object"
+              },
+              "results": {
+                "description": "Results",
+                "items": {
+                  "description": "StepResult used to describe the Results of a Step.",
+                  "properties": {
+                    "description": {
+                      "description": "Description is a human-readable description of the result",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name the given name",
+                      "type": "string"
+                    },
+                    "properties": {
+                      "additionalProperties": {
+                        "description": "PropertySpec defines the struct for object keys",
+                        "properties": {
+                          "type": {
+                            "description": "ParamType indicates the type of an input parameter;\nUsed to distinguish between a single string and an array of strings.",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "description": "Properties is the JSON Schema properties to support key-value pairs results.",
+                      "type": "object"
+                    },
+                    "type": {
+                      "description": "The possible types are 'string', 'array', and 'object', with 'string' as the default.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "script": {
+                "description": "Script",
+                "type": "string"
+              },
+              "securityContext": {
+                "description": "SecurityContext",
+                "properties": {
+                  "allowPrivilegeEscalation": {
+                    "description": "AllowPrivilegeEscalation controls whether a process can gain more\nprivileges than its parent process. This bool directly controls if\nthe no_new_privs flag will be set on the container process.\nAllowPrivilegeEscalation is true always when the container is:\n1) run as Privileged\n2) has CAP_SYS_ADMIN\nNote that this field cannot be set when spec.os.name is windows.",
+                    "type": "boolean"
+                  },
+                  "appArmorProfile": {
+                    "description": "appArmorProfile is the AppArmor options to use by this container. If set, this profile\noverrides the pod's appArmorProfile.\nNote that this field cannot be set when spec.os.name is windows.",
+                    "properties": {
+                      "localhostProfile": {
+                        "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                        "type": "string"
+                      },
+                      "type": {
+                        "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "type"
+                    ],
+                    "type": "object"
+                  },
+                  "capabilities": {
+                    "description": "The capabilities to add/drop when running containers.\nDefaults to the default set of capabilities granted by the container runtime.\nNote that this field cannot be set when spec.os.name is windows.",
+                    "properties": {
+                      "add": {
+                        "description": "Added capabilities",
+                        "items": {
+                          "description": "Capability represent POSIX capabilities type",
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "drop": {
+                        "description": "Removed capabilities",
+                        "items": {
+                          "description": "Capability represent POSIX capabilities type",
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "privileged": {
+                    "description": "Run container in privileged mode.\nProcesses in privileged containers are essentially equivalent to root on the host.\nDefaults to false.\nNote that this field cannot be set when spec.os.name is windows.",
+                    "type": "boolean"
+                  },
+                  "procMount": {
+                    "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
+                    "type": "string"
+                  },
+                  "readOnlyRootFilesystem": {
+                    "description": "Whether this container has a read-only root filesystem.\nDefault is false.\nNote that this field cannot be set when spec.os.name is windows.",
+                    "type": "boolean"
+                  },
+                  "runAsGroup": {
+                    "description": "The GID to run the entrypoint of the container process.\nUses runtime default if unset.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "runAsNonRoot": {
+                    "description": "Indicates that the container must run as a non-root user.\nIf true, the Kubelet will validate the image at runtime to ensure that it\ndoes not run as UID 0 (root) and fail to start the container if it does.\nIf unset or false, no such validation will be performed.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
+                    "type": "boolean"
+                  },
+                  "runAsUser": {
+                    "description": "The UID to run the entrypoint of the container process.\nDefaults to user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "seLinuxOptions": {
+                    "description": "The SELinux context to be applied to the container.\nIf unspecified, the container runtime will allocate a random SELinux context for each\ncontainer.  May also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+                    "properties": {
+                      "level": {
+                        "description": "Level is SELinux level label that applies to the container.",
+                        "type": "string"
+                      },
+                      "role": {
+                        "description": "Role is a SELinux role label that applies to the container.",
+                        "type": "string"
+                      },
+                      "type": {
+                        "description": "Type is a SELinux type label that applies to the container.",
+                        "type": "string"
+                      },
+                      "user": {
+                        "description": "User is a SELinux user label that applies to the container.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "seccompProfile": {
+                    "description": "The seccomp options to use by this container. If seccomp options are\nprovided at both the pod \u0026 container level, the container options\noverride the pod options.\nNote that this field cannot be set when spec.os.name is windows.",
+                    "properties": {
+                      "localhostProfile": {
+                        "description": "localhostProfile indicates a profile defined in a file on the node should be used.\nThe profile must be preconfigured on the node to work.\nMust be a descending path, relative to the kubelet's configured seccomp profile location.\nMust be set if type is \"Localhost\". Must NOT be set for any other type.",
+                        "type": "string"
+                      },
+                      "type": {
+                        "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "type"
+                    ],
+                    "type": "object"
+                  },
+                  "windowsOptions": {
+                    "description": "The Windows specific settings applied to all containers.\nIf unspecified, the options from the PodSecurityContext will be used.\nIf set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is linux.",
+                    "properties": {
+                      "gmsaCredentialSpec": {
+                        "description": "GMSACredentialSpec is where the GMSA admission webhook\n(https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the\nGMSA credential spec named by the GMSACredentialSpecName field.",
+                        "type": "string"
+                      },
+                      "gmsaCredentialSpecName": {
+                        "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                        "type": "string"
+                      },
+                      "hostProcess": {
+                        "description": "HostProcess determines if a container should be run as a 'Host Process' container.\nAll of a Pod's containers must have the same effective HostProcess value\n(it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).\nIn addition, if HostProcess is true then HostNetwork must also be set to true.",
+                        "type": "boolean"
+                      },
+                      "runAsUserName": {
+                        "description": "The UserName in Windows to run the entrypoint of the container process.\nDefaults to the user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext. If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "type": "object"
+              },
+              "startupProbe": {
+                "description": "Deprecated: This field will be removed in a future release.\nDeprecatedStartupProbe",
+                "properties": {
+                  "exec": {
+                    "description": "Exec specifies a command to execute in the container.",
+                    "properties": {
+                      "command": {
+                        "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "failureThreshold": {
+                    "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "grpc": {
+                    "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                    "properties": {
+                      "port": {
+                        "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "service": {
+                        "default": "",
+                        "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object"
+                  },
+                  "httpGet": {
+                    "description": "HTTPGet specifies an HTTP GET request to perform.",
+                    "properties": {
+                      "host": {
+                        "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                        "type": "string"
+                      },
+                      "httpHeaders": {
+                        "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                        "items": {
+                          "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                          "properties": {
+                            "name": {
+                              "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                              "type": "string"
+                            },
+                            "value": {
+                              "description": "The header field value",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "value"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "path": {
+                        "description": "Path to access on the HTTP server.",
+                        "type": "string"
+                      },
+                      "port": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
+                      },
+                      "scheme": {
+                        "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object"
+                  },
+                  "initialDelaySeconds": {
+                    "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "periodSeconds": {
+                    "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "successThreshold": {
+                    "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "tcpSocket": {
+                    "description": "TCPSocket specifies a connection to a TCP port.",
+                    "properties": {
+                      "host": {
+                        "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                        "type": "string"
+                      },
+                      "port": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object"
+                  },
+                  "terminationGracePeriodSeconds": {
+                    "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "timeoutSeconds": {
+                    "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                    "format": "int32",
+                    "type": "integer"
+                  }
+                },
+                "type": "object"
+              },
+              "stderrConfig": {
+                "description": "StderrConfig",
+                "properties": {
+                  "path": {
+                    "description": "Path",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "stdin": {
+                "description": "Deprecated: This field will be removed in a future release.\nDeprecatedStdin",
+                "type": "boolean"
+              },
+              "stdinOnce": {
+                "description": "Deprecated: This field will be removed in a future release.\nDeprecatedStdinOnce",
+                "type": "boolean"
+              },
+              "stdoutConfig": {
+                "description": "StdoutConfig",
+                "properties": {
+                  "path": {
+                    "description": "Path",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "terminationMessagePath": {
+                "description": "DeprecatedTerminationMessagePath\nDeprecated: This field will be removed in a future release and can't be meaningfully used.",
+                "type": "string"
+              },
+              "terminationMessagePolicy": {
+                "description": "DeprecatedTerminationMessagePolicy\nDeprecated: This field will be removed in a future release and can't be meaningfully used.",
+                "type": "string"
+              },
+              "timeout": {
+                "description": "Timeout",
+                "type": "string"
+              },
+              "tty": {
+                "description": "Deprecated: This field will be removed in a future release.\nDeprecatedTTY",
+                "type": "boolean"
+              },
+              "volumeDevices": {
+                "description": "VolumeDevices",
+                "items": {
+                  "description": "volumeDevice describes a mapping of a raw block device within a container.",
+                  "properties": {
+                    "devicePath": {
+                      "description": "devicePath is the path inside of the container that the device will be mapped to.",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "name must match the name of a persistentVolumeClaim in the pod",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "devicePath",
+                    "name"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "volumeMounts": {
+                "description": "VolumeMounts",
+                "items": {
+                  "description": "VolumeMount describes a mounting of a Volume within a container.",
+                  "properties": {
+                    "mountPath": {
+                      "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
+                      "type": "string"
+                    },
+                    "mountPropagation": {
+                      "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "This must match the Name of a Volume.",
+                      "type": "string"
+                    },
+                    "readOnly": {
+                      "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
+                      "type": "boolean"
+                    },
+                    "recursiveReadOnly": {
+                      "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
+                      "type": "string"
+                    },
+                    "subPath": {
+                      "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
+                      "type": "string"
+                    },
+                    "subPathExpr": {
+                      "description": "Expanded path within the volume from which the container's volume should be mounted.\nBehaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.\nDefaults to \"\" (volume's root).\nSubPathExpr and SubPath are mutually exclusive.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "mountPath",
+                    "name"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "when": {
+                "description": "WhenExpressions",
+                "items": {
+                  "description": "WhenExpression",
+                  "properties": {
+                    "cel": {
+                      "description": "CEL",
+                      "type": "string"
+                    },
+                    "input": {
+                      "description": "Input",
+                      "type": "string"
+                    },
+                    "operator": {
+                      "description": "Operator",
+                      "type": "string"
+                    },
+                    "values": {
+                      "description": "Values",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "workingDir": {
+                "description": "WorkingDir",
+                "type": "string"
+              },
+              "workspaces": {
+                "description": "Workspaces",
+                "items": {
+                  "description": "WorkspaceUsage",
+                  "properties": {
+                    "mountPath": {
+                      "description": "MountPath",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "mountPath",
+                    "name"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "volumes": {
+          "description": "Volumes"
+        },
+        "workspaces": {
+          "description": "Workspaces",
+          "items": {
+            "description": "WorkspaceDeclaration",
+            "properties": {
+              "description": {
+                "description": "Description",
+                "type": "string"
+              },
+              "mountPath": {
+                "description": "MountPath",
+                "type": "string"
+              },
+              "name": {
+                "description": "Name",
+                "type": "string"
+              },
+              "optional": {
+                "description": "Optional",
+                "type": "boolean"
+              },
+              "readOnly": {
+                "description": "ReadOnly",
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "title": "Tekton Task v1beta1",
+  "type": "object"
+}

--- a/schema/v1beta1/taskrun.json
+++ b/schema/v1beta1/taskrun.json
@@ -1,0 +1,2076 @@
+{
+  "$id": "https://tekton.dev/schemas/v1beta1/taskrun.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "TaskRun\nDeprecated: Please use v1.TaskRun instead.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Spec",
+      "properties": {
+        "computeResources": {
+          "description": "ComputeResources",
+          "properties": {
+            "claims": {
+              "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+              "items": {
+                "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                "properties": {
+                  "name": {
+                    "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                    "type": "string"
+                  },
+                  "request": {
+                    "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "limits": {
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+              },
+              "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+              "type": "object"
+            },
+            "requests": {
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+              },
+              "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "debug": {
+          "description": "Debug",
+          "properties": {
+            "breakpoints": {
+              "description": "Breakpoints",
+              "properties": {
+                "beforeSteps": {
+                  "description": "BeforeSteps",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "onFailure": {
+                  "description": "OnFailure",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "managedBy": {
+          "description": "ManagedBy",
+          "type": "string"
+        },
+        "params": {
+          "description": "Params",
+          "items": {
+            "description": "Param",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "value": {
+                "description": "Value"
+              }
+            },
+            "required": [
+              "name",
+              "value"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "podTemplate": {
+          "description": "PodTemplate",
+          "properties": {
+            "affinity": {
+              "description": "If specified, the pod's scheduling constraints.\nSee Pod.spec.affinity (API version: v1)"
+            },
+            "automountServiceAccountToken": {
+              "description": "AutomountServiceAccountToken indicates whether pods running as this\nservice account should have an API token automatically mounted.",
+              "type": "boolean"
+            },
+            "dnsConfig": {
+              "description": "Specifies the DNS parameters of a pod.\nParameters specified here will be merged to the generated DNS\nconfiguration based on DNSPolicy.",
+              "properties": {
+                "nameservers": {
+                  "description": "A list of DNS name server IP addresses.\nThis will be appended to the base nameservers generated from DNSPolicy.\nDuplicated nameservers will be removed.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "options": {
+                  "description": "A list of DNS resolver options.\nThis will be merged with the base options generated from DNSPolicy.\nDuplicated entries will be removed. Resolution options given in Options\nwill override those that appear in the base DNSPolicy.",
+                  "items": {
+                    "description": "PodDNSConfigOption defines DNS resolver options of a pod.",
+                    "properties": {
+                      "name": {
+                        "description": "Name is this DNS resolver option's name.\nRequired.",
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "Value is this DNS resolver option's value.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "searches": {
+                  "description": "A list of DNS search domains for host-name lookup.\nThis will be appended to the base search paths generated from DNSPolicy.\nDuplicated search paths will be removed.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            },
+            "dnsPolicy": {
+              "description": "Set DNS policy for the pod. Defaults to \"ClusterFirst\". Valid values are\n'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig\nwill be merged with the policy selected with DNSPolicy.",
+              "type": "string"
+            },
+            "enableServiceLinks": {
+              "description": "EnableServiceLinks indicates whether information about services should be injected into pod's\nenvironment variables, matching the syntax of Docker links.\nOptional: Defaults to true.",
+              "type": "boolean"
+            },
+            "env": {
+              "description": "List of environment variables that can be provided to the containers belonging to the pod.",
+              "items": {
+                "description": "EnvVar represents an environment variable present in a Container.",
+                "properties": {
+                  "name": {
+                    "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                    "type": "string"
+                  },
+                  "value": {
+                    "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
+                    "type": "string"
+                  },
+                  "valueFrom": {
+                    "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                    "properties": {
+                      "configMapKeyRef": {
+                        "description": "Selects a key of a ConfigMap.",
+                        "properties": {
+                          "key": {
+                            "description": "The key to select.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "default": "",
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the ConfigMap or its key must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object"
+                      },
+                      "fieldRef": {
+                        "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['\u003cKEY\u003e']`, `metadata.annotations['\u003cKEY\u003e']`,\nspec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                        "properties": {
+                          "apiVersion": {
+                            "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                            "type": "string"
+                          },
+                          "fieldPath": {
+                            "description": "Path of the field to select in the specified API version.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "fieldPath"
+                        ],
+                        "type": "object"
+                      },
+                      "resourceFieldRef": {
+                        "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                        "properties": {
+                          "containerName": {
+                            "description": "Container name: required for volumes, optional for env vars",
+                            "type": "string"
+                          },
+                          "divisor": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                          },
+                          "resource": {
+                            "description": "Required: resource to select",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "resource"
+                        ],
+                        "type": "object"
+                      },
+                      "secretKeyRef": {
+                        "description": "Selects a key of a secret in the pod's namespace",
+                        "properties": {
+                          "key": {
+                            "description": "The key of the secret to select from.  Must be a valid secret key.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "default": "",
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the Secret or its key must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "hostAliases": {
+              "description": "HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts\nfile if specified. This is only valid for non-hostNetwork pods.",
+              "items": {
+                "description": "HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the\npod's hosts file.",
+                "properties": {
+                  "hostnames": {
+                    "description": "Hostnames for the above IP address.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "ip": {
+                    "description": "IP address of the host file entry.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "ip"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "hostNetwork": {
+              "description": "HostNetwork specifies whether the pod may use the node network namespace",
+              "type": "boolean"
+            },
+            "hostUsers": {
+              "description": "HostUsers indicates whether the pod will use the host's user namespace.\nOptional: Default to true.\nIf set to true or not present, the pod will be run in the host user namespace, useful\nfor when the pod needs a feature only available to the host user namespace, such as\nloading a kernel module with CAP_SYS_MODULE.\nWhen set to false, a new user namespace is created for the pod. Setting false\nis useful to mitigating container breakout vulnerabilities such as allowing\ncontainers to run as root without their user having root privileges on the host.\nThis field depends on the kubernetes feature gate UserNamespacesSupport being enabled.",
+              "type": "boolean"
+            },
+            "imagePullSecrets": {
+              "description": "ImagePullSecrets gives the name of the secret used by the pod to pull the image if specified",
+              "items": {
+                "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                "properties": {
+                  "name": {
+                    "default": "",
+                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "nodeSelector": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "NodeSelector is a selector which must be true for the pod to fit on a node.\nSelector which must match a node's labels for the pod to be scheduled on that node.\nMore info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/",
+              "type": "object"
+            },
+            "priorityClassName": {
+              "description": "If specified, indicates the pod's priority. \"system-node-critical\" and\n\"system-cluster-critical\" are two special keywords which indicate the\nhighest priorities with the former being the highest priority. Any other\nname must be defined by creating a PriorityClass object with that name.\nIf not specified, the pod priority will be default or zero if there is no\ndefault.",
+              "type": "string"
+            },
+            "runtimeClassName": {
+              "description": "RuntimeClassName refers to a RuntimeClass object in the node.k8s.io\ngroup, which should be used to run this pod. If no RuntimeClass resource\nmatches the named class, the pod will not be run. If unset or empty, the\n\"legacy\" RuntimeClass will be used, which is an implicit class with an\nempty definition that uses the default runtime handler.\nMore info: https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md\nThis is a beta feature as of Kubernetes v1.14.",
+              "type": "string"
+            },
+            "schedulerName": {
+              "description": "SchedulerName specifies the scheduler to be used to dispatch the Pod",
+              "type": "string"
+            },
+            "securityContext": {
+              "description": "SecurityContext holds pod-level security attributes and common container settings.\nOptional: Defaults to empty.  See type description for default values of each field.\nSee Pod.spec.securityContext (API version: v1)"
+            },
+            "tolerations": {
+              "description": "If specified, the pod's tolerations.",
+              "items": {
+                "description": "The pod this Toleration is attached to tolerates any taint that matches\nthe triple \u003ckey,value,effect\u003e using the matching operator \u003coperator\u003e.",
+                "properties": {
+                  "effect": {
+                    "description": "Effect indicates the taint effect to match. Empty means match all taint effects.\nWhen specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                    "type": "string"
+                  },
+                  "key": {
+                    "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys.\nIf the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "Operator represents a key's relationship to the value.\nValid operators are Exists and Equal. Defaults to Equal.\nExists is equivalent to wildcard for value, so that a pod can\ntolerate all taints of a particular category.",
+                    "type": "string"
+                  },
+                  "tolerationSeconds": {
+                    "description": "TolerationSeconds represents the period of time the toleration (which must be\nof effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,\nit is not set, which means tolerate the taint forever (do not evict). Zero and\nnegative values will be treated as 0 (evict immediately) by the system.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "value": {
+                    "description": "Value is the taint value the toleration matches to.\nIf the operator is Exists, the value should be empty, otherwise just a regular string.",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "topologySpreadConstraints": {
+              "description": "TopologySpreadConstraints controls how Pods are spread across your cluster among\nfailure-domains such as regions, zones, nodes, and other user-defined topology domains.",
+              "items": {
+                "description": "TopologySpreadConstraint specifies how to spread matching pods among the given topology.",
+                "properties": {
+                  "labelSelector": {
+                    "description": "LabelSelector is used to find matching pods.\nPods that match this label selector are counted to determine the number of pods\nin their corresponding topology domain.",
+                    "properties": {
+                      "matchExpressions": {
+                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                        "items": {
+                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                          "properties": {
+                            "key": {
+                              "description": "key is the label key that the selector applies to.",
+                              "type": "string"
+                            },
+                            "operator": {
+                              "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                              "type": "string"
+                            },
+                            "values": {
+                              "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "required": [
+                            "key",
+                            "operator"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "matchLabels": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                        "type": "object"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "matchLabelKeys": {
+                    "description": "MatchLabelKeys is a set of pod label keys to select the pods over which\nspreading will be calculated. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are ANDed with labelSelector\nto select the group of existing pods over which spreading will be calculated\nfor the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.\nMatchLabelKeys cannot be set when LabelSelector isn't set.\nKeys that don't exist in the incoming pod labels will\nbe ignored. A null or empty list means only match against labelSelector.\n\nThis is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "maxSkew": {
+                    "description": "MaxSkew describes the degree to which pods may be unevenly distributed.\nWhen `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference\nbetween the number of matching pods in the target topology and the global minimum.\nThe global minimum is the minimum number of matching pods in an eligible domain\nor zero if the number of eligible domains is less than MinDomains.\nFor example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same\nlabelSelector spread as 2/2/1:\nIn this case, the global minimum is 1.\n| zone1 | zone2 | zone3 |\n|  P P  |  P P  |   P   |\n- if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;\nscheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)\nviolate MaxSkew(1).\n- if MaxSkew is 2, incoming pod can be scheduled onto any zone.\nWhen `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence\nto topologies that satisfy it.\nIt's a required field. Default value is 1 and 0 is not allowed.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "minDomains": {
+                    "description": "MinDomains indicates a minimum number of eligible domains.\nWhen the number of eligible domains with matching topology keys is less than minDomains,\nPod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed.\nAnd when the number of eligible domains with matching topology keys equals or greater than minDomains,\nthis value has no effect on scheduling.\nAs a result, when the number of eligible domains is less than minDomains,\nscheduler won't schedule more than maxSkew Pods to those domains.\nIf value is nil, the constraint behaves as if MinDomains is equal to 1.\nValid values are integers greater than 0.\nWhen value is not nil, WhenUnsatisfiable must be DoNotSchedule.\n\nFor example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same\nlabelSelector spread as 2/2/2:\n| zone1 | zone2 | zone3 |\n|  P P  |  P P  |  P P  |\nThe number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0.\nIn this situation, new pod with the same labelSelector cannot be scheduled,\nbecause computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,\nit will violate MaxSkew.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "nodeAffinityPolicy": {
+                    "description": "NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector\nwhen calculating pod topology spread skew. Options are:\n- Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.\n- Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.\n\nIf this value is nil, the behavior is equivalent to the Honor policy.\nThis is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.",
+                    "type": "string"
+                  },
+                  "nodeTaintsPolicy": {
+                    "description": "NodeTaintsPolicy indicates how we will treat node taints when calculating\npod topology spread skew. Options are:\n- Honor: nodes without taints, along with tainted nodes for which the incoming pod\nhas a toleration, are included.\n- Ignore: node taints are ignored. All nodes are included.\n\nIf this value is nil, the behavior is equivalent to the Ignore policy.\nThis is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.",
+                    "type": "string"
+                  },
+                  "topologyKey": {
+                    "description": "TopologyKey is the key of node labels. Nodes that have a label with this key\nand identical values are considered to be in the same topology.\nWe consider each \u003ckey, value\u003e as a \"bucket\", and try to put balanced number\nof pods into each bucket.\nWe define a domain as a particular instance of a topology.\nAlso, we define an eligible domain as a domain whose nodes meet the requirements of\nnodeAffinityPolicy and nodeTaintsPolicy.\ne.g. If TopologyKey is \"kubernetes.io/hostname\", each Node is a domain of that topology.\nAnd, if TopologyKey is \"topology.kubernetes.io/zone\", each zone is a domain of that topology.\nIt's a required field.",
+                    "type": "string"
+                  },
+                  "whenUnsatisfiable": {
+                    "description": "WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy\nthe spread constraint.\n- DoNotSchedule (default) tells the scheduler not to schedule it.\n- ScheduleAnyway tells the scheduler to schedule the pod in any location,\n  but giving higher precedence to topologies that would help reduce the\n  skew.\nA constraint is considered \"Unsatisfiable\" for an incoming pod\nif and only if every possible node assignment for that pod would violate\n\"MaxSkew\" on some topology.\nFor example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same\nlabelSelector spread as 3/1/1:\n| zone1 | zone2 | zone3 |\n| P P P |   P   |   P   |\nIf WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled\nto zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies\nMaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler\nwon't make it *more* imbalanced.\nIt's a required field.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "maxSkew",
+                  "topologyKey",
+                  "whenUnsatisfiable"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "volumes": {
+              "description": "List of volumes that can be mounted by containers belonging to the pod.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes\nSee Pod.spec.volumes (API version: v1)"
+            }
+          },
+          "type": "object"
+        },
+        "resources": {
+          "description": "Resources\nDeprecated: Unused, preserved only for backwards compatibility",
+          "properties": {
+            "inputs": {
+              "description": "Inputs",
+              "items": {
+                "description": "TaskResourceBinding\nDeprecated: Unused, preserved only for backwards compatibility",
+                "properties": {
+                  "name": {
+                    "description": "Name",
+                    "type": "string"
+                  },
+                  "paths": {
+                    "description": "Paths",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "resourceRef": {
+                    "description": "ResourceRef",
+                    "properties": {
+                      "apiVersion": {
+                        "description": "APIVersion",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "resourceSpec": {
+                    "description": "ResourceSpec",
+                    "properties": {
+                      "description": {
+                        "description": "Description is a user-facing description of the resource that may be\nused to populate a UI.",
+                        "type": "string"
+                      },
+                      "params": {
+                        "items": {
+                          "description": "ResourceParam declares a string value to use for the parameter called Name, and is used in\nthe specific context of PipelineResources.\n\nDeprecated: Unused, preserved only for backwards compatibility",
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "value"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "secrets": {
+                        "description": "Secrets to fetch to populate some of resource fields",
+                        "items": {
+                          "description": "SecretParam indicates which secret can be used to populate a field of the resource\n\nDeprecated: Unused, preserved only for backwards compatibility",
+                          "properties": {
+                            "fieldName": {
+                              "type": "string"
+                            },
+                            "secretKey": {
+                              "type": "string"
+                            },
+                            "secretName": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "fieldName",
+                            "secretKey",
+                            "secretName"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "type": {
+                        "description": "PipelineResourceType represents the type of endpoint the pipelineResource is, so that the\ncontroller will know this pipelineResource shouldx be fetched and optionally what\nadditional metatdata should be provided for it.\n\nDeprecated: Unused, preserved only for backwards compatibility",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "params",
+                      "type"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "outputs": {
+              "description": "Outputs",
+              "items": {
+                "description": "TaskResourceBinding\nDeprecated: Unused, preserved only for backwards compatibility",
+                "properties": {
+                  "name": {
+                    "description": "Name",
+                    "type": "string"
+                  },
+                  "paths": {
+                    "description": "Paths",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "resourceRef": {
+                    "description": "ResourceRef",
+                    "properties": {
+                      "apiVersion": {
+                        "description": "APIVersion",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "resourceSpec": {
+                    "description": "ResourceSpec",
+                    "properties": {
+                      "description": {
+                        "description": "Description is a user-facing description of the resource that may be\nused to populate a UI.",
+                        "type": "string"
+                      },
+                      "params": {
+                        "items": {
+                          "description": "ResourceParam declares a string value to use for the parameter called Name, and is used in\nthe specific context of PipelineResources.\n\nDeprecated: Unused, preserved only for backwards compatibility",
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "value"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "secrets": {
+                        "description": "Secrets to fetch to populate some of resource fields",
+                        "items": {
+                          "description": "SecretParam indicates which secret can be used to populate a field of the resource\n\nDeprecated: Unused, preserved only for backwards compatibility",
+                          "properties": {
+                            "fieldName": {
+                              "type": "string"
+                            },
+                            "secretKey": {
+                              "type": "string"
+                            },
+                            "secretName": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "fieldName",
+                            "secretKey",
+                            "secretName"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "type": {
+                        "description": "PipelineResourceType represents the type of endpoint the pipelineResource is, so that the\ncontroller will know this pipelineResource shouldx be fetched and optionally what\nadditional metatdata should be provided for it.\n\nDeprecated: Unused, preserved only for backwards compatibility",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "params",
+                      "type"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "retries": {
+          "description": "Retries",
+          "type": "integer"
+        },
+        "serviceAccountName": {
+          "description": "ServiceAccountName",
+          "type": "string"
+        },
+        "sidecarOverrides": {
+          "description": "SidecarOverrides",
+          "items": {
+            "description": "TaskRunSidecarOverride",
+            "properties": {
+              "name": {
+                "description": "Name",
+                "type": "string"
+              },
+              "resources": {
+                "description": "Resources",
+                "properties": {
+                  "claims": {
+                    "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                    "items": {
+                      "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                      "properties": {
+                        "name": {
+                          "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                          "type": "string"
+                        },
+                        "request": {
+                          "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "limits": {
+                    "additionalProperties": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                    },
+                    "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                    "type": "object"
+                  },
+                  "requests": {
+                    "additionalProperties": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                    },
+                    "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                    "type": "object"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "required": [
+              "name",
+              "resources"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "status": {
+          "description": "Status",
+          "type": "string"
+        },
+        "statusMessage": {
+          "description": "StatusMessage",
+          "type": "string"
+        },
+        "stepOverrides": {
+          "description": "StepOverrides",
+          "items": {
+            "description": "TaskRunStepOverride",
+            "properties": {
+              "name": {
+                "description": "Name",
+                "type": "string"
+              },
+              "resources": {
+                "description": "Resources",
+                "properties": {
+                  "claims": {
+                    "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                    "items": {
+                      "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                      "properties": {
+                        "name": {
+                          "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                          "type": "string"
+                        },
+                        "request": {
+                          "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "limits": {
+                    "additionalProperties": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                    },
+                    "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                    "type": "object"
+                  },
+                  "requests": {
+                    "additionalProperties": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                    },
+                    "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                    "type": "object"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "required": [
+              "name",
+              "resources"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "taskRef": {
+          "description": "TaskRef",
+          "properties": {
+            "apiVersion": {
+              "description": "APIVersion",
+              "type": "string"
+            },
+            "bundle": {
+              "description": "Deprecated: Please use ResolverRef with the bundles resolver instead.\nBundle",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name",
+              "type": "string"
+            },
+            "params": {
+              "description": "Params",
+              "items": {
+                "description": "Param",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "description": "Value"
+                  }
+                },
+                "required": [
+                  "name",
+                  "value"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "resolver": {
+              "description": "Resolver",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "taskSpec": {
+          "description": "TaskSpec"
+        },
+        "timeout": {
+          "description": "Timeout",
+          "type": "string"
+        },
+        "workspaces": {
+          "description": "Workspaces",
+          "items": {
+            "description": "WorkspaceBinding",
+            "properties": {
+              "configMap": {
+                "description": "ConfigMap",
+                "properties": {
+                  "defaultMode": {
+                    "description": "defaultMode is optional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDefaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "items": {
+                    "description": "items if unspecified, each key-value pair in the Data field of the referenced\nConfigMap will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the ConfigMap,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                    "items": {
+                      "description": "Maps a string key to a path within a volume.",
+                      "properties": {
+                        "key": {
+                          "description": "key is the key to project.",
+                          "type": "string"
+                        },
+                        "mode": {
+                          "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "path": {
+                          "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "key",
+                        "path"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "name": {
+                    "default": "",
+                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                    "type": "string"
+                  },
+                  "optional": {
+                    "description": "optional specify whether the ConfigMap or its keys must be defined",
+                    "type": "boolean"
+                  }
+                },
+                "type": "object"
+              },
+              "csi": {
+                "description": "CSI",
+                "properties": {
+                  "driver": {
+                    "description": "driver is the name of the CSI driver that handles this volume.\nConsult with your admin for the correct name as registered in the cluster.",
+                    "type": "string"
+                  },
+                  "fsType": {
+                    "description": "fsType to mount. Ex. \"ext4\", \"xfs\", \"ntfs\".\nIf not provided, the empty value is passed to the associated CSI driver\nwhich will determine the default filesystem to apply.",
+                    "type": "string"
+                  },
+                  "nodePublishSecretRef": {
+                    "description": "nodePublishSecretRef is a reference to the secret object containing\nsensitive information to pass to the CSI driver to complete the CSI\nNodePublishVolume and NodeUnpublishVolume calls.\nThis field is optional, and  may be empty if no secret is required. If the\nsecret object contains more than one secret, all secret references are passed.",
+                    "properties": {
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "readOnly": {
+                    "description": "readOnly specifies a read-only configuration for the volume.\nDefaults to false (read/write).",
+                    "type": "boolean"
+                  },
+                  "volumeAttributes": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "volumeAttributes stores driver-specific properties that are passed to the CSI\ndriver. Consult your driver's documentation for supported values.",
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "driver"
+                ],
+                "type": "object"
+              },
+              "emptyDir": {
+                "description": "EmptyDir",
+                "properties": {
+                  "medium": {
+                    "description": "medium represents what type of storage medium should back this directory.\nThe default is \"\" which means to use the node's default medium.\nMust be an empty string (default) or Memory.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                    "type": "string"
+                  },
+                  "sizeLimit": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "description": "sizeLimit is the total amount of local storage required for this EmptyDir volume.\nThe size limit is also applicable for memory medium.\nThe maximum usage on memory medium EmptyDir would be the minimum value between\nthe SizeLimit specified here and the sum of memory limits of all containers in a pod.\nThe default is nil which means that the limit is undefined.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                  }
+                },
+                "type": "object"
+              },
+              "name": {
+                "description": "Name",
+                "type": "string"
+              },
+              "persistentVolumeClaim": {
+                "description": "PersistentVolumeClaim",
+                "properties": {
+                  "claimName": {
+                    "description": "claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "readOnly Will force the ReadOnly setting in VolumeMounts.\nDefault false.",
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "claimName"
+                ],
+                "type": "object"
+              },
+              "projected": {
+                "description": "Projected",
+                "properties": {
+                  "defaultMode": {
+                    "description": "defaultMode are the mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "sources": {
+                    "description": "sources is the list of volume projections. Each entry in this list\nhandles one source.",
+                    "items": {
+                      "description": "Projection that may be projected along with other supported volume types.\nExactly one of these fields must be set.",
+                      "properties": {
+                        "clusterTrustBundle": {
+                          "description": "ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field\nof ClusterTrustBundle objects in an auto-updating file.\n\nAlpha, gated by the ClusterTrustBundleProjection feature gate.\n\nClusterTrustBundle objects can either be selected by name, or by the\ncombination of signer name and a label selector.\n\nKubelet performs aggressive normalization of the PEM contents written\ninto the pod filesystem.  Esoteric PEM features such as inter-block\ncomments and block headers are stripped.  Certificates are deduplicated.\nThe ordering of certificates within the file is arbitrary, and Kubelet\nmay change the order over time.",
+                          "properties": {
+                            "labelSelector": {
+                              "description": "Select all ClusterTrustBundles that match this label selector.  Only has\neffect if signerName is set.  Mutually-exclusive with name.  If unset,\ninterpreted as \"match nothing\".  If set but empty, interpreted as \"match\neverything\".",
+                              "properties": {
+                                "matchExpressions": {
+                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                  "items": {
+                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "key is the label key that the selector applies to.",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "operator"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "matchLabels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "name": {
+                              "description": "Select a single ClusterTrustBundle by object name.  Mutually-exclusive\nwith signerName and labelSelector.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "If true, don't block pod startup if the referenced ClusterTrustBundle(s)\naren't available.  If using name, then the named ClusterTrustBundle is\nallowed not to exist.  If using signerName, then the combination of\nsignerName and labelSelector is allowed to match zero\nClusterTrustBundles.",
+                              "type": "boolean"
+                            },
+                            "path": {
+                              "description": "Relative path from the volume root to write the bundle.",
+                              "type": "string"
+                            },
+                            "signerName": {
+                              "description": "Select all ClusterTrustBundles that match this signer name.\nMutually-exclusive with name.  The contents of all selected\nClusterTrustBundles will be unified and deduplicated.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "path"
+                          ],
+                          "type": "object"
+                        },
+                        "configMap": {
+                          "description": "configMap information about the configMap data to project",
+                          "properties": {
+                            "items": {
+                              "description": "items if unspecified, each key-value pair in the Data field of the referenced\nConfigMap will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the ConfigMap,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                              "items": {
+                                "description": "Maps a string key to a path within a volume.",
+                                "properties": {
+                                  "key": {
+                                    "description": "key is the key to project.",
+                                    "type": "string"
+                                  },
+                                  "mode": {
+                                    "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "path": {
+                                    "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "path"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "optional specify whether the ConfigMap or its keys must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "downwardAPI": {
+                          "description": "downwardAPI information about the downwardAPI data to project",
+                          "properties": {
+                            "items": {
+                              "description": "Items is a list of DownwardAPIVolume file",
+                              "items": {
+                                "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                                "properties": {
+                                  "fieldRef": {
+                                    "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.",
+                                    "properties": {
+                                      "apiVersion": {
+                                        "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                        "type": "string"
+                                      },
+                                      "fieldPath": {
+                                        "description": "Path of the field to select in the specified API version.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "fieldPath"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "mode": {
+                                    "description": "Optional: mode bits used to set permissions on this file, must be an octal value\nbetween 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "path": {
+                                    "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                                    "type": "string"
+                                  },
+                                  "resourceFieldRef": {
+                                    "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                                    "properties": {
+                                      "containerName": {
+                                        "description": "Container name: required for volumes, optional for env vars",
+                                        "type": "string"
+                                      },
+                                      "divisor": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                                      },
+                                      "resource": {
+                                        "description": "Required: resource to select",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "resource"
+                                    ],
+                                    "type": "object"
+                                  }
+                                },
+                                "required": [
+                                  "path"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "secret": {
+                          "description": "secret information about the secret data to project",
+                          "properties": {
+                            "items": {
+                              "description": "items if unspecified, each key-value pair in the Data field of the referenced\nSecret will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the Secret,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                              "items": {
+                                "description": "Maps a string key to a path within a volume.",
+                                "properties": {
+                                  "key": {
+                                    "description": "key is the key to project.",
+                                    "type": "string"
+                                  },
+                                  "mode": {
+                                    "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "path": {
+                                    "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "path"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "optional field specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "serviceAccountToken": {
+                          "description": "serviceAccountToken is information about the serviceAccountToken data to project",
+                          "properties": {
+                            "audience": {
+                              "description": "audience is the intended audience of the token. A recipient of a token\nmust identify itself with an identifier specified in the audience of the\ntoken, and otherwise should reject the token. The audience defaults to the\nidentifier of the apiserver.",
+                              "type": "string"
+                            },
+                            "expirationSeconds": {
+                              "description": "expirationSeconds is the requested duration of validity of the service\naccount token. As the token approaches expiration, the kubelet volume\nplugin will proactively rotate the service account token. The kubelet will\nstart trying to rotate the token if the token is older than 80 percent of\nits time to live or if the token is older than 24 hours.Defaults to 1 hour\nand must be at least 10 minutes.",
+                              "format": "int64",
+                              "type": "integer"
+                            },
+                            "path": {
+                              "description": "path is the path relative to the mount point of the file to project the\ntoken into.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "path"
+                          ],
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              },
+              "secret": {
+                "description": "Secret",
+                "properties": {
+                  "defaultMode": {
+                    "description": "defaultMode is Optional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values\nfor mode bits. Defaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "items": {
+                    "description": "items If unspecified, each key-value pair in the Data field of the referenced\nSecret will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the Secret,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                    "items": {
+                      "description": "Maps a string key to a path within a volume.",
+                      "properties": {
+                        "key": {
+                          "description": "key is the key to project.",
+                          "type": "string"
+                        },
+                        "mode": {
+                          "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "path": {
+                          "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "key",
+                        "path"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "optional": {
+                    "description": "optional field specify whether the Secret or its keys must be defined",
+                    "type": "boolean"
+                  },
+                  "secretName": {
+                    "description": "secretName is the name of the secret in the pod's namespace to use.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "subPath": {
+                "description": "SubPath",
+                "type": "string"
+              },
+              "volumeClaimTemplate": {
+                "description": "VolumeClaimTemplate"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "status": {
+      "description": "Status",
+      "properties": {
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Annotations is additional Status fields for the Resource to save some\nadditional State as well as convey more information to the user. This is\nroughly akin to Annotations on any k8s resource, just the reconciler conveying\nricher information outwards.",
+          "type": "object"
+        },
+        "cloudEvents": {
+          "description": "Deprecated: Removed in v0.44.0.\nCloudEvents",
+          "items": {
+            "description": "CloudEventDelivery",
+            "properties": {
+              "status": {
+                "description": "CloudEventDeliveryState",
+                "properties": {
+                  "condition": {
+                    "description": "Condition",
+                    "type": "string"
+                  },
+                  "message": {
+                    "description": "Error",
+                    "type": "string"
+                  },
+                  "retryCount": {
+                    "description": "RetryCount",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "sentAt": {
+                    "description": "SentAt",
+                    "format": "date-time",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "message",
+                  "retryCount"
+                ],
+                "type": "object"
+              },
+              "target": {
+                "description": "Target",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "completionTime": {
+          "description": "CompletionTime",
+          "format": "date-time",
+          "type": "string"
+        },
+        "conditions": {
+          "description": "Conditions the latest available observations of a resource's current state.",
+          "items": {
+            "description": "Condition defines a readiness condition for a Knative resource.\nSee: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "LastTransitionTime is the last time the condition transitioned from one status to another.\nWe use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic\ndifferences (all other things held constant).",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity with which to treat failures of this type of condition.\nWhen this is not specified, it defaults to Error.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the 'Generation' of the Service that\nwas last processed by the controller.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "podName": {
+          "description": "PodName",
+          "type": "string"
+        },
+        "provenance": {
+          "description": "Provenance",
+          "properties": {
+            "configSource": {
+              "description": "ConfigSource\nDeprecated: Use RefSource instead",
+              "properties": {
+                "digest": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Digest",
+                  "type": "object"
+                },
+                "entryPoint": {
+                  "description": "EntryPoint",
+                  "type": "string"
+                },
+                "uri": {
+                  "description": "URI",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "featureFlags": {
+              "description": "FeatureFlags",
+              "properties": {
+                "awaitSidecarReadiness": {
+                  "type": "boolean"
+                },
+                "coschedule": {
+                  "type": "string"
+                },
+                "disableCredsInit": {
+                  "type": "boolean"
+                },
+                "disableInlineSpec": {
+                  "type": "string"
+                },
+                "enableAPIFields": {
+                  "type": "string"
+                },
+                "enableArtifacts": {
+                  "type": "boolean"
+                },
+                "enableCELInWhenExpression": {
+                  "type": "boolean"
+                },
+                "enableConciseResolverSyntax": {
+                  "type": "boolean"
+                },
+                "enableKeepPodOnCancel": {
+                  "type": "boolean"
+                },
+                "enableKubernetesSidecar": {
+                  "type": "boolean"
+                },
+                "enableParamEnum": {
+                  "type": "boolean"
+                },
+                "enableProvenanceInStatus": {
+                  "type": "boolean"
+                },
+                "enableStepActions": {
+                  "description": "EnableStepActions is a no-op flag since StepActions are stable",
+                  "type": "boolean"
+                },
+                "enableWaitExponentialBackoff": {
+                  "type": "boolean"
+                },
+                "enforceNonfalsifiability": {
+                  "type": "string"
+                },
+                "maxResultSize": {
+                  "type": "integer"
+                },
+                "requireGitSSHSecretKnownHosts": {
+                  "type": "boolean"
+                },
+                "resultExtractionMethod": {
+                  "type": "string"
+                },
+                "runningInEnvWithInjectedSidecars": {
+                  "type": "boolean"
+                },
+                "sendCloudEventsForRuns": {
+                  "type": "boolean"
+                },
+                "setSecurityContext": {
+                  "type": "boolean"
+                },
+                "setSecurityContextReadOnlyRootFilesystem": {
+                  "type": "boolean"
+                },
+                "verificationNoMatchPolicy": {
+                  "description": "VerificationNoMatchPolicy is the feature flag for \"trusted-resources-verification-no-match-policy\"\nVerificationNoMatchPolicy can be set to \"ignore\", \"warn\" and \"fail\" values.\nignore: skip trusted resources verification when no matching verification policies found\nwarn: skip trusted resources verification when no matching verification policies found and log a warning\nfail: fail the taskrun or pipelines run if no matching verification policies found",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "refSource": {
+              "description": "RefSource",
+              "properties": {
+                "digest": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Digest",
+                  "type": "object"
+                },
+                "entryPoint": {
+                  "description": "EntryPoint",
+                  "type": "string"
+                },
+                "uri": {
+                  "description": "URI",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "resourcesResult": {
+          "description": "ResourcesResult\nDeprecated: this field is not populated and is preserved only for backwards compatibility",
+          "items": {
+            "description": "RunResult is used to write key/value pairs to TaskRun pod termination messages.\nThe key/value pairs may come from the entrypoint binary, or represent a TaskRunResult.\nIf they represent a TaskRunResult, the key is the name of the result and the value is the\nJSON-serialized value of the result.",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "resourceName": {
+                "description": "ResourceName may be used in tests, but it is not populated in termination messages.\nIt is preserved here for backwards compatibility and will not be ported to v1.",
+                "type": "string"
+              },
+              "type": {
+                "description": "ResultType used to find out whether a RunResult is from a task result or not\nNote that ResultsType is another type which is used to define the data type\n(e.g. string, array, etc) we used for Results",
+                "type": "integer"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "retriesStatus": {
+          "description": "RetriesStatus"
+        },
+        "sidecars": {
+          "description": "Sidecars",
+          "items": {
+            "description": "SidecarState",
+            "properties": {
+              "container": {
+                "type": "string"
+              },
+              "imageID": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "running": {
+                "description": "Details about a running container",
+                "properties": {
+                  "startedAt": {
+                    "description": "Time at which the container was last (re-)started",
+                    "format": "date-time",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "terminated": {
+                "description": "Details about a terminated container",
+                "properties": {
+                  "containerID": {
+                    "description": "Container's ID in the format '\u003ctype\u003e://\u003ccontainer_id\u003e'",
+                    "type": "string"
+                  },
+                  "exitCode": {
+                    "description": "Exit status from the last termination of the container",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "finishedAt": {
+                    "description": "Time at which the container last terminated",
+                    "format": "date-time",
+                    "type": "string"
+                  },
+                  "message": {
+                    "description": "Message regarding the last termination of the container",
+                    "type": "string"
+                  },
+                  "reason": {
+                    "description": "(brief) reason from the last termination of the container",
+                    "type": "string"
+                  },
+                  "signal": {
+                    "description": "Signal from the last termination of the container",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "startedAt": {
+                    "description": "Time at which previous execution of the container started",
+                    "format": "date-time",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "exitCode"
+                ],
+                "type": "object"
+              },
+              "waiting": {
+                "description": "Details about a waiting container",
+                "properties": {
+                  "message": {
+                    "description": "Message regarding why the container is not yet running.",
+                    "type": "string"
+                  },
+                  "reason": {
+                    "description": "(brief) reason the container is not yet running.",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "spanContext": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "SpanContext",
+          "type": "object"
+        },
+        "startTime": {
+          "description": "StartTime",
+          "format": "date-time",
+          "type": "string"
+        },
+        "steps": {
+          "description": "Steps",
+          "items": {
+            "description": "StepState",
+            "properties": {
+              "container": {
+                "type": "string"
+              },
+              "imageID": {
+                "type": "string"
+              },
+              "inputs": {
+                "items": {
+                  "description": "Artifact",
+                  "properties": {
+                    "buildOutput": {
+                      "description": "BuildOutput",
+                      "type": "boolean"
+                    },
+                    "name": {
+                      "description": "Name",
+                      "type": "string"
+                    },
+                    "values": {
+                      "description": "Values",
+                      "items": {
+                        "description": "ArtifactValue",
+                        "properties": {
+                          "digest": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "uri": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "name": {
+                "type": "string"
+              },
+              "outputs": {
+                "items": {
+                  "description": "Artifact",
+                  "properties": {
+                    "buildOutput": {
+                      "description": "BuildOutput",
+                      "type": "boolean"
+                    },
+                    "name": {
+                      "description": "Name",
+                      "type": "string"
+                    },
+                    "values": {
+                      "description": "Values",
+                      "items": {
+                        "description": "ArtifactValue",
+                        "properties": {
+                          "digest": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "uri": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "provenance": {
+                "description": "Provenance",
+                "properties": {
+                  "configSource": {
+                    "description": "ConfigSource\nDeprecated: Use RefSource instead",
+                    "properties": {
+                      "digest": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "Digest",
+                        "type": "object"
+                      },
+                      "entryPoint": {
+                        "description": "EntryPoint",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "URI",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "featureFlags": {
+                    "description": "FeatureFlags",
+                    "properties": {
+                      "awaitSidecarReadiness": {
+                        "type": "boolean"
+                      },
+                      "coschedule": {
+                        "type": "string"
+                      },
+                      "disableCredsInit": {
+                        "type": "boolean"
+                      },
+                      "disableInlineSpec": {
+                        "type": "string"
+                      },
+                      "enableAPIFields": {
+                        "type": "string"
+                      },
+                      "enableArtifacts": {
+                        "type": "boolean"
+                      },
+                      "enableCELInWhenExpression": {
+                        "type": "boolean"
+                      },
+                      "enableConciseResolverSyntax": {
+                        "type": "boolean"
+                      },
+                      "enableKeepPodOnCancel": {
+                        "type": "boolean"
+                      },
+                      "enableKubernetesSidecar": {
+                        "type": "boolean"
+                      },
+                      "enableParamEnum": {
+                        "type": "boolean"
+                      },
+                      "enableProvenanceInStatus": {
+                        "type": "boolean"
+                      },
+                      "enableStepActions": {
+                        "description": "EnableStepActions is a no-op flag since StepActions are stable",
+                        "type": "boolean"
+                      },
+                      "enableWaitExponentialBackoff": {
+                        "type": "boolean"
+                      },
+                      "enforceNonfalsifiability": {
+                        "type": "string"
+                      },
+                      "maxResultSize": {
+                        "type": "integer"
+                      },
+                      "requireGitSSHSecretKnownHosts": {
+                        "type": "boolean"
+                      },
+                      "resultExtractionMethod": {
+                        "type": "string"
+                      },
+                      "runningInEnvWithInjectedSidecars": {
+                        "type": "boolean"
+                      },
+                      "sendCloudEventsForRuns": {
+                        "type": "boolean"
+                      },
+                      "setSecurityContext": {
+                        "type": "boolean"
+                      },
+                      "setSecurityContextReadOnlyRootFilesystem": {
+                        "type": "boolean"
+                      },
+                      "verificationNoMatchPolicy": {
+                        "description": "VerificationNoMatchPolicy is the feature flag for \"trusted-resources-verification-no-match-policy\"\nVerificationNoMatchPolicy can be set to \"ignore\", \"warn\" and \"fail\" values.\nignore: skip trusted resources verification when no matching verification policies found\nwarn: skip trusted resources verification when no matching verification policies found and log a warning\nfail: fail the taskrun or pipelines run if no matching verification policies found",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "refSource": {
+                    "description": "RefSource",
+                    "properties": {
+                      "digest": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "Digest",
+                        "type": "object"
+                      },
+                      "entryPoint": {
+                        "description": "EntryPoint",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "URI",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "type": "object"
+              },
+              "results": {
+                "items": {
+                  "description": "TaskRunResult",
+                  "properties": {
+                    "name": {
+                      "description": "Name",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "Type",
+                      "type": "string"
+                    },
+                    "value": {
+                      "description": "Value"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "value"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "running": {
+                "description": "Details about a running container",
+                "properties": {
+                  "startedAt": {
+                    "description": "Time at which the container was last (re-)started",
+                    "format": "date-time",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "terminated": {
+                "description": "Details about a terminated container",
+                "properties": {
+                  "containerID": {
+                    "description": "Container's ID in the format '\u003ctype\u003e://\u003ccontainer_id\u003e'",
+                    "type": "string"
+                  },
+                  "exitCode": {
+                    "description": "Exit status from the last termination of the container",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "finishedAt": {
+                    "description": "Time at which the container last terminated",
+                    "format": "date-time",
+                    "type": "string"
+                  },
+                  "message": {
+                    "description": "Message regarding the last termination of the container",
+                    "type": "string"
+                  },
+                  "reason": {
+                    "description": "(brief) reason from the last termination of the container",
+                    "type": "string"
+                  },
+                  "signal": {
+                    "description": "Signal from the last termination of the container",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "startedAt": {
+                    "description": "Time at which previous execution of the container started",
+                    "format": "date-time",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "exitCode"
+                ],
+                "type": "object"
+              },
+              "waiting": {
+                "description": "Details about a waiting container",
+                "properties": {
+                  "message": {
+                    "description": "Message regarding why the container is not yet running.",
+                    "type": "string"
+                  },
+                  "reason": {
+                    "description": "(brief) reason the container is not yet running.",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "taskResults": {
+          "description": "TaskRunResults",
+          "items": {
+            "description": "TaskRunResult",
+            "properties": {
+              "name": {
+                "description": "Name",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type",
+                "type": "string"
+              },
+              "value": {
+                "description": "Value"
+              }
+            },
+            "required": [
+              "name",
+              "value"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "taskSpec": {
+          "description": "TaskSpec"
+        }
+      },
+      "required": [
+        "podName"
+      ],
+      "type": "object"
+    }
+  },
+  "title": "Tekton TaskRun v1beta1",
+  "type": "object"
+}


### PR DESCRIPTION
Fixes #8983

## Changes
- Add `hack/jsonschema-gen/main.go`: Tool to extract OpenAPIV3Schema from CRDs and convert to JSON Schema
- Add `hack/update-jsonschema.sh`: Script to run the generator
- Add `schema/` directory with pre-generated JSON Schema files for v1, v1beta1, v1alpha1 APIs

## Details
The generated schemas:
- Use JSON Schema draft 2020-12
- Are self-contained with no external $ref dependencies
- Filter out Kubernetes-specific extensions (x-kubernetes-*)
- Include proper $schema and $id metadata

## Test plan
- [x] Unit tests pass for jsonschema-gen tool
- [x] Generated JSON files are valid JSON Schema
- [x] Schemas contain no external references ($ref)

```release-note
Add self-contained JSON Schema generation tool for Tekton CRDs, enabling IDE autocompletion and validation
```