### PR TITLE
Fix parameter resolution for defaults with `$(params.X)` references

### DIFF
--- a/pkg/reconciler/pipelinerun/resources/apply_test.go
+++ b/pkg/reconciler/pipelinerun/resources/apply_test.go
@@ -17,12 +17,11 @@ limitations under the License.
 package resources_test
 
 import (
-	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	cfgtesting "github.com/tektoncd/pipeline/pkg/apis/config/testing"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/reconciler/pipelinerun/resources"
@@ -41,7 +40,6 @@ func TestApplyParameters(t *testing.T) {
 		original v1.PipelineSpec
 		params   []v1.Param
 		expected v1.PipelineSpec
-		wc       func(context.Context) context.Context
 	}{
 		{
 			name: "single parameter",
@@ -222,7 +220,6 @@ func TestApplyParameters(t *testing.T) {
 					},
 				}},
 			},
-			wc: cfgtesting.EnableAlphaAPIFields,
 		},
 		{
 			name: "parameter propagation object finally task",
@@ -253,7 +250,6 @@ func TestApplyParameters(t *testing.T) {
 					},
 				}},
 			},
-			wc: cfgtesting.EnableAlphaAPIFields,
 		},
 		{
 			name: "parameter propagation with task default but no task winner pipeline",
@@ -637,7 +633,6 @@ func TestApplyParameters(t *testing.T) {
 					},
 				}},
 			},
-			wc: cfgtesting.EnableAlphaAPIFields,
 		},
 		{
 			name: "Finally task parameter propagation object with task default but no task winner pipeline",
@@ -693,7 +688,6 @@ func TestApplyParameters(t *testing.T) {
 					},
 				}},
 			},
-			wc: cfgtesting.EnableAlphaAPIFields,
 		},
 		{
 			name: "parameter propagation object with task default and task winner task",
@@ -758,7 +752,6 @@ func TestApplyParameters(t *testing.T) {
 					},
 				}},
 			},
-			wc: cfgtesting.EnableAlphaAPIFields,
 		},
 		{
 			name: "Finally task parameter propagation object with task default and task winner task",
@@ -823,7 +816,6 @@ func TestApplyParameters(t *testing.T) {
 					},
 				}},
 			},
-			wc: cfgtesting.EnableAlphaAPIFields,
 		},
 		{
 			name: "single parameter with when expression",
@@ -1445,7 +1437,6 @@ func TestApplyParameters(t *testing.T) {
 					},
 				}},
 			},
-			wc: cfgtesting.EnableAlphaAPIFields,
 		},
 		{
 			name: "single parameter in finally workspace subpath",
@@ -1791,21 +1782,366 @@ func TestApplyParameters(t *testing.T) {
 				}},
 			},
 		},
+		{
+			name: "parameter default value inherited from another parameter",
+			original: v1.PipelineSpec{
+				Params: []v1.ParamSpec{
+					{Name: "fallback-param", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("pipeline fallback value")},
+					{Name: "param", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("$(params.fallback-param)")},
+				},
+				Tasks: []v1.PipelineTask{{
+					Params: v1.Params{
+						{Name: "task-param", Value: *v1.NewStructuredValues("$(params.param)")},
+					},
+				}},
+			},
+			params: v1.Params{{Name: "fallback-param", Value: *v1.NewStructuredValues("override fallback param value")}},
+			expected: v1.PipelineSpec{
+				Params: []v1.ParamSpec{
+					{Name: "fallback-param", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("pipeline fallback value")},
+					{Name: "param", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("$(params.fallback-param)")},
+				},
+				Tasks: []v1.PipelineTask{{
+					Params: v1.Params{
+						{Name: "task-param", Value: *v1.NewStructuredValues("override fallback param value")},
+					},
+				}},
+			},
+		},
+		{
+			name: "parameter default value inherited from another parameter - no override",
+			original: v1.PipelineSpec{
+				Params: []v1.ParamSpec{
+					{Name: "fallback-param", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("pipeline fallback value")},
+					{Name: "param", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("$(params.fallback-param)")},
+				},
+				Tasks: []v1.PipelineTask{{
+					Params: v1.Params{
+						{Name: "task-param", Value: *v1.NewStructuredValues("$(params.param)")},
+					},
+				}},
+			},
+			params: v1.Params{},
+			expected: v1.PipelineSpec{
+				Params: []v1.ParamSpec{
+					{Name: "fallback-param", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("pipeline fallback value")},
+					{Name: "param", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("$(params.fallback-param)")},
+				},
+				Tasks: []v1.PipelineTask{{
+					Params: v1.Params{
+						{Name: "task-param", Value: *v1.NewStructuredValues("pipeline fallback value")},
+					},
+				}},
+			},
+		},
+		{
+			name: "parameter default value inherited from another parameter - override param",
+			original: v1.PipelineSpec{
+				Params: []v1.ParamSpec{
+					{Name: "fallback-param", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("pipeline fallback value")},
+					{Name: "param", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("$(params.fallback-param)")},
+				},
+				Tasks: []v1.PipelineTask{{
+					Params: v1.Params{
+						{Name: "task-param", Value: *v1.NewStructuredValues("$(params.param)")},
+					},
+				}},
+			},
+			params: v1.Params{{Name: "param", Value: *v1.NewStructuredValues("override param value")}},
+			expected: v1.PipelineSpec{
+				Params: []v1.ParamSpec{
+					{Name: "fallback-param", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("pipeline fallback value")},
+					{Name: "param", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("$(params.fallback-param)")},
+				},
+				Tasks: []v1.PipelineTask{{
+					Params: v1.Params{
+						{Name: "task-param", Value: *v1.NewStructuredValues("override param value")},
+					},
+				}},
+			},
+		},
+		{
+			name: "three-level dependency chain - forward order",
+			original: v1.PipelineSpec{
+				Params: []v1.ParamSpec{
+					{Name: "base-registry", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("docker.io")},
+					{Name: "registry", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("$(params.base-registry)/myorg")},
+					{Name: "image-url", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("$(params.registry)/app:v1")},
+				},
+				Tasks: []v1.PipelineTask{{
+					Params: v1.Params{
+						{Name: "task-param", Value: *v1.NewStructuredValues("$(params.image-url)")},
+					},
+				}},
+			},
+			params: v1.Params{},
+			expected: v1.PipelineSpec{
+				Params: []v1.ParamSpec{
+					{Name: "base-registry", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("docker.io")},
+					{Name: "registry", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("$(params.base-registry)/myorg")},
+					{Name: "image-url", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("$(params.registry)/app:v1")},
+				},
+				Tasks: []v1.PipelineTask{{
+					Params: v1.Params{
+						{Name: "task-param", Value: *v1.NewStructuredValues("docker.io/myorg/app:v1")},
+					},
+				}},
+			},
+		},
+		{
+			name: "three-level dependency chain - reverse order",
+			original: v1.PipelineSpec{
+				Params: []v1.ParamSpec{
+					{Name: "image-url", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("$(params.registry)/app:v1")},
+					{Name: "registry", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("$(params.base-registry)/myorg")},
+					{Name: "base-registry", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("docker.io")},
+				},
+				Tasks: []v1.PipelineTask{{
+					Params: v1.Params{
+						{Name: "task-param", Value: *v1.NewStructuredValues("$(params.image-url)")},
+					},
+				}},
+			},
+			params: v1.Params{},
+			expected: v1.PipelineSpec{
+				Params: []v1.ParamSpec{
+					{Name: "image-url", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("$(params.registry)/app:v1")},
+					{Name: "registry", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("$(params.base-registry)/myorg")},
+					{Name: "base-registry", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("docker.io")},
+				},
+				Tasks: []v1.PipelineTask{{
+					Params: v1.Params{
+						{Name: "task-param", Value: *v1.NewStructuredValues("docker.io/myorg/app:v1")},
+					},
+				}},
+			},
+		},
+		{
+			name: "multiple param references in one default",
+			original: v1.PipelineSpec{
+				Params: []v1.ParamSpec{
+					{Name: "registry", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("gcr.io")},
+					{Name: "project", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("my-project")},
+					{Name: "app", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("backend")},
+					{Name: "version", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("1.0.0")},
+					{Name: "full-image", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("$(params.registry)/$(params.project)/$(params.app):$(params.version)")},
+				},
+				Tasks: []v1.PipelineTask{{
+					Params: v1.Params{
+						{Name: "task-param", Value: *v1.NewStructuredValues("$(params.full-image)")},
+					},
+				}},
+			},
+			params: v1.Params{},
+			expected: v1.PipelineSpec{
+				Params: []v1.ParamSpec{
+					{Name: "registry", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("gcr.io")},
+					{Name: "project", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("my-project")},
+					{Name: "app", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("backend")},
+					{Name: "version", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("1.0.0")},
+					{Name: "full-image", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("$(params.registry)/$(params.project)/$(params.app):$(params.version)")},
+				},
+				Tasks: []v1.PipelineTask{{
+					Params: v1.Params{
+						{Name: "task-param", Value: *v1.NewStructuredValues("gcr.io/my-project/backend:1.0.0")},
+					},
+				}},
+			},
+		},
+		{
+			name: "array default referencing string param",
+			original: v1.PipelineSpec{
+				Params: []v1.ParamSpec{
+					{Name: "registry", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("docker.io")},
+					{Name: "images", Type: v1.ParamTypeArray, Default: v1.NewStructuredValues("$(params.registry)/app1", "$(params.registry)/app2", "alpine")},
+				},
+				Tasks: []v1.PipelineTask{{
+					Params: v1.Params{
+						{Name: "task-images", Value: *v1.NewStructuredValues("$(params.images[*])")},
+					},
+				}},
+			},
+			params: v1.Params{},
+			expected: v1.PipelineSpec{
+				Params: []v1.ParamSpec{
+					{Name: "registry", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("docker.io")},
+					{Name: "images", Type: v1.ParamTypeArray, Default: v1.NewStructuredValues("$(params.registry)/app1", "$(params.registry)/app2", "alpine")},
+				},
+				Tasks: []v1.PipelineTask{{
+					Params: v1.Params{
+						{Name: "task-images", Value: *v1.NewStructuredValues("docker.io/app1", "docker.io/app2", "alpine")},
+					},
+				}},
+			},
+		},
+		{
+			name: "object default referencing string param",
+			original: v1.PipelineSpec{
+				Params: []v1.ParamSpec{
+					{Name: "registry", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("gcr.io")},
+					{Name: "port", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("5000")},
+					{Name: "config", Type: v1.ParamTypeObject, Default: v1.NewObject(map[string]string{
+						"host": "$(params.registry)",
+						"port": "$(params.port)",
+					})},
+				},
+				Tasks: []v1.PipelineTask{{
+					Params: v1.Params{
+						{Name: "task-host", Value: *v1.NewStructuredValues("$(params.config.host)")},
+						{Name: "task-port", Value: *v1.NewStructuredValues("$(params.config.port)")},
+					},
+				}},
+			},
+			params: v1.Params{},
+			expected: v1.PipelineSpec{
+				Params: []v1.ParamSpec{
+					{Name: "registry", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("gcr.io")},
+					{Name: "port", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("5000")},
+					{Name: "config", Type: v1.ParamTypeObject, Default: v1.NewObject(map[string]string{
+						"host": "$(params.registry)",
+						"port": "$(params.port)",
+					})},
+				},
+				Tasks: []v1.PipelineTask{{
+					Params: v1.Params{
+						{Name: "task-host", Value: *v1.NewStructuredValues("gcr.io")},
+						{Name: "task-port", Value: *v1.NewStructuredValues("5000")},
+					},
+				}},
+			},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			ctx := t.Context()
-			if tt.wc != nil {
-				ctx = tt.wc(ctx)
-			}
 			run := &v1.PipelineRun{
 				Spec: v1.PipelineRunSpec{
 					Params: tt.params,
 				},
 			}
-			got := resources.ApplyParameters(ctx, &tt.original, run)
+			got, err := resources.ApplyParameters(&tt.original, run)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 			if d := cmp.Diff(&tt.expected, got); d != "" {
 				t.Errorf("ApplyParameters() got diff %s", diff.PrintWantGot(d))
+			}
+		})
+	}
+}
+
+func TestApplyParameters_Errors(t *testing.T) {
+	for _, tt := range []struct {
+		name          string
+		original      v1.PipelineSpec
+		params        []v1.Param
+		expectedError error
+	}{
+		{
+			name: "circular dependency between two params",
+			original: v1.PipelineSpec{
+				Params: []v1.ParamSpec{
+					{Name: "image-url", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("$(params.full-path)/app")},
+					{Name: "full-path", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("$(params.image-url)")},
+				},
+				Tasks: []v1.PipelineTask{{
+					Params: v1.Params{
+						{Name: "task-param", Value: *v1.NewStructuredValues("$(params.image-url)")},
+					},
+				}},
+			},
+			params:        v1.Params{},
+			expectedError: errors.New("parameter resolution failed: circular dependency detected in param"),
+		},
+		{
+			name: "self-referencing param",
+			original: v1.PipelineSpec{
+				Params: []v1.ParamSpec{
+					{Name: "registry", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("$(params.registry)")},
+				},
+				Tasks: []v1.PipelineTask{{
+					Params: v1.Params{
+						{Name: "task-param", Value: *v1.NewStructuredValues("$(params.registry)")},
+					},
+				}},
+			},
+			params:        v1.Params{},
+			expectedError: errors.New("parameter resolution failed: circular dependency detected in param"),
+		},
+		{
+			name: "three-param circular chain",
+			original: v1.PipelineSpec{
+				Params: []v1.ParamSpec{
+					{Name: "a", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("$(params.b)")},
+					{Name: "b", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("$(params.c)")},
+					{Name: "c", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("$(params.a)")},
+				},
+				Tasks: []v1.PipelineTask{{
+					Params: v1.Params{
+						{Name: "task-param", Value: *v1.NewStructuredValues("$(params.a)")},
+					},
+				}},
+			},
+			params:        v1.Params{},
+			expectedError: errors.New("parameter resolution failed: circular dependency detected in param"),
+		},
+		{
+			name: "param references non-existent param",
+			original: v1.PipelineSpec{
+				Params: []v1.ParamSpec{
+					{Name: "image-url", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("$(params.registry)/app")},
+				},
+				Tasks: []v1.PipelineTask{{
+					Params: v1.Params{
+						{Name: "task-param", Value: *v1.NewStructuredValues("$(params.image-url)")},
+					},
+				}},
+			},
+			params:        v1.Params{},
+			expectedError: errors.New("parameter resolution failed: param"),
+		},
+		{
+			name: "recursion depth exceeded",
+			original: v1.PipelineSpec{
+				Params: []v1.ParamSpec{
+					{Name: "a", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("$(params.b)")},
+					{Name: "b", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("$(params.c)")},
+					{Name: "c", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("$(params.d)")},
+					{Name: "d", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("$(params.e)")},
+					{Name: "e", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("$(params.f)")},
+					{Name: "f", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("$(params.g)")},
+					{Name: "g", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("$(params.h)")},
+					{Name: "h", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("$(params.i)")},
+					{Name: "i", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("$(params.j)")},
+					{Name: "j", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("$(params.k)")},
+					{Name: "k", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("$(params.l)")},
+					{Name: "l", Type: v1.ParamTypeString, Default: v1.NewStructuredValues("$(params.a)")},
+				},
+				Tasks: []v1.PipelineTask{{
+					Params: v1.Params{
+						{Name: "task-param", Value: *v1.NewStructuredValues("$(params.a)")},
+					},
+				}},
+			},
+			params:        v1.Params{},
+			expectedError: errors.New("parameter resolution failed: maximum recursion depth"),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			pr := &v1.PipelineRun{
+				Spec: v1.PipelineRunSpec{
+					Params: tt.params,
+				},
+			}
+
+			_, err := resources.ApplyParameters(&tt.original, pr)
+
+			if err == nil {
+				t.Fatalf("expected error containing %q but got none", tt.expectedError.Error())
+			}
+
+			if !strings.Contains(err.Error(), tt.expectedError.Error()) {
+				t.Fatalf("error = %q, want to contain %q", err.Error(), tt.expectedError.Error())
 			}
 		})
 	}
@@ -2108,7 +2444,10 @@ func TestApplyParameters_ArrayIndexing(t *testing.T) {
 					Params: tt.params,
 				},
 			}
-			got := resources.ApplyParameters(t.Context(), &tt.original, run)
+			got, err := resources.ApplyParameters(&tt.original, run)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 			if d := cmp.Diff(&tt.expected, got); d != "" {
 				t.Errorf("ApplyParameters() got diff %s", diff.PrintWantGot(d))
 			}
@@ -2360,7 +2699,10 @@ func TestApplyReplacementsMatrix(t *testing.T) {
 					Params: tt.params,
 				},
 			}
-			got := resources.ApplyParameters(t.Context(), &tt.original, run)
+			got, err := resources.ApplyParameters(&tt.original, run)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 			if d := cmp.Diff(&tt.expected, got); d != "" {
 				t.Errorf("ApplyParameters() got diff %s", diff.PrintWantGot(d))
 			}
@@ -3839,7 +4181,7 @@ func TestApplyFinallyResultsToPipelineResults(t *testing.T) {
 		},
 	} {
 		t.Run(tc.description, func(t *testing.T) {
-			received, _ := resources.ApplyTaskResultsToPipelineResults(t.Context(), tc.results, tc.taskResults, tc.runResults, nil /* skippedTasks */)
+			received, _ := resources.ApplyTaskResultsToPipelineResults(tc.results, tc.taskResults, tc.runResults, nil /* skippedTasks */)
 			if d := cmp.Diff(tc.expected, received); d != "" {
 				t.Error(diff.PrintWantGot(d))
 			}
@@ -4172,9 +4514,9 @@ func TestApplyTaskResultsToPipelineResults_Success(t *testing.T) {
 		}},
 	}} {
 		t.Run(tc.description, func(t *testing.T) {
-			received, err := resources.ApplyTaskResultsToPipelineResults(t.Context(), tc.results, tc.taskResults, tc.runResults, tc.taskstatus)
+			received, err := resources.ApplyTaskResultsToPipelineResults(tc.results, tc.taskResults, tc.runResults, tc.taskstatus)
 			if err != nil {
-				t.Errorf("Got unecpected error:%v", err)
+				t.Errorf("Got unexpected error:%v", err)
 			}
 			if d := cmp.Diff(tc.expectedResults, received); d != "" {
 				t.Error(diff.PrintWantGot(d))
@@ -4388,7 +4730,7 @@ func TestApplyTaskResultsToPipelineResults_Error(t *testing.T) {
 		expectedError:   errors.New("invalid pipelineresults [foo], the referenced results don't exist"),
 	}} {
 		t.Run(tc.description, func(t *testing.T) {
-			received, err := resources.ApplyTaskResultsToPipelineResults(t.Context(), tc.results, tc.taskResults, tc.runResults, nil /*skipped tasks*/)
+			received, err := resources.ApplyTaskResultsToPipelineResults(tc.results, tc.taskResults, tc.runResults, nil /*skipped tasks*/)
 			if err == nil {
 				t.Errorf("Expect error but got nil")
 				return
@@ -5294,7 +5636,7 @@ func TestApplyParametersToWorkspaceBindings(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			resources.ApplyParametersToWorkspaceBindings(t.Context(), tt.pr)
+			resources.ApplyParametersToWorkspaceBindings(tt.pr)
 			if d := cmp.Diff(tt.expectedPr, tt.pr); d != "" {
 				t.Fatalf("TestApplyParametersToWorkspaceBindings() %s, got: %v", tt.name, diff.PrintWantGot(d))
 			}

--- a/pkg/reconciler/pipelinerun/resources/pipelineref.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelineref.go
@@ -66,7 +66,7 @@ func GetPipelineFunc(ctx context.Context, k8s kubernetes.Interface, tekton clien
 	switch {
 	case pr != nil && pr.Resolver != "" && requester != nil:
 		return func(ctx context.Context, name string) (*v1.Pipeline, *v1.RefSource, *trustedresources.VerificationResult, error) {
-			stringReplacements, arrayReplacements, objectReplacements := paramsFromPipelineRun(ctx, pipelineRun)
+			stringReplacements, arrayReplacements, objectReplacements := paramsFromPipelineRun(pipelineRun)
 			for k, v := range GetContextReplacements("", pipelineRun) {
 				stringReplacements[k] = v
 			}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR completely rewrites the parameter resolution algorithm in `ApplyParameters` to fix critical bugs where pipeline parameter defaults containing `$(params.X)` references were not being resolved.

Fixes #8862
Fixes #9270 

## Problem

The legacy implementation had fundamental design flaws:

1. **No parameter reference resolution**: Default values containing `$(params.X)` were copied verbatim into replacement maps
2. **Single-pass processing**: Only one linear pass through parameters with no iteration to resolve dependencies
3. **Array/object defaults broken**: Array elements and object values with `$(params.X)` stored literally
4. **Order-dependent behavior**: Declaration order affected resolution, but resolution didn't happen anyway
5. **No validation**: No detection of circular deps, missing refs, or unresolved expressions
6. **Late failures**: Errors surfaced during task pod creation with misleading messages like `non-existent variable in "echo \"$(params.X)\""` instead of clear parameter resolution errors

## Solution

This commit restructures `ApplyParameters` into 6 distinct phases:

1. **Extract params from PipelineRun** - Get user-provided values
2. **Build maps of unresolved defaults by type** - Separate string/array/object params
3. **Recursively resolve string params with dependency tracking** - Handle arbitrary dependency chains
4. **Resolve array params with substitution** - Apply replacements to array elements
5. **Resolve object params with substitution** - Apply replacements to object values
6. **Apply all replacements to PipelineSpec** - Final substitution

### Key Improvements

- **O(n) complexity** with single-pass recursive resolution
- **Circular dependency detection** prevents infinite loops and provides clear error messages
- **Missing parameter reference detection** with actionable errors at validation time
- **Supports arbitrary dependency chains** regardless of declaration order (declarative, not imperative)
- **All parameter patterns handled**: `params.X`, `params["X"]`, `params['X']`
- **Maximum recursion depth of 10 levels** prevents stack overflow attacks
- **Full resolution** of parameters in defaults, arrays, and objects

### Example Fixes

**Before** (fails with misleading error):

```yaml
params:
  - name: registry
    default: "docker.io"
  - name: image
    default: "$(params.registry)/myapp:latest"  # Not resolved ❌
```

Task receives literal `$(params.registry)/myapp:latest` → pod creation fails

**After** (works correctly):

```yaml
params:
  - name: registry
    default: "docker.io"
  - name: image
    default: "$(params.registry)/myapp:latest"  # Resolved ✅
```

Task receives `docker.io/myapp:latest` → pod created successfully

**Circular dependency detection**:

```yaml
params:
  - name: a
    default: $(params.b)
  - name: b
    default: $(params.a)
```

**Before**: Pod creation fails with `non-existent variable`
**After**: Clear error at PipelineRun creation: `circular dependency detected: params.a -> params.b -> params.a`

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Fixed bug where pipeline parameter defaults containing references to other parameters (e.g., `default: $(params.registry)/app`) were not resolved, causing task pod creation failures. Parameter resolution now supports arbitrary dependency chains, detects circular dependencies with clear error messages, and works with all parameter types (string, array, object) and notation styles (params.X, params["X"], params['X']).
```
