### PR TITLE
fix: Align ConfigMap configstore with existing implementation

### DIFF
--- a/pkg/remoteresolution/resolver/framework/cache/configstore.go
+++ b/pkg/remoteresolution/resolver/framework/cache/configstore.go
@@ -55,8 +55,8 @@ type Config struct {
 }
 
 type CacheConfigStore struct {
-	untyped         *configmap.UntypedStore
 	cacheConfigName string
+	untyped         *configmap.UntypedStore
 }
 
 func NewCacheConfigStore(cacheConfigName string, logger configmap.Logger) *CacheConfigStore {


### PR DESCRIPTION
Fixes #9275

## Changes
- Reorder CacheConfigStore struct fields to match the existing ConfigStore pattern
- Place cacheConfigName field before untyped field for consistency