### PR TITLE
feat: Add SHA-256 support for Git resolver revision validation

### DIFF
--- a/docs/git-resolver.md
+++ b/docs/git-resolver.md
@@ -22,7 +22,7 @@ This Resolver responds to type `git`.
 | `tokenKey`    | An optional key in the token secret name in the `PipelineRun` namespace to fetch the token from. Defaults to `token`.                                                      | `token`                                                     |
 | `gitToken`       | An optional secret name in the `PipelineRun` namespace to fetch the token from when doing opration with the `git clone`. When empty it will use anonymous cloning. | `secret-gitauth-token` |
 | `gitTokenKey` | An optional key in the token secret name in the `PipelineRun` namespace to fetch the token from when using the `git clone`. Defaults to `token`.                                                      | `token`                                                     |
-| `revision`    | Git revision to checkout a file from. This can be commit SHA, branch or tag.                                                                                               | `aeb957601cf41c012be462827053a21a420befca` `main` `v0.38.2` |
+| `revision`    | Git revision to checkout a file from. This can be commit SHA (SHA-1 or SHA-256), branch or tag.                                                                                               | `aeb957601cf41c012be462827053a21a420befca` `main` `v0.38.2` |
 | `pathInRepo`  | Where to find the file in the repo.                                                                                                                                        | `task/golang-build/0.3/golang-build.yaml`                   |
 | `serverURL`   | An optional server URL (that includes the https:// prefix) to connect for API operations                                                                                   | `https:/github.mycompany.com`                               |
 | `scmType`     | An optional SCM type to use for API operations                                                                                                                             | `github`, `gitlab`, `gitea`                                 |
@@ -386,7 +386,7 @@ spec:
   - If users choose to use anonymous cloning, the url is just user-provided value for the `url` param in the [SPDX download format](https://spdx.github.io/spdx-spec/package-information/#77-package-download-location-field).
   - If scm api is used, it would be the clone URL of the repo fetched from scm repository service in the [SPDX download format](https://spdx.github.io/spdx-spec/package-information/#77-package-download-location-field).
 - `digest`
-  - The algorithm name is fixed "sha1", but subject to be changed to "sha256" once Git eventually uses SHA256 at some point later. See <https://git-scm.com/docs/hash-function-transition> for more details.
+  - The Git resolver supports both SHA-1 and SHA-256 commit hashes for revision validation. See <https://git-scm.com/docs/hash-function-transition> for more details.
   - The value is the actual commit sha at the moment of resolving the resource even if a user provides a tag/branch name for the param `revision`.
 - `entrypoint`: the user-provided value for the `path` param.
 

--- a/pkg/remoteresolution/resolver/git/resolver_test.go
+++ b/pkg/remoteresolution/resolver/git/resolver_test.go
@@ -215,6 +215,50 @@ func TestValidateParams_Failure(t *testing.T) {
 		})
 	}
 }
+func TestResolver_IsImmutable(t *testing.T) {
+	tests := []struct {
+		name     string
+		revision string
+		want     bool
+	}{
+		{
+			name:     "valid SHA-1 format",
+			revision: "0123456789abcdef0123456789abcdef01234567",
+			want:     true,
+		},
+		{
+			name:     "valid SHA-256 format",
+			revision: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			want:     true,
+		},
+		{
+			name:     "between SHA-1 and SHA-256 - 50 chars",
+			revision: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1",
+			want:     false,
+		},
+		{
+			name:     "empty string",
+			revision: "",
+			want:     false,
+		},
+	}
+	resolver := &Resolver{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := []pipelinev1.Param{
+				{
+					Name:  gitresolution.RevisionParam,
+					Value: *pipelinev1.NewStructuredValues(tt.revision),
+				},
+			}
+
+			got := resolver.IsImmutable(params)
+			if got != tt.want {
+				t.Errorf("IsImmutable() = %v, want %v for revision %q", got, tt.want, tt.revision)
+			}
+		})
+	}
+}
 
 func TestGetResolutionTimeoutDefault(t *testing.T) {
 	resolver := Resolver{}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Added  SHA-256 hash support to the Git resolver's `IsImmutable` method to future-proof for Git v3+, which uses SHA-256 commit hashes (64 characters)
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
# Fixes #9276 
# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Git resolver now supports SHA-256 commit hashes for revision validation.
```
