### PR TITLE
docs: Document roadmap project board workflows and best practices

### DIFF
--- a/roadmap.md
+++ b/roadmap.md
@@ -1,63 +1,110 @@
 # Tekton Pipelines Roadmap
 
-Our community roadmap can be found [here](https://github.com/orgs/tektoncd/projects/26/views/16).
-This project automatically includes issues and PRs with label `area/roadmap`.
+**Project Board:** https://github.com/orgs/tektoncd/projects/16
+
+## Purpose
+
+The Tekton Pipelines Roadmap project board tracks the development roadmap for the `tektoncd/pipeline` component. It provides visibility into planned features, ongoing work, and completed items including:
+
+- Feature requests and enhancements
+- TEPs (Tekton Enhancement Proposals)
+- Epics and their sub-issues
+- Infrastructure improvements
 
 See [The Tekton mission and vision](https://github.com/tektoncd/community/blob/main/roadmap.md#mission-and-vision)
 for more information on our long-term goals.
 
-## 2021 Roadmap
+## Status Columns
 
-*2021 Roadmap appears below for historic purposes.*
+| Status | Meaning |
+|--------|---------|
+| **Todo** | Planned work, not yet started |
+| **In Progress** | Actively being worked on |
+| **Review** | Implementation complete, awaiting review |
+| **Done** | Completed and closed |
+| **Hold** | Paused or blocked |
 
-* [v1 API](https://github.com/tektoncd/pipeline/issues/3548)
-  * Support alpha fields within v1 and beta types ([TEP-0033](https://github.com/tektoncd/community/blob/main/teps/0033-tekton-feature-gates.md))
-* When expressions:
-  * Option to skip Task only ([TEP-0007](https://github.com/tektoncd/community/blob/main/teps/0007-conditions-beta.md#skipping-1))
-  * [Support in Finally Tasks](https://github.com/tektoncd/pipeline/issues/3438) ([TEP-0045](https://github.com/tektoncd/community/blob/main/teps/0045-whenexpressions-in-finally-tasks.md))
-* [Env vars at runtime](https://github.com/tektoncd/pipeline/issues/1606)
-* Workspaces/PVCs/Affinity Assistant ([TEP-0046](https://github.com/tektoncd/community/pull/318)
-  * [Investigate custom scheduler for PVCs](https://github.com/tektoncd/pipeline/issues/3052)
-* [OCI bundles to beta](https://github.com/tektoncd/pipeline/issues/3661) (and then v1)
-* Expanded expression support via [CelRun Task](https://github.com/tektoncd/pipeline/issues/3149)
-* [Pipelines in Pipelines](https://github.com/tektoncd/pipeline/issues/2134)
-* Support for more complex failure scenarios
-  * Allow task failure ([TEP-0050](https://github.com/tektoncd/community/pull/342))
-  * Allow step failure ([TEP-0040](https://github.com/tektoncd/community/pull/302))
-  * Decisions regarding more complex graph construction on failure
-* [Instrument Tekton resources](https://github.com/tektoncd/pipeline/issues/2814)
-  * Minimize overhead of running a pipeline
-* Improve ability to compose Tasks with Tasks ([TEP-0044](https://github.com/tektoncd/community/pull/316)) 
-* [Workspaces “from” other Tasks (express resource dependencies on workspaces)](https://github.com/tektoncd/pipeline/issues/3109)
-* [Custom Tasks](https://github.com/tektoncd/community/blob/main/teps/0002-custom-tasks.md) completion:
-  * [Pipeline Results](https://github.com/tektoncd/pipeline/issues/3595)
-  * Example controller for folks who want to create custom tasks
-  * Experimental custom tasks promotion (e.g. [CELRun](https://github.com/tektoncd/experimental/tree/main/cel)):
-    * Plan around how to promote (what requirements, process)
-    * Continuous integration + release automation
-    * Documentation and examples at tekton.dev
-    * Integration with operator
-* [Adding support for other architectures](https://github.com/tektoncd/pipeline/issues/856)
-* [Improve UX of getting credentials into Tasks](https://github.com/tektoncd/pipeline/issues/2343) - nearly complete
-  via [TEP-0029](https://github.com/tektoncd/community/blob/main/teps/0029-step-workspaces.md)
-* [Notifications](https://github.com/tektoncd/pipeline/issues/1740)
-* [Performant Tekton](https://github.com/tektoncd/pipeline/issues/540)
-  ([TEP-0036](https://github.com/tektoncd/community/blob/main/teps/0036-start-measuring-tekton-pipelines-performance.md))
-* [Debug mode](https://github.com/tektoncd/pipeline/issues/2069)
-* [PipelineResources: beta or bust](https://github.com/tektoncd/pipeline/issues/1673)
-  ([some discussion and analysis](https://docs.google.com/document/d/1Et10YdBXBe3o2x6lCfTindFnuBKOxuUGESLb__t11xk/edit#heading=h.xz4bckr3atww))
-* [Looping syntax](https://github.com/tektoncd/pipeline/issues/2050)
-* [Concurrency limits](https://github.com/tektoncd/experimental/issues/699)
-  ([TEP-0013](https://github.com/tektoncd/community/pull/228))
-* [Partial Pipeline execution](https://github.com/tektoncd/pipeline/issues/50)
-* [Testing tools](https://github.com/tektoncd/pipeline/issues/1289)
-* Decisions around what to do with SCM support and the images released as part of Tekton Pipelines to support
-  [PipelineResources](https://github.com/tektoncd/pipeline/issues/1673)
-* [Rich type support for Params](https://github.com/tektoncd/pipeline/issues/1393)
-* Decide if these are in scope for Tekton Pipelines:
-  * [Local execution](https://github.com/tektoncd/pipeline/issues/235)
-    (and [tektoncd/community#145](https://github.com/tektoncd/community/issues/145))
-  * [Config as code](https://github.com/tektoncd/pipeline/issues/859)
-    ([TEP-0048](https://github.com/tektoncd/community/pull/341),
-    [task references via git](https://github.com/tektoncd/pipeline/issues/2298))
-* [Rework PipelineRun and TaskRun Status](https://github.com/tektoncd/pipeline/issues/3792)
+## How Items Get Added
+
+### Automatic Addition (Recommended)
+
+Add the `area/roadmap` label to any open issue or PR in `tektoncd/pipeline`. The automation will:
+1. Add the item to the project board
+2. Set its status to **Todo**
+
+Sub-issues of items already on the board are automatically added as well.
+
+### Manual Addition
+
+Maintainers can manually add items via the project board interface for items that don't have the `area/roadmap` label.
+
+## How Items Move
+
+Most status transitions happen automatically based on GitHub events:
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                        ENTRY POINTS                             │
+├─────────────────────────────────────────────────────────────────┤
+│  Label "area/roadmap" added       ───────────────► Todo         │
+│  Sub-issue created                ───────────────► Todo         │
+│  Manually added to project        ───────────────► Todo         │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                    AUTOMATED TRANSITIONS                        │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│   Todo                                                          │
+│     │                                                           │
+│     │  PR linked to issue                                       │
+│     │  Changes requested on PR                                  │
+│     ▼                                                           │
+│   In Progress                                                   │
+│     │                                                           │
+│     │  Issue closed                                             │
+│     │  PR merged                                                │
+│     ▼                                                           │
+│   Done                                                          │
+│     │                                                           │
+│     │  Issue reopened ──────────────────────► In Progress       │
+│     │                                                           │
+│     │  Closed > 1 year with no updates                          │
+│     ▼                                                           │
+│   [Archived]                                                    │
+│                                                                 │
+├─────────────────────────────────────────────────────────────────┤
+│                     MANUAL TRANSITIONS                          │
+├─────────────────────────────────────────────────────────────────┤
+│   Any status ◄──────────────────────────────► Hold              │
+│   In Progress ──────────────────────────────► Review            │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Best Practices
+
+### For Contributors
+
+| Action | How |
+|--------|-----|
+| **Get your feature on the roadmap** | Add `area/roadmap` label to your issue |
+| **Signal you're working on something** | Link your PR to the issue — status moves to "In Progress" automatically |
+| **Break down large features** | Use GitHub sub-issues; they're auto-added to the board |
+| **Check what's planned** | Review the Todo column before proposing duplicate work |
+
+### For Maintainers
+
+| Action | How |
+|--------|-----|
+| **Prioritize roadmap items** | Use the board's drag-and-drop to reorder within columns |
+| **Block work temporarily** | Move items to Hold manually; add a comment explaining why |
+| **Signal review needed** | Move items to Review manually when implementation is complete |
+| **Keep the board clean** | Items auto-archive after 1 year closed, but you can archive manually |
+| **Track epic progress** | Use sub-issues — the board shows sub-issue completion progress |
+
+### Things to Avoid
+
+- **Don't manually set Done** — let the automation handle it when issues close or PRs merge
+- **Don't remove `area/roadmap` label** to remove from board — the item stays; archive it instead if needed
+- **Don't duplicate items** — search the board before adding new roadmap items


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Updates `roadmap.md` to document how the GitHub Projects board (#16) works for tracking the Tekton Pipelines roadmap.

**What's changed:**
- Fixed incorrect project link (was `projects/26/views/16`, now correctly `projects/16`)
- Removed outdated 2021 roadmap section
- Added documentation for:
  - Purpose and what the board tracks
  - Status columns and their meanings (Todo, In Progress, Review, Done, Hold)
  - How items get added (automatic via `area/roadmap` label, manual addition)
  - How items move through the workflow (with ASCII diagram showing automated transitions)
  - Best practices for contributors and maintainers

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```