### PR TITLE
perf(controller): add informer cache transform to reduce memory usage

### DIFF
--- a/config/config-feature-flags.yaml
+++ b/config/config-feature-flags.yaml
@@ -145,3 +145,13 @@ data:
   # Alpha feature — this is a short-term measure. External result storage
   # (TEP-0164) will address the underlying 4KB limitation.
   enable-termination-message-compression: "false"
+  # Controls whether informer cache transforms are enabled. When enabled (default),
+  # the controller strips large, unnecessary metadata fields (managedFields and the
+  # kubectl last-applied-configuration annotation) from PipelineRuns, TaskRuns,
+  # CustomRuns, and Pods stored in the informer cache to reduce memory usage.
+  #
+  # Set to "false" to disable if you encounter issues with missing data in cached objects.
+  # Changes require a controller restart to take effect.
+  #
+  # See https://github.com/tektoncd/pipeline/issues/7691 for more info.
+  enable-informer-cache-transforms: "true"

--- a/docs/developers/README.md
+++ b/docs/developers/README.md
@@ -19,6 +19,7 @@ channel for training and tutorials on Tekton!
   - [TaskRun Logic](./taskruns.md): How TaskRuns are run in pods.
   - [Resources Labeling](./resources-labelling.md): Labels applied to Tekton resources.
   - [Multi-Tenant Support](./multi-tenant-support.md): Running Tekton in multi-tenant configurations.
+  - [Informer Cache Transform](../tekton-controller-performance-configuration.md#informer-cache-transform-memory-optimization): Memory optimization that strips fields from cached objects.
 - [API Versioning](./api-versioning.md): How Tekton supports multiple API versions and feature gates.
 - How specific features are implemented:
   - [Results](./results-lifecycle.md)

--- a/docs/developers/controller-logic.md
+++ b/docs/developers/controller-logic.md
@@ -51,6 +51,14 @@ The Knative [docs on dependency injection](https://github.com/knative/pkg/tree/m
 for generated reconcilers and webhooks, as well as the concept of ["informers"](https://github.com/knative/pkg/tree/main/injection#consuming-informers),
 which notify the reconcilers about other objects in the cluster.
 
+> **Note on Informer Cache Transforms**: Tekton applies [cache transform functions](../tekton-controller-performance-configuration.md#informer-cache-transform-memory-optimization)
+> to reduce memory usage. Objects retrieved from the informer cache (via listers) have large, unnecessary metadata
+> fields stripped (`managedFields` and the `last-applied-configuration` annotation). Only the controller's in-memory
+> cache is affected; the full objects always remain in etcd.
+>
+> **Developer Warning**: If you add reconciliation logic that reads a field from cached objects, verify that field
+> is not stripped by the transform. See `internal/reconciler/cachetransform/` for the complete list of stripped fields.
+
 #### Example: How does the TaskRun reconciler work?
 
 Please read ["Generated reconciler responsibilities"](https://github.com/knative/pkg/tree/main/injection#generated-reconciler-responsibilities)
@@ -70,3 +78,37 @@ It creates a pod to run the TaskRun and exits the reconcile loop.
 Later, the pod completes, resulting in another event that triggers reconciliation of the TaskRun that owns it.
 The reconciler sees that the TaskRun has a pod associated with it, and that the pod has completed. It updates the TaskRun status to mark it as completed
 and exits the reconcile loop.
+
+### Informer Cache Transforms
+
+To reduce controller memory usage, Tekton applies cache transform functions that strip unnecessary fields from objects before they are stored in the informer cache. This is implemented in `internal/reconciler/cachetransform/`.
+
+These transforms only affect the controller's **in-memory** informer cache; the full objects always remain in etcd.
+
+#### How It Works
+
+The `cachetransform.Setup` helper is called from the TaskRun and PipelineRun controller constructors (`NewController`). It calls `SharedIndexInformer.SetTransform` on the relevant informers so that objects are transformed as they enter the cache. Wiring it from the controllers (rather than globally) keeps the behaviour visible at the call sites.
+
+#### Fields Stripped
+
+**All cached objects** (PipelineRuns, TaskRuns, CustomRuns, Pods):
+- `metadata.managedFields` - Server-side apply metadata (can be 25-30% of object size)
+- `kubectl.kubernetes.io/last-applied-configuration` annotation
+
+No other fields are stripped. In particular, status fields are **not** stripped from completed objects, because several of them are still read from the cache after completion — for example `TaskRun.status.taskSpec` (read by the parent PipelineRun on every reconcile), `TaskRun.status.steps`/`status.sidecars` (used by `retryTaskRun()` and sidecar stop handling), and `PipelineRun.status.pipelineSpec` (needed once Pipelines-in-Pipelines result propagation lands). Stripping additional fields is being evaluated separately.
+
+#### Configuration
+
+The transforms are enabled by default and can be disabled by setting `enable-informer-cache-transforms: "false"` in the `feature-flags` ConfigMap. Changes require a controller restart.
+
+#### Developer Guidelines
+
+When adding new reconciliation logic:
+
+1. **Check if the field is stripped**: Review `internal/reconciler/cachetransform/` to see if the field you need is stripped from cached objects.
+
+2. **Use the API client for stripped fields**: If you need a stripped field, use the Kubernetes API client directly instead of the lister to get the full object from etcd.
+
+3. **Update transforms if needed**: If a field should not be stripped because it's needed for reconciliation, update the transform functions and add tests.
+
+4. **Consider memory impact**: Before stripping additional fields, verify they are never read from the cache, and weigh the memory savings against the added risk.

--- a/docs/tekton-controller-performance-configuration.md
+++ b/docs/tekton-controller-performance-configuration.md
@@ -11,6 +11,9 @@ Configure ThreadsPerController, QPS and Burst
 - [Overview](#overview)
 - [Performance Configuration](#performance-configuration)
   - [Configure Thread, QPS and Burst](#configure-thread-qps-and-burst)
+- [Informer Cache Transform (Memory Optimization)](#informer-cache-transform-memory-optimization)
+  - [Configuration](#configuration)
+  - [Important Notes](#important-notes)
 
 ## Overview
 
@@ -55,3 +58,37 @@ If flags and environment variables are set, command line args will take preceden
 **Note**:
 <!-- wokeignore:rule=master -->
 Although in above example, you set QPS and Burst to be `50` and `50`. However, the actual values of them are [multiplied by `2`](https://github.com/pierretasci/pipeline/blob/master/cmd/controller/main.go#L83-L84), so the actual QPS and Burst is `100` and `100`.
+
+## Informer Cache Transform (Memory Optimization)
+
+---
+
+The Tekton controller uses informer caches to watch and react to changes in Kubernetes objects. To reduce memory usage, Tekton Pipeline applies **cache transform functions** that strip large, unnecessary metadata fields from objects before they are stored in the informer cache.
+
+This optimization is **enabled by default**. It strips `managedFields` (server-side apply metadata, which can be 25-30% of an object's size) and the `kubectl.kubernetes.io/last-applied-configuration` annotation from cached PipelineRuns, TaskRuns, CustomRuns, and Pods.
+
+### Configuration
+
+The cache transforms are **enabled by default**. To disable them (e.g., for troubleshooting), set `enable-informer-cache-transforms` to `false` in the `feature-flags` ConfigMap:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: feature-flags
+  namespace: tekton-pipelines
+data:
+  enable-informer-cache-transforms: "false"
+```
+
+**Note:** Changes to this setting require a controller restart to take effect.
+
+### Important Notes
+
+1. **Read-only optimization**: The transform only affects what is stored in the in-memory cache. The complete objects remain unchanged in etcd.
+
+2. **No impact on API access**: When you use `kubectl get` or the Kubernetes API, you always get the complete object from etcd, not the cached version.
+
+3. **Controller behavior unchanged**: The controller reconciliation logic continues to work correctly because it only needs the preserved fields.
+
+For detailed technical information about which fields are stripped, see the [developer documentation](developers/controller-logic.md).

--- a/internal/reconciler/cachetransform/cachetransform.go
+++ b/internal/reconciler/cachetransform/cachetransform.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package cachetransform provides cache transform functions for reducing memory
+// usage in the Tekton Pipeline controller informer caches.
+//
+// Transform functions are applied to objects before they are stored in the
+// informer cache, allowing us to strip large, unnecessary fields while
+// preserving the data needed for reconciliation. They only affect the
+// controller's in-memory informer cache; the full objects always remain in
+// etcd.
+//
+// The transforms are wired into the TaskRun and PipelineRun controllers via
+// Setup (see setup.go), which calls SharedIndexInformer.SetTransform.
+//
+// Scope: these transforms currently strip only universally-safe metadata
+// fields (managedFields and the kubectl last-applied-configuration annotation).
+// Stripping status fields from completed objects was intentionally deferred:
+// several of those fields (TaskRun status.taskSpec/steps/sidecars and
+// PipelineRun status.pipelineSpec) are still read from cache after completion
+// (by the parent PipelineRun, by retryTaskRun, by stopSidecars, and by upcoming
+// Pipelines-in-Pipelines result propagation).
+//
+// DEVELOPER WARNING:
+// If you add new reconciliation logic that reads a field from cached objects
+// (via listers), you MUST verify that field is not stripped by these transforms.
+// Fields stripped from cached objects will be nil/empty even though they exist
+// in etcd. If you need a stripped field, either:
+//  1. Use the Kubernetes API client directly to fetch the full object from etcd, or
+//  2. Update the transform functions to preserve the field (consider memory impact).
+//
+// See docs/developers/controller-logic.md for more details.
+package cachetransform
+
+import (
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+const (
+	// LastAppliedConfigAnnotation is the annotation used by kubectl to store
+	// the last applied configuration. This can be very large and is not needed
+	// in the cache.
+	LastAppliedConfigAnnotation = "kubectl.kubernetes.io/last-applied-configuration"
+)
+
+// ForTektonResource is a cache.TransformFunc that strips unnecessary metadata
+// fields from cached PipelineRuns, TaskRuns and CustomRuns to reduce memory
+// usage.
+//
+// Objects that are not PipelineRuns, TaskRuns or CustomRuns are passed through
+// unchanged. Tombstone objects (DeletedFinalStateUnknown) are unwrapped,
+// transformed, and rewrapped.
+func ForTektonResource(obj interface{}) (interface{}, error) {
+	if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+		transformed, err := ForTektonResource(tombstone.Obj)
+		if err != nil {
+			return obj, nil //nolint:nilerr // Intentional: return original object on error for graceful degradation
+		}
+		return cache.DeletedFinalStateUnknown{Key: tombstone.Key, Obj: transformed}, nil
+	}
+
+	switch o := obj.(type) {
+	case *v1.PipelineRun:
+		stripMetadata(&o.ObjectMeta)
+		return o, nil
+	case *v1.TaskRun:
+		stripMetadata(&o.ObjectMeta)
+		return o, nil
+	case *v1beta1.CustomRun:
+		stripMetadata(&o.ObjectMeta)
+		return o, nil
+	default:
+		return obj, nil
+	}
+}
+
+// ForPod is a cache.TransformFunc that strips unnecessary metadata fields from
+// cached Pods to reduce memory usage in the TaskRun controller.
+//
+// Only universally-safe metadata is stripped; the Pod spec and status are left
+// intact. Tombstone objects (DeletedFinalStateUnknown) are unwrapped,
+// transformed, and rewrapped.
+func ForPod(obj interface{}) (interface{}, error) {
+	if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+		transformed, err := ForPod(tombstone.Obj)
+		if err != nil {
+			return obj, nil //nolint:nilerr // Intentional: return original object on error for graceful degradation
+		}
+		return cache.DeletedFinalStateUnknown{Key: tombstone.Key, Obj: transformed}, nil
+	}
+
+	if pod, ok := obj.(*corev1.Pod); ok {
+		stripMetadata(&pod.ObjectMeta)
+		return pod, nil
+	}
+
+	return obj, nil
+}
+
+// stripMetadata removes universally-safe, large metadata fields that are never
+// read from the cache by any reconciler:
+//   - managedFields (can be 25-30% of object size)
+//   - the kubectl last-applied-configuration annotation
+//
+// delete on a nil map is a no-op, so no nil check is needed for Annotations.
+func stripMetadata(meta *metav1.ObjectMeta) {
+	meta.ManagedFields = nil
+	delete(meta.Annotations, LastAppliedConfigAnnotation)
+}

--- a/internal/reconciler/cachetransform/cachetransform_test.go
+++ b/internal/reconciler/cachetransform/cachetransform_test.go
@@ -1,0 +1,248 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cachetransform
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+)
+
+func managedFields() []metav1.ManagedFieldsEntry {
+	return []metav1.ManagedFieldsEntry{{
+		Manager:    "kubectl",
+		Operation:  metav1.ManagedFieldsOperationUpdate,
+		APIVersion: "tekton.dev/v1",
+	}}
+}
+
+func annotations() map[string]string {
+	return map[string]string{
+		LastAppliedConfigAnnotation: `{"large":"json"}`,
+		"tekton.dev/keep":           "yes",
+	}
+}
+
+// assertStrippedMetadata verifies the universally-safe metadata fields were
+// stripped while other annotations were preserved.
+func assertStrippedMetadata(t *testing.T, meta metav1.ObjectMeta) {
+	t.Helper()
+	if meta.ManagedFields != nil {
+		t.Errorf("expected ManagedFields to be stripped, got %v", meta.ManagedFields)
+	}
+	if _, exists := meta.Annotations[LastAppliedConfigAnnotation]; exists {
+		t.Errorf("expected %s annotation to be stripped", LastAppliedConfigAnnotation)
+	}
+	if got := meta.Annotations["tekton.dev/keep"]; got != "yes" {
+		t.Errorf("expected unrelated annotation to be preserved, got %q", got)
+	}
+}
+
+func TestForTektonResource_StripsMetadata(t *testing.T) {
+	doneStatus := duckv1.Status{Conditions: duckv1.Conditions{{
+		Type:   apis.ConditionSucceeded,
+		Status: corev1.ConditionTrue,
+	}}}
+
+	tests := []struct {
+		name string
+		obj  interface{}
+		meta func(interface{}) metav1.ObjectMeta
+	}{{
+		name: "completed PipelineRun keeps pipelineSpec",
+		obj: &v1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{ManagedFields: managedFields(), Annotations: annotations()},
+			Status: v1.PipelineRunStatus{
+				Status:                  doneStatus,
+				PipelineRunStatusFields: v1.PipelineRunStatusFields{PipelineSpec: &v1.PipelineSpec{}},
+			},
+		},
+		meta: func(o interface{}) metav1.ObjectMeta { return o.(*v1.PipelineRun).ObjectMeta },
+	}, {
+		name: "completed TaskRun keeps taskSpec/steps/sidecars",
+		obj: &v1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{ManagedFields: managedFields(), Annotations: annotations()},
+			Status: v1.TaskRunStatus{
+				Status: doneStatus,
+				TaskRunStatusFields: v1.TaskRunStatusFields{
+					TaskSpec: &v1.TaskSpec{},
+					Steps:    []v1.StepState{{Name: "step1"}},
+					Sidecars: []v1.SidecarState{{Name: "sidecar1"}},
+				},
+			},
+		},
+		meta: func(o interface{}) metav1.ObjectMeta { return o.(*v1.TaskRun).ObjectMeta },
+	}, {
+		name: "completed CustomRun",
+		obj: &v1beta1.CustomRun{
+			ObjectMeta: metav1.ObjectMeta{ManagedFields: managedFields(), Annotations: annotations()},
+			Status:     v1beta1.CustomRunStatus{Status: doneStatus},
+		},
+		meta: func(o interface{}) metav1.ObjectMeta { return o.(*v1beta1.CustomRun).ObjectMeta },
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := ForTektonResource(tc.obj)
+			if err != nil {
+				t.Fatalf("ForTektonResource returned error: %v", err)
+			}
+			assertStrippedMetadata(t, tc.meta(out))
+		})
+	}
+}
+
+func TestForTektonResource_PreservesLoadBearingStatusFields(t *testing.T) {
+	done := duckv1.Status{Conditions: duckv1.Conditions{{Type: apis.ConditionSucceeded, Status: corev1.ConditionTrue}}}
+
+	t.Run("PipelineRun pipelineSpec", func(t *testing.T) {
+		pr := &v1.PipelineRun{Status: v1.PipelineRunStatus{
+			Status:                  done,
+			PipelineRunStatusFields: v1.PipelineRunStatusFields{PipelineSpec: &v1.PipelineSpec{}},
+		}}
+		out, _ := ForTektonResource(pr)
+		if out.(*v1.PipelineRun).Status.PipelineSpec == nil {
+			t.Error("expected completed PipelineRun.Status.PipelineSpec to be preserved")
+		}
+	})
+
+	t.Run("TaskRun taskSpec/steps/sidecars", func(t *testing.T) {
+		tr := &v1.TaskRun{Status: v1.TaskRunStatus{
+			Status: done,
+			TaskRunStatusFields: v1.TaskRunStatusFields{
+				TaskSpec: &v1.TaskSpec{},
+				Steps:    []v1.StepState{{Name: "step1"}},
+				Sidecars: []v1.SidecarState{{Name: "sidecar1"}},
+			},
+		}}
+		out, _ := ForTektonResource(tr)
+		st := out.(*v1.TaskRun).Status
+		if st.TaskSpec == nil {
+			t.Error("expected completed TaskRun.Status.TaskSpec to be preserved")
+		}
+		if len(st.Steps) != 1 {
+			t.Error("expected completed TaskRun.Status.Steps to be preserved")
+		}
+		if len(st.Sidecars) != 1 {
+			t.Error("expected completed TaskRun.Status.Sidecars to be preserved")
+		}
+	})
+}
+
+func TestForTektonResource_PassesThroughUnknownObjects(t *testing.T) {
+	in := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cm"}}
+	out, err := ForTektonResource(in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if diff := cmp.Diff(in, out); diff != "" {
+		t.Errorf("expected unknown object to pass through unchanged (-want +got):\n%s", diff)
+	}
+}
+
+func TestForTektonResource_HandlesTombstones(t *testing.T) {
+	tombstone := cache.DeletedFinalStateUnknown{
+		Key: "ns/pr",
+		Obj: &v1.PipelineRun{ObjectMeta: metav1.ObjectMeta{ManagedFields: managedFields(), Annotations: annotations()}},
+	}
+	out, err := ForTektonResource(tombstone)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	wrapped, ok := out.(cache.DeletedFinalStateUnknown)
+	if !ok {
+		t.Fatalf("expected DeletedFinalStateUnknown, got %T", out)
+	}
+	if wrapped.Key != "ns/pr" {
+		t.Errorf("expected tombstone key preserved, got %q", wrapped.Key)
+	}
+	assertStrippedMetadata(t, wrapped.Obj.(*v1.PipelineRun).ObjectMeta)
+}
+
+func TestForPod_StripsMetadataAndPreservesSpecStatus(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "pod",
+			Namespace:       "ns",
+			ManagedFields:   managedFields(),
+			Annotations:     annotations(),
+			Labels:          map[string]string{"app": "tekton"},
+			OwnerReferences: []metav1.OwnerReference{{Name: "owner"}},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "step-a", Image: "img"}},
+			Volumes:    []corev1.Volume{{Name: "ws"}},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodSucceeded},
+	}
+
+	out, err := ForPod(pod)
+	if err != nil {
+		t.Fatalf("ForPod returned error: %v", err)
+	}
+	got := out.(*corev1.Pod)
+
+	assertStrippedMetadata(t, got.ObjectMeta)
+	// Required metadata preserved.
+	if got.Labels["app"] != "tekton" {
+		t.Error("expected Labels to be preserved")
+	}
+	if len(got.OwnerReferences) != 1 {
+		t.Error("expected OwnerReferences to be preserved")
+	}
+	// Spec and status preserved (only metadata is stripped).
+	if diff := cmp.Diff(pod.Spec, got.Spec); diff != "" {
+		t.Errorf("expected Pod.Spec preserved (-want +got):\n%s", diff)
+	}
+	if got.Status.Phase != corev1.PodSucceeded {
+		t.Error("expected Pod.Status to be preserved")
+	}
+}
+
+func TestForPod_PassesThroughNonPods(t *testing.T) {
+	in := &v1.TaskRun{ObjectMeta: metav1.ObjectMeta{Name: "tr"}}
+	out, err := ForPod(in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if diff := cmp.Diff(in, out); diff != "" {
+		t.Errorf("expected non-pod to pass through unchanged (-want +got):\n%s", diff)
+	}
+}
+
+func TestForPod_HandlesTombstones(t *testing.T) {
+	tombstone := cache.DeletedFinalStateUnknown{
+		Key: "ns/pod",
+		Obj: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{ManagedFields: managedFields(), Annotations: annotations()}},
+	}
+	out, err := ForPod(tombstone)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	wrapped, ok := out.(cache.DeletedFinalStateUnknown)
+	if !ok {
+		t.Fatalf("expected DeletedFinalStateUnknown, got %T", out)
+	}
+	assertStrippedMetadata(t, wrapped.Obj.(*corev1.Pod).ObjectMeta)
+}

--- a/internal/reconciler/cachetransform/setup.go
+++ b/internal/reconciler/cachetransform/setup.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cachetransform
+
+import (
+	"context"
+	"strconv"
+	"sync"
+
+	"github.com/tektoncd/pipeline/pkg/apis/config"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
+	"knative.dev/pkg/logging"
+	"knative.dev/pkg/system"
+)
+
+// featureFlag is the feature-flags ConfigMap key that toggles the cache
+// transforms. It is enabled by default; operators can opt out by setting it to
+// "false". Changes require a controller restart to take effect.
+const featureFlag = "enable-informer-cache-transforms"
+
+var (
+	// enabledOnce ensures we only read the ConfigMap once at startup.
+	enabledOnce sync.Once
+	// enabledValue caches the result of the ConfigMap check.
+	enabledValue bool
+)
+
+// Setup applies a cache transform to an informer if the feature is enabled.
+//
+// It must be called before the informer starts (i.e. in the controller's
+// NewController constructor). SetTransform returns an error only if the
+// informer has already started, which would be a programming error, so we fail
+// fast. When called multiple times on the same informer the last call wins;
+// this is harmless because all callers use the same transform function.
+func Setup(ctx context.Context, informer cache.SharedIndexInformer, transformFn cache.TransformFunc) {
+	if !enabled(ctx) {
+		return
+	}
+	if err := informer.SetTransform(transformFn); err != nil {
+		logging.FromContext(ctx).Fatalf("Failed to set informer cache transform: %v", err)
+	}
+}
+
+// enabled reports whether informer cache transforms are enabled, reading the
+// enable-informer-cache-transforms key from the feature-flags ConfigMap.
+//
+// The ConfigMap is read directly via the Kubernetes API because Setup runs
+// during controller construction, before the config store is attached to
+// context. The result is cached with sync.Once since the value cannot change
+// without a controller restart and Setup is called for several informers.
+func enabled(ctx context.Context) bool {
+	enabledOnce.Do(func() {
+		enabledValue = readEnabledFromConfigMap(ctx)
+		if enabledValue {
+			logging.FromContext(ctx).Info("Informer cache transforms enabled")
+		} else {
+			logging.FromContext(ctx).Info("Informer cache transforms disabled")
+		}
+	})
+	return enabledValue
+}
+
+// readEnabledFromConfigMap reads the feature flag from the feature-flags
+// ConfigMap, defaulting to enabled when the ConfigMap or key is missing or
+// invalid.
+func readEnabledFromConfigMap(ctx context.Context) bool {
+	logger := logging.FromContext(ctx)
+	kubeClient := kubeclient.Get(ctx)
+
+	cm, err := kubeClient.CoreV1().ConfigMaps(system.Namespace()).Get(ctx, config.GetFeatureFlagsConfigName(), metav1.GetOptions{})
+	if err != nil {
+		logger.Warnw("Failed to read feature-flags ConfigMap, defaulting to enabled informer cache transforms", "error", err)
+		return true
+	}
+
+	val, ok := cm.Data[featureFlag]
+	if !ok {
+		return true
+	}
+
+	enabled, err := strconv.ParseBool(val)
+	if err != nil {
+		logger.Warnw("Invalid value for "+featureFlag+", defaulting to enabled", "value", val, "error", err)
+		return true
+	}
+	return enabled
+}

--- a/pkg/reconciler/pipelinerun/controller.go
+++ b/pkg/reconciler/pipelinerun/controller.go
@@ -19,6 +19,7 @@ package pipelinerun
 import (
 	"context"
 
+	"github.com/tektoncd/pipeline/internal/reconciler/cachetransform"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
@@ -69,6 +70,14 @@ func NewController(opts *pipeline.Options, clock clock.PassiveClock) func(contex
 		taskRunInformer := taskruninformer.Get(ctx)
 		customRunInformer := customruninformer.Get(ctx)
 		pipelineRunInformer := pipelineruninformer.Get(ctx)
+
+		// NOTE: a cache transform strips non-mandatory fields from the cached
+		// PipelineRuns, TaskRuns and CustomRuns to reduce controller memory usage.
+		// If you add logic that reads a field from these listers, verify it is not
+		// stripped. See internal/reconciler/cachetransform.
+		cachetransform.Setup(ctx, pipelineRunInformer.Informer(), cachetransform.ForTektonResource)
+		cachetransform.Setup(ctx, taskRunInformer.Informer(), cachetransform.ForTektonResource)
+		cachetransform.Setup(ctx, customRunInformer.Informer(), cachetransform.ForTektonResource)
 		resolutionInformer := resolutioninformer.Get(ctx)
 		verificationpolicyInformer := verificationpolicyinformer.Get(ctx)
 		secretinformer := secretinformer.Get(ctx)

--- a/pkg/reconciler/taskrun/controller.go
+++ b/pkg/reconciler/taskrun/controller.go
@@ -19,6 +19,7 @@ package taskrun
 import (
 	"context"
 
+	"github.com/tektoncd/pipeline/internal/reconciler/cachetransform"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
@@ -70,6 +71,13 @@ func NewController(opts *pipeline.Options, clock clock.PassiveClock) func(contex
 		pipelineclientset := pipelineclient.Get(ctx)
 		taskRunInformer := taskruninformer.Get(ctx)
 		podInformer := filteredpodinformer.Get(ctx, v1.ManagedByLabelKey)
+
+		// NOTE: a cache transform strips non-mandatory fields from the cached
+		// TaskRuns and Pods to reduce controller memory usage. If you add logic
+		// that reads a field from these listers, verify it is not stripped.
+		// See internal/reconciler/cachetransform.
+		cachetransform.Setup(ctx, taskRunInformer.Informer(), cachetransform.ForTektonResource)
+		cachetransform.Setup(ctx, podInformer.Informer(), cachetransform.ForPod)
 		limitrangeInformer := limitrangeinformer.Get(ctx)
 		verificationpolicyInformer := verificationpolicyinformer.Get(ctx)
 		resolutionInformer := resolutioninformer.Get(ctx)


### PR DESCRIPTION
# Changes

Add a cache transform that strips unnecessary fields from PipelineRuns, TaskRuns, CustomRuns and Pods before they are stored in the informer cache. This reduces memory usage for controllers processing large numbers of runs.

**What gets stripped:**

From all objects (PipelineRuns, TaskRuns, CustomRuns, Pods):
- `managedFields` (can be 25-30% of object size)
- `kubectl.kubernetes.io/last-applied-configuration` annotation

Fixes: #7691

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Add informer cache transform to reduce controller memory usage by stripping unnecessary fields (managedFields and last-applied-configuration from completed runs).
```