### PR TITLE
chore(ci): update cherry-pick workflow to fix multi-commit PRs

### DIFF
--- a/.github/workflows/cherry-pick-command.yaml
+++ b/.github/workflows/cherry-pick-command.yaml
@@ -27,6 +27,6 @@ permissions:
 jobs:
   cherry-pick:
     name: Cherry Pick Actions
-    uses: tektoncd/plumbing/.github/workflows/_cherry-pick-command.yaml@4b57443b85569e5bb7d9ee440bf5cae99cb642cb  # main
+    uses: tektoncd/plumbing/.github/workflows/_cherry-pick-command.yaml@03501984b53f82be58454f64218ea5c3122b898e  # main
     secrets:
       CHATOPS_TOKEN: ${{ secrets.CHATOPS_TOKEN }}


### PR DESCRIPTION
# Changes

Updates the cherry-pick workflow reference from plumbing to include
the fix for cherry-picking all commits from rebase-merged PRs.

Previously, the `/cherry-pick` command would only cherry-pick the last commit
from PRs with multiple commits. Now it properly cherry-picks all commits in order.

See: tektoncd/plumbing#3063

/kind bug

# Submitter Checklist

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)