### PR TITLE
feat: Add secret masking to step logs

### DIFF
--- a/cmd/entrypoint/main.go
+++ b/cmd/entrypoint/main.go
@@ -56,6 +56,7 @@ var (
 		" Set to \"stopAndFail\" to declare a failure with a step error and stop executing the rest of the steps.")
 	stepMetadataDir        = flag.String("step_metadata_dir", "", "If specified, create directory to store the step metadata e.g. /tekton/steps/<step-name>/")
 	resultExtractionMethod = flag.String("result_from", entrypoint.ResultExtractionMethodTerminationMessage, "The method using which to extract results from tasks. Default is using the termination message.")
+	secretMaskFile         = flag.String("secret_mask_file", "", "If specified, file containing base64-encoded secrets to mask in stdout/stderr (one per line)")
 )
 
 const (
@@ -135,8 +136,9 @@ func main() {
 		TerminationPath: *terminationPath,
 		Waiter:          &realWaiter{waitPollingInterval: defaultWaitPollingInterval, breakpointOnFailure: *breakpointOnFailure},
 		Runner: &realRunner{
-			stdoutPath: *stdoutPath,
-			stderrPath: *stderrPath,
+			stdoutPath:     *stdoutPath,
+			stderrPath:     *stderrPath,
+			secretMaskFile: *secretMaskFile,
 		},
 		PostWriter:             &realPostWriter{},
 		Results:                strings.Split(*results, ","),

--- a/cmd/entrypoint/masking_writer.go
+++ b/cmd/entrypoint/masking_writer.go
@@ -1,0 +1,155 @@
+//go:build !windows
+
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"io"
+	"sort"
+)
+
+const maskReplacement = "***"
+
+type maskingWriter struct {
+	underlying    io.Writer
+	secrets       [][]byte
+	maxSecretLen  int
+	carry         []byte
+	maskTokenByte []byte
+}
+
+func newMaskingWriter(w io.Writer, secrets []string) *maskingWriter {
+	mw := &maskingWriter{
+		underlying:    w,
+		maskTokenByte: []byte(maskReplacement),
+	}
+
+	secretBytes := make([][]byte, 0, len(secrets))
+	for _, s := range secrets {
+		if len(s) >= 3 {
+			secret := []byte(s)
+			secretBytes = append(secretBytes, secret)
+			if len(secret) > mw.maxSecretLen {
+				mw.maxSecretLen = len(secret)
+			}
+		}
+	}
+
+	sort.Slice(secretBytes, func(i, j int) bool {
+		if len(secretBytes[i]) == len(secretBytes[j]) {
+			return bytes.Compare(secretBytes[i], secretBytes[j]) < 0
+		}
+		return len(secretBytes[i]) > len(secretBytes[j])
+	})
+	mw.secrets = secretBytes
+
+	if mw.maxSecretLen > 1 {
+		mw.carry = make([]byte, 0, mw.maxSecretLen-1)
+	}
+	return mw
+}
+
+func (m *maskingWriter) MaxSecretLen() int {
+	return m.maxSecretLen
+}
+
+func (m *maskingWriter) Write(p []byte) (n int, err error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	if m.maxSecretLen == 0 {
+		_, err = m.underlying.Write(p)
+		return len(p), err
+	}
+
+	m.carry = append(m.carry, p...)
+
+	hold := m.maxSecretLen - 1
+	safeEmitUntil := len(m.carry) - hold
+	if safeEmitUntil <= 0 {
+		return len(p), nil
+	}
+
+	var out bytes.Buffer
+	for {
+		safeEmitUntil = len(m.carry) - hold
+		if safeEmitUntil <= 0 {
+			break
+		}
+
+		matchStart, matchLen, ok := m.findEarliestMatch(m.carry)
+		if !ok || matchStart >= safeEmitUntil {
+			out.Write(m.carry[:safeEmitUntil])
+			m.carry = append(m.carry[:0], m.carry[safeEmitUntil:]...)
+			break
+		}
+
+		out.Write(m.carry[:matchStart])
+		out.Write(m.maskTokenByte)
+		m.carry = append(m.carry[:0], m.carry[matchStart+matchLen:]...)
+	}
+
+	if out.Len() > 0 {
+		_, err = m.underlying.Write(out.Bytes())
+	}
+	return len(p), err
+}
+
+func (m *maskingWriter) Flush() error {
+	if len(m.carry) == 0 {
+		return nil
+	}
+	var out bytes.Buffer
+	for len(m.carry) > 0 {
+		matchStart, matchLen, ok := m.findEarliestMatch(m.carry)
+		if !ok {
+			out.Write(m.carry)
+			m.carry = m.carry[:0]
+			break
+		}
+		out.Write(m.carry[:matchStart])
+		out.Write(m.maskTokenByte)
+		m.carry = append(m.carry[:0], m.carry[matchStart+matchLen:]...)
+	}
+	_, err := m.underlying.Write(out.Bytes())
+	m.carry = m.carry[:0]
+	return err
+}
+
+func (m *maskingWriter) findEarliestMatch(data []byte) (start int, matchLen int, found bool) {
+	bestStart := -1
+	bestLen := 0
+	for _, secret := range m.secrets {
+		idx := bytes.Index(data, secret)
+		if idx == -1 {
+			continue
+		}
+		if bestStart == -1 || idx < bestStart || (idx == bestStart && len(secret) > bestLen) {
+			bestStart = idx
+			bestLen = len(secret)
+		}
+		if bestStart == 0 && bestLen == m.maxSecretLen {
+			break
+		}
+	}
+	if bestStart == -1 {
+		return 0, 0, false
+	}
+	return bestStart, bestLen, true
+}

--- a/cmd/entrypoint/masking_writer_test.go
+++ b/cmd/entrypoint/masking_writer_test.go
@@ -1,0 +1,191 @@
+//go:build !windows
+
+/*
+Copyright 2025 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestMaskingWriter(t *testing.T) {
+	testCases := []struct {
+		name     string
+		secrets  []string
+		input    string
+		expected string
+	}{
+		{
+			name:     "no secrets",
+			secrets:  nil,
+			input:    "hello world",
+			expected: "hello world",
+		},
+		{
+			name:     "single secret",
+			secrets:  []string{"password123"},
+			input:    "The password is password123!",
+			expected: "The password is ***!",
+		},
+		{
+			name:     "multiple secrets",
+			secrets:  []string{"secret1", "secret2"},
+			input:    "secret1 and secret2 are here",
+			expected: "*** and *** are here",
+		},
+		{
+			name:     "short secret skipped",
+			secrets:  []string{"ab"},
+			input:    "ab ab ab", //nolint:dupword // intentional test data with repeated words
+			expected: "ab ab ab", //nolint:dupword // intentional test data with repeated words
+		},
+		{
+			name:     "repeated secret",
+			secrets:  []string{"token"},
+			input:    "token token token", //nolint:dupword // intentional test data with repeated words
+			expected: "*** *** ***",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			w := newMaskingWriter(&buf, tc.secrets)
+			if _, err := w.Write([]byte(tc.input)); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if err := w.Flush(); err != nil {
+				t.Fatalf("unexpected flush error: %v", err)
+			}
+			if got := buf.String(); got != tc.expected {
+				t.Errorf("got %q, want %q", got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestMaskingWriterSplitAcrossWrites(t *testing.T) {
+	var buf bytes.Buffer
+	w := newMaskingWriter(&buf, []string{"supersecretpassword"})
+
+	if _, err := w.Write([]byte("prefix supersecret")); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := w.Write([]byte("password suffix")); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatalf("unexpected flush error: %v", err)
+	}
+
+	if got, want := buf.String(), "prefix *** suffix"; got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestMaskingWriterLargeSecretAcrossChunks(t *testing.T) {
+	secret := strings.Repeat("s", 70000)
+	var buf bytes.Buffer
+	w := newMaskingWriter(&buf, []string{secret})
+
+	prefix := "start "
+	if _, err := w.Write([]byte(prefix)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for i := 0; i < len(secret); i += 8192 {
+		end := i + 8192
+		if end > len(secret) {
+			end = len(secret)
+		}
+		if _, err := w.Write([]byte(secret[i:end])); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+	suffix := " end"
+	if _, err := w.Write([]byte(suffix)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatalf("unexpected flush error: %v", err)
+	}
+
+	got := buf.String()
+	if strings.Contains(got, secret) {
+		t.Fatal("expected long secret to be masked")
+	}
+	want := prefix + "***" + suffix
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestMaskingWriterOverlappingSecrets(t *testing.T) {
+	var buf bytes.Buffer
+	w := newMaskingWriter(&buf, []string{"abc", "abcdef"})
+
+	if _, err := w.Write([]byte("abcdef")); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatalf("unexpected flush error: %v", err)
+	}
+
+	if got, want := buf.String(), "***"; got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestLoadSecretsForMasking(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "secrets")
+	content := "c2VjcmV0MQ==\ncGFzc3dvcmQ=\n"
+	if err := os.WriteFile(filePath, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	got, err := loadSecretsForMasking(filePath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := map[string]bool{"secret1": true, "password": true}
+	for _, s := range got {
+		if !expected[s] {
+			t.Fatalf("unexpected secret: %s", s)
+		}
+		delete(expected, s)
+	}
+	if len(expected) != 0 {
+		t.Fatalf("missing secrets: %v", expected)
+	}
+}
+
+func TestLoadSecretsForMaskingInvalidLine(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "secrets")
+	if err := os.WriteFile(filePath, []byte("not-base64\n"), 0644); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	if _, err := loadSecretsForMasking(filePath); err == nil {
+		t.Fatalf("expected error")
+	}
+}

--- a/cmd/entrypoint/runner_windows.go
+++ b/cmd/entrypoint/runner_windows.go
@@ -32,8 +32,9 @@ import (
 
 // realRunner actually runs commands.
 type realRunner struct {
-	stdoutPath string
-	stderrPath string
+	stdoutPath     string
+	stderrPath     string
+	secretMaskFile string
 }
 
 var _ entrypoint.Runner = (*realRunner)(nil)
@@ -41,6 +42,9 @@ var _ entrypoint.Runner = (*realRunner)(nil)
 func (rr *realRunner) Run(ctx context.Context, args ...string) error {
 	if rr.stdoutPath != "" || rr.stderrPath != "" {
 		return errors.New("step.StdoutPath and step.StderrPath not supported on Windows")
+	}
+	if rr.secretMaskFile != "" {
+		return errors.New("secret masking is not supported on Windows")
 	}
 	if len(args) == 0 {
 		return nil

--- a/cmd/entrypoint/subcommands/secret_mask_init.go
+++ b/cmd/entrypoint/subcommands/secret_mask_init.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2025 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package subcommands
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// SecretMaskInitCommand is the name of the secret mask initialization command
+const SecretMaskInitCommand = "secret-mask-init"
+
+// SecretMaskDataEnvVar is the env var containing base64(gzip(secret mask data)).
+const SecretMaskDataEnvVar = "TEKTON_SECRET_MASK_DATA" //nolint:gosec // G101: not a hardcoded credential, just a variable name
+
+// secretMaskInit decodes and writes the secret mask data to the specified file path.
+func secretMaskInit(filePath string) error {
+	data := os.Getenv(SecretMaskDataEnvVar)
+	if data == "" {
+		return fmt.Errorf("environment variable %s is not set", SecretMaskDataEnvVar)
+	}
+
+	compressedData, err := base64.StdEncoding.DecodeString(data)
+	if err != nil {
+		return fmt.Errorf("decode %s: %w", SecretMaskDataEnvVar, err)
+	}
+	gzr, err := gzip.NewReader(bytes.NewReader(compressedData))
+	if err != nil {
+		return fmt.Errorf("decompress %s: %w", SecretMaskDataEnvVar, err)
+	}
+	decodedData, readErr := io.ReadAll(gzr)
+	closeErr := gzr.Close()
+	if readErr != nil {
+		return fmt.Errorf("read decompressed %s: %w", SecretMaskDataEnvVar, readErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("close decompressed %s: %w", SecretMaskDataEnvVar, closeErr)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
+		return err
+	}
+	return os.WriteFile(filePath, decodedData, 0444) //nolint:gosec // G306: intentionally world-readable, contains non-sensitive mask patterns
+}

--- a/cmd/entrypoint/subcommands/secret_mask_init_test.go
+++ b/cmd/entrypoint/subcommands/secret_mask_init_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package subcommands
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSecretMaskInit(t *testing.T) {
+	for _, tt := range []struct {
+		name        string
+		envValue    string
+		wantErr     string
+		wantContent string
+	}{{
+		name:        "writes decoded secret mask data",
+		envValue:    mustGzipAndBase64("c2VjcmV0MQ==\ncGFzc3dvcmQ=\n"),
+		wantContent: "c2VjcmV0MQ==\ncGFzc3dvcmQ=\n",
+	}, {
+		name:        "file has correct permissions",
+		envValue:    mustGzipAndBase64("secret1\n"),
+		wantContent: "secret1\n",
+	}, {
+		name:     "missing env var",
+		envValue: "",
+		wantErr:  "is not set",
+	}, {
+		name:     "invalid base64 payload",
+		envValue: "%%%",
+		wantErr:  "decode",
+	}, {
+		name:     "invalid gzip payload",
+		envValue: base64.StdEncoding.EncodeToString([]byte("not-gzip")),
+		wantErr:  "decompress",
+	}} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(SecretMaskDataEnvVar, tt.envValue)
+			filePath := filepath.Join(t.TempDir(), "secret-mask", "secrets")
+
+			err := secretMaskInit(filePath)
+
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			data, err := os.ReadFile(filePath)
+			if err != nil {
+				t.Fatalf("failed reading output file: %v", err)
+			}
+			if got := string(data); got != tt.wantContent {
+				t.Errorf("got content %q, want %q", got, tt.wantContent)
+			}
+
+			info, err := os.Stat(filePath)
+			if err != nil {
+				t.Fatalf("failed to stat output file: %v", err)
+			}
+			expectedPerm := os.FileMode(0444)
+			if got := info.Mode().Perm(); got != expectedPerm {
+				t.Errorf("expected mode %#o, got %#o", expectedPerm, got)
+			}
+		})
+	}
+}
+
+func mustGzipAndBase64(data string) string {
+	var buf bytes.Buffer
+	zw := gzip.NewWriter(&buf)
+	if _, err := zw.Write([]byte(data)); err != nil {
+		panic(err)
+	}
+	if err := zw.Close(); err != nil {
+		panic(err)
+	}
+	return base64.StdEncoding.EncodeToString(buf.Bytes())
+}

--- a/cmd/entrypoint/subcommands/subcommands.go
+++ b/cmd/entrypoint/subcommands/subcommands.go
@@ -92,6 +92,16 @@ func Process(args []string) error {
 			return SubcommandError{subcommand: StepInitCommand, message: err.Error()}
 		}
 		return OK{message: "Setup /step directories"}
+	case SecretMaskInitCommand:
+		// If invoked in "secret-mask-init" mode (`entrypoint secret-mask-init <file-path>`),
+		// write the secret mask data (from environment variable) to the specified file.
+		if len(args) == 2 {
+			filePath := args[1]
+			if err := secretMaskInit(filePath); err != nil {
+				return SubcommandError{subcommand: SecretMaskInitCommand, message: err.Error()}
+			}
+			return OK{message: "Initialized secret mask file"}
+		}
 	default:
 	}
 	return nil

--- a/config/300-crds/300-pipelinerun.yaml
+++ b/config/300-crds/300-pipelinerun.yaml
@@ -2172,6 +2172,8 @@ spec:
                           type: boolean
                         enableProvenanceInStatus:
                           type: boolean
+                        enableSecretMasking:
+                          type: boolean
                         enableStepActions:
                           description: EnableStepActions is a no-op flag since StepActions are stable
                           type: boolean
@@ -2544,6 +2546,8 @@ spec:
                                     type: boolean
                                   enableProvenanceInStatus:
                                     type: boolean
+                                  enableSecretMasking:
+                                    type: boolean
                                   enableStepActions:
                                     description: EnableStepActions is a no-op flag since StepActions are stable
                                     type: boolean
@@ -2806,6 +2810,8 @@ spec:
                                         enableParamEnum:
                                           type: boolean
                                         enableProvenanceInStatus:
+                                          type: boolean
+                                        enableSecretMasking:
                                           type: boolean
                                         enableStepActions:
                                           description: EnableStepActions is a no-op flag since StepActions are stable
@@ -5046,6 +5052,8 @@ spec:
                         enableParamEnum:
                           type: boolean
                         enableProvenanceInStatus:
+                          type: boolean
+                        enableSecretMasking:
                           type: boolean
                         enableStepActions:
                           description: EnableStepActions is a no-op flag since StepActions are stable

--- a/config/300-crds/300-taskrun.yaml
+++ b/config/300-crds/300-taskrun.yaml
@@ -1726,6 +1726,8 @@ spec:
                           type: boolean
                         enableProvenanceInStatus:
                           type: boolean
+                        enableSecretMasking:
+                          type: boolean
                         enableStepActions:
                           description: EnableStepActions is a no-op flag since StepActions are stable
                           type: boolean
@@ -1988,6 +1990,8 @@ spec:
                               enableParamEnum:
                                 type: boolean
                               enableProvenanceInStatus:
+                                type: boolean
+                              enableSecretMasking:
                                 type: boolean
                               enableStepActions:
                                 description: EnableStepActions is a no-op flag since StepActions are stable
@@ -3701,6 +3705,8 @@ spec:
                           type: boolean
                         enableProvenanceInStatus:
                           type: boolean
+                        enableSecretMasking:
+                          type: boolean
                         enableStepActions:
                           description: EnableStepActions is a no-op flag since StepActions are stable
                           type: boolean
@@ -3955,6 +3961,8 @@ spec:
                               enableParamEnum:
                                 type: boolean
                               enableProvenanceInStatus:
+                                type: boolean
+                              enableSecretMasking:
                                 type: boolean
                               enableStepActions:
                                 description: EnableStepActions is a no-op flag since StepActions are stable

--- a/config/config-feature-flags.yaml
+++ b/config/config-feature-flags.yaml
@@ -136,3 +136,7 @@ data:
   # If set to "false", exponential backoff will be disabled.
   # For advanced tuning of backoff parameters, update the 'wait-exponential-backoff' ConfigMap.
   enable-wait-exponential-backoff: "false"
+  # Setting this flag to "true" enables masking of secret values in step stdout/stderr.
+  # Secret values from secretKeyRef environment variables and secret volumes will be
+  # replaced with "***" in the logs.
+  enable-secret-masking: "false"

--- a/docs/additional-configs.md
+++ b/docs/additional-configs.md
@@ -369,7 +369,16 @@ to run in namespaces with `restricted` pod security admission. By default, this 
 - `set-security-context-read-only-root-filesystem`: Set this flag to `true` to enable `readOnlyRootFilesystem` in the
   security context for containers injected by Tekton. This makes the root filesystem of the container read-only,
   enhancing security. Note that this requires `set-security-context` to be enabled. By default, this flag is set
-  to `false`. Note: This feature does not work in windows as it is not supported there, [Comparison with linux](https://kubernetes.io/docs/concepts/windows/intro/#compatibility-linux-similarities). 
+  to `false`. Note: This feature does not work in windows as it is not supported there, [Comparison with linux](https://kubernetes.io/docs/concepts/windows/intro/#compatibility-linux-similarities).
+
+- `enable-secret-masking`: Set this flag to `"true"` to enable masking of secret values in step stdout/stderr.
+  Secret values from `secretKeyRef` environment variables and secret volumes will be replaced with `***` in the logs.
+  To reduce payload size, Tekton passes the internal secret mask data to the init container as a gzip-compressed, base64-encoded value.
+  By default, this is set to `false`. This is an `alpha` feature.
+  Current limitation: stream-safe masking buffers up to `largest-secret-size - 1` bytes to avoid leaking values split across
+  write boundaries. For large secrets, this can delay log visibility. The entrypoint emits a warning when the largest secret
+  is large enough to cause noticeable delay. A Kubernetes Secret object can be up to 1 MiB total data.
+  Note: This feature is not supported on Windows.
 
 ### Alpha Features
 
@@ -395,6 +404,7 @@ Features currently in "alpha" are:
 | [keep pod on cancel](./taskruns.md#cancelling-a-taskrun)                                                     | N/A                                                                                                                  | [v0.52.0](https://github.com/tektoncd/pipeline/releases/tag/v0.52.0) | `keep-pod-on-cancel`                             |
 | [CEL in WhenExpression](./pipelines.md#use-cel-expression-in-whenexpression)                                                  | [TEP-0145](https://github.com/tektoncd/community/blob/main/teps/0145-cel-in-whenexpression.md)                       | [v0.53.0](https://github.com/tektoncd/pipeline/releases/tag/v0.53.0) | `enable-cel-in-whenexpression`                   |
 | [Param Enum](./taskruns.md#parameter-enums)                                                                  | [TEP-0144](https://github.com/tektoncd/community/blob/main/teps/0144-param-enum.md)                                  | [v0.54.0](https://github.com/tektoncd/pipeline/releases/tag/v0.54.0) | `enable-param-enum`                              |
+| Secret Masking                                                                                               | N/A                                                                                                                  | N/A                                                                  | `enable-secret-masking`                          |
 
 ### Beta Features
 

--- a/pkg/apis/config/feature_flags.go
+++ b/pkg/apis/config/feature_flags.go
@@ -111,6 +111,10 @@ const (
 	EnableWaitExponentialBackoff = "enable-wait-exponential-backoff"
 	// DefaultEnableWaitExponentialBackoff is the default value for EnableWaitExponentialBackoff
 	DefaultEnableWaitExponentialBackoff = false
+	// EnableSecretMasking is the flag to enable masking of secret values in step stdout/stderr
+	EnableSecretMasking = "enable-secret-masking"
+	// DefaultEnableSecretMasking is the default value for EnableSecretMasking
+	DefaultEnableSecretMasking = false
 
 	// EnableStepActions is the flag to enable step actions (no-op since it's stable)
 	EnableStepActions = "enable-step-actions"
@@ -210,6 +214,7 @@ type FeatureFlags struct {
 	EnableConciseResolverSyntax  bool   `json:"enableConciseResolverSyntax,omitempty"`
 	EnableKubernetesSidecar      bool   `json:"enableKubernetesSidecar,omitempty"`
 	EnableWaitExponentialBackoff bool   `json:"enableWaitExponentialBackoff,omitempty"`
+	EnableSecretMasking          bool   `json:"enableSecretMasking,omitempty"`
 }
 
 // GetFeatureFlagsConfigName returns the name of the configmap containing all
@@ -315,6 +320,9 @@ func NewFeatureFlagsFromMap(cfgMap map[string]string) (*FeatureFlags, error) {
 		return nil, err
 	}
 	if err := setFeature(EnableWaitExponentialBackoff, DefaultEnableWaitExponentialBackoff, &tc.EnableWaitExponentialBackoff); err != nil {
+		return nil, err
+	}
+	if err := setFeature(EnableSecretMasking, DefaultEnableSecretMasking, &tc.EnableSecretMasking); err != nil {
 		return nil, err
 	}
 

--- a/pkg/apis/config/feature_flags_test.go
+++ b/pkg/apis/config/feature_flags_test.go
@@ -80,6 +80,7 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 				DisableInlineSpec:                        "pipeline,pipelinerun,taskrun",
 				EnableConciseResolverSyntax:              true,
 				EnableKubernetesSidecar:                  true,
+				EnableSecretMasking:                      true,
 			},
 			fileName: "feature-flags-all-flags-set",
 		},

--- a/pkg/apis/config/testdata/feature-flags-all-flags-set.yaml
+++ b/pkg/apis/config/testdata/feature-flags-all-flags-set.yaml
@@ -38,3 +38,4 @@ data:
   disable-inline-spec: "pipeline,pipelinerun,taskrun"
   enable-concise-resolver-syntax: "true"
   enable-kubernetes-sidecar: "true"
+  enable-secret-masking: "true"

--- a/pkg/pod/secret_masking.go
+++ b/pkg/pod/secret_masking.go
@@ -1,0 +1,218 @@
+/*
+Copyright 2025 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pod
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"strings"
+
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	// SecretMaskVolumeName is the name of the emptyDir volume for secret masking
+	SecretMaskVolumeName = "tekton-internal-secret-mask" //nolint:gosec // G101: not a hardcoded credential, just a volume name
+	// SecretMaskMountPath is the mount path for the secret mask volume
+	SecretMaskMountPath = "/tekton/secret-mask" //nolint:gosec // G101: not a hardcoded credential, just a mount path
+	// SecretMaskFileName is the name of the file containing secrets to mask
+	SecretMaskFileName = "secrets"
+	// SecretMaskDataEnvVar is the env var carrying base64(gzip(secret mask data)) to the init container.
+	SecretMaskDataEnvVar = "TEKTON_SECRET_MASK_DATA" //nolint:gosec // G101: not a hardcoded credential, just a variable name
+)
+
+// SecretMaskFilePath returns the full path to the secrets mask file.
+func SecretMaskFilePath() string {
+	return SecretMaskMountPath + "/" + SecretMaskFileName
+}
+
+// CollectSecretsForMasking gathers secret values from steps and volumes and returns them base64-encoded, one per line.
+func CollectSecretsForMasking(ctx context.Context, kubeclient kubernetes.Interface, namespace string, taskSpec *v1.TaskSpec, steps []v1.Step, volumes []corev1.Volume) (string, error) {
+	secretValues := make(map[string]struct{})
+
+	addValues := func(values []string) {
+		for _, value := range values {
+			if value == "" {
+				continue
+			}
+			secretValues[value] = struct{}{}
+		}
+	}
+
+	for _, step := range steps {
+		for _, env := range step.Env {
+			if env.ValueFrom == nil || env.ValueFrom.SecretKeyRef == nil {
+				continue
+			}
+			secretRef := env.ValueFrom.SecretKeyRef
+			value, err := getSecretValue(ctx, kubeclient, namespace, secretRef.Name, secretRef.Key)
+			if err != nil {
+				if secretRef.Optional != nil && *secretRef.Optional {
+					continue
+				}
+				return "", err
+			}
+			addValues([]string{value})
+		}
+
+		for _, envFrom := range step.EnvFrom {
+			if envFrom.SecretRef == nil {
+				continue
+			}
+			values, err := getAllSecretValues(ctx, kubeclient, namespace, envFrom.SecretRef.Name)
+			if err != nil {
+				if envFrom.SecretRef.Optional != nil && *envFrom.SecretRef.Optional {
+					continue
+				}
+				return "", err
+			}
+			addValues(values)
+		}
+	}
+
+	addSecretVolumes := func(vols []corev1.Volume) error {
+		for _, vol := range vols {
+			if vol.Secret == nil {
+				continue
+			}
+			values, err := getAllSecretValues(ctx, kubeclient, namespace, vol.Secret.SecretName)
+			if err != nil {
+				if vol.Secret.Optional != nil && *vol.Secret.Optional {
+					continue
+				}
+				return err
+			}
+			addValues(values)
+		}
+		return nil
+	}
+
+	if err := addSecretVolumes(volumes); err != nil {
+		return "", err
+	}
+	if taskSpec != nil {
+		if err := addSecretVolumes(taskSpec.Volumes); err != nil {
+			return "", err
+		}
+	}
+
+	var lines []string
+	for secret := range secretValues {
+		if len(secret) < 3 {
+			continue
+		}
+		lines = append(lines, base64.StdEncoding.EncodeToString([]byte(secret)))
+	}
+
+	return strings.Join(lines, "\n"), nil
+}
+
+func getSecretValue(ctx context.Context, kubeclient kubernetes.Interface, namespace, secretName, key string) (string, error) {
+	secret, err := kubeclient.CoreV1().Secrets(namespace).Get(ctx, secretName, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	data, ok := secret.Data[key]
+	if !ok {
+		return "", fmt.Errorf("secret %s missing key %s", secretName, key)
+	}
+	return string(data), nil
+}
+
+func getAllSecretValues(ctx context.Context, kubeclient kubernetes.Interface, namespace, secretName string) ([]string, error) {
+	secret, err := kubeclient.CoreV1().Secrets(namespace).Get(ctx, secretName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	values := make([]string, 0, len(secret.Data))
+	for _, data := range secret.Data {
+		values = append(values, string(data))
+	}
+	return values, nil
+}
+
+func encodeSecretMaskData(data string) (string, error) {
+	var gz bytes.Buffer
+	zw := gzip.NewWriter(&gz)
+	if _, err := zw.Write([]byte(data)); err != nil {
+		return "", fmt.Errorf("compress secret mask data: %w", err)
+	}
+	if err := zw.Close(); err != nil {
+		return "", fmt.Errorf("finalize compressed secret mask data: %w", err)
+	}
+	return base64.StdEncoding.EncodeToString(gz.Bytes()), nil
+}
+
+// SecretMaskVolume returns the emptyDir volume for storing secret mask data.
+func SecretMaskVolume() corev1.Volume {
+	return corev1.Volume{
+		Name: SecretMaskVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{
+				Medium: corev1.StorageMediumMemory,
+			},
+		},
+	}
+}
+
+// SecretMaskVolumeMount returns the volume mount for the secret mask volume.
+func SecretMaskVolumeMount() corev1.VolumeMount {
+	return corev1.VolumeMount{
+		Name:      SecretMaskVolumeName,
+		MountPath: SecretMaskMountPath,
+		ReadOnly:  true,
+	}
+}
+
+// SecretMaskInitVolumeMount returns the volume mount for the init container (writable).
+func SecretMaskInitVolumeMount() corev1.VolumeMount {
+	return corev1.VolumeMount{
+		Name:      SecretMaskVolumeName,
+		MountPath: SecretMaskMountPath,
+		ReadOnly:  false,
+	}
+}
+
+func secretMaskInitContainer(image, secretData string, securityContext SecurityContextConfig, windows bool) corev1.Container {
+	command := []string{"/ko-app/entrypoint", "secret-mask-init", SecretMaskFilePath()}
+
+	container := corev1.Container{
+		Name:       "secret-mask-init",
+		Image:      image,
+		Command:    command,
+		WorkingDir: "/",
+		Env: []corev1.EnvVar{
+			{
+				Name:  SecretMaskDataEnvVar,
+				Value: secretData,
+			},
+		},
+		VolumeMounts: []corev1.VolumeMount{SecretMaskInitVolumeMount()},
+	}
+
+	if securityContext.SetSecurityContext {
+		container.SecurityContext = securityContext.GetSecurityContext(windows)
+	}
+
+	return container
+}

--- a/pkg/pod/secret_masking_test.go
+++ b/pkg/pod/secret_masking_test.go
@@ -1,0 +1,329 @@
+/*
+Copyright 2025 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pod
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/base64"
+	"io"
+	"sort"
+	"strings"
+	"testing"
+
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakek8s "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestCollectSecretsForMasking(t *testing.T) {
+	ctx := context.Background()
+	optional := true
+
+	secret1 := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-secret",
+			Namespace: "default",
+		},
+		Data: map[string][]byte{
+			"password": []byte("supersecretpassword"),
+			"token":    []byte("mytoken123"),
+			"short":    []byte("ab"),
+		},
+	}
+
+	secret2 := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "other-secret",
+			Namespace: "default",
+		},
+		Data: map[string][]byte{
+			"api-key": []byte("apikey456"),
+		},
+	}
+
+	kubeclient := fakek8s.NewSimpleClientset(secret1, secret2)
+
+	testCases := []struct {
+		name            string
+		steps           []v1.Step
+		volumes         []corev1.Volume
+		taskSpecVolumes []corev1.Volume
+		expected        []string
+		expectErr       bool
+	}{
+		{
+			name: "env secretKeyRef",
+			steps: []v1.Step{{
+				Name: "step1",
+				Env: []corev1.EnvVar{{
+					Name: "MY_PASSWORD",
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "my-secret"},
+							Key:                  "password",
+						},
+					},
+				}},
+			}},
+			expected: []string{"supersecretpassword"},
+		},
+		{
+			name: "envFrom secretRef",
+			steps: []v1.Step{{
+				Name: "step1",
+				EnvFrom: []corev1.EnvFromSource{{
+					SecretRef: &corev1.SecretEnvSource{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "my-secret"},
+					},
+				}},
+			}},
+			expected: []string{"supersecretpassword", "mytoken123"},
+		},
+		{
+			name:  "secret volume",
+			steps: []v1.Step{{Name: "step1"}},
+			volumes: []corev1.Volume{{
+				Name: "secret-vol",
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{SecretName: "other-secret"},
+				},
+			}},
+			expected: []string{"apikey456"},
+		},
+		{
+			name:  "taskSpec secret volume",
+			steps: []v1.Step{{Name: "step1"}},
+			taskSpecVolumes: []corev1.Volume{{
+				Name: "secret-vol",
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{SecretName: "other-secret"},
+				},
+			}},
+			expected: []string{"apikey456"},
+		},
+		{
+			name: "multiple sources",
+			steps: []v1.Step{{
+				Name: "step1",
+				Env: []corev1.EnvVar{{
+					Name: "MY_PASSWORD",
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "my-secret"},
+							Key:                  "password",
+						},
+					},
+				}},
+			}},
+			volumes: []corev1.Volume{{
+				Name: "secret-vol",
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{SecretName: "other-secret"},
+				},
+			}},
+			expected: []string{"supersecretpassword", "apikey456"},
+		},
+		{
+			name: "missing secret",
+			steps: []v1.Step{{
+				Name: "step1",
+				Env: []corev1.EnvVar{{
+					Name: "MY_VAR",
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "missing"},
+							Key:                  "key",
+						},
+					},
+				}},
+			}},
+			expectErr: true,
+		},
+		{
+			name: "missing key",
+			steps: []v1.Step{{
+				Name: "step1",
+				Env: []corev1.EnvVar{{
+					Name: "MY_VAR",
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "my-secret"},
+							Key:                  "missing-key",
+						},
+					},
+				}},
+			}},
+			expectErr: true,
+		},
+		{
+			name: "optional missing secret",
+			steps: []v1.Step{{
+				Name: "step1",
+				Env: []corev1.EnvVar{{
+					Name: "MY_VAR",
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "missing"},
+							Key:                  "key",
+							Optional:             &optional,
+						},
+					},
+				}},
+			}},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			taskSpec := &v1.TaskSpec{Volumes: tc.taskSpecVolumes}
+			result, err := CollectSecretsForMasking(ctx, kubeclient, "default", taskSpec, tc.steps, tc.volumes)
+			if tc.expectErr {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			got := decodeSecretLines(t, result)
+			if !sameStrings(got, tc.expected) {
+				t.Fatalf("got %v, want %v", got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestSecretMaskInitContainer(t *testing.T) {
+	secretData, err := encodeSecretMaskData("c2VjcmV0MQ==\ncGFzc3dvcmQ=")
+	if err != nil {
+		t.Fatalf("unexpected error encoding secret mask data: %v", err)
+	}
+	securityContext := SecurityContextConfig{
+		SetSecurityContext:        true,
+		SetReadOnlyRootFilesystem: false,
+	}
+
+	container := secretMaskInitContainer("entrypoint:latest", secretData, securityContext, false)
+
+	if container.Name != "secret-mask-init" {
+		t.Errorf("expected name 'secret-mask-init', got %q", container.Name)
+	}
+	if container.Image != "entrypoint:latest" {
+		t.Errorf("expected image 'entrypoint:latest', got %q", container.Image)
+	}
+	if len(container.Command) != 3 {
+		t.Fatalf("expected 3 command args, got %d: %v", len(container.Command), container.Command)
+	}
+	if container.Command[0] != "/ko-app/entrypoint" {
+		t.Errorf("expected command[0] to be '/ko-app/entrypoint', got %q", container.Command[0])
+	}
+	if container.Command[1] != "secret-mask-init" {
+		t.Errorf("expected command[1] to be 'secret-mask-init', got %q", container.Command[1])
+	}
+	if container.Command[2] != SecretMaskFilePath() {
+		t.Errorf("expected command[2] to be %q, got %q", SecretMaskFilePath(), container.Command[2])
+	}
+	if len(container.Env) != 1 {
+		t.Fatalf("expected 1 env var, got %d", len(container.Env))
+	}
+	if container.Env[0].Name != SecretMaskDataEnvVar {
+		t.Errorf("expected env var name %q, got %q", SecretMaskDataEnvVar, container.Env[0].Name)
+	}
+	if container.Env[0].Value != secretData {
+		t.Errorf("expected env var value to be the secret data")
+	}
+	if len(container.VolumeMounts) != 1 {
+		t.Fatalf("expected 1 volume mount, got %d", len(container.VolumeMounts))
+	}
+	if container.VolumeMounts[0].Name != SecretMaskVolumeName {
+		t.Errorf("expected volume name %q, got %q", SecretMaskVolumeName, container.VolumeMounts[0].Name)
+	}
+	if container.VolumeMounts[0].ReadOnly {
+		t.Error("init container volume mount should be writable")
+	}
+	if container.SecurityContext == nil {
+		t.Error("expected security context to be set")
+	}
+}
+
+func TestEncodeSecretMaskData(t *testing.T) {
+	original := "c2VjcmV0MQ==\ncGFzc3dvcmQ="
+	encoded, err := encodeSecretMaskData(original)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	compressed, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		t.Fatalf("failed base64 decode: %v", err)
+	}
+	gzr, err := gzip.NewReader(bytes.NewReader(compressed))
+	if err != nil {
+		t.Fatalf("failed to create gzip reader: %v", err)
+	}
+	decoded, err := io.ReadAll(gzr)
+	if err != nil {
+		t.Fatalf("failed to read gzip stream: %v", err)
+	}
+	if err := gzr.Close(); err != nil {
+		t.Fatalf("failed to close gzip reader: %v", err)
+	}
+
+	if got := string(decoded); got != original {
+		t.Fatalf("got %q, want %q", got, original)
+	}
+}
+
+func decodeSecretLines(t *testing.T, result string) []string {
+	t.Helper()
+	if result == "" {
+		return nil
+	}
+	lines := strings.Split(result, "\n")
+	secrets := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+		decoded, err := base64.StdEncoding.DecodeString(line)
+		if err != nil {
+			t.Fatalf("failed to decode line %q: %v", line, err)
+		}
+		secrets = append(secrets, string(decoded))
+	}
+	return secrets
+}
+
+func sameStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	ac := append([]string(nil), a...)
+	bc := append([]string(nil), b...)
+	sort.Strings(ac)
+	sort.Strings(bc)
+	for i := range ac {
+		if ac[i] != bc[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary

Add secret masking for step stdout/stderr behind the `enable-secret-masking` feature flag.

## How it works

- During pod creation, Tekton collects secret values referenced from step `secretKeyRef`, `envFrom.secretRef`, and secret volumes (including TaskSpec volumes).
- Collected values are de-duplicated and short values are skipped.
- The mask payload is prepared as base64-per-secret lines, then wrapped as `base64(gzip(payload))` and passed to the init container via `TEKTON_SECRET_MASK_DATA`.
- The `secret-mask-init` subcommand decodes and uncompresses the env payload and writes a secret-mask file consumed by the entrypoint.
- The runner loads the secret-mask file and decodes each line back to secret bytes.
- A stream-safe masking writer redacts matching values to `***` in stdout/stderr (and optional log files), handling split writes without leaking partial secret matches.

This commit wires the controller, init subcommand, runner integration, feature-flag surface, CRD/config plumbing, tests, and docs needed for this behavior.

## Caveats

This is not 100% secure. The secret values are still present in the pod specification. Users with `pods/get` permission can still access them via `kubectl get pod -o yaml` (but so is the secrets on the namespace then 🙃)

This feature will not work on Windows nodes in this initial implementation.

However, this change provides meaningful improvements:

| Aspect | Before | After |
|--------|--------|-------|
| Visible in `kubectl describe pod` | Yes (in command) | No |
| Visible in process listings (`ps aux`) | Yes | No |
| Visible in `kubectl get pod -o yaml` | Yes | Yes |

## Demo

https://github.com/user-attachments/assets/28fe86dc-2f6a-40d5-9863-67daf78b77dd

---

# Submitter Checklist

- [X] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing
- [X] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [X] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [X] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [X] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md)
- [X] Has a kind label
- [X] Release notes block updated

# Release Notes

```release-note
Add feature-flag `enable-secret-masking` to enable masking of secrets in step logs. When enabled, secret values from environment variables and volume mounts are redacted with `***` in stdout/stderr. This prevents leaking secrets when viewing logs via `kubectl logs` or similar tools.
```