### PR TITLE
fix: set default resource requirements on internal containers

### DIFF
--- a/docs/additional-configs.md
+++ b/docs/additional-configs.md
@@ -237,7 +237,7 @@ data:
         cpu: "500m"
 ```
 
-Any resource requirements set at the `Task` and `TaskRun` levels will overidde the default one specified in the `config-defaults` configmap.
+Any resource requirements set at the `Task` and `TaskRun` levels will override the default one specified in the `config-defaults` configmap.
 
 ## Customizing basic execution parameters
 

--- a/docs/compute-resources.md
+++ b/docs/compute-resources.md
@@ -51,8 +51,8 @@ which run sequentially. However, the pod's effective resource requirements are s
 sum of its containers' resource requirements. This means that when specifying resource 
 requirements for `Step` containers, they must be treated as if they are running in parallel.
 
-Tekton adjusts `Step` resource requirements to comply with [LimitRanges](#limitrange-support).
-[ResourceQuotas](#resourcequota-support) are not currently supported.
+Tekton adjusts `Step` resource requirements to comply with [LimitRanges](#limitrange-support)
+and [ResourceQuotas](#resourcequota-support).
 
 Instead of specifying resource requirements on each `Step`, users can choose to specify resource requirements at the Task-level. If users specify a Task-level resource request, it will ensure that the kubelet reserves only that amount of resources to execute the `Task`'s `Steps`.
 If users specify a Task-level resource limit, no `Step` may use more than that amount of resources.
@@ -316,15 +316,15 @@ The maximum of the "min" values is the output "min" value.
 Kubernetes allows users to define [ResourceQuotas](https://kubernetes.io/docs/concepts/policy/resource-quotas/),
 which restrict the maximum resource requests and limits of all pods running in a namespace.
 
-To deploy Tekton TaskRuns or PipelineRuns in namespaces with ResourceQuotas, compute resource requirements
-must be set for all containers in a `TaskRun`'s pod, including the init containers injected by Tekton.
-`Step` and `Sidecar` resource requirements can be configured directly through the API, as described in
-[Task Resource Requirements](#task-resource-requirements). To configure resource requirements for Tekton's init containers,
-deploy a LimitRange in the same namespace. The LimitRange's `default` and `defaultRequest` will be applied to the init containers,
-and divided among the `Steps` and `Sidecars`, as described in [LimitRange Support](#limitrange-support).
+Tekton's internal containers (`prepare`, `place-scripts`, `working-dir-initializer`,
+`sidecar-tekton-log-results`) ship with minimal default resource requests so that pods can be
+scheduled in namespaces with ResourceQuotas without requiring a LimitRange. These defaults can
+be overridden using the `default-container-resource-requirements` ConfigMap
+(see [Configuring default resources requirements](./additional-configs.md#configuring-default-resources-requirements)).
 
-[#2933](https://github.com/tektoncd/pipeline/issues/2933) tracks support for running `TaskRuns` in a namespace with a ResourceQuota
-without having to use LimitRanges.
+`Step` and `Sidecar` resource requirements can be configured directly through the API, as described in
+[Task Resource Requirements](#task-resource-requirements). You can also deploy a LimitRange
+in the same namespace, as described in [LimitRange Support](#limitrange-support).
 
 ResourceQuotas consider the effective resource requests and limits of a pod, which Kubernetes determines by summing the resource requirements
 of its containers (under the assumption that they run in parallel). When using LimitRanges to set compute resources for `TaskRun` pods,

--- a/docs/compute-resources.md
+++ b/docs/compute-resources.md
@@ -317,9 +317,11 @@ Kubernetes allows users to define [ResourceQuotas](https://kubernetes.io/docs/co
 which restrict the maximum resource requests and limits of all pods running in a namespace.
 
 Tekton's internal containers (`prepare`, `place-scripts`, `working-dir-initializer`,
-`sidecar-tekton-log-results`) ship with minimal default resource requests so that pods can be
-scheduled in namespaces with ResourceQuotas without requiring a LimitRange. These defaults can
-be overridden using the `default-container-resource-requirements` ConfigMap
+`sidecar-tekton-log-results`) ship with minimal default resource requests and limits so that pods can be
+scheduled in namespaces with ResourceQuotas without requiring a LimitRange. The default requests and limits
+are `10m` CPU / `32Mi` memory for `prepare`, `10m` CPU / `16Mi` memory for `working-dir-initializer`,
+`100m` CPU / `32Mi` memory for `place-scripts`, and `50m` CPU / `32Mi` memory for `sidecar-tekton-log-results`.
+These defaults can be overridden using the `default-container-resource-requirements` ConfigMap
 (see [Configuring default resources requirements](./additional-configs.md#configuring-default-resources-requirements)).
 
 `Step` and `Sidecar` resource requirements can be configured directly through the API, as described in

--- a/pkg/internal/defaultresourcerequirements/transformer.go
+++ b/pkg/internal/defaultresourcerequirements/transformer.go
@@ -18,15 +18,16 @@ package defaultresourcerequirements
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/tektoncd/pipeline/pkg/apis/config"
-	"github.com/tektoncd/pipeline/pkg/pod"
+	podpkg "github.com/tektoncd/pipeline/pkg/pod"
 	corev1 "k8s.io/api/core/v1"
 )
 
-// NewTransformer returns a pod.Transformer that will modify container resources if needed
-func NewTransformer(ctx context.Context) pod.Transformer {
+// NewTransformer returns a podpkg.Transformer that will modify container resources if needed
+func NewTransformer(ctx context.Context) podpkg.Transformer {
 	// update init container and containers resource requirements
 	// resource limits and requests values are taken from a config map
 	configDefaults := config.FromContextOrDefaults(ctx).Defaults
@@ -59,6 +60,11 @@ func updateResourceRequirements(resourceRequirementsMap map[string]corev1.Resour
 		}
 	}
 
+	// Track internal containers that get a specific (named or prefix) match,
+	// so the "default" fallback does not overwrite a more specific entry.
+	// Key format: "init:<index>" or "container:<index>".
+	matchedBySpecificEntry := map[string]bool{}
+
 	// update the containers resource requirements which does not have resource requirements
 	for _, containerName := range containerNames {
 		resourceRequirements := resourceRequirementsMap[containerName]
@@ -69,15 +75,21 @@ func updateResourceRequirements(resourceRequirementsMap map[string]corev1.Resour
 		// update init containers
 		for index := range pod.Spec.InitContainers {
 			targetContainer := pod.Spec.InitContainers[index]
-			if containerName == targetContainer.Name && targetContainer.Resources.Size() == 0 {
+			if containerName == targetContainer.Name && (targetContainer.Resources.Size() == 0 || podpkg.IsInternalContainer(targetContainer.Name)) {
 				pod.Spec.InitContainers[index].Resources = resourceRequirements
+				if podpkg.IsInternalContainer(targetContainer.Name) {
+					matchedBySpecificEntry[fmt.Sprintf("init:%d", index)] = true
+				}
 			}
 		}
 		// update containers
 		for index := range pod.Spec.Containers {
 			targetContainer := pod.Spec.Containers[index]
-			if containerName == targetContainer.Name && targetContainer.Resources.Size() == 0 {
+			if containerName == targetContainer.Name && (targetContainer.Resources.Size() == 0 || podpkg.IsInternalContainer(targetContainer.Name)) {
 				pod.Spec.Containers[index].Resources = resourceRequirements
+				if podpkg.IsInternalContainer(targetContainer.Name) {
+					matchedBySpecificEntry[fmt.Sprintf("container:%d", index)] = true
+				}
 			}
 		}
 	}
@@ -97,15 +109,25 @@ func updateResourceRequirements(resourceRequirementsMap map[string]corev1.Resour
 		// update init containers
 		for index := range pod.Spec.InitContainers {
 			targetContainer := pod.Spec.InitContainers[index]
-			if strings.HasPrefix(targetContainer.Name, containerPrefix) && targetContainer.Resources.Size() == 0 {
+			key := fmt.Sprintf("init:%d", index)
+			// Skip internal containers that already got a more specific named match
+			if strings.HasPrefix(targetContainer.Name, containerPrefix) && (targetContainer.Resources.Size() == 0 || (podpkg.IsInternalContainer(targetContainer.Name) && !matchedBySpecificEntry[key])) {
 				pod.Spec.InitContainers[index].Resources = resourceRequirements
+				if podpkg.IsInternalContainer(targetContainer.Name) {
+					matchedBySpecificEntry[key] = true
+				}
 			}
 		}
 		// update containers
 		for index := range pod.Spec.Containers {
 			targetContainer := pod.Spec.Containers[index]
-			if strings.HasPrefix(targetContainer.Name, containerPrefix) && targetContainer.Resources.Size() == 0 {
+			key := fmt.Sprintf("container:%d", index)
+			// Skip internal containers that already got a more specific named match
+			if strings.HasPrefix(targetContainer.Name, containerPrefix) && (targetContainer.Resources.Size() == 0 || (podpkg.IsInternalContainer(targetContainer.Name) && !matchedBySpecificEntry[key])) {
 				pod.Spec.Containers[index].Resources = resourceRequirements
+				if podpkg.IsInternalContainer(targetContainer.Name) {
+					matchedBySpecificEntry[key] = true
+				}
 			}
 		}
 	}
@@ -114,13 +136,18 @@ func updateResourceRequirements(resourceRequirementsMap map[string]corev1.Resour
 	if resourceRequirements, found := resourceRequirementsMap[config.ResourceRequirementDefaultContainerKey]; found && resourceRequirements.Size() != 0 {
 		// update init containers
 		for index := range pod.Spec.InitContainers {
-			if pod.Spec.InitContainers[index].Resources.Size() == 0 {
+			// For internal containers, only apply the default if no specific (named/prefix) entry already matched.
+			internal := podpkg.IsInternalContainer(pod.Spec.InitContainers[index].Name)
+			alreadyMatched := matchedBySpecificEntry[fmt.Sprintf("init:%d", index)]
+			if pod.Spec.InitContainers[index].Resources.Size() == 0 || (internal && !alreadyMatched) {
 				pod.Spec.InitContainers[index].Resources = resourceRequirements
 			}
 		}
 		// update containers
 		for index := range pod.Spec.Containers {
-			if pod.Spec.Containers[index].Resources.Size() == 0 {
+			internal := podpkg.IsInternalContainer(pod.Spec.Containers[index].Name)
+			alreadyMatched := matchedBySpecificEntry[fmt.Sprintf("container:%d", index)]
+			if pod.Spec.Containers[index].Resources.Size() == 0 || (internal && !alreadyMatched) {
 				pod.Spec.Containers[index].Resources = resourceRequirements
 			}
 		}

--- a/pkg/internal/defaultresourcerequirements/transformer_test.go
+++ b/pkg/internal/defaultresourcerequirements/transformer_test.go
@@ -320,7 +320,7 @@ func TestNewTransformer(t *testing.T) {
 			},
 		},
 
-		// verifies with existing data
+		// verifies with existing data — internal containers (prepare) get ConfigMap override
 		{
 			name: "test-with-existing-data",
 			targetPod: &corev1.Pod{
@@ -365,13 +365,15 @@ func TestNewTransformer(t *testing.T) {
 					Spec: corev1.PodSpec{
 						InitContainers: []corev1.Container{
 							{Name: "place-scripts"},
+							// ConfigMap "prepare" overrides code-level defaults on internal container
 							{Name: "prepare", Resources: corev1.ResourceRequirements{
 								Limits: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("500m"),
-									corev1.ResourceMemory: resource.MustParse("256Mi"),
+									corev1.ResourceCPU:    resource.MustParse("1"),
+									corev1.ResourceMemory: resource.MustParse("512Mi"),
 								},
 								Requests: corev1.ResourceList{
-									corev1.ResourceMemory: resource.MustParse("128Mi"),
+									corev1.ResourceCPU:    resource.MustParse("500m"),
+									corev1.ResourceMemory: resource.MustParse("256Mi"),
 								},
 							}},
 							{Name: "working-dir-initializer"},
@@ -385,6 +387,518 @@ func TestNewTransformer(t *testing.T) {
 					},
 				}
 				return expectedPod
+			},
+		},
+
+		// verifies that ConfigMap entries override code-level resource defaults on internal containers.
+		// The ConfigMap "prepare" entry overrides the code-level defaults on the prepare init container,
+		// and the "default" entry overrides all other internal containers that lack a named ConfigMap match.
+		{
+			name: "test-configmap-overrides-code-level-defaults",
+			targetPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "custom-ns"},
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Name: "prepare",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("10m"),
+									corev1.ResourceMemory: resource.MustParse("16Mi"),
+								},
+							},
+						},
+						{
+							Name: "place-scripts",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("10m"),
+									corev1.ResourceMemory: resource.MustParse("32Mi"),
+								},
+							},
+						},
+						{
+							Name: "working-dir-initializer",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("10m"),
+									corev1.ResourceMemory: resource.MustParse("16Mi"),
+								},
+							},
+						},
+					},
+					Containers: []corev1.Container{
+						{Name: "scripts-01"},
+						{
+							Name: "sidecar-tekton-log-results",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("10m"),
+									corev1.ResourceMemory: resource.MustParse("32Mi"),
+								},
+							},
+						},
+					},
+				},
+			},
+			resourceRequirements: map[string]corev1.ResourceRequirements{
+				"prepare": {
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("512Mi"),
+					},
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("256Mi"),
+					},
+				},
+				"default": {
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("256Mi"),
+					},
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("250m"),
+						corev1.ResourceMemory: resource.MustParse("128Mi"),
+					},
+				},
+			},
+			getExpectedPod: func() *corev1.Pod {
+				return &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "custom-ns"},
+					Spec: corev1.PodSpec{
+						InitContainers: []corev1.Container{
+							// ConfigMap "prepare" entry overrides code-level defaults
+							{
+								Name: "prepare",
+								Resources: corev1.ResourceRequirements{
+									Limits: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("1"),
+										corev1.ResourceMemory: resource.MustParse("512Mi"),
+									},
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("500m"),
+										corev1.ResourceMemory: resource.MustParse("256Mi"),
+									},
+								},
+							},
+							// ConfigMap "default" entry overrides code-level defaults
+							{
+								Name: "place-scripts",
+								Resources: corev1.ResourceRequirements{
+									Limits: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("500m"),
+										corev1.ResourceMemory: resource.MustParse("256Mi"),
+									},
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("250m"),
+										corev1.ResourceMemory: resource.MustParse("128Mi"),
+									},
+								},
+							},
+							// ConfigMap "default" entry overrides code-level defaults
+							{
+								Name: "working-dir-initializer",
+								Resources: corev1.ResourceRequirements{
+									Limits: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("500m"),
+										corev1.ResourceMemory: resource.MustParse("256Mi"),
+									},
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("250m"),
+										corev1.ResourceMemory: resource.MustParse("128Mi"),
+									},
+								},
+							},
+						},
+						Containers: []corev1.Container{
+							// no code-level default: gets ConfigMap "default" values
+							{
+								Name: "scripts-01",
+								Resources: corev1.ResourceRequirements{
+									Limits: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("500m"),
+										corev1.ResourceMemory: resource.MustParse("256Mi"),
+									},
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("250m"),
+										corev1.ResourceMemory: resource.MustParse("128Mi"),
+									},
+								},
+							},
+							// ConfigMap "default" entry overrides code-level defaults
+							{
+								Name: "sidecar-tekton-log-results",
+								Resources: corev1.ResourceRequirements{
+									Limits: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("500m"),
+										corev1.ResourceMemory: resource.MustParse("256Mi"),
+									},
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("250m"),
+										corev1.ResourceMemory: resource.MustParse("128Mi"),
+									},
+								},
+							},
+						},
+					},
+				}
+			},
+		},
+
+		// verifies that internal containers keep code-level defaults when no ConfigMap entry matches
+		{
+			name: "test-code-level-defaults-when-no-configmap-match",
+			targetPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "custom-ns"},
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Name: "prepare",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("10m"),
+									corev1.ResourceMemory: resource.MustParse("16Mi"),
+								},
+							},
+						},
+						{
+							Name: "place-scripts",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("10m"),
+									corev1.ResourceMemory: resource.MustParse("32Mi"),
+								},
+							},
+						},
+					},
+					Containers: []corev1.Container{
+						{Name: "step-my-step"},
+						{
+							Name: "sidecar-tekton-log-results",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("10m"),
+									corev1.ResourceMemory: resource.MustParse("32Mi"),
+								},
+							},
+						},
+					},
+				},
+			},
+			resourceRequirements: map[string]corev1.ResourceRequirements{
+				"some-other-container": {
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("2"),
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
+					},
+				},
+			},
+			getExpectedPod: func() *corev1.Pod {
+				return &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "custom-ns"},
+					Spec: corev1.PodSpec{
+						InitContainers: []corev1.Container{
+							// no ConfigMap match, code-level defaults preserved
+							{
+								Name: "prepare",
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("10m"),
+										corev1.ResourceMemory: resource.MustParse("16Mi"),
+									},
+								},
+							},
+							// no ConfigMap match, code-level defaults preserved
+							{
+								Name: "place-scripts",
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("10m"),
+										corev1.ResourceMemory: resource.MustParse("32Mi"),
+									},
+								},
+							},
+						},
+						Containers: []corev1.Container{
+							// no code-level defaults, no ConfigMap match: stays empty
+							{Name: "step-my-step"},
+							// no ConfigMap match, code-level defaults preserved
+							{
+								Name: "sidecar-tekton-log-results",
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("10m"),
+										corev1.ResourceMemory: resource.MustParse("32Mi"),
+									},
+								},
+							},
+						},
+					},
+				}
+			},
+		},
+
+		// verifies that a non-internal step container with existing resources is NOT overwritten
+		// by the ConfigMap "default" entry, while internal containers still get overridden.
+		{
+			name: "test-non-internal-container-resources-preserved-with-default",
+			targetPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "custom-ns"},
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Name: "prepare",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("10m"),
+									corev1.ResourceMemory: resource.MustParse("16Mi"),
+								},
+							},
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name: "step-user-step",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("2"),
+									corev1.ResourceMemory: resource.MustParse("1Gi"),
+								},
+							},
+						},
+						{Name: "step-no-resources"},
+					},
+				},
+			},
+			resourceRequirements: map[string]corev1.ResourceRequirements{
+				"default": {
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("256Mi"),
+					},
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("250m"),
+						corev1.ResourceMemory: resource.MustParse("128Mi"),
+					},
+				},
+			},
+			getExpectedPod: func() *corev1.Pod {
+				return &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "custom-ns"},
+					Spec: corev1.PodSpec{
+						InitContainers: []corev1.Container{
+							// internal container: "default" overrides code-level defaults
+							{
+								Name: "prepare",
+								Resources: corev1.ResourceRequirements{
+									Limits: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("500m"),
+										corev1.ResourceMemory: resource.MustParse("256Mi"),
+									},
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("250m"),
+										corev1.ResourceMemory: resource.MustParse("128Mi"),
+									},
+								},
+							},
+						},
+						Containers: []corev1.Container{
+							// non-internal container WITH existing resources: preserved, NOT overwritten
+							{
+								Name: "step-user-step",
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("2"),
+										corev1.ResourceMemory: resource.MustParse("1Gi"),
+									},
+								},
+							},
+							// non-internal container WITHOUT resources: gets "default"
+							{
+								Name: "step-no-resources",
+								Resources: corev1.ResourceRequirements{
+									Limits: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("500m"),
+										corev1.ResourceMemory: resource.MustParse("256Mi"),
+									},
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("250m"),
+										corev1.ResourceMemory: resource.MustParse("128Mi"),
+									},
+								},
+							},
+						},
+					},
+				}
+			},
+		},
+
+		// verifies that a named ConfigMap entry for a non-internal container does NOT
+		// override its existing resources (only internal containers get overridden).
+		{
+			name: "test-named-entry-does-not-override-non-internal-container-with-resources",
+			targetPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "custom-ns"},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "step-user-build",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("2"),
+									corev1.ResourceMemory: resource.MustParse("1Gi"),
+								},
+							},
+						},
+					},
+				},
+			},
+			resourceRequirements: map[string]corev1.ResourceRequirements{
+				"step-user-build": {
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("100m"),
+						corev1.ResourceMemory: resource.MustParse("64Mi"),
+					},
+				},
+			},
+			getExpectedPod: func() *corev1.Pod {
+				return &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "custom-ns"},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							// non-internal container with existing resources: NOT overridden by named entry
+							{
+								Name: "step-user-build",
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("2"),
+										corev1.ResourceMemory: resource.MustParse("1Gi"),
+									},
+								},
+							},
+						},
+					},
+				}
+			},
+		},
+
+		// verifies that a prefix-only entry overrides internal container code-level defaults
+		// when no named entry exists (prefix > default for internal containers).
+		{
+			name: "test-prefix-only-overrides-internal-container-defaults",
+			targetPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "custom-ns"},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "sidecar-tekton-log-results",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("10m"),
+									corev1.ResourceMemory: resource.MustParse("32Mi"),
+								},
+							},
+						},
+					},
+				},
+			},
+			resourceRequirements: map[string]corev1.ResourceRequirements{
+				"prefix-sidecar": {
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("200m"),
+						corev1.ResourceMemory: resource.MustParse("128Mi"),
+					},
+				},
+				"default": {
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("50m"),
+						corev1.ResourceMemory: resource.MustParse("32Mi"),
+					},
+				},
+			},
+			getExpectedPod: func() *corev1.Pod {
+				return &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "custom-ns"},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							// prefix entry wins over default for internal container
+							{
+								Name: "sidecar-tekton-log-results",
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("200m"),
+										corev1.ResourceMemory: resource.MustParse("128Mi"),
+									},
+								},
+							},
+						},
+					},
+				}
+			},
+		},
+
+		// verifies that a named ConfigMap entry takes precedence over a prefix entry
+		// for the same internal container (named > prefix > default).
+		{
+			name: "test-named-entry-takes-precedence-over-prefix-for-internal-container",
+			targetPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "custom-ns"},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "sidecar-tekton-log-results",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("10m"),
+									corev1.ResourceMemory: resource.MustParse("32Mi"),
+								},
+							},
+						},
+					},
+				},
+			},
+			resourceRequirements: map[string]corev1.ResourceRequirements{
+				// Named entry for the exact container
+				"sidecar-tekton-log-results": {
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("512Mi"),
+					},
+				},
+				// Prefix entry that also matches
+				"prefix-sidecar": {
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("100m"),
+						corev1.ResourceMemory: resource.MustParse("64Mi"),
+					},
+				},
+				// Default entry
+				"default": {
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("50m"),
+						corev1.ResourceMemory: resource.MustParse("32Mi"),
+					},
+				},
+			},
+			getExpectedPod: func() *corev1.Pod {
+				return &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "custom-ns"},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							// Named entry wins over prefix and default
+							{
+								Name: "sidecar-tekton-log-results",
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("1"),
+										corev1.ResourceMemory: resource.MustParse("512Mi"),
+									},
+								},
+							},
+						},
+					},
+				}
 			},
 		},
 	}

--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -37,6 +37,7 @@ import (
 	tknreconciler "github.com/tektoncd/pipeline/pkg/reconciler"
 	"github.com/tektoncd/pipeline/pkg/spire"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/version"
@@ -83,6 +84,12 @@ const (
 
 	// K8s version to determine if to use native k8s sidecar or Tekton sidecar
 	SidecarK8sMinorVersionCheck = 29
+
+	// Internal container name constants. These containers are created by Tekton
+	// and are not user-defined steps or sidecars.
+	ContainerNamePrepare               = "prepare"
+	ContainerNamePlaceScripts          = "place-scripts"
+	ContainerNameWorkingDirInitializer = "working-dir-initializer"
 )
 
 // These are effectively const, but Go doesn't have such an annotation.
@@ -131,7 +138,26 @@ var (
 
 	// MaxActiveDeadlineSeconds is a maximum permitted value to be used for a task with no timeout
 	MaxActiveDeadlineSeconds = int64(math.MaxInt32)
+
+	// internalContainerDefaultCPU is the default CPU request for init containers (prepare, place-scripts, working-dir-initializer).
+	internalContainerDefaultCPU = resource.MustParse("10m")
+	// internalContainerDefaultSidecarCPU is the default CPU request for the results sidecar which runs continuously.
+	internalContainerDefaultSidecarCPU = resource.MustParse("50m")
+	// internalContainerDefaultMemorySmall is the default memory request (16Mi) for prepare and working-dir-initializer.
+	internalContainerDefaultMemorySmall = resource.MustParse("16Mi")
+	// internalContainerDefaultMemoryMedium is the default memory request (32Mi) for place-scripts and results sidecar.
+	internalContainerDefaultMemoryMedium = resource.MustParse("32Mi")
 )
+
+// IsInternalContainer returns true if the container name is one of Tekton's
+// internal containers (prepare, place-scripts, working-dir-initializer, or
+// the results sidecar).
+func IsInternalContainer(name string) bool {
+	return name == ContainerNamePrepare ||
+		name == ContainerNamePlaceScripts ||
+		name == ContainerNameWorkingDirInitializer ||
+		name == pipeline.ReservedResultsSidecarContainerName
+}
 
 // Builder exposes options to configure Pod construction from TaskSpecs/Runs.
 type Builder struct {
@@ -624,7 +650,7 @@ func entrypointInitContainer(image string, steps []v1.Step, securityContext Secu
 	// container to place the entrypoint binary. Also add timeout flags
 	// to entrypoint binary.
 	prepareInitContainer := corev1.Container{
-		Name:  "prepare",
+		Name:  ContainerNamePrepare,
 		Image: image,
 		// Rewrite default WorkingDir from "/home/nonroot" to "/"
 		// as suggested at https://github.com/GoogleContainerTools/distroless/issues/718
@@ -632,6 +658,16 @@ func entrypointInitContainer(image string, steps []v1.Step, securityContext Secu
 		WorkingDir:   "/",
 		Command:      command,
 		VolumeMounts: volumeMounts,
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    internalContainerDefaultCPU,
+				corev1.ResourceMemory: internalContainerDefaultMemorySmall,
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    internalContainerDefaultCPU,
+				corev1.ResourceMemory: internalContainerDefaultMemorySmall,
+			},
+		},
 	}
 	if securityContext.SetSecurityContext {
 		prepareInitContainer.SecurityContext = securityContext.GetSecurityContext(windows)
@@ -697,6 +733,16 @@ func createResultsSidecar(taskSpec v1.TaskSpec, image string, securityContext Se
 			{
 				Name:  "SIDECAR_LOG_POLLING_INTERVAL",
 				Value: pollingInterval.String(),
+			},
+		},
+		ComputeResources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    internalContainerDefaultSidecarCPU,
+				corev1.ResourceMemory: internalContainerDefaultMemoryMedium,
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    internalContainerDefaultSidecarCPU,
+				corev1.ResourceMemory: internalContainerDefaultMemoryMedium,
 			},
 		},
 	}

--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -139,11 +139,16 @@ var (
 	// MaxActiveDeadlineSeconds is a maximum permitted value to be used for a task with no timeout
 	MaxActiveDeadlineSeconds = int64(math.MaxInt32)
 
-	// internalContainerDefaultCPU is the default CPU request for init containers (prepare, place-scripts, working-dir-initializer).
+	// internalContainerDefaultCPU is the default CPU request for lightweight init containers (prepare, working-dir-initializer).
 	internalContainerDefaultCPU = resource.MustParse("10m")
+	// internalContainerDefaultScriptCPU is the default CPU request for the script materialization init container.
+	// This init container can process large inline scripts, so avoid throttling it as aggressively as the lightweight init containers.
+	internalContainerDefaultScriptCPU = resource.MustParse("100m")
 	// internalContainerDefaultSidecarCPU is the default CPU request for the results sidecar which runs continuously.
 	internalContainerDefaultSidecarCPU = resource.MustParse("50m")
-	// internalContainerDefaultMemorySmall is the default memory request (16Mi) for prepare and working-dir-initializer.
+	// internalContainerDefaultPrepareMemory is the default memory request for the prepare init container.
+	internalContainerDefaultPrepareMemory = resource.MustParse("32Mi")
+	// internalContainerDefaultMemorySmall is the default memory request (16Mi) for working-dir-initializer.
 	internalContainerDefaultMemorySmall = resource.MustParse("16Mi")
 	// internalContainerDefaultMemoryMedium is the default memory request (32Mi) for place-scripts and results sidecar.
 	internalContainerDefaultMemoryMedium = resource.MustParse("32Mi")
@@ -661,11 +666,11 @@ func entrypointInitContainer(image string, steps []v1.Step, securityContext Secu
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    internalContainerDefaultCPU,
-				corev1.ResourceMemory: internalContainerDefaultMemorySmall,
+				corev1.ResourceMemory: internalContainerDefaultPrepareMemory,
 			},
 			Limits: corev1.ResourceList{
 				corev1.ResourceCPU:    internalContainerDefaultCPU,
-				corev1.ResourceMemory: internalContainerDefaultMemorySmall,
+				corev1.ResourceMemory: internalContainerDefaultPrepareMemory,
 			},
 		},
 	}

--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -480,6 +480,16 @@ func TestPodBuild(t *testing.T) {
 						Args:         []string{filepath.Join(pipeline.WorkspaceDir, "test")},
 						WorkingDir:   pipeline.WorkspaceDir,
 						VolumeMounts: implicitVolumeMounts,
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("10m"),
+								corev1.ResourceMemory: resource.MustParse("16Mi"),
+							},
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("10m"),
+								corev1.ResourceMemory: resource.MustParse("16Mi"),
+							},
+						},
 					},
 				},
 				Containers: []corev1.Container{{
@@ -557,9 +567,6 @@ func TestPodBuild(t *testing.T) {
 				}, {
 					Name:  "sidecar-sc-name",
 					Image: "sidecar-image",
-					Resources: corev1.ResourceRequirements{
-						Requests: nil,
-					},
 				}},
 				Volumes: append(implicitVolumes, binVolume, runVolume(0), downwardVolume, corev1.Volume{
 					Name:         "tekton-creds-init-home-0",
@@ -592,6 +599,16 @@ func TestPodBuild(t *testing.T) {
 						Image:        "busybox",
 						Command:      []string{"sh"},
 						VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("10m"),
+								corev1.ResourceMemory: resource.MustParse("32Mi"),
+							},
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("10m"),
+								corev1.ResourceMemory: resource.MustParse("32Mi"),
+							},
+						},
 						Args: []string{"-c", `scriptfile="/tekton/scripts/sidecar-script-0-9l9zj"
 touch ${scriptfile} && chmod +x ${scriptfile}
 cat > ${scriptfile} << '_EOF_'
@@ -1049,6 +1066,16 @@ _EOF_
 /tekton/bin/entrypoint decode-script "${scriptfile}"
 `},
 						VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("10m"),
+								corev1.ResourceMemory: resource.MustParse("32Mi"),
+							},
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("10m"),
+								corev1.ResourceMemory: resource.MustParse("32Mi"),
+							},
+						},
 					},
 				},
 				Containers: []corev1.Container{{
@@ -1167,6 +1194,16 @@ _EOF_
 /tekton/bin/entrypoint decode-script "${scriptfile}"
 `},
 						VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("10m"),
+								corev1.ResourceMemory: resource.MustParse("32Mi"),
+							},
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("10m"),
+								corev1.ResourceMemory: resource.MustParse("32Mi"),
+							},
+						},
 					},
 				},
 				Containers: []corev1.Container{{
@@ -2053,7 +2090,14 @@ _EOF_
 						"{}",
 					},
 					Resources: corev1.ResourceRequirements{
-						Requests: nil,
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("50m"),
+							corev1.ResourceMemory: resource.MustParse("32Mi"),
+						},
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("50m"),
+							corev1.ResourceMemory: resource.MustParse("32Mi"),
+						},
 					},
 					VolumeMounts: append([]corev1.VolumeMount{
 						{Name: "tekton-internal-bin", ReadOnly: true, MountPath: "/tekton/bin"},
@@ -2135,7 +2179,14 @@ _EOF_
 						"{\"step-name\":[\"step-foo\"]}",
 					},
 					Resources: corev1.ResourceRequirements{
-						Requests: nil,
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("50m"),
+							corev1.ResourceMemory: resource.MustParse("32Mi"),
+						},
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("50m"),
+							corev1.ResourceMemory: resource.MustParse("32Mi"),
+						},
 					},
 					VolumeMounts: append([]corev1.VolumeMount{
 						{Name: "tekton-internal-bin", ReadOnly: true, MountPath: "/tekton/bin"},
@@ -2211,7 +2262,14 @@ _EOF_
 						"{}",
 					},
 					Resources: corev1.ResourceRequirements{
-						Requests: nil,
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("50m"),
+							corev1.ResourceMemory: resource.MustParse("32Mi"),
+						},
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("50m"),
+							corev1.ResourceMemory: resource.MustParse("32Mi"),
+						},
 					},
 					VolumeMounts: append([]corev1.VolumeMount{
 						{Name: "tekton-internal-bin", ReadOnly: true, MountPath: "/tekton/bin"},
@@ -2291,7 +2349,14 @@ _EOF_
 						"{}",
 					},
 					Resources: corev1.ResourceRequirements{
-						Requests: nil,
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("50m"),
+							corev1.ResourceMemory: resource.MustParse("32Mi"),
+						},
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("50m"),
+							corev1.ResourceMemory: resource.MustParse("32Mi"),
+						},
 					},
 					VolumeMounts: append([]corev1.VolumeMount{
 						{Name: "tekton-internal-bin", ReadOnly: true, MountPath: "/tekton/bin"},
@@ -2376,7 +2441,14 @@ _EOF_
 						"{\"step-name\":[\"step-foo\"]}",
 					},
 					Resources: corev1.ResourceRequirements{
-						Requests: nil,
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("50m"),
+							corev1.ResourceMemory: resource.MustParse("32Mi"),
+						},
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("50m"),
+							corev1.ResourceMemory: resource.MustParse("32Mi"),
+						},
 					},
 					VolumeMounts: append([]corev1.VolumeMount{
 						{Name: "tekton-internal-bin", ReadOnly: true, MountPath: "/tekton/bin"},
@@ -2455,7 +2527,14 @@ _EOF_
 						"{}",
 					},
 					Resources: corev1.ResourceRequirements{
-						Requests: nil,
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("50m"),
+							corev1.ResourceMemory: resource.MustParse("32Mi"),
+						},
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("50m"),
+							corev1.ResourceMemory: resource.MustParse("32Mi"),
+						},
 					},
 					VolumeMounts: append([]corev1.VolumeMount{
 						{Name: "tekton-internal-bin", ReadOnly: true, MountPath: "/tekton/bin"},
@@ -2735,6 +2814,16 @@ func TestPodBuildwithAlphaAPIEnabled(t *testing.T) {
 		Image:        "busybox",
 		Command:      []string{"sh"},
 		VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, binMount, debugScriptsVolumeMount},
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceMemory: resource.MustParse("32Mi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceMemory: resource.MustParse("32Mi"),
+			},
+		},
 		Args: []string{"-c", `tmpfile="/tekton/debug/scripts/debug-continue"
 touch ${tmpfile} && chmod +x ${tmpfile}
 cat > ${tmpfile} << 'debug-continue-heredoc-randomly-generated-9l9zj'
@@ -3456,6 +3545,16 @@ func TestPrepareInitContainers(t *testing.T) {
 			WorkingDir:   "/",
 			Command:      []string{"/ko-app/entrypoint", "init", "/ko-app/entrypoint", entrypointBinary, "step-foo"},
 			VolumeMounts: []corev1.VolumeMount{binMount, internalStepsMount},
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("10m"),
+					corev1.ResourceMemory: resource.MustParse("16Mi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("10m"),
+					corev1.ResourceMemory: resource.MustParse("16Mi"),
+				},
+			},
 		},
 	}, {
 		name: "nothing-special-two-steps",
@@ -3470,6 +3569,16 @@ func TestPrepareInitContainers(t *testing.T) {
 			WorkingDir:   "/",
 			Command:      []string{"/ko-app/entrypoint", "init", "/ko-app/entrypoint", entrypointBinary, "step-foo", "step-bar"},
 			VolumeMounts: []corev1.VolumeMount{binMount, internalStepsMount},
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("10m"),
+					corev1.ResourceMemory: resource.MustParse("16Mi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("10m"),
+					corev1.ResourceMemory: resource.MustParse("16Mi"),
+				},
+			},
 		},
 	}, {
 		name: "nothing-special-two-steps-security-context",
@@ -3486,6 +3595,16 @@ func TestPrepareInitContainers(t *testing.T) {
 			WorkingDir:   "/",
 			Command:      []string{"/ko-app/entrypoint", "init", "/ko-app/entrypoint", entrypointBinary, "step-foo", "step-bar"},
 			VolumeMounts: []corev1.VolumeMount{binMount, internalStepsMount},
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("10m"),
+					corev1.ResourceMemory: resource.MustParse("16Mi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("10m"),
+					corev1.ResourceMemory: resource.MustParse("16Mi"),
+				},
+			},
 			SecurityContext: SecurityContextConfig{
 				SetSecurityContext:        true,
 				SetReadOnlyRootFilesystem: true,
@@ -3505,6 +3624,16 @@ func TestPrepareInitContainers(t *testing.T) {
 			WorkingDir:   "/",
 			Command:      []string{"/ko-app/entrypoint", "init", "/ko-app/entrypoint", entrypointBinary, "step-foo", "step-bar"},
 			VolumeMounts: []corev1.VolumeMount{binMount, internalStepsMount},
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("10m"),
+					corev1.ResourceMemory: resource.MustParse("16Mi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("10m"),
+					corev1.ResourceMemory: resource.MustParse("16Mi"),
+				},
+			},
 		},
 	}, {
 		name: "nothing-special-two-steps-windows-security-context",
@@ -3517,11 +3646,21 @@ func TestPrepareInitContainers(t *testing.T) {
 		setSecurityContextReadOnlyRootFilesystem: true,
 		windows:                                  true,
 		want: corev1.Container{
-			Name:            "prepare",
-			Image:           images.EntrypointImage,
-			WorkingDir:      "/",
-			Command:         []string{"/ko-app/entrypoint", "init", "/ko-app/entrypoint", entrypointBinary, "step-foo", "step-bar"},
-			VolumeMounts:    []corev1.VolumeMount{binMount, internalStepsMount},
+			Name:         "prepare",
+			Image:        images.EntrypointImage,
+			WorkingDir:   "/",
+			Command:      []string{"/ko-app/entrypoint", "init", "/ko-app/entrypoint", entrypointBinary, "step-foo", "step-bar"},
+			VolumeMounts: []corev1.VolumeMount{binMount, internalStepsMount},
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("10m"),
+					corev1.ResourceMemory: resource.MustParse("16Mi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("10m"),
+					corev1.ResourceMemory: resource.MustParse("16Mi"),
+				},
+			},
 			SecurityContext: WindowsSecurityContext,
 		},
 	}}

--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -601,11 +601,11 @@ func TestPodBuild(t *testing.T) {
 						VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("10m"),
+								corev1.ResourceCPU:    resource.MustParse("100m"),
 								corev1.ResourceMemory: resource.MustParse("32Mi"),
 							},
 							Limits: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("10m"),
+								corev1.ResourceCPU:    resource.MustParse("100m"),
 								corev1.ResourceMemory: resource.MustParse("32Mi"),
 							},
 						},
@@ -1068,11 +1068,11 @@ _EOF_
 						VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("10m"),
+								corev1.ResourceCPU:    resource.MustParse("100m"),
 								corev1.ResourceMemory: resource.MustParse("32Mi"),
 							},
 							Limits: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("10m"),
+								corev1.ResourceCPU:    resource.MustParse("100m"),
 								corev1.ResourceMemory: resource.MustParse("32Mi"),
 							},
 						},
@@ -1196,11 +1196,11 @@ _EOF_
 						VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("10m"),
+								corev1.ResourceCPU:    resource.MustParse("100m"),
 								corev1.ResourceMemory: resource.MustParse("32Mi"),
 							},
 							Limits: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("10m"),
+								corev1.ResourceCPU:    resource.MustParse("100m"),
 								corev1.ResourceMemory: resource.MustParse("32Mi"),
 							},
 						},
@@ -2816,11 +2816,11 @@ func TestPodBuildwithAlphaAPIEnabled(t *testing.T) {
 		VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, binMount, debugScriptsVolumeMount},
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceCPU:    resource.MustParse("100m"),
 				corev1.ResourceMemory: resource.MustParse("32Mi"),
 			},
 			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceCPU:    resource.MustParse("100m"),
 				corev1.ResourceMemory: resource.MustParse("32Mi"),
 			},
 		},
@@ -3548,11 +3548,11 @@ func TestPrepareInitContainers(t *testing.T) {
 			Resources: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("10m"),
-					corev1.ResourceMemory: resource.MustParse("16Mi"),
+					corev1.ResourceMemory: resource.MustParse("32Mi"),
 				},
 				Limits: corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("10m"),
-					corev1.ResourceMemory: resource.MustParse("16Mi"),
+					corev1.ResourceMemory: resource.MustParse("32Mi"),
 				},
 			},
 		},
@@ -3572,11 +3572,11 @@ func TestPrepareInitContainers(t *testing.T) {
 			Resources: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("10m"),
-					corev1.ResourceMemory: resource.MustParse("16Mi"),
+					corev1.ResourceMemory: resource.MustParse("32Mi"),
 				},
 				Limits: corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("10m"),
-					corev1.ResourceMemory: resource.MustParse("16Mi"),
+					corev1.ResourceMemory: resource.MustParse("32Mi"),
 				},
 			},
 		},
@@ -3598,11 +3598,11 @@ func TestPrepareInitContainers(t *testing.T) {
 			Resources: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("10m"),
-					corev1.ResourceMemory: resource.MustParse("16Mi"),
+					corev1.ResourceMemory: resource.MustParse("32Mi"),
 				},
 				Limits: corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("10m"),
-					corev1.ResourceMemory: resource.MustParse("16Mi"),
+					corev1.ResourceMemory: resource.MustParse("32Mi"),
 				},
 			},
 			SecurityContext: SecurityContextConfig{
@@ -3627,11 +3627,11 @@ func TestPrepareInitContainers(t *testing.T) {
 			Resources: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("10m"),
-					corev1.ResourceMemory: resource.MustParse("16Mi"),
+					corev1.ResourceMemory: resource.MustParse("32Mi"),
 				},
 				Limits: corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("10m"),
-					corev1.ResourceMemory: resource.MustParse("16Mi"),
+					corev1.ResourceMemory: resource.MustParse("32Mi"),
 				},
 			},
 		},
@@ -3654,11 +3654,11 @@ func TestPrepareInitContainers(t *testing.T) {
 			Resources: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("10m"),
-					corev1.ResourceMemory: resource.MustParse("16Mi"),
+					corev1.ResourceMemory: resource.MustParse("32Mi"),
 				},
 				Limits: corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("10m"),
-					corev1.ResourceMemory: resource.MustParse("16Mi"),
+					corev1.ResourceMemory: resource.MustParse("32Mi"),
 				},
 			},
 			SecurityContext: WindowsSecurityContext,

--- a/pkg/pod/script.go
+++ b/pkg/pod/script.go
@@ -96,11 +96,21 @@ func convertScripts(shellImageLinux string, shellImageWin string, steps []v1.Ste
 	}
 
 	placeScriptsInit := corev1.Container{
-		Name:         "place-scripts",
+		Name:         ContainerNamePlaceScripts,
 		Image:        shellImage,
 		Command:      []string{shellCommand},
 		Args:         []string{shellArg, ""},
 		VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    internalContainerDefaultCPU,
+				corev1.ResourceMemory: internalContainerDefaultMemoryMedium,
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    internalContainerDefaultCPU,
+				corev1.ResourceMemory: internalContainerDefaultMemoryMedium,
+			},
+		},
 	}
 
 	if securityContext.SetSecurityContext {

--- a/pkg/pod/script.go
+++ b/pkg/pod/script.go
@@ -103,11 +103,11 @@ func convertScripts(shellImageLinux string, shellImageWin string, steps []v1.Ste
 		VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    internalContainerDefaultCPU,
+				corev1.ResourceCPU:    internalContainerDefaultScriptCPU,
 				corev1.ResourceMemory: internalContainerDefaultMemoryMedium,
 			},
 			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    internalContainerDefaultCPU,
+				corev1.ResourceCPU:    internalContainerDefaultScriptCPU,
 				corev1.ResourceMemory: internalContainerDefaultMemoryMedium,
 			},
 		},

--- a/pkg/pod/script_test.go
+++ b/pkg/pod/script_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/tektoncd/pipeline/test/diff"
 	"github.com/tektoncd/pipeline/test/names"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 func TestConvertScripts_NothingToConvert_EmptySidecars(t *testing.T) {
@@ -158,7 +159,17 @@ IyEvYmluL3NoCnNldCAtZQpuby1zaGViYW5n
 _EOF_
 /tekton/bin/entrypoint decode-script "${scriptfile}"
 `},
-		VolumeMounts:    []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
+		VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceMemory: resource.MustParse("32Mi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceMemory: resource.MustParse("32Mi"),
+			},
+		},
 		SecurityContext: SecurityContextConfig{SetSecurityContext: true, SetReadOnlyRootFilesystem: true}.GetSecurityContext(false),
 	}
 	want := []corev1.Container{{
@@ -464,7 +475,17 @@ else
 fi
 debug-fail-continue-heredoc-randomly-generated-6nl7g
 `},
-				VolumeMounts:    []corev1.VolumeMount{writeScriptsVolumeMount, binMount, debugScriptsVolumeMount},
+				VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, binMount, debugScriptsVolumeMount},
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("10m"),
+						corev1.ResourceMemory: resource.MustParse("32Mi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("10m"),
+						corev1.ResourceMemory: resource.MustParse("32Mi"),
+					},
+				},
 				SecurityContext: SecurityContextConfig{SetSecurityContext: true, SetReadOnlyRootFilesystem: true}.GetSecurityContext(false),
 			},
 			wantSteps: []corev1.Container{{
@@ -607,7 +628,17 @@ else
 fi
 debug-beforestep-fail-continue-heredoc-randomly-generated-6nl7g
 `},
-				VolumeMounts:    []corev1.VolumeMount{writeScriptsVolumeMount, binMount, debugScriptsVolumeMount},
+				VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, binMount, debugScriptsVolumeMount},
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("10m"),
+						corev1.ResourceMemory: resource.MustParse("32Mi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("10m"),
+						corev1.ResourceMemory: resource.MustParse("32Mi"),
+					},
+				},
 				SecurityContext: SecurityContextConfig{SetSecurityContext: true, SetReadOnlyRootFilesystem: true}.GetSecurityContext(false),
 			},
 			wantSteps: []corev1.Container{{
@@ -690,7 +721,17 @@ IyEvYmluL3NoCnNpZGVjYXItMQ==
 _EOF_
 /tekton/bin/entrypoint decode-script "${scriptfile}"
 `},
-		VolumeMounts:    []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
+		VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceMemory: resource.MustParse("32Mi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceMemory: resource.MustParse("32Mi"),
+			},
+		},
 		SecurityContext: SecurityContextConfig{SetSecurityContext: true, SetReadOnlyRootFilesystem: true}.GetSecurityContext(false),
 	}
 	want := []corev1.Container{{
@@ -777,7 +818,17 @@ script-3
 no-shebang
 "@ | Out-File -FilePath /tekton/scripts/script-3-mssqb.cmd
 `},
-		VolumeMounts:    []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
+		VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceMemory: resource.MustParse("32Mi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceMemory: resource.MustParse("32Mi"),
+			},
+		},
 		SecurityContext: WindowsSecurityContext,
 	}
 	want := []corev1.Container{{
@@ -860,7 +911,17 @@ script-3
 sidecar-1
 "@ | Out-File -FilePath /tekton/scripts/sidecar-script-0-mssqb
 `},
-		VolumeMounts:    []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
+		VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceMemory: resource.MustParse("32Mi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceMemory: resource.MustParse("32Mi"),
+			},
+		},
 		SecurityContext: WindowsSecurityContext,
 	}
 	want := []corev1.Container{{
@@ -922,7 +983,17 @@ sidecar-1`,
 sidecar-1
 "@ | Out-File -FilePath /tekton/scripts/sidecar-script-0-9l9zj
 `},
-		VolumeMounts:    []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
+		VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceMemory: resource.MustParse("32Mi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceMemory: resource.MustParse("32Mi"),
+			},
+		},
 		SecurityContext: WindowsSecurityContext,
 	}
 	want := []corev1.Container{{

--- a/pkg/pod/script_test.go
+++ b/pkg/pod/script_test.go
@@ -162,11 +162,11 @@ _EOF_
 		VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceCPU:    resource.MustParse("100m"),
 				corev1.ResourceMemory: resource.MustParse("32Mi"),
 			},
 			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceCPU:    resource.MustParse("100m"),
 				corev1.ResourceMemory: resource.MustParse("32Mi"),
 			},
 		},
@@ -478,11 +478,11 @@ debug-fail-continue-heredoc-randomly-generated-6nl7g
 				VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, binMount, debugScriptsVolumeMount},
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("10m"),
+						corev1.ResourceCPU:    resource.MustParse("100m"),
 						corev1.ResourceMemory: resource.MustParse("32Mi"),
 					},
 					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("10m"),
+						corev1.ResourceCPU:    resource.MustParse("100m"),
 						corev1.ResourceMemory: resource.MustParse("32Mi"),
 					},
 				},
@@ -631,11 +631,11 @@ debug-beforestep-fail-continue-heredoc-randomly-generated-6nl7g
 				VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, binMount, debugScriptsVolumeMount},
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("10m"),
+						corev1.ResourceCPU:    resource.MustParse("100m"),
 						corev1.ResourceMemory: resource.MustParse("32Mi"),
 					},
 					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("10m"),
+						corev1.ResourceCPU:    resource.MustParse("100m"),
 						corev1.ResourceMemory: resource.MustParse("32Mi"),
 					},
 				},
@@ -724,11 +724,11 @@ _EOF_
 		VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceCPU:    resource.MustParse("100m"),
 				corev1.ResourceMemory: resource.MustParse("32Mi"),
 			},
 			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceCPU:    resource.MustParse("100m"),
 				corev1.ResourceMemory: resource.MustParse("32Mi"),
 			},
 		},
@@ -821,11 +821,11 @@ no-shebang
 		VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceCPU:    resource.MustParse("100m"),
 				corev1.ResourceMemory: resource.MustParse("32Mi"),
 			},
 			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceCPU:    resource.MustParse("100m"),
 				corev1.ResourceMemory: resource.MustParse("32Mi"),
 			},
 		},
@@ -914,11 +914,11 @@ sidecar-1
 		VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceCPU:    resource.MustParse("100m"),
 				corev1.ResourceMemory: resource.MustParse("32Mi"),
 			},
 			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceCPU:    resource.MustParse("100m"),
 				corev1.ResourceMemory: resource.MustParse("32Mi"),
 			},
 		},
@@ -986,11 +986,11 @@ sidecar-1
 		VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceCPU:    resource.MustParse("100m"),
 				corev1.ResourceMemory: resource.MustParse("32Mi"),
 			},
 			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceCPU:    resource.MustParse("100m"),
 				corev1.ResourceMemory: resource.MustParse("32Mi"),
 			},
 		},

--- a/pkg/pod/workingdir_init.go
+++ b/pkg/pod/workingdir_init.go
@@ -62,12 +62,22 @@ func workingDirInit(workingdirinitImage string, stepContainers []corev1.Containe
 	}
 
 	c := &corev1.Container{
-		Name:         "working-dir-initializer",
+		Name:         ContainerNameWorkingDirInitializer,
 		Image:        workingdirinitImage,
 		Command:      []string{"/ko-app/workingdirinit"},
 		Args:         relativeDirs,
 		WorkingDir:   pipeline.WorkspaceDir,
 		VolumeMounts: implicitVolumeMounts,
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    internalContainerDefaultCPU,
+				corev1.ResourceMemory: internalContainerDefaultMemorySmall,
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    internalContainerDefaultCPU,
+				corev1.ResourceMemory: internalContainerDefaultMemorySmall,
+			},
+		},
 	}
 	if securityContext.SetSecurityContext {
 		c.SecurityContext = securityContext.GetSecurityContext(windows)

--- a/pkg/pod/workingdir_init_test.go
+++ b/pkg/pod/workingdir_init_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/tektoncd/pipeline/test/diff"
 	"github.com/tektoncd/pipeline/test/names"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 func TestWorkingDirInit(t *testing.T) {
@@ -65,6 +66,16 @@ func TestWorkingDirInit(t *testing.T) {
 			Args:         []string{"/workspace/bbb", "aaa", "zzz"},
 			WorkingDir:   pipeline.WorkspaceDir,
 			VolumeMounts: implicitVolumeMounts,
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("10m"),
+					corev1.ResourceMemory: resource.MustParse("16Mi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("10m"),
+					corev1.ResourceMemory: resource.MustParse("16Mi"),
+				},
+			},
 		},
 	}, {
 		desc: "workingDirs are unique and sorted, absolute dirs are ignored, + securitycontext",
@@ -86,12 +97,22 @@ func TestWorkingDirInit(t *testing.T) {
 		setSecurityContext:             true,
 		setSecurityContextReadOnlyRoot: true,
 		want: &corev1.Container{
-			Name:            "working-dir-initializer",
-			Image:           images.WorkingDirInitImage,
-			Command:         []string{"/ko-app/workingdirinit"},
-			Args:            []string{"/workspace/bbb", "aaa", "zzz"},
-			WorkingDir:      pipeline.WorkspaceDir,
-			VolumeMounts:    implicitVolumeMounts,
+			Name:         "working-dir-initializer",
+			Image:        images.WorkingDirInitImage,
+			Command:      []string{"/ko-app/workingdirinit"},
+			Args:         []string{"/workspace/bbb", "aaa", "zzz"},
+			WorkingDir:   pipeline.WorkspaceDir,
+			VolumeMounts: implicitVolumeMounts,
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("10m"),
+					corev1.ResourceMemory: resource.MustParse("16Mi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("10m"),
+					corev1.ResourceMemory: resource.MustParse("16Mi"),
+				},
+			},
 			SecurityContext: SecurityContextConfig{SetSecurityContext: true, SetReadOnlyRootFilesystem: true}.GetSecurityContext(false),
 		},
 	}, {
@@ -119,6 +140,16 @@ func TestWorkingDirInit(t *testing.T) {
 			Args:         []string{"/workspace/bbb", "aaa", "zzz"},
 			WorkingDir:   pipeline.WorkspaceDir,
 			VolumeMounts: implicitVolumeMounts,
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("10m"),
+					corev1.ResourceMemory: resource.MustParse("16Mi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("10m"),
+					corev1.ResourceMemory: resource.MustParse("16Mi"),
+				},
+			},
 		},
 	}, {
 		desc: "workingDirs are unique and sorted, absolute dirs are ignored, uses windows, + securityContext",
@@ -141,12 +172,22 @@ func TestWorkingDirInit(t *testing.T) {
 		setSecurityContext:             true,
 		setSecurityContextReadOnlyRoot: true,
 		want: &corev1.Container{
-			Name:            "working-dir-initializer",
-			Image:           images.WorkingDirInitImage,
-			Command:         []string{"/ko-app/workingdirinit"},
-			Args:            []string{"/workspace/bbb", "aaa", "zzz"},
-			WorkingDir:      pipeline.WorkspaceDir,
-			VolumeMounts:    implicitVolumeMounts,
+			Name:         "working-dir-initializer",
+			Image:        images.WorkingDirInitImage,
+			Command:      []string{"/ko-app/workingdirinit"},
+			Args:         []string{"/workspace/bbb", "aaa", "zzz"},
+			WorkingDir:   pipeline.WorkspaceDir,
+			VolumeMounts: implicitVolumeMounts,
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("10m"),
+					corev1.ResourceMemory: resource.MustParse("16Mi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("10m"),
+					corev1.ResourceMemory: resource.MustParse("16Mi"),
+				},
+			},
 			SecurityContext: WindowsSecurityContext,
 		},
 	}} {

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -352,6 +352,16 @@ func placeToolsInitContainer(steps []string) corev1.Container {
 		WorkingDir: "/",
 		Name:       "prepare",
 		Image:      "override-with-entrypoint:latest",
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceMemory: resource.MustParse("16Mi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceMemory: resource.MustParse("16Mi"),
+			},
+		},
 	}
 }
 

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -355,11 +355,11 @@ func placeToolsInitContainer(steps []string) corev1.Container {
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("10m"),
-				corev1.ResourceMemory: resource.MustParse("16Mi"),
+				corev1.ResourceMemory: resource.MustParse("32Mi"),
 			},
 			Limits: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("10m"),
-				corev1.ResourceMemory: resource.MustParse("16Mi"),
+				corev1.ResourceMemory: resource.MustParse("32Mi"),
 			},
 		},
 	}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Fixes #2933

Tekton's internal containers (`prepare`, `place-scripts`, `working-dir-initializer`, `sidecar-tekton-log-results`) are created without resource requests, causing pod rejection in namespaces with `ResourceQuota` that requires explicit resource requests on all containers.

This PR adds minimal resource requirements (requests **and** limits: 10-100m CPU, 16-32Mi memory) as code-level defaults, **while preserving the `default-container-resource-requirements` ConfigMap override behavior**.

## Approach

1. **Code-level defaults** in container creation functions (`pod.go`, `script.go`, `workingdir_init.go`) provide a safety net so pods always have resource requirements.
2. **Matching requests and limits** ensure internal containers do not prevent Guaranteed QoS when step containers also have matching requests and limits.
3. **Transformer fix** in `transformer.go` allows ConfigMap entries (both named and `default`) to override code-level defaults on internal containers. This preserves the [documented ConfigMap behavior](https://github.com/tektoncd/pipeline/blob/main/docs/additional-configs.md#configuring-default-resources-requirements).

Resource values are defined as unexported package-level vars in `pod.go`:

| Var | Value | Used by |
|-----|-------|---------|
| `internalContainerDefaultCPU` | 10m | prepare, working-dir-initializer |
| `internalContainerDefaultScriptCPU` | 100m | place-scripts |
| `internalContainerDefaultSidecarCPU` | 50m | results sidecar |
| `internalContainerDefaultPrepareMemory` | 32Mi | prepare |
| `internalContainerDefaultMemorySmall` | 16Mi | working-dir-initializer |
| `internalContainerDefaultMemoryMedium` | 32Mi | place-scripts, results sidecar |

Internal container names are exported as constants (`ContainerNamePrepare`, `ContainerNamePlaceScripts`, `ContainerNameWorkingDirInitializer`) with an `IsInternalContainer()` helper to identify them.

## Transformer changes

The `IsInternalContainer()` function identifies the 4 internal containers. For these containers:
- Named/prefix ConfigMap entries override code-level defaults (even when `Resources.Size() != 0`)
- The `default` ConfigMap entry overrides code-level defaults when no named/prefix entry matched
- A `matchedBySpecificEntry` tracker prevents the `default` entry from overwriting a more specific named match

## QoS behavior

Internal containers set matching `requests == limits`, so they do not prevent Guaranteed QoS when step containers also have matching requests and limits. The `default-container-resource-requirements` ConfigMap can be used to tune these values for specific cluster requirements.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Internal Tekton containers (prepare, place-scripts, working-dir-initializer, sidecar-tekton-log-results) now include minimal resource requirements (requests and limits: 10m CPU, 16-32Mi memory), allowing pipelines to run in namespaces with ResourceQuota. Matching requests and limits ensure these containers do not prevent Guaranteed QoS. The default-container-resource-requirements ConfigMap can still override these defaults.
```

/kind bug
