### PR TITLE
fix: surface specific TaskRun failure reasons when pod fails

### DIFF
--- a/docs/pipeline-api.md
+++ b/docs/pipeline-api.md
@@ -5536,6 +5536,16 @@ TaskRuns failed due to reconciler/validation error should not use this reason.</
 </tr><tr><td><p>&#34;TaskRunImagePullFailed&#34;</p></td>
 <td><p>TaskRunReasonImagePullFailed is the reason set when the step of a task fails due to image not being pulled</p>
 </td>
+</tr><tr><td><p>&#34;InitContainerFailed&#34;</p></td>
+<td><p>TaskRunReasonInitContainerFailed indicates an internal Tekton init
+container (prepare, place-scripts, working-dir-initializer) failed
+(non-OOM), e.g., due to node memory pressure or runtime errors.</p>
+</td>
+</tr><tr><td><p>&#34;InitContainerOOM&#34;</p></td>
+<td><p>TaskRunReasonInitContainerOOM indicates an internal Tekton init
+container (prepare, place-scripts, working-dir-initializer) was
+killed due to running out of memory (OOMKilled).</p>
+</td>
 </tr><tr><td><p>&#34;InvalidParamValue&#34;</p></td>
 <td><p>TaskRunReasonInvalidParamValue indicates that the TaskRun Param input value is not allowed.</p>
 </td>
@@ -5544,6 +5554,10 @@ TaskRuns failed due to reconciler/validation error should not use this reason.</
 </td>
 </tr><tr><td><p>&#34;PodCreationFailed&#34;</p></td>
 <td><p>TaskRunReasonPodCreationFailed is the reason set when the pod backing the TaskRun fails to be created (e.g., CreateContainerError)</p>
+</td>
+</tr><tr><td><p>&#34;PodEvicted&#34;</p></td>
+<td><p>TaskRunReasonPodEvicted indicates that the TaskRun&rsquo;s pod was evicted
+(e.g., due to exceeding ephemeral storage limits or node pressure).</p>
 </td>
 </tr><tr><td><p>&#34;ResourceVerificationFailed&#34;</p></td>
 <td><p>TaskRunReasonResourceVerificationFailed indicates that the task fails the trusted resource verification,
@@ -5555,8 +5569,24 @@ it could be the content has changed, signature is invalid or public key is inval
 </tr><tr><td><p>&#34;Running&#34;</p></td>
 <td><p>TaskRunReasonRunning is the reason set when the TaskRun is running</p>
 </td>
+</tr><tr><td><p>&#34;SidecarFailed&#34;</p></td>
+<td><p>TaskRunReasonSidecarFailed indicates a sidecar container failed
+(non-OOM), e.g., bad image or crash.</p>
+</td>
+</tr><tr><td><p>&#34;SidecarOOM&#34;</p></td>
+<td><p>TaskRunReasonSidecarOOM indicates a sidecar container was killed due
+to running out of memory (OOMKilled).</p>
+</td>
 </tr><tr><td><p>&#34;Started&#34;</p></td>
 <td><p>TaskRunReasonStarted is the reason set when the TaskRun has just started</p>
+</td>
+</tr><tr><td><p>&#34;StepFailed&#34;</p></td>
+<td><p>TaskRunReasonStepFailed indicates a step container failed (non-OOM),
+e.g., bad image, crash, or non-zero exit code.</p>
+</td>
+</tr><tr><td><p>&#34;StepOOM&#34;</p></td>
+<td><p>TaskRunReasonStepOOM indicates a step container was killed due to
+running out of memory (OOMKilled).</p>
 </td>
 </tr><tr><td><p>&#34;TaskRunStopSidecarFailed&#34;</p></td>
 <td><p>TaskRunReasonStopSidecarFailed indicates that the sidecar is not properly stopped.</p>

--- a/docs/taskruns.md
+++ b/docs/taskruns.md
@@ -776,6 +776,20 @@ fully-qualified name of the container image, and the corresponding digest.
 **Note:** If any `Pods` have been [`OOMKilled`](https://kubernetes.io/docs/tasks/administer-cluster/out-of-resource/)
 by Kubernetes, the `TaskRun` is marked as failed even if its exit code is 0.
 
+When a `TaskRun` fails due to a pod-level issue, the `reason` field in the `Succeeded` condition
+indicates the specific failure type:
+
+| Reason | Description |
+|--------|-------------|
+| `PodEvicted` | The pod was evicted by Kubernetes (e.g. ephemeral storage limit exceeded). |
+| `InitContainerOOM` | An internal Tekton init container (`prepare`, `place-scripts`, `working-dir-initializer`) was terminated due to an out-of-memory condition. |
+| `InitContainerFailed` | An internal Tekton init container failed (e.g. node memory pressure caused the container runtime to kill it). |
+| `StepOOM` | A step container was terminated due to an out-of-memory condition (`OOMKilled`). |
+| `StepFailed` | A step container exited with a non-zero exit code (not OOM). |
+| `SidecarOOM` | A sidecar container was terminated due to an out-of-memory condition (`OOMKilled`). |
+| `SidecarFailed` | A sidecar container exited with a non-zero exit code (not OOM). |
+| `Failed` | Default fallback for other failures. |
+
 The following example shows the `status` field of a `TaskRun` that has executed successfully:
 
 ```yaml

--- a/pkg/apis/pipeline/v1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1/taskrun_types.go
@@ -237,6 +237,29 @@ const (
 	// TaskRunReasonResourceVerificationFailed indicates that the task fails the trusted resource verification,
 	// it could be the content has changed, signature is invalid or public key is invalid
 	TaskRunReasonResourceVerificationFailed TaskRunReason = "ResourceVerificationFailed"
+	// TaskRunReasonPodEvicted indicates that the TaskRun's pod was evicted
+	// (e.g., due to exceeding ephemeral storage limits or node pressure).
+	TaskRunReasonPodEvicted TaskRunReason = "PodEvicted"
+	// TaskRunReasonStepOOM indicates a step container was killed due to
+	// running out of memory (OOMKilled).
+	TaskRunReasonStepOOM TaskRunReason = "StepOOM"
+	// TaskRunReasonStepFailed indicates a step container failed (non-OOM),
+	// e.g., bad image, crash, or non-zero exit code.
+	TaskRunReasonStepFailed TaskRunReason = "StepFailed"
+	// TaskRunReasonSidecarOOM indicates a sidecar container was killed due
+	// to running out of memory (OOMKilled).
+	TaskRunReasonSidecarOOM TaskRunReason = "SidecarOOM"
+	// TaskRunReasonSidecarFailed indicates a sidecar container failed
+	// (non-OOM), e.g., bad image or crash.
+	TaskRunReasonSidecarFailed TaskRunReason = "SidecarFailed"
+	// TaskRunReasonInitContainerOOM indicates an internal Tekton init
+	// container (prepare, place-scripts, working-dir-initializer) was
+	// killed due to running out of memory (OOMKilled).
+	TaskRunReasonInitContainerOOM TaskRunReason = "InitContainerOOM"
+	// TaskRunReasonInitContainerFailed indicates an internal Tekton init
+	// container (prepare, place-scripts, working-dir-initializer) failed
+	// (non-OOM), e.g., due to node memory pressure or runtime errors.
+	TaskRunReasonInitContainerFailed TaskRunReason = "InitContainerFailed"
 	// TaskRunReasonFailureIgnored is the reason set when the Taskrun has failed due to pod execution error and the failure is ignored for the owning PipelineRun.
 	// TaskRuns failed due to reconciler/validation error should not use this reason.
 	TaskRunReasonFailureIgnored TaskRunReason = "FailureIgnored"

--- a/pkg/pod/status.go
+++ b/pkg/pod/status.go
@@ -611,7 +611,8 @@ func updateCompletedTaskRunStatus(logger *zap.SugaredLogger, trs *v1.TaskRunStat
 		if onError == v1.PipelineTaskContinue {
 			markStatusFailure(trs, v1.TaskRunReasonFailureIgnored.String(), msg)
 		} else {
-			markStatusFailure(trs, v1.TaskRunReasonFailed.String(), msg)
+			reason := getFailureReason(pod).String()
+			markStatusFailure(trs, reason, msg)
 		}
 	} else {
 		markStatusSuccess(trs)
@@ -752,6 +753,130 @@ func checkContainersCompleted(pod *corev1.Pod, nameFilters []containerNameFilter
 	return true
 }
 
+// failureInfo holds the classified failure reason and the container that
+// caused it. This ensures getFailureMessage always describes the same
+// container that getFailureReason classified.
+type failureInfo struct {
+	reason    v1.TaskRunReason
+	container *corev1.ContainerStatus
+	isInit    bool // true when the failing container is an init container
+}
+
+// getFailureInfo classifies the pod failure and returns both a specific
+// TaskRunReason and the container that caused it.
+// This surfaces meaningful failure reasons instead of the generic "Failed"
+// for all failure types.
+// See https://github.com/tektoncd/pipeline/issues/7396
+//
+// Precondition: DidTaskRunFail(pod) returned true.
+// This is guaranteed because init container failures and sidecar OOM
+// cause Kubernetes to set pod.Status.Phase = PodFailed.
+//
+// Priority order (sidecar failures surface before step failures
+// because a crashed sidecar is likely the root cause):
+//  1. PodEvicted            - pod-level eviction (ephemeral storage, node pressure)
+//  2. InitContainerOOM      - internal Tekton init container OOMKilled
+//  3. InitContainerFailed   - internal Tekton init container failed (non-OOM)
+//  4. SidecarOOM            - sidecar OOMKilled (init or regular container)
+//  5. StepOOM               - step OOMKilled
+//  6. SidecarFailed         - sidecar failed non-OOM (init or regular container)
+//  7. StepFailed            - step failed non-OOM
+//  8. Failed                - generic fallthrough (unknown)
+func getFailureInfo(pod *corev1.Pod) failureInfo {
+	// Check pod-level eviction first, this is authoritative.
+	if pod.Status.Reason == evicted {
+		return failureInfo{reason: v1.TaskRunReasonPodEvicted}
+	}
+
+	// Check init containers. Init containers include native sidecars
+	// (sidecar-*, with restartPolicy: Always) and internal Tekton
+	// containers (prepare, place-scripts, working-dir-initializer).
+	// Note: steps are regular containers, not init containers.
+	//
+	// Priority is enforced via separate passes (not index order):
+	// SidecarOOM > InitContainerOOM > SidecarFailed > InitContainerFailed
+	for i, s := range pod.Status.InitContainerStatuses {
+		if s.State.Terminated == nil {
+			continue
+		}
+		if isOOMKilled(s) && IsContainerSidecar(s.Name) {
+			return failureInfo{reason: v1.TaskRunReasonSidecarOOM, container: &pod.Status.InitContainerStatuses[i], isInit: true}
+		}
+	}
+	for i, s := range pod.Status.InitContainerStatuses {
+		if s.State.Terminated == nil {
+			continue
+		}
+		if isOOMKilled(s) && !IsContainerSidecar(s.Name) {
+			return failureInfo{reason: v1.TaskRunReasonInitContainerOOM, container: &pod.Status.InitContainerStatuses[i], isInit: true}
+		}
+	}
+	for i, s := range pod.Status.InitContainerStatuses {
+		if s.State.Terminated == nil {
+			continue
+		}
+		if s.State.Terminated.ExitCode != 0 && IsContainerSidecar(s.Name) {
+			return failureInfo{reason: v1.TaskRunReasonSidecarFailed, container: &pod.Status.InitContainerStatuses[i], isInit: true}
+		}
+	}
+	for i, s := range pod.Status.InitContainerStatuses {
+		if s.State.Terminated == nil {
+			continue
+		}
+		if s.State.Terminated.ExitCode != 0 && !IsContainerSidecar(s.Name) {
+			return failureInfo{reason: v1.TaskRunReasonInitContainerFailed, container: &pod.Status.InitContainerStatuses[i], isInit: true}
+		}
+	}
+
+	// Check regular containers. Steps and sidecars run in parallel here,
+	// so OOM is checked across all containers first (likely root cause),
+	// then sidecar failures before step failures.
+	//
+	// Sidecar OOM has higher priority than step OOM, so scan for
+	// sidecar OOM first, then step OOM in a separate loop.
+	for i, s := range pod.Status.ContainerStatuses {
+		if s.State.Terminated == nil {
+			continue
+		}
+		if isOOMKilled(s) && IsContainerSidecar(s.Name) {
+			return failureInfo{reason: v1.TaskRunReasonSidecarOOM, container: &pod.Status.ContainerStatuses[i]}
+		}
+	}
+	for i, s := range pod.Status.ContainerStatuses {
+		if s.State.Terminated == nil {
+			continue
+		}
+		if isOOMKilled(s) && IsContainerStep(s.Name) {
+			return failureInfo{reason: v1.TaskRunReasonStepOOM, container: &pod.Status.ContainerStatuses[i]}
+		}
+	}
+	for i, s := range pod.Status.ContainerStatuses {
+		if s.State.Terminated == nil {
+			continue
+		}
+		if s.State.Terminated.ExitCode != 0 && IsContainerSidecar(s.Name) {
+			return failureInfo{reason: v1.TaskRunReasonSidecarFailed, container: &pod.Status.ContainerStatuses[i]}
+		}
+	}
+	for i, s := range pod.Status.ContainerStatuses {
+		if s.State.Terminated == nil {
+			continue
+		}
+		if s.State.Terminated.ExitCode != 0 && IsContainerStep(s.Name) {
+			return failureInfo{reason: v1.TaskRunReasonStepFailed, container: &pod.Status.ContainerStatuses[i]}
+		}
+	}
+
+	// Default: generic failure (internal init container crash or unknown).
+	return failureInfo{reason: v1.TaskRunReasonFailed}
+}
+
+// getFailureReason classifies the pod failure and returns a specific
+// TaskRunReason. Delegates to getFailureInfo.
+func getFailureReason(pod *corev1.Pod) v1.TaskRunReason {
+	return getFailureInfo(pod).reason
+}
+
 func getFailureMessage(logger *zap.SugaredLogger, pod *corev1.Pod) string {
 	// If a pod was evicted, use the pods status message before trying to
 	// determine a failure message from the pod's container statuses. A
@@ -761,26 +886,27 @@ func getFailureMessage(logger *zap.SugaredLogger, pod *corev1.Pod) string {
 		return pod.Status.Message
 	}
 
-	// First, try to surface an error about the actual init container that failed.
-	for _, status := range pod.Status.InitContainerStatuses {
-		if msg := extractContainerFailureMessage(logger, status, pod.ObjectMeta); len(msg) > 0 {
-			return "init container failed, " + msg
-		}
-	}
-
-	// Next, try to surface an error about the actual build step that failed.
-	for _, status := range pod.Status.ContainerStatuses {
-		if msg := extractContainerFailureMessage(logger, status, pod.ObjectMeta); len(msg) > 0 {
+	// Use getFailureInfo to identify the specific container that caused
+	// the failure, ensuring the message describes the same container as
+	// the reason classification.
+	info := getFailureInfo(pod)
+	if info.container != nil {
+		if msg := extractContainerFailureMessage(logger, *info.container, pod.ObjectMeta); len(msg) > 0 {
+			if info.isInit {
+				return "init container failed, " + msg
+			}
 			return msg
 		}
 	}
+
 	// Next, return the Pod's status message if it has one.
 	if pod.Status.Message != "" {
 		return pod.Status.Message
 	}
 
+	// OOM fallback: check both steps and sidecars for OOMKilled.
 	for _, s := range pod.Status.ContainerStatuses {
-		if IsContainerStep(s.Name) {
+		if IsContainerStep(s.Name) || IsContainerSidecar(s.Name) {
 			if s.State.Terminated != nil {
 				if isOOMKilled(s) {
 					return oomKilled

--- a/pkg/pod/status_test.go
+++ b/pkg/pod/status_test.go
@@ -974,7 +974,7 @@ func TestMakeTaskRunStatus(t *testing.T) {
 			}},
 		},
 		want: v1.TaskRunStatus{
-			Status: statusFailure(v1.TaskRunReasonFailed.String(), "\"step-failure\" exited with code 123"),
+			Status: statusFailure(v1.TaskRunReasonStepFailed.String(), "\"step-failure\" exited with code 123"),
 			TaskRunStatusFields: v1.TaskRunStatusFields{
 				Steps: []v1.StepState{{
 					ContainerState: corev1.ContainerState{
@@ -1024,7 +1024,7 @@ func TestMakeTaskRunStatus(t *testing.T) {
 			}},
 		},
 		want: v1.TaskRunStatus{
-			Status: statusFailure(v1.TaskRunReasonFailed.String(), "OOMKilled"),
+			Status: statusFailure(v1.TaskRunReasonStepOOM.String(), "OOMKilled"),
 			TaskRunStatusFields: v1.TaskRunStatusFields{
 				Steps: []v1.StepState{{
 					ContainerState: corev1.ContainerState{
@@ -1467,7 +1467,7 @@ func TestMakeTaskRunStatus(t *testing.T) {
 			}},
 		},
 		want: v1.TaskRunStatus{
-			Status: statusFailure(v1.TaskRunReasonFailed.String(), "\"step-one\" exited with code 137: OOMKilled"),
+			Status: statusFailure(v1.TaskRunReasonStepOOM.String(), "\"step-one\" exited with code 137: OOMKilled"),
 			TaskRunStatusFields: v1.TaskRunStatusFields{
 				Steps: []v1.StepState{{
 					ContainerState: corev1.ContainerState{
@@ -2007,7 +2007,7 @@ func TestMakeTaskRunStatus(t *testing.T) {
 			},
 		},
 		want: v1.TaskRunStatus{
-			Status: statusFailure(v1.TaskRunReasonFailed.String(), "init container failed, \"init-A\" exited with code 1"),
+			Status: statusFailure(v1.TaskRunReasonInitContainerFailed.String(), "init container failed, \"init-A\" exited with code 1"),
 			TaskRunStatusFields: v1.TaskRunStatusFields{
 				Steps: []v1.StepState{{
 					ContainerState: corev1.ContainerState{
@@ -2056,12 +2056,225 @@ func TestMakeTaskRunStatus(t *testing.T) {
 			},
 		},
 		want: v1.TaskRunStatus{
-			Status: statusFailure(v1.TaskRunReasonFailed.String(), "Usage of EmptyDir volume \"ws-b6dfk\" exceeds the limit \"10Gi\"."),
+			Status: statusFailure(v1.TaskRunReasonPodEvicted.String(), "Usage of EmptyDir volume \"ws-b6dfk\" exceeds the limit \"10Gi\"."),
 			TaskRunStatusFields: v1.TaskRunStatusFields{
 				Steps: []v1.StepState{{
 					ContainerState: corev1.ContainerState{
 						Terminated: &corev1.ContainerStateTerminated{
 							ExitCode: 137,
+						},
+					},
+					Name:      "A",
+					Container: "step-A",
+				}},
+				Sidecars:       []v1.SidecarState{},
+				Artifacts:      &v1.Artifacts{},
+				CompletionTime: &metav1.Time{Time: time.Now()},
+			},
+		},
+	}, {
+		desc: "report StepOOM reason when step container was OOM-killed",
+		pod: corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod",
+				Namespace: "foo",
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name: "step-A",
+				}},
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodFailed,
+				ContainerStatuses: []corev1.ContainerStatus{
+					{
+						Name: "step-A",
+						State: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{
+								ExitCode: 137,
+								Reason:   "OOMKilled",
+							},
+						},
+					},
+				},
+			},
+		},
+		want: v1.TaskRunStatus{
+			Status: statusFailure(v1.TaskRunReasonStepOOM.String(), `"step-A" exited with code 137: OOMKilled`),
+			TaskRunStatusFields: v1.TaskRunStatusFields{
+				Steps: []v1.StepState{{
+					ContainerState: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							ExitCode: 137,
+							Reason:   "OOMKilled",
+						},
+					},
+					Name:      "A",
+					Container: "step-A",
+				}},
+				Sidecars:       []v1.SidecarState{},
+				Artifacts:      &v1.Artifacts{},
+				CompletionTime: &metav1.Time{Time: time.Now()},
+			},
+		},
+	}, {
+		desc: "report SidecarOOM reason when sidecar was OOM-killed",
+		pod: corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod",
+				Namespace: "foo",
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "step-A"},
+					{Name: "sidecar-logging"},
+				},
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodFailed,
+				ContainerStatuses: []corev1.ContainerStatus{
+					{
+						Name: "step-A",
+						State: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{
+								ExitCode: 0,
+							},
+						},
+					},
+					{
+						Name: "sidecar-logging",
+						State: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{
+								ExitCode: 137,
+								Reason:   "OOMKilled",
+							},
+						},
+					},
+				},
+			},
+		},
+		want: v1.TaskRunStatus{
+			Status: statusFailure(v1.TaskRunReasonSidecarOOM.String(), `"sidecar-logging" exited with code 137: OOMKilled`),
+			TaskRunStatusFields: v1.TaskRunStatusFields{
+				Steps: []v1.StepState{{
+					ContainerState: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							ExitCode: 0,
+						},
+					},
+					Name:      "A",
+					Container: "step-A",
+				}},
+				Sidecars: []v1.SidecarState{{
+					ContainerState: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							ExitCode: 137,
+							Reason:   "OOMKilled",
+						},
+					},
+					Name:      "logging",
+					Container: "sidecar-logging",
+				}},
+				Artifacts:      &v1.Artifacts{},
+				CompletionTime: &metav1.Time{Time: time.Now()},
+			},
+		},
+	}, {
+		desc: "report InitContainerFailed reason when prepare init container fails",
+		pod: corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod",
+				Namespace: "foo",
+			},
+			Spec: corev1.PodSpec{
+				InitContainers: []corev1.Container{{
+					Name: "prepare",
+				}},
+				Containers: []corev1.Container{{
+					Name: "step-A",
+				}},
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodFailed,
+				InitContainerStatuses: []corev1.ContainerStatus{{
+					Name: "prepare",
+					State: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							ExitCode: 255,
+							Reason:   "Error",
+						},
+					},
+				}},
+				ContainerStatuses: []corev1.ContainerStatus{{
+					Name: "step-A",
+					State: corev1.ContainerState{
+						Waiting: &corev1.ContainerStateWaiting{
+							Reason: "PodInitializing",
+						},
+					},
+				}},
+			},
+		},
+		want: v1.TaskRunStatus{
+			Status: statusFailure(v1.TaskRunReasonInitContainerFailed.String(), `init container failed, "prepare" exited with code 255: Error`),
+			TaskRunStatusFields: v1.TaskRunStatusFields{
+				Steps: []v1.StepState{{
+					ContainerState: corev1.ContainerState{
+						Waiting: &corev1.ContainerStateWaiting{
+							Reason: "PodInitializing",
+						},
+					},
+					Name:      "A",
+					Container: "step-A",
+				}},
+				Sidecars:       []v1.SidecarState{},
+				Artifacts:      &v1.Artifacts{},
+				CompletionTime: &metav1.Time{Time: time.Now()},
+			},
+		},
+	}, {
+		desc: "report InitContainerOOM reason when prepare init container is OOM-killed",
+		pod: corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod",
+				Namespace: "foo",
+			},
+			Spec: corev1.PodSpec{
+				InitContainers: []corev1.Container{{
+					Name: "prepare",
+				}},
+				Containers: []corev1.Container{{
+					Name: "step-A",
+				}},
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodFailed,
+				InitContainerStatuses: []corev1.ContainerStatus{{
+					Name: "prepare",
+					State: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							ExitCode: 137,
+							Reason:   "OOMKilled",
+						},
+					},
+				}},
+				ContainerStatuses: []corev1.ContainerStatus{{
+					Name: "step-A",
+					State: corev1.ContainerState{
+						Waiting: &corev1.ContainerStateWaiting{
+							Reason: "PodInitializing",
+						},
+					},
+				}},
+			},
+		},
+		want: v1.TaskRunStatus{
+			Status: statusFailure(v1.TaskRunReasonInitContainerOOM.String(), `init container failed, "prepare" exited with code 137: OOMKilled`),
+			TaskRunStatusFields: v1.TaskRunStatusFields{
+				Steps: []v1.StepState{{
+					ContainerState: corev1.ContainerState{
+						Waiting: &corev1.ContainerStateWaiting{
+							Reason: "PodInitializing",
 						},
 					},
 					Name:      "A",
@@ -2894,7 +3107,7 @@ func TestMakeRunStatusJSONError(t *testing.T) {
 		},
 	}
 	wantTr := v1.TaskRunStatus{
-		Status: statusFailure(v1.TaskRunReasonFailed.String(), "\"step-non-json\" exited with code 1"),
+		Status: statusFailure(v1.TaskRunReasonStepFailed.String(), "\"step-non-json\" exited with code 1"),
 		TaskRunStatusFields: v1.TaskRunStatusFields{
 			PodName: "pod",
 			Steps: []v1.StepState{{
@@ -3655,6 +3868,614 @@ func TestUpdateIncompleteTaskRunStatus_SubPathError(t *testing.T) {
 			updateIncompleteTaskRunStatus(tt.trs, tt.pod)
 			if d := cmp.Diff(tt.expected, tt.trs.GetCondition(apis.ConditionSucceeded), cmpopts.IgnoreFields(apis.Condition{}, "LastTransitionTime.Inner.Time")); d != "" {
 				t.Errorf("Unexpected status: %s", diff.PrintWantGot(d))
+			}
+		})
+	}
+}
+
+func Test_getFailureInfo(t *testing.T) {
+	tests := []struct {
+		name       string
+		pod        *corev1.Pod
+		wantReason v1.TaskRunReason
+	}{{
+		name: "pod evicted",
+		pod: &corev1.Pod{
+			Status: corev1.PodStatus{
+				Phase:  corev1.PodFailed,
+				Reason: "Evicted",
+			},
+		},
+		wantReason: v1.TaskRunReasonPodEvicted,
+	}, {
+		name: "init container OOM",
+		pod: &corev1.Pod{
+			Status: corev1.PodStatus{
+				Phase: corev1.PodFailed,
+				InitContainerStatuses: []corev1.ContainerStatus{{
+					Name: "prepare",
+					State: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							ExitCode: 137,
+							Reason:   "OOMKilled",
+						},
+					},
+				}},
+			},
+		},
+		wantReason: v1.TaskRunReasonInitContainerOOM,
+	}, {
+		name: "init container failed (non-OOM)",
+		pod: &corev1.Pod{
+			Status: corev1.PodStatus{
+				Phase: corev1.PodFailed,
+				InitContainerStatuses: []corev1.ContainerStatus{{
+					Name: "prepare",
+					State: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							ExitCode: 1,
+							Reason:   "Error",
+						},
+					},
+				}},
+			},
+		},
+		wantReason: v1.TaskRunReasonInitContainerFailed,
+	}, {
+		name: "sidecar OOM in init container (native sidecar)",
+		pod: &corev1.Pod{
+			Status: corev1.PodStatus{
+				Phase: corev1.PodFailed,
+				InitContainerStatuses: []corev1.ContainerStatus{{
+					Name: "sidecar-logging",
+					State: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							ExitCode: 137,
+							Reason:   "OOMKilled",
+						},
+					},
+				}},
+			},
+		},
+		wantReason: v1.TaskRunReasonSidecarOOM,
+	}, {
+		name: "sidecar failed in init container (native sidecar, non-OOM)",
+		pod: &corev1.Pod{
+			Status: corev1.PodStatus{
+				Phase: corev1.PodFailed,
+				InitContainerStatuses: []corev1.ContainerStatus{{
+					Name: "sidecar-logging",
+					State: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							ExitCode: 1,
+							Reason:   "Error",
+						},
+					},
+				}},
+			},
+		},
+		wantReason: v1.TaskRunReasonSidecarFailed,
+	}, {
+		name: "step OOM",
+		pod: &corev1.Pod{
+			Status: corev1.PodStatus{
+				Phase: corev1.PodFailed,
+				ContainerStatuses: []corev1.ContainerStatus{{
+					Name: "step-build",
+					State: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							ExitCode: 137,
+							Reason:   "OOMKilled",
+						},
+					},
+				}},
+			},
+		},
+		wantReason: v1.TaskRunReasonStepOOM,
+	}, {
+		name: "sidecar OOM in regular container",
+		pod: &corev1.Pod{
+			Status: corev1.PodStatus{
+				Phase: corev1.PodFailed,
+				ContainerStatuses: []corev1.ContainerStatus{{
+					Name: "sidecar-logging",
+					State: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							ExitCode: 137,
+							Reason:   "OOMKilled",
+						},
+					},
+				}},
+			},
+		},
+		wantReason: v1.TaskRunReasonSidecarOOM,
+	}, {
+		name: "sidecar failed (non-OOM, regular container)",
+		pod: &corev1.Pod{
+			Status: corev1.PodStatus{
+				Phase: corev1.PodFailed,
+				ContainerStatuses: []corev1.ContainerStatus{{
+					Name: "sidecar-logging",
+					State: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							ExitCode: 1,
+							Reason:   "Error",
+						},
+					},
+				}},
+			},
+		},
+		wantReason: v1.TaskRunReasonSidecarFailed,
+	}, {
+		name: "step failed (non-OOM)",
+		pod: &corev1.Pod{
+			Status: corev1.PodStatus{
+				Phase: corev1.PodFailed,
+				ContainerStatuses: []corev1.ContainerStatus{{
+					Name: "step-build",
+					State: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							ExitCode: 1,
+						},
+					},
+				}},
+			},
+		},
+		wantReason: v1.TaskRunReasonStepFailed,
+	}, {
+		name: "generic failure (no containers failed)",
+		pod: &corev1.Pod{
+			Status: corev1.PodStatus{
+				Phase: corev1.PodFailed,
+			},
+		},
+		wantReason: v1.TaskRunReasonFailed,
+	}, {
+		name: "step OOM + sidecar OOM (sidecar listed second) -> SidecarOOM",
+		pod: &corev1.Pod{
+			Status: corev1.PodStatus{
+				Phase: corev1.PodFailed,
+				ContainerStatuses: []corev1.ContainerStatus{
+					{
+						Name: "step-build",
+						State: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{
+								ExitCode: 137,
+								Reason:   "OOMKilled",
+							},
+						},
+					},
+					{
+						Name: "sidecar-logging",
+						State: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{
+								ExitCode: 137,
+								Reason:   "OOMKilled",
+							},
+						},
+					},
+				},
+			},
+		},
+		wantReason: v1.TaskRunReasonSidecarOOM,
+	}, {
+		name: "step failed + sidecar failed -> SidecarFailed",
+		pod: &corev1.Pod{
+			Status: corev1.PodStatus{
+				Phase: corev1.PodFailed,
+				ContainerStatuses: []corev1.ContainerStatus{
+					{
+						Name: "step-build",
+						State: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{
+								ExitCode: 1,
+							},
+						},
+					},
+					{
+						Name: "sidecar-logging",
+						State: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{
+								ExitCode: 1,
+							},
+						},
+					},
+				},
+			},
+		},
+		wantReason: v1.TaskRunReasonSidecarFailed,
+	}, {
+		name: "init container failed + step OOM -> InitContainerFailed",
+		pod: &corev1.Pod{
+			Status: corev1.PodStatus{
+				Phase: corev1.PodFailed,
+				InitContainerStatuses: []corev1.ContainerStatus{{
+					Name: "prepare",
+					State: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							ExitCode: 1,
+							Reason:   "Error",
+						},
+					},
+				}},
+				ContainerStatuses: []corev1.ContainerStatus{{
+					Name: "step-build",
+					State: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							ExitCode: 137,
+							Reason:   "OOMKilled",
+						},
+					},
+				}},
+			},
+		},
+		wantReason: v1.TaskRunReasonInitContainerFailed,
+	}, {
+		name: "init container failed at index 0 + sidecar OOM at index 1 -> SidecarOOM",
+		pod: &corev1.Pod{
+			Status: corev1.PodStatus{
+				Phase: corev1.PodFailed,
+				InitContainerStatuses: []corev1.ContainerStatus{
+					{
+						Name: "prepare",
+						State: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{
+								ExitCode: 1,
+								Reason:   "Error",
+							},
+						},
+					},
+					{
+						Name: "sidecar-logging",
+						State: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{
+								ExitCode: 137,
+								Reason:   "OOMKilled",
+							},
+						},
+					},
+				},
+			},
+		},
+		wantReason: v1.TaskRunReasonSidecarOOM,
+	}, {
+		name: "eviction + container failures -> PodEvicted",
+		pod: &corev1.Pod{
+			Status: corev1.PodStatus{
+				Phase:   corev1.PodFailed,
+				Reason:  "Evicted",
+				Message: "The node was low on resource: memory.",
+				ContainerStatuses: []corev1.ContainerStatus{
+					{
+						Name: "step-build",
+						State: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{
+								ExitCode: 137,
+								Reason:   "OOMKilled",
+							},
+						},
+					},
+					{
+						Name: "sidecar-logging",
+						State: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{
+								ExitCode: 1,
+							},
+						},
+					},
+				},
+			},
+		},
+		wantReason: v1.TaskRunReasonPodEvicted,
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info := getFailureInfo(tt.pod)
+			if info.reason != tt.wantReason {
+				t.Errorf("getFailureInfo().reason = %q, want %q", info.reason, tt.wantReason)
+			}
+			// Also verify getFailureReason returns the same thing
+			if got := getFailureReason(tt.pod); got != tt.wantReason {
+				t.Errorf("getFailureReason() = %q, want %q", got, tt.wantReason)
+			}
+		})
+	}
+}
+
+func TestMakeTaskRunStatus_SidecarFailed(t *testing.T) {
+	// Sidecar crashes with non-zero exit (not OOM). Verify SidecarFailed is returned.
+	pod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod",
+			Namespace: "foo",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "step-A"},
+				{Name: "sidecar-logging"},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodFailed,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name: "step-A",
+					State: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							ExitCode: 0,
+						},
+					},
+				},
+				{
+					Name: "sidecar-logging",
+					State: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							ExitCode: 1,
+							Reason:   "Error",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	want := v1.TaskRunStatus{
+		Status: statusFailure(v1.TaskRunReasonSidecarFailed.String(), `"sidecar-logging" exited with code 1: Error`),
+		TaskRunStatusFields: v1.TaskRunStatusFields{
+			Steps: []v1.StepState{{
+				ContainerState: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{
+						ExitCode: 0,
+					},
+				},
+				Name:      "A",
+				Container: "step-A",
+				Results:   []v1.TaskRunResult{},
+			}},
+			Sidecars: []v1.SidecarState{{
+				ContainerState: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{
+						ExitCode: 1,
+						Reason:   "Error",
+					},
+				},
+				Name:      "logging",
+				Container: "sidecar-logging",
+			}},
+			Artifacts:      &v1.Artifacts{},
+			CompletionTime: &metav1.Time{Time: time.Now()},
+		},
+	}
+
+	tr := v1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "task-run",
+			Namespace: "foo",
+		},
+	}
+	logger, _ := logging.NewLogger("", "status")
+	kubeclient := fakek8s.NewSimpleClientset()
+	got, err := MakeTaskRunStatus(t.Context(), logger, tr, &pod, kubeclient, &v1.TaskSpec{})
+	if err != nil {
+		t.Errorf("MakeTaskRunStatus: %s", err)
+	}
+
+	want.PodName = "pod"
+
+	ensureTimeNotNil := cmp.Comparer(func(x, y *metav1.Time) bool {
+		if x == nil {
+			return y == nil
+		}
+		return y != nil
+	})
+	if d := cmp.Diff(want, got, ignoreVolatileTime, ensureTimeNotNil); d != "" {
+		t.Errorf("Diff %s", diff.PrintWantGot(d))
+	}
+}
+
+func TestMakeTaskRunStatus_MultiFailurePriority(t *testing.T) {
+	// Multi-failure tests verifying priority ordering through MakeTaskRunStatus.
+	for _, tc := range []struct {
+		name       string
+		pod        corev1.Pod
+		wantReason string
+	}{{
+		name: "step OOM + sidecar OOM (sidecar listed second) -> SidecarOOM reason",
+		pod: corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "foo"},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "step-build"},
+					{Name: "sidecar-logging"},
+				},
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodFailed,
+				ContainerStatuses: []corev1.ContainerStatus{
+					{
+						Name: "step-build",
+						State: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{
+								ExitCode: 137,
+								Reason:   "OOMKilled",
+							},
+						},
+					},
+					{
+						Name: "sidecar-logging",
+						State: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{
+								ExitCode: 137,
+								Reason:   "OOMKilled",
+							},
+						},
+					},
+				},
+			},
+		},
+		wantReason: v1.TaskRunReasonSidecarOOM.String(),
+	}, {
+		name: "step failed + sidecar failed -> SidecarFailed reason",
+		pod: corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "foo"},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "step-build"},
+					{Name: "sidecar-logging"},
+				},
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodFailed,
+				ContainerStatuses: []corev1.ContainerStatus{
+					{
+						Name: "step-build",
+						State: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{
+								ExitCode: 1,
+							},
+						},
+					},
+					{
+						Name: "sidecar-logging",
+						State: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{
+								ExitCode: 1,
+							},
+						},
+					},
+				},
+			},
+		},
+		wantReason: v1.TaskRunReasonSidecarFailed.String(),
+	}, {
+		name: "eviction + container failures -> PodEvicted reason",
+		pod: corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "foo"},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "step-build"},
+				},
+			},
+			Status: corev1.PodStatus{
+				Phase:   corev1.PodFailed,
+				Reason:  "Evicted",
+				Message: "The node was low on resource: memory.",
+				ContainerStatuses: []corev1.ContainerStatus{
+					{
+						Name: "step-build",
+						State: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{
+								ExitCode: 137,
+								Reason:   "OOMKilled",
+							},
+						},
+					},
+				},
+			},
+		},
+		wantReason: v1.TaskRunReasonPodEvicted.String(),
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			tr := v1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "task-run",
+					Namespace: "foo",
+				},
+			}
+			logger, _ := logging.NewLogger("", "status")
+			kubeclient := fakek8s.NewSimpleClientset()
+			got, err := MakeTaskRunStatus(t.Context(), logger, tr, &tc.pod, kubeclient, &v1.TaskSpec{})
+			if err != nil {
+				t.Errorf("MakeTaskRunStatus: %s", err)
+			}
+			cond := got.GetCondition(apis.ConditionSucceeded)
+			if cond == nil {
+				t.Fatal("Expected condition to be set")
+			}
+			if cond.Reason != tc.wantReason {
+				t.Errorf("Reason = %q, want %q", cond.Reason, tc.wantReason)
+			}
+		})
+	}
+}
+
+func Test_getFailureMessage_consistent_with_reason(t *testing.T) {
+	// Verify that when multiple containers fail, getFailureMessage describes
+	// the same container that getFailureReason classified.
+	logger, _ := logging.NewLogger("", "status")
+
+	tests := []struct {
+		name        string
+		pod         *corev1.Pod
+		wantReason  v1.TaskRunReason
+		wantMsgPart string // substring that must appear in the message
+	}{{
+		name: "sidecar OOM listed after step OOM -> message mentions sidecar",
+		pod: &corev1.Pod{
+			Status: corev1.PodStatus{
+				Phase: corev1.PodFailed,
+				ContainerStatuses: []corev1.ContainerStatus{
+					{
+						Name: "step-build",
+						State: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{
+								ExitCode: 137,
+								Reason:   "OOMKilled",
+							},
+						},
+					},
+					{
+						Name: "sidecar-logging",
+						State: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{
+								ExitCode: 137,
+								Reason:   "OOMKilled",
+							},
+						},
+					},
+				},
+			},
+		},
+		wantReason:  v1.TaskRunReasonSidecarOOM,
+		wantMsgPart: "sidecar-logging",
+	}, {
+		name: "sidecar failed listed after step failed -> message mentions sidecar",
+		pod: &corev1.Pod{
+			Status: corev1.PodStatus{
+				Phase: corev1.PodFailed,
+				ContainerStatuses: []corev1.ContainerStatus{
+					{
+						Name: "step-build",
+						State: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{
+								ExitCode: 1,
+							},
+						},
+					},
+					{
+						Name: "sidecar-logging",
+						State: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{
+								ExitCode: 1,
+							},
+						},
+					},
+				},
+			},
+		},
+		wantReason:  v1.TaskRunReasonSidecarFailed,
+		wantMsgPart: "sidecar-logging",
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reason := getFailureReason(tt.pod)
+			if reason != tt.wantReason {
+				t.Errorf("getFailureReason() = %q, want %q", reason, tt.wantReason)
+			}
+			msg := getFailureMessage(logger, tt.pod)
+			if !strings.Contains(msg, tt.wantMsgPart) {
+				t.Errorf("getFailureMessage() = %q, want it to contain %q", msg, tt.wantMsgPart)
 			}
 		})
 	}

--- a/test/larger_results_sidecar_logs_test.go
+++ b/test/larger_results_sidecar_logs_test.go
@@ -584,7 +584,7 @@ status:
   conditions:
     - type: "Succeeded"
       status: "False"
-      reason: "Failed"
+      reason: "StepFailed"
   podName: larger-results-sidecar-logs-failed-task-pod
   taskSpec:
     results:

--- a/test/taskrun_test.go
+++ b/test/taskrun_test.go
@@ -581,7 +581,7 @@ spec:
 		t.Fatalf("task should have been a failure")
 	}
 
-	expectedReason := "Failed"
+	expectedReason := "StepFailed"
 	actualReason := taskrun.Status.GetCondition(apis.ConditionSucceeded).GetReason()
 	if actualReason != expectedReason {
 		t.Fatalf("expected TaskRun to have failed reason %s, got %s", expectedReason, actualReason)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Surfaces specific failure reasons in the TaskRun `Succeeded` condition instead of
the generic `Failed` for all pod-level failures. This helps users and automation
quickly distinguish between different failure types without digging into pod status.

## New failure reasons

| Reason | Description |
|--------|-------------|
| `PodEvicted` | Pod was evicted by Kubernetes (e.g., ephemeral storage limit exceeded) |
| `InitContainerOOM` | Internal Tekton init container (`prepare`, `place-scripts`, `working-dir-initializer`) was OOMKilled |
| `InitContainerFailed` | Internal Tekton init container failed (e.g., node memory pressure, CRI-O exit code 255) |
| `StepOOM` | A step container was OOMKilled |
| `StepFailed` | A step container exited with non-zero exit code (not OOM) |
| `SidecarOOM` | A sidecar container was OOMKilled |
| `SidecarFailed` | A sidecar container exited with non-zero exit code (not OOM) |
| `Failed` | Default fallback for unknown failures |

## Priority order

When multiple containers fail, the reason is chosen by priority:
1. Pod eviction (pod-level, authoritative)
2. Init container failures (run first, block everything)
3. Sidecar OOM → Step OOM (OOM is likely root cause)
4. Sidecar failed → Step failed (non-OOM failures)

## Implementation

- New `TaskRunReason` constants in `pkg/apis/pipeline/v1/taskrun_types.go`
- `getFailureReason()` in `pkg/pod/status.go` classifies pod failures by examining
  init container statuses, container statuses, and pod-level eviction
- Called from `updateCompletedTaskRunStatus()` when a pod has failed

## Related Issues

- Closes #7396 (Surface specific failure reasons for TaskRuns)
- Related to #7385 (Better Container termination status for image pull errors)
- Directly addresses support cases where `prepare` init container fails with exit
  code 255/137 under node memory pressure — now reported as `InitContainerFailed`
  instead of generic `Failed`

# Submitter Checklist

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md#principles) including completing the contributor CLA
- [x] Each commit in the PR has a meaningful subject line and body

# Release Note

```release-note
TaskRun failure reasons now distinguish between different pod-level failure types:
PodEvicted, InitContainerOOM, InitContainerFailed, StepOOM, StepFailed, SidecarOOM,
and SidecarFailed, replacing the generic "Failed" reason.
```