### PR TITLE
ci: add /rebase slash command workflow

### DIFF
--- a/.github/workflows/rebase-command.yaml
+++ b/.github/workflows/rebase-command.yaml
@@ -1,0 +1,30 @@
+# Rebase Command Workflow
+#
+# This workflow is triggered by the /rebase slash command from the slash.yml workflow.
+# It automatically rebases a PR branch against its base branch and force pushes the result.
+#
+# Usage: Comment `/rebase` on an open pull request
+#
+# Security Notes:
+# - Only users with "write" permission can trigger this command (enforced in slash.yml)
+# - Cannot rebase PRs from forks (branch must be in tektoncd/pipeline)
+# - Uses CHATOPS_TOKEN to push rebased branches
+# - Uses --force-with-lease for safe force pushing
+
+name: Rebase Command
+
+on:
+  repository_dispatch:
+    types: [rebase-command]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  rebase:
+    name: Rebase PR
+    uses: tektoncd/plumbing/.github/workflows/_rebase-command.yaml@4e60dd3785868521b0542134f5f57f2989c8883d  # main
+    secrets:
+      CHATOPS_TOKEN: ${{ secrets.CHATOPS_TOKEN }}

--- a/.github/workflows/slash.yml
+++ b/.github/workflows/slash.yml
@@ -15,6 +15,7 @@
 # - /retest: re-trigger workflows that failed on a given PR
 # - /e2e-extras: run extra e2e tests on a given PR
 # - /cherry-pick <branch>: cherry-picks the merged PR to the specified branch
+# - /rebase: rebase a PR branch against its base branch
 #
 # When a command is recognised, the rocket and eyes emojis are added
 
@@ -47,6 +48,12 @@ jobs:
             },
             {
               "command": "cherry-pick",
+              "permission": "write",
+              "issue_type": "pull-request",
+              "repository": "tektoncd/pipeline"
+            },
+            {
+              "command": "rebase",
               "permission": "write",
               "issue_type": "pull-request",
               "repository": "tektoncd/pipeline"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,21 @@ Automatically cherry-picks a merged PR to one or more target branches.
 
 The command creates a new PR with the cherry-picked changes for each target branch.
 
+### `/rebase`
+
+Rebases a PR branch against its base branch and force pushes the result.
+
+**Usage**: `/rebase`
+
+**Requirements**:
+- PR must be open
+- PR must not be from a fork (branch must be in tektoncd/pipeline)
+- User must have write permissions
+
+The command rebases the PR's head branch onto the base branch. If there are
+conflicts, it reports them in a comment. Uses `--force-with-lease` for safe
+force pushing.
+
 ## Contributing to Tekton documentation
 
 If you want to contribute to Tekton documentation, see the


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Adds the `/rebase` slash command to the pipeline repository by:

1. **`rebase-command.yaml`** -- New caller workflow that invokes `tektoncd/plumbing/.github/workflows/_rebase-command.yaml` (pinned to `4e60dd3785868521b0542134f5f57f2989c8883d`)
2. **`slash.yml`** -- Registers the `/rebase` command with `peter-evans/slash-command-dispatch`
3. **`CONTRIBUTING.md`** -- Documents the new command alongside `/cherry-pick`

### How it works

When a user with write permission comments `/rebase` on a PR:
1. `slash.yml` intercepts the comment and fires a `repository_dispatch` event of type `rebase-command`
2. `rebase-command.yaml` triggers and invokes the plumbing reusable workflow
3. The reusable workflow rebases the PR branch onto its base branch and force pushes with `--force-with-lease`
4. If there are conflicts, they are reported in a PR comment

### Motivation

Cherry-pick PRs (e.g. #9355) frequently need rebasing before they can be merged. Without `/rebase`, maintainers must manually check out, rebase, and force push. The plumbing reusable workflow (`_rebase-command.yaml`) already exists but the pipeline repo does not have the caller workflow to invoke it.

This follows the same pattern as the existing `/cherry-pick` command (`cherry-pick-command.yaml`).

### Limitations

- Cannot rebase PRs from forks (branch must be in `tektoncd/pipeline`)
- User must have write permissions

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```

/kind feature
/area ci