### PR TITLE
[DRAFT] Add deliveryTraceparent annotation for external trace context

### DIFF
--- a/docs/developers/tracing.md
+++ b/docs/developers/tracing.md
@@ -31,3 +31,80 @@ The configmap `config/config-tracing.yaml` contains the configuration for tracin
 * enabled: Set this to true to enable tracing
 * endpoint: API endpoint for jaeger collector to send the traces. By default the endpoint is configured to be `http://jaeger-collector.jaeger.svc.cluster.local:14268/api/traces`.
 * credentialsSecret: Name of the secret which contains `username` and `password` to authenticate against the endpoint
+
+## Remote Parent Trace Context
+
+Per the [W3C Trace Context](https://www.w3.org/TR/trace-context/) specification,
+a component receiving a `traceparent` should create child spans under that parent.
+Tekton supports this for PipelineRuns via resource annotations, which serve as the
+TextMapCarrier equivalent since PipelineRuns are created via Kubernetes manifests
+rather than HTTP requests.
+
+The following annotations are recognized:
+
+| Annotation | W3C Spec | Required |
+|---|---|---|
+| `tekton.dev/traceparent` | [Trace Context `traceparent`](https://www.w3.org/TR/trace-context/#traceparent-header) | Yes |
+| `tekton.dev/tracestate` | [Trace Context `tracestate`](https://www.w3.org/TR/trace-context/#tracestate-header) | No |
+
+When `tekton.dev/traceparent` is present and valid, Tekton extracts a remote
+SpanContext using a standard OpenTelemetry TextMapPropagator. The
+`PipelineRun:ReconcileKind` span starts as a direct child of the remote parent.
+This enables distributed tracing across system boundaries — for example, an
+orchestrator can propagate its trace context to PipelineRuns it creates, and
+each PipelineRun will appear as a child span in the same trace.
+
+### Relationship to `pipelinerunSpanContext`
+
+Both `tekton.dev/traceparent` and `tekton.dev/pipelinerunSpanContext` accept a
+SpanContext and parent the `ReconcileKind` span under it. The behavioral outcome
+is identical — the difference is in format and intended use:
+
+| | `pipelinerunSpanContext` | `traceparent` |
+|---|---|---|
+| **Format** | JSON-encoded OTel TextMapCarrier (`{"traceparent":"00-...","tracestate":"..."}`) | Raw W3C `traceparent` string (`00-...`) |
+| **Intended use** | Tekton-internal: parent PipelineRun propagating to child PipelineRuns | External systems providing a remote parent |
+| **Validation** | None — malformed JSON silently produces a root span | Validates via `IsValid()`, logs a warning on invalid input |
+| **Precedence** | Checked first (wins if both are present) | Checked second |
+
+The `traceparent` annotation provides a standard W3C format that external systems
+can produce without constructing Tekton's internal JSON carrier. An external system
+*could* achieve the same result by injecting a correctly-formatted
+`pipelinerunSpanContext`, but `traceparent` offers a documented, stable API for
+this purpose.
+
+### Example
+
+```yaml
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: my-pipelinerun
+  annotations:
+    tekton.dev/traceparent: "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+    tekton.dev/tracestate: "vendorname=opaqueValue"
+spec:
+  pipelineRef:
+    name: my-pipeline
+```
+
+### Precedence Rules
+
+The trace context is determined in the following order:
+
+1. If `status.SpanContext` already exists, it is used (PipelineRun is already being traced)
+2. If `tekton.dev/pipelinerunSpanContext` annotation exists, it is adopted directly
+3. If `tekton.dev/traceparent` annotation exists and is valid, it is adopted as a remote parent
+4. Otherwise, a new root span is created
+
+### Traceparent Format
+
+The traceparent must follow the [W3C Trace Context](https://www.w3.org/TR/trace-context/#traceparent-header) format:
+`{version}-{trace-id}-{parent-id}-{flags}`
+
+Example: `00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01`
+
+- `version`: 2 hex digits (currently `00`)
+- `trace-id`: 32 hex digits
+- `parent-id`: 16 hex digits
+- `flags`: 2 hex digits (e.g., `01` for sampled)

--- a/docs/labels.md
+++ b/docs/labels.md
@@ -122,3 +122,37 @@ and then to the associated `Pods`. As for `Pipeline` and `PipelineRun`, if a ann
 - For standalone `TaskRuns` (that is, ones not executing as part of a `Pipeline`), annotations
 propagate from the [referenced `Task`](taskruns.md#specifying-the-target-task), if one exists, to
 the corresponding `TaskRun`, and then to the associated `Pod`. The same as above applies.
+
+## Reserved Annotations
+
+The following annotations are reserved for Tekton's internal use. Do not remove them manually.
+
+<table>
+	<tbody>
+		<tr>
+			<td><b>Annotation</b></td>
+			<td><b>Used On</b></td>
+			<td><b>Description</b></td>
+		</tr>
+		<tr>
+			<td><code>tekton.dev/pipelinerunSpanContext</code></td>
+			<td><code>PipelineRuns</code></td>
+			<td>JSON-encoded span context for internal Tekton trace propagation. The span context is adopted directly without creating an intermediate span.</td>
+		</tr>
+		<tr>
+			<td><code>tekton.dev/taskrunSpanContext</code></td>
+			<td><code>TaskRuns</code></td>
+			<td>JSON-encoded span context propagated from the parent <code>PipelineRun</code>.</td>
+		</tr>
+		<tr>
+			<td><code>tekton.dev/traceparent</code></td>
+			<td><code>PipelineRuns</code></td>
+			<td><a href="https://www.w3.org/TR/trace-context/#traceparent-header">W3C Trace Context</a> traceparent for remote parent propagation. When set with a valid traceparent, Tekton extracts it as a remote parent SpanContext so that <code>PipelineRun:ReconcileKind</code> spans are direct children of the external span. See <a href="developers/tracing.md#remote-parent-trace-context">tracing documentation</a> for details.</td>
+		</tr>
+		<tr>
+			<td><code>tekton.dev/tracestate</code></td>
+			<td><code>PipelineRuns</code></td>
+			<td><a href="https://www.w3.org/TR/trace-context/#tracestate-header">W3C Trace Context</a> tracestate, carried alongside <code>traceparent</code> when present.</td>
+		</tr>
+	</tbody>
+</table>


### PR DESCRIPTION
Add support for the `tekton.dev/deliveryTraceparent` annotation to allow external systems to provide a W3C traceparent that becomes the remote parent for PipelineRun execution traces.

This enables distributed tracing across system boundaries - when an external system creates a PipelineRun, it can set the deliveryTraceparent annotation with its current trace context, and Tekton will adopt that as the remote parent rather than creating a new root span.

The annotation is only used when:
- No SpanContext exists in status (not already tracing)
- No pipelinerunSpanContext annotation exists (takes precedence)
- The traceparent value is valid W3C format

```release-note
PipelineRuns now accept a `tekton.dev/deliveryTraceparent` annotation
containing a W3C traceparent string. When set, Tekton adopts the provided
trace context as the remote parent for execution traces, enabling distributed
tracing across system boundaries. The annotation is only used when no
existing trace context is present.
```
