### PR TITLE
fix(pipelines): allow pipeline param defaults to use non-param variables

### DIFF
--- a/examples/v1/pipelineruns/using_context_variables.yaml
+++ b/examples/v1/pipelineruns/using_context_variables.yaml
@@ -6,6 +6,9 @@ spec:
   taskRunTemplate:
     serviceAccountName: 'default'
   pipelineSpec:
+    params:
+      - name: pipelineRun-name-from-defaults
+        default: "pipelinerun: $(context.pipelineRun.name)"
     tasks:
     - name: task1
       retries: 7
@@ -16,6 +19,8 @@ spec:
         value: "$(context.pipeline.name)"
       - name: pipelineRun-name
         value: "$(context.pipelineRun.name)"
+      - name: pipelineRun-name-from-defaults
+        value: "$(params.pipelineRun-name-from-defaults)"
       - name: pipelineRun-namespace
         value: "$(context.pipelineRun.namespace)"
       - name: pipelineTask-retries
@@ -40,6 +45,7 @@ spec:
             echo "TaskRun name: $(context.taskRun.name)"
             echo "Pipeline name from params: $(params.pipeline-name)"
             echo "PipelineRun name from params: $(params.pipelineRun-name)"
+            echo "PipelineRun name from pipeline defaults: $(params.pipelineRun-name-from-defaults)"
             echo "PipelineRun namespace from params: $(params.pipelineRun-namespace)"
         - image: mirror.gcr.io/ubuntu
           name: print-retries

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -263,6 +263,9 @@ spec:
     type: string
   - name: bar
     type: string
+  - name: paramWithContextDefault
+    type: string
+    default: "name:$(context.pipeline.name)"
   tasks:
   - name: unit-test-2
     params:
@@ -294,6 +297,8 @@ spec:
       value: $(context.pipelineTask.retries)
     - name: param-not-found
       value: $(params.notfound)
+    - name: paramWithContextDefault
+      value: $(params.paramWithContextDefault)
     retries: 5
     taskRef:
       name: unit-test-task
@@ -384,6 +389,8 @@ spec:
     value: "5"
   - name: param-not-found
     value: $(params.notfound)
+  - name: paramWithContextDefault
+    value: name:test-pipeline
   retries: 5
   serviceAccountName: test-sa
   taskRef:

--- a/pkg/reconciler/pipelinerun/resources/apply.go
+++ b/pkg/reconciler/pipelinerun/resources/apply.go
@@ -328,11 +328,19 @@ func resolveStringParamRecursively(
 // Example: "$(params.registry)/app:$(params.tag)" → ["params.registry", "params.tag"]
 func extractParamReferences(paramValue string) []string {
 	param := v1.Param{Value: *v1.NewStructuredValues(paramValue)}
-	result, ok := param.GetVarSubstitutionExpressions()
+	variableRefs, ok := param.GetVarSubstitutionExpressions()
 	if !ok {
 		return []string{}
 	}
-	return result
+
+	// Filter references to non-parameter variables
+	paramRefs := make([]string, 0, len(variableRefs))
+	for _, variable := range variableRefs {
+		if strings.HasPrefix(variable, "params.") {
+			paramRefs = append(paramRefs, variable)
+		}
+	}
+	return paramRefs
 }
 
 // resolveArrayParam resolves an array parameter by applying string parameter substitutions to each element and adds


### PR DESCRIPTION
# Changes

Before this fix, [a recent change](https://github.com/tektoncd/pipeline/pull/9271) caused pipeline param default evaluation to fail if any variabes were referenced besides other params, such as `$(context.pipeline.name)`. This was due to the recursive parameter default resolution was expecting all `$(*)` variables to be resolvable while it was only expanding `$(params.*)` variables.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->



<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Fixed a bug which caused PipelineRun validation to fail when a pipeline parameter's default value referenced a non-parameter variable (e.g. `$(context.pipelineRun.name)`)
```
