### PR TITLE
docs: clarify flag availability across controller binaries

### DIFF
--- a/docs/tekton-controller-flags.md
+++ b/docs/tekton-controller-flags.md
@@ -7,60 +7,79 @@ weight: 105
 
 # Tekton Controllers flags
 
-The different controllers `tektoncd/pipeline` ships comes with a set of flags
+The different controllers `tektoncd/pipeline` ships come with a set of flags
 that can be changed (in the `yaml` payloads) for advanced use cases. This page
-is documenting them.
+documents them.
 
-## Common set of flags
+## Flag availability overview
 
-The following flags are available on all "controllers", aka `controller`, `webhook`, `events` and `resolvers`.
+Not all flags are available on every controller. The table below shows which
+flags and environment variables are supported by each controller binary.
 
-```
-  -add_dir_header
-        If true, adds the file directory to the header of the log messages
-  -alsologtostderr
-        log to standard error as well as files (no effect when -logtostderr=true)
-  -cluster string
-        Defaults to the current cluster in kubeconfig.
-  -disable-ha
-        Whether to disable high-availability functionality for this component.  This flag will be deprecated and removed when we have promoted this feature to stable, so do not pass it without filing an issue upstream!
-  -kube-api-burst int
-        Maximum burst for throttle.
-  -kube-api-qps float
-        Maximum QPS to the server from the client.
-  -kubeconfig string
-        Path to a kubeconfig. Only required if out-of-cluster.
-  -log_backtrace_at value
-        when logging hits line file:N, emit a stack trace
-  -log_dir string
-        If non-empty, write log files in this directory (no effect when -logtostderr=true)
-  -log_file string
-        If non-empty, use this log file (no effect when -logtostderr=true)
-  -log_file_max_size uint
-        Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-  -logtostderr
-        log to standard error instead of files (default true)
-  -one_output
-        If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-  -server string
-        The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.
-  -skip_headers
-        If true, avoid header prefixes in the log messages
-  -skip_log_headers
-        If true, avoid headers when opening log files (no effect when -logtostderr=true)
-  -stderrthreshold value
-        logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
-  -v value
-        number for the log level verbosity
-  -vmodule value
-        comma-separated list of pattern=N settings for file-filtered logging
-```
+### Flags from `knative/pkg` (available on all controllers)
+
+These flags are registered by
+[`injection.ParseAndGetRESTConfigOrDie()`](https://github.com/knative/pkg/tree/main/injection)
+and [`klog`](https://github.com/kubernetes/klog), and are available on **all**
+controllers (`controller`, `webhook`, `events`, `resolvers`):
+
+| Flag | Description |
+|------|-------------|
+| `-cluster` | Defaults to the current cluster in kubeconfig. |
+| `-server` | The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster. |
+| `-kubeconfig` | Path to a kubeconfig. Only required if out-of-cluster. |
+| `-kube-api-burst` | Maximum burst for throttle. |
+| `-kube-api-qps` | Maximum QPS to the server from the client. |
+| `-v` | Number for the log level verbosity. |
+| `-vmodule` | Comma-separated list of `pattern=N` settings for file-filtered logging. |
+| `-add_dir_header` | If true, adds the file directory to the header of the log messages. |
+| `-alsologtostderr` | Log to standard error as well as files (no effect when `-logtostderr=true`). |
+| `-log_backtrace_at` | When logging hits line `file:N`, emit a stack trace. |
+| `-log_dir` | If non-empty, write log files in this directory (no effect when `-logtostderr=true`). |
+| `-log_file` | If non-empty, use this log file (no effect when `-logtostderr=true`). |
+| `-log_file_max_size` | Maximum size a log file can grow to in megabytes (default 1800, 0 = unlimited; no effect when `-logtostderr=true`). |
+| `-logtostderr` | Log to standard error instead of files (default true). |
+| `-one_output` | If true, only write logs to their native severity level (no effect when `-logtostderr=true`). |
+| `-skip_headers` | If true, avoid header prefixes in the log messages. |
+| `-skip_log_headers` | If true, avoid headers when opening log files (no effect when `-logtostderr=true`). |
+| `-stderrthreshold` | Logs at or above this threshold go to stderr (default 2; no effect when `-logtostderr=true` or `-alsologtostderr=false`). |
+
+### Flags and environment variables that vary by controller
+
+The following flags and environment variables are **not** available on all
+controllers. Their availability depends on whether the controller calls
+[`sharedmain.MainWithContext()`](https://github.com/knative/pkg/tree/main/injection/sharedmain)
+(which registers `--disable-ha` and reads `K_THREADS_PER_CONTROLLER`) or
+registers flags directly in its own `main()`.
+
+| Flag / Environment Variable | Source | `controller` | `webhook` | `events` | `resolvers` |
+|------------------------------|--------|:---:|:---:|:---:|:---:|
+| `--disable-ha` | `sharedmain` / Tekton | Yes | Yes | Yes | No |
+| `--threads-per-controller` | Tekton | Yes | No | No | Yes |
+| `--namespace` | Tekton | Yes | No | No | No |
+| `--resync-period` | Tekton | Yes | No | No | No |
+| `THREADS_PER_CONTROLLER` env var | Tekton | Yes | No | No | Yes |
+| `K_THREADS_PER_CONTROLLER` env var | `sharedmain` | No | Yes | Yes | No |
+
+> **Note:** `controller` and `resolvers` read the `THREADS_PER_CONTROLLER`
+> environment variable (without the `K_` prefix) in their own code before
+> parsing flags, while `webhook` and `events` read `K_THREADS_PER_CONTROLLER`
+> (with the `K_` prefix) via `sharedmain.MainWithContext()`. Both environment
+> variables set the same underlying
+> `controller.DefaultThreadsPerController` value; the difference is only in the
+> variable name.
 
 ## `controller`
 
-The main controller binary has additional flags to configure its behavior.
+The main controller binary
+([`cmd/controller/main.go`](https://github.com/tektoncd/pipeline/blob/main/cmd/controller/main.go))
+has additional flags to configure its behavior.
 
 ```
+  -disable-ha
+        Whether to disable high-availability functionality for this component.
+        This flag will be deprecated and removed when we have promoted this
+        feature to stable, so do not pass it without filing an issue upstream!
   -entrypoint-image string
         The container image containing our entrypoint binary.
   -namespace string
@@ -80,3 +99,53 @@ The main controller binary has additional flags to configure its behavior.
   -workingdirinit-image string
         The container image containing our working dir init binary.
 ```
+
+**Environment variables:** `THREADS_PER_CONTROLLER`
+
+## `webhook`
+
+The webhook binary
+([`cmd/webhook/main.go`](https://github.com/tektoncd/pipeline/blob/main/cmd/webhook/main.go))
+calls `sharedmain.MainWithContext()`, which provides:
+
+```
+  -disable-ha
+        Whether to disable high-availability functionality for this component.
+        This flag will be deprecated and removed when we have promoted this
+        feature to stable, so do not pass it without filing an issue upstream!
+```
+
+**Environment variables:** `K_THREADS_PER_CONTROLLER`
+
+## `events`
+
+The events controller binary
+([`cmd/events/main.go`](https://github.com/tektoncd/pipeline/blob/main/cmd/events/main.go))
+calls `sharedmain.Main()`, which provides:
+
+```
+  -disable-ha
+        Whether to disable high-availability functionality for this component.
+        This flag will be deprecated and removed when we have promoted this
+        feature to stable, so do not pass it without filing an issue upstream!
+```
+
+**Environment variables:** `K_THREADS_PER_CONTROLLER`
+
+## `resolvers`
+
+The resolvers binary
+([`cmd/resolvers/main.go`](https://github.com/tektoncd/pipeline/blob/main/cmd/resolvers/main.go))
+has the following additional flag:
+
+```
+  -threads-per-controller int
+        Threads (goroutines) to create per controller (default 2)
+```
+
+**Environment variables:** `THREADS_PER_CONTROLLER`
+
+> **Note:** The `resolvers` binary does **not** support `--disable-ha`. It
+> calls `injection.ParseAndGetRESTConfigOrDie()` followed by
+> `sharedmain.MainWithConfig()`, which does not register the `--disable-ha`
+> flag.


### PR DESCRIPTION
# Changes

Restructure the `docs/tekton-controller-flags.md` documentation to clearly communicate which flags and environment variables are available on each controller binary (`controller`, `webhook`, `events`, `resolvers`).

### What changed

- **Separated flags by source**: flags from `knative/pkg` (common to all controllers) are now clearly distinguished from Tekton-specific flags
- **Added per-controller availability table**: a table shows exactly which flags and env vars each controller supports
- **Added per-controller sections**: each controller now has its own section documenting its specific flags and environment variables
- **Corrected inaccuracies**: source code verification revealed that:
  - `resolvers` does **not** support `--disable-ha` (it uses `MainWithConfig`, not `MainWithContext`)
  - `controller` and `resolvers` use `THREADS_PER_CONTROLLER` env var (no `K_` prefix), while `webhook` and `events` use `K_THREADS_PER_CONTROLLER` (with `K_` prefix) via `sharedmain`

Fixes #9292

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Restructured docs/tekton-controller-flags.md to clarify flag and environment variable availability per controller binary, and corrected inaccuracies in --disable-ha and THREADS_PER_CONTROLLER documentation.
```