### PR TITLE
ci: replace e2e-only fan-in with unified CI summary job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -175,16 +175,36 @@ jobs:
     needs: [build]
     uses: ./.github/workflows/e2e-matrix.yml
 
-  e2e-summary:
-    name: e2e tests
-    needs: [e2e-tests]
+  ci-summary:
+    name: CI summary
+    needs: [build, buildFips, linting, tests, generated, multi-arch-build, e2e-tests]
     runs-on: ubuntu-latest
     if: always()
     steps:
-    - name: Check e2e results
+    - name: Check CI results
       run: |
-        if [ "${{ needs.e2e-tests.result }}" != "success" ]; then
-          echo "e2e-tests failed or were cancelled"
+        results=(
+          "build=${{ needs.build.result }}"
+          "buildFips=${{ needs.buildFips.result }}"
+          "linting=${{ needs.linting.result }}"
+          "tests=${{ needs.tests.result }}"
+          "generated=${{ needs.generated.result }}"
+          "multi-arch-build=${{ needs.multi-arch-build.result }}"
+          "e2e-tests=${{ needs.e2e-tests.result }}"
+        )
+        failed=0
+        for r in "${results[@]}"; do
+          name="${r%%=*}"
+          result="${r#*=}"
+          echo "${name}: ${result}"
+          if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
+            failed=1
+          fi
+        done
+        if [ "$failed" -eq 1 ]; then
+          echo ""
+          echo "Some CI jobs failed or were cancelled"
           exit 1
         fi
-        echo "All e2e tests passed"
+        echo ""
+        echo "All CI checks passed"


### PR DESCRIPTION
# Changes

The `e2e-summary` fan-in job currently checks `needs.e2e-tests.result != "success"` and fails if the result is anything else — including `skipped`. This causes docs-only PRs to always fail the "e2e tests" check, because:

1. `changes` detects docs-only → `non-docs = false`
2. `build` is skipped (guarded by `if: non-docs == true`)
3. `e2e-tests` is skipped (depends on `build`)
4. `e2e-summary` sees `result == "skipped"` and fails ❌

See https://github.com/tektoncd/pipeline/pull/9390 for an example.

This PR replaces the e2e-only `e2e-summary` job with a unified `ci-summary` job that:
- **Fans in all CI jobs** (build, buildFips, linting, tests, generated, multi-arch-build, e2e-tests)
- **Treats `skipped` as passing** — skipped jobs are expected for docs-only PRs
- **Only fails on `failure` or `cancelled`** results
- **Prints each job result** for easy debugging

**Note:** If `e2e tests` was a required status check in branch protection, it needs to be updated to `CI summary`.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```