### PR TITLE
fix: Remove redundant shortNames from ResolutionRequest CRD

### DIFF
--- a/config/300-crds/300-resolutionrequest.yaml
+++ b/config/300-crds/300-resolutionrequest.yaml
@@ -28,9 +28,6 @@ spec:
     categories:
       - tekton
       - tekton-pipelines
-    shortNames:
-      - resolutionrequest
-      - resolutionrequests
   versions:
     - name: v1alpha1
       served: true


### PR DESCRIPTION
# Changes

Remove the `shortNames` field from the `ResolutionRequest` CRD. The short names
(`resolutionrequest`, `resolutionrequests`) were identical to the singular and
plural names, providing no actual shortcut value.

Starting with Kubernetes 1.33, this causes a `ShortNamesConflict` condition on
the CRD because the API server now validates that short names don't collide with
the already-registered singular/plural names.

Fixes #9378

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Remove redundant shortNames from ResolutionRequest CRD that caused ShortNamesConflict on Kubernetes 1.33+
```