### PR TITLE
ci: Update cherry-pick command to latest plumbing

### DIFF
--- a/.github/workflows/cherry-pick-command.yaml
+++ b/.github/workflows/cherry-pick-command.yaml
@@ -27,6 +27,6 @@ permissions:
 jobs:
   cherry-pick:
     name: Cherry Pick Actions
-    uses: tektoncd/plumbing/.github/workflows/_cherry-pick-command.yaml@03501984b53f82be58454f64218ea5c3122b898e  # main
+    uses: tektoncd/plumbing/.github/workflows/_cherry-pick-command.yaml@9f8e1781d5cc431e5c95190a9fc14dfba1cec391  # main
     secrets:
       CHATOPS_TOKEN: ${{ secrets.CHATOPS_TOKEN }}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Update the cherry-pick slash command workflow to the latest version from
`tektoncd/plumbing` (commit `9f8e1781d5cc`).

This picks up two improvements:

- **Update existing PR on re-run** (`25254e85`): Instead of just reporting that
  a cherry-pick PR already exists and exiting, it now resets the branch and
  force-pushes to update the existing PR. This is useful when the original PR
  was amended after a first cherry-pick attempt.

- **Fetch PR ref to access fork commits** (`9f8e1781`): Fetches
  `refs/pull/<number>/head` before cherry-picking so that commits from fork PRs
  are available locally. Previously, cherry-picking a merged PR that originated
  from a fork would fail because the commits weren't fetched.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```