### PR TITLE
[cherry-pick: release-v1.0.x] tekton: update plumbing ref to include full image references fix

### DIFF
--- a/tekton/release-pipeline.yaml
+++ b/tekton/release-pipeline.yaml
@@ -94,7 +94,7 @@ spec:
           - name: org
             value: tektoncd
           - name: revision
-            value: aeed19e5a36f335ebfdc4b96fa78d1ce5bb4f7b8
+            value: 995bffb1e4bcee00d0e363f4f3db7f25051ab137
           - name: pathInRepo
             value: tekton/resources/release/base/prerelease_checks.yaml
       params:


### PR DESCRIPTION
This is a cherry-pick of #9399

---

# Changes

Update the plumbing revision used by the `precheck` task in the release pipeline to include the fix from tektoncd/plumbing#3110 which replaces short image URLs with full image references (e.g. `alpine` → `docker.io/library/alpine`).

Newer k8s versions no longer allow short image URLs, which would break our releases.

```release-note
NONE
```