### PR TITLE
Assess several new gosec findings

### DIFF
--- a/cmd/workingdirinit/main.go
+++ b/cmd/workingdirinit/main.go
@@ -35,6 +35,7 @@ func main() {
 		p := cleanPath(d)
 
 		if !filepath.IsAbs(p) || strings.HasPrefix(p, ws+string(filepath.Separator)) {
+			// #nosec G703 -- purpose of this executable is to create arbitrary directories
 			if err := os.MkdirAll(p, 0755); err != nil {
 				log.Fatalf("Failed to mkdir %q: %v", p, err)
 			}

--- a/pkg/credentials/gitcreds/basic.go
+++ b/pkg/credentials/gitcreds/basic.go
@@ -98,6 +98,7 @@ func (dc *basicGitConfig) Write(directory string) error {
 	}
 	gitCredentials = append(gitCredentials, "") // Get a trailing newline
 	gitCredentialsContent := strings.Join(gitCredentials, "\n")
+	// #nosec G703 -- no path traversal with that path that is Tekton's creds directory which is a constant joined with a constant file name
 	return os.WriteFile(gitCredentialsPath, []byte(gitCredentialsContent), 0600)
 }
 

--- a/pkg/credentials/writer/writer.go
+++ b/pkg/credentials/writer/writer.go
@@ -90,6 +90,7 @@ func CopyCredsToHome(credPaths []string) error {
 // destination path. A missing source file is treated as normal behaviour
 // and no error is returned.
 func tryCopyCred(source, destination string) error {
+	// #nosec G703 -- no path traversal with that path that is Tekton's creds directory which is a constant joined with a credential file
 	fromInfo, err := os.Lstat(source)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -98,6 +99,7 @@ func tryCopyCred(source, destination string) error {
 		return fmt.Errorf("unable to read source file info: %w", err)
 	}
 
+	// #nosec G703 -- no path traversal with that path that is Tekton's creds directory which is a constant joined with a credential file
 	fromFile, err := os.Open(filepath.Clean(source))
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -108,6 +110,7 @@ func tryCopyCred(source, destination string) error {
 	defer fromFile.Close()
 
 	if fromInfo.IsDir() {
+		// #nosec G703 -- no path traversal with that path that is properly joining the home path and a credential file
 		err := os.MkdirAll(destination, credsDirPermissions)
 		if err != nil {
 			return fmt.Errorf("unable to create destination directory: %w", err)
@@ -125,6 +128,7 @@ func tryCopyCred(source, destination string) error {
 		}
 	} else {
 		flags := os.O_RDWR | os.O_CREATE | os.O_TRUNC
+		// #nosec G703 -- no path traversal with that path that is properly joining the home path and a credential file
 		toFile, err := os.OpenFile(destination, flags, credsFilePermissions)
 		if err != nil {
 			return fmt.Errorf("unable to open destination: %w", err)

--- a/pkg/entrypoint/entrypointer.go
+++ b/pkg/entrypoint/entrypointer.go
@@ -867,6 +867,7 @@ func writeToTempFile(v string) (*os.File, error) {
 	if err != nil {
 		return nil, err
 	}
+	// #nosec G703 -- no path traversal with that path that comes from CreateTemp()
 	err = os.Chmod(tmp.Name(), 0o755)
 	if err != nil {
 		return nil, err

--- a/pkg/resolution/resolver/http/resolver.go
+++ b/pkg/resolution/resolver/http/resolver.go
@@ -290,6 +290,7 @@ func FetchHttpResource(ctx context.Context, params map[string]string, kubeclient
 		}
 	}
 
+	// #nosec G704 -- URL cannot be constant in this case.
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("error fetching URL: %w", err)

--- a/pkg/resolution/resolver/hub/resolver.go
+++ b/pkg/resolution/resolver/hub/resolver.go
@@ -223,6 +223,7 @@ func fetchHubResource(ctx context.Context, apiEndpoint string, v interface{}) er
 		return fmt.Errorf("constructing request: %w", err)
 	}
 
+	// #nosec G704 -- URL cannot be constant in this case.
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("requesting resource from Hub: %w", err)

--- a/test/featureflags.go
+++ b/test/featureflags.go
@@ -160,6 +160,7 @@ func getAPIFeatureGate() (string, error) {
 		ns = "tekton-pipelines"
 	}
 
+	// #nosec G702 -- no command injection here with well-defined command and arguments
 	cmd := exec.Command("kubectl", "get", "configmap", "feature-flags", "-n", ns, "-o", `jsonpath="{.data['enable-api-fields']}"`)
 	output, err := cmd.Output()
 	if err != nil {


### PR DESCRIPTION
# Changes

GoSec v2.23 recently released and includes a couple of new rules that we are looking at downstream. I am hereby adding nosec comments to those with high severity with my assessments.

/kind cleanup

# Submitter Checklist

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
