### PR TITLE
tekton: update plumbing ref to latest commit

### DIFF
--- a/tekton/release-pipeline.yaml
+++ b/tekton/release-pipeline.yaml
@@ -96,7 +96,7 @@ spec:
           - name: url
             value: https://github.com/tektoncd/plumbing
           - name: revision
-            value: 995bffb1e4bcee00d0e363f4f3db7f25051ab137
+            value: 50bc706c351cc05087564bb17afc1e658090edb0
           - name: pathInRepo
             value: tekton/resources/release/base/prerelease_checks_oci.yaml
       params:


### PR DESCRIPTION
<!-- 🎉 Thank you for the PR!!! 🎉 -->

# Changes

Follow-up to #9399: the plumbing revision used there (`995bffb`) was the first commit that fixed short image URLs ("Short image URLs are not allowed anymore"), but it was missing follow-up fixes:

- tektoncd/plumbing#3112 (`b5d215c`) fixed 22 additional files including `prerelease_checks_oci.yaml` (the file our precheck task references)
- `ae23f15` fixed remaining files missed in the above

Rather than pinning to a specific fix commit, this updates the revision to the latest `main` of tektoncd/plumbing to pick up all fixes.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```