### PR TITLE
fix: propagate PipelineRun tasks/finally timeout to child TaskRuns

### DIFF
--- a/docs/pipelineruns.md
+++ b/docs/pipelineruns.md
@@ -1398,10 +1398,18 @@ or `finally` Tasks, and the PipelineRun will fail.
 To specify a timeout for an individual Task, use `pipeline.spec.tasks[].timeout`.
 When `timeouts.tasks` has elapsed, any running child TaskRuns will be canceled, finally Tasks will run if `timeouts.finally` is specified,
 and the PipelineRun will fail.
+When `timeouts.tasks` exceeds the global default timeout, it is also used as the individual TaskRun timeout
+for tasks that do not have an explicit timeout set via `pipeline.spec.tasks[].timeout` or `taskRunSpecs[].timeout`.
+This prevents individual TaskRuns from being prematurely canceled at the global default timeout.
+This also applies to computed tasks timeouts (e.g., `pipeline: 2h` minus `finally: 10m` = `1h50m`).
+When the computed or explicit tasks timeout is smaller than the global default, the global default is used
+for individual TaskRuns and the PipelineRun's cumulative enforcement handles cancellation.
 - `finally`: the timeout for the cumulative time taken by `finally` Tasks specified in `pipeline.spec.finally`.
 (Since all `finally` Tasks run in parallel, this is functionally equivalent to the timeout for any `finally` Task.)
 When `timeouts.finally` has elapsed, any running `finally` TaskRuns will be canceled,
 and the PipelineRun will fail.
+Similar to `timeouts.tasks`, when `timeouts.finally` exceeds the global default timeout,
+it is used as the individual timeout for `finally` TaskRuns that do not have an explicit timeout.
 
 For example:
 

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -26,6 +26,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"time"
 
 	"k8s.io/apimachinery/pkg/util/wait"
 
@@ -1172,6 +1173,8 @@ func (c *Reconciler) createTaskRun(ctx context.Context, taskRunName string, para
 
 	if rpt.PipelineTask.Timeout != nil {
 		tr.Spec.Timeout = rpt.PipelineTask.Timeout
+	} else if timeout := pipelineRunTimeout(ctx, pr, rpt, facts); timeout != nil {
+		tr.Spec.Timeout = timeout
 	}
 
 	// taskRunSpec timeout overrides pipeline task timeout
@@ -1280,6 +1283,9 @@ func (c *Reconciler) createCustomRun(ctx context.Context, runName string, params
 	params = append(params, rpt.PipelineTask.Params...)
 
 	taskTimeout := rpt.PipelineTask.Timeout
+	if taskTimeout == nil {
+		taskTimeout = pipelineRunTimeout(ctx, pr, rpt, facts)
+	}
 	// taskRunSpec timeout overrides pipeline task timeout
 	if taskRunSpec.Timeout != nil {
 		taskTimeout = taskRunSpec.Timeout
@@ -1510,6 +1516,38 @@ func (c *Reconciler) taskWorkspaceByWorkspaceVolumeSource(ctx context.Context, p
 	}
 
 	return binding
+}
+
+// pipelineRunTimeout returns the applicable PipelineRun-level timeout for a task,
+// based on whether it is a regular task or a finally task.
+// It only returns a value when the PipelineRun timeout exceeds the global default
+// (or is explicitly zero, meaning no timeout)
+func pipelineRunTimeout(ctx context.Context, pr *v1.PipelineRun, rpt *resources.ResolvedPipelineTask, facts *resources.PipelineRunFacts) *metav1.Duration {
+	var prTimeout *metav1.Duration
+	if facts.FinalTasksGraph != nil && rpt.IsFinalTask(facts) {
+		prTimeout = pr.FinallyTimeout()
+	} else {
+		prTimeout = pr.TasksTimeout()
+	}
+
+	if prTimeout == nil {
+		return nil
+	}
+
+	if prTimeout.Duration == config.NoTimeoutDuration {
+		return prTimeout
+	}
+
+	defaultTimeout := time.Duration(config.FromContextOrDefaults(ctx).Defaults.DefaultTimeoutMinutes) * time.Minute
+	if prTimeout.Duration > defaultTimeout {
+		return prTimeout
+	}
+	// When the PipelineRun timeout is smaller than or equal to the global default
+	// (e.g., tasks: 20m with default: 60m), we return nil and the global default to
+	// the TaskRun gets applied. The PipelineRun's cumulative timer will
+	// cancel the TaskRun at 20m, before the 60m default fires, so there is no
+	// risk of premature cancellation and no need to set an individual timeout.
+	return nil
 }
 
 // combinedSubPath returns the combined value of the optional subPath from workspaceBinding and the optional

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -4169,6 +4169,366 @@ spec:
 	}
 }
 
+// TestReconcileTimeoutPropagationToTaskRun is a comprehensive test covering all
+// scenarios for how PipelineRun timeouts propagate to child TaskRuns.
+func TestReconcileTimeoutPropagationToTaskRun(t *testing.T) {
+	tcs := []struct {
+		name            string
+		pipeline        string
+		pipelineRun     string
+		expectedTimeout *metav1.Duration
+	}{{
+		name: "timeouts.tasks propagated when no per-task timeout set",
+		pipeline: `
+metadata:
+  name: test-pipeline
+  namespace: foo
+spec:
+  tasks:
+  - name: hello-world-1
+    taskRef:
+      name: hello-world`,
+		pipelineRun: `
+metadata:
+  name: test-pipeline-run
+  namespace: foo
+spec:
+  pipelineRef:
+    name: test-pipeline
+  timeouts:
+    pipeline: 2h0m0s
+    tasks: 1h55m0s`,
+		expectedTimeout: &metav1.Duration{Duration: 115 * time.Minute},
+	}, {
+		name: "taskRunSpecs timeout takes precedence over timeouts.tasks",
+		pipeline: `
+metadata:
+  name: test-pipeline
+  namespace: foo
+spec:
+  tasks:
+  - name: hello-world-1
+    taskRef:
+      name: hello-world`,
+		pipelineRun: `
+metadata:
+  name: test-pipeline-run
+  namespace: foo
+spec:
+  pipelineRef:
+    name: test-pipeline
+  timeouts:
+    pipeline: 2h0m0s
+    tasks: 1h55m0s
+  taskRunSpecs:
+  - pipelineTaskName: hello-world-1
+    timeout: "30m"`,
+		expectedTimeout: &metav1.Duration{Duration: 30 * time.Minute},
+	}, {
+		name: "pipeline task timeout takes precedence over timeouts.tasks",
+		pipeline: `
+metadata:
+  name: test-pipeline
+  namespace: foo
+spec:
+  tasks:
+  - name: hello-world-1
+    taskRef:
+      name: hello-world
+    timeout: "45m"`,
+		pipelineRun: `
+metadata:
+  name: test-pipeline-run
+  namespace: foo
+spec:
+  pipelineRef:
+    name: test-pipeline
+  timeouts:
+    pipeline: 2h0m0s
+    tasks: 1h55m0s`,
+		expectedTimeout: &metav1.Duration{Duration: 45 * time.Minute},
+	}, {
+		name: "no timeouts set - TaskRun gets nil (webhook applies global default)",
+		pipeline: `
+metadata:
+  name: test-pipeline
+  namespace: foo
+spec:
+  tasks:
+  - name: hello-world-1
+    taskRef:
+      name: hello-world`,
+		pipelineRun: `
+metadata:
+  name: test-pipeline-run
+  namespace: foo
+spec:
+  pipelineRef:
+    name: test-pipeline`,
+		expectedTimeout: nil,
+	}, {
+		name: "only timeouts.pipeline set - TasksTimeout returns nil, global default applies",
+		pipeline: `
+metadata:
+  name: test-pipeline
+  namespace: foo
+spec:
+  tasks:
+  - name: hello-world-1
+    taskRef:
+      name: hello-world`,
+		pipelineRun: `
+metadata:
+  name: test-pipeline-run
+  namespace: foo
+spec:
+  pipelineRef:
+    name: test-pipeline
+  timeouts:
+    pipeline: 2h0m0s`,
+		expectedTimeout: nil,
+	}, {
+		name: "computed tasks timeout from pipeline minus finally",
+		pipeline: `
+metadata:
+  name: test-pipeline
+  namespace: foo
+spec:
+  tasks:
+  - name: hello-world-1
+    taskRef:
+      name: hello-world`,
+		pipelineRun: `
+metadata:
+  name: test-pipeline-run
+  namespace: foo
+spec:
+  pipelineRef:
+    name: test-pipeline
+  timeouts:
+    pipeline: 2h0m0s
+    finally: 10m0s`,
+		expectedTimeout: &metav1.Duration{Duration: 110 * time.Minute},
+	}, {
+		name: "computed tasks timeout below default not propagated",
+		pipeline: `
+metadata:
+  name: test-pipeline
+  namespace: foo
+spec:
+  tasks:
+  - name: hello-world-1
+    taskRef:
+      name: hello-world`,
+		pipelineRun: `
+metadata:
+  name: test-pipeline-run
+  namespace: foo
+spec:
+  pipelineRef:
+    name: test-pipeline
+  timeouts:
+    pipeline: 1h0m0s
+    finally: 20m0s`,
+		expectedTimeout: nil,
+	}, {
+		name: "timeouts.tasks zero means no timeout",
+		pipeline: `
+metadata:
+  name: test-pipeline
+  namespace: foo
+spec:
+  tasks:
+  - name: hello-world-1
+    taskRef:
+      name: hello-world`,
+		pipelineRun: `
+metadata:
+  name: test-pipeline-run
+  namespace: foo
+spec:
+  pipelineRef:
+    name: test-pipeline
+  timeouts:
+    pipeline: "0"
+    tasks: "0"`,
+		expectedTimeout: &metav1.Duration{Duration: 0},
+	}, {
+		name: "timeouts.tasks smaller than global default not propagated - cumulative enforcement handles it",
+		pipeline: `
+metadata:
+  name: test-pipeline
+  namespace: foo
+spec:
+  tasks:
+  - name: hello-world-1
+    taskRef:
+      name: hello-world`,
+		pipelineRun: `
+metadata:
+  name: test-pipeline-run
+  namespace: foo
+spec:
+  pipelineRef:
+    name: test-pipeline
+  timeouts:
+    pipeline: 1h0m0s
+    tasks: 30m0s`,
+		expectedTimeout: nil,
+	}, {
+		name: "all three set - taskRunSpecs wins over pipelineTask and timeouts.tasks",
+		pipeline: `
+metadata:
+  name: test-pipeline
+  namespace: foo
+spec:
+  tasks:
+  - name: hello-world-1
+    taskRef:
+      name: hello-world
+    timeout: "45m"`,
+		pipelineRun: `
+metadata:
+  name: test-pipeline-run
+  namespace: foo
+spec:
+  pipelineRef:
+    name: test-pipeline
+  timeouts:
+    pipeline: 2h0m0s
+    tasks: 1h55m0s
+  taskRunSpecs:
+  - pipelineTaskName: hello-world-1
+    timeout: "20m"`,
+		expectedTimeout: &metav1.Duration{Duration: 20 * time.Minute},
+	}}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			names.TestingSeed()
+			namespace := "foo"
+			prName := "test-pipeline-run"
+			trName := "test-pipeline-run-hello-world-1"
+
+			ps := []*v1.Pipeline{parse.MustParseV1Pipeline(t, tc.pipeline)}
+			prs := []*v1.PipelineRun{parse.MustParseV1PipelineRun(t, tc.pipelineRun)}
+			ts := []*v1.Task{simpleHelloWorldTask}
+
+			d := test.Data{
+				PipelineRuns: prs,
+				Pipelines:    ps,
+				Tasks:        ts,
+			}
+			prt := newPipelineRunTest(t, d)
+			defer prt.Cancel()
+
+			_, clients := prt.reconcileRun(namespace, prName, []string{}, false)
+
+			taskRuns := getTaskRunsForPipelineRun(prt.TestAssets.Ctx, t, clients, namespace, prName)
+			validateTaskRunsCount(t, taskRuns, 1)
+
+			actual := getTaskRunByName(t, taskRuns, trName)
+
+			if tc.expectedTimeout == nil {
+				if actual.Spec.Timeout != nil {
+					t.Errorf("expected TaskRun timeout to be nil, but was %v", actual.Spec.Timeout)
+				}
+			} else {
+				if actual.Spec.Timeout == nil {
+					t.Errorf("expected TaskRun timeout to be %v, but was nil", tc.expectedTimeout)
+				} else if *actual.Spec.Timeout != *tc.expectedTimeout {
+					t.Errorf("expected TaskRun timeout to be %v, but was %v", tc.expectedTimeout, actual.Spec.Timeout)
+				}
+			}
+		})
+	}
+}
+
+// TestReconcileFinallyTimeoutPropagatedToTaskRun tests that spec.timeouts.finally
+// is propagated to finally TaskRuns when no per-task timeout is set.
+func TestReconcileFinallyTimeoutPropagatedToTaskRun(t *testing.T) {
+	names.TestingSeed()
+
+	namespace := "foo"
+	prName := "test-pipeline-run"
+
+	ps := []*v1.Pipeline{parse.MustParseV1Pipeline(t, `
+metadata:
+  name: test-pipeline
+  namespace: foo
+spec:
+  tasks:
+  - name: task1
+    taskRef:
+      name: hello-world
+  finally:
+  - name: final-task-1
+    taskRef:
+      name: some-task
+`)}
+
+	prs := []*v1.PipelineRun{parse.MustParseV1PipelineRun(t, `
+metadata:
+  name: test-pipeline-run
+  namespace: foo
+spec:
+  pipelineRef:
+    name: test-pipeline
+  timeouts:
+    pipeline: 3h0m0s
+    tasks: 1h50m0s
+    finally: 1h10m0s
+status:
+  startTime: "2022-01-01T00:00:00Z"
+  childReferences:
+  - apiVersion: tekton.dev/v1
+    kind: TaskRun
+    name: test-pipeline-run-task1
+    pipelineTaskName: task1
+    status:
+      conditions:
+      - lastTransitionTime: null
+        status: "True"
+        type: Succeeded
+`)}
+
+	trs := []*v1.TaskRun{
+		getTaskRun(t, "test-pipeline-run-task1", prName, "test-pipeline", "task1", corev1.ConditionTrue),
+	}
+	ts := []*v1.Task{simpleHelloWorldTask, simpleSomeTask}
+
+	d := test.Data{
+		PipelineRuns: prs,
+		Pipelines:    ps,
+		Tasks:        ts,
+		TaskRuns:     trs,
+	}
+	prt := newPipelineRunTest(t, d)
+	defer prt.Cancel()
+
+	_, clients := prt.reconcileRun(namespace, prName, []string{}, false)
+
+	taskRuns := getTaskRunsForPipelineRun(prt.TestAssets.Ctx, t, clients, namespace, prName)
+
+	var finallyTaskRun *v1.TaskRun
+	for name, tr := range taskRuns {
+		if name != "test-pipeline-run-task1" {
+			finallyTaskRun = tr
+			break
+		}
+	}
+	if finallyTaskRun == nil {
+		t.Fatal("expected a finally TaskRun to be created, but none was found")
+	}
+
+	expectedTimeout := metav1.Duration{Duration: 70 * time.Minute}
+	if finallyTaskRun.Spec.Timeout == nil {
+		t.Errorf("expected finally TaskRun timeout to be %v, but was nil", expectedTimeout)
+	} else if *finallyTaskRun.Spec.Timeout != expectedTimeout {
+		t.Errorf("expected finally TaskRun timeout to be %v, but was %v", expectedTimeout, finallyTaskRun.Spec.Timeout)
+	}
+}
+
 // TestReconcileCustomRunSpecTimeout tests that timeout specified in taskRunSpecs
 // is applied to CustomRuns
 func TestReconcileCustomRunSpecTimeout(t *testing.T) {
@@ -4227,6 +4587,66 @@ spec:
 		t.Errorf("expected CustomRun timeout to be set, but was nil")
 	} else if *actual.Spec.Timeout != expectedTimeout {
 		t.Errorf("expected CustomRun timeout to be %v, but was %v", expectedTimeout, *actual.Spec.Timeout)
+	}
+}
+
+// TestReconcileCustomRunTasksTimeoutPropagated tests that timeouts.tasks
+// is propagated to CustomRuns when it exceeds the global default.
+func TestReconcileCustomRunTasksTimeoutPropagated(t *testing.T) {
+	names.TestingSeed()
+
+	namespace := "foo"
+	prName := "test-pipeline-run"
+
+	ps := []*v1.Pipeline{parse.MustParseV1Pipeline(t, `
+metadata:
+  name: test-pipeline
+  namespace: foo
+spec:
+  tasks:
+  - name: hello-world-1
+    taskRef:
+      apiVersion: example.dev/v0
+      kind: Example
+`)}
+	prs := []*v1.PipelineRun{parse.MustParseV1PipelineRun(t, `
+metadata:
+  name: test-pipeline-run
+  namespace: foo
+spec:
+  pipelineRef:
+    name: test-pipeline
+  timeouts:
+    pipeline: 2h0m0s
+    tasks: 1h55m0s
+`)}
+
+	d := test.Data{
+		PipelineRuns: prs,
+		Pipelines:    ps,
+	}
+	prt := newPipelineRunTest(t, d)
+	defer prt.Cancel()
+
+	_, clients := prt.reconcileRun("foo", prName, []string{}, false)
+
+	customRuns, err := clients.Pipeline.TektonV1beta1().CustomRuns(namespace).List(prt.TestAssets.Ctx, metav1.ListOptions{
+		LabelSelector: "tekton.dev/pipelineRun=" + prName,
+	})
+	if err != nil {
+		t.Fatalf("Failure to list CustomRuns: %s", err)
+	}
+
+	if len(customRuns.Items) != 1 {
+		t.Fatalf("Expected 1 CustomRun but got %d", len(customRuns.Items))
+	}
+
+	actual := &customRuns.Items[0]
+	expectedTimeout := metav1.Duration{Duration: 115 * time.Minute}
+	if actual.Spec.Timeout == nil {
+		t.Errorf("expected CustomRun timeout to be %v (from PipelineRun tasks timeout), but was nil", expectedTimeout)
+	} else if *actual.Spec.Timeout != expectedTimeout {
+		t.Errorf("expected CustomRun timeout to be %v (from PipelineRun tasks timeout), but was %v", expectedTimeout, *actual.Spec.Timeout)
 	}
 }
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

When a PipelineRun specifies `spec.timeouts.tasks` (or `spec.timeouts.finally`) but no per-task timeout is set via `pipeline.spec.tasks[].timeout` or `pipelineRun.spec.taskRunSpecs[].timeout`, the created TaskRun/CustomRun
receives no explicit timeout. The webhook then applies the global default (`default-timeout-minutes`, typically 1h), causing the TaskRun to be cancelled prematurely by the TaskRun reconciler, even when the PipelineRun allows a longer duration.

This commit propagates the PipelineRun-level tasks/finally timeout to child TaskRuns and CustomRuns when no per-task timeout is explicitly configured and the PipelineRun timeout exceeds the global default. When the PipelineRun timeout is smaller than the default, the PipelineRun's cumulative enforcement handles cancellation.

### Timeout precedence (highest to lowest)

1. `pipelineRun.spec.taskRunSpecs[].timeout`
2. `pipeline.spec.tasks[].timeout`
3. `pipelineRun.spec.timeouts.tasks` / `pipelineRun.spec.timeouts.finally` (when > global default)
4. Global default (`default-timeout-minutes`)


<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
fixes: https://github.com/tektoncd/pipeline/issues/8539
/kind bug
# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
When `spec.timeouts.tasks` or `spec.timeouts.finally` on a PipelineRun exceeds the global default timeout, the value is now propagated to individual child TaskRuns that do not have an explicit per-task timeout. This prevents TaskRuns from being prematurely canceled at the global default (e.g., 1h) when the PipelineRun allows a longer duration.
```
