### PR TITLE
tekton: add draft release creation to release pipeline

### DIFF
--- a/tekton/release-pipeline.yaml
+++ b/tekton/release-pipeline.yaml
@@ -50,6 +50,12 @@ spec:
     - name: runTests
       description: If set to something other than "true", skip the build and test tasks
       default: "true"
+    - name: previousReleaseTag
+      description: Previous release tag for changelog generation (e.g. v1.8.0). If empty, auto-detected from git tags.
+      default: ""
+    - name: releaseName
+      description: Release name (e.g. "Devon Rex Dreadnought"). If empty, uses version tag.
+      default: ""
   workspaces:
     - name: workarea
       description: The workspace where the repo will be cloned.
@@ -57,6 +63,9 @@ spec:
       description: The secret that contains auth credentials to push to the output bucket
     - name: release-images-secret
       description: The secret that contains a service account authorized to push to the imageRegistry
+    - name: github-secret
+      description: The secret containing GITHUB_TOKEN for creating draft releases
+      optional: true
   results:
     - name: commit-sha
       description: the sha of the commit that was released
@@ -306,3 +315,246 @@ spec:
 
               echo "${BASE_URL}/release.yaml" > $(results.release.path)
               echo "${BASE_URL}/release.notags.yaml" > $(results.release-no-tag.path)
+
+    - name: detect-previous-tag
+      runAfter: [git-clone]
+      params:
+        - name: versionTag
+          value: $(params.versionTag)
+        - name: previousReleaseTag
+          value: $(params.previousReleaseTag)
+        - name: releaseName
+          value: $(params.releaseName)
+      workspaces:
+        - name: source
+          workspace: workarea
+          subPath: git
+      taskSpec:
+        params:
+          - name: versionTag
+          - name: previousReleaseTag
+          - name: releaseName
+        results:
+          - name: previous-tag
+            description: The previous release tag
+          - name: release-name
+            description: The release name to use
+        workspaces:
+          - name: source
+        steps:
+          - name: detect
+            image: docker.io/library/alpine:3.21
+            workingDir: $(workspaces.source.path)
+            script: |
+              #!/bin/sh
+              set -e
+              apk add --no-cache git > /dev/null 2>&1
+              git config --global --add safe.directory $(workspaces.source.path)
+
+              VERSION="$(params.versionTag)"
+              PREVIOUS="$(params.previousReleaseTag)"
+              NAME="$(params.releaseName)"
+
+              # Detect previous tag if not provided
+              if [ -z "${PREVIOUS}" ]; then
+                git fetch --tags
+                # Get the tag just before the current version
+                # Sort tags by version, find the one right before the current version
+                PREVIOUS=$(git tag --sort=-v:refname | grep '^v[0-9]' | while read tag; do
+                  # Compare: if tag < VERSION, it's the previous one
+                  if [ "$(printf '%s\n%s' "$tag" "$VERSION" | sort -V | head -1)" = "$tag" ] && [ "$tag" != "$VERSION" ]; then
+                    echo "$tag"
+                    break
+                  fi
+                done)
+                if [ -z "${PREVIOUS}" ]; then
+                  echo "WARNING: Could not auto-detect previous tag"
+                  PREVIOUS="unknown"
+                fi
+                echo "Auto-detected previous tag: ${PREVIOUS}"
+              fi
+              printf '%s' "${PREVIOUS}" > "$(results.previous-tag.path)"
+
+              # Use provided name or fall back to version
+              if [ -z "${NAME}" ]; then
+                NAME="Release ${VERSION}"
+              fi
+              printf '%s' "${NAME}" > "$(results.release-name.path)"
+
+    - name: wait-for-chains
+      runAfter: [publish-images]
+      timeout: "30m"
+      when:
+        - input: "$(workspaces.github-secret.bound)"
+          operator: in
+          values: ["true"]
+      params:
+        - name: pipelineRunName
+          value: $(context.pipelineRun.name)
+        - name: namespace
+          value: $(context.pipelineRun.namespace)
+      taskSpec:
+        params:
+          - name: pipelineRunName
+          - name: namespace
+        results:
+          - name: rekor-uuid
+            description: Rekor UUID from Chains transparency log
+          - name: signed
+            description: Whether Chains signing succeeded (true, failed, or timeout)
+        steps:
+          - name: wait-and-extract
+            image: docker.io/library/alpine/k8s:1.32.2
+            script: |
+              #!/bin/sh
+              set -e
+
+              NAMESPACE="$(params.namespace)"
+              PIPELINERUN="$(params.pipelineRunName)"
+
+              # Find the TaskRun name for publish-images
+              # The TaskRun name follows the pattern: <pipelinerun>-<taskname>-<random>
+              echo "Looking for publish-images TaskRun in PipelineRun ${PIPELINERUN}..."
+              TASKRUN_NAME=""
+              MAX_FIND_ATTEMPTS=10
+              FIND_ATTEMPT=0
+              while [ -z "${TASKRUN_NAME}" ] && [ $FIND_ATTEMPT -lt $MAX_FIND_ATTEMPTS ]; do
+                TASKRUN_NAME=$(kubectl get taskrun -n "${NAMESPACE}" \
+                  -l tekton.dev/pipelineRun="${PIPELINERUN}",tekton.dev/pipelineTask=publish-images \
+                  -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+                if [ -z "${TASKRUN_NAME}" ]; then
+                  FIND_ATTEMPT=$((FIND_ATTEMPT + 1))
+                  echo "  Attempt ${FIND_ATTEMPT}/${MAX_FIND_ATTEMPTS} - TaskRun not found yet..."
+                  sleep 10
+                fi
+              done
+
+              if [ -z "${TASKRUN_NAME}" ]; then
+                echo "ERROR: Could not find publish-images TaskRun"
+                printf 'unknown' > "$(results.rekor-uuid.path)"
+                printf 'error' > "$(results.signed.path)"
+                exit 1
+              fi
+
+              echo "Found TaskRun: ${TASKRUN_NAME}"
+              echo "Waiting for Chains to sign TaskRun ${TASKRUN_NAME}..."
+
+              MAX_ATTEMPTS=60  # 30 minutes with 30s interval
+              ATTEMPT=0
+              while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
+                SIGNED=$(kubectl get taskrun "${TASKRUN_NAME}" -n "${NAMESPACE}" \
+                  -o jsonpath='{.metadata.annotations.chains\.tekton\.dev/signed}' 2>/dev/null || echo "")
+
+                if [ "${SIGNED}" = "true" ] || [ "${SIGNED}" = "failed" ]; then
+                  echo "Chains signing status: ${SIGNED}"
+                  printf '%s' "${SIGNED}" > "$(results.signed.path)"
+
+                  # Extract Rekor UUID from transparency URL
+                  TRANSPARENCY=$(kubectl get taskrun "${TASKRUN_NAME}" -n "${NAMESPACE}" \
+                    -o jsonpath='{.metadata.annotations.chains\.tekton\.dev/transparency}' 2>/dev/null || echo "")
+
+                  if [ -n "${TRANSPARENCY}" ]; then
+                    # URL format: https://rekor.sigstore.dev/api/v1/log/entries?logIndex=NNNN
+                    REKOR_UUID=$(echo "${TRANSPARENCY}" | grep -oE 'logIndex=[0-9]+' | cut -d= -f2)
+                    if [ -z "${REKOR_UUID}" ]; then
+                      # Might be a direct UUID format
+                      REKOR_UUID="${TRANSPARENCY}"
+                    fi
+                    echo "Rekor UUID: ${REKOR_UUID}"
+                    printf '%s' "${REKOR_UUID}" > "$(results.rekor-uuid.path)"
+                  else
+                    echo "WARNING: No transparency URL found"
+                    printf 'unknown' > "$(results.rekor-uuid.path)"
+                  fi
+                  exit 0
+                fi
+
+                ATTEMPT=$((ATTEMPT + 1))
+                echo "  Attempt ${ATTEMPT}/${MAX_ATTEMPTS} - signing status: '${SIGNED}'"
+                sleep 30
+              done
+
+              echo "ERROR: Timed out waiting for Chains to sign"
+              printf 'timeout' > "$(results.signed.path)"
+              printf 'unknown' > "$(results.rekor-uuid.path)"
+              exit 1
+
+    - name: prepare-draft-release
+      runAfter: [publish-to-bucket, detect-previous-tag]
+      when:
+        - input: "$(workspaces.github-secret.bound)"
+          operator: in
+          values: ["true"]
+      params:
+        - name: package
+          value: $(params.package)
+        - name: versionTag
+          value: $(params.versionTag)
+      workspaces:
+        - name: workarea
+          workspace: workarea
+      taskSpec:
+        params:
+          - name: package
+          - name: versionTag
+        results:
+          - name: package
+            description: The package in org/repo format (without github.com/ prefix)
+        workspaces:
+          - name: workarea
+        steps:
+          - name: setup
+            image: docker.io/library/alpine:3.21
+            script: |
+              #!/bin/sh
+              set -e
+              WORKAREA="$(workspaces.workarea.path)"
+
+              # The create-draft-release-oci task expects:
+              #   <workspace>/repo    -> git checkout
+              #   <workspace>/release -> release artifacts
+              # The release pipeline uses:
+              #   <workspace>/git     -> git checkout
+              #   <workspace>/bucket/<versionTag> -> release artifacts
+              ln -sfn "${WORKAREA}/git" "${WORKAREA}/repo"
+              ln -sfn "${WORKAREA}/bucket/$(params.versionTag)" "${WORKAREA}/release"
+              echo "Created workspace symlinks:"
+              ls -la "${WORKAREA}/repo" "${WORKAREA}/release"
+
+              # Strip github.com/ prefix from package for the draft release task
+              # (it expects org/repo format, e.g. tektoncd/pipeline)
+              PACKAGE=$(echo "$(params.package)" | sed 's|^github\.com/||')
+              printf '%s' "${PACKAGE}" > "$(results.package.path)"
+              echo "Package: ${PACKAGE}"
+
+    - name: create-draft-release
+      runAfter: [prepare-draft-release, wait-for-chains]
+      when:
+        - input: "$(workspaces.github-secret.bound)"
+          operator: in
+          values: ["true"]
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/tektoncd/plumbing
+          - name: revision
+            value: c6ccd417b39dd9d0c3055795f00cbce051f6bc9e
+          - name: pathInRepo
+            value: tekton/resources/release/base/github_release_oci.yaml
+      params:
+        - name: package
+          value: $(tasks.prepare-draft-release.results.package)
+        - name: git-revision
+          value: $(params.gitRevision)
+        - name: release-name
+          value: $(tasks.detect-previous-tag.results.release-name)
+        - name: release-tag
+          value: $(params.versionTag)
+        - name: previous-release-tag
+          value: $(tasks.detect-previous-tag.results.previous-tag)
+        - name: rekor-uuid
+          value: $(tasks.wait-for-chains.results.rekor-uuid)
+      workspaces:
+        - name: shared
+          workspace: workarea

--- a/tekton/release-pipeline.yaml
+++ b/tekton/release-pipeline.yaml
@@ -64,7 +64,11 @@ spec:
     - name: release-images-secret
       description: The secret that contains a service account authorized to push to the imageRegistry
     - name: github-secret
-      description: The secret containing GITHUB_TOKEN for creating draft releases
+      description: |
+        The secret containing GITHUB_TOKEN for creating draft releases.
+        When not bound, the draft-release tasks (wait-for-chains, prepare-draft-release,
+        create-draft-release) are skipped and the draft must be created manually
+        following the cheat sheet instructions.
       optional: true
   results:
     - name: commit-sha
@@ -316,71 +320,6 @@ spec:
               echo "${BASE_URL}/release.yaml" > $(results.release.path)
               echo "${BASE_URL}/release.notags.yaml" > $(results.release-no-tag.path)
 
-    - name: detect-previous-tag
-      runAfter: [git-clone]
-      params:
-        - name: versionTag
-          value: $(params.versionTag)
-        - name: previousReleaseTag
-          value: $(params.previousReleaseTag)
-        - name: releaseName
-          value: $(params.releaseName)
-      workspaces:
-        - name: source
-          workspace: workarea
-          subPath: git
-      taskSpec:
-        params:
-          - name: versionTag
-          - name: previousReleaseTag
-          - name: releaseName
-        results:
-          - name: previous-tag
-            description: The previous release tag
-          - name: release-name
-            description: The release name to use
-        workspaces:
-          - name: source
-        steps:
-          - name: detect
-            image: docker.io/library/alpine:3.21
-            workingDir: $(workspaces.source.path)
-            script: |
-              #!/bin/sh
-              set -e
-              apk add --no-cache git > /dev/null 2>&1
-              git config --global --add safe.directory $(workspaces.source.path)
-
-              VERSION="$(params.versionTag)"
-              PREVIOUS="$(params.previousReleaseTag)"
-              NAME="$(params.releaseName)"
-
-              # Detect previous tag if not provided
-              if [ -z "${PREVIOUS}" ]; then
-                git fetch --tags
-                # Get the tag just before the current version
-                # Sort tags by version, find the one right before the current version
-                PREVIOUS=$(git tag --sort=-v:refname | grep '^v[0-9]' | while read tag; do
-                  # Compare: if tag < VERSION, it's the previous one
-                  if [ "$(printf '%s\n%s' "$tag" "$VERSION" | sort -V | head -1)" = "$tag" ] && [ "$tag" != "$VERSION" ]; then
-                    echo "$tag"
-                    break
-                  fi
-                done)
-                if [ -z "${PREVIOUS}" ]; then
-                  echo "WARNING: Could not auto-detect previous tag"
-                  PREVIOUS="unknown"
-                fi
-                echo "Auto-detected previous tag: ${PREVIOUS}"
-              fi
-              printf '%s' "${PREVIOUS}" > "$(results.previous-tag.path)"
-
-              # Use provided name or fall back to version
-              if [ -z "${NAME}" ]; then
-                NAME="Release ${VERSION}"
-              fi
-              printf '%s' "${NAME}" > "$(results.release-name.path)"
-
     - name: wait-for-chains
       runAfter: [publish-images]
       timeout: "30m"
@@ -433,7 +372,9 @@ spec:
                 echo "ERROR: Could not find publish-images TaskRun"
                 printf 'unknown' > "$(results.rekor-uuid.path)"
                 printf 'error' > "$(results.signed.path)"
-                exit 1
+                # Don't fail the pipeline — the release artifacts are already published.
+                # The draft release can be created manually using the cheat sheet.
+                exit 0
               fi
 
               echo "Found TaskRun: ${TASKRUN_NAME}"
@@ -474,13 +415,15 @@ spec:
                 sleep 30
               done
 
-              echo "ERROR: Timed out waiting for Chains to sign"
+              echo "WARNING: Timed out waiting for Chains to sign"
               printf 'timeout' > "$(results.signed.path)"
               printf 'unknown' > "$(results.rekor-uuid.path)"
-              exit 1
+              # Don't fail the pipeline — the release artifacts are already published.
+              # The draft release can be created manually using the cheat sheet.
+              exit 0
 
     - name: prepare-draft-release
-      runAfter: [publish-to-bucket, detect-previous-tag]
+      runAfter: [publish-to-bucket]
       when:
         - input: "$(workspaces.github-secret.bound)"
           operator: in
@@ -490,6 +433,10 @@ spec:
           value: $(params.package)
         - name: versionTag
           value: $(params.versionTag)
+        - name: previousReleaseTag
+          value: $(params.previousReleaseTag)
+        - name: releaseName
+          value: $(params.releaseName)
       workspaces:
         - name: workarea
           workspace: workarea
@@ -497,9 +444,15 @@ spec:
         params:
           - name: package
           - name: versionTag
+          - name: previousReleaseTag
+          - name: releaseName
         results:
           - name: package
             description: The package in org/repo format (without github.com/ prefix)
+          - name: previous-tag
+            description: The previous release tag
+          - name: release-name
+            description: The release name to use
         workspaces:
           - name: workarea
         steps:
@@ -508,7 +461,12 @@ spec:
             script: |
               #!/bin/sh
               set -e
+              apk add --no-cache git > /dev/null 2>&1
+
               WORKAREA="$(workspaces.workarea.path)"
+              VERSION="$(params.versionTag)"
+              PREVIOUS="$(params.previousReleaseTag)"
+              NAME="$(params.releaseName)"
 
               # The create-draft-release-oci task expects:
               #   <workspace>/repo    -> git checkout
@@ -517,7 +475,7 @@ spec:
               #   <workspace>/git     -> git checkout
               #   <workspace>/bucket/<versionTag> -> release artifacts
               ln -sfn "${WORKAREA}/git" "${WORKAREA}/repo"
-              ln -sfn "${WORKAREA}/bucket/$(params.versionTag)" "${WORKAREA}/release"
+              ln -sfn "${WORKAREA}/bucket/${VERSION}" "${WORKAREA}/release"
               echo "Created workspace symlinks:"
               ls -la "${WORKAREA}/repo" "${WORKAREA}/release"
 
@@ -527,10 +485,37 @@ spec:
               printf '%s' "${PACKAGE}" > "$(results.package.path)"
               echo "Package: ${PACKAGE}"
 
+              # Detect previous tag if not provided
+              if [ -z "${PREVIOUS}" ]; then
+                git config --global --add safe.directory "${WORKAREA}/git"
+                git -C "${WORKAREA}/git" fetch --tags
+                PREVIOUS=$(git -C "${WORKAREA}/git" tag --sort=-v:refname | grep '^v[0-9]' | while read tag; do
+                  if [ "$(printf '%s\n%s' "$tag" "$VERSION" | sort -V | head -1)" = "$tag" ] && [ "$tag" != "$VERSION" ]; then
+                    echo "$tag"
+                    break
+                  fi
+                done)
+                if [ -z "${PREVIOUS}" ]; then
+                  echo "WARNING: Could not auto-detect previous tag"
+                  PREVIOUS="unknown"
+                fi
+                echo "Auto-detected previous tag: ${PREVIOUS}"
+              fi
+              printf '%s' "${PREVIOUS}" > "$(results.previous-tag.path)"
+
+              # Use provided name or fall back to version
+              if [ -z "${NAME}" ]; then
+                NAME="Release ${VERSION}"
+              fi
+              printf '%s' "${NAME}" > "$(results.release-name.path)"
+
     - name: create-draft-release
       runAfter: [prepare-draft-release, wait-for-chains]
       when:
         - input: "$(workspaces.github-secret.bound)"
+          operator: in
+          values: ["true"]
+        - input: "$(tasks.wait-for-chains.results.signed)"
           operator: in
           values: ["true"]
       taskRef:
@@ -538,6 +523,9 @@ spec:
         params:
           - name: url
             value: https://github.com/tektoncd/plumbing
+          # Pinned to current HEAD. Update after tektoncd/plumbing#3169 merges
+          # (modernizes hub→gh, adds flexible path params, removing the need
+          # for the prepare-draft-release symlink task).
           - name: revision
             value: c6ccd417b39dd9d0c3055795f00cbce051f6bc9e
           - name: pathInRepo
@@ -548,11 +536,11 @@ spec:
         - name: git-revision
           value: $(params.gitRevision)
         - name: release-name
-          value: $(tasks.detect-previous-tag.results.release-name)
+          value: $(tasks.prepare-draft-release.results.release-name)
         - name: release-tag
           value: $(params.versionTag)
         - name: previous-release-tag
-          value: $(tasks.detect-previous-tag.results.previous-tag)
+          value: $(tasks.prepare-draft-release.results.previous-tag)
         - name: rekor-uuid
           value: $(tasks.wait-for-chains.results.rekor-uuid)
       workspaces:


### PR DESCRIPTION
# Changes

Add automatic GitHub draft release creation to the release pipeline. When the optional `github-secret` workspace is bound, the pipeline will wait for Tekton Chains to sign the `publish-images` TaskRun, extract the Rekor UUID, and create a draft GitHub release with categorized release notes — eliminating the manual `release-draft-oci` step from the cheat sheet.

Four new tasks (all skipped when `github-secret` is not bound):

- **`detect-previous-tag`** — auto-detects the previous release tag from git tags if `previousReleaseTag` is empty. Runs in parallel after `git-clone`.
- **`wait-for-chains`** — polls the `publish-images` TaskRun for `chains.tekton.dev/signed` annotation and extracts the Rekor UUID from the transparency log URL. 30-minute timeout.
- **`prepare-draft-release`** — maps the pipeline's workspace layout (`git/`, `bucket/<tag>/`) to the plumbing task's expected layout (`repo/`, `release/`) via symlinks, and strips the `github.com/` prefix from the package param.
- **`create-draft-release`** — references the existing `create-draft-release-oci` task from [tektoncd/plumbing](https://github.com/tektoncd/plumbing/blob/main/tekton/resources/release/base/github_release_oci.yaml) via the git resolver.

New pipeline parameters: `previousReleaseTag` and `releaseName` (both optional with defaults).

New optional workspace: `github-secret` (backward compatible — nightly builds are unaffected).

The cheat sheet is updated to use `--serviceaccount release-right-meow` (needed for `wait-for-chains` RBAC) and documents the automated draft flow with manual fallback.

Related: https://github.com/tektoncd/plumbing/issues/58

/kind feature

# Submitter Checklist

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```