### PR TITLE
feat: Add support for PipelineRef in Pipeline in pipeline

### DIFF
--- a/config/300-crds/300-pipeline.yaml
+++ b/config/300-crds/300-pipeline.yaml
@@ -835,8 +835,10 @@ spec:
                         x-kubernetes-list-type: atomic
                       pipelineRef:
                         description: |-
-                          PipelineRef is a reference to a pipeline definition
-                          Note: PipelineRef is in preview mode and not yet supported
+                          PipelineRef is a reference to a pipeline definition.
+                          This is an alpha field. You must set the "enable-api-fields" feature flag
+                          to "alpha" for this field to be supported. When enabled, the referenced
+                          Pipeline is executed as a child PipelineRun owned by the parent PipelineRun.
                         type: object
                         properties:
                           apiVersion:
@@ -871,8 +873,10 @@ spec:
                             type: string
                       pipelineSpec:
                         description: |-
-                          PipelineSpec is a specification of a pipeline
-                          Note: PipelineSpec is in preview mode and not yet supported
+                          PipelineSpec is a specification of a pipeline.
+                          This is an alpha field. You must set the "enable-api-fields" feature flag
+                          to "alpha" for this field to be supported. When enabled, the embedded
+                          Pipeline is executed as a child PipelineRun owned by the parent PipelineRun.
                           Specifying PipelineSpec can be disabled by setting
                           `disable-inline-spec` feature flag.
                           See Pipeline.spec (API version: tekton.dev/v1)
@@ -1174,8 +1178,10 @@ spec:
                         x-kubernetes-list-type: atomic
                       pipelineRef:
                         description: |-
-                          PipelineRef is a reference to a pipeline definition
-                          Note: PipelineRef is in preview mode and not yet supported
+                          PipelineRef is a reference to a pipeline definition.
+                          This is an alpha field. You must set the "enable-api-fields" feature flag
+                          to "alpha" for this field to be supported. When enabled, the referenced
+                          Pipeline is executed as a child PipelineRun owned by the parent PipelineRun.
                         type: object
                         properties:
                           apiVersion:
@@ -1210,8 +1216,10 @@ spec:
                             type: string
                       pipelineSpec:
                         description: |-
-                          PipelineSpec is a specification of a pipeline
-                          Note: PipelineSpec is in preview mode and not yet supported
+                          PipelineSpec is a specification of a pipeline.
+                          This is an alpha field. You must set the "enable-api-fields" feature flag
+                          to "alpha" for this field to be supported. When enabled, the embedded
+                          Pipeline is executed as a child PipelineRun owned by the parent PipelineRun.
                           Specifying PipelineSpec can be disabled by setting
                           `disable-inline-spec` feature flag.
                           See Pipeline.spec (API version: tekton.dev/v1)

--- a/docs/pipeline-api.md
+++ b/docs/pipeline-api.md
@@ -3114,8 +3114,10 @@ PipelineRef
 </td>
 <td>
 <em>(Optional)</em>
-<p>PipelineRef is a reference to a pipeline definition
-Note: PipelineRef is in preview mode and not yet supported</p>
+<p>PipelineRef is a reference to a pipeline definition.
+This is an alpha field. You must set the &ldquo;enable-api-fields&rdquo; feature flag
+to &ldquo;alpha&rdquo; for this field to be supported. When enabled, the referenced
+Pipeline is executed as a child PipelineRun owned by the parent PipelineRun.</p>
 </td>
 </tr>
 <tr>
@@ -3129,8 +3131,10 @@ PipelineSpec
 </td>
 <td>
 <em>(Optional)</em>
-<p>PipelineSpec is a specification of a pipeline
-Note: PipelineSpec is in preview mode and not yet supported
+<p>PipelineSpec is a specification of a pipeline.
+This is an alpha field. You must set the &ldquo;enable-api-fields&rdquo; feature flag
+to &ldquo;alpha&rdquo; for this field to be supported. When enabled, the embedded
+Pipeline is executed as a child PipelineRun owned by the parent PipelineRun.
 Specifying PipelineSpec can be disabled by setting
 <code>disable-inline-spec</code> feature flag.
 See Pipeline.spec (API version: tekton.dev/v1)</p>
@@ -12481,8 +12485,10 @@ PipelineRef
 </td>
 <td>
 <em>(Optional)</em>
-<p>PipelineRef is a reference to a pipeline definition
-Note: PipelineRef is in preview mode and not yet supported</p>
+<p>PipelineRef is a reference to a pipeline definition.
+This is an alpha field. You must set the &ldquo;enable-api-fields&rdquo; feature flag
+to &ldquo;alpha&rdquo; for this field to be supported. When enabled, the referenced
+Pipeline is executed as a child PipelineRun owned by the parent PipelineRun.</p>
 </td>
 </tr>
 <tr>
@@ -12496,8 +12502,10 @@ PipelineSpec
 </td>
 <td>
 <em>(Optional)</em>
-<p>PipelineSpec is a specification of a pipeline
-Note: PipelineSpec is in preview mode and not yet supported
+<p>PipelineSpec is a specification of a pipeline.
+This is an alpha field. You must set the &ldquo;enable-api-fields&rdquo; feature flag
+to &ldquo;alpha&rdquo; for this field to be supported. When enabled, the embedded
+Pipeline is executed as a child PipelineRun owned by the parent PipelineRun.
 Specifying PipelineSpec can be disabled by setting
 <code>disable-inline-spec</code> feature flag.
 See Pipeline.spec (API version: tekton.dev/v1beta1)</p>

--- a/docs/pipelines-in-pipelines.md
+++ b/docs/pipelines-in-pipelines.md
@@ -11,14 +11,18 @@ weight: 406
 - [Specifying `pipelineRef` in `Tasks`](#specifying-pipelineref-in-pipelinetasks)
 - [Specifying `pipelineSpec` in `Tasks`](#specifying-pipelinespec-in-pipelinetasks)
 - [Specifying `Parameters`](#specifying-parameters)
+- [Specifying `Workspaces`](#specifying-workspaces)
+- [Known Limitations](#known-limitations)
 
 ## Overview
 
 A mechanism to define and execute Pipelines in Pipelines, alongside Tasks and Custom Tasks, for a more in-depth background and inspiration, refer to the proposal [TEP-0056](https://github.com/tektoncd/community/blob/main/teps/0056-pipelines-in-pipelines.md "Proposal").
 
-> :seedling: **Pipelines in Pipelines not yet [alpha](additional-configs.md#alpha-features) feature.**
-> If the `enable-api-fields` feature flag is set to `"alpha"` users may specify `pipelineRef` or `pipelineSpec` in a `pipelineTask`, however this feature is not yet supported/implemented.
-> **Specifying a `pipelineRef` or `pipelineSpec` in a `pipelineTask` will not cause the Pipeline to run at this time.**
+> :seedling: **Pipelines in Pipelines is an [alpha](additional-configs.md#alpha-features) feature.**
+> The `enable-api-fields` feature flag must be set to `"alpha"` to specify `pipelineRef` or `pipelineSpec` in a `pipelineTask`.
+> When enabled, a `PipelineTask` that references a child `Pipeline` will produce a child `PipelineRun` owned by the parent `PipelineRun`.
+> Recursive `pipelineRef` references are detected by walking the parent `PipelineRun` owner chain and fail fast with a clear error.
+> See [Known Limitations](#known-limitations) for the current caveats.
 
 ## Specifying `pipelineRef` in `pipelineTasks`
 
@@ -113,3 +117,74 @@ spec:
       taskRef:
         name: notification
 ```
+
+## Specifying `Workspaces`
+
+A `PipelineTask` that references a child `Pipeline` can map parent workspaces to the child's declared workspaces the same way it does for `Tasks`. The bindings declared on the `PipelineTask` are propagated to the child `PipelineRun`, which then forwards them to the child `Pipeline`'s workspaces.
+
+```yaml
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: security-scans
+spec:
+  workspaces:
+    - name: source
+  tasks:
+    - name: scorecards
+      workspaces:
+        - name: source
+      taskRef:
+        name: scorecards
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: clone-scan-notify
+spec:
+  workspaces:
+    - name: shared-ws
+  tasks:
+    - name: git-clone
+      workspaces:
+        - name: output
+          workspace: shared-ws
+      taskRef:
+        name: git-clone
+    - name: security-scans
+      runAfter:
+        - git-clone
+      workspaces:
+        - name: source
+          workspace: shared-ws
+      pipelineRef:
+        name: security-scans
+```
+
+## Known Limitations
+
+The initial alpha implementation has the following limitations. These are expected to be addressed in follow-up work.
+
+### Other current limitations
+
+- `When` expressions in the parent `Pipeline` cannot reference results of a `PipelineTask` that uses `pipelineRef` or `pipelineSpec` (corollary of the result-propagation gap below).
+- Per-`PipelineTask` `timeout` and `retries` are not applied to the child `PipelineRun`. The child runs with its own default timeouts and is created at most once per parent reconcile.
+- The parent `PipelineRun.Spec.Timeouts` is not propagated to the child `PipelineRun`; the child uses its own defaults.
+- `pipelineRef` cycle detection is best-effort and runs at child reconcile time: it walks the `ownerReferences` chain and matches the `tekton.dev/pipeline` label, so cycles are caught when the offending child is reconciled rather than at parent submission.
+- Validation of non-optional child `Workspaces` happens at the child `PipelineRun`, not at the parent. If the parent omits a binding for a non-optional child workspace, the child fails rather than the parent (tracked in [#9924](https://github.com/tektoncd/pipeline/issues/9924)).
+- [Execution `Status`](https://github.com/tektoncd/community/blob/main/teps/0056-pipelines-in-pipelines.md#execution-status) of a `PipelineTask` that uses `pipelineRef` or `pipelineSpec` is not surfaced, so a `finally` task cannot branch on whether a child `Pipeline` succeeded, failed, or was skipped via `$(tasks.<pipelineTaskName>.status)`.
+- [`Matrix`](https://github.com/tektoncd/community/blob/main/teps/0056-pipelines-in-pipelines.md#matrix) fan-out of a `PipelineTask` that uses `pipelineRef` or `pipelineSpec` is not supported: such a task cannot be combined with a `matrix` to produce multiple child `PipelineRuns`.
+
+
+### Results from child Pipelines are not propagated
+
+`Results` produced by a child `Pipeline` are **not** surfaced on the parent `PipelineRun`:
+
+- They are not aggregated into the parent `PipelineRun`'s `status.results`.
+- They cannot be consumed by other `PipelineTasks` via `$(tasks.<task-name>.results.<result-name>)` or by `when` expressions in the parent.
+
+To enforce this at authoring time, the pipeline validating webhook rejects any result reference whose target is a `PipelineTask` using `pipelineRef` or `pipelineSpec`, with an error like:
+
+> `result reference to pipelineTask "child" is not supported: referenced task uses pipelineRef or pipelineSpec and result propagation from child Pipelines is not yet implemented`
+
+Until propagation is implemented, pass values into a child `Pipeline` through `params` on the `PipelineTask`, and keep the parent `Pipeline`'s `results` sourced from regular `TaskRun`s.

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -504,7 +504,7 @@ tasks:
 
 > :seedling: **Specifying `pipelines` in `PipelineTasks` is an [alpha](additional-configs.md#alpha-features) feature.**
 > The `enable-api-fields` feature flag must be set to `"alpha"` to specify `PipelineRef` or `PipelineSpec` in a `PipelineTask`.
-> This feature is in **Preview Only** mode and not yet supported/implemented.
+> When enabled, the parent `PipelineRun` reconciles a child `PipelineRun` for each `PipelineTask` that uses `pipelineRef` or `pipelineSpec`. See [Pipelines in Pipelines](./pipelines-in-pipelines.md) for details and [known limitations](./pipelines-in-pipelines.md#known-limitations).
 
 Apart from `taskRef` and `taskSpec`, `pipelineRef` and `pipelineSpec` allows you to specify a `pipeline`  in `pipelineTask`.
 This allows you to generate a child `pipelineRun` which is inherited by the parent `pipelineRun`.
@@ -1058,7 +1058,7 @@ tasks:
 Compose a set of `Tasks` as a unit of execution using `Pipelines` in `Pipelines`, which allows for guarding a `Task` and
 its dependent `Tasks` (as a sub-`Pipeline`) using `when` expressions.
 
-**Note:** `Pipelines` in `Pipelines` is an [experimental feature](https://github.com/tektoncd/experimental/tree/main/pipelines-in-pipelines)
+**Note:** `Pipelines` in `Pipelines` is an [alpha feature](./pipelines-in-pipelines.md). The `enable-api-fields` feature flag must be set to `"alpha"`.
 
 Taking the use case below, a user who wants to guard `manual-approval` and its dependent `Tasks`:
 

--- a/examples/v1/pipelineruns/alpha/pipelines-in-pipelines-ref-complex.yaml
+++ b/examples/v1/pipelineruns/alpha/pipelines-in-pipelines-ref-complex.yaml
@@ -1,0 +1,121 @@
+# Pipelines-in-Pipelines example: two levels of pipelineRef nesting that
+# propagate multiple params and multiple workspaces through every level
+# (parent -> child -> grandchild). Requires the alpha feature flag
+# (enable-api-fields: alpha) to be set on the cluster.
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: grandchild-pipeline
+spec:
+  description: Innermost Pipeline; receives params and two workspaces from its callers.
+  params:
+    - name: greeting
+      type: string
+    - name: target
+      type: string
+  workspaces:
+    - name: source
+    - name: shared-config
+  tasks:
+    - name: show
+      params:
+        - name: greeting
+          value: $(params.greeting)
+        - name: target
+          value: $(params.target)
+      workspaces:
+        - name: source
+          workspace: source
+        - name: shared-config
+          workspace: shared-config
+      taskSpec:
+        params:
+          - name: greeting
+          - name: target
+        workspaces:
+          - name: source
+          - name: shared-config
+        steps:
+          - name: greet
+            image: mirror.gcr.io/busybox
+            script: |
+              echo "$(params.greeting), $(params.target)!"
+              echo "source workspace at $(workspaces.source.path):"
+              ls -la $(workspaces.source.path)
+              cat $(workspaces.shared-config.path)/note 2>/dev/null || echo "(no note in shared-config)"
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: child-pipeline-complex
+spec:
+  description: Intermediate Pipeline; forwards params and workspaces to grandchild via pipelineRef.
+  params:
+    - name: greeting
+      type: string
+    - name: target
+      type: string
+  workspaces:
+    - name: source
+    - name: shared-config
+  tasks:
+    - name: grandchild
+      pipelineRef:
+        name: grandchild-pipeline
+      params:
+        - name: greeting
+          value: $(params.greeting)
+        - name: target
+          value: $(params.target)
+      workspaces:
+        - name: source
+          workspace: source
+        - name: shared-config
+          workspace: shared-config
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: pipelines-in-pipelines-ref-complex
+spec:
+  description: Two-level nested pipelineRef with multiple params and multiple workspaces.
+  params:
+    - name: greeting
+      type: string
+    - name: target
+      type: string
+  workspaces:
+    - name: source
+    - name: shared-config
+  tasks:
+    - name: child
+      pipelineRef:
+        name: child-pipeline-complex
+      params:
+        - name: greeting
+          value: $(params.greeting)
+        - name: target
+          value: $(params.target)
+      workspaces:
+        - name: source
+          workspace: source
+        - name: shared-config
+          workspace: shared-config
+---
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  generateName: pipelines-in-pipelines-ref-complex-run-
+spec:
+  pipelineRef:
+    name: pipelines-in-pipelines-ref-complex
+  params:
+    - name: greeting
+      value: hello
+    - name: target
+      value: pipelines-in-pipelines
+  workspaces:
+    - name: source
+      emptyDir: {}
+    - name: shared-config
+      emptyDir: {}

--- a/examples/v1/pipelineruns/alpha/pipelines-in-pipelines-ref.yaml
+++ b/examples/v1/pipelineruns/alpha/pipelines-in-pipelines-ref.yaml
@@ -1,0 +1,36 @@
+# Pipelines-in-Pipelines example: a parent Pipeline that references a
+# standalone child Pipeline via `pipelineRef`. Requires the alpha feature
+# flag (enable-api-fields: alpha) to be set on the cluster. One level of
+# nesting (parent -> child).
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: child-pipeline
+spec:
+  description: A child Pipeline referenced by name from another Pipeline.
+  tasks:
+    - name: hello
+      taskSpec:
+        steps:
+          - name: echo
+            image: mirror.gcr.io/busybox
+            script: 'echo "hello from the referenced child Pipeline"'
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: pipelines-in-pipelines-ref
+spec:
+  description: Run the referenced child Pipeline via pipelineRef.
+  tasks:
+    - name: child
+      pipelineRef:
+        name: child-pipeline
+---
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  generateName: pipelines-in-pipelines-ref-run-
+spec:
+  pipelineRef:
+    name: pipelines-in-pipelines-ref

--- a/examples/v1/pipelineruns/alpha/pipelines-in-pipelines.yaml
+++ b/examples/v1/pipelineruns/alpha/pipelines-in-pipelines.yaml
@@ -1,0 +1,27 @@
+# Pipelines-in-Pipelines example: a parent Pipeline that runs a single child
+# Pipeline defined inline with `pipelineSpec`. Requires the alpha feature
+# flag (enable-api-fields: alpha) to be set on the cluster.
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: pipelines-in-pipelines-spec
+spec:
+  description: Run a single inline child Pipeline via pipelineSpec.
+  tasks:
+    - name: child
+      pipelineSpec:
+        tasks:
+          - name: hello
+            taskSpec:
+              steps:
+                - name: echo
+                  image: mirror.gcr.io/busybox
+                  script: 'echo "hello from the inline child Pipeline"'
+---
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  generateName: pipelines-in-pipelines-spec-run-
+spec:
+  pipelineRef:
+    name: pipelines-in-pipelines-spec

--- a/pkg/apis/pipeline/v1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1/openapi_generated.go
@@ -2027,13 +2027,13 @@ func schema_pkg_apis_pipeline_v1_PipelineTask(ref common.ReferenceCallback) comm
 					},
 					"pipelineRef": {
 						SchemaProps: spec.SchemaProps{
-							Description: "PipelineRef is a reference to a pipeline definition Note: PipelineRef is in preview mode and not yet supported",
+							Description: "PipelineRef is a reference to a pipeline definition. This is an alpha field. You must set the \"enable-api-fields\" feature flag to \"alpha\" for this field to be supported. When enabled, the referenced Pipeline is executed as a child PipelineRun owned by the parent PipelineRun.",
 							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineRef"),
 						},
 					},
 					"pipelineSpec": {
 						SchemaProps: spec.SchemaProps{
-							Description: "PipelineSpec is a specification of a pipeline Note: PipelineSpec is in preview mode and not yet supported Specifying PipelineSpec can be disabled by setting `disable-inline-spec` feature flag. See Pipeline.spec (API version: tekton.dev/v1)",
+							Description: "PipelineSpec is a specification of a pipeline. This is an alpha field. You must set the \"enable-api-fields\" feature flag to \"alpha\" for this field to be supported. When enabled, the embedded Pipeline is executed as a child PipelineRun owned by the parent PipelineRun. Specifying PipelineSpec can be disabled by setting `disable-inline-spec` feature flag. See Pipeline.spec (API version: tekton.dev/v1)",
 							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.PipelineSpec"),
 						},
 					},

--- a/pkg/apis/pipeline/v1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1/pipeline_types.go
@@ -242,13 +242,17 @@ type PipelineTask struct {
 	// +optional
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
 
-	// PipelineRef is a reference to a pipeline definition
-	// Note: PipelineRef is in preview mode and not yet supported
+	// PipelineRef is a reference to a pipeline definition.
+	// This is an alpha field. You must set the "enable-api-fields" feature flag
+	// to "alpha" for this field to be supported. When enabled, the referenced
+	// Pipeline is executed as a child PipelineRun owned by the parent PipelineRun.
 	// +optional
 	PipelineRef *PipelineRef `json:"pipelineRef,omitempty"`
 
-	// PipelineSpec is a specification of a pipeline
-	// Note: PipelineSpec is in preview mode and not yet supported
+	// PipelineSpec is a specification of a pipeline.
+	// This is an alpha field. You must set the "enable-api-fields" feature flag
+	// to "alpha" for this field to be supported. When enabled, the embedded
+	// Pipeline is executed as a child PipelineRun owned by the parent PipelineRun.
 	// Specifying PipelineSpec can be disabled by setting
 	// `disable-inline-spec` feature flag.
 	// See Pipeline.spec (API version: tekton.dev/v1)

--- a/pkg/apis/pipeline/v1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1/pipeline_validation.go
@@ -87,6 +87,10 @@ func (ps *PipelineSpec) Validate(ctx context.Context) (errs *apis.FieldError) {
 	errs = errs.Also(validatePipelineWorkspacesDeclarations(ps.Workspaces))
 	// Validate the pipeline's results
 	errs = errs.Also(validatePipelineResults(ps.Results, ps.Tasks, ps.Finally))
+	// Reject result references to PipelineTasks that use pipelineRef or pipelineSpec.
+	// Result propagation from a child Pipeline is not implemented in the initial
+	// Pipelines-in-Pipelines alpha; see docs/pipelines-in-pipelines.md#limitations.
+	errs = errs.Also(validatePipelineRefResultReferencesDisallowed(ps.Tasks, ps.Finally))
 	errs = errs.Also(validateTasksAndFinallySection(ps))
 	errs = errs.Also(validateFinalTasks(ps.Tasks, ps.Finally))
 	errs = errs.Also(validateWhenExpressions(ctx, ps.Tasks, ps.Finally))
@@ -741,6 +745,43 @@ func taskContainsResult(resultExpression string, pipelineTaskNames sets.String, 
 		}
 	}
 	return true
+}
+
+// validatePipelineRefResultReferencesDisallowed rejects any result reference
+// (`$(tasks.<name>.results.*)` or `$(finally.<name>.results.*)`) whose target
+// PipelineTask is a Pipeline-in-Pipeline (uses pipelineRef or pipelineSpec).
+//
+// Result propagation from a child Pipeline is not yet implemented: the
+// reconciler's convertToResultRefs path reads from ResolvedPipelineTask.TaskRuns
+// which is empty for a child-pipeline task, so without this guard such a
+// reference would panic the controller at runtime. Once propagation lands,
+// this guard can be removed.
+func validatePipelineRefResultReferencesDisallowed(tasks []PipelineTask, finally []PipelineTask) (errs *apis.FieldError) {
+	pipelineRefTasks := sets.NewString()
+	for _, t := range tasks {
+		if t.PipelineRef != nil || t.PipelineSpec != nil {
+			pipelineRefTasks.Insert(t.Name)
+		}
+	}
+	if pipelineRefTasks.Len() == 0 {
+		return nil
+	}
+
+	check := func(pts []PipelineTask, field string) {
+		for idx, pt := range pts {
+			for _, ref := range PipelineTaskResultRefs(&pt) {
+				if pipelineRefTasks.Has(ref.PipelineTask) {
+					errs = errs.Also(apis.ErrInvalidValue(
+						fmt.Sprintf("result reference to pipelineTask %q is not supported: referenced task uses pipelineRef or pipelineSpec and result propagation from child Pipelines is not yet implemented",
+							ref.PipelineTask),
+						"").ViaFieldIndex(field, idx))
+				}
+			}
+		}
+	}
+	check(tasks, "tasks")
+	check(finally, "finally")
+	return errs
 }
 
 func validateTasksAndFinallySection(ps *PipelineSpec) *apis.FieldError {

--- a/pkg/apis/pipeline/v1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1/pipeline_validation_test.go
@@ -4959,3 +4959,98 @@ func TestGetIndexingReferencesToArrayParams(t *testing.T) {
 		})
 	}
 }
+
+func TestValidatePipelineRefResultReferencesDisallowed(t *testing.T) {
+	// happy path: a PinP task that is not consumed by any result reference is allowed.
+	t.Run("pipelineRef task not referenced", func(t *testing.T) {
+		tasks := []PipelineTask{
+			{
+				Name:        "child",
+				PipelineRef: &PipelineRef{Name: "child-pipeline"},
+			},
+			{
+				Name:    "consumer",
+				TaskRef: &TaskRef{Name: "echo"},
+				Params: Params{{
+					Name:  "msg",
+					Value: *NewStructuredValues("hello"),
+				}},
+			},
+		}
+		if err := validatePipelineRefResultReferencesDisallowed(tasks, nil); err != nil {
+			t.Errorf("unexpected error for non-referencing pipeline: %v", err)
+		}
+	})
+
+	tests := []struct {
+		desc    string
+		tasks   []PipelineTask
+		finally []PipelineTask
+		wantMsg string
+	}{{
+		desc: "task params reference a pipelineRef task result",
+		tasks: []PipelineTask{
+			{
+				Name:        "child",
+				PipelineRef: &PipelineRef{Name: "child-pipeline"},
+			},
+			{
+				Name:    "consumer",
+				TaskRef: &TaskRef{Name: "echo"},
+				Params: Params{{
+					Name:  "msg",
+					Value: *NewStructuredValues("$(tasks.child.results.out)"),
+				}},
+			},
+		},
+		wantMsg: `invalid value: result reference to pipelineTask "child" is not supported: referenced task uses pipelineRef or pipelineSpec and result propagation from child Pipelines is not yet implemented: tasks[1]`,
+	}, {
+		desc: "task when expression references a pipelineSpec task result",
+		tasks: []PipelineTask{
+			{
+				Name:         "child",
+				PipelineSpec: &PipelineSpec{},
+			},
+			{
+				Name:    "consumer",
+				TaskRef: &TaskRef{Name: "echo"},
+				When: WhenExpressions{{
+					Input:    "$(tasks.child.results.out)",
+					Operator: "in",
+					Values:   []string{"go"},
+				}},
+			},
+		},
+		wantMsg: `invalid value: result reference to pipelineTask "child" is not supported: referenced task uses pipelineRef or pipelineSpec and result propagation from child Pipelines is not yet implemented: tasks[1]`,
+	}, {
+		desc: "finally task references a pipelineRef task result",
+		tasks: []PipelineTask{
+			{
+				Name:        "child",
+				PipelineRef: &PipelineRef{Name: "child-pipeline"},
+			},
+		},
+		finally: []PipelineTask{
+			{
+				Name:    "notify",
+				TaskRef: &TaskRef{Name: "notify"},
+				Params: Params{{
+					Name:  "msg",
+					Value: *NewStructuredValues("$(tasks.child.results.out)"),
+				}},
+			},
+		},
+		wantMsg: `invalid value: result reference to pipelineTask "child" is not supported: referenced task uses pipelineRef or pipelineSpec and result propagation from child Pipelines is not yet implemented: finally[0]`,
+	}}
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			err := validatePipelineRefResultReferencesDisallowed(tc.tasks, tc.finally)
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if d := cmp.Diff(tc.wantMsg, err.Error(), cmpopts.IgnoreUnexported(apis.FieldError{})); d != "" {
+				t.Errorf("unexpected error diff %s", diff.PrintWantGot(d))
+			}
+		})
+	}
+}

--- a/pkg/apis/pipeline/v1/swagger.json
+++ b/pkg/apis/pipeline/v1/swagger.json
@@ -983,11 +983,11 @@
           }
         },
         "pipelineRef": {
-          "description": "PipelineRef is a reference to a pipeline definition Note: PipelineRef is in preview mode and not yet supported",
+          "description": "PipelineRef is a reference to a pipeline definition. This is an alpha field. You must set the \"enable-api-fields\" feature flag to \"alpha\" for this field to be supported. When enabled, the referenced Pipeline is executed as a child PipelineRun owned by the parent PipelineRun.",
           "$ref": "#/definitions/v1.PipelineRef"
         },
         "pipelineSpec": {
-          "description": "PipelineSpec is a specification of a pipeline Note: PipelineSpec is in preview mode and not yet supported Specifying PipelineSpec can be disabled by setting `disable-inline-spec` feature flag. See Pipeline.spec (API version: tekton.dev/v1)",
+          "description": "PipelineSpec is a specification of a pipeline. This is an alpha field. You must set the \"enable-api-fields\" feature flag to \"alpha\" for this field to be supported. When enabled, the embedded Pipeline is executed as a child PipelineRun owned by the parent PipelineRun. Specifying PipelineSpec can be disabled by setting `disable-inline-spec` feature flag. See Pipeline.spec (API version: tekton.dev/v1)",
           "$ref": "#/definitions/v1.PipelineSpec"
         },
         "retries": {

--- a/pkg/apis/pipeline/v1beta1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1beta1/openapi_generated.go
@@ -2677,13 +2677,13 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineTask(ref common.ReferenceCallback)
 					},
 					"pipelineRef": {
 						SchemaProps: spec.SchemaProps{
-							Description: "PipelineRef is a reference to a pipeline definition Note: PipelineRef is in preview mode and not yet supported",
+							Description: "PipelineRef is a reference to a pipeline definition. This is an alpha field. You must set the \"enable-api-fields\" feature flag to \"alpha\" for this field to be supported. When enabled, the referenced Pipeline is executed as a child PipelineRun owned by the parent PipelineRun.",
 							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineRef"),
 						},
 					},
 					"pipelineSpec": {
 						SchemaProps: spec.SchemaProps{
-							Description: "PipelineSpec is a specification of a pipeline Note: PipelineSpec is in preview mode and not yet supported Specifying PipelineSpec can be disabled by setting `disable-inline-spec` feature flag. See Pipeline.spec (API version: tekton.dev/v1beta1)",
+							Description: "PipelineSpec is a specification of a pipeline. This is an alpha field. You must set the \"enable-api-fields\" feature flag to \"alpha\" for this field to be supported. When enabled, the embedded Pipeline is executed as a child PipelineRun owned by the parent PipelineRun. Specifying PipelineSpec can be disabled by setting `disable-inline-spec` feature flag. See Pipeline.spec (API version: tekton.dev/v1beta1)",
 							Ref:         ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineSpec"),
 						},
 					},

--- a/pkg/apis/pipeline/v1beta1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types.go
@@ -255,13 +255,17 @@ type PipelineTask struct {
 	// +optional
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
 
-	// PipelineRef is a reference to a pipeline definition
-	// Note: PipelineRef is in preview mode and not yet supported
+	// PipelineRef is a reference to a pipeline definition.
+	// This is an alpha field. You must set the "enable-api-fields" feature flag
+	// to "alpha" for this field to be supported. When enabled, the referenced
+	// Pipeline is executed as a child PipelineRun owned by the parent PipelineRun.
 	// +optional
 	PipelineRef *PipelineRef `json:"pipelineRef,omitempty"`
 
-	// PipelineSpec is a specification of a pipeline
-	// Note: PipelineSpec is in preview mode and not yet supported
+	// PipelineSpec is a specification of a pipeline.
+	// This is an alpha field. You must set the "enable-api-fields" feature flag
+	// to "alpha" for this field to be supported. When enabled, the embedded
+	// Pipeline is executed as a child PipelineRun owned by the parent PipelineRun.
 	// Specifying PipelineSpec can be disabled by setting
 	// `disable-inline-spec` feature flag.
 	// See Pipeline.spec (API version: tekton.dev/v1beta1)

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation.go
@@ -89,6 +89,10 @@ func (ps *PipelineSpec) Validate(ctx context.Context) (errs *apis.FieldError) {
 	errs = errs.Also(validatePipelineWorkspacesDeclarations(ps.Workspaces))
 	// Validate the pipeline's results
 	errs = errs.Also(validatePipelineResults(ps.Results, ps.Tasks, ps.Finally))
+	// Reject result references to PipelineTasks that use pipelineRef or pipelineSpec.
+	// Result propagation from a child Pipeline is not implemented in the initial
+	// Pipelines-in-Pipelines alpha; see docs/pipelines-in-pipelines.md#limitations.
+	errs = errs.Also(validatePipelineRefResultReferencesDisallowed(ps.Tasks, ps.Finally))
 	errs = errs.Also(validateTasksAndFinallySection(ps))
 	errs = errs.Also(validateFinalTasks(ps.Tasks, ps.Finally))
 	errs = errs.Also(validateWhenExpressions(ctx, ps.Tasks, ps.Finally))
@@ -729,6 +733,43 @@ func validateTasksAndFinallySection(ps *PipelineSpec) *apis.FieldError {
 		return apis.ErrInvalidValue(fmt.Sprintf("spec.tasks is empty but spec.finally has %d tasks", len(ps.Finally)), "finally")
 	}
 	return nil
+}
+
+// validatePipelineRefResultReferencesDisallowed rejects any result reference
+// (`$(tasks.<name>.results.*)` or `$(finally.<name>.results.*)`) whose target
+// PipelineTask is a Pipeline-in-Pipeline (uses pipelineRef or pipelineSpec).
+//
+// Result propagation from a child Pipeline is not yet implemented: the
+// reconciler's convertToResultRefs path reads from ResolvedPipelineTask.TaskRuns
+// which is empty for a child-pipeline task, so without this guard such a
+// reference would panic the controller at runtime. Once propagation lands,
+// this guard can be removed.
+func validatePipelineRefResultReferencesDisallowed(tasks []PipelineTask, finally []PipelineTask) (errs *apis.FieldError) {
+	pipelineRefTasks := sets.NewString()
+	for _, t := range tasks {
+		if t.PipelineRef != nil || t.PipelineSpec != nil {
+			pipelineRefTasks.Insert(t.Name)
+		}
+	}
+	if pipelineRefTasks.Len() == 0 {
+		return nil
+	}
+
+	check := func(pts []PipelineTask, field string) {
+		for idx, pt := range pts {
+			for _, ref := range PipelineTaskResultRefs(&pt) {
+				if pipelineRefTasks.Has(ref.PipelineTask) {
+					errs = errs.Also(apis.ErrInvalidValue(
+						fmt.Sprintf("result reference to pipelineTask %q is not supported: referenced task uses pipelineRef or pipelineSpec and result propagation from child Pipelines is not yet implemented",
+							ref.PipelineTask),
+						"").ViaFieldIndex(field, idx))
+				}
+			}
+		}
+	}
+	check(tasks, "tasks")
+	check(finally, "finally")
+	return errs
 }
 
 func validateFinalTasks(tasks []PipelineTask, finalTasks []PipelineTask) (errs *apis.FieldError) {

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
@@ -4931,3 +4931,98 @@ func TestGetIndexingReferencesToArrayParams(t *testing.T) {
 		})
 	}
 }
+
+func TestValidatePipelineRefResultReferencesDisallowed(t *testing.T) {
+	// happy path: a PinP task that is not consumed by any result reference is allowed.
+	t.Run("pipelineRef task not referenced", func(t *testing.T) {
+		tasks := []PipelineTask{
+			{
+				Name:        "child",
+				PipelineRef: &PipelineRef{Name: "child-pipeline"},
+			},
+			{
+				Name:    "consumer",
+				TaskRef: &TaskRef{Name: "echo"},
+				Params: Params{{
+					Name:  "msg",
+					Value: *NewStructuredValues("hello"),
+				}},
+			},
+		}
+		if err := validatePipelineRefResultReferencesDisallowed(tasks, nil); err != nil {
+			t.Errorf("unexpected error for non-referencing pipeline: %v", err)
+		}
+	})
+
+	tests := []struct {
+		desc    string
+		tasks   []PipelineTask
+		finally []PipelineTask
+		wantMsg string
+	}{{
+		desc: "task params reference a pipelineRef task result",
+		tasks: []PipelineTask{
+			{
+				Name:        "child",
+				PipelineRef: &PipelineRef{Name: "child-pipeline"},
+			},
+			{
+				Name:    "consumer",
+				TaskRef: &TaskRef{Name: "echo"},
+				Params: Params{{
+					Name:  "msg",
+					Value: *NewStructuredValues("$(tasks.child.results.out)"),
+				}},
+			},
+		},
+		wantMsg: `invalid value: result reference to pipelineTask "child" is not supported: referenced task uses pipelineRef or pipelineSpec and result propagation from child Pipelines is not yet implemented: tasks[1]`,
+	}, {
+		desc: "task when expression references a pipelineSpec task result",
+		tasks: []PipelineTask{
+			{
+				Name:         "child",
+				PipelineSpec: &PipelineSpec{},
+			},
+			{
+				Name:    "consumer",
+				TaskRef: &TaskRef{Name: "echo"},
+				WhenExpressions: WhenExpressions{{
+					Input:    "$(tasks.child.results.out)",
+					Operator: "in",
+					Values:   []string{"go"},
+				}},
+			},
+		},
+		wantMsg: `invalid value: result reference to pipelineTask "child" is not supported: referenced task uses pipelineRef or pipelineSpec and result propagation from child Pipelines is not yet implemented: tasks[1]`,
+	}, {
+		desc: "finally task references a pipelineRef task result",
+		tasks: []PipelineTask{
+			{
+				Name:        "child",
+				PipelineRef: &PipelineRef{Name: "child-pipeline"},
+			},
+		},
+		finally: []PipelineTask{
+			{
+				Name:    "notify",
+				TaskRef: &TaskRef{Name: "notify"},
+				Params: Params{{
+					Name:  "msg",
+					Value: *NewStructuredValues("$(tasks.child.results.out)"),
+				}},
+			},
+		},
+		wantMsg: `invalid value: result reference to pipelineTask "child" is not supported: referenced task uses pipelineRef or pipelineSpec and result propagation from child Pipelines is not yet implemented: finally[0]`,
+	}}
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			err := validatePipelineRefResultReferencesDisallowed(tc.tasks, tc.finally)
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if d := cmp.Diff(tc.wantMsg, err.Error(), cmpopts.IgnoreUnexported(apis.FieldError{})); d != "" {
+				t.Errorf("unexpected error diff %s", diff.PrintWantGot(d))
+			}
+		})
+	}
+}

--- a/pkg/apis/pipeline/v1beta1/swagger.json
+++ b/pkg/apis/pipeline/v1beta1/swagger.json
@@ -1321,11 +1321,11 @@
           }
         },
         "pipelineRef": {
-          "description": "PipelineRef is a reference to a pipeline definition Note: PipelineRef is in preview mode and not yet supported",
+          "description": "PipelineRef is a reference to a pipeline definition. This is an alpha field. You must set the \"enable-api-fields\" feature flag to \"alpha\" for this field to be supported. When enabled, the referenced Pipeline is executed as a child PipelineRun owned by the parent PipelineRun.",
           "$ref": "#/definitions/v1beta1.PipelineRef"
         },
         "pipelineSpec": {
-          "description": "PipelineSpec is a specification of a pipeline Note: PipelineSpec is in preview mode and not yet supported Specifying PipelineSpec can be disabled by setting `disable-inline-spec` feature flag. See Pipeline.spec (API version: tekton.dev/v1beta1)",
+          "description": "PipelineSpec is a specification of a pipeline. This is an alpha field. You must set the \"enable-api-fields\" feature flag to \"alpha\" for this field to be supported. When enabled, the embedded Pipeline is executed as a child PipelineRun owned by the parent PipelineRun. Specifying PipelineSpec can be disabled by setting `disable-inline-spec` feature flag. See Pipeline.spec (API version: tekton.dev/v1beta1)",
           "$ref": "#/definitions/v1beta1.PipelineSpec"
         },
         "resources": {

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -424,6 +424,16 @@ func (c *Reconciler) resolvePipelineState(
 			vp,
 		)
 
+		getChildPipelineFunc := resources.GetChildPipelineFunc(
+			ctx,
+			c.KubeClientSet,
+			c.PipelineClientSet,
+			c.resolutionRequester,
+			pr,
+			pipelineTask.PipelineRef,
+			vp,
+		)
+
 		getTaskRunFunc := func(name string) (*v1.TaskRun, error) {
 			tr, err := c.taskRunLister.TaskRuns(pr.Namespace).Get(name)
 			if err != nil {
@@ -472,6 +482,7 @@ func (c *Reconciler) resolvePipelineState(
 		resolvedTask, err := resources.ResolvePipelineTask(ctx,
 			*pr,
 			getChildPipelineRunFunc,
+			getChildPipelineFunc,
 			getTaskFunc,
 			getTaskRunFunc,
 			getCustomRunFunc,
@@ -486,10 +497,15 @@ func (c *Reconciler) resolvePipelineState(
 				return nil, err
 			}
 			var nfErr *resources.TaskNotFoundError
+			var pnfErr *resources.PipelineNotFoundError
 			if errors.As(err, &nfErr) {
 				pr.Status.MarkFailed(v1.PipelineRunReasonCouldntGetTask.String(),
 					"Pipeline %s/%s can't be Run; it contains Tasks that don't exist: %s",
 					pipelineMeta.Namespace, pipelineMeta.Name, nfErr)
+			} else if errors.As(err, &pnfErr) {
+				pr.Status.MarkFailed(v1.PipelineRunReasonCouldntGetPipeline.String(),
+					"Pipeline %s/%s can't be Run; it contains child Pipelines that don't exist: %s",
+					pipelineMeta.Namespace, pipelineMeta.Name, pnfErr)
 			} else {
 				pr.Status.MarkFailed(v1.PipelineRunReasonFailedValidation.String(),
 					"PipelineRun %s/%s can't be Run; couldn't resolve all references: %s",
@@ -500,6 +516,14 @@ func (c *Reconciler) resolvePipelineState(
 
 		if resolvedTask.ResolvedTask != nil && resolvedTask.ResolvedTask.VerificationResult != nil {
 			cond, err := conditionFromVerificationResult(resolvedTask.ResolvedTask.VerificationResult, pr, pipelineTask.Name)
+			pr.Status.SetCondition(cond)
+			if err != nil {
+				pr.Status.MarkFailed(v1.PipelineRunReasonResourceVerificationFailed.String(), err.Error())
+				return nil, controller.NewPermanentError(err)
+			}
+		}
+		if resolvedTask.ResolvedPipeline.VerificationResult != nil {
+			cond, err := conditionFromVerificationResult(resolvedTask.ResolvedPipeline.VerificationResult, pr, pipelineTask.Name)
 			pr.Status.SetCondition(cond)
 			if err != nil {
 				pr.Status.MarkFailed(v1.PipelineRunReasonResourceVerificationFailed.String(), err.Error())
@@ -1112,8 +1136,7 @@ func (c *Reconciler) createChildPipelineRuns(
 
 	var childPipelineRuns []*v1.PipelineRun
 	for _, childPipelineRunName := range rpt.ChildPipelineRunNames {
-		var params v1.Params
-		childPipelineRun, err := c.createChildPipelineRun(ctx, childPipelineRunName, params, rpt, pr, facts)
+		childPipelineRun, err := c.createChildPipelineRun(ctx, childPipelineRunName, rpt, pr, facts)
 		if err != nil {
 			err := c.handleRunCreationError(pr, err)
 			return nil, err
@@ -1127,7 +1150,6 @@ func (c *Reconciler) createChildPipelineRuns(
 func (c *Reconciler) createChildPipelineRun(
 	ctx context.Context,
 	childPipelineRunName string,
-	params v1.Params,
 	rpt *resources.ResolvedPipelineTask,
 	pr *v1.PipelineRun,
 	facts *resources.PipelineRunFacts,
@@ -1138,17 +1160,50 @@ func (c *Reconciler) createChildPipelineRun(
 	logger := logging.FromContext(ctx)
 	rpt.PipelineTask = resources.ApplyPipelineTaskContexts(rpt.PipelineTask, pr.Status, facts)
 
+	// For PipelineRef tasks, detect and prevent pipeline-in-pipeline cycles
+	// by walking up the ownerReferences chain and checking tekton.dev/pipeline labels.
+	// detectPipelineRefCycle classifies its own errors: a real cycle is permanent,
+	// a transient lister failure stays retryable.
+	if rpt.PipelineTask.PipelineRef != nil && rpt.ResolvedPipeline.PipelineName != "" {
+		if err := c.detectPipelineRefCycle(pr, rpt.ResolvedPipeline.PipelineName); err != nil {
+			return nil, err
+		}
+	}
+
+	childAnnotations := createChildResourceAnnotations(pr)
+
+	childLabels := createChildResourceLabels(pr, rpt.PipelineTask.Name, true)
+	// Override the pipeline label with the child's actual pipeline name to avoid
+	// inheriting the parent's pipeline name from label propagation.
+	if rpt.ResolvedPipeline.PipelineName != "" {
+		childLabels[pipeline.PipelineLabelKey] = rpt.ResolvedPipeline.PipelineName
+	}
+
+	childWorkspaces, err := c.getChildPipelineRunWorkspaces(ctx, pr, rpt)
+	if err != nil {
+		return nil, err
+	}
+
+	childSpec := v1.PipelineRunSpec{
+		TaskRunTemplate: pr.Spec.TaskRunTemplate,
+		Params:          rpt.PipelineTask.Params,
+		Workspaces:      childWorkspaces,
+	}
+	if rpt.PipelineTask.PipelineRef != nil {
+		childSpec.PipelineRef = rpt.PipelineTask.PipelineRef
+	} else {
+		childSpec.PipelineSpec = rpt.ResolvedPipeline.PipelineSpec
+	}
+
 	newChildPipelineRun := &v1.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            childPipelineRunName,
 			Namespace:       pr.Namespace,
 			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(pr)},
-			Labels:          createChildResourceLabels(pr, rpt.PipelineTask.Name, true),
-			Annotations:     createChildResourceAnnotations(pr),
+			Labels:          childLabels,
+			Annotations:     childAnnotations,
 		},
-		Spec: v1.PipelineRunSpec{
-			PipelineSpec: rpt.PipelineTask.PipelineSpec,
-		},
+		Spec: childSpec,
 	}
 
 	logger.Infof(
@@ -1160,6 +1215,95 @@ func (c *Reconciler) createChildPipelineRun(
 	return c.PipelineClientSet.TektonV1().
 		PipelineRuns(pr.Namespace).
 		Create(ctx, newChildPipelineRun, metav1.CreateOptions{})
+}
+
+// getChildPipelineRunWorkspaces resolves workspace bindings from the parent PipelineRun
+// for the given PipelineTask that references a child Pipeline. It reuses the same volume
+// source handling as TaskRun workspaces.
+func (c *Reconciler) getChildPipelineRunWorkspaces(ctx context.Context, pr *v1.PipelineRun, rpt *resources.ResolvedPipelineTask) ([]v1.WorkspaceBinding, error) {
+	if len(rpt.PipelineTask.Workspaces) == 0 {
+		return nil, nil
+	}
+
+	parentWorkspaces := make(map[string]v1.WorkspaceBinding, len(pr.Spec.Workspaces))
+	for _, binding := range pr.Spec.Workspaces {
+		parentWorkspaces[binding.Name] = binding
+	}
+
+	var (
+		pipelinePVCWorkspaceName string
+		childWorkspaces          []v1.WorkspaceBinding
+	)
+	for _, ws := range rpt.PipelineTask.Workspaces {
+		childPipelineWorkspaceName, childPipelineSubPath, pipelineWorkspaceName := ws.Name, ws.SubPath, ws.Workspace
+		parentName := pipelineWorkspaceName
+		if parentName == "" {
+			parentName = childPipelineWorkspaceName
+		}
+		b, hasBinding := parentWorkspaces[parentName]
+		if !hasBinding {
+			// Tracking parent-side validation of non-optional child workspaces:
+			// https://github.com/tektoncd/pipeline/issues/9924 (TEP-0056).
+			// Today, missing non-optional child workspaces fail the child PipelineRun
+			// rather than the parent.
+			continue
+		}
+		if b.PersistentVolumeClaim != nil || b.VolumeClaimTemplate != nil {
+			pipelinePVCWorkspaceName = parentName
+		}
+
+		aaBehavior, err := affinityassistant.GetAffinityAssistantBehavior(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		// Reuses the task workspace binding logic which already
+		// cover cases PVC, VolumeTemplates which is identical in this case
+		childWorkspaces = append(childWorkspaces, c.taskWorkspaceByWorkspaceVolumeSource(
+			ctx, pipelinePVCWorkspaceName, pr.Name, b,
+			childPipelineWorkspaceName, childPipelineSubPath,
+			*kmeta.NewControllerRef(pr), aaBehavior,
+		))
+	}
+	return childWorkspaces, nil
+}
+
+// detectPipelineRefCycle walks up the ownerReferences chain from the current PipelineRun
+// and checks the tekton.dev/pipeline label at each level. If the target pipeline name
+// appears in any ancestor, a cycle is detected and a permanent error is returned. A
+// transient lister failure during the walk is returned unwrapped so the caller can
+// retry rather than fail the PipelineRun permanently.
+func (c *Reconciler) detectPipelineRefCycle(pr *v1.PipelineRun, targetPipelineName string) error {
+	current := pr
+	var visited []string
+	for {
+		pipelineName := current.Labels[pipeline.PipelineLabelKey]
+		if pipelineName == targetPipelineName {
+			return controller.NewPermanentError(fmt.Errorf(
+				"detected cycle in pipeline-in-pipeline: pipeline %q is already running in ancestor chain %v",
+				targetPipelineName, visited,
+			))
+		}
+		if pipelineName != "" {
+			visited = append(visited, pipelineName)
+		}
+
+		// Find PipelineRun owner
+		ownerRef := metav1.GetControllerOf(current)
+		if ownerRef == nil || ownerRef.Kind != pipelineRun {
+			break
+		}
+
+		parent, err := c.pipelineRunLister.PipelineRuns(current.Namespace).Get(ownerRef.Name)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				break
+			}
+			return fmt.Errorf("cycle detection in pipeline-in-pipeline: could not look up parent PipelineRun %s: %w", ownerRef.Name, err)
+		}
+		current = parent
+	}
+	return nil
 }
 
 func (c *Reconciler) createTaskRuns(ctx context.Context, rpt *resources.ResolvedPipelineTask, pr *v1.PipelineRun, facts *resources.PipelineRunFacts) ([]*v1.TaskRun, error) {

--- a/pkg/reconciler/pipelinerun/pipelinerun_pinp_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_pinp_test.go
@@ -2,18 +2,25 @@ package pipelinerun
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	listers "github.com/tektoncd/pipeline/pkg/client/listers/pipeline/v1"
+	"github.com/tektoncd/pipeline/pkg/reconciler/pipelinerun/resources"
 	th "github.com/tektoncd/pipeline/pkg/reconciler/testing"
 	"github.com/tektoncd/pipeline/test"
 	"github.com/tektoncd/pipeline/test/diff"
 	"github.com/tektoncd/pipeline/test/names"
+	"go.opentelemetry.io/otel/trace"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -457,4 +464,766 @@ func reconcileWithError(
 	)
 
 	return reconciledRun
+}
+
+// TestReconcile_NestedChildPipelineRunsWithPipelineRef verifies the reconciliation logic for
+// multi-level nested PipelineRuns using PipelineRef. It tests a parent pipeline (A) that
+// references child pipeline (B) via PipelineRef, which itself references grandchild pipeline (C)
+// via PipelineRef. This test requires multiple reconciliation cycles:
+//   - First reconciliation: Parent creates child PipelineRun with PipelineRef to B
+//   - Second reconciliation: Child creates grandchild PipelineRun with PipelineRef to C
+func TestReconcile_NestedChildPipelineRunsWithPipelineRef(t *testing.T) {
+	names.TestingSeed()
+	namespace := "foo"
+	parentPipelineRunName := "parent-pipeline-run"
+	parentPipeline,
+		childPipeline,
+		grandchildPipeline,
+		parentPipelineRun,
+		expectedChildPipelineRun,
+		expectedGrandchildPipelineRun := th.NestedPipelineRefsInPipeline(t, namespace, parentPipelineRunName)
+	expectedEvents := []string{
+		"Normal Started",
+		"Normal Running Tasks Completed: 0",
+	}
+	testData := test.Data{
+		PipelineRuns: []*v1.PipelineRun{parentPipelineRun},
+		Pipelines:    []*v1.Pipeline{parentPipeline, childPipeline, grandchildPipeline},
+		ConfigMaps:   th.NewAlphaFeatureFlagsConfigMapInSlice(),
+	}
+
+	// first reconcile parent PipelineRun once which creates the child
+	reconciledRunParent, childPipelineRuns := reconcileOncePinP(
+		t,
+		testData,
+		namespace,
+		parentPipelineRun.Name,
+		expectedEvents,
+	)
+
+	validatePinP(
+		t,
+		reconciledRunParent.Status,
+		reconciledRunParent.Name,
+		childPipelineRuns,
+		[]*v1.PipelineRun{expectedChildPipelineRun},
+	)
+
+	// use the child from previous reconcile
+	childPipelineRun := getChildPipelineRunByName(t, childPipelineRuns, expectedChildPipelineRun.Name)
+	childTestData := test.Data{
+		PipelineRuns: []*v1.PipelineRun{childPipelineRun},
+		Pipelines:    []*v1.Pipeline{childPipeline, grandchildPipeline},
+		ConfigMaps:   th.NewAlphaFeatureFlagsConfigMapInSlice(),
+	}
+
+	// second reconcile child PipelineRun which creates the grandchild
+	reconciledRunChild, grandchildPipelineRuns := reconcileOncePinP(
+		t,
+		childTestData,
+		namespace,
+		childPipelineRun.Name,
+		expectedEvents,
+	)
+
+	validatePinP(
+		t,
+		reconciledRunChild.Status,
+		reconciledRunChild.Name,
+		grandchildPipelineRuns,
+		[]*v1.PipelineRun{expectedGrandchildPipelineRun},
+	)
+}
+
+// TestReconcile_ChildPipelineRunPipelineRefNotFound verifies that when a PipelineTask
+// references a nonexistent Pipeline, the PipelineRun is marked as failed.
+func TestReconcile_ChildPipelineRunPipelineRefNotFound(t *testing.T) {
+	names.TestingSeed()
+	namespace := "foo"
+
+	parentPipeline, pr := th.OnePipelineRefMissing(t, namespace, "not-found-pr")
+
+	testData := test.Data{
+		PipelineRuns: []*v1.PipelineRun{pr},
+		Pipelines:    []*v1.Pipeline{parentPipeline},
+		ConfigMaps:   th.NewAlphaFeatureFlagsConfigMapInSlice(),
+	}
+
+	prt := newPipelineRunTest(t, testData)
+	defer prt.Cancel()
+
+	reconciledRun, _ := prt.reconcileRun(namespace, pr.Name, []string{}, true)
+
+	// The run should be marked as failed since the referenced pipeline doesn't exist
+	th.CheckPipelineRunConditionStatusAndReason(
+		t,
+		reconciledRun.Status,
+		corev1.ConditionFalse,
+		v1.PipelineRunReasonCouldntGetPipeline.String(),
+	)
+}
+
+// TestReconcile_ChildPipelineRunPipelineRef verifies that a PipelineTask with a pipelineRef (instead
+// of inline pipelineSpec) is correctly resolved and creates a child PipelineRun with the resolved spec.
+func TestReconcile_ChildPipelineRunPipelineRef(t *testing.T) {
+	names.TestingSeed()
+	namespace := "foo"
+	parentPipelineRunName := "parent-pipeline-run"
+
+	parentPipeline, childPipeline, parentPipelineRun, expectedChildPipelineRun :=
+		th.OnePipelineRefInPipeline(t, namespace, parentPipelineRunName)
+
+	testData := test.Data{
+		PipelineRuns: []*v1.PipelineRun{parentPipelineRun},
+		Pipelines:    []*v1.Pipeline{parentPipeline, childPipeline},
+		ConfigMaps:   th.NewAlphaFeatureFlagsConfigMapInSlice(),
+	}
+
+	reconciledRun, childPipelineRuns := reconcileOncePinP(
+		t,
+		testData,
+		namespace,
+		parentPipelineRunName,
+		[]string{"Normal Started", "Normal Running Tasks Completed: 0"},
+	)
+
+	validatePinP(
+		t,
+		reconciledRun.Status,
+		reconciledRun.Name,
+		childPipelineRuns,
+		[]*v1.PipelineRun{expectedChildPipelineRun},
+	)
+}
+
+// TestReconcile_ChildPipelineRunPipelineRefWithParams verifies that params from the
+// PipelineTask are propagated to the child PipelineRun spec.
+func TestReconcile_ChildPipelineRunPipelineRefWithParams(t *testing.T) {
+	names.TestingSeed()
+	namespace := "foo"
+	parentPipelineRunName := "parent-pipeline-run"
+
+	parentPipeline, childPipeline, parentPipelineRun, expectedChildPipelineRun :=
+		th.OnePipelineRefInPipelineWithParams(t, namespace, parentPipelineRunName)
+
+	testData := test.Data{
+		PipelineRuns: []*v1.PipelineRun{parentPipelineRun},
+		Pipelines:    []*v1.Pipeline{parentPipeline, childPipeline},
+		ConfigMaps:   th.NewAlphaFeatureFlagsConfigMapInSlice(),
+	}
+
+	reconciledRun, childPipelineRuns := reconcileOncePinP(
+		t,
+		testData,
+		namespace,
+		parentPipelineRunName,
+		[]string{"Normal Started", "Normal Running Tasks Completed: 0"},
+	)
+
+	validatePinP(
+		t,
+		reconciledRun.Status,
+		reconciledRun.Name,
+		childPipelineRuns,
+		[]*v1.PipelineRun{expectedChildPipelineRun},
+	)
+}
+
+// TestReconcile_ChildPipelineRunPipelineRefWithWorkspaces verifies that workspace bindings
+// from the parent PipelineRun are mapped and propagated to the child PipelineRun spec.
+func TestReconcile_ChildPipelineRunPipelineRefWithWorkspaces(t *testing.T) {
+	names.TestingSeed()
+	namespace := "foo"
+	parentPipelineRunName := "parent-pipeline-run"
+
+	parentPipeline, childPipeline, parentPipelineRun, expectedChildPipelineRun :=
+		th.OnePipelineRefInPipelineWithWorkspaces(t, namespace, parentPipelineRunName)
+
+	testData := test.Data{
+		PipelineRuns: []*v1.PipelineRun{parentPipelineRun},
+		Pipelines:    []*v1.Pipeline{parentPipeline, childPipeline},
+		ConfigMaps:   th.NewAlphaFeatureFlagsConfigMapInSlice(),
+	}
+
+	reconciledRun, childPipelineRuns := reconcileOncePinP(
+		t,
+		testData,
+		namespace,
+		parentPipelineRunName,
+		[]string{"Normal Started", "Normal Running Tasks Completed: 0"},
+	)
+
+	validatePinP(
+		t,
+		reconciledRun.Status,
+		reconciledRun.Name,
+		childPipelineRuns,
+		[]*v1.PipelineRun{expectedChildPipelineRun},
+	)
+}
+
+// TestReconcile_ChildPipelineRunPipelineRefWithParamsAndWorkspaces verifies that both params
+// and workspaces are propagated to the child PipelineRun spec.
+func TestReconcile_ChildPipelineRunPipelineRefWithParamsAndWorkspaces(t *testing.T) {
+	names.TestingSeed()
+	namespace := "foo"
+	parentPipelineRunName := "parent-pipeline-run"
+
+	parentPipeline, childPipeline, parentPipelineRun, expectedChildPipelineRun :=
+		th.OnePipelineRefInPipelineWithParamsAndWorkspaces(t, namespace, parentPipelineRunName)
+
+	testData := test.Data{
+		PipelineRuns: []*v1.PipelineRun{parentPipelineRun},
+		Pipelines:    []*v1.Pipeline{parentPipeline, childPipeline},
+		ConfigMaps:   th.NewAlphaFeatureFlagsConfigMapInSlice(),
+	}
+
+	reconciledRun, childPipelineRuns := reconcileOncePinP(
+		t,
+		testData,
+		namespace,
+		parentPipelineRunName,
+		[]string{"Normal Started", "Normal Running Tasks Completed: 0"},
+	)
+
+	validatePinP(
+		t,
+		reconciledRun.Status,
+		reconciledRun.Name,
+		childPipelineRuns,
+		[]*v1.PipelineRun{expectedChildPipelineRun},
+	)
+}
+
+// TestReconcile_ChildPipelineRunsMultiplePipelineRefs verifies that a parent
+// Pipeline with more than one pipelineRef PipelineTask produces one child
+// PipelineRun per task in a single reconcile — exercising the loop over
+// multiple child-pipeline references.
+func TestReconcile_ChildPipelineRunsMultiplePipelineRefs(t *testing.T) {
+	names.TestingSeed()
+	namespace := "foo"
+
+	parentPipeline, childPipelines, parentPipelineRun, _ :=
+		th.MultiplePipelineRefsInPipeline(t, namespace, "parent-pipeline-run")
+
+	testData := test.Data{
+		PipelineRuns: []*v1.PipelineRun{parentPipelineRun},
+		Pipelines:    append([]*v1.Pipeline{parentPipeline}, childPipelines...),
+		ConfigMaps:   th.NewAlphaFeatureFlagsConfigMapInSlice(),
+	}
+
+	reconciledRun, childPipelineRuns := reconcileOncePinP(
+		t,
+		testData,
+		namespace,
+		parentPipelineRun.Name,
+		[]string{"Normal Started", "Normal Running Tasks Completed: 0"},
+	)
+
+	th.CheckPipelineRunConditionStatusAndReason(
+		t,
+		reconciledRun.Status,
+		corev1.ConditionUnknown,
+		v1.PipelineRunReasonRunning.String(),
+	)
+	validateChildPipelineRunCount(t, childPipelineRuns, 2)
+}
+
+// TestReconcile_ChildPipelineRunsMixedPipelineRefSpecAndTaskRef verifies that a parent
+// Pipeline mixing a pipelineRef PipelineTask, an inline pipelineSpec PipelineTask, and a
+// regular taskRef task resolves all three: a child PipelineRun is created for the
+// pipelineRef and pipelineSpec tasks and a TaskRun for the direct taskRef task.
+func TestReconcile_ChildPipelineRunsMixedPipelineRefSpecAndTaskRef(t *testing.T) {
+	names.TestingSeed()
+	namespace := "foo"
+
+	task, parentPipeline, childRef, parentPipelineRun, _, _ :=
+		th.MixedPipelineRefSpecAndTaskRefInPipeline(t, namespace, "parent-pipeline-run")
+
+	testData := test.Data{
+		PipelineRuns: []*v1.PipelineRun{parentPipelineRun},
+		Pipelines:    []*v1.Pipeline{parentPipeline, childRef},
+		Tasks:        []*v1.Task{task},
+		ConfigMaps:   th.NewAlphaFeatureFlagsConfigMapInSlice(),
+	}
+
+	reconciledRun, childPipelineRuns := reconcileOncePinP(
+		t,
+		testData,
+		namespace,
+		parentPipelineRun.Name,
+		[]string{"Normal Started", "Normal Running Tasks Completed: 0"},
+	)
+
+	th.CheckPipelineRunConditionStatusAndReason(
+		t,
+		reconciledRun.Status,
+		corev1.ConditionUnknown,
+		v1.PipelineRunReasonRunning.String(),
+	)
+	// Two child PipelineRuns (pipelineRef + pipelineSpec); the direct taskRef task
+	// produces a TaskRun, not a child PipelineRun.
+	validateChildPipelineRunCount(t, childPipelineRuns, 2)
+}
+
+// TestReconcile_ChildPipelineRunPipelineRefWhenSkipped verifies that a pipelineRef
+// PipelineTask guarded by a when expression that evaluates to false is skipped:
+// no child PipelineRun is created and the parent PipelineRun completes
+// successfully (reason Completed, since a task was skipped).
+func TestReconcile_ChildPipelineRunPipelineRefWhenSkipped(t *testing.T) {
+	names.TestingSeed()
+	namespace := "foo"
+
+	parentPipeline, childPipeline, parentPipelineRun :=
+		th.PipelineRefInPipelineWhenSkipped(t, namespace, "parent-pipeline-run")
+
+	testData := test.Data{
+		PipelineRuns: []*v1.PipelineRun{parentPipelineRun},
+		Pipelines:    []*v1.Pipeline{parentPipeline, childPipeline},
+		ConfigMaps:   th.NewAlphaFeatureFlagsConfigMapInSlice(),
+	}
+
+	reconciledRun, childPipelineRuns := reconcileOncePinP(
+		t,
+		testData,
+		namespace,
+		parentPipelineRun.Name,
+		[]string{"Normal Started", "Normal Succeeded"},
+	)
+
+	// No child PipelineRun is created for the skipped task, and the run succeeds.
+	validateChildPipelineRunCount(t, childPipelineRuns, 0)
+	th.CheckPipelineRunConditionStatusAndReason(
+		t,
+		reconciledRun.Status,
+		corev1.ConditionTrue,
+		v1.PipelineRunReasonCompleted.String(),
+	)
+}
+
+// TestGetChildPipelineRunWorkspaces_Success exercises every branch of
+// getChildPipelineRunWorkspaces that produces workspace bindings: no workspaces,
+// explicit and fallback name mapping, multiple workspaces, unbound workspaces,
+// PVC sources, the PVC-then-non-PVC iteration order, SubPath propagation, and
+// the edge cases of fan-out and fully-unbound child workspaces. It mirrors the
+// direct table-driven style of the sibling TestGetTaskrunWorkspaces_Success.
+func TestGetChildPipelineRunWorkspaces_Success(t *testing.T) {
+	tests := []struct {
+		name             string
+		parentWorkspaces []v1.WorkspaceBinding
+		childWorkspaces  []v1.WorkspacePipelineTaskBinding
+		want             []v1.WorkspaceBinding
+	}{{
+		name:            "no workspaces returns nil",
+		childWorkspaces: nil,
+		want:            nil,
+	}, {
+		name:             "single emptyDir workspace with explicit mapping",
+		parentWorkspaces: []v1.WorkspaceBinding{{Name: "parent-ws", EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+		childWorkspaces:  []v1.WorkspacePipelineTaskBinding{{Name: "child-ws", Workspace: "parent-ws"}},
+		want:             []v1.WorkspaceBinding{{Name: "child-ws", EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+	}, {
+		name: "multiple workspaces",
+		parentWorkspaces: []v1.WorkspaceBinding{
+			{Name: "p1", EmptyDir: &corev1.EmptyDirVolumeSource{}},
+			{Name: "p2", EmptyDir: &corev1.EmptyDirVolumeSource{}},
+		},
+		childWorkspaces: []v1.WorkspacePipelineTaskBinding{
+			{Name: "c1", Workspace: "p1"},
+			{Name: "c2", Workspace: "p2"},
+		},
+		want: []v1.WorkspaceBinding{
+			{Name: "c1", EmptyDir: &corev1.EmptyDirVolumeSource{}},
+			{Name: "c2", EmptyDir: &corev1.EmptyDirVolumeSource{}},
+		},
+	}, {
+		name:             "empty Workspace field falls back to child workspace name",
+		parentWorkspaces: []v1.WorkspaceBinding{{Name: "shared", EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+		childWorkspaces:  []v1.WorkspacePipelineTaskBinding{{Name: "shared"}},
+		want:             []v1.WorkspaceBinding{{Name: "shared", EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+	}, {
+		name:             "unbound workspace is skipped",
+		parentWorkspaces: []v1.WorkspaceBinding{{Name: "data", EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+		childWorkspaces: []v1.WorkspacePipelineTaskBinding{
+			{Name: "data", Workspace: "data"},
+			{Name: "missing", Workspace: "does-not-exist"},
+		},
+		want: []v1.WorkspaceBinding{{Name: "data", EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+	}, {
+		name:             "PVC-source workspace",
+		parentWorkspaces: []v1.WorkspaceBinding{{Name: "pvc-ws", PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "my-pvc"}}},
+		childWorkspaces:  []v1.WorkspacePipelineTaskBinding{{Name: "child-pvc", Workspace: "pvc-ws"}},
+		want:             []v1.WorkspaceBinding{{Name: "child-pvc", PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "my-pvc"}}},
+	}, {
+		name: "PVC workspace then non-PVC workspace",
+		parentWorkspaces: []v1.WorkspaceBinding{
+			{Name: "pvc-ws", PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "my-pvc"}},
+			{Name: "ed-ws", EmptyDir: &corev1.EmptyDirVolumeSource{}},
+		},
+		childWorkspaces: []v1.WorkspacePipelineTaskBinding{
+			{Name: "c-pvc", Workspace: "pvc-ws"},
+			{Name: "c-ed", Workspace: "ed-ws"},
+		},
+		want: []v1.WorkspaceBinding{
+			{Name: "c-pvc", PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "my-pvc"}},
+			{Name: "c-ed", EmptyDir: &corev1.EmptyDirVolumeSource{}},
+		},
+	}, {
+		name:             "SubPath is combined from parent binding and pipelineTask binding",
+		parentWorkspaces: []v1.WorkspaceBinding{{Name: "ws", EmptyDir: &corev1.EmptyDirVolumeSource{}, SubPath: "parent-sub"}},
+		childWorkspaces:  []v1.WorkspacePipelineTaskBinding{{Name: "ws", Workspace: "ws", SubPath: "child-sub"}},
+		want:             []v1.WorkspaceBinding{{Name: "ws", EmptyDir: &corev1.EmptyDirVolumeSource{}, SubPath: "parent-sub/child-sub"}},
+	}, {
+		name:             "same parent workspace mapped to two child workspaces",
+		parentWorkspaces: []v1.WorkspaceBinding{{Name: "shared-vol", PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "my-pvc"}}},
+		childWorkspaces: []v1.WorkspacePipelineTaskBinding{
+			{Name: "source", Workspace: "shared-vol"},
+			{Name: "cache", Workspace: "shared-vol"},
+		},
+		want: []v1.WorkspaceBinding{
+			{Name: "source", PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "my-pvc"}},
+			{Name: "cache", PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "my-pvc"}},
+		},
+	}, {
+		name:             "no child workspace name matches any parent workspace",
+		parentWorkspaces: []v1.WorkspaceBinding{{Name: "data", EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+		childWorkspaces: []v1.WorkspacePipelineTaskBinding{
+			{Name: "src"},
+			{Name: "artifacts"},
+		},
+		want: nil,
+	}, {
+		name:             "parent PipelineRun has no workspaces",
+		parentWorkspaces: nil,
+		childWorkspaces:  []v1.WorkspacePipelineTaskBinding{{Name: "source", Workspace: "shared-vol"}},
+		want:             nil,
+	}}
+
+	c := Reconciler{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pr := &v1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{Name: "parent-pr", Namespace: "foo"},
+				Spec:       v1.PipelineRunSpec{Workspaces: tt.parentWorkspaces},
+			}
+			rpt := &resources.ResolvedPipelineTask{
+				PipelineTask: &v1.PipelineTask{Name: "child-task", Workspaces: tt.childWorkspaces},
+			}
+
+			got, err := c.getChildPipelineRunWorkspaces(t.Context(), pr, rpt)
+			if err != nil {
+				t.Fatalf("getChildPipelineRunWorkspaces() unexpected error: %v", err)
+			}
+			if d := cmp.Diff(tt.want, got); d != "" {
+				t.Errorf("getChildPipelineRunWorkspaces() bindings diff %s", diff.PrintWantGot(d))
+			}
+		})
+	}
+}
+
+// TestGetChildPipelineRunWorkspaces_Failure verifies that an error from
+// GetAffinityAssistantBehavior — the only error path in the function — is
+// propagated to the caller. An unknown "coschedule" feature-flag value makes
+// GetAffinityAssistantBehavior fail.
+func TestGetChildPipelineRunWorkspaces_Failure(t *testing.T) {
+	cfg := config.FromContextOrDefaults(t.Context())
+	cfg.FeatureFlags.Coschedule = "bogus-coschedule"
+	ctx := config.ToContext(t.Context(), cfg)
+
+	c := Reconciler{}
+	pr := &v1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "parent-pr", Namespace: "foo"},
+		Spec: v1.PipelineRunSpec{
+			Workspaces: []v1.WorkspaceBinding{{Name: "ws", EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+		},
+	}
+	rpt := &resources.ResolvedPipelineTask{
+		PipelineTask: &v1.PipelineTask{
+			Name:       "child-task",
+			Workspaces: []v1.WorkspacePipelineTaskBinding{{Name: "ws", Workspace: "ws"}},
+		},
+	}
+
+	if _, err := c.getChildPipelineRunWorkspaces(ctx, pr, rpt); err == nil {
+		t.Fatal("getChildPipelineRunWorkspaces() expected an error for an invalid coschedule flag, got nil")
+	}
+}
+
+// TestCreateChildPipelineRun_WorkspaceResolutionError verifies that an error
+// from child workspace resolution is propagated by createChildPipelineRun
+// instead of a child PipelineRun being created. An invalid coschedule flag in
+// the context makes getChildPipelineRunWorkspaces fail. A pipelineSpec child
+// task is used so cycle detection is skipped and workspace resolution is the
+// first failing step.
+func TestCreateChildPipelineRun_WorkspaceResolutionError(t *testing.T) {
+	cfg := config.FromContextOrDefaults(t.Context())
+	cfg.FeatureFlags.Coschedule = "bogus-coschedule"
+	ctx := config.ToContext(t.Context(), cfg)
+
+	c := &Reconciler{tracerProvider: trace.NewNoopTracerProvider()}
+	pr := &v1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "parent-pr", Namespace: "foo"},
+		Spec: v1.PipelineRunSpec{
+			Workspaces: []v1.WorkspaceBinding{{Name: "ws", EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+		},
+	}
+	rpt := &resources.ResolvedPipelineTask{
+		PipelineTask: &v1.PipelineTask{
+			Name:         "child-task",
+			PipelineSpec: &v1.PipelineSpec{},
+			Workspaces:   []v1.WorkspacePipelineTaskBinding{{Name: "ws", Workspace: "ws"}},
+		},
+		ResolvedPipeline: resources.ResolvedPipeline{PipelineSpec: &v1.PipelineSpec{}},
+	}
+
+	if _, err := c.createChildPipelineRun(ctx, "child-pr", rpt, pr, nil); err == nil {
+		t.Fatal("createChildPipelineRun() expected a workspace resolution error, got nil")
+	}
+}
+
+// errPipelineRunLister is a minimal stub of listers.PipelineRunLister whose
+// only purpose is to make Get return a fixed non-NotFound error. The standard
+// indexer-backed lister installed by test.SeedTestData can only return
+// NotFound or success, so it cannot exercise detectPipelineRefCycle's
+// "lister returned a transient error" branch.
+type errPipelineRunLister struct{ err error }
+
+func (l *errPipelineRunLister) List(labels.Selector) ([]*v1.PipelineRun, error) {
+	return nil, l.err
+}
+
+func (l *errPipelineRunLister) PipelineRuns(string) listers.PipelineRunNamespaceLister {
+	return errPipelineRunNamespaceLister{err: l.err}
+}
+
+type errPipelineRunNamespaceLister struct{ err error }
+
+func (l errPipelineRunNamespaceLister) List(labels.Selector) ([]*v1.PipelineRun, error) {
+	return nil, l.err
+}
+
+func (l errPipelineRunNamespaceLister) Get(string) (*v1.PipelineRun, error) {
+	return nil, l.err
+}
+
+// TestReconcile_ChildPipelineRunPipelineRefCycleDetection verifies that a self-referencing
+// pipeline cycle (A -> A) is detected via ownerReferences walk-up and the PipelineRun is
+// marked as failed.
+func TestReconcile_ChildPipelineRunPipelineRefCycleDetection(t *testing.T) {
+	names.TestingSeed()
+	namespace := "foo"
+
+	selfRefPipeline, pr := th.SelfReferencingPipelineRefCycle(t, namespace, "cycle-pr")
+
+	testData := test.Data{
+		PipelineRuns: []*v1.PipelineRun{pr},
+		Pipelines:    []*v1.Pipeline{selfRefPipeline},
+		ConfigMaps:   th.NewAlphaFeatureFlagsConfigMapInSlice(),
+	}
+
+	prt := newPipelineRunTest(t, testData)
+	defer prt.Cancel()
+
+	reconciledRun, _ := prt.reconcileRun(namespace, pr.Name, []string{}, true)
+
+	// The run should be marked as failed due to cycle detection
+	th.CheckPipelineRunConditionStatusAndReason(
+		t,
+		reconciledRun.Status,
+		corev1.ConditionFalse,
+		"CreateRunFailed",
+	)
+}
+
+// TestReconcile_ChildPipelineRunPipelineRefCycleDetection_TwoLevel verifies that a two-level
+// pipeline cycle (A → B → A) is detected via ownerReferences walk-up. This requires two
+// reconciliation steps:
+//  1. Reconcile A's PipelineRun — creates child PipelineRun for B (no cycle yet)
+//  2. Reconcile B's PipelineRun — walks up ownerRefs, finds A's label matches target "pipeline-a" → cycle detected
+func TestReconcile_ChildPipelineRunPipelineRefCycleDetection_TwoLevel(t *testing.T) {
+	names.TestingSeed()
+	namespace := "foo"
+
+	pipelineA, pipelineB, parentPR := th.TwoLevelPipelineRefCycle(t, namespace, "parent-pr")
+
+	// Step 1: Reconcile A's PipelineRun — should create child for B (no cycle)
+	testData := test.Data{
+		PipelineRuns: []*v1.PipelineRun{parentPR},
+		Pipelines:    []*v1.Pipeline{pipelineA, pipelineB},
+		ConfigMaps:   th.NewAlphaFeatureFlagsConfigMapInSlice(),
+	}
+	expectedEvents := []string{
+		"Normal Started",
+		"Normal Running Tasks Completed: 0",
+	}
+
+	_, childPipelineRuns := reconcileOncePinP(
+		t,
+		testData,
+		namespace,
+		parentPR.Name,
+		expectedEvents,
+	)
+
+	// Verify that the child PipelineRun for B was created
+	validateChildPipelineRunCount(t, childPipelineRuns, 1)
+	var childPR *v1.PipelineRun
+	for _, cpr := range childPipelineRuns {
+		childPR = cpr
+	}
+
+	// Step 2: Reconcile B's PipelineRun — should detect cycle (A is in ancestor chain)
+	// Include both the parent and child in the test data so the lister can walk up ownerRefs.
+	childTestData := test.Data{
+		PipelineRuns: []*v1.PipelineRun{parentPR, childPR},
+		Pipelines:    []*v1.Pipeline{pipelineA, pipelineB},
+		ConfigMaps:   th.NewAlphaFeatureFlagsConfigMapInSlice(),
+	}
+
+	prt := newPipelineRunTest(t, childTestData)
+	defer prt.Cancel()
+
+	reconciledChild, _ := prt.reconcileRun(namespace, childPR.Name, []string{}, true)
+
+	// The child run should be marked as failed due to cycle detection
+	th.CheckPipelineRunConditionStatusAndReason(
+		t,
+		reconciledChild.Status,
+		corev1.ConditionFalse,
+		"CreateRunFailed",
+	)
+}
+
+// TestReconcile_ChildPipelineRunPipelineRefParentNotFound verifies that cycle
+// detection terminates cleanly when a PipelineRun's ownerReference points at a
+// parent that no longer exists (e.g. garbage-collected). Reconciling such a
+// PipelineRun, the ancestor walk hits a NotFound from the lister, treats the
+// chain as ended, and reconciliation proceeds normally: the child Pipeline is
+// resolved and its PipelineRun created rather than the run being failed on a
+// phantom cycle. This exercises the NotFound branch of detectPipelineRefCycle
+// through the reconciler instead of calling it directly.
+func TestReconcile_ChildPipelineRunPipelineRefParentNotFound(t *testing.T) {
+	names.TestingSeed()
+	namespace := "foo"
+	controller := true
+
+	grandchildPipeline := &v1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: "grandchild-pipeline", Namespace: namespace},
+		Spec: v1.PipelineSpec{
+			Tasks: []v1.PipelineTask{{
+				Name: "grandchild-task",
+				TaskSpec: &v1.EmbeddedTask{TaskSpec: v1.TaskSpec{
+					Steps: []v1.Step{{Name: "mystep", Image: "mirror.gcr.io/busybox", Script: "echo hi"}},
+				}},
+			}},
+		},
+	}
+	// child-pipeline has a pipelineRef task, so reconciling its PipelineRun runs
+	// cycle detection with target "grandchild-pipeline".
+	childPipeline := &v1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: "child-pipeline", Namespace: namespace},
+		Spec: v1.PipelineSpec{
+			Tasks: []v1.PipelineTask{{
+				Name:        "ref-grandchild",
+				PipelineRef: &v1.PipelineRef{Name: "grandchild-pipeline"},
+			}},
+		},
+	}
+	// pr is owned by a PipelineRun that is never seeded, so the ancestor walk
+	// hits a NotFound and must terminate without reporting a cycle.
+	pr := &v1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "child-pr",
+			Namespace: namespace,
+			Labels:    map[string]string{pipeline.PipelineLabelKey: "child-pipeline"},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "tekton.dev/v1",
+				Kind:       "PipelineRun",
+				Name:       "missing-parent",
+				Controller: &controller,
+			}},
+		},
+		Spec: v1.PipelineRunSpec{PipelineRef: &v1.PipelineRef{Name: "child-pipeline"}},
+	}
+
+	testData := test.Data{
+		PipelineRuns: []*v1.PipelineRun{pr},
+		Pipelines:    []*v1.Pipeline{childPipeline, grandchildPipeline},
+		ConfigMaps:   th.NewAlphaFeatureFlagsConfigMapInSlice(),
+	}
+
+	// reconcileOncePinP expects the "Running" events and no permanent error;
+	// a phantom cycle would instead fail the run with CreateRunFailed.
+	reconciledRun, childPipelineRuns := reconcileOncePinP(
+		t,
+		testData,
+		namespace,
+		pr.Name,
+		[]string{"Normal Started", "Normal Running Tasks Completed: 0"},
+	)
+
+	th.CheckPipelineRunConditionStatusAndReason(
+		t,
+		reconciledRun.Status,
+		corev1.ConditionUnknown,
+		v1.PipelineRunReasonRunning.String(),
+	)
+	validateChildPipelineRunCount(t, childPipelineRuns, 1)
+}
+
+// TestDetectPipelineRefCycle_OwnerNotPipelineRun verifies that the cycle walker
+// returns nil when the controller-owner reference is set but its Kind is not
+// "PipelineRun" — the second half of the `ownerRef == nil || ownerRef.Kind != "PipelineRun"`
+// guard. The walker must break before consulting the lister; the sentinel
+// errPipelineRunLister surfaces a regression if it ever does.
+func TestDetectPipelineRefCycle_OwnerNotPipelineRun(t *testing.T) {
+	namespace := "foo"
+
+	// The 4th return value is the expected child PipelineRun: it already carries a
+	// tekton.dev/pipeline label and a PipelineRun owner-ref, which is what the cycle
+	// walker reads. Overriding the owner-ref to a non-PipelineRun (Job) kind makes
+	// the walker break before it ever consults the lister.
+	_, _, _, pr := th.OnePipelineRefInPipeline(t, namespace, "parent-pr")
+	controller := true
+	pr.OwnerReferences = []metav1.OwnerReference{{
+		APIVersion: "batch/v1",
+		Kind:       "Job",
+		Name:       "some-job",
+		Controller: &controller,
+	}}
+
+	r := &Reconciler{pipelineRunLister: &errPipelineRunLister{err: errors.New("lister must not be called")}}
+
+	if err := r.detectPipelineRefCycle(pr, "some-other-pipeline"); err != nil {
+		t.Fatalf("detectPipelineRefCycle returned unexpected error: %v", err)
+	}
+}
+
+// TestDetectPipelineRefCycle_ParentLookupError verifies that a non-NotFound
+// error from the lister is wrapped and returned to the caller so the
+// PipelineRun is retried rather than misclassified as having no cycle.
+// Indexer-backed listers cannot produce this error in normal test data, so we
+// substitute a stub lister that always errors.
+func TestDetectPipelineRefCycle_ParentLookupError(t *testing.T) {
+	namespace := "foo"
+
+	// The 4th return value is the expected child PipelineRun, whose PipelineRun
+	// owner-ref points at "parent-pr"; the stub lister errors on that lookup, so
+	// the walker must wrap and return the error.
+	_, _, _, pr := th.OnePipelineRefInPipeline(t, namespace, "parent-pr")
+
+	listerErr := errors.New("indexer not synced")
+	r := &Reconciler{pipelineRunLister: &errPipelineRunLister{err: listerErr}}
+
+	err := r.detectPipelineRefCycle(pr, "some-other-pipeline")
+	if err == nil {
+		t.Fatal("detectPipelineRefCycle returned nil; expected wrapped lister error")
+	}
+	if !errors.Is(err, listerErr) {
+		t.Fatalf("returned error does not wrap the lister error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "cycle detection in pipeline-in-pipeline") ||
+		!strings.Contains(err.Error(), "parent-pr") {
+		t.Fatalf("error message missing expected context: %v", err)
+	}
 }

--- a/pkg/reconciler/pipelinerun/resources/pipelineref.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelineref.go
@@ -63,37 +63,57 @@ func GetPipelineFunc(ctx context.Context, k8s kubernetes.Interface, tekton clien
 		}
 	}
 
-	switch {
-	case pr != nil && pr.Resolver != "" && requester != nil:
-		return func(ctx context.Context, name string) (*v1.Pipeline, *v1.RefSource, *trustedresources.VerificationResult, error) {
-			stringReplacements, arrayReplacements, objectReplacements := paramsFromPipelineRun(pipelineRun)
-			for k, v := range GetContextReplacements("", pipelineRun) {
-				stringReplacements[k] = v
-			}
-			replacedParams := pr.Params.ReplaceVariables(stringReplacements, arrayReplacements, objectReplacements)
-			var url string
-			// The name is url-like so its not a local reference.
-			if err := v1.RefNameLikeUrl(pr.Name); err == nil {
-				// apply variable replacements in the name.
-				pr.Name = substitution.ApplyReplacements(pr.Name, stringReplacements)
-				url = pr.Name
-			}
-			resolverPayload := remoteresource.ResolverPayload{
-				ResolutionSpec: &resolutionV1beta1.ResolutionRequestSpec{
-					Params: replacedParams,
-					URL:    url,
-				},
-			}
-			resolver := resolution.NewResolver(requester, pipelineRun, string(pr.Resolver), resolverPayload)
-			return resolvePipeline(ctx, resolver, name, namespace, k8s, tekton, verificationPolicies)
+	if pr != nil && pr.Resolver != "" && requester != nil {
+		return pipelineResolverFunc(ctx, k8s, tekton, requester, pipelineRun, pr, namespace, verificationPolicies)
+	}
+
+	// Even if there is no pipeline ref, we should try to return a local resolver.
+	local := &LocalPipelineRefResolver{
+		Namespace:    namespace,
+		Tektonclient: tekton,
+	}
+	return local.GetPipeline
+}
+
+// GetChildPipelineFunc is a factory function that will use the given PipelineRef from a PipelineTask
+// to return a valid GetPipeline function that looks up the pipeline. It handles both local cluster
+// and remote resolution.
+func GetChildPipelineFunc(ctx context.Context, k8s kubernetes.Interface, tekton clientset.Interface, requester remoteresource.Requester, pipelineRun *v1.PipelineRun, pipelineRef *v1.PipelineRef, verificationPolicies []*v1alpha1.VerificationPolicy) rprp.GetPipeline {
+	namespace := pipelineRun.Namespace
+
+	if pipelineRef != nil && pipelineRef.Resolver != "" && requester != nil {
+		return pipelineResolverFunc(ctx, k8s, tekton, requester, pipelineRun, pipelineRef, namespace, verificationPolicies)
+	}
+
+	local := &LocalPipelineRefResolver{
+		Namespace:    namespace,
+		Tektonclient: tekton,
+	}
+	return local.GetPipeline
+}
+
+// pipelineResolverFunc returns a GetPipeline function that resolves a pipeline using a remote resolver.
+// It is shared by GetPipelineFunc and GetChildPipelineFunc to avoid code duplication.
+func pipelineResolverFunc(_ context.Context, k8s kubernetes.Interface, tekton clientset.Interface, requester remoteresource.Requester, pipelineRun *v1.PipelineRun, pipelineRef *v1.PipelineRef, namespace string, verificationPolicies []*v1alpha1.VerificationPolicy) rprp.GetPipeline {
+	return func(ctx context.Context, name string) (*v1.Pipeline, *v1.RefSource, *trustedresources.VerificationResult, error) {
+		stringReplacements, arrayReplacements, objectReplacements := paramsFromPipelineRun(pipelineRun)
+		for k, v := range GetContextReplacements("", pipelineRun) {
+			stringReplacements[k] = v
 		}
-	default:
-		// Even if there is no pipeline ref, we should try to return a local resolver.
-		local := &LocalPipelineRefResolver{
-			Namespace:    namespace,
-			Tektonclient: tekton,
+		replacedParams := pipelineRef.Params.ReplaceVariables(stringReplacements, arrayReplacements, objectReplacements)
+		var url string
+		if err := v1.RefNameLikeUrl(pipelineRef.Name); err == nil {
+			pipelineRef.Name = substitution.ApplyReplacements(pipelineRef.Name, stringReplacements)
+			url = pipelineRef.Name
 		}
-		return local.GetPipeline
+		resolverPayload := remoteresource.ResolverPayload{
+			ResolutionSpec: &resolutionV1beta1.ResolutionRequestSpec{
+				Params: replacedParams,
+				URL:    url,
+			},
+		}
+		resolver := resolution.NewResolver(requester, pipelineRun, string(pipelineRef.Resolver), resolverPayload)
+		return resolvePipeline(ctx, resolver, name, namespace, k8s, tekton, verificationPolicies)
 	}
 }
 

--- a/pkg/reconciler/pipelinerun/resources/pipelineref_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelineref_test.go
@@ -1399,3 +1399,180 @@ func signInterface(signer signature.Signer, i interface{}) ([]byte, error) {
 
 	return sig, nil
 }
+
+func TestGetChildPipelineFunc_Local(t *testing.T) {
+	ctx := context.Background()
+	cfg := config.NewStore(logging.FromContext(ctx))
+	ctx = cfg.ToContext(ctx)
+
+	childPipeline := parse.MustParseV1Pipeline(t, `
+metadata:
+  name: child-pipeline
+  namespace: default
+spec:
+  tasks:
+  - name: child-task
+    taskSpec:
+      steps:
+      - name: step1
+        image: mirror.gcr.io/busybox
+`)
+	tektonClient := fake.NewSimpleClientset(childPipeline)
+
+	pr := &v1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default"},
+	}
+	pipelineRef := &v1.PipelineRef{Name: "child-pipeline"}
+
+	fn := resources.GetChildPipelineFunc(ctx, fakek8s.NewSimpleClientset(), tektonClient, nil, pr, pipelineRef, nil)
+	p, refSource, vr, err := fn(ctx, "child-pipeline")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.Name != "child-pipeline" {
+		t.Errorf("expected pipeline name 'child-pipeline', got %q", p.Name)
+	}
+	if refSource != nil {
+		t.Errorf("expected nil refSource for local resolution, got %v", refSource)
+	}
+	if vr != nil {
+		t.Errorf("expected nil verification result for local resolution, got %v", vr)
+	}
+}
+
+func TestGetChildPipelineFunc_NilPipelineRef(t *testing.T) {
+	ctx := context.Background()
+	cfg := config.NewStore(logging.FromContext(ctx))
+	ctx = cfg.ToContext(ctx)
+
+	childPipeline := parse.MustParseV1Pipeline(t, `
+metadata:
+  name: child-pipeline
+  namespace: default
+spec:
+  tasks:
+  - name: child-task
+    taskSpec:
+      steps:
+      - name: step1
+        image: mirror.gcr.io/busybox
+`)
+	tektonClient := fake.NewSimpleClientset(childPipeline)
+
+	pr := &v1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default"},
+	}
+
+	// nil pipelineRef should fall through to local resolver
+	fn := resources.GetChildPipelineFunc(ctx, fakek8s.NewSimpleClientset(), tektonClient, nil, pr, nil, nil)
+	p, _, _, err := fn(ctx, "child-pipeline")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.Name != "child-pipeline" {
+		t.Errorf("expected pipeline name 'child-pipeline', got %q", p.Name)
+	}
+}
+
+func TestGetChildPipelineFunc_LocalNotFound(t *testing.T) {
+	ctx := context.Background()
+	cfg := config.NewStore(logging.FromContext(ctx))
+	ctx = cfg.ToContext(ctx)
+
+	tektonClient := fake.NewSimpleClientset() // no pipelines
+	pr := &v1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default"},
+	}
+	pipelineRef := &v1.PipelineRef{Name: "nonexistent"}
+
+	fn := resources.GetChildPipelineFunc(ctx, fakek8s.NewSimpleClientset(), tektonClient, nil, pr, pipelineRef, nil)
+	_, _, _, err := fn(ctx, "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for nonexistent pipeline, got nil")
+	}
+}
+
+// TestGetChildPipelineFunc_ResolverWithoutRequester covers the dispatcher branch where
+// the PipelineRef has a Resolver set but the caller did not supply a remote-resolution
+// Requester. The dispatcher must fall through to the local resolver rather than panic
+// or attempt remote resolution.
+func TestGetChildPipelineFunc_ResolverWithoutRequester(t *testing.T) {
+	ctx := context.Background()
+	cfg := config.NewStore(logging.FromContext(ctx))
+	ctx = cfg.ToContext(ctx)
+
+	childPipeline := parse.MustParseV1Pipeline(t, `
+metadata:
+  name: child-pipeline
+  namespace: default
+spec:
+  tasks:
+  - name: child-task
+    taskSpec:
+      steps:
+      - name: step1
+        image: mirror.gcr.io/busybox
+`)
+	tektonClient := fake.NewSimpleClientset(childPipeline)
+
+	pr := &v1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default"},
+	}
+	pipelineRef := &v1.PipelineRef{
+		Name:        "child-pipeline",
+		ResolverRef: v1.ResolverRef{Resolver: "git"},
+	}
+
+	fn := resources.GetChildPipelineFunc(ctx, fakek8s.NewSimpleClientset(), tektonClient, nil /* requester */, pr, pipelineRef, nil)
+	p, refSource, vr, err := fn(ctx, "child-pipeline")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.Name != "child-pipeline" {
+		t.Errorf("expected pipeline name 'child-pipeline', got %q", p.Name)
+	}
+	if refSource != nil {
+		t.Errorf("expected nil refSource for local resolution, got %v", refSource)
+	}
+	if vr != nil {
+		t.Errorf("expected nil verification result for local resolution, got %v", vr)
+	}
+}
+
+// TestGetChildPipelineFunc_RemoteResolution covers the dispatcher branch where the
+// PipelineRef has a Resolver set and a Requester is supplied: the resolver path must
+// be taken and the resolved Pipeline returned to the caller. This mirrors the pattern
+// used by TestGetPipelineFunc_RemoteResolution.
+func TestGetChildPipelineFunc_RemoteResolution(t *testing.T) {
+	ctx, clients := getFakePipelineClient(t)
+	ctx = cfgtesting.EnableStableAPIFields(ctx)
+	cfg := config.FromContextOrDefaults(ctx)
+	ctx = config.ToContext(ctx, cfg)
+
+	pipelineYAML := strings.Join([]string{
+		"kind: Pipeline",
+		"apiVersion: tekton.dev/v1",
+		pipelineYAMLString,
+	}, "\n")
+	wantPipeline := parse.MustParseV1PipelineAndSetDefaults(t, pipelineYAMLString)
+
+	pipelineRef := &v1.PipelineRef{ResolverRef: v1.ResolverRef{Resolver: "git"}}
+	resolved := resolution.NewResolvedResource([]byte(pipelineYAML), nil /* annotations */, sampleRefSource.DeepCopy(), nil /* data error */)
+	requester := resolution.NewRequester(resolved, nil, resource.ResolverPayload{})
+
+	pr := &v1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default"},
+	}
+
+	fn := resources.GetChildPipelineFunc(ctx, fakek8s.NewSimpleClientset(), clients, requester, pr, pipelineRef, nil)
+	resolvedPipeline, resolvedRefSource, _, err := fn(ctx, pipelineRef.Name)
+	if err != nil {
+		t.Fatalf("failed to call pipelinefn: %s", err.Error())
+	}
+	if d := cmp.Diff(wantPipeline, resolvedPipeline); d != "" {
+		t.Errorf("resolved pipeline did not match: %s", diff.PrintWantGot(d))
+	}
+	if d := cmp.Diff(sampleRefSource, resolvedRefSource); d != "" {
+		t.Errorf("refSources did not match: %s", diff.PrintWantGot(d))
+	}
+}

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -29,6 +29,7 @@ import (
 	pipelineErrors "github.com/tektoncd/pipeline/pkg/apis/pipeline/errors"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	rprp "github.com/tektoncd/pipeline/pkg/reconciler/pipelinerun/pipelinespec"
 	"github.com/tektoncd/pipeline/pkg/reconciler/taskrun/resources"
 	"github.com/tektoncd/pipeline/pkg/remote"
 	resolutioncommon "github.com/tektoncd/pipeline/pkg/resolution/common"
@@ -75,6 +76,20 @@ func (e *TaskNotFoundError) Error() string {
 }
 
 func (e *TaskNotFoundError) Unwrap() error {
+	return e.Err
+}
+
+// PipelineNotFoundError indicates that the resolution failed because a referenced Pipeline couldn't be retrieved
+type PipelineNotFoundError struct {
+	Name string
+	Err  error
+}
+
+func (e *PipelineNotFoundError) Error() string {
+	return fmt.Sprintf("Couldn't retrieve Pipeline %q: %s", e.Name, e.Err.Error())
+}
+
+func (e *PipelineNotFoundError) Unwrap() error {
 	return e.Err
 }
 
@@ -149,11 +164,19 @@ func (t ResolvedPipelineTask) isDone(facts *PipelineRunFacts) bool {
 
 // IsRunning returns true only if the task is neither succeeded, cancelled nor failed
 func (t ResolvedPipelineTask) IsRunning() bool {
-	if t.IsCustomTask() && len(t.CustomRuns) == 0 {
-		return false
-	}
-	if !t.IsCustomTask() && len(t.TaskRuns) == 0 {
-		return false
+	switch {
+	case t.IsCustomTask():
+		if len(t.CustomRuns) == 0 {
+			return false
+		}
+	case t.IsChildPipeline():
+		if len(t.ChildPipelineRuns) == 0 {
+			return false
+		}
+	default:
+		if len(t.TaskRuns) == 0 {
+			return false
+		}
 	}
 	return !t.isSuccessful() && !t.isFailure()
 }
@@ -165,7 +188,7 @@ func (t ResolvedPipelineTask) IsCustomTask() bool {
 
 // IsChildPipeline returns true if the PipelineTask references a child Pipeline.
 func (t ResolvedPipelineTask) IsChildPipeline() bool {
-	return t.PipelineTask.PipelineSpec != nil
+	return t.PipelineTask.PipelineSpec != nil || t.PipelineTask.PipelineRef != nil
 }
 
 // getReason returns the latest reason if the run has completed successfully
@@ -682,6 +705,7 @@ func ResolvePipelineTask(
 	ctx context.Context,
 	pipelineRun v1.PipelineRun,
 	getChildPipelineRun GetPipelineRun,
+	getChildPipeline rprp.GetPipeline,
 	getTask resources.GetTask,
 	getTaskRun resources.GetTaskRun,
 	getRun GetRun,
@@ -716,9 +740,8 @@ func ResolvePipelineTask(
 			numCombinations,
 		)
 
-		// happy path: no pipelineRef, no local/remote resolution, no getPipeline
 		for _, childPipelineRunName := range rpt.ChildPipelineRunNames {
-			if err := rpt.setChildPipelineRunsAndResolvedPipeline(ctx, childPipelineRunName, getChildPipelineRun, pipelineTask); err != nil {
+			if err := rpt.setChildPipelineRunsAndResolvedPipeline(ctx, childPipelineRunName, getChildPipelineRun, getChildPipeline, pipelineTask); err != nil {
 				return nil, err
 			}
 		}
@@ -751,29 +774,48 @@ func (t *ResolvedPipelineTask) setChildPipelineRunsAndResolvedPipeline(
 	ctx context.Context,
 	childPipelineRunName string,
 	getChildPipelineRun GetPipelineRun,
+	getChildPipeline rprp.GetPipeline,
 	pipelineTask v1.PipelineTask,
 ) error {
 	childPipelineRun, err := getChildPipelineRun(childPipelineRunName)
-	if err != nil {
-		if !kerrors.IsNotFound(err) {
-			return fmt.Errorf("error retrieving child PipelineRun %s: %w", childPipelineRunName, err)
-		}
+	if err != nil && !kerrors.IsNotFound(err) {
+		return fmt.Errorf("error retrieving child PipelineRun %s: %w", childPipelineRunName, err)
 	}
 	if childPipelineRun != nil {
 		t.ChildPipelineRuns = append(t.ChildPipelineRuns, childPipelineRun)
 	}
 
-	rp := ResolvedPipeline{}
-	switch {
-	case pipelineTask.PipelineSpec != nil:
-		rp.PipelineSpec = pipelineTask.PipelineSpec
-	case pipelineTask.PipelineRef != nil:
-		return fmt.Errorf("PipelineRef for PipelineTask %q is not yet implemented", pipelineTask.Name)
-	default:
-		return fmt.Errorf("PipelineSpec in PipelineTask %q missing", pipelineTask.Name)
+	if pipelineTask.PipelineSpec == nil && pipelineTask.PipelineRef == nil {
+		return fmt.Errorf("PipelineTask %q must specify one of PipelineRef or PipelineSpec", pipelineTask.Name)
 	}
 
-	t.ResolvedPipeline = rp
+	if pipelineTask.PipelineSpec != nil {
+		t.ResolvedPipeline = ResolvedPipeline{PipelineSpec: pipelineTask.PipelineSpec}
+		return nil
+	}
+
+	// pipelineTask.PipelineRef != nil
+	p, _, vr, err := getChildPipeline(ctx, pipelineTask.PipelineRef.Name)
+	if errors.Is(err, remote.ErrRequestInProgress) || (err != nil && resolutioncommon.IsErrTransient(err)) {
+		return err
+	}
+	if err != nil {
+		name := pipelineTask.PipelineRef.Name
+		if len(strings.TrimSpace(name)) == 0 {
+			name = resource.GenerateErrorLogString(string(pipelineTask.PipelineRef.Resolver), pipelineTask.PipelineRef.Params)
+		}
+		return &PipelineNotFoundError{
+			Name: name,
+			Err:  err,
+		}
+	}
+
+	spec := p.Spec
+	t.ResolvedPipeline = ResolvedPipeline{
+		PipelineSpec:       &spec,
+		PipelineName:       p.Name,
+		VerificationResult: vr,
+	}
 	return nil
 }
 
@@ -788,10 +830,8 @@ func (t *ResolvedPipelineTask) setTaskRunsAndResolvedTask(
 	pipelineTask v1.PipelineTask,
 ) error {
 	taskRun, err := getTaskRun(taskRunName)
-	if err != nil {
-		if !kerrors.IsNotFound(err) {
-			return fmt.Errorf("error retrieving TaskRun %s: %w", taskRunName, err)
-		}
+	if err != nil && !kerrors.IsNotFound(err) {
+		return fmt.Errorf("error retrieving TaskRun %s: %w", taskRunName, err)
 	}
 	if taskRun != nil {
 		t.TaskRuns = append(t.TaskRuns, taskRun)
@@ -850,10 +890,7 @@ func resolveTask(
 	case pipelineTask.TaskSpec != nil:
 		rt.TaskSpec = &pipelineTask.TaskSpec.TaskSpec
 	default:
-		// If the alpha feature is enabled, and the user has configured pipelineSpec or pipelineRef, it will enter here.
-		// Currently, the controller is not yet adapted, and to avoid a panic, an error message is provided here.
-		// TODO: Adjust the logic here once the feature is supported in the future.
-		return nil, fmt.Errorf("currently, Task %q does not support PipelineRef, please use PipelineSpec, TaskRef or TaskSpec instead", pipelineTask.Name)
+		return nil, fmt.Errorf("PipelineTask %q must specify one of TaskRef, TaskSpec, PipelineRef, or PipelineSpec", pipelineTask.Name)
 	}
 	rt.TaskSpec.SetDefaults(ctx)
 	return rt, nil

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"sort"
-	"strings"
 	"testing"
 	"time"
 
@@ -33,6 +32,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/reconciler/apiserver"
 	"github.com/tektoncd/pipeline/pkg/reconciler/pipeline/dag"
 	"github.com/tektoncd/pipeline/pkg/reconciler/taskrun/resources"
+	"github.com/tektoncd/pipeline/pkg/remote"
 	resolutioncommon "github.com/tektoncd/pipeline/pkg/resolution/common"
 	"github.com/tektoncd/pipeline/pkg/trustedresources"
 	"github.com/tektoncd/pipeline/test/diff"
@@ -62,6 +62,10 @@ func nopGetTaskRun(string) (*v1.TaskRun, error) {
 
 func nopGetPipelineRun(string) (*v1.PipelineRun, error) {
 	return nil, errors.New("GetPipelineRun should not be called")
+}
+
+func nopGetPipeline(context.Context, string) (*v1.Pipeline, *v1.RefSource, *trustedresources.VerificationResult, error) {
+	return nil, nil, nil, errors.New("GetPipeline should not be called")
 }
 
 func getTaskFn(vr *trustedresources.VerificationResult, err error) resources.GetTask {
@@ -2611,7 +2615,7 @@ func TestResolvePipelineRun_CustomTask(t *testing.T) {
 	cfg := config.NewStore(logtesting.TestLogger(t))
 	ctx = cfg.ToContext(ctx)
 	for _, task := range pts {
-		ps, err := ResolvePipelineTask(ctx, pr, nopGetPipelineRun, nopGetTask, nopGetTaskRun, getRun, task, nil)
+		ps, err := ResolvePipelineTask(ctx, pr, nopGetPipelineRun, nopGetPipeline, nopGetTask, nopGetTaskRun, getRun, task, nil)
 		if err != nil {
 			t.Fatalf("ResolvePipelineTask: %v", err)
 		}
@@ -2639,7 +2643,7 @@ func TestResolvePipelineRun_CustomTask(t *testing.T) {
 	}
 }
 
-func TestResolvePipelineRun_ChildPipeline(t *testing.T) {
+func TestResolvePipelineRun_ChildPipelineWithPipelineSpec(t *testing.T) {
 	cfg := config.NewStore(logtesting.TestLogger(t))
 	ctx := cfg.ToContext(t.Context())
 
@@ -2669,6 +2673,7 @@ func TestResolvePipelineRun_ChildPipeline(t *testing.T) {
 			ctx,
 			parentPr,
 			getChildPipelineRun,
+			nopGetPipeline,
 			nopGetTask,
 			nopGetTaskRun,
 			nopGetCustomRun,
@@ -2707,7 +2712,7 @@ func TestResolvePipelineRun_PipelineTaskHasNoResources(t *testing.T) {
 	}
 	pipelineState := PipelineRunState{}
 	for _, task := range pts {
-		ps, err := ResolvePipelineTask(t.Context(), pr, nopGetPipelineRun, getTask, getTaskRun, nopGetCustomRun, task, nil)
+		ps, err := ResolvePipelineTask(t.Context(), pr, nopGetPipelineRun, nopGetPipeline, getTask, getTaskRun, nopGetCustomRun, task, nil)
 		if err != nil {
 			t.Errorf("Error getting tasks for fake pipeline %s: %s", p.ObjectMeta.Name, err)
 		}
@@ -2729,25 +2734,43 @@ func TestResolvePipelineRun_PipelineTaskHasNoResources(t *testing.T) {
 }
 
 func TestResolvePipelineRun_PipelineTaskHasPipelineRef(t *testing.T) {
-	pt := v1.PipelineTask{
-		Name:        "pipeline-in-pipeline",
-		PipelineRef: &v1.PipelineRef{Name: "pipeline"},
-	}
-
-	getTask := getTaskFn(nil, nil)
-	getTaskRun := getTaskRunFn(&trs[0])
-	pr := v1.PipelineRun{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "pipelinerun",
+	childPipeline := &v1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: "child-pipeline"},
+		Spec: v1.PipelineSpec{
+			Tasks: []v1.PipelineTask{{
+				Name:    "child-task",
+				TaskRef: &v1.TaskRef{Name: "a-task"},
+			}},
 		},
 	}
-
-	_, err := ResolvePipelineTask(t.Context(), pr, nopGetPipelineRun, getTask, getTaskRun, nopGetCustomRun, pt, nil)
-	if err == nil {
-		t.Errorf("Error getting tasks for fake pipeline %s, expected an error but got nil.", p.ObjectMeta.Name)
+	pt := v1.PipelineTask{
+		Name:        "pipeline-in-pipeline",
+		PipelineRef: &v1.PipelineRef{Name: "child-pipeline"},
 	}
-	if !strings.Contains(err.Error(), "does not support PipelineRef, please use PipelineSpec, TaskRef or TaskSpec instead") {
-		t.Errorf("Error getting tasks for fake pipeline %s: expected contains keyword but got %s", p.ObjectMeta.Name, err)
+	getPipeline := func(ctx context.Context, name string) (*v1.Pipeline, *v1.RefSource, *trustedresources.VerificationResult, error) {
+		return childPipeline, nil, nil, nil
+	}
+	pr := v1.PipelineRun{ObjectMeta: metav1.ObjectMeta{Name: "pipelinerun"}}
+	getChildPipelineRun := func(name string) (*v1.PipelineRun, error) { return nil, nil } //nolint:nilnil
+
+	expectedState := PipelineRunState{{
+		PipelineTask:          &pt,
+		ChildPipelineRunNames: []string{"pipelinerun-pipeline-in-pipeline"},
+		ChildPipelineRuns:     nil,
+		ResolvedPipeline: ResolvedPipeline{
+			PipelineName: "child-pipeline",
+			PipelineSpec: &childPipeline.Spec,
+		},
+	}}
+
+	rpt, err := ResolvePipelineTask(t.Context(), pr, getChildPipelineRun, getPipeline, nopGetTask, nopGetTaskRun, nopGetCustomRun, pt, nil)
+	if err != nil {
+		t.Fatalf("Did not expect error: %v", err)
+	}
+
+	actualState := PipelineRunState{rpt}
+	if d := cmp.Diff(expectedState, actualState); d != "" {
+		t.Errorf("Unexpected pipeline state: %s", diff.PrintWantGot(d))
 	}
 }
 
@@ -2794,7 +2817,7 @@ func TestResolvePipelineRun_TaskDoesntExist(t *testing.T) {
 		},
 	}
 	for _, pt := range pts {
-		_, err := ResolvePipelineTask(t.Context(), pr, nopGetPipelineRun, getTask, getTaskRun, nopGetCustomRun, pt, nil)
+		_, err := ResolvePipelineTask(t.Context(), pr, nopGetPipelineRun, nopGetPipeline, getTask, getTaskRun, nopGetCustomRun, pt, nil)
 		var tnf *TaskNotFoundError
 		switch {
 		case err == nil:
@@ -2836,7 +2859,7 @@ func TestResolvePipelineRun_VerificationFailed(t *testing.T) {
 		},
 	}
 	for _, pt := range pts {
-		rt, _ := ResolvePipelineTask(t.Context(), pr, nopGetPipelineRun, getTask, getTaskRun, nopGetCustomRun, pt, nil)
+		rt, _ := ResolvePipelineTask(t.Context(), pr, nopGetPipelineRun, nopGetPipeline, getTask, getTaskRun, nopGetCustomRun, pt, nil)
 		if d := cmp.Diff(verificationResult, rt.ResolvedTask.VerificationResult, cmpopts.EquateErrors()); d != "" {
 			t.Error(diff.PrintWantGot(d))
 		}
@@ -2867,7 +2890,7 @@ func TestResolvePipelineRun_TransientError(t *testing.T) {
 					Name: "pipelinerun",
 				},
 			}
-			_, err := ResolvePipelineTask(t.Context(), pr, nopGetPipelineRun, getTask, getTaskRun, nopGetCustomRun, pt, nil)
+			_, err := ResolvePipelineTask(t.Context(), pr, nopGetPipelineRun, nopGetPipeline, getTask, getTaskRun, nopGetCustomRun, pt, nil)
 
 			// This is really testing is that if the getTask function give ResolvePipelineTask a transient error,
 			// ResolvePipielineTask does not swallow that error
@@ -3113,7 +3136,7 @@ func TestResolvePipeline_WhenExpressions(t *testing.T) {
 	}
 
 	t.Run("When Expressions exist", func(t *testing.T) {
-		_, err := ResolvePipelineTask(t.Context(), pr, nopGetPipelineRun, getTask, getTaskRun, nopGetCustomRun, pt, nil)
+		_, err := ResolvePipelineTask(t.Context(), pr, nopGetPipelineRun, nopGetPipeline, getTask, getTaskRun, nopGetCustomRun, pt, nil)
 		if err != nil {
 			t.Fatalf("Did not expect error when resolving PipelineRun: %v", err)
 		}
@@ -3213,7 +3236,7 @@ func TestIsCustomTask(t *testing.T) {
 			ctx := t.Context()
 			cfg := config.NewStore(logtesting.TestLogger(t))
 			ctx = cfg.ToContext(ctx)
-			rpt, err := ResolvePipelineTask(ctx, pr, nopGetPipelineRun, getTask, getTaskRun, getRun, tc.pt, nil)
+			rpt, err := ResolvePipelineTask(ctx, pr, nopGetPipelineRun, nopGetPipeline, getTask, getTaskRun, getRun, tc.pt, nil)
 			if err != nil {
 				t.Fatalf("Did not expect error when resolving PipelineRun: %v", err)
 			}
@@ -3234,6 +3257,13 @@ func TestIsChildPipeline(t *testing.T) {
 	getTask := getTaskFn(nil, nil)
 	getTaskRun := getTaskRunFn(nil)
 	getChildPipelineRun := func(name string) (*v1.PipelineRun, error) { return nil, nil } //nolint:nilnil
+	childPipeline := &v1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: "child-pipeline"},
+		Spec:       v1.PipelineSpec{},
+	}
+	getPipeline := func(_ context.Context, _ string) (*v1.Pipeline, *v1.RefSource, *trustedresources.VerificationResult, error) {
+		return childPipeline, nil, nil, nil
+	}
 
 	for _, tc := range []struct {
 		name string
@@ -3253,12 +3283,18 @@ func TestIsChildPipeline(t *testing.T) {
 			TaskSpec: &v1.EmbeddedTask{},
 		},
 		want: false,
+	}, {
+		name: "pipelineTask with PipelineRef",
+		pt: v1.PipelineTask{
+			PipelineRef: &v1.PipelineRef{Name: "child-pipeline"},
+		},
+		want: true,
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := t.Context()
 			cfg := config.NewStore(logtesting.TestLogger(t))
 			ctx = cfg.ToContext(ctx)
-			rpt, err := ResolvePipelineTask(ctx, pr, getChildPipelineRun, getTask, getTaskRun, nopGetCustomRun, tc.pt, nil)
+			rpt, err := ResolvePipelineTask(ctx, pr, getChildPipelineRun, getPipeline, getTask, getTaskRun, nopGetCustomRun, tc.pt, nil)
 			if err != nil {
 				t.Fatalf("Did not expect error when resolving PipelineRun: %v", err)
 			}
@@ -4060,7 +4096,7 @@ func TestIsMatrixed(t *testing.T) {
 				},
 			})
 			ctx = cfg.ToContext(ctx)
-			rpt, err := ResolvePipelineTask(ctx, pr, nopGetPipelineRun, getTask, getTaskRun, getRun, tc.pt, nil)
+			rpt, err := ResolvePipelineTask(ctx, pr, nopGetPipelineRun, nopGetPipeline, getTask, getTaskRun, getRun, tc.pt, nil)
 			if err != nil {
 				t.Fatalf("Did not expect error when resolving PipelineRun: %v", err)
 			}
@@ -4217,7 +4253,7 @@ func TestResolvePipelineRunTask_WithMatrix(t *testing.T) {
 				},
 			})
 			ctx = cfg.ToContext(ctx)
-			rpt, err := ResolvePipelineTask(ctx, pr, nopGetPipelineRun, getTask, getTaskRun, getRun, tc.pt, tc.pst)
+			rpt, err := ResolvePipelineTask(ctx, pr, nopGetPipelineRun, nopGetPipeline, getTask, getTaskRun, getRun, tc.pt, tc.pst)
 			if err != nil {
 				t.Fatalf("Did not expect error when resolving PipelineRun: %v", err)
 			}
@@ -4383,7 +4419,7 @@ func TestResolvePipelineRunTask_WithMatrixedCustomTask(t *testing.T) {
 			if tc.getRun == nil {
 				tc.getRun = getRun
 			}
-			rpt, err := ResolvePipelineTask(ctx, pr, nopGetPipelineRun, getTask, getTaskRun, tc.getRun, tc.pt, tc.pst)
+			rpt, err := ResolvePipelineTask(ctx, pr, nopGetPipelineRun, nopGetPipeline, getTask, getTaskRun, tc.getRun, tc.pt, tc.pst)
 			if err != nil {
 				t.Fatalf("Did not expect error when resolving PipelineRun: %v", err)
 			}
@@ -5229,6 +5265,55 @@ func TestIsRunning(t *testing.T) {
 			CustomRuns:   []*v1beta1.CustomRun{withCustomRunCancelled(withCustomRunRetries(makeCustomRunFailed(customRuns[0]))), makeCustomRunStarted(customRuns[1])},
 		},
 		want: true,
+	}, {
+		name: "child pipelinerun not started",
+		rpt: ResolvedPipelineTask{
+			PipelineTask: &v1.PipelineTask{
+				Name:         "task",
+				PipelineSpec: &v1.PipelineSpec{Tasks: []v1.PipelineTask{{Name: "inner"}}},
+			},
+		},
+		want: false,
+	}, {
+		name: "child pipelinerun running",
+		rpt: ResolvedPipelineTask{
+			PipelineTask: &v1.PipelineTask{
+				Name:         "task",
+				PipelineSpec: &v1.PipelineSpec{Tasks: []v1.PipelineTask{{Name: "inner"}}},
+			},
+			ChildPipelineRuns: []*v1.PipelineRun{makePipelineRunStarted(prs[0])},
+		},
+		want: true,
+	}, {
+		name: "child pipelinerun succeeded",
+		rpt: ResolvedPipelineTask{
+			PipelineTask: &v1.PipelineTask{
+				Name:         "task",
+				PipelineSpec: &v1.PipelineSpec{Tasks: []v1.PipelineTask{{Name: "inner"}}},
+			},
+			ChildPipelineRuns: []*v1.PipelineRun{makePipelineRunSucceeded(prs[0])},
+		},
+		want: false,
+	}, {
+		name: "child pipelinerun failed",
+		rpt: ResolvedPipelineTask{
+			PipelineTask: &v1.PipelineTask{
+				Name:         "task",
+				PipelineSpec: &v1.PipelineSpec{Tasks: []v1.PipelineTask{{Name: "inner"}}},
+			},
+			ChildPipelineRuns: []*v1.PipelineRun{makePipelineRunFailed(prs[0])},
+		},
+		want: false,
+	}, {
+		name: "pipelineRef child pipelinerun running",
+		rpt: ResolvedPipelineTask{
+			PipelineTask: &v1.PipelineTask{
+				Name:        "task",
+				PipelineRef: &v1.PipelineRef{Name: "inner"},
+			},
+			ChildPipelineRuns: []*v1.PipelineRun{makePipelineRunStarted(prs[0])},
+		},
+		want: true,
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := tc.rpt.IsRunning(); got != tc.want {
@@ -6025,5 +6110,219 @@ func TestValidateParamEnumSubset_Invalid(t *testing.T) {
 		if d := cmp.Diff(tc.wantErr.Error(), err.Error()); d != "" {
 			t.Errorf("expecting error does not match in ValidateParamEnumSubset: %s", diff.PrintWantGot(d))
 		}
+	}
+}
+
+func TestSetChildPipelineRunsAndResolvedPipeline(t *testing.T) {
+	childPipeline := &v1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: "child-pipeline"},
+		Spec: v1.PipelineSpec{
+			Tasks: []v1.PipelineTask{{
+				Name:    "child-task",
+				TaskRef: &v1.TaskRef{Name: "a-task"},
+			}},
+		},
+	}
+	existingChildPipelineRun := &v1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "child-pr"},
+	}
+
+	for _, tc := range []struct {
+		name                   string
+		childPipelineRunFn     func(string) (*v1.PipelineRun, error)
+		getPipelineFn          func(context.Context, string) (*v1.Pipeline, *v1.RefSource, *trustedresources.VerificationResult, error)
+		pipelineTask           v1.PipelineTask
+		wantErr                bool
+		wantErrType            interface{}
+		wantPipelineName       string
+		wantChildPRCount       int
+		wantVerificationResult *trustedresources.VerificationResult
+	}{{
+		name: "PipelineSpec set inline",
+		childPipelineRunFn: func(name string) (*v1.PipelineRun, error) {
+			return nil, kerrors.NewNotFound(v1.Resource("pipelinerun"), name)
+		},
+		getPipelineFn: nopGetPipeline,
+		pipelineTask: v1.PipelineTask{
+			Name: "pip-task",
+			PipelineSpec: &v1.PipelineSpec{
+				Tasks: []v1.PipelineTask{{Name: "inline-task"}},
+			},
+		},
+		wantChildPRCount: 0,
+	}, {
+		name: "PipelineRef resolves successfully",
+		childPipelineRunFn: func(name string) (*v1.PipelineRun, error) {
+			return nil, kerrors.NewNotFound(v1.Resource("pipelinerun"), name)
+		},
+		getPipelineFn: func(_ context.Context, _ string) (*v1.Pipeline, *v1.RefSource, *trustedresources.VerificationResult, error) {
+			return childPipeline, nil, nil, nil
+		},
+		pipelineTask: v1.PipelineTask{
+			Name:        "pip-task",
+			PipelineRef: &v1.PipelineRef{Name: "child-pipeline"},
+		},
+		wantPipelineName: "child-pipeline",
+		wantChildPRCount: 0,
+	}, {
+		name: "child PipelineRun found",
+		childPipelineRunFn: func(_ string) (*v1.PipelineRun, error) {
+			return existingChildPipelineRun, nil
+		},
+		getPipelineFn: nopGetPipeline,
+		pipelineTask: v1.PipelineTask{
+			Name: "pip-task",
+			PipelineSpec: &v1.PipelineSpec{
+				Tasks: []v1.PipelineTask{{Name: "inline-task"}},
+			},
+		},
+		wantChildPRCount: 1,
+	}, {
+		name: "child PipelineRun retrieval error (non-NotFound)",
+		childPipelineRunFn: func(_ string) (*v1.PipelineRun, error) {
+			return nil, errors.New("some api error")
+		},
+		getPipelineFn: nopGetPipeline,
+		pipelineTask: v1.PipelineTask{
+			Name:         "pip-task",
+			PipelineSpec: &v1.PipelineSpec{},
+		},
+		wantErr: true,
+	}, {
+		name: "neither PipelineSpec nor PipelineRef set",
+		childPipelineRunFn: func(name string) (*v1.PipelineRun, error) {
+			return nil, kerrors.NewNotFound(v1.Resource("pipelinerun"), name)
+		},
+		getPipelineFn: nopGetPipeline,
+		pipelineTask:  v1.PipelineTask{Name: "pip-task"},
+		wantErr:       true,
+	}, {
+		name: "PipelineRef resolution — ErrRequestInProgress",
+		childPipelineRunFn: func(name string) (*v1.PipelineRun, error) {
+			return nil, kerrors.NewNotFound(v1.Resource("pipelinerun"), name)
+		},
+		getPipelineFn: func(_ context.Context, _ string) (*v1.Pipeline, *v1.RefSource, *trustedresources.VerificationResult, error) {
+			return nil, nil, nil, remote.ErrRequestInProgress
+		},
+		pipelineTask: v1.PipelineTask{
+			Name:        "pip-task",
+			PipelineRef: &v1.PipelineRef{Name: "child-pipeline"},
+		},
+		wantErr: true,
+	}, {
+		name: "PipelineRef resolution — transient error",
+		childPipelineRunFn: func(name string) (*v1.PipelineRun, error) {
+			return nil, kerrors.NewNotFound(v1.Resource("pipelinerun"), name)
+		},
+		getPipelineFn: func(_ context.Context, _ string) (*v1.Pipeline, *v1.RefSource, *trustedresources.VerificationResult, error) {
+			return nil, nil, nil, kerrors.NewConflict(v1.Resource("pipeline"), "child-pipeline", errors.New("conflict"))
+		},
+		pipelineTask: v1.PipelineTask{
+			Name:        "pip-task",
+			PipelineRef: &v1.PipelineRef{Name: "child-pipeline"},
+		},
+		wantErr: true,
+	}, {
+		name: "PipelineRef resolution — pipeline not found",
+		childPipelineRunFn: func(name string) (*v1.PipelineRun, error) {
+			return nil, kerrors.NewNotFound(v1.Resource("pipelinerun"), name)
+		},
+		getPipelineFn: func(_ context.Context, _ string) (*v1.Pipeline, *v1.RefSource, *trustedresources.VerificationResult, error) {
+			return nil, nil, nil, errors.New("pipeline not found")
+		},
+		pipelineTask: v1.PipelineTask{
+			Name:        "pip-task",
+			PipelineRef: &v1.PipelineRef{Name: "child-pipeline"},
+		},
+		wantErr:     true,
+		wantErrType: &PipelineNotFoundError{},
+	}, {
+		// A resolver-only PipelineRef has an empty Name; on failure the error
+		// name is derived from the resolver + params via GenerateErrorLogString.
+		name: "PipelineRef resolution — resolver ref with empty name",
+		childPipelineRunFn: func(name string) (*v1.PipelineRun, error) {
+			return nil, kerrors.NewNotFound(v1.Resource("pipelinerun"), name)
+		},
+		getPipelineFn: func(_ context.Context, _ string) (*v1.Pipeline, *v1.RefSource, *trustedresources.VerificationResult, error) {
+			return nil, nil, nil, errors.New("resolution failed")
+		},
+		pipelineTask: v1.PipelineTask{
+			Name: "pip-task",
+			PipelineRef: &v1.PipelineRef{
+				ResolverRef: v1.ResolverRef{
+					Resolver: "git",
+					Params: v1.Params{{
+						Name:  "url",
+						Value: v1.ParamValue{Type: v1.ParamTypeString, StringVal: "https://example.com/repo"},
+					}},
+				},
+			},
+		},
+		wantErr:     true,
+		wantErrType: &PipelineNotFoundError{},
+	}, {
+		name: "PipelineRef resolution propagates VerificationResult",
+		childPipelineRunFn: func(name string) (*v1.PipelineRun, error) {
+			return nil, kerrors.NewNotFound(v1.Resource("pipelinerun"), name)
+		},
+		getPipelineFn: func(_ context.Context, _ string) (*v1.Pipeline, *v1.RefSource, *trustedresources.VerificationResult, error) {
+			return childPipeline, nil, &trustedresources.VerificationResult{
+				VerificationResultType: trustedresources.VerificationError,
+				Err:                    trustedresources.ErrResourceVerificationFailed,
+			}, nil
+		},
+		pipelineTask: v1.PipelineTask{
+			Name:        "pip-task",
+			PipelineRef: &v1.PipelineRef{Name: "child-pipeline"},
+		},
+		wantPipelineName: "child-pipeline",
+		wantChildPRCount: 0,
+		wantVerificationResult: &trustedresources.VerificationResult{
+			VerificationResultType: trustedresources.VerificationError,
+			Err:                    trustedresources.ErrResourceVerificationFailed,
+		},
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			rpt := &ResolvedPipelineTask{}
+			err := rpt.setChildPipelineRunsAndResolvedPipeline(
+				t.Context(),
+				"child-pr-name",
+				tc.childPipelineRunFn,
+				tc.getPipelineFn,
+				tc.pipelineTask,
+			)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error but got nil")
+				}
+				if tc.wantErrType != nil {
+					var pnfErr *PipelineNotFoundError
+					if !errors.As(err, &pnfErr) {
+						t.Errorf("expected PipelineNotFoundError, got %T: %v", err, err)
+					}
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got := len(rpt.ChildPipelineRuns); got != tc.wantChildPRCount {
+				t.Errorf("expected %d ChildPipelineRuns, got %d", tc.wantChildPRCount, got)
+			}
+			if tc.wantPipelineName != "" {
+				if rpt.ResolvedPipeline.PipelineName != tc.wantPipelineName {
+					t.Errorf("expected PipelineName %q, got %q", tc.wantPipelineName, rpt.ResolvedPipeline.PipelineName)
+				}
+			}
+			if rpt.ResolvedPipeline.PipelineSpec == nil {
+				t.Error("expected ResolvedPipeline.PipelineSpec to be non-nil")
+			}
+			vrCmp := cmp.Comparer(func(x, y trustedresources.VerificationResult) bool {
+				return x.VerificationResultType == y.VerificationResultType && (errors.Is(x.Err, y.Err) || errors.Is(y.Err, x.Err))
+			})
+			if d := cmp.Diff(tc.wantVerificationResult, rpt.ResolvedPipeline.VerificationResult, vrCmp); d != "" {
+				t.Errorf("unexpected ResolvedPipeline.VerificationResult (-want +got): %s", d)
+			}
+		})
 	}
 }

--- a/pkg/reconciler/pipelinerun/resources/pipelinespec.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinespec.go
@@ -1,6 +1,9 @@
 package resources
 
-import v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+import (
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"github.com/tektoncd/pipeline/pkg/trustedresources"
+)
 
 // ResolvedPipeline contains the data that is needed to execute
 // a child PipelineRun.
@@ -8,6 +11,10 @@ type ResolvedPipeline struct {
 	PipelineName string
 	Kind         string
 	PipelineSpec *v1.PipelineSpec
+	// VerificationResult is the result from trusted resources verification
+	// for the resolved child Pipeline. Nil for inline PipelineSpec children
+	// or when the trusted-resources feature is disabled.
+	VerificationResult *trustedresources.VerificationResult
 }
 
 // GetPipelineRun is a function used to retrieve child PipelineRuns

--- a/pkg/reconciler/testing/factory.go
+++ b/pkg/reconciler/testing/factory.go
@@ -9,6 +9,7 @@ import (
 	"github.com/tektoncd/pipeline/test/parse"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"knative.dev/pkg/kmeta"
 )
 
 var (
@@ -94,6 +95,8 @@ spec:
         - name: mystep
           image: mirror.gcr.io/busybox
           script: 'echo "Hello from child PipelineRun 1!"'
+  taskRunTemplate:
+    serviceAccountName: default
 `, childPipelineTaskName1),
 	)
 
@@ -115,6 +118,8 @@ spec:
     - name: %s
       taskRef:
         name: %s
+  taskRunTemplate:
+    serviceAccountName: default
 `, childPipelineTaskName2, taskName),
 	)
 
@@ -179,10 +184,369 @@ spec:
         - name: mystep
           image: mirror.gcr.io/busybox
           script: 'echo "Hello from child PipelineRun!"'
+  taskRunTemplate:
+    serviceAccountName: default
 `, childPipelineTaskName),
 	)
 
 	return parentPipeline, parentPipelineRun, expectedChildPipelineRun
+}
+
+// OnePipelineRefInPipeline creates a standalone child Pipeline and a parent Pipeline that references
+// the child via pipelineRef (instead of inline pipelineSpec). It also creates the according PipelineRun
+// for it and the expected child PipelineRun against which the test will validate.
+func OnePipelineRefInPipeline(t *testing.T, namespace, parentPipelineRunName string) (*v1.Pipeline, *v1.Pipeline, *v1.PipelineRun, *v1.PipelineRun) {
+	t.Helper()
+	uid := "bar"
+	parentPipelineName := "parent-pipeline"
+	childPipelineName := "child-pipeline"
+	childPipelineTaskName := "child-pipeline-task"
+
+	childPipeline := parse.MustParseV1Pipeline(t, fmt.Sprintf(`
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  tasks:
+  - name: %s
+    taskSpec:
+      steps:
+      - name: mystep
+        image: mirror.gcr.io/busybox
+        script: 'echo "Hello from child PipelineRun!"'
+`, childPipelineName, namespace, childPipelineTaskName))
+
+	parentPipeline := parse.MustParseV1Pipeline(t, fmt.Sprintf(`
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  tasks:
+  - name: %s
+    pipelineRef:
+      name: %s
+`, parentPipelineName, namespace, childPipelineName, childPipelineName))
+
+	parentPipelineRun := parse.MustParseV1PipelineRun(t, fmt.Sprintf(`
+metadata:
+  name: %s
+  namespace: %s
+  uid: %s
+spec:
+  pipelineRef:
+    name: %s
+`, parentPipelineRunName, namespace, uid, parentPipelineName))
+
+	expectedName := parentPipelineRunName + "-" + childPipelineName
+	childObjectMeta := childPipelineRunWithObjectMeta(
+		expectedName,
+		namespace,
+		parentPipelineRunName,
+		parentPipelineName,
+		childPipelineName,
+		uid,
+	)
+	// Override the pipeline label with the child's actual pipeline name
+	// (the reconciler does this to avoid propagating the parent's label).
+	childObjectMeta.Labels[pipeline.PipelineLabelKey] = childPipelineName
+	expectedChildPipelineRun := parse.MustParseChildPipelineRunWithObjectMeta(
+		t,
+		childObjectMeta,
+		fmt.Sprintf(`
+spec:
+  pipelineRef:
+    name: %s
+  taskRunTemplate:
+    serviceAccountName: default
+`, childPipelineName),
+	)
+
+	return parentPipeline, childPipeline, parentPipelineRun, expectedChildPipelineRun
+}
+
+// OnePipelineRefInPipelineWithParams creates a parent Pipeline that references a child Pipeline
+// via pipelineRef with params passed through. It returns (parentPipeline, childPipeline, parentPipelineRun, expectedChildPipelineRun).
+func OnePipelineRefInPipelineWithParams(t *testing.T, namespace, parentPipelineRunName string) (*v1.Pipeline, *v1.Pipeline, *v1.PipelineRun, *v1.PipelineRun) {
+	t.Helper()
+	uid := "bar"
+	parentPipelineName := "parent-pipeline"
+	childPipelineName := "child-pipeline"
+	childPipelineTaskName := "child-pipeline-task"
+
+	childPipeline := parse.MustParseV1Pipeline(t, fmt.Sprintf(`
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  params:
+  - name: msg
+    type: string
+  tasks:
+  - name: %s
+    taskSpec:
+      params:
+      - name: msg
+        type: string
+      steps:
+      - name: mystep
+        image: mirror.gcr.io/busybox
+        script: 'echo $(params.msg)'
+    params:
+    - name: msg
+      value: $(params.msg)
+`, childPipelineName, namespace, childPipelineTaskName))
+
+	parentPipeline := parse.MustParseV1Pipeline(t, fmt.Sprintf(`
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  params:
+  - name: greeting
+    type: string
+  tasks:
+  - name: %s
+    pipelineRef:
+      name: %s
+    params:
+    - name: msg
+      value: $(params.greeting)
+`, parentPipelineName, namespace, childPipelineName, childPipelineName))
+
+	parentPipelineRun := parse.MustParseV1PipelineRun(t, fmt.Sprintf(`
+metadata:
+  name: %s
+  namespace: %s
+  uid: %s
+spec:
+  pipelineRef:
+    name: %s
+  params:
+  - name: greeting
+    value: hello-world
+`, parentPipelineRunName, namespace, uid, parentPipelineName))
+
+	expectedName := parentPipelineRunName + "-" + childPipelineName
+	childObjectMeta := childPipelineRunWithObjectMeta(
+		expectedName,
+		namespace,
+		parentPipelineRunName,
+		parentPipelineName,
+		childPipelineName,
+		uid,
+	)
+	childObjectMeta.Labels[pipeline.PipelineLabelKey] = childPipelineName
+	expectedChildPipelineRun := parse.MustParseChildPipelineRunWithObjectMeta(
+		t,
+		childObjectMeta,
+		fmt.Sprintf(`
+spec:
+  pipelineRef:
+    name: %s
+  params:
+  - name: msg
+    value: hello-world
+  taskRunTemplate:
+    serviceAccountName: default
+`, childPipelineName),
+	)
+
+	return parentPipeline, childPipeline, parentPipelineRun, expectedChildPipelineRun
+}
+
+// OnePipelineRefInPipelineWithWorkspaces creates a parent Pipeline that references a child Pipeline
+// via pipelineRef with workspaces mapped through. It returns (parentPipeline, childPipeline, parentPipelineRun, expectedChildPipelineRun).
+func OnePipelineRefInPipelineWithWorkspaces(t *testing.T, namespace, parentPipelineRunName string) (*v1.Pipeline, *v1.Pipeline, *v1.PipelineRun, *v1.PipelineRun) {
+	t.Helper()
+	uid := "bar"
+	parentPipelineName := "parent-pipeline"
+	childPipelineName := "child-pipeline"
+	childPipelineTaskName := "child-pipeline-task"
+
+	childPipeline := parse.MustParseV1Pipeline(t, fmt.Sprintf(`
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  workspaces:
+  - name: child-ws
+  tasks:
+  - name: %s
+    taskSpec:
+      steps:
+      - name: mystep
+        image: mirror.gcr.io/busybox
+        script: 'ls $(workspaces.child-ws.path)'
+      workspaces:
+      - name: child-ws
+    workspaces:
+    - name: child-ws
+      workspace: child-ws
+`, childPipelineName, namespace, childPipelineTaskName))
+
+	parentPipeline := parse.MustParseV1Pipeline(t, fmt.Sprintf(`
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  workspaces:
+  - name: parent-ws
+  tasks:
+  - name: %s
+    pipelineRef:
+      name: %s
+    workspaces:
+    - name: child-ws
+      workspace: parent-ws
+`, parentPipelineName, namespace, childPipelineName, childPipelineName))
+
+	parentPipelineRun := parse.MustParseV1PipelineRun(t, fmt.Sprintf(`
+metadata:
+  name: %s
+  namespace: %s
+  uid: %s
+spec:
+  pipelineRef:
+    name: %s
+  workspaces:
+  - name: parent-ws
+    emptyDir: {}
+`, parentPipelineRunName, namespace, uid, parentPipelineName))
+
+	expectedName := parentPipelineRunName + "-" + childPipelineName
+	childObjectMeta := childPipelineRunWithObjectMeta(
+		expectedName,
+		namespace,
+		parentPipelineRunName,
+		parentPipelineName,
+		childPipelineName,
+		uid,
+	)
+	childObjectMeta.Labels[pipeline.PipelineLabelKey] = childPipelineName
+	expectedChildPipelineRun := parse.MustParseChildPipelineRunWithObjectMeta(
+		t,
+		childObjectMeta,
+		fmt.Sprintf(`
+spec:
+  pipelineRef:
+    name: %s
+  workspaces:
+  - name: child-ws
+    emptyDir: {}
+  taskRunTemplate:
+    serviceAccountName: default
+`, childPipelineName),
+	)
+
+	return parentPipeline, childPipeline, parentPipelineRun, expectedChildPipelineRun
+}
+
+// OnePipelineRefInPipelineWithParamsAndWorkspaces creates a parent Pipeline that references a child Pipeline
+// via pipelineRef with both params and workspaces. It returns (parentPipeline, childPipeline, parentPipelineRun, expectedChildPipelineRun).
+func OnePipelineRefInPipelineWithParamsAndWorkspaces(t *testing.T, namespace, parentPipelineRunName string) (*v1.Pipeline, *v1.Pipeline, *v1.PipelineRun, *v1.PipelineRun) {
+	t.Helper()
+	uid := "bar"
+	parentPipelineName := "parent-pipeline"
+	childPipelineName := "child-pipeline"
+	childPipelineTaskName := "child-pipeline-task"
+
+	childPipeline := parse.MustParseV1Pipeline(t, fmt.Sprintf(`
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  params:
+  - name: msg
+    type: string
+  workspaces:
+  - name: child-ws
+  tasks:
+  - name: %s
+    taskSpec:
+      params:
+      - name: msg
+        type: string
+      steps:
+      - name: mystep
+        image: mirror.gcr.io/busybox
+        script: 'echo $(params.msg) && ls $(workspaces.child-ws.path)'
+      workspaces:
+      - name: child-ws
+    params:
+    - name: msg
+      value: $(params.msg)
+    workspaces:
+    - name: child-ws
+      workspace: child-ws
+`, childPipelineName, namespace, childPipelineTaskName))
+
+	parentPipeline := parse.MustParseV1Pipeline(t, fmt.Sprintf(`
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  params:
+  - name: greeting
+    type: string
+  workspaces:
+  - name: parent-ws
+  tasks:
+  - name: %s
+    pipelineRef:
+      name: %s
+    params:
+    - name: msg
+      value: $(params.greeting)
+    workspaces:
+    - name: child-ws
+      workspace: parent-ws
+`, parentPipelineName, namespace, childPipelineName, childPipelineName))
+
+	parentPipelineRun := parse.MustParseV1PipelineRun(t, fmt.Sprintf(`
+metadata:
+  name: %s
+  namespace: %s
+  uid: %s
+spec:
+  pipelineRef:
+    name: %s
+  params:
+  - name: greeting
+    value: hello-world
+  workspaces:
+  - name: parent-ws
+    emptyDir: {}
+`, parentPipelineRunName, namespace, uid, parentPipelineName))
+
+	expectedName := parentPipelineRunName + "-" + childPipelineName
+	childObjectMeta := childPipelineRunWithObjectMeta(
+		expectedName,
+		namespace,
+		parentPipelineRunName,
+		parentPipelineName,
+		childPipelineName,
+		uid,
+	)
+	childObjectMeta.Labels[pipeline.PipelineLabelKey] = childPipelineName
+	expectedChildPipelineRun := parse.MustParseChildPipelineRunWithObjectMeta(
+		t,
+		childObjectMeta,
+		fmt.Sprintf(`
+spec:
+  pipelineRef:
+    name: %s
+  params:
+  - name: msg
+    value: hello-world
+  workspaces:
+  - name: child-ws
+    emptyDir: {}
+  taskRunTemplate:
+    serviceAccountName: default
+`, childPipelineName),
+	)
+
+	return parentPipeline, childPipeline, parentPipelineRun, expectedChildPipelineRun
 }
 
 func WithAnnotationAndLabel(pr *v1.PipelineRun, withUnused bool) *v1.PipelineRun {
@@ -277,7 +641,7 @@ spec:
 `, parentPipelineRunName, namespace, uid, parentPipelineName))
 
 	// expected child pipeline run created by parent
-	expectedChildName := parentPipelineRunName + "-" + childPipelineName
+	expectedChildName := kmeta.ChildName(parentPipelineRunName, "-"+childPipelineName)
 	expectedChildPipelineRun := parse.MustParseChildPipelineRunWithObjectMeta(
 		t,
 		childPipelineRunWithObjectMeta(
@@ -301,11 +665,13 @@ spec:
             - name: mystep
               image: mirror.gcr.io/busybox
               script: 'echo "Hello from grandchild Pipeline!"'
+  taskRunTemplate:
+    serviceAccountName: default
 `, grandchildPipelineName, grandchildPipelineTaskName),
 	)
 
 	// expected grandchild pipeline run created by child
-	expectedGrandchildName := expectedChildName + "-" + grandchildPipelineName
+	expectedGrandchildName := kmeta.ChildName(expectedChildName, "-"+grandchildPipelineName)
 	expectedGrandchildPipelineRun := parse.MustParseChildPipelineRunWithObjectMeta(
 		t,
 		childPipelineRunWithObjectMeta(
@@ -326,8 +692,589 @@ spec:
         - name: mystep
           image: mirror.gcr.io/busybox
           script: 'echo "Hello from grandchild Pipeline!"'
+  taskRunTemplate:
+    serviceAccountName: default
 `, grandchildPipelineTaskName),
 	)
 
 	return parentPipeline, parentPipelineRun, expectedChildPipelineRun, expectedGrandchildPipelineRun
+}
+
+// NestedPipelineRefsInPipeline creates a three-level nested pipeline structure using PipelineRef:
+// Parent Pipeline (A) -> Child Pipeline (B) via PipelineRef -> Grandchild Pipeline (C) via PipelineRef
+// Returns all three pipelines, the parent PipelineRun, expected child PipelineRun, and expected grandchild PipelineRun.
+func NestedPipelineRefsInPipeline(t *testing.T, namespace, parentPipelineRunName string) (*v1.Pipeline, *v1.Pipeline, *v1.Pipeline, *v1.PipelineRun, *v1.PipelineRun, *v1.PipelineRun) {
+	t.Helper()
+	uid := "nested-ref"
+	parentPipelineName := "parent-pipeline"
+	childPipelineName := "child-ppl"
+	grandchildPipelineName := "grandchild-ppl"
+	grandchildTaskName := "grandchild-task"
+
+	grandchildPipeline := parse.MustParseV1Pipeline(t, fmt.Sprintf(`
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  tasks:
+  - name: %s
+    taskSpec:
+      steps:
+      - name: mystep
+        image: mirror.gcr.io/busybox
+        script: 'echo "Hello from grandchild Pipeline!"'
+`, grandchildPipelineName, namespace, grandchildTaskName))
+
+	childPipeline := parse.MustParseV1Pipeline(t, fmt.Sprintf(`
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  tasks:
+  - name: %s
+    pipelineRef:
+      name: %s
+`, childPipelineName, namespace, grandchildPipelineName, grandchildPipelineName))
+
+	parentPipeline := parse.MustParseV1Pipeline(t, fmt.Sprintf(`
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  tasks:
+  - name: %s
+    pipelineRef:
+      name: %s
+`, parentPipelineName, namespace, childPipelineName, childPipelineName))
+
+	parentPipelineRun := parse.MustParseV1PipelineRun(t, fmt.Sprintf(`
+metadata:
+  name: %s
+  namespace: %s
+  uid: %s
+spec:
+  pipelineRef:
+    name: %s
+`, parentPipelineRunName, namespace, uid, parentPipelineName))
+
+	// expected child pipeline run created by parent
+	expectedChildName := kmeta.ChildName(parentPipelineRunName, "-"+childPipelineName)
+	childObjectMeta := childPipelineRunWithObjectMeta(
+		expectedChildName,
+		namespace,
+		parentPipelineRunName,
+		parentPipelineName,
+		childPipelineName,
+		uid,
+	)
+	childObjectMeta.Labels[pipeline.PipelineLabelKey] = childPipelineName
+	expectedChildPipelineRun := parse.MustParseChildPipelineRunWithObjectMeta(
+		t,
+		childObjectMeta,
+		fmt.Sprintf(`
+spec:
+  pipelineRef:
+    name: %s
+  taskRunTemplate:
+    serviceAccountName: default
+`, childPipelineName),
+	)
+
+	// expected grandchild pipeline run created by child
+	expectedGrandchildName := kmeta.ChildName(expectedChildName, "-"+grandchildPipelineName)
+	grandchildObjectMeta := childPipelineRunWithObjectMeta(
+		expectedGrandchildName,
+		namespace,
+		expectedChildName,
+		expectedChildName,
+		grandchildPipelineName,
+		"", // keep empty, UID is not set on actual child PipelineRun by fake client
+	)
+	grandchildObjectMeta.Labels[pipeline.PipelineLabelKey] = grandchildPipelineName
+	expectedGrandchildPipelineRun := parse.MustParseChildPipelineRunWithObjectMeta(
+		t,
+		grandchildObjectMeta,
+		fmt.Sprintf(`
+spec:
+  pipelineRef:
+    name: %s
+  taskRunTemplate:
+    serviceAccountName: default
+`, grandchildPipelineName),
+	)
+
+	return parentPipeline, childPipeline, grandchildPipeline, parentPipelineRun, expectedChildPipelineRun, expectedGrandchildPipelineRun
+}
+
+// SelfReferencingPipelineRefCycle returns a Pipeline whose only PipelineTask
+// has a pipelineRef back to itself, and a PipelineRun that runs it. The
+// PipelineRun is pre-labelled with tekton.dev/pipeline so unit-level reconcile
+// tests (which seed the run directly) exercise the cycle-detection label walk.
+// Shared by unit and e2e tests for self-cycle detection.
+func SelfReferencingPipelineRefCycle(t *testing.T, namespace, parentPipelineRunName string) (*v1.Pipeline, *v1.PipelineRun) {
+	t.Helper()
+	pipelineName := "self-ref-pipeline"
+	pipelineObj := &v1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: pipelineName, Namespace: namespace},
+		Spec: v1.PipelineSpec{Tasks: []v1.PipelineTask{{
+			Name:        "ref-self",
+			PipelineRef: &v1.PipelineRef{Name: pipelineName},
+		}}},
+	}
+	pipelineRun := &v1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      parentPipelineRunName,
+			Namespace: namespace,
+			Labels:    map[string]string{pipeline.PipelineLabelKey: pipelineName},
+		},
+		Spec: v1.PipelineRunSpec{PipelineRef: &v1.PipelineRef{Name: pipelineName}},
+	}
+	return pipelineObj, pipelineRun
+}
+
+// TwoLevelPipelineRefCycle returns Pipelines pipeline-a and pipeline-b where
+// each references the other via pipelineRef, plus a PipelineRun that runs
+// pipeline-a. Shared by unit and e2e tests for two-level cycle detection.
+func TwoLevelPipelineRefCycle(t *testing.T, namespace, parentPipelineRunName string) (*v1.Pipeline, *v1.Pipeline, *v1.PipelineRun) {
+	t.Helper()
+	const (
+		pipelineAName = "pipeline-a"
+		pipelineBName = "pipeline-b"
+	)
+	pipelineA := &v1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: pipelineAName, Namespace: namespace},
+		Spec: v1.PipelineSpec{Tasks: []v1.PipelineTask{{
+			Name:        pipelineBName,
+			PipelineRef: &v1.PipelineRef{Name: pipelineBName},
+		}}},
+	}
+	pipelineB := &v1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: pipelineBName, Namespace: namespace},
+		Spec: v1.PipelineSpec{Tasks: []v1.PipelineTask{{
+			Name:        pipelineAName,
+			PipelineRef: &v1.PipelineRef{Name: pipelineAName},
+		}}},
+	}
+	parentPipelineRun := &v1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      parentPipelineRunName,
+			Namespace: namespace,
+			Labels:    map[string]string{pipeline.PipelineLabelKey: pipelineAName},
+		},
+		Spec: v1.PipelineRunSpec{PipelineRef: &v1.PipelineRef{Name: pipelineAName}},
+	}
+	return pipelineA, pipelineB, parentPipelineRun
+}
+
+// OnePipelineRefMissing returns a parent Pipeline that references a
+// non-existent Pipeline by name, plus a PipelineRun that runs the parent.
+// Shared by unit and e2e tests for the missing-child-pipeline failure path.
+func OnePipelineRefMissing(t *testing.T, namespace, parentPipelineRunName string) (*v1.Pipeline, *v1.PipelineRun) {
+	t.Helper()
+	parentPipeline := &v1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: "parent-ref-not-found", Namespace: namespace},
+		Spec: v1.PipelineSpec{Tasks: []v1.PipelineTask{{
+			Name:        "ref-nonexistent",
+			PipelineRef: &v1.PipelineRef{Name: "nonexistent-pipeline"},
+		}}},
+	}
+	parentPipelineRun := &v1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{Name: parentPipelineRunName, Namespace: namespace},
+		Spec:       v1.PipelineRunSpec{PipelineRef: &v1.PipelineRef{Name: "parent-ref-not-found"}},
+	}
+	return parentPipeline, parentPipelineRun
+}
+
+// OnePipelineRefMissingWorkspace returns a parent Pipeline that references a
+// child Pipeline declaring a workspace, where the parent omits the
+// corresponding binding — so the child PipelineRun fails workspace
+// validation.
+func OnePipelineRefMissingWorkspace(t *testing.T, namespace, parentPipelineRunName string) (*v1.Pipeline, *v1.Pipeline, *v1.PipelineRun) {
+	t.Helper()
+	childPipeline := parse.MustParseV1Pipeline(t, fmt.Sprintf(`
+metadata:
+  name: child-pipeline-workspace
+  namespace: %s
+spec:
+  workspaces:
+  - name: child-ws
+  tasks:
+  - name: use-workspace
+    taskSpec:
+      steps:
+      - name: ls
+        image: mirror.gcr.io/busybox
+        script: |
+          ls $(workspaces.shared.path)
+      workspaces:
+      - name: shared
+    workspaces:
+    - name: shared
+      workspace: child-ws
+`, namespace))
+	parentPipeline := parse.MustParseV1Pipeline(t, fmt.Sprintf(`
+metadata:
+  name: parent-pipeline-missing-ws
+  namespace: %s
+spec:
+  tasks:
+  - name: child-pipeline-workspace
+    pipelineRef:
+      name: child-pipeline-workspace
+`, namespace))
+	parentPipelineRun := parse.MustParseV1PipelineRun(t, fmt.Sprintf(`
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  pipelineRef:
+    name: parent-pipeline-missing-ws
+`, parentPipelineRunName, namespace))
+	return parentPipeline, childPipeline, parentPipelineRun
+}
+
+// pinpChildTaskSpecPipeline returns a minimal standalone child Pipeline with a
+// single taskSpec task, for use as a pipelineRef target in PinP tests. The task
+// echoes the pipeline name so child PipelineRuns are distinguishable at runtime.
+func pinpChildTaskSpecPipeline(t *testing.T, name, namespace string) *v1.Pipeline {
+	t.Helper()
+	return parse.MustParseV1Pipeline(t, fmt.Sprintf(`
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  tasks:
+  - name: run
+    taskSpec:
+      steps:
+      - name: echo
+        image: mirror.gcr.io/busybox
+        script: 'echo %s'
+`, name, namespace, name))
+}
+
+// MultiplePipelineRefsInPipeline returns a parent Pipeline with two pipelineRef
+// PipelineTasks (each targeting a standalone child Pipeline), the two child
+// Pipelines, the parent PipelineRun, and the two expected child PipelineRuns.
+// Shared by unit and e2e tests for the multi-child pipelineRef path.
+func MultiplePipelineRefsInPipeline(t *testing.T, namespace, parentPipelineRunName string) (*v1.Pipeline, []*v1.Pipeline, *v1.PipelineRun, []*v1.PipelineRun) {
+	t.Helper()
+	childA := pinpChildTaskSpecPipeline(t, "child-a", namespace)
+	childB := pinpChildTaskSpecPipeline(t, "child-b", namespace)
+
+	parentPipeline := parse.MustParseV1Pipeline(t, fmt.Sprintf(`
+metadata:
+  name: parent-multi-ref
+  namespace: %s
+spec:
+  tasks:
+  - name: child-a
+    pipelineRef:
+      name: child-a
+  - name: child-b
+    pipelineRef:
+      name: child-b
+`, namespace))
+
+	parentPipelineRun := parse.MustParseV1PipelineRun(t, fmt.Sprintf(`
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  pipelineRef:
+    name: parent-multi-ref
+`, parentPipelineRunName, namespace))
+
+	var expectedChildPipelineRuns []*v1.PipelineRun
+	for _, name := range []string{"child-a", "child-b"} {
+		expectedChildPipelineRuns = append(expectedChildPipelineRuns, &v1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{Name: kmeta.ChildName(parentPipelineRunName, "-"+name), Namespace: namespace},
+			Spec:       v1.PipelineRunSpec{PipelineRef: &v1.PipelineRef{Name: name}},
+		})
+	}
+
+	return parentPipeline, []*v1.Pipeline{childA, childB}, parentPipelineRun, expectedChildPipelineRuns
+}
+
+// MixedPipelineRefSpecAndTaskRefInPipeline returns a parent Pipeline that mixes
+// the three child kinds in one Pipeline: a pipelineRef child, an inline
+// pipelineSpec child, and a regular taskRef task. It returns the referenced
+// Task, the parent Pipeline, the standalone child Pipeline (the pipelineRef
+// target), the parent PipelineRun, and the expected pipelineRef and pipelineSpec
+// child PipelineRuns. Shared by unit and e2e tests for the mixed-children path.
+func MixedPipelineRefSpecAndTaskRefInPipeline(t *testing.T, namespace, parentPipelineRunName string) (*v1.Task, *v1.Pipeline, *v1.Pipeline, *v1.PipelineRun, *v1.PipelineRun, *v1.PipelineRun) {
+	t.Helper()
+	helloTask := parse.MustParseV1Task(t, fmt.Sprintf(`
+metadata:
+  name: hello-task
+  namespace: %s
+spec:
+  steps:
+  - name: echo
+    image: mirror.gcr.io/busybox
+    script: 'echo hello'
+`, namespace))
+
+	childRef := pinpChildTaskSpecPipeline(t, "child-ref", namespace)
+
+	parentPipeline := parse.MustParseV1Pipeline(t, fmt.Sprintf(`
+metadata:
+  name: parent-mixed
+  namespace: %s
+spec:
+  tasks:
+  - name: ref-child
+    pipelineRef:
+      name: child-ref
+  - name: spec-child
+    pipelineSpec:
+      tasks:
+      - name: inline
+        taskSpec:
+          steps:
+          - name: echo
+            image: mirror.gcr.io/busybox
+            script: 'echo spec-child'
+  - name: direct-task
+    taskRef:
+      name: hello-task
+`, namespace))
+
+	parentPipelineRun := parse.MustParseV1PipelineRun(t, fmt.Sprintf(`
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  pipelineRef:
+    name: parent-mixed
+`, parentPipelineRunName, namespace))
+
+	expectedRefChild := &v1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{Name: kmeta.ChildName(parentPipelineRunName, "-ref-child"), Namespace: namespace},
+		Spec:       v1.PipelineRunSpec{PipelineRef: &v1.PipelineRef{Name: "child-ref"}},
+	}
+	// The pipelineSpec child carries the inline spec copied from the parent's
+	// spec-child task, so createKindsMap can derive its leaf TaskRun and
+	// assertPinP can diff the resolved spec.
+	expectedSpecChild := &v1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{Name: kmeta.ChildName(parentPipelineRunName, "-spec-child"), Namespace: namespace},
+		Spec:       v1.PipelineRunSpec{PipelineSpec: parentPipeline.Spec.Tasks[1].PipelineSpec},
+	}
+
+	return helloTask, parentPipeline, childRef, parentPipelineRun, expectedRefChild, expectedSpecChild
+}
+
+// PipelineRefInPipelineWhenSkipped returns a parent Pipeline whose only
+// PipelineTask references a child Pipeline but is guarded by a when expression
+// that evaluates to false, plus the child Pipeline and the parent PipelineRun.
+// No child PipelineRun is expected. Shared by unit and e2e tests for the
+// when-expression-skips-child path.
+func PipelineRefInPipelineWhenSkipped(t *testing.T, namespace, parentPipelineRunName string) (*v1.Pipeline, *v1.Pipeline, *v1.PipelineRun) {
+	t.Helper()
+	childPipeline := pinpChildTaskSpecPipeline(t, "child-skip", namespace)
+
+	// "run" is not in ["no"], so the guard is false and the task is skipped.
+	parentPipeline := parse.MustParseV1Pipeline(t, fmt.Sprintf(`
+metadata:
+  name: parent-when-skip
+  namespace: %s
+spec:
+  tasks:
+  - name: maybe-child
+    when:
+    - input: "run"
+      operator: in
+      values: ["no"]
+    pipelineRef:
+      name: child-skip
+`, namespace))
+
+	parentPipelineRun := parse.MustParseV1PipelineRun(t, fmt.Sprintf(`
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  pipelineRef:
+    name: parent-when-skip
+`, parentPipelineRunName, namespace))
+
+	return parentPipeline, childPipeline, parentPipelineRun
+}
+
+// PipelineRefInFinally returns a parent Pipeline with a main task and a finally
+// PipelineTask that references a child Pipeline, plus the child Pipeline, the
+// parent PipelineRun, and the expected finally child PipelineRun. Used by e2e
+// tests for the pipelineRef-in-finally path.
+func PipelineRefInFinally(t *testing.T, namespace, parentPipelineRunName string) (*v1.Pipeline, *v1.Pipeline, *v1.PipelineRun, *v1.PipelineRun) {
+	t.Helper()
+	finallyChild := pinpChildTaskSpecPipeline(t, "child-finally", namespace)
+
+	parentPipeline := parse.MustParseV1Pipeline(t, fmt.Sprintf(`
+metadata:
+  name: parent-finally
+  namespace: %s
+spec:
+  tasks:
+  - name: main
+    taskSpec:
+      steps:
+      - name: echo
+        image: mirror.gcr.io/busybox
+        script: 'echo main'
+  finally:
+  - name: cleanup-child
+    pipelineRef:
+      name: child-finally
+`, namespace))
+
+	parentPipelineRun := parse.MustParseV1PipelineRun(t, fmt.Sprintf(`
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  pipelineRef:
+    name: parent-finally
+`, parentPipelineRunName, namespace))
+
+	expectedChildPipelineRun := &v1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{Name: kmeta.ChildName(parentPipelineRunName, "-cleanup-child"), Namespace: namespace},
+		Spec:       v1.PipelineRunSpec{PipelineRef: &v1.PipelineRef{Name: "child-finally"}},
+	}
+
+	return parentPipeline, finallyChild, parentPipelineRun, expectedChildPipelineRun
+}
+
+// PipelineRefWithPVCWorkspace returns a parent Pipeline that writes a file to a
+// PVC-backed workspace and then maps that same workspace into a child Pipeline
+// via pipelineRef, where a task in the child reads the file back. It returns the
+// child Pipeline, the parent Pipeline, the parent PipelineRun (with a
+// volumeClaimTemplate workspace), and the expected child PipelineRun. The parent
+// only succeeds if the child sees the parent-written data, proving the volume is
+// shared across the parent->child boundary. Used by e2e tests.
+func PipelineRefWithPVCWorkspace(t *testing.T, namespace, parentPipelineRunName string) (*v1.Pipeline, *v1.Pipeline, *v1.PipelineRun, *v1.PipelineRun) {
+	t.Helper()
+	childPipeline := parse.MustParseV1Pipeline(t, fmt.Sprintf(`
+metadata:
+  name: child-reader
+  namespace: %s
+spec:
+  workspaces:
+  - name: child-ws
+  tasks:
+  - name: read
+    workspaces:
+    - name: ws
+      workspace: child-ws
+    taskSpec:
+      workspaces:
+      - name: ws
+      steps:
+      - name: read
+        image: mirror.gcr.io/busybox
+        script: |
+          grep -q hello-pinp $(workspaces.ws.path)/data
+`, namespace))
+
+	parentPipeline := parse.MustParseV1Pipeline(t, fmt.Sprintf(`
+metadata:
+  name: parent-pvc-ws
+  namespace: %s
+spec:
+  workspaces:
+  - name: shared
+  tasks:
+  - name: write
+    workspaces:
+    - name: ws
+      workspace: shared
+    taskSpec:
+      workspaces:
+      - name: ws
+      steps:
+      - name: write
+        image: mirror.gcr.io/busybox
+        script: |
+          echo hello-pinp > $(workspaces.ws.path)/data
+  - name: reader-child
+    runAfter: [write]
+    workspaces:
+    - name: child-ws
+      workspace: shared
+    pipelineRef:
+      name: child-reader
+`, namespace))
+
+	parentPipelineRun := parse.MustParseV1PipelineRun(t, fmt.Sprintf(`
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  pipelineRef:
+    name: parent-pvc-ws
+  workspaces:
+  - name: shared
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 16Mi
+`, parentPipelineRunName, namespace))
+
+	expectedChildPipelineRun := &v1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{Name: kmeta.ChildName(parentPipelineRunName, "-reader-child"), Namespace: namespace},
+		Spec:       v1.PipelineRunSpec{PipelineRef: &v1.PipelineRef{Name: "child-reader"}},
+	}
+
+	return parentPipeline, childPipeline, parentPipelineRun, expectedChildPipelineRun
+}
+
+// ChildPipelineViaClusterResolver returns a parent Pipeline whose PipelineTask
+// resolves its child Pipeline through the cluster resolver (rather than a local
+// name ref), plus the resolved child Pipeline, the parent PipelineRun, and the
+// expected child PipelineRun. The expected child PipelineRun carries only the
+// resolved tekton.dev/pipeline label (its Spec is left empty because the
+// reconciler stores the resolver ref, which tests don't reconstruct). Used by
+// e2e tests for the child-pipeline-via-resolver path.
+func ChildPipelineViaClusterResolver(t *testing.T, namespace, parentPipelineRunName string) (*v1.Pipeline, *v1.Pipeline, *v1.PipelineRun, *v1.PipelineRun) {
+	t.Helper()
+	resolvedChild := pinpChildTaskSpecPipeline(t, "resolved-child", namespace)
+
+	parentPipeline := parse.MustParseV1Pipeline(t, fmt.Sprintf(`
+metadata:
+  name: parent-resolver
+  namespace: %s
+spec:
+  tasks:
+  - name: via-resolver
+    pipelineRef:
+      resolver: cluster
+      params:
+      - name: kind
+        value: pipeline
+      - name: name
+        value: resolved-child
+      - name: namespace
+        value: %s
+`, namespace, namespace))
+
+	parentPipelineRun := parse.MustParseV1PipelineRun(t, fmt.Sprintf(`
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  pipelineRef:
+    name: parent-resolver
+`, parentPipelineRunName, namespace))
+
+	expectedChildPipelineRun := &v1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      kmeta.ChildName(parentPipelineRunName, "-via-resolver"),
+			Namespace: namespace,
+			Labels:    map[string]string{pipeline.PipelineLabelKey: "resolved-child"},
+		},
+	}
+
+	return parentPipeline, resolvedChild, parentPipelineRun, expectedChildPipelineRun
 }

--- a/test/pipelinerun_pinp_test.go
+++ b/test/pipelinerun_pinp_test.go
@@ -21,13 +21,19 @@ package test
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	th "github.com/tektoncd/pipeline/pkg/reconciler/testing"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
+	"knative.dev/pkg/kmeta"
 	knativetest "knative.dev/pkg/test"
 )
 
@@ -49,28 +55,65 @@ func TestPipelineRun_PinP_OneChildPipelineRunFromPipelineSpec(t *testing.T) {
 		parentPipelineRun,
 		expectedChildPipelineRun := th.OnePipelineInPipeline(t, namespace, "parent-pipeline-run")
 	parentPipelineRun = th.WithAnnotationAndLabel(parentPipelineRun, false)
-	expectedKinds := createKindsMap(parentPipelineRun, []*v1.PipelineRun{expectedChildPipelineRun})
+	expectedKinds := createKindsMap(parentPipelineRun, []*v1.PipelineRun{expectedChildPipelineRun}, []*v1.Pipeline{parentPipeline})
 	expectedEventsAmount := 3
 
 	// WHEN
-	createResourcesAndWaitForPipelineRun(ctx, t, c, namespace, parentPipeline, parentPipelineRun, nil)
+	createResourcesAndWaitForPipelineRunSuccess(ctx, t, c, namespace, []*v1.Pipeline{parentPipeline}, parentPipelineRun, nil)
 
 	// THEN
-	assertPinP(ctx, t, c, namespace, expectedChildPipelineRun)
+	assertPinP(ctx, t, c, expectedChildPipelineRun)
 	assertEvents(ctx, t, expectedEventsAmount, expectedKinds, c, namespace)
 }
 
-func createKindsMap(parentPipelineRun *v1.PipelineRun, childPipelineRuns []*v1.PipelineRun) map[string][]string {
+// createKindsMap returns the expected "PipelineRun" and "TaskRun" event source
+// names for a PinP test: the parent PipelineRun, every child PipelineRun, and
+// each leaf-task TaskRun reachable from the parent and child PipelineRuns. A
+// PipelineRun's spec is resolved either inline (pipelineSpec) or by looking up
+// its pipelineRef in the supplied pipelines; pass every Pipeline involved
+// (parent and children) so ref-based specs can be resolved. Tasks that are
+// themselves nested Pipelines are skipped — only leaf Tasks produce TaskRuns.
+func createKindsMap(
+	parentPipelineRun *v1.PipelineRun,
+	childPipelineRuns []*v1.PipelineRun,
+	pipelines []*v1.Pipeline,
+) map[string][]string {
 	prNames := []string{parentPipelineRun.Name}
 	for _, cpr := range childPipelineRuns {
 		prNames = append(prNames, cpr.Name)
 	}
 
+	pipelineSpecByName := make(map[string]v1.PipelineSpec, len(pipelines))
+	for _, p := range pipelines {
+		pipelineSpecByName[p.Name] = p.Spec
+	}
+
 	var trNames []string
-	for _, cpr := range childPipelineRuns {
-		// collect names of TaskRuns; ignore nested PipelineRuns
-		if cpr.Spec.PipelineSpec.Tasks[0].PipelineSpec == nil {
-			trNames = append(trNames, cpr.Name+"-"+cpr.Spec.PipelineSpec.Tasks[0].Name)
+	allPRs := append([]*v1.PipelineRun{parentPipelineRun}, childPipelineRuns...)
+	for _, pr := range allPRs {
+		// Resolve the PipelineRun's spec: inline or via ref.
+		var spec *v1.PipelineSpec
+		switch {
+		case pr.Spec.PipelineSpec != nil:
+			spec = pr.Spec.PipelineSpec
+		case pr.Spec.PipelineRef != nil:
+			if s, ok := pipelineSpecByName[pr.Spec.PipelineRef.Name]; ok {
+				spec = &s
+			}
+		}
+		if spec == nil {
+			continue
+		}
+
+		// Leaf tasks (a Task, not a nested Pipeline) produce TaskRuns. Use
+		// kmeta.ChildName — the same helper the reconciler uses — so derived
+		// names match even when they are hashed past the 63-char limit.
+		tasks := append([]v1.PipelineTask{}, spec.Tasks...)
+		tasks = append(tasks, spec.Finally...)
+		for _, task := range tasks {
+			if task.PipelineSpec == nil && task.PipelineRef == nil {
+				trNames = append(trNames, kmeta.ChildName(pr.Name, "-"+task.Name))
+			}
 		}
 	}
 
@@ -80,31 +123,71 @@ func createKindsMap(parentPipelineRun *v1.PipelineRun, childPipelineRuns []*v1.P
 	}
 }
 
+// assertPinP verifies that the expected child PipelineRun exists, succeeded,
+// has labels/annotations propagated correctly from its parent, and matches the
+// expected spec. It handles both PipelineSpec children (where the
+// tekton.dev/pipeline label is the child PipelineRun's own name) and PipelineRef
+// children (where it is the resolved Pipeline's name).
 func assertPinP(
 	ctx context.Context,
 	t *testing.T,
 	c *clients,
-	namespace string,
-	childPipelineRun *v1.PipelineRun,
+	expected *v1.PipelineRun,
 ) {
 	t.Helper()
 
-	t.Logf("Making sure the expected child PipelineRun %q was created", childPipelineRun.Name)
-	actualCpr, err := c.V1PipelineRunClient.Get(ctx, childPipelineRun.Name, metav1.GetOptions{})
+	t.Logf("Making sure the expected child PipelineRun %q was created", expected.Name)
+	actual, err := c.V1PipelineRunClient.Get(ctx, expected.Name, metav1.GetOptions{})
 	if err != nil {
-		t.Fatalf("Error listing child PipelineRuns for PipelineRun %s: %s", childPipelineRun.Name, err)
+		t.Fatalf("Error getting child PipelineRun %s: %s", expected.Name, err)
 	}
 	th.CheckPipelineRunConditionStatusAndReason(
 		t,
-		actualCpr.Status,
+		actual.Status,
 		corev1.ConditionTrue,
 		v1.PipelineRunReasonSuccessful.String(),
 	)
-	t.Logf("Checking that labels were propagated correctly for child PipelineRun %q", actualCpr.Name)
-	directParentPrName := actualCpr.OwnerReferences[0].Name
-	checkLabelPropagationToChildPipelineRun(ctx, t, c, namespace, directParentPrName, actualCpr)
-	t.Logf("Checking that annotations were propagated correctly for child PipelineRun %q", actualCpr.Name)
-	checkAnnotationPropagationToChildPipelineRun(ctx, t, c, namespace, directParentPrName, actualCpr)
+	directParentPrName := actual.OwnerReferences[0].Name
+	t.Logf("Checking that labels were propagated correctly for child PipelineRun %q", actual.Name)
+	if actual.Spec.PipelineRef != nil {
+		// The expected tekton.dev/pipeline label is the resolved child Pipeline
+		// name. For a local name ref it equals the ref name; for a resolver ref
+		// (whose Name is empty) the caller supplies it on the expected labels.
+		expectedPipelineName := expected.Labels[pipeline.PipelineLabelKey]
+		if expectedPipelineName == "" {
+			expectedPipelineName = actual.Spec.PipelineRef.Name
+		}
+		checkLabelPropagationToChildPipelineRunRef(ctx, t, c, directParentPrName, actual, expectedPipelineName)
+	} else {
+		checkLabelPropagationToChildPipelineRun(ctx, t, c, directParentPrName, actual)
+	}
+	t.Logf("Checking that annotations were propagated correctly for child PipelineRun %q", actual.Name)
+	checkAnnotationPropagationToChildPipelineRun(ctx, t, c, directParentPrName, actual)
+
+	// Spec diff: only run when the caller provided a non-minimal expected.Spec
+	// (i.e. it specifies how the child Pipeline is selected). For minimal
+	// expected PipelineRuns (just an ObjectMeta), the label/annotation check above
+	// is the contract — the controller adds spec details we don't model in tests.
+	// Ignored fields:
+	//   - ignoreSAPipelineRunSpec: test cluster default vs explicit SA.
+	//   - PipelineRunSpec.Timeouts: only set on the parent.
+	//   - PipelineRunSpec.Workspaces: the reconciler synthesises PVC claim names
+	//     for volumeClaimTemplate-backed parent workspaces; hashes aren't worth
+	//     reconstructing in tests.
+	//   - TaskRef.Kind: the webhook defaults it to "Task" when unset; factories
+	//     don't always pre-set it.
+	if expected.Spec.PipelineRef == nil && expected.Spec.PipelineSpec == nil {
+		return
+	}
+	opts := []cmp.Option{
+		ignoreSAPipelineRunSpec,
+		cmpopts.IgnoreFields(v1.PipelineRunSpec{}, "Timeouts", "Workspaces"),
+		cmpopts.IgnoreFields(v1.TaskRef{}, "Kind"),
+		cmpopts.EquateEmpty(),
+	}
+	if diff := cmp.Diff(expected.Spec, actual.Spec, opts...); diff != "" {
+		t.Fatalf("Unexpected child PipelineRun spec (-want, +got): %s", diff)
+	}
 }
 
 // @test:execution=parallel
@@ -126,15 +209,15 @@ func TestPipelineRun_PinP_TwoChildPipelineRunsMixedTasks(t *testing.T) {
 		parentPipelineRun,
 		expectedChildPipelineRuns := th.TwoPipelinesInPipelineMixedTasks(t, namespace, "parent-pipeline-mixed")
 	parentPipelineRun = th.WithAnnotationAndLabel(parentPipelineRun, false)
-	expectedKinds := createKindsMap(parentPipelineRun, expectedChildPipelineRuns)
+	expectedKinds := createKindsMap(parentPipelineRun, expectedChildPipelineRuns, []*v1.Pipeline{parentPipeline})
 	expectedEventsAmount := 5
 
 	// WHEN
-	createResourcesAndWaitForPipelineRun(ctx, t, c, namespace, parentPipeline, parentPipelineRun, task)
+	createResourcesAndWaitForPipelineRunSuccess(ctx, t, c, namespace, []*v1.Pipeline{parentPipeline}, parentPipelineRun, task)
 
 	// THEN
-	assertPinP(ctx, t, c, namespace, expectedChildPipelineRuns[0])
-	assertPinP(ctx, t, c, namespace, expectedChildPipelineRuns[1])
+	assertPinP(ctx, t, c, expectedChildPipelineRuns[0])
+	assertPinP(ctx, t, c, expectedChildPipelineRuns[1])
 	assertEvents(ctx, t, expectedEventsAmount, expectedKinds, c, namespace)
 }
 
@@ -162,31 +245,173 @@ func TestPipelineRun_PinP_TwoLevelDeepNestedChildPipelineRuns(t *testing.T) {
 		[]*v1.PipelineRun{
 			expectedChildPipelineRun,
 			expectedGrandchildPipelineRun,
-		})
+		},
+		[]*v1.Pipeline{parentPipeline})
 	expectedEventsAmount := 4
 
 	// WHEN
-	createResourcesAndWaitForPipelineRun(ctx, t, c, namespace, parentPipeline, parentPipelineRun, nil)
+	createResourcesAndWaitForPipelineRunSuccess(ctx, t, c, namespace, []*v1.Pipeline{parentPipeline}, parentPipelineRun, nil)
 
 	// THEN
-	assertPinP(ctx, t, c, namespace, expectedChildPipelineRun)
-	assertPinP(ctx, t, c, namespace, expectedGrandchildPipelineRun)
+	assertPinP(ctx, t, c, expectedChildPipelineRun)
+	assertPinP(ctx, t, c, expectedGrandchildPipelineRun)
 	assertEvents(ctx, t, expectedEventsAmount, expectedKinds, c, namespace)
 }
 
+// @test:execution=parallel
+func TestPipelineRun_PinP_OneChildPipelineRunFromPipelineRef(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	c, namespace := setup(ctx, t, requireAnyGate(map[string]string{
+		"enable-api-fields": "alpha",
+	}))
+	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
+	defer tearDown(ctx, t, c, namespace)
+
+	// GIVEN
+	t.Logf("Setting up test resources for one child PipelineRun from PipelineRef in namespace %q", namespace)
+	parentPipeline, childPipeline, parentPipelineRun, expectedChildPipelineRun :=
+		th.OnePipelineRefInPipeline(t, namespace, "parent-pipeline-run")
+	parentPipelineRun = th.WithAnnotationAndLabel(parentPipelineRun, false)
+	expectedKinds := createKindsMap(parentPipelineRun, []*v1.PipelineRun{expectedChildPipelineRun}, []*v1.Pipeline{parentPipeline, childPipeline})
+	expectedEventsAmount := 3
+
+	// WHEN
+	createResourcesAndWaitForPipelineRunSuccess(ctx, t, c, namespace, []*v1.Pipeline{parentPipeline, childPipeline}, parentPipelineRun, nil)
+
+	// THEN
+	assertPinP(ctx, t, c, expectedChildPipelineRun)
+	assertEvents(ctx, t, expectedEventsAmount, expectedKinds, c, namespace)
+}
+
+// @test:execution=parallel
+func TestPipelineRun_PinP_TwoLevelDeepNestedChildPipelineRunsWithPipelineRef(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	c, namespace := setup(ctx, t, requireAnyGate(map[string]string{
+		"enable-api-fields": "alpha",
+	}))
+	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
+	defer tearDown(ctx, t, c, namespace)
+
+	// GIVEN
+	t.Logf("Setting up test resources for two level deep nested child PipelineRuns with PipelineRef in namespace %q", namespace)
+	parentPipeline, childPipeline, grandchildPipeline,
+		parentPipelineRun,
+		expectedChildPipelineRun,
+		expectedGrandchildPipelineRun := th.NestedPipelineRefsInPipeline(t, namespace, "parent-pipeline-nested-ref")
+	parentPipelineRun = th.WithAnnotationAndLabel(parentPipelineRun, false)
+	// Only the three PipelineRun "Succeeded" events are asserted here.
+	// grandchildPipeline is deliberately left out of the createKindsMap lookup so
+	// the deeply-nested grandchild TaskRun is not required — its name is hashed
+	// past 63 chars and this test's intent is the nested PipelineRun creation, not
+	// that leaf TaskRun. (createKindsMap itself now hashes via kmeta.ChildName, so
+	// it would derive the correct name if the pipeline were included.)
+	expectedKinds := createKindsMap(parentPipelineRun,
+		[]*v1.PipelineRun{expectedChildPipelineRun, expectedGrandchildPipelineRun},
+		[]*v1.Pipeline{parentPipeline, childPipeline})
+	expectedEventsAmount := 3
+
+	// WHEN
+	createResourcesAndWaitForPipelineRunSuccess(ctx, t, c, namespace, []*v1.Pipeline{parentPipeline, childPipeline, grandchildPipeline}, parentPipelineRun, nil)
+
+	// THEN
+	assertPinP(ctx, t, c, expectedChildPipelineRun)
+	assertPinP(ctx, t, c, expectedGrandchildPipelineRun)
+	assertEvents(ctx, t, expectedEventsAmount, expectedKinds, c, namespace)
+}
+
+// assertFailureMessage fetches the named PipelineRun and asserts that its
+// Succeeded condition is false and that the condition message contains the
+// given substring.
+func assertFailureMessage(ctx context.Context, t *testing.T, c *clients, prName, expectedMessage string) {
+	t.Helper()
+	pr, err := c.V1PipelineRunClient.Get(ctx, prName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Error getting PipelineRun %s: %s", prName, err)
+	}
+	condition := pr.Status.GetCondition(apis.ConditionSucceeded)
+	if condition == nil || condition.Status != corev1.ConditionFalse || !strings.Contains(condition.Message, expectedMessage) {
+		t.Fatalf("Expected PipelineRun %s to be failed with message containing %q; got condition: %+v", prName, expectedMessage, condition)
+	}
+}
+
+// checkLabelPropagationToChildPipelineRunRef checks label propagation for PipelineRef children.
+// Unlike PipelineSpec children (where tekton.dev/pipeline = childPr.Name), PipelineRef children
+// have tekton.dev/pipeline set to the resolved Pipeline name, which the caller passes in
+// expectedPipelineName.
+func checkLabelPropagationToChildPipelineRunRef(
+	ctx context.Context,
+	t *testing.T,
+	c *clients,
+	parentPrName string,
+	childPr *v1.PipelineRun,
+	expectedPipelineName string,
+) {
+	t.Helper()
+
+	labels := make(map[string]string)
+
+	parentPr, err := c.V1PipelineRunClient.Get(ctx, parentPrName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't get expected PipelineRun for %s: %s", childPr.Name, err)
+	}
+
+	// Copy non-overwritten labels from parent
+	for key, val := range parentPr.ObjectMeta.Labels {
+		if key == pipeline.MemberOfLabelKey ||
+			key == pipeline.PipelineLabelKey ||
+			key == pipeline.PipelineRunLabelKey ||
+			key == pipeline.PipelineRunUIDLabelKey ||
+			key == pipeline.PipelineTaskLabelKey {
+			continue
+		}
+		labels[key] = val
+	}
+
+	// Child references the parent PipelineRun
+	labels[pipeline.PipelineRunLabelKey] = parentPr.Name
+
+	// For PipelineRef children, tekton.dev/pipeline is set to the resolved child
+	// Pipeline name (not the child PR name like for PipelineSpec children). Assert
+	// the exact expected value.
+	if childPr.Labels[pipeline.PipelineLabelKey] != expectedPipelineName {
+		t.Errorf("Expected tekton.dev/pipeline=%q, got %q",
+			expectedPipelineName, childPr.Labels[pipeline.PipelineLabelKey])
+	}
+	labels[pipeline.PipelineLabelKey] = expectedPipelineName
+
+	assertLabelsMatch(t, labels, childPr.ObjectMeta.Labels)
+	t.Logf("Labels propagated from parent PipelineRun to child PipelineRun (PipelineRef): %#v", labels)
+}
+
+// createResourcesAndWaitForPipelineRun creates the given pipelines (and optional
+// task), creates the PipelineRun, and waits until it reaches the supplied
+// inState (e.g. PipelineRunSucceed, PipelineRunFailed, or a Chain of accessors).
+// It is the single creation helper used by every PinP e2e test; the
+// createResourcesAndWaitForPipelineRunSuccess / ...Failed decorators wrap it for
+// the common success and failure cases.
 func createResourcesAndWaitForPipelineRun(
 	ctx context.Context,
 	t *testing.T,
 	c *clients,
 	namespace string,
-	pipeline *v1.Pipeline,
+	pipelines []*v1.Pipeline,
 	pipelineRun *v1.PipelineRun,
 	task *v1.Task,
+	inState ConditionAccessorFn,
+	stateName string,
 ) {
 	t.Helper()
 
-	if _, err := c.V1PipelineClient.Create(ctx, pipeline, metav1.CreateOptions{}); err != nil {
-		t.Fatalf("Failed to create Pipeline `%s`: %s", pipeline.Name, err)
+	for _, p := range pipelines {
+		if _, err := c.V1PipelineClient.Create(ctx, p, metav1.CreateOptions{}); err != nil {
+			t.Fatalf("Failed to create Pipeline `%s`: %s", p.Name, err)
+		}
 	}
 
 	if task != nil {
@@ -199,18 +424,72 @@ func createResourcesAndWaitForPipelineRun(
 		t.Fatalf("Failed to create PipelineRun `%s`: %s", pipelineRun.Name, err)
 	}
 
-	t.Logf("Waiting for PipelineRun %q in namespace %q to complete", pipelineRun.Name, namespace)
+	t.Logf("Waiting for PipelineRun %q in namespace %q to reach %s", pipelineRun.Name, namespace, stateName)
 	if err := WaitForPipelineRunState(
 		ctx,
 		c,
 		pipelineRun.Name,
 		timeout,
-		PipelineRunSucceed(pipelineRun.Name),
-		"PipelineRunSuccess",
+		inState,
+		stateName,
 		v1Version,
 	); err != nil {
-		t.Fatalf("Error waiting for PipelineRun %s to finish: %s", pipelineRun.Name, err)
+		t.Fatalf("Error waiting for PipelineRun %s to reach %s: %s", pipelineRun.Name, stateName, err)
 	}
+}
+
+// createResourcesAndWaitForPipelineRunSuccess creates the resources and waits
+// for the PipelineRun to succeed. It is the common-case decorator over
+// createResourcesAndWaitForPipelineRun.
+func createResourcesAndWaitForPipelineRunSuccess(
+	ctx context.Context,
+	t *testing.T,
+	c *clients,
+	namespace string,
+	pipelines []*v1.Pipeline,
+	pipelineRun *v1.PipelineRun,
+	task *v1.Task,
+) {
+	t.Helper()
+
+	createResourcesAndWaitForPipelineRun(
+		ctx,
+		t,
+		c,
+		namespace,
+		pipelines,
+		pipelineRun,
+		task,
+		PipelineRunSucceed(pipelineRun.Name),
+		"PipelineRunSuccess",
+	)
+}
+
+// createResourcesAndWaitForPipelineRunFailed creates the resources and waits for
+// the PipelineRun to fail. It is the common-case decorator over
+// createResourcesAndWaitForPipelineRun.
+func createResourcesAndWaitForPipelineRunFailed(
+	ctx context.Context,
+	t *testing.T,
+	c *clients,
+	namespace string,
+	pipelines []*v1.Pipeline,
+	pipelineRun *v1.PipelineRun,
+	task *v1.Task,
+) {
+	t.Helper()
+
+	createResourcesAndWaitForPipelineRun(
+		ctx,
+		t,
+		c,
+		namespace,
+		pipelines,
+		pipelineRun,
+		task,
+		PipelineRunFailed(pipelineRun.Name),
+		"PipelineRunFailed",
+	)
 }
 
 func assertEvents(
@@ -263,7 +542,6 @@ func checkLabelPropagationToChildPipelineRun(
 	ctx context.Context,
 	t *testing.T,
 	c *clients,
-	namespace string,
 	parentPrName string,
 	childPr *v1.PipelineRun,
 ) {
@@ -326,7 +604,6 @@ func checkAnnotationPropagationToChildPipelineRun(
 	ctx context.Context,
 	t *testing.T,
 	c *clients,
-	namespace string,
 	parentPrName string,
 	childPr *v1.PipelineRun,
 ) {
@@ -361,4 +638,330 @@ func checkAnnotationPropagationToChildPipelineRun(
 	if len(annotations) > 0 {
 		t.Logf("Propagated annotations: %#v", annotations)
 	}
+}
+
+// @test:execution=parallel
+func TestPipelineRun_PinP_PipelineRefWithParamsAndWorkspaces(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	c, namespace := setup(ctx, t, requireAnyGate(map[string]string{
+		"enable-api-fields": "alpha",
+	}))
+	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
+	defer tearDown(ctx, t, c, namespace)
+
+	// GIVEN
+	parentPipeline, childPipeline, parentPipelineRun, expectedChildPipelineRun :=
+		th.OnePipelineRefInPipelineWithParamsAndWorkspaces(t, namespace, "parent-pipeline-run")
+	parentPipelineRun = th.WithAnnotationAndLabel(parentPipelineRun, false)
+	expectedKinds := createKindsMap(parentPipelineRun, []*v1.PipelineRun{expectedChildPipelineRun}, []*v1.Pipeline{parentPipeline, childPipeline})
+	expectedEventsAmount := 3
+
+	// WHEN
+	createResourcesAndWaitForPipelineRunSuccess(ctx, t, c, namespace, []*v1.Pipeline{parentPipeline, childPipeline}, parentPipelineRun, nil)
+
+	// THEN
+	assertPinP(ctx, t, c, expectedChildPipelineRun)
+	assertEvents(ctx, t, expectedEventsAmount, expectedKinds, c, namespace)
+}
+
+// @test:execution=parallel
+func TestPipelineRun_PinP_SelfReferencingPipelineRefCycleDetection(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	c, namespace := setup(ctx, t, requireAnyGate(map[string]string{
+		"enable-api-fields": "alpha",
+	}))
+	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
+	defer tearDown(ctx, t, c, namespace)
+
+	// GIVEN: Pipeline references itself via PipelineRef — a self-referencing cycle.
+	selfRefPipeline, pipelineRun := th.SelfReferencingPipelineRefCycle(t, namespace, "pr-cycle-self")
+
+	// WHEN
+	createResourcesAndWaitForPipelineRunFailed(ctx, t, c, namespace, []*v1.Pipeline{selfRefPipeline}, pipelineRun, nil)
+
+	// THEN: PipelineRun fails due to cycle detection.
+	assertFailureMessage(ctx, t, c, pipelineRun.Name, "detected cycle in pipeline-in-pipeline")
+}
+
+// @test:execution=parallel
+func TestPipelineRun_PinP_TwoLevelPipelineRefCycleDetection(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	c, namespace := setup(ctx, t, requireAnyGate(map[string]string{
+		"enable-api-fields": "alpha",
+	}))
+	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
+	defer tearDown(ctx, t, c, namespace)
+
+	// GIVEN: pipeline-a -> pipeline-b -> pipeline-a (two-level cycle).
+	pipelineA, pipelineB, pipelineRun := th.TwoLevelPipelineRefCycle(t, namespace, "pr-cycle-two-level")
+	childPipelineRunName := pipelineRun.Name + "-pipeline-b"
+
+	// WHEN: wait for the top-level PipelineRun to fail; the cycle is detected
+	// before the grandchild is created, so checking the child message is enough.
+	createResourcesAndWaitForPipelineRunFailed(ctx, t, c, namespace, []*v1.Pipeline{pipelineA, pipelineB}, pipelineRun, nil)
+
+	// THEN
+	assertFailureMessage(ctx, t, c, childPipelineRunName, "detected cycle in pipeline-in-pipeline")
+}
+
+// @test:execution=parallel
+func TestPipelineRun_PinP_PipelineRefNotFound(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	c, namespace := setup(ctx, t, requireAnyGate(map[string]string{
+		"enable-api-fields": "alpha",
+	}))
+	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
+	defer tearDown(ctx, t, c, namespace)
+
+	// GIVEN: a parent Pipeline whose pipelineRef points at a non-existent Pipeline.
+	parentPipeline, pipelineRun := th.OnePipelineRefMissing(t, namespace, "pr-ref-not-found")
+
+	// WHEN: Create only the parent Pipeline (the referenced child is intentionally missing).
+	createResourcesAndWaitForPipelineRun(ctx, t, c, namespace,
+		[]*v1.Pipeline{parentPipeline}, pipelineRun, nil,
+		Chain(
+			FailedWithReason(v1.PipelineRunReasonCouldntGetPipeline.String(), pipelineRun.Name),
+			FailedWithMessage("nonexistent-pipeline", pipelineRun.Name),
+		),
+		"PipelineRunFailed")
+}
+
+// @test:execution=parallel
+func TestPipelineRun_PinP_MissingWorkspaceBinding(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	c, namespace := setup(ctx, t, requireAnyGate(map[string]string{
+		"enable-api-fields": "alpha",
+	}))
+	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
+	defer tearDown(ctx, t, c, namespace)
+
+	// GIVEN: parent that omits the child Pipeline's required workspace binding.
+	parentPipeline, childPipeline, parentPipelineRun := th.OnePipelineRefMissingWorkspace(t, namespace, "pr-pinp-missing-ws")
+	childPipelineRunName := parentPipelineRun.Name + "-child-pipeline-workspace"
+
+	// WHEN: parent fails after the child workspace validation fails.
+	createResourcesAndWaitForPipelineRunFailed(ctx, t, c, namespace, []*v1.Pipeline{parentPipeline, childPipeline}, parentPipelineRun, nil)
+
+	// THEN
+	assertFailureMessage(ctx, t, c, childPipelineRunName,
+		`pipeline requires workspace with name "child-ws" be provided by pipelinerun`)
+}
+
+// @test:execution=parallel
+// TestPipelineRun_PinP_MultiplePipelineRefChildren verifies that a parent Pipeline
+// with more than one pipelineRef PipelineTask creates and completes one child
+// PipelineRun per task. The existing suite only covers multiple children via
+// pipelineSpec; this exercises the multi-child path for resolved pipelineRefs.
+func TestPipelineRun_PinP_MultiplePipelineRefChildren(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	c, namespace := setup(ctx, t, requireAnyGate(map[string]string{
+		"enable-api-fields": "alpha",
+	}))
+	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
+	defer tearDown(ctx, t, c, namespace)
+
+	// GIVEN: two child Pipelines and a parent that references both via pipelineRef.
+	parentPipeline, childPipelines, parentPipelineRun, expectedChildPRs :=
+		th.MultiplePipelineRefsInPipeline(t, namespace, "pr-multi-ref")
+	expectedKinds := createKindsMap(parentPipelineRun, expectedChildPRs, append([]*v1.Pipeline{parentPipeline}, childPipelines...))
+	expectedEventsAmount := 5
+
+	// WHEN
+	createResourcesAndWaitForPipelineRunSuccess(ctx, t, c, namespace, append([]*v1.Pipeline{parentPipeline}, childPipelines...), parentPipelineRun, nil)
+
+	// THEN: both child PipelineRuns were created and succeeded.
+	for _, cpr := range expectedChildPRs {
+		assertPinP(ctx, t, c, cpr)
+	}
+	assertEvents(ctx, t, expectedEventsAmount, expectedKinds, c, namespace)
+}
+
+// @test:execution=parallel
+// TestPipelineRun_PinP_MixedPipelineRefSpecAndTaskRef verifies that a single parent
+// Pipeline can mix a pipelineRef child, an inline pipelineSpec child, and a regular
+// taskRef task: two child PipelineRuns and one TaskRun are created and all complete.
+func TestPipelineRun_PinP_MixedPipelineRefSpecAndTaskRef(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	c, namespace := setup(ctx, t, requireAnyGate(map[string]string{
+		"enable-api-fields": "alpha",
+	}))
+	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
+	defer tearDown(ctx, t, c, namespace)
+
+	// GIVEN
+	task, parentPipeline, childRef, parentPipelineRun, expectedRefChild, expectedSpecChild :=
+		th.MixedPipelineRefSpecAndTaskRefInPipeline(t, namespace, "pr-mixed")
+	expectedKinds := createKindsMap(parentPipelineRun,
+		[]*v1.PipelineRun{expectedRefChild, expectedSpecChild},
+		[]*v1.Pipeline{parentPipeline, childRef})
+	expectedEventsAmount := 6
+
+	// WHEN
+	createResourcesAndWaitForPipelineRunSuccess(ctx, t, c, namespace, []*v1.Pipeline{parentPipeline, childRef}, parentPipelineRun, task)
+
+	// THEN: the pipelineRef child and the pipelineSpec child both succeeded.
+	assertPinP(ctx, t, c, expectedRefChild)
+	assertPinP(ctx, t, c, expectedSpecChild)
+	assertEvents(ctx, t, expectedEventsAmount, expectedKinds, c, namespace)
+}
+
+// @test:execution=parallel
+// TestPipelineRun_PinP_ChildPipelineViaClusterResolver verifies the headline
+// "child pipeline via resolver" capability end-to-end: the parent PipelineTask
+// resolves its child Pipeline through the cluster resolver (rather than a local
+// name ref), and the resulting child PipelineRun runs and succeeds.
+func TestPipelineRun_PinP_ChildPipelineViaClusterResolver(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	c, namespace := setup(ctx, t, requireAnyGate(map[string]string{
+		"enable-api-fields": "alpha",
+	}))
+	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
+	defer tearDown(ctx, t, c, namespace)
+
+	// GIVEN: a child Pipeline resolved through the cluster resolver instead of a local ref.
+	parentPipeline, resolvedChild, parentPipelineRun, expectedChildPipelineRun :=
+		th.ChildPipelineViaClusterResolver(t, namespace, "pr-resolver")
+	// The child PR's Spec.PipelineRef is the resolver ref (Name=""), so
+	// createKindsMap can't auto-derive its TaskRun via lookup — build the map by hand.
+	childPRName := expectedChildPipelineRun.Name
+	expectedKinds := map[string][]string{
+		"PipelineRun": {parentPipelineRun.Name, childPRName},
+		"TaskRun":     {kmeta.ChildName(childPRName, "-run")},
+	}
+	expectedEventsAmount := 3
+
+	// WHEN
+	createResourcesAndWaitForPipelineRunSuccess(ctx, t, c, namespace, []*v1.Pipeline{parentPipeline, resolvedChild}, parentPipelineRun, nil)
+
+	// THEN: the resolver-backed child PipelineRun was created, succeeded, and is
+	// labelled with the resolved Pipeline name.
+	assertPinP(ctx, t, c, expectedChildPipelineRun)
+	assertEvents(ctx, t, expectedEventsAmount, expectedKinds, c, namespace)
+}
+
+// @test:execution=parallel
+// TestPipelineRun_PinP_PipelineRefWithPVCWorkspace verifies that a PVC-backed
+// (volumeClaimTemplate) workspace is genuinely shared from the parent into a
+// child Pipeline at runtime: a parent task writes a file to the workspace, and
+// a task in the child Pipeline (which receives the same workspace) reads it
+// back. The parent only succeeds if the child sees the parent-written data,
+// proving the underlying volume is the same across the parent->child boundary.
+// The existing workspace e2e coverage uses emptyDir, which cannot prove sharing.
+func TestPipelineRun_PinP_PipelineRefWithPVCWorkspace(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	c, namespace := setup(ctx, t, requireAnyGate(map[string]string{
+		"enable-api-fields": "alpha",
+	}))
+	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
+	defer tearDown(ctx, t, c, namespace)
+
+	// GIVEN: a child Pipeline that reads a file from its workspace, and a parent
+	// that first writes that file to a PVC-backed workspace, then maps the same
+	// workspace into the child via pipelineRef.
+	parentPipeline, childPipeline, parentPipelineRun, expectedChildPR :=
+		th.PipelineRefWithPVCWorkspace(t, namespace, "pr-pvc-ws")
+	// extras: the parent's writer task is a taskSpec on the parent (not a child PR).
+	expectedKinds := createKindsMap(parentPipelineRun,
+		[]*v1.PipelineRun{expectedChildPR},
+		[]*v1.Pipeline{parentPipeline, childPipeline})
+	expectedEventsAmount := 4
+
+	// WHEN: createResourcesAndWaitForPipelineRunSuccess waits for the parent to succeed,
+	// which only happens if the child's read (grep) of the parent-written file passes.
+	createResourcesAndWaitForPipelineRunSuccess(ctx, t, c, namespace, []*v1.Pipeline{parentPipeline, childPipeline}, parentPipelineRun, nil)
+
+	// THEN: the child PipelineRun that received the shared PVC workspace succeeded.
+	assertPinP(ctx, t, c, expectedChildPR)
+	assertEvents(ctx, t, expectedEventsAmount, expectedKinds, c, namespace)
+}
+
+// @test:execution=parallel
+// TestPipelineRun_PinP_PipelineRefWhenExpressionSkipsChild verifies that a
+// pipelineRef PipelineTask guarded by a when expression that evaluates to false
+// is skipped: no child PipelineRun is created and the parent succeeds.
+func TestPipelineRun_PinP_PipelineRefWhenExpressionSkipsChild(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	c, namespace := setup(ctx, t, requireAnyGate(map[string]string{
+		"enable-api-fields": "alpha",
+	}))
+	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
+	defer tearDown(ctx, t, c, namespace)
+
+	// GIVEN: a parent whose only task references a child Pipeline but is guarded
+	// by a when expression that is false ("run" is not in ["no"]).
+	parentPipeline, childPipeline, parentPipelineRun :=
+		th.PipelineRefInPipelineWhenSkipped(t, namespace, "pr-when-skip")
+
+	// WHEN: the parent succeeds (a skipped-only-task pipeline completes successfully).
+	createResourcesAndWaitForPipelineRunSuccess(ctx, t, c, namespace, []*v1.Pipeline{parentPipeline, childPipeline}, parentPipelineRun, nil)
+
+	// THEN: no child PipelineRun was created for the skipped task.
+	childPRName := parentPipelineRun.Name + "-maybe-child"
+	if _, err := c.V1PipelineRunClient.Get(ctx, childPRName, metav1.GetOptions{}); err == nil {
+		t.Fatalf("Expected child PipelineRun %s to be skipped (not created), but it exists", childPRName)
+	} else if !apierrors.IsNotFound(err) {
+		t.Fatalf("Unexpected error checking for skipped child PipelineRun %s: %s", childPRName, err)
+	}
+}
+
+// @test:execution=parallel
+// TestPipelineRun_PinP_PipelineRefInFinally verifies that a pipelineRef
+// PipelineTask placed in a parent Pipeline's finally section runs as a child
+// PipelineRun after the main tasks complete, and succeeds.
+func TestPipelineRun_PinP_PipelineRefInFinally(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	c, namespace := setup(ctx, t, requireAnyGate(map[string]string{
+		"enable-api-fields": "alpha",
+	}))
+	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
+	defer tearDown(ctx, t, c, namespace)
+
+	// GIVEN: a parent with a main task and a finally task that references a child Pipeline.
+	parentPipeline, finallyChild, parentPipelineRun, expectedChildPR :=
+		th.PipelineRefInFinally(t, namespace, "pr-finally")
+	// extras: the parent's main task is a taskSpec on the parent (not a child PR).
+	expectedKinds := createKindsMap(parentPipelineRun,
+		[]*v1.PipelineRun{expectedChildPR},
+		[]*v1.Pipeline{parentPipeline, finallyChild})
+	expectedEventsAmount := 4
+
+	// WHEN
+	createResourcesAndWaitForPipelineRunSuccess(ctx, t, c, namespace, []*v1.Pipeline{parentPipeline, finallyChild}, parentPipelineRun, nil)
+
+	// THEN: the finally child PipelineRun was created and succeeded.
+	assertPinP(ctx, t, c, expectedChildPR)
+	assertEvents(ctx, t, expectedEventsAmount, expectedKinds, c, namespace)
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Add support for referencing a `Pipeline` inside another `Pipeline` definition using `pipelineRef`, including remote resolvers.

**Pipeline resolution:**
- `GetChildPipelineFunc` factory resolves `pipelineRef` locally or through remote resolvers, reusing the `pipelineResolverFunc` extracted from `GetPipelineFunc`
- `PipelineNotFoundError` type for clear error reporting when a child `Pipeline` cannot be resolved
- Verification result handling for remotely-resolved child `Pipelines`

**Child PipelineRun creation:**
- `createChildPipelineRun` builds a child `PipelineRun` with `pipelineRef` or `pipelineSpec`, propagating `params`, `workspaces` and `TaskRunTemplate` (including `ServiceAccountName`) from the parent
- `getChildPipelineRunWorkspaces` resolves workspace bindings from the parent, reusing the existing volume source handling

**Cycle detection:**
- `detectPipelineRefCycle` walks the `ownerReferences` chain and matches the `tekton.dev/pipeline` label to detect single-level and multi-level cycles at reconcile time, failing with a permanent error

**Validation:**
- `validatePipelineRefResultReferencesDisallowed` rejects result references (`$(tasks.<name>.results.*)`) targeting `PipelineTasks` that use `pipelineRef` or `pipelineSpec`, since result propagation from child `Pipelines` is not yet implemented

Closes #10174
Relates to #7166

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
`PipelineTask.pipelineRef` is now supported for Pipelines-in-Pipelines as an `alpha` feature. Child pipelines can be referenced locally or through a resolver, and `params` and `workspaces` from the `PipelineTask` are
  propagated to the child `PipelineRun`. PipelineRuns now also fail with clearer errors when a child pipeline cannot be resolved or when nested `pipelineRef` usage creates a cycle. Refer to TEP-0056 for the Pipelines-in-Pipelines design.
```