### PR TITLE
Move v0.68 LTS to End of Life releases

### DIFF
--- a/releases.md
+++ b/releases.md
@@ -65,12 +65,6 @@ Further documentation available:
 - **End of Life**: 2026-04-29
 - **Patch Releases**: [v1.0.0][v1.0-0]
 
-### v0.68 (LTS)
-- **Latest Release**: [v0.68.1][v0.68-1] (2025-03-20) ([docs][v0.68-1-docs], [examples][v0.68-1-examples])
-- **Initial Release**: [v0.68.0][v0.68-0] (2025-01-30)
-- **End of Life**: 2026-01-30
-- **Patch Releases**: [v0.68.0][v0.68-0], [v0.68.1][v0.68-1]
-
 ## End of Life Releases
 
 ### v1.7
@@ -114,6 +108,12 @@ Further documentation available:
 - **Initial Release**: [v0.69.0][v0.69-0] (2025-03-07)
 - **End of Life**: 2025-03-28
 - **Patch Releases**: [v0.69.0][v0.69-0]
+
+### v0.68 (LTS)
+- **Latest Release**: [v0.68.1][v0.68-1] (2025-03-20) ([docs][v0.68-1-docs], [examples][v0.68-1-examples])
+- **Initial Release**: [v0.68.0][v0.68-0] (2025-01-30)
+- **End of Life**: 2026-01-30
+- **Patch Releases**: [v0.68.0][v0.68-0], [v0.68.1][v0.68-1]
 
 ### v0.66
 - **Latest Release**: [v0.66.0][v0.66-0] (2024-12-04) ([docs][v0.66-0-docs], [examples][v0.66-0-examples])


### PR DESCRIPTION
# Changes

v0.68 LTS reached its end of life on 2026-01-30. Move it from the
active supported releases section to the End of Life Releases section
in `releases.md`.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```