### PR TITLE
[release-v1.3.x] Cherry-pick: docs: Switch from deprecated Tekton Hub to ArtifactHub

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -134,7 +134,7 @@ of the event. Inside the root key, the whole `spec` and `status` of the resource
       "params": [
         {
           "name": "url",
-          "value": "https://api.hub.tekton.dev/resource/96"
+          "value": "https://artifacthub.io/packages/tekton-task/tekton-catalog-tasks/git-clone"
         }
       ],
       "resources": {},

--- a/docs/hub-resolver.md
+++ b/docs/hub-resolver.md
@@ -14,7 +14,7 @@ Use resolver type `hub`.
 | Param Name       | Description                                                                   | Example Value                                              |
 |------------------|-------------------------------------------------------------------------------|------------------------------------------------------------|
 | `catalog`        | The catalog from where to pull the resource (Optional)                        | Default:  `tekton-catalog-tasks` (for `task` kind);  `tekton-catalog-pipelines` (for `pipeline` kind)                                        |
-| `type`           | The type of Hub from where to pull the resource (Optional). Either `artifact` or `tekton` | Default:  `artifact`                                         |
+| `type`           | The type of Hub from where to pull the resource (Optional). Either `artifact` or `tekton` | Default:  `artifact` (recommended). Note: `tekton` type is deprecated.                                         |
 | `kind`           | Either `task` or `pipeline` (Optional)                                        | Default: `task`                                                     |
 | `name`           | The name of the task or pipeline to fetch from the hub                        | `golang-build`                                             |
 | `version`        | Version or a Constraint (see [below](#version-constraint) of a task or a pipeline to pull in from. Wrap the number in quotes!   | `"0.5.0"`, `">= 0.5.0"`                                                    |
@@ -49,9 +49,9 @@ for the name, namespace and defaults that the resolver ships with.
 ### Configuring the Hub API endpoint
 
 The Hub Resolver supports to resolve resources from the [Artifact Hub](https://artifacthub.io/) and the [Tekton Hub](https://hub.tekton.dev/),
-which can be configured by setting the `type` field of the resolver. 
+which can be configured by setting the `type` field of the resolver.
 
-*(Please note that the [Tekton Hub](https://hub.tekton.dev/) will be deprecated after [migration to the Artifact Hub](https://github.com/tektoncd/hub/issues/667) is done.)*
+** DEPRECATION NOTICE: [Tekton Hub](https://hub.tekton.dev/) is deprecated. Users should migrate to [Artifact Hub](https://artifacthub.io/) for discovering and managing Tekton resources. See the [migration guide](https://github.com/tektoncd/hub/issues/667) for more information.**
 
 When setting the `type` field to `artifact`, the resolver will hit the public hub api at https://artifacthub.io/ by default
 but you can configure your own (for example to use a private hub

--- a/examples/v1/pipelineruns/beta/http-resolver-credentials.yaml
+++ b/examples/v1/pipelineruns/beta/http-resolver-credentials.yaml
@@ -17,11 +17,11 @@ metadata:
   generateName: http-resolver-
 spec:
   workspaces:
-  - name: output
-    emptyDir: {}
+    - name: output
+      emptyDir: {}
   pipelineSpec:
     workspaces:
-    - name: output
+      - name: output
     tasks:
       - name: http-resolver
         taskRef:

--- a/examples/v1/pipelineruns/beta/http-resolver.yaml
+++ b/examples/v1/pipelineruns/beta/http-resolver.yaml
@@ -5,11 +5,11 @@ metadata:
   generateName: http-resolver-
 spec:
   workspaces:
-  - name: output
-    emptyDir: {}
+    - name: output
+      emptyDir: {}
   pipelineSpec:
     workspaces:
-    - name: output
+      - name: output
     tasks:
       - name: http-resolver
         taskRef:


### PR DESCRIPTION
# Changes

Cherry-pick of 639c79d95ef2 from main to release-v1.3.x.

The `api.hub.tekton.dev` service has been deprecated and shut down. The http-resolver example YAML files still reference it, causing consistent e2e test failures in alpha CI:

- `TestExamples/v1/pipelineruns/beta/http-resolver`
- `TestExamples/v1/pipelineruns/beta/http-resolver-credentials`

Both fail with:
```
dial tcp: lookup api.hub.tekton.dev on 10.96.0.10:53: no such host
```

This cherry-pick updates:
- Example YAML files to use `https://raw.githubusercontent.com/tektoncd/catalog/main/task/git-clone/0.10/git-clone.yaml` instead of the defunct Tekton Hub API
- `docs/hub-resolver.md` with deprecation notice for Tekton Hub
- `docs/events.md` to reference ArtifactHub

Original commit by @shubbhar.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```