### PR TITLE
[cherry-pick: release-v1.0.x] tekton: update plumbing ref to latest commit

### DIFF
--- a/tekton/release-pipeline.yaml
+++ b/tekton/release-pipeline.yaml
@@ -95,7 +95,7 @@ spec:
           - name: org
             value: tektoncd
           - name: revision
-            value: 8d3152d3d39982ce1768325b373d321efaa83031
+            value: 50bc706c351cc05087564bb17afc1e658090edb0
           - name: pathInRepo
             value: tekton/resources/release/base/prerelease_checks_oci.yaml
       params:


### PR DESCRIPTION
# Changes

Cherry-pick of https://github.com/tektoncd/pipeline/commit/5a40b3f2b83c from main to release-v1.0.x.

Update the plumbing revision used by the precheck task to the latest
commit on tektoncd/plumbing main (`50bc706c351cc05087564bb17afc1e658090edb0`). This includes all the full image
reference fixes (tektoncd/plumbing#3110, #3112, and follow-ups).

# Submitter Checklist

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string \"action required\" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```