### PR TITLE
Add Gitea e2e tests to CI

### DIFF
--- a/test/git-resolver/gitea.yaml
+++ b/test/git-resolver/gitea.yaml
@@ -489,7 +489,7 @@ spec:
           image: mirror.gcr.io/library/memcached:1.6
           imagePullPolicy: "IfNotPresent"
           args:
-            - /run.sh
+            - memcached
           env:
             - name: BITNAMI_DEBUG
               value: "false"

--- a/test/resolvers_gitea_test.go
+++ b/test/resolvers_gitea_test.go
@@ -1,4 +1,4 @@
-//go:build e2e && gitea
+//go:build e2e
 
 /*
  Copyright 2025 The Tekton Authors


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
- Remove the `gitea` build tag from `resolvers_gitea_test.go` so Gitea resolver tests run as part of existing e2e jobs instead of requiring a separate CI job
- Fix memcached startup args in `gitea.yaml` (official image has no `/run.sh`)

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
