### PR TITLE
Add per-resolution url parameter to Hub Resolver

### DIFF
--- a/docs/hub-resolver.md
+++ b/docs/hub-resolver.md
@@ -18,6 +18,7 @@ Use resolver type `hub`.
 | `kind`           | Either `task` or `pipeline` (Optional)                                        | Default: `task`                                                     |
 | `name`           | The name of the task or pipeline to fetch from the hub                        | `golang-build`                                             |
 | `version`        | Version or a Constraint (see [below](#version-constraint) of a task or a pipeline to pull in from. Wrap the number in quotes!   | `"0.5.0"`, `">= 0.5.0"`                                                    |
+| `url`            | Custom hub API endpoint to query instead of the cluster-configured default (Optional). Must be an absolute HTTP or HTTPS URL. Overrides `ARTIFACT_HUB_API` or `TEKTON_HUB_API` based on `type`. | `https://internal-hub.example.com`                        |
 
 The Catalogs in the Artifact Hub follows the semVer (i.e.` <major-version>.<minor-version>.0`) and the Catalogs in the Tekton Hub follows the simplified semVer (i.e. `<major-version>.<minor-version>`). Both full and simplified semantic versioning will be accepted by the `version` parameter. The Hub Resolver will map the version to the format expected by the target Hub `type`.
 
@@ -127,6 +128,37 @@ spec:
   # Resolution of the pipeline will succeed but the PipelineRun
   # overall will not succeed without those parameters.
 ```
+
+### Task Resolution from a Private Hub
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: private-hub-task-reference
+spec:
+  taskRef:
+    resolver: hub
+    params:
+    - name: url
+      value: https://internal-hub.example.com
+    - name: catalog
+      value: my-team-catalog
+    - name: type
+      value: artifact
+    - name: kind
+      value: task
+    - name: name
+      value: my-task
+    - name: version
+      value: "1.0.0"
+```
+
+When the `url` parameter is not specified, the resolver falls back to the
+cluster-configured default (`ARTIFACT_HUB_API` or `TEKTON_HUB_API` environment
+variable). This allows Pipeline authors to explicitly choose which hub instance
+to query on a per-resolution basis, which is useful in multi-team environments
+or air-gapped deployments where resources are hosted on private hub instances.
 
 ### Version constraint
 

--- a/pkg/resolution/resolver/hub/params.go
+++ b/pkg/resolution/resolver/hub/params.go
@@ -48,3 +48,9 @@ const ParamCatalog = "catalog"
 
 // ParamType is the parameter defining what the hub type to pull the resource from.
 const ParamType = "type"
+
+// ParamURL is the parameter defining a custom hub API endpoint to use
+// instead of the cluster-configured default. When specified, it overrides
+// the ARTIFACT_HUB_API or TEKTON_HUB_API environment variable based on the
+// resolution type.
+const ParamURL = resource.ParamURL


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Implements **Option A** from #9353: adds a `url` parameter to the Hub Resolver that allows Pipeline authors to override the hub API endpoint on a per-resolution basis, instead of relying solely on the cluster-wide `ARTIFACT_HUB_API` or
`TEKTON_HUB_API` environment variables.
  - Adds a new optional `url` param that accepts an absolute HTTP/HTTPS URL
  - When specified, overrides `ARTIFACT_HUB_API` or `TEKTON_HUB_API` based on `type`
  - When omitted, falls back to the cluster-configured default
  - Validates the URL scheme
  
Option B (multiple default URLs with fallback at the cluster level) will be addressed in a follow-up PR
  
# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
 Hub Resolver now supports an optional 'url' parameter to override the hub API endpoint per resolution, enabling use of internal hub instances.
```
