### PR TITLE
doc: Fix broken Tekton Bundles example link in taskruns.md

### DIFF
--- a/docs/taskruns.md
+++ b/docs/taskruns.md
@@ -164,7 +164,7 @@ spec:
       value: Task
 ```
 
-A working example can be found [here](../examples/v1beta1/taskruns/no-ci/tekton-bundles.yaml).
+A working example can be found [here](../examples/v1/taskruns/beta/bundles-resolver.yaml).
 
 Any of the above options will fetch the image using the `ImagePullSecrets` attached to the
 `ServiceAccount` specified in the `TaskRun`. See the [Service Account](#service-account)


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Fixes the broken Tekton Bundles example link in `taskruns.md`. The previous link pointed to `examples/v1beta1/taskruns/no-ci/tekton-bundles.yaml`, which no longer exists after the v1beta1→v1 migration. The link now points to the v1 example at `examples/v1/taskruns/beta/bundles-resolver.yaml`.

Related to #7192.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
