### PR TITLE
ci: add a comment on PR with slash commands available

### DIFF
--- a/.github/workflows/chatops_retest.yaml
+++ b/.github/workflows/chatops_retest.yaml
@@ -9,8 +9,7 @@
 # - or the issuer is the owner the PR
 name: Rerun Failed Actions
 
-permissions:
-  contents: read
+permissions: {}
 
 on:
   repository_dispatch:
@@ -19,5 +18,7 @@ on:
 jobs:
   retest:
     name: Rerun Failed Actions
+    permissions:
+      contents: read
     uses: tektoncd/plumbing/.github/workflows/_chatops_retest.yml@48c53b4e7f1e0bb206575b80eb9fcf07b5854907  # main
     secrets: inherit

--- a/.github/workflows/cherry-pick-command.yaml
+++ b/.github/workflows/cherry-pick-command.yaml
@@ -19,14 +19,15 @@ on:
   repository_dispatch:
     types: [cherry-pick-command]
 
-permissions:
-  contents: write
-  pull-requests: write
-  issues: write
+permissions: {}
 
 jobs:
   cherry-pick:
-    name: Cherry Pick Actions
+    name: Cherry-pick PR
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
     uses: tektoncd/plumbing/.github/workflows/_cherry-pick-command.yaml@9f8e1781d5cc431e5c95190a9fc14dfba1cec391  # main
     secrets:
       CHATOPS_TOKEN: ${{ secrets.CHATOPS_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,30 +10,37 @@ defaults:
   run:
     shell: bash
 
-permissions:
-  contents: read
-  checks: write # Used to annotate code in the PR
+permissions: {}
 
 jobs:
   changes:
     name: categorize changes
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       non-docs: ${{ steps.detect.outputs.non-docs }}
       yaml: ${{ steps.detect.outputs.yaml }}
     steps:
     - name: Get base depth
       id: base-depth
-      run: echo "base-depth=$(expr ${{ github.event.pull_request.commits }} + 1)" >> $GITHUB_OUTPUT
+      env:
+        COMMITS: ${{ github.event.pull_request.commits }}
+      run: echo "base-depth=$(expr "${COMMITS}" + 1)" >> $GITHUB_OUTPUT
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
+        persist-credentials: false
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: ${{ steps.base-depth.outputs.base-depth }}
     - name: detect
       id: detect
+      env:
+        BASE_REF: ${{ github.base_ref }}
+        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       run: |
-        git fetch origin ${{ github.base_ref }}
-        CHANGED_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }} | tr ' ' '\n')
+        git fetch origin "${BASE_REF}"
+        CHANGED_FILES=$(git diff --name-only "${BASE_SHA}"..."${HEAD_SHA}" | tr ' ' '\n')
 
         echo -e "Changed files:\n${CHANGED_FILES}"
 
@@ -64,10 +71,14 @@ jobs:
   build:
     name: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: [changes]
     if: ${{ needs.changes.outputs.non-docs == 'true' }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      with:
+        persist-credentials: false
     - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6.3.0
       with:
         go-version-file: "go.mod"
@@ -77,10 +88,14 @@ jobs:
   buildFips:
     name: buildFips
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: [changes]
     if: ${{ needs.changes.outputs.non-docs == 'true' }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      with:
+        persist-credentials: false
     - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6.3.0
       with:
         go-version-file: "go.mod"
@@ -91,10 +106,13 @@ jobs:
   linting:
     name: lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: [changes]
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
+        persist-credentials: false
         fetch-depth: 0
     - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6.3.0
       with:
@@ -127,8 +145,12 @@ jobs:
     needs: [build]
     name: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      with:
+        persist-credentials: false
     - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6.3.0
       with:
         go-version-file: "go.mod"
@@ -139,8 +161,12 @@ jobs:
     needs: [build]
     name: Check generated code
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      with:
+        persist-credentials: false
     - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6.3.0
       with:
         go-version-file: "go.mod"
@@ -151,10 +177,14 @@ jobs:
     needs: [build]
     name: Multi-arch build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       KOCACHE: /tmp/ko-cache
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      with:
+        persist-credentials: false
     - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6.3.0
       with:
         go-version-file: "go.mod"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,8 +11,7 @@
 #
 name: "CodeQL"
 
-permissions:
-  contents: read
+permissions: {}
 
 on:
   push:
@@ -55,6 +54,8 @@ jobs:
 
     - name: Checkout repository
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
     - name: Setup go
       uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v5
       with:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -9,12 +9,13 @@
 name: 'Dependency Review'
 on: [pull_request]
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   dependency-review:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
@@ -23,6 +24,8 @@ jobs:
 
       - name: 'Checkout Repository'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
         with:

--- a/.github/workflows/e2e-matrix-extras.yaml
+++ b/.github/workflows/e2e-matrix-extras.yaml
@@ -4,10 +4,7 @@ on:
   repository_dispatch:
     types: [e2e-extras-command]
 
-permissions:
-  contents: read
-  pull-requests: read
-  checks: write
+permissions: {}
 
 defaults:
   run:
@@ -16,6 +13,9 @@ defaults:
 jobs:
   run-if-requested:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
     - name: Show Github Object
       run: |
@@ -27,34 +27,43 @@ jobs:
     - name: Set PR variables
       id: pr
       uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+      env:
+        ISSUE_NUMBER: ${{ github.event.client_payload.github.payload.issue.number }}
       with:
         script: |
           const pr = await github.rest.pulls.get({
             owner: context.repo.owner,
             repo: context.repo.repo,
-            pull_number: ${{ github.event.client_payload.github.payload.issue.number }}
+            pull_number: parseInt(process.env.ISSUE_NUMBER)
           });
           core.setOutput('sha', pr.data.head.sha);
 
     - name: Create comment
       if: ${{ failure() }}
       uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
+      env:
+        COMMAND: ${{ github.event.client_payload.slash_command.command }}
+        REPO: ${{ github.event.client_payload.github.payload.repository.full_name }}
+        ISSUE_NUMBER: ${{ github.event.client_payload.github.payload.issue.number }}
       with:
         token: ${{ secrets.CHATOPS_TOKEN }}
-        repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
-        issue-number: ${{ github.event.client_payload.github.payload.issue.number }}
+        repository: ${{ env.REPO }}
+        issue-number: ${{ env.ISSUE_NUMBER }}
         body: |
-          Something went wrong with your `/${{ github.event.client_payload.slash_command.command }}` command: [please check the logs][1].
+          Something went wrong with your `/${{ env.COMMAND }}` command: [please check the logs][1].
 
           [1]: ${{ steps.vars.outputs.run-url }}
 
     - name: Add reaction
       if: ${{ success() }}
       uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
+      env:
+        REPO: ${{ github.event.client_payload.github.payload.repository.full_name }}
+        COMMENT_ID: ${{ github.event.client_payload.github.payload.comment.id }}
       with:
         token: ${{ secrets.CHATOPS_TOKEN }}
-        repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
-        comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+        repository: ${{ env.REPO }}
+        comment-id: ${{ env.COMMENT_ID }}
         reactions: hooray
     outputs:
       sha: ${{ steps.pr.outputs.sha }}
@@ -67,6 +76,9 @@ jobs:
       cancel-in-progress: true
     name: e2e tests (extras)
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      checks: write
     strategy:
       fail-fast: false
       matrix:
@@ -99,20 +111,24 @@ jobs:
     - name: Report tests check
       uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
       id: check-run
+      env:
+        HEAD_SHA: ${{ needs.run-if-requested.outputs.sha }}
+        RUN_ID: ${{ github.run_id }}
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
           const check = await github.rest.checks.create({
             name: 'run tests',
-            head_sha: '${{ needs.run-if-requested.outputs.sha }}',
+            head_sha: process.env.HEAD_SHA,
             status: 'in_progress',
-            details_url: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}',
+            details_url: '${{ github.server_url }}/${{ github.repository }}/actions/runs/' + process.env.RUN_ID,
             ...context.repo
           })
           return { id: check.data.id }
 
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
+        persist-credentials: false
         ref: ${{ needs.run-if-requested.outputs.sha }}
     - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6.3.0
       with:
@@ -137,16 +153,20 @@ jobs:
         echo "${GOPATH}/bin" >> "$GITHUB_PATH"
 
     - name: Run tests
+      env:
+        RUN_ID: ${{ github.run_id }}
+        K8S_VERSION: ${{ matrix.k8s-version }}
+        FEATURE_FLAGS: ${{ matrix.feature-flags }}
       run: |
         export PATH="$(echo "$PATH" | sed -e 's/^\/bin://'):/bin"
         export KO_DEFAULTPLATFORMS=linux/$(go env GOARCH)
         ./hack/setup-kind.sh \
           --registry-url $(echo ${KO_DOCKER_REPO} | cut -d'/' -f 1) \
-          --cluster-suffix c${{ github.run_id }}.local \
+          --cluster-suffix "c${RUN_ID}.local" \
           --nodes 3 \
-          --k8s-version ${{ matrix.k8s-version }} \
+          --k8s-version "${K8S_VERSION}" \
           --e2e-script ./test/e2e-tests.sh \
-          --e2e-env ./test/e2e-tests-kind-${{ matrix.feature-flags }}.env
+          --e2e-env "./test/e2e-tests-kind-${FEATURE_FLAGS}.env"
 
     - name: Upload test results
       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -3,9 +3,7 @@ name: Tekton Integration
 
 on: [workflow_call]
 
-permissions:
-  contents: read
-  checks: write
+permissions: {}
 
 defaults:
   run:
@@ -18,6 +16,9 @@ jobs:
       cancel-in-progress: true
     name: e2e tests
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      checks: write
     strategy:
       fail-fast: false # Keep running if one leg fails.
       matrix:
@@ -70,6 +71,8 @@ jobs:
         echo "--- Disk space after cleanup ---"
         df -h
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      with:
+        persist-credentials: false
     - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6.3.0
       with:
         go-version-file: "go.mod"
@@ -96,6 +99,10 @@ jobs:
         echo "${GOPATH}/bin" >> "$GITHUB_PATH"
 
     - name: Run tests
+      env:
+        K8S_VERSION: ${{ matrix.k8s-version }}
+        FEATURE_FLAGS: ${{ matrix.feature-flags }}
+        RUN_ID: ${{ github.run_id }}
       run: |
         # This is a hack to make sure binary in /bin from the base image are not picked by default
         # On ubuntu-arm, there is a /bin/go that shadows the one setup-go installs
@@ -103,11 +110,11 @@ jobs:
         export KO_DEFAULTPLATFORMS=linux/$(go env GOARCH)
         ./hack/setup-kind.sh \
           --registry-url $(echo ${KO_DOCKER_REPO} | cut -d'/' -f 1) \
-          --cluster-suffix c${{ github.run_id }}.local \
+          --cluster-suffix "c${RUN_ID}.local" \
           --nodes 3 \
-          --k8s-version ${{ matrix.k8s-version }} \
+          --k8s-version "${K8S_VERSION}" \
           --e2e-script ./test/e2e-tests.sh \
-          --e2e-env ./test/e2e-tests-kind-${{ matrix.feature-flags }}.env
+          --e2e-env "./test/e2e-tests-kind-${FEATURE_FLAGS}.env"
 
     - name: Upload test results
       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
@@ -122,12 +129,14 @@ jobs:
 
     - name: Dump Artifacts
       if: ${{ failure() }}
+      env:
+        ARTIFACTS: ${{ env.ARTIFACTS }}
       run: |
-        if [[ -d ${{ env.ARTIFACTS }} ]]; then
-          cd ${{ env.ARTIFACTS }}
+        if [[ -d "${ARTIFACTS}" ]]; then
+          cd "${ARTIFACTS}"
           for x in $(find . -type f); do
             echo "::group:: artifact $x"
-            cat $x
+            cat "$x"
             echo '::endgroup::'
           done
         fi

--- a/.github/workflows/go-coverage.yml
+++ b/.github/workflows/go-coverage.yml
@@ -1,7 +1,6 @@
 name: Go coverage
 
-permissions:
-  contents: read
+permissions: {}
 
 on:
   pull_request:
@@ -26,6 +25,7 @@ jobs:
     name: Go coverage
     runs-on: ubuntu-24.04
     permissions:
+      contents: read
       pull-requests: write
 
     steps:
@@ -37,6 +37,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           path: ${{ github.workspace }}/src/github.com/tektoncd/pipeline
 
       - name: Set up Go

--- a/.github/workflows/labels.yaml
+++ b/.github/workflows/labels.yaml
@@ -9,15 +9,15 @@ on:
       - labeled
       - unlabeled
 
-permissions:
-  contents: read
-  pull-requests: read
+permissions: {}
 
 jobs:
 
   check_labels:
     name: Check kind labels
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     steps:
       - uses: agilepathway/label-checker@c3d16ad512e7cea5961df85ff2486bb774caf3c5 # v1.6.65
         with:

--- a/.github/workflows/nightly-builds.yaml
+++ b/.github/workflows/nightly-builds.yaml
@@ -40,15 +40,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Generate version info
         id: version
+        env:
+          LATEST_SHA: ${{ github.sha }}
         run: |
-          latest_sha=${{ github.sha }}
-          date_tag=$(date +v%Y%m%d-${latest_sha:0:7})
+          date_tag=$(date +v%Y%m%d-${LATEST_SHA:0:7})
           echo "version_tag=${date_tag}" >> "$GITHUB_OUTPUT"
-          echo "latest_sha=${latest_sha}" >> "$GITHUB_OUTPUT"
+          echo "latest_sha=${LATEST_SHA}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Kind cluster
         uses: chainguard-dev/actions/setup-kind@7440e20e3e0bb180a2f6e330bcd53504e2ac8980  # v1.6.8

--- a/.github/workflows/rebase-command.yaml
+++ b/.github/workflows/rebase-command.yaml
@@ -17,14 +17,15 @@ on:
   repository_dispatch:
     types: [rebase-command]
 
-permissions:
-  contents: write
-  pull-requests: write
-  issues: write
+permissions: {}
 
 jobs:
   rebase:
     name: Rebase PR
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
     uses: tektoncd/plumbing/.github/workflows/_rebase-command.yaml@4e60dd3785868521b0542134f5f57f2989c8883d  # main
     secrets:
       CHATOPS_TOKEN: ${{ secrets.CHATOPS_TOKEN }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -14,8 +14,8 @@ on:
   push:
     branches: [ "main" ]
 
-# Declare default permissions as read only.
-permissions: read-all
+# Declare default permissions as empty.
+permissions: {}
 
 jobs:
   analysis:

--- a/.github/workflows/slash-commands-docs.yml
+++ b/.github/workflows/slash-commands-docs.yml
@@ -10,14 +10,14 @@ on:
   pull_request_target:
     types: [opened]
 
-permissions:
-  pull-requests: write
-  contents: read
+permissions: {}
 
 jobs:
   comment:
     name: Post slash commands documentation
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
     - name: Check for existing comment
       id: check

--- a/.github/workflows/slash-commands-docs.yml
+++ b/.github/workflows/slash-commands-docs.yml
@@ -7,7 +7,7 @@
 name: Slash Commands PR Comment
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened]
 
 permissions:
@@ -37,19 +37,23 @@ jobs:
       uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
       with:
         script: |
-          const body = `<!-- tekton-slash-commands -->
-          ## Slash commands
+          const body = [
+            '<!-- tekton-slash-commands -->',
+            '## Slash commands',
+            '',
+            'You can use these commands by commenting on this PR. All require **write** access to the repository.',
+            '',
+            '| Command | When to use |',
+            '|---------|-------------|',
+            '| `/kind <type>` | Set the kind label for this PR (e.g. `bug`, `feature`, `documentation`) |',
+            '| `/retest` | Re-run failed GitHub Actions checks on this PR |',
+            '| `/e2e-extras` | Run extra end-to-end tests (not part of default CI) |',
+            '| `/rebase` | Rebase this PR onto its base branch (PR must be from tektoncd/pipeline, not a fork) |',
+            '| `/cherry-pick <branch>` | After merge: cherry-pick this PR to the given branch(es) |',
+            '',
+            'See [CONTRIBUTING.md - Slash Commands](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md#slash-commands) for details.',
+          ].join('\n');
 
-          You can use these commands by commenting on this PR. All require **write** access to the repository.
-
-          | Command | When to use |
-          |---------|-------------|
-          | \`/retest\` | Re-run failed GitHub Actions checks on this PR |
-          | \`/e2e-extras\` | Run extra end-to-end tests (not part of default CI) |
-          | \`/rebase\` | Rebase this PR onto its base branch (PR must be from tektoncd/pipeline, not a fork) |
-          | \`/cherry-pick <branch>\` | After merge: cherry-pick this PR to the given branch(es) |
-
-          See [CONTRIBUTING.md - Slash Commands](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md#slash-commands) for details.`;
           await github.rest.issues.createComment({
             owner: context.repo.owner,
             repo: context.repo.repo,

--- a/.github/workflows/slash-commands-docs.yml
+++ b/.github/workflows/slash-commands-docs.yml
@@ -1,0 +1,59 @@
+# Post slash command documentation on new pull requests
+#
+# This workflow adds a comment to new PRs so contributors know about
+# available slash commands and when to use them.
+# See https://github.com/tektoncd/pipeline/issues/9148
+
+name: Slash Commands PR Comment
+
+on:
+  pull_request:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  comment:
+    name: Post slash commands documentation
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check for existing comment
+      id: check
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+      with:
+        script: |
+          const marker = '<!-- tekton-slash-commands -->';
+          const { data: comments } = await github.rest.issues.listComments({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.issue.number,
+          });
+          const existing = comments.find(c => c.body && c.body.includes(marker));
+          core.setOutput('exists', existing ? 'true' : 'false');
+    - name: Post slash commands documentation
+      if: steps.check.outputs.exists != 'true'
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+      with:
+        script: |
+          const body = `<!-- tekton-slash-commands -->
+          ## Slash commands
+
+          You can use these commands by commenting on this PR. All require **write** access to the repository.
+
+          | Command | When to use |
+          |---------|-------------|
+          | \`/retest\` | Re-run failed GitHub Actions checks on this PR |
+          | \`/e2e-extras\` | Run extra end-to-end tests (not part of default CI) |
+          | \`/rebase\` | Rebase this PR onto its base branch (PR must be from tektoncd/pipeline, not a fork) |
+          | \`/cherry-pick <branch>\` | After merge: cherry-pick this PR to the given branch(es) |
+
+          See [CONTRIBUTING.md - Slash Commands](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md#slash-commands) for details.`;
+          await github.rest.issues.createComment({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.issue.number,
+            body,
+          });
+          core.info('Posted slash commands documentation.');

--- a/.github/workflows/slash.yml
+++ b/.github/workflows/slash.yml
@@ -24,12 +24,13 @@ on:
   issue_comment:
     types: [created]
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   check_comments:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - name: route-land
       uses: peter-evans/slash-command-dispatch@9bdcd7914ec1b75590b790b844aa3b8eee7c683a # v5.0.2

--- a/.github/workflows/woke.yml
+++ b/.github/workflows/woke.yml
@@ -1,7 +1,6 @@
 name: 'woke'
 
-permissions:
-  contents: read
+permissions: {}
 
 on:
   - pull_request
@@ -9,6 +8,8 @@ jobs:
   woke:
     name: 'woke'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
@@ -16,6 +17,8 @@ jobs:
           egress-policy: audit
       - name: 'Checkout'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
         
       - name: Get changed files
         id: changed-files

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -1,0 +1,27 @@
+name: zizmor
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Zizmor security audit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: nscott/zizmor-action@1db5a13ca37c0d57f184c6e7e62ffabe2c5e4ab5 # v1.6.1
+        with:
+          fail-on-error: true
+          upload-sarif: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,23 @@ The project includes GitHub slash commands to automate common workflows.
 All commands require **write** access to the repository and must be placed at
 the beginning of a comment line.
 
+### `/kind`
+
+Sets the kind label for a pull request (for example, `kind/bug`, `kind/feature`, or `kind/documentation`).
+
+**Usage**: `/kind <type>`
+
+**Examples**:
+- `/kind bug`
+- `/kind feature`
+- `/kind documentation`
+
+**Requirements**:
+- User must have write permissions
+- Comment on the PR
+
+Use this to categorize the type of change being made so it matches the PR template checklist.
+
 ### `/retest`
 
 Re-runs failed GitHub Actions checks on a pull request.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,34 @@ For support in contributing to specific areas, contact the relevant [Tekton Pipe
 
 ## Slash Commands
 
-The project includes GitHub slash commands to automate common workflows:
+The project includes GitHub slash commands to automate common workflows.
+All commands require **write** access to the repository and must be placed at
+the beginning of a comment line.
+
+### `/retest`
+
+Re-runs failed GitHub Actions checks on a pull request.
+
+**Usage**: `/retest`
+
+**Requirements**:
+- User must be a maintainer or the PR author
+- Comment on the PR
+
+Use this when CI has failed due to flakes or transient issues and you want to
+re-run the failed jobs without pushing a new commit.
+
+### `/e2e-extras`
+
+Runs extra end-to-end tests that are not part of the default CI matrix.
+
+**Usage**: `/e2e-extras`
+
+**Requirements**:
+- User must have write permissions
+
+Use this when you need broader e2e coverage (e.g. different Kubernetes versions
+or feature flags) before merging.
 
 ### `/cherry-pick`
 


### PR DESCRIPTION

# Changes

Adds a CI workflow that posts a short guide on available slash commands when a new pull request is opened, and documents those commands in `CONTRIBUTING.md`.

- Adds `.github/workflows/slash-commands-docs.yml` which:
  - Triggers on `pull_request_target` with `types: [opened]`.
  - Checks for an existing marker comment (`<!-- tekton-slash-commands -->`) to avoid duplicates.
  - Posts a markdown comment describing the supported slash commands and linking to the detailed docs.
- Updates `CONTRIBUTING.md` to:
  - Document `/kind` and how it’s used to categorize PRs.
  - Document `/retest` and `/e2e-extras` and when to use them.
  - Keep `/rebase` and `/cherry-pick` descriptions in one place for discoverability.

This makes slash commands more visible to contributors and reduces confusion about how to trigger CI and other automation from PR comments.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed (N/A – CI workflow and docs only)
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind documentation`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Documentation: Add a CI workflow that comments on new pull requests with a summary of available GitHub slash commands and document /kind, /retest, and /e2e-extras usage in CONTRIBUTING.md.