### PR TITLE
Add multi-URL support and per-resolution url param to Hub Resolver

### DIFF
--- a/config/resolvers/hubresolver-config.yaml
+++ b/config/resolvers/hubresolver-config.yaml
@@ -32,3 +32,14 @@ data:
   default-kind: "task"
   # the default hub source to pull the resource from.
   default-type: "artifact"
+  # Ordered list of Artifact Hub API URLs to try. First successful response wins.
+  # If not set, the ARTIFACT_HUB_API env var or default (https://artifacthub.io) is used.
+  # URLs must use http or https scheme.
+  # artifact-hub-urls: |
+  #   - https://internal-hub.example.com/
+  #   - https://artifacthub.io/
+  # Ordered list of Tekton Hub API URLs to try. First successful response wins.
+  # If not set, the TEKTON_HUB_API env var is used.
+  # URLs must use http or https scheme.
+  # tekton-hub-urls: |
+  #   - https://api.hub.tekton.dev/

--- a/docs/hub-resolver.md
+++ b/docs/hub-resolver.md
@@ -18,6 +18,7 @@ Use resolver type `hub`.
 | `kind`           | Either `task` or `pipeline` (Optional)                                        | Default: `task`                                                     |
 | `name`           | The name of the task or pipeline to fetch from the hub                        | `golang-build`                                             |
 | `version`        | Version or a Constraint (see [below](#version-constraint) of a task or a pipeline to pull in from. Wrap the number in quotes!   | `"0.5.0"`, `">= 0.5.0"`                                                    |
+| `url`            | Custom hub API endpoint to query instead of the cluster-configured default (Optional). Must be an absolute HTTP or HTTPS URL. Overrides all other URL configuration (ConfigMap URL lists, environment variables, and defaults). | `https://internal-hub.example.com`                        |
 
 The Catalogs in the Artifact Hub follows the semVer (i.e.` <major-version>.<minor-version>.0`) and the Catalogs in the Tekton Hub follows the simplified semVer (i.e. `<major-version>.<minor-version>`). Both full and simplified semantic versioning will be accepted by the `version` parameter. The Hub Resolver will map the version to the format expected by the target Hub `type`.
 
@@ -44,6 +45,8 @@ for the name, namespace and defaults that the resolver ships with.
 | `default-artifact-hub-pipeline-catalog`| The default artifact hub catalog from where to pull the resource for pipeline kind.  | `tekton-catalog-pipelines`               |
 | `default-kind`              | The default object kind for references.              | `task`, `pipeline`     |
 | `default-type`              | The default hub from where to pull the resource.     | `artifact`, `tekton`   |
+| `artifact-hub-urls`         | Ordered YAML list of Artifact Hub API URLs to try. First successful response wins. If not set, the `ARTIFACT_HUB_API` env var or default is used. URLs must use `http` or `https` scheme. | See [below](#configuring-multiple-hub-urls) |
+| `tekton-hub-urls`           | Ordered YAML list of Tekton Hub API URLs to try. First successful response wins. If not set, the `TEKTON_HUB_API` env var is used. URLs must use `http` or `https` scheme. | See [below](#configuring-multiple-hub-urls) |
 
 ### Configuring the Hub API endpoint
 
@@ -127,6 +130,72 @@ spec:
   # Resolution of the pipeline will succeed but the PipelineRun
   # overall will not succeed without those parameters.
 ```
+
+### Task Resolution from a Private Hub
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: private-hub-task-reference
+spec:
+  taskRef:
+    resolver: hub
+    params:
+    - name: url
+      value: https://internal-hub.example.com
+    - name: catalog
+      value: my-team-catalog
+    - name: type
+      value: artifact
+    - name: kind
+      value: task
+    - name: name
+      value: my-task
+    - name: version
+      value: "1.0.0"
+```
+
+When the `url` parameter is not specified, the resolver falls back to the
+cluster-configured defaults: first checking the ConfigMap URL lists
+(`artifact-hub-urls` / `tekton-hub-urls`), then the environment variables
+(`ARTIFACT_HUB_API` / `TEKTON_HUB_API`). This allows Pipeline authors to
+explicitly choose which hub instance to query on a per-resolution basis, which
+is useful in multi-team environments or air-gapped deployments where resources
+are hosted on private hub instances.
+
+### Configuring Multiple Hub URLs
+
+You can configure multiple hub API URLs in the `hubresolver-config` ConfigMap.
+The resolver will try each URL in order and return the first successful result.
+This is useful for layered catalogs, multi-team environments, or air-gapped
+deployments where resources may exist on different hub instances.
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hubresolver-config
+  namespace: tekton-pipelines-resolvers
+data:
+  artifact-hub-urls: |
+    - https://internal-hub.example.com/
+    - https://artifacthub.io/
+  tekton-hub-urls: |
+    - https://internal-tekton-hub.example.com/
+    - https://api.hub.tekton.dev/
+```
+
+> **Note:** All URLs (whether in the ConfigMap lists, the `url` parameter, or environment variables) must use `http` or `https` scheme. Other schemes (e.g., `ftp://`) will be rejected.
+
+**URL precedence** (highest to lowest):
+1. Per-resolution `url` parameter — single URL override for a specific resolution request
+2. ConfigMap URL lists (`artifact-hub-urls` / `tekton-hub-urls`) — tried in order, first success wins
+3. Environment variable (`ARTIFACT_HUB_API` / `TEKTON_HUB_API`) — single URL fallback
+4. Default URL (`https://artifacthub.io` for artifact type)
+
+If the ConfigMap URL list keys are not set (commented out by default), the
+resolver behaves exactly as before, using the environment variable or default URL.
 
 ### Version constraint
 

--- a/pkg/remoteresolution/resolver/hub/config.go
+++ b/pkg/remoteresolution/resolver/hub/config.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2024 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hub
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"sigs.k8s.io/yaml"
+)
+
+// ConfigArtifactHubURLs is the configuration field name for controlling
+// the Artifact Hub API URLs to fetch remote resources from.
+// Value is a YAML list of URLs, tried in order; first success wins.
+const ConfigArtifactHubURLs = "artifact-hub-urls"
+
+// ConfigTektonHubURLs is the configuration field name for controlling
+// the Tekton Hub API URLs to fetch remote resources from.
+// Value is a YAML list of URLs, tried in order; first success wins.
+const ConfigTektonHubURLs = "tekton-hub-urls"
+
+// parseURLList parses a YAML list string from a ConfigMap value into
+// a slice of URL strings. Each URL is trimmed of whitespace and trailing slashes.
+// Returns nil if the input is empty or not a valid YAML list.
+func parseURLList(yamlList string) ([]string, error) {
+	yamlList = strings.TrimSpace(yamlList)
+	if yamlList == "" {
+		return nil, nil
+	}
+	var urls []string
+	if err := yaml.Unmarshal([]byte(yamlList), &urls); err != nil {
+		return nil, fmt.Errorf("failed to parse URL list: %w", err)
+	}
+	for i, u := range urls {
+		urls[i] = strings.TrimRight(strings.TrimSpace(u), "/")
+		if err := validateHubURL(urls[i]); err != nil {
+			return nil, err
+		}
+	}
+	return urls, nil
+}
+
+// validateHubURL checks that rawURL is a valid absolute http(s) URL.
+func validateHubURL(rawURL string) error {
+	u, err := url.ParseRequestURI(rawURL)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return fmt.Errorf("url must be a valid absolute URL: %s", rawURL)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("url must use http or https scheme: %s", rawURL)
+	}
+	return nil
+}

--- a/pkg/remoteresolution/resolver/hub/params.go
+++ b/pkg/remoteresolution/resolver/hub/params.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2024 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hub
+
+import "github.com/tektoncd/pipeline/pkg/resolution/resource"
+
+// ParamURL is the parameter defining a custom hub API endpoint to use
+// instead of the cluster-configured default. When specified, it overrides
+// the ARTIFACT_HUB_API or TEKTON_HUB_API environment variable based on the
+// resolution type.
+const ParamURL = resource.ParamURL

--- a/pkg/remoteresolution/resolver/hub/resolve.go
+++ b/pkg/remoteresolution/resolver/hub/resolve.go
@@ -1,0 +1,292 @@
+/*
+Copyright 2024 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hub
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	goversion "github.com/hashicorp/go-version"
+	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	resolutionframework "github.com/tektoncd/pipeline/pkg/resolution/resolver/framework"
+	hub "github.com/tektoncd/pipeline/pkg/resolution/resolver/hub"
+	"knative.dev/pkg/logging"
+)
+
+var errNoVersionFound = errors.New("no version found")
+
+// Response types for hub API calls.
+
+type tektonHubDataResponse struct {
+	YAML string `json:"yaml"`
+}
+
+type tektonHubResponse struct {
+	Data tektonHubDataResponse `json:"data"`
+}
+
+type artifactHubDataResponse struct {
+	YAML string `json:"manifestRaw"`
+}
+
+type artifactHubResponse struct {
+	Data artifactHubDataResponse `json:"data"`
+}
+
+type artifactHubavailableVersionsResults struct {
+	Version    string `json:"version"`
+	Prerelease bool   `json:"prerelease"`
+}
+
+type artifactHubListResult struct {
+	AvailableVersions []artifactHubavailableVersionsResults `json:"available_versions"`
+	Version           string                                `json:"version"`
+}
+
+type tektonHubListResultVersion struct {
+	Version string `json:"version"`
+}
+
+type tektonHubListDataResult struct {
+	Versions []tektonHubListResultVersion `json:"versions"`
+}
+
+type tektonHubListResult struct {
+	Data tektonHubListDataResult `json:"data"`
+}
+
+// resolvedHubResource wraps the data we want to return to Pipelines.
+type resolvedHubResource struct {
+	URL     string
+	Content []byte
+}
+
+var _ resolutionframework.ResolvedResource = &resolvedHubResource{}
+
+func (rr *resolvedHubResource) Data() []byte {
+	return rr.Content
+}
+
+func (*resolvedHubResource) Annotations() map[string]string {
+	return nil
+}
+
+func (rr *resolvedHubResource) RefSource() *pipelinev1.RefSource {
+	h := sha256.New()
+	h.Write(rr.Content)
+	sha256CheckSum := hex.EncodeToString(h.Sum(nil))
+
+	return &pipelinev1.RefSource{
+		URI: rr.URL,
+		Digest: map[string]string{
+			"sha256": sha256CheckSum,
+		},
+	}
+}
+
+// fetchHubResource fetches a resource from the hub API endpoint and unmarshals the response.
+func fetchHubResource(ctx context.Context, apiEndpoint string, v any) error {
+	// #nosec G107 -- URL cannot be constant in this case.
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiEndpoint, nil)
+	if err != nil {
+		return fmt.Errorf("constructing request: %w", err)
+	}
+
+	// #nosec G704 -- URL cannot be constant in this case.
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("requesting resource from Hub: %w", err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("requested resource '%s' not found on hub", apiEndpoint)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("error reading response body: %w", err)
+	}
+
+	err = json.Unmarshal(body, v)
+	if err != nil {
+		return fmt.Errorf("error unmarshalling json response: %w", err)
+	}
+	return nil
+}
+
+// resolveVersion normalizes the version string for the given hub type.
+func resolveVersion(version, hubType string) string {
+	semVer := strings.Split(version, ".")
+	if hubType == hub.ArtifactHubType && len(semVer) == 2 {
+		return version + ".0"
+	} else if hubType == hub.TektonHubType && len(semVer) > 2 {
+		return strings.Join(semVer[0:2], ".")
+	}
+	return version
+}
+
+// resolveHubURLs returns the ordered list of hub URLs to try.
+// Precedence: ConfigMap YAML list > env var URL.
+func resolveHubURLs(ctx context.Context, conf map[string]string, envVarURL, configKey string) []string {
+	if yamlStr, ok := conf[configKey]; ok && strings.TrimSpace(yamlStr) != "" {
+		urls, err := parseURLList(yamlStr)
+		if err != nil {
+			logger := logging.FromContext(ctx)
+			logger.Warnf("failed to parse %s ConfigMap value, falling back to env var URL: %v", configKey, err)
+		} else if len(urls) > 0 {
+			return urls
+		}
+	}
+	if envVarURL != "" {
+		return []string{envVarURL}
+	}
+	return nil
+}
+
+// fetchResourceFromURL fetches a resource from a single hub URL.
+func fetchResourceFromURL(ctx context.Context, paramsMap map[string]string, baseURL string) (resolutionframework.ResolvedResource, error) {
+	switch paramsMap[hub.ParamType] {
+	case hub.ArtifactHubType:
+		url := fmt.Sprintf(fmt.Sprintf("%s/%s", baseURL, hub.ArtifactHubYamlEndpoint),
+			paramsMap[hub.ParamKind], paramsMap[hub.ParamCatalog], paramsMap[hub.ParamName], paramsMap[hub.ParamVersion])
+		resp := artifactHubResponse{}
+		if err := fetchHubResource(ctx, url, &resp); err != nil {
+			return nil, fmt.Errorf("fail to fetch Artifact Hub resource: %w", err)
+		}
+		return &resolvedHubResource{
+			URL:     url,
+			Content: []byte(resp.Data.YAML),
+		}, nil
+	case hub.TektonHubType:
+		url := fmt.Sprintf(fmt.Sprintf("%s/%s", baseURL, hub.TektonHubYamlEndpoint),
+			paramsMap[hub.ParamCatalog], paramsMap[hub.ParamKind], paramsMap[hub.ParamName], paramsMap[hub.ParamVersion])
+		resp := tektonHubResponse{}
+		if err := fetchHubResource(ctx, url, &resp); err != nil {
+			return nil, fmt.Errorf("fail to fetch Tekton Hub resource: %w", err)
+		}
+		return &resolvedHubResource{
+			URL:     url,
+			Content: []byte(resp.Data.YAML),
+		}, nil
+	}
+	return nil, fmt.Errorf("hub resolver type: %s is not supported", paramsMap[hub.ParamType])
+}
+
+// fetchResourceWithFallback tries each URL in order, returns the first successful result.
+// When there is only one URL, error messages are preserved exactly as before.
+func fetchResourceWithFallback(ctx context.Context, paramsMap map[string]string, urls []string) (resolutionframework.ResolvedResource, error) {
+	var errs []error
+	for _, baseURL := range urls {
+		result, err := fetchResourceFromURL(ctx, paramsMap, baseURL)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		return result, nil
+	}
+	if len(errs) == 1 {
+		return nil, errs[0]
+	}
+	return nil, fmt.Errorf("failed to fetch resource from any configured hub URL: %w", errors.Join(errs...))
+}
+
+// resolveVersionConstraintFromURL resolves a version constraint from a single hub URL.
+func resolveVersionConstraintFromURL(ctx context.Context, paramsMap map[string]string, constraint goversion.Constraints, baseURL string) (*goversion.Version, error) {
+	var ret *goversion.Version
+	if paramsMap[hub.ParamType] == hub.ArtifactHubType {
+		allVersionsURL := fmt.Sprintf("%s/%s", baseURL, fmt.Sprintf(
+			hub.ArtifactHubListTasksEndpoint,
+			paramsMap[hub.ParamKind], paramsMap[hub.ParamCatalog], paramsMap[hub.ParamName]))
+		resp := artifactHubListResult{}
+		if err := fetchHubResource(ctx, allVersionsURL, &resp); err != nil {
+			return nil, fmt.Errorf("fail to fetch Artifact Hub resource: %w", err)
+		}
+		for _, vers := range resp.AvailableVersions {
+			if vers.Prerelease {
+				continue
+			}
+			checkV, err := goversion.NewVersion(vers.Version)
+			if err != nil {
+				return nil, fmt.Errorf("fail to parse version %s from %s: %w", hub.ArtifactHubType, vers.Version, err)
+			}
+			if checkV == nil {
+				continue
+			}
+			if constraint.Check(checkV) {
+				if ret != nil && ret.GreaterThan(checkV) {
+					continue
+				}
+				ret = checkV
+			}
+		}
+	} else if paramsMap[hub.ParamType] == hub.TektonHubType {
+		allVersionsURL := fmt.Sprintf("%s/%s", baseURL,
+			fmt.Sprintf(hub.TektonHubListTasksEndpoint,
+				paramsMap[hub.ParamCatalog], paramsMap[hub.ParamKind], paramsMap[hub.ParamName]))
+		resp := tektonHubListResult{}
+		if err := fetchHubResource(ctx, allVersionsURL, &resp); err != nil {
+			return nil, fmt.Errorf("fail to fetch Tekton Hub resource: %w", err)
+		}
+		for _, vers := range resp.Data.Versions {
+			checkV, err := goversion.NewVersion(vers.Version)
+			if err != nil {
+				return nil, fmt.Errorf("fail to parse version %s from %s: %w", hub.TektonHubType, vers, err)
+			}
+			if checkV == nil {
+				continue
+			}
+			if constraint.Check(checkV) {
+				if ret != nil && ret.GreaterThan(checkV) {
+					continue
+				}
+				ret = checkV
+			}
+		}
+	}
+	if ret == nil {
+		return nil, fmt.Errorf("%w for constraint %s", errNoVersionFound, paramsMap[hub.ParamVersion])
+	}
+	return ret, nil
+}
+
+// resolveVersionConstraintWithFallback tries each URL in order for version constraint resolution.
+// Returns the resolved version and the URL that satisfied the constraint, so the caller can
+// pin subsequent fetches to the same hub.
+func resolveVersionConstraintWithFallback(ctx context.Context, paramsMap map[string]string, constraint goversion.Constraints, urls []string) (*goversion.Version, string, error) {
+	var errs []error
+	for _, baseURL := range urls {
+		ver, err := resolveVersionConstraintFromURL(ctx, paramsMap, constraint, baseURL)
+		if err != nil {
+			if errors.Is(err, errNoVersionFound) {
+				// Hub was reachable but had no matching version — don't try other hubs.
+				return nil, "", err
+			}
+			errs = append(errs, err)
+			continue
+		}
+		return ver, baseURL, nil
+	}
+	if len(errs) == 1 {
+		return nil, "", errs[0]
+	}
+	return nil, "", fmt.Errorf("failed to resolve version constraint from any configured hub URL: %w", errors.Join(errs...))
+}

--- a/pkg/remoteresolution/resolver/hub/resolver.go
+++ b/pkg/remoteresolution/resolver/hub/resolver.go
@@ -15,12 +15,19 @@ package hub
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
 
+	goversion "github.com/hashicorp/go-version"
+	resolverconfig "github.com/tektoncd/pipeline/pkg/apis/config/resolver"
+	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/apis/resolution/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/remoteresolution/resolver/framework"
 	"github.com/tektoncd/pipeline/pkg/resolution/common"
 	resolutionframework "github.com/tektoncd/pipeline/pkg/resolution/resolver/framework"
-	"github.com/tektoncd/pipeline/pkg/resolution/resolver/hub"
+	hub "github.com/tektoncd/pipeline/pkg/resolution/resolver/hub"
 )
 
 const (
@@ -35,6 +42,8 @@ const (
 
 	// TektonHubType is the value to use setting the type field to tekton
 	TektonHubType = "tekton"
+
+	disabledError = "cannot handle resolution request, enable-hub-resolver feature flag not true"
 )
 
 var _ framework.Resolver = (*Resolver)(nil)
@@ -72,10 +81,213 @@ func (r *Resolver) GetSelector(_ context.Context) map[string]string {
 
 // Validate ensures parameters from a request are as expected.
 func (r *Resolver) Validate(ctx context.Context, req *v1beta1.ResolutionRequestSpec) error {
+	if isDisabled(ctx) {
+		return errors.New(disabledError)
+	}
+
+	paramsMap := extractParams(req.Params)
+
+	// Validate URL param if provided.
+	if paramURL := paramsMap[ParamURL]; paramURL != "" {
+		if err := validateHubURL(paramURL); err != nil {
+			return fmt.Errorf("failed to validate params: invalid url param: %w", err)
+		}
+	}
+
+	// For TektonHub type with no env var URL, check if url param or ConfigMap URLs are available.
+	hasURLOverride := paramsMap[ParamURL] != ""
+	conf := resolutionframework.GetResolverConfigFromContext(ctx)
+	hubType := paramsMap[hub.ParamType]
+	if hubType == "" {
+		hubType = conf[hub.ConfigType]
+	}
+	if hubType == hub.TektonHubType && r.TektonHubURL == "" {
+		if hasURLOverride {
+			// URL param overrides the env var, pass a placeholder to skip the env var check.
+			return hub.ValidateParams(ctx, req.Params, "url-param-configured")
+		}
+		configURLs, _ := parseURLList(conf[ConfigTektonHubURLs])
+		if len(configURLs) > 0 {
+			// ConfigMap URLs are available, skip the env var check.
+			return hub.ValidateParams(ctx, req.Params, "configmap-urls-configured")
+		}
+	}
+
 	return hub.ValidateParams(ctx, req.Params, r.TektonHubURL)
 }
 
 // Resolve uses the given params to resolve the requested file or resource.
 func (r *Resolver) Resolve(ctx context.Context, req *v1beta1.ResolutionRequestSpec) (resolutionframework.ResolvedResource, error) {
-	return hub.Resolve(ctx, req.Params, r.TektonHubURL, r.ArtifactHubURL)
+	if isDisabled(ctx) {
+		return nil, errors.New(disabledError)
+	}
+
+	paramsMap, err := populateDefaultParams(ctx, req.Params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to populate default params: %w", err)
+	}
+	if err := r.validateParamsForResolve(ctx, paramsMap); err != nil {
+		return nil, fmt.Errorf("failed to validate params: %w", err)
+	}
+
+	// Determine ordered list of hub URLs to try.
+	// Precedence: url param > ConfigMap YAML list > env var URL.
+	var urls []string
+	if paramURL := paramsMap[ParamURL]; paramURL != "" {
+		urls = []string{strings.TrimRight(paramURL, "/")}
+	} else {
+		conf := resolutionframework.GetResolverConfigFromContext(ctx)
+		switch paramsMap[hub.ParamType] {
+		case hub.ArtifactHubType:
+			urls = resolveHubURLs(ctx, conf, r.ArtifactHubURL, ConfigArtifactHubURLs)
+		case hub.TektonHubType:
+			urls = resolveHubURLs(ctx, conf, r.TektonHubURL, ConfigTektonHubURLs)
+		}
+	}
+
+	if len(urls) == 0 {
+		return nil, fmt.Errorf("no hub URL configured for type %s", paramsMap[hub.ParamType])
+	}
+
+	if constraint, err := goversion.NewConstraint(paramsMap[hub.ParamVersion]); err == nil {
+		chosen, constraintURL, err := resolveVersionConstraintWithFallback(ctx, paramsMap, constraint, urls)
+		if err != nil {
+			return nil, err
+		}
+		paramsMap[hub.ParamVersion] = chosen.String()
+		// Pin subsequent fetch to the same hub that satisfied the constraint.
+		urls = []string{constraintURL}
+	}
+
+	resVer := resolveVersion(paramsMap[hub.ParamVersion], paramsMap[hub.ParamType])
+	paramsMap[hub.ParamVersion] = resVer
+
+	return fetchResourceWithFallback(ctx, paramsMap, urls)
+}
+
+// isDisabled checks if the hub resolver feature flag is disabled.
+func isDisabled(ctx context.Context) bool {
+	cfg := resolverconfig.FromContextOrDefaults(ctx)
+	return !cfg.FeatureFlags.EnableHubResolver
+}
+
+// extractParams converts a param slice to a simple map.
+func extractParams(params []pipelinev1.Param) map[string]string {
+	paramsMap := make(map[string]string)
+	for _, p := range params {
+		paramsMap[p.Name] = p.Value.StringVal
+	}
+	return paramsMap
+}
+
+// populateDefaultParams populates the params map with defaults from the resolver config.
+func populateDefaultParams(ctx context.Context, params []pipelinev1.Param) (map[string]string, error) {
+	conf := resolutionframework.GetResolverConfigFromContext(ctx)
+	paramsMap := extractParams(params)
+
+	// type
+	if _, ok := paramsMap[hub.ParamType]; !ok {
+		if typeString, ok := conf[hub.ConfigType]; ok {
+			paramsMap[hub.ParamType] = typeString
+		} else {
+			return nil, errors.New("default type was not set during installation of the hub resolver")
+		}
+	}
+
+	// kind
+	if _, ok := paramsMap[hub.ParamKind]; !ok {
+		if kindString, ok := conf[hub.ConfigKind]; ok {
+			paramsMap[hub.ParamKind] = kindString
+		} else {
+			return nil, errors.New("default resource kind was not set during installation of the hub resolver")
+		}
+	}
+
+	// catalog
+	resCatName, err := resolveCatalogName(paramsMap, conf)
+	if err != nil {
+		return nil, err
+	}
+	paramsMap[hub.ParamCatalog] = resCatName
+
+	return paramsMap, nil
+}
+
+// resolveCatalogName resolves the catalog name from params or config defaults.
+func resolveCatalogName(paramsMap, conf map[string]string) (string, error) {
+	var configTHCatalog, configAHTaskCatalog, configAHPipelineCatalog string
+	var ok bool
+
+	if configTHCatalog, ok = conf[hub.ConfigTektonHubCatalog]; !ok {
+		return "", errors.New("default Tekton Hub catalog was not set during installation of the hub resolver")
+	}
+	if configAHTaskCatalog, ok = conf[hub.ConfigArtifactHubTaskCatalog]; !ok {
+		return "", errors.New("default Artifact Hub task catalog was not set during installation of the hub resolver")
+	}
+	if configAHPipelineCatalog, ok = conf[hub.ConfigArtifactHubPipelineCatalog]; !ok {
+		return "", errors.New("default Artifact Hub pipeline catalog was not set during installation of the hub resolver")
+	}
+	if _, ok := paramsMap[hub.ParamCatalog]; !ok {
+		switch paramsMap[hub.ParamType] {
+		case hub.ArtifactHubType:
+			switch paramsMap[hub.ParamKind] {
+			case "task":
+				return configAHTaskCatalog, nil
+			case "pipeline":
+				return configAHPipelineCatalog, nil
+			default:
+				return "", fmt.Errorf("failed to resolve catalog name with kind: %s", paramsMap[hub.ParamKind])
+			}
+		case hub.TektonHubType:
+			return configTHCatalog, nil
+		default:
+			return "", fmt.Errorf("failed to resolve catalog name with type: %s", paramsMap[hub.ParamType])
+		}
+	}
+
+	return paramsMap[hub.ParamCatalog], nil
+}
+
+// validateParamsForResolve validates params for the resolve path (internal, after populateDefaultParams).
+func (r *Resolver) validateParamsForResolve(ctx context.Context, paramsMap map[string]string) error {
+	var missingParams []string
+	if _, ok := paramsMap[hub.ParamName]; !ok {
+		missingParams = append(missingParams, hub.ParamName)
+	}
+	if _, ok := paramsMap[hub.ParamVersion]; !ok {
+		missingParams = append(missingParams, hub.ParamVersion)
+	}
+	if kind, ok := paramsMap[hub.ParamKind]; ok {
+		supportedKinds := []string{"task", "pipeline", "stepaction"}
+		if !slices.Contains(supportedKinds, kind) {
+			return fmt.Errorf("kind param must be one of: %s", strings.Join(supportedKinds, ", "))
+		}
+	}
+
+	if paramURL, ok := paramsMap[ParamURL]; ok && paramURL != "" {
+		if err := validateHubURL(paramURL); err != nil {
+			return fmt.Errorf("invalid url param: %w", err)
+		}
+	}
+
+	hasURLOverride := paramsMap[ParamURL] != ""
+	if hubType, ok := paramsMap[hub.ParamType]; ok {
+		if hubType != hub.ArtifactHubType && hubType != hub.TektonHubType {
+			return fmt.Errorf("type param must be %s or %s", hub.ArtifactHubType, hub.TektonHubType)
+		}
+
+		if hubType == hub.TektonHubType && r.TektonHubURL == "" && !hasURLOverride {
+			conf := resolutionframework.GetResolverConfigFromContext(ctx)
+			configURLs, _ := parseURLList(conf[ConfigTektonHubURLs])
+			if len(configURLs) == 0 {
+				return errors.New("please configure TEKTON_HUB_API env variable to use tekton type")
+			}
+		}
+	}
+
+	if len(missingParams) > 0 {
+		return fmt.Errorf("missing required hub resolver params: %s", strings.Join(missingParams, ", "))
+	}
+
+	return nil
 }

--- a/pkg/remoteresolution/resolver/hub/resolver_test.go
+++ b/pkg/remoteresolution/resolver/hub/resolver_test.go
@@ -18,10 +18,12 @@ package hub
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -318,5 +320,910 @@ func checkExpectedErr(t *testing.T, expectedErr, actualErr error) {
 	}
 	if d := cmp.Diff(expectedErr.Error(), actualErr.Error()); d != "" {
 		t.Fatalf("expected err '%v' but got '%v'", expectedErr, actualErr)
+	}
+}
+
+// Multi-URL tests: per-resolution URL param override
+
+func TestValidateURLParam(t *testing.T) {
+	testCases := []struct {
+		testName     string
+		kind         string
+		version      string
+		catalog      string
+		resourceName string
+		hubType      string
+		hubURL       string
+		expectedErr  error
+	}{
+		{
+			testName:     "tekton type with url override bypasses env var check",
+			kind:         "task",
+			resourceName: "foo",
+			version:      "bar",
+			catalog:      "baz",
+			hubType:      TektonHubType,
+			hubURL:       "https://custom-tekton-hub.example.com",
+		},
+		{
+			testName:     "artifact type with url override",
+			kind:         "task",
+			resourceName: "foo",
+			version:      "bar",
+			catalog:      "baz",
+			hubType:      ArtifactHubType,
+			hubURL:       "https://internal-hub.example.com",
+		},
+		{
+			testName:     "invalid url param",
+			kind:         "task",
+			resourceName: "foo",
+			version:      "bar",
+			catalog:      "baz",
+			hubType:      ArtifactHubType,
+			hubURL:       "not-a-url",
+			expectedErr:  errors.New("failed to validate params: invalid url param: url must be a valid absolute URL: not-a-url"),
+		},
+		{
+			testName:     "file scheme rejected",
+			kind:         "task",
+			resourceName: "foo",
+			version:      "bar",
+			catalog:      "baz",
+			hubType:      ArtifactHubType,
+			hubURL:       "file:///etc/passwd",
+			expectedErr:  errors.New("failed to validate params: invalid url param: url must be a valid absolute URL: file:///etc/passwd"),
+		},
+		{
+			testName:     "ftp scheme rejected",
+			kind:         "task",
+			resourceName: "foo",
+			version:      "bar",
+			catalog:      "baz",
+			hubType:      ArtifactHubType,
+			hubURL:       "ftp://example.com",
+			expectedErr:  errors.New("failed to validate params: invalid url param: url must use http or https scheme: ftp://example.com"),
+		},
+		{
+			testName:     "gopher scheme rejected",
+			kind:         "task",
+			resourceName: "foo",
+			version:      "bar",
+			catalog:      "baz",
+			hubType:      ArtifactHubType,
+			hubURL:       "gopher://example.com",
+			expectedErr:  errors.New("failed to validate params: invalid url param: url must use http or https scheme: gopher://example.com"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+			resolver := Resolver{}
+			params := map[string]string{
+				hubresolver.ParamKind:    tc.kind,
+				hubresolver.ParamName:    tc.resourceName,
+				hubresolver.ParamVersion: tc.version,
+				hubresolver.ParamCatalog: tc.catalog,
+				hubresolver.ParamType:    tc.hubType,
+			}
+			if tc.hubURL != "" {
+				params[ParamURL] = tc.hubURL
+			}
+			req := v1beta1.ResolutionRequestSpec{
+				Params: toParams(params),
+			}
+			err := resolver.Validate(contextWithConfig(), &req)
+			if tc.expectedErr != nil {
+				checkExpectedErr(t, tc.expectedErr, err)
+			} else if err != nil {
+				t.Fatalf("unexpected error validating params: %v", err)
+			}
+		})
+	}
+}
+
+func TestResolveURLParamOverride(t *testing.T) {
+	testCases := []struct {
+		name         string
+		kind         string
+		imageName    string
+		version      string
+		catalog      string
+		hubType      string
+		input        string
+		expectedRes  []byte
+		expectedPath string
+	}{
+		{
+			name:         "url param overrides artifact hub default",
+			kind:         "task",
+			imageName:    "foo",
+			version:      "baz",
+			catalog:      "Tekton",
+			hubType:      ArtifactHubType,
+			input:        `{"data":{"manifestRaw":"from custom hub"}}`,
+			expectedRes:  []byte("from custom hub"),
+			expectedPath: "/" + fmt.Sprintf(hubresolver.ArtifactHubYamlEndpoint, "task", "Tekton", "foo", "baz"),
+		},
+		{
+			name:         "url param overrides tekton hub default",
+			kind:         "task",
+			imageName:    "foo",
+			version:      "baz",
+			catalog:      "Tekton",
+			hubType:      TektonHubType,
+			input:        `{"data":{"yaml":"from custom tekton hub"}}`,
+			expectedRes:  []byte("from custom tekton hub"),
+			expectedPath: "/" + fmt.Sprintf(hubresolver.TektonHubYamlEndpoint, "Tekton", "task", "foo", "baz"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			overrideSvr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != tc.expectedPath {
+					t.Errorf("expected request path %s but got %s", tc.expectedPath, r.URL.Path)
+				}
+				fmt.Fprint(w, tc.input)
+			}))
+			defer overrideSvr.Close()
+
+			defaultSvr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				t.Fatal("default server should not be called when url param is set")
+			}))
+			defer defaultSvr.Close()
+
+			resolver := &Resolver{
+				TektonHubURL:   defaultSvr.URL,
+				ArtifactHubURL: defaultSvr.URL,
+			}
+
+			params := map[string]string{
+				hubresolver.ParamKind:    tc.kind,
+				hubresolver.ParamName:    tc.imageName,
+				hubresolver.ParamVersion: tc.version,
+				hubresolver.ParamCatalog: tc.catalog,
+				hubresolver.ParamType:    tc.hubType,
+				ParamURL:                 overrideSvr.URL,
+			}
+			req := v1beta1.ResolutionRequestSpec{
+				Params: toParams(params),
+			}
+
+			output, err := resolver.Resolve(contextWithConfig(), &req)
+			if err != nil {
+				t.Fatalf("unexpected error resolving: %v", err)
+			}
+			if d := cmp.Diff(tc.expectedRes, output.Data()); d != "" {
+				t.Errorf("unexpected resource from Resolve: %s", diff.PrintWantGot(d))
+			}
+
+			if output.RefSource() == nil {
+				t.Fatal("expected non-nil RefSource")
+			}
+			if !strings.HasPrefix(output.RefSource().URI, overrideSvr.URL) {
+				t.Errorf("expected RefSource URI to start with override URL %s but got %s", overrideSvr.URL, output.RefSource().URI)
+			}
+		})
+	}
+}
+
+func TestResolveURLParamWithNoDefaultTektonHub(t *testing.T) {
+	overrideSvr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"data":{"yaml":"from override"}}`)
+	}))
+	defer overrideSvr.Close()
+
+	resolver := &Resolver{
+		TektonHubURL:   "",
+		ArtifactHubURL: "https://artifacthub.io",
+	}
+
+	params := map[string]string{
+		hubresolver.ParamKind:    "task",
+		hubresolver.ParamName:    "foo",
+		hubresolver.ParamVersion: "baz",
+		hubresolver.ParamCatalog: "Tekton",
+		hubresolver.ParamType:    TektonHubType,
+		ParamURL:                 overrideSvr.URL,
+	}
+	req := v1beta1.ResolutionRequestSpec{
+		Params: toParams(params),
+	}
+
+	output, err := resolver.Resolve(contextWithConfig(), &req)
+	if err != nil {
+		t.Fatalf("unexpected error: should resolve with url param even when TEKTON_HUB_API is empty: %v", err)
+	}
+	if d := cmp.Diff([]byte("from override"), output.Data()); d != "" {
+		t.Errorf("unexpected resource from Resolve: %s", diff.PrintWantGot(d))
+	}
+}
+
+func TestResolveURLParamWithVersionConstraint(t *testing.T) {
+	testCases := []struct {
+		name        string
+		kind        string
+		taskName    string
+		version     string
+		catalog     string
+		hubType     string
+		resultList  any
+		resultTask  any
+		expectedRes string
+	}{
+		{
+			name:     "artifact hub version constraint with URL override",
+			kind:     "task",
+			taskName: "something",
+			version:  ">= 0.1",
+			catalog:  "Tekton",
+			hubType:  ArtifactHubType,
+			resultList: &artifactHubListResult{
+				AvailableVersions: []artifactHubavailableVersionsResults{
+					{Version: "0.1.0"},
+					{Version: "0.2.0"},
+				},
+			},
+			resultTask: &artifactHubResponse{
+				Data: artifactHubDataResponse{YAML: "from override"},
+			},
+			expectedRes: "from override",
+		},
+		{
+			name:     "tekton hub version constraint with URL override",
+			kind:     "task",
+			taskName: "something",
+			version:  ">= 0.1",
+			catalog:  "Tekton",
+			hubType:  TektonHubType,
+			resultList: &tektonHubListResult{
+				Data: tektonHubListDataResult{
+					Versions: []tektonHubListResultVersion{
+						{Version: "0.1"},
+						{Version: "0.2"},
+					},
+				},
+			},
+			resultTask: &tektonHubResponse{
+				Data: tektonHubDataResponse{YAML: "from override"},
+			},
+			expectedRes: "from override",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			overrideSvr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var ret any
+				listURL := fmt.Sprintf(hubresolver.ArtifactHubListTasksEndpoint, tc.kind, tc.catalog, tc.taskName)
+				if tc.hubType == TektonHubType {
+					listURL = fmt.Sprintf(hubresolver.TektonHubListTasksEndpoint, tc.catalog, tc.kind, tc.taskName)
+				}
+				if r.URL.Path == "/"+listURL {
+					ret = tc.resultList
+				} else {
+					ret = tc.resultTask
+				}
+				output, _ := json.Marshal(ret)
+				fmt.Fprint(w, string(output))
+			}))
+			defer overrideSvr.Close()
+
+			defaultSvr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				t.Fatal("default server should not be called when url param is set")
+			}))
+			defer defaultSvr.Close()
+
+			resolver := &Resolver{
+				TektonHubURL:   defaultSvr.URL,
+				ArtifactHubURL: defaultSvr.URL,
+			}
+
+			params := map[string]string{
+				hubresolver.ParamKind:    tc.kind,
+				hubresolver.ParamName:    tc.taskName,
+				hubresolver.ParamVersion: tc.version,
+				hubresolver.ParamCatalog: tc.catalog,
+				hubresolver.ParamType:    tc.hubType,
+				ParamURL:                 overrideSvr.URL,
+			}
+			req := v1beta1.ResolutionRequestSpec{
+				Params: toParams(params),
+			}
+
+			output, err := resolver.Resolve(contextWithConfig(), &req)
+			if err != nil {
+				t.Fatalf("unexpected error resolving: %v", err)
+			}
+			if d := cmp.Diff(tc.expectedRes, string(output.Data())); d != "" {
+				t.Errorf("unexpected resource from Resolve: %s", diff.PrintWantGot(d))
+			}
+		})
+	}
+}
+
+func TestResolveURLParamTrailingSlash(t *testing.T) {
+	overrideSvr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "//") {
+			t.Errorf("request path contains double slash: %s", r.URL.Path)
+		}
+		fmt.Fprint(w, `{"data":{"manifestRaw":"from override"}}`)
+	}))
+	defer overrideSvr.Close()
+
+	resolver := &Resolver{
+		TektonHubURL:   "https://should-not-be-used.example.com",
+		ArtifactHubURL: "https://should-not-be-used.example.com",
+	}
+
+	params := map[string]string{
+		hubresolver.ParamKind:    "task",
+		hubresolver.ParamName:    "foo",
+		hubresolver.ParamVersion: "baz",
+		hubresolver.ParamCatalog: "Tekton",
+		hubresolver.ParamType:    ArtifactHubType,
+		ParamURL:                 overrideSvr.URL + "/",
+	}
+	req := v1beta1.ResolutionRequestSpec{
+		Params: toParams(params),
+	}
+
+	output, err := resolver.Resolve(contextWithConfig(), &req)
+	if err != nil {
+		t.Fatalf("unexpected error resolving: %v", err)
+	}
+	if d := cmp.Diff([]byte("from override"), output.Data()); d != "" {
+		t.Errorf("unexpected resource from Resolve: %s", diff.PrintWantGot(d))
+	}
+}
+
+// Multi-URL tests: ConfigMap URL list and fallback
+
+func TestParseURLList(t *testing.T) {
+	testCases := []struct {
+		name        string
+		input       string
+		expected    []string
+		expectedErr bool
+	}{
+		{name: "single URL", input: "- https://hub.example.com", expected: []string{"https://hub.example.com"}},
+		{name: "multiple URLs", input: "- https://internal-hub.example.com/\n- https://artifacthub.io/", expected: []string{"https://internal-hub.example.com", "https://artifacthub.io"}},
+		{name: "trailing slashes removed", input: "- https://hub.example.com///", expected: []string{"https://hub.example.com"}},
+		{name: "empty string", input: "", expected: nil},
+		{name: "whitespace only", input: "   \n  ", expected: nil},
+		{name: "invalid YAML", input: "not: a: list: {[}", expectedErr: true},
+		{name: "ftp URL rejected", input: "- ftp://example.com", expectedErr: true},
+		{name: "non-URL string rejected", input: "- not-a-url", expectedErr: true},
+		{name: "mixed valid and invalid URLs rejected", input: "- https://good.example.com\n- ftp://bad.example.com", expectedErr: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := parseURLList(tc.input)
+			if tc.expectedErr {
+				if err == nil {
+					t.Fatal("expected error but got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if d := cmp.Diff(tc.expected, result); d != "" {
+				t.Errorf("unexpected result: %s", diff.PrintWantGot(d))
+			}
+		})
+	}
+}
+
+func TestValidateHubURL(t *testing.T) {
+	testCases := []struct {
+		name      string
+		url       string
+		expectErr bool
+	}{
+		{name: "valid http URL", url: "http://example.com"},
+		{name: "valid https URL", url: "https://example.com"},
+		{name: "valid https URL with path", url: "https://hub.example.com/api/v1"},
+		{name: "ftp scheme rejected", url: "ftp://example.com", expectErr: true},
+		{name: "gopher scheme rejected", url: "gopher://example.com", expectErr: true},
+		{name: "missing host", url: "https://", expectErr: true},
+		{name: "malformed URL", url: "not-a-url", expectErr: true},
+		{name: "file scheme rejected", url: "file:///etc/passwd", expectErr: true},
+		{name: "empty string", url: "", expectErr: true},
+		{name: "URL with port", url: "https://example.com:8080"},
+		{name: "URL with query params", url: "https://example.com/api/v1?key=val"},
+		{name: "data URL rejected", url: "data:text/html,<h1>hi</h1>", expectErr: true},
+		{name: "javascript URL rejected", url: "javascript:alert(1)", expectErr: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateHubURL(tc.url)
+			if tc.expectErr && err == nil {
+				t.Errorf("expected error for URL %q but got nil", tc.url)
+			}
+			if !tc.expectErr && err != nil {
+				t.Errorf("unexpected error for URL %q: %v", tc.url, err)
+			}
+		})
+	}
+}
+
+func TestResolveHubURLs(t *testing.T) {
+	testCases := []struct {
+		name      string
+		conf      map[string]string
+		envVarURL string
+		configKey string
+		expected  []string
+	}{
+		{
+			name:      "ConfigMap URLs take precedence over env var",
+			conf:      map[string]string{ConfigArtifactHubURLs: "- https://internal.example.com\n- https://artifacthub.io"},
+			envVarURL: "https://env-var.example.com",
+			configKey: ConfigArtifactHubURLs,
+			expected:  []string{"https://internal.example.com", "https://artifacthub.io"},
+		},
+		{
+			name:      "falls back to env var when ConfigMap key absent",
+			conf:      map[string]string{},
+			envVarURL: "https://env-var.example.com",
+			configKey: ConfigArtifactHubURLs,
+			expected:  []string{"https://env-var.example.com"},
+		},
+		{
+			name:      "falls back to env var when ConfigMap key empty",
+			conf:      map[string]string{ConfigArtifactHubURLs: ""},
+			envVarURL: "https://env-var.example.com",
+			configKey: ConfigArtifactHubURLs,
+			expected:  []string{"https://env-var.example.com"},
+		},
+		{
+			name:      "returns nil when no URL configured",
+			conf:      map[string]string{},
+			envVarURL: "",
+			configKey: ConfigTektonHubURLs,
+			expected:  nil,
+		},
+		{
+			name:      "falls back to env var on invalid YAML",
+			conf:      map[string]string{ConfigTektonHubURLs: "not: valid: yaml: {[}"},
+			envVarURL: "https://env-var.example.com",
+			configKey: ConfigTektonHubURLs,
+			expected:  []string{"https://env-var.example.com"},
+		},
+		{
+			name:      "falls back to env var on invalid URL scheme in ConfigMap",
+			conf:      map[string]string{ConfigArtifactHubURLs: "- ftp://example.com"},
+			envVarURL: "https://env-var.example.com",
+			configKey: ConfigArtifactHubURLs,
+			expected:  []string{"https://env-var.example.com"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			result := resolveHubURLs(ctx, tc.conf, tc.envVarURL, tc.configKey)
+			if d := cmp.Diff(tc.expected, result); d != "" {
+				t.Errorf("unexpected result: %s", diff.PrintWantGot(d))
+			}
+		})
+	}
+}
+
+func TestResolveFallback(t *testing.T) {
+	testCases := []struct {
+		name        string
+		hubType     string
+		server1Code int
+		server1Body string
+		server2Body string
+		expectedRes string
+	}{
+		{
+			name:        "first server fails, second succeeds (artifact)",
+			hubType:     ArtifactHubType,
+			server1Code: http.StatusNotFound,
+			server2Body: `{"data":{"manifestRaw":"from second"}}`,
+			expectedRes: "from second",
+		},
+		{
+			name:        "first server succeeds, second not contacted (artifact)",
+			hubType:     ArtifactHubType,
+			server1Code: http.StatusOK,
+			server1Body: `{"data":{"manifestRaw":"from first"}}`,
+			server2Body: `{"data":{"manifestRaw":"from second"}}`,
+			expectedRes: "from first",
+		},
+		{
+			name:        "first server fails, second succeeds (tekton)",
+			hubType:     TektonHubType,
+			server1Code: http.StatusNotFound,
+			server2Body: `{"data":{"yaml":"from second"}}`,
+			expectedRes: "from second",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			svr1Called := false
+			svr1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				svr1Called = true
+				if tc.server1Code == http.StatusNotFound {
+					w.WriteHeader(http.StatusNotFound)
+					return
+				}
+				fmt.Fprint(w, tc.server1Body)
+			}))
+			defer svr1.Close()
+
+			svr2Called := false
+			svr2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				svr2Called = true
+				fmt.Fprint(w, tc.server2Body)
+			}))
+			defer svr2.Close()
+
+			urlYAML := fmt.Sprintf("- %s\n- %s", svr1.URL, svr2.URL)
+			configKey := ConfigArtifactHubURLs
+			if tc.hubType == TektonHubType {
+				configKey = ConfigTektonHubURLs
+			}
+			config := map[string]string{
+				"default-tekton-hub-catalog":            "Tekton",
+				"default-artifact-hub-task-catalog":     "tekton-catalog-tasks",
+				"default-artifact-hub-pipeline-catalog": "tekton-catalog-pipelines",
+				"default-type":                          "artifact",
+				configKey:                               urlYAML,
+			}
+			ctx := resolutionframework.InjectResolverConfigToContext(context.Background(), config)
+
+			resolver := &Resolver{}
+
+			params := map[string]string{
+				hubresolver.ParamKind:    "task",
+				hubresolver.ParamName:    "foo",
+				hubresolver.ParamVersion: "baz",
+				hubresolver.ParamCatalog: "Tekton",
+				hubresolver.ParamType:    tc.hubType,
+			}
+			req := v1beta1.ResolutionRequestSpec{
+				Params: toParams(params),
+			}
+
+			output, err := resolver.Resolve(ctx, &req)
+			if err != nil {
+				t.Fatalf("unexpected error resolving: %v", err)
+			}
+
+			if !svr1Called {
+				t.Error("expected first server to be called")
+			}
+			if tc.server1Code == http.StatusNotFound && !svr2Called {
+				t.Error("expected second server to be called when first fails")
+			}
+			if tc.server1Code == http.StatusOK && svr2Called {
+				t.Error("second server should not be called when first succeeds")
+			}
+
+			if d := cmp.Diff(tc.expectedRes, string(output.Data())); d != "" {
+				t.Errorf("unexpected resource from Resolve: %s", diff.PrintWantGot(d))
+			}
+		})
+	}
+}
+
+func TestResolveFallbackAllFail(t *testing.T) {
+	svr1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer svr1.Close()
+
+	svr2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer svr2.Close()
+
+	urlYAML := fmt.Sprintf("- %s\n- %s", svr1.URL, svr2.URL)
+	config := map[string]string{
+		"default-tekton-hub-catalog":            "Tekton",
+		"default-artifact-hub-task-catalog":     "tekton-catalog-tasks",
+		"default-artifact-hub-pipeline-catalog": "tekton-catalog-pipelines",
+		"default-type":                          "artifact",
+		ConfigArtifactHubURLs:                   urlYAML,
+	}
+	ctx := resolutionframework.InjectResolverConfigToContext(context.Background(), config)
+
+	resolver := &Resolver{}
+
+	params := map[string]string{
+		hubresolver.ParamKind:    "task",
+		hubresolver.ParamName:    "foo",
+		hubresolver.ParamVersion: "baz",
+		hubresolver.ParamCatalog: "Tekton",
+		hubresolver.ParamType:    ArtifactHubType,
+	}
+	req := v1beta1.ResolutionRequestSpec{
+		Params: toParams(params),
+	}
+
+	_, err := resolver.Resolve(ctx, &req)
+	if err == nil {
+		t.Fatal("expected error when all hub URLs fail")
+	}
+	if !strings.Contains(err.Error(), "failed to fetch resource from any configured hub URL") {
+		t.Errorf("expected aggregated error message, got: %v", err)
+	}
+}
+
+func TestResolveFallbackVersionConstraintNoVersionStopsFallback(t *testing.T) {
+	svr1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		listURL := fmt.Sprintf(hubresolver.ArtifactHubListTasksEndpoint, "task", "Tekton", "something")
+		if r.URL.Path == "/"+listURL {
+			resp := artifactHubListResult{
+				AvailableVersions: []artifactHubavailableVersionsResults{
+					{Version: "0.1.0"},
+				},
+			}
+			output, _ := json.Marshal(resp)
+			fmt.Fprint(w, string(output))
+		} else {
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer svr1.Close()
+
+	svr2Called := false
+	svr2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		svr2Called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer svr2.Close()
+
+	urlYAML := fmt.Sprintf("- %s\n- %s", svr1.URL, svr2.URL)
+	config := map[string]string{
+		"default-tekton-hub-catalog":            "Tekton",
+		"default-artifact-hub-task-catalog":     "tekton-catalog-tasks",
+		"default-artifact-hub-pipeline-catalog": "tekton-catalog-pipelines",
+		"default-type":                          "artifact",
+		ConfigArtifactHubURLs:                   urlYAML,
+	}
+	ctx := resolutionframework.InjectResolverConfigToContext(context.Background(), config)
+
+	resolver := &Resolver{}
+
+	params := map[string]string{
+		hubresolver.ParamKind:    "task",
+		hubresolver.ParamName:    "something",
+		hubresolver.ParamVersion: ">= 0.2.0",
+		hubresolver.ParamCatalog: "Tekton",
+		hubresolver.ParamType:    ArtifactHubType,
+	}
+	req := v1beta1.ResolutionRequestSpec{
+		Params: toParams(params),
+	}
+
+	_, err := resolver.Resolve(ctx, &req)
+	if err == nil {
+		t.Fatal("expected error but got nil")
+	}
+	if !strings.Contains(err.Error(), "no version found") {
+		t.Errorf("expected 'no version found' error, got: %v", err)
+	}
+	if svr2Called {
+		t.Error("second hub should not have been contacted when first hub had no matching version")
+	}
+}
+
+func TestResolveFallbackVersionConstraintUnreachableFallsThrough(t *testing.T) {
+	svr1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer svr1.Close()
+
+	svr2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		listURL := fmt.Sprintf(hubresolver.ArtifactHubListTasksEndpoint, "task", "Tekton", "something")
+		if r.URL.Path == "/"+listURL {
+			resp := artifactHubListResult{
+				AvailableVersions: []artifactHubavailableVersionsResults{
+					{Version: "0.1.0"},
+					{Version: "0.2.0"},
+				},
+			}
+			output, _ := json.Marshal(resp)
+			fmt.Fprint(w, string(output))
+		} else {
+			resp := artifactHubResponse{
+				Data: artifactHubDataResponse{YAML: "from second hub"},
+			}
+			output, _ := json.Marshal(resp)
+			fmt.Fprint(w, string(output))
+		}
+	}))
+	defer svr2.Close()
+
+	urlYAML := fmt.Sprintf("- %s\n- %s", svr1.URL, svr2.URL)
+	config := map[string]string{
+		"default-tekton-hub-catalog":            "Tekton",
+		"default-artifact-hub-task-catalog":     "tekton-catalog-tasks",
+		"default-artifact-hub-pipeline-catalog": "tekton-catalog-pipelines",
+		"default-type":                          "artifact",
+		ConfigArtifactHubURLs:                   urlYAML,
+	}
+	ctx := resolutionframework.InjectResolverConfigToContext(context.Background(), config)
+
+	resolver := &Resolver{}
+
+	params := map[string]string{
+		hubresolver.ParamKind:    "task",
+		hubresolver.ParamName:    "something",
+		hubresolver.ParamVersion: ">= 0.2.0",
+		hubresolver.ParamCatalog: "Tekton",
+		hubresolver.ParamType:    ArtifactHubType,
+	}
+	req := v1beta1.ResolutionRequestSpec{
+		Params: toParams(params),
+	}
+
+	output, err := resolver.Resolve(ctx, &req)
+	if err != nil {
+		t.Fatalf("unexpected error resolving: %v", err)
+	}
+	if d := cmp.Diff("from second hub", string(output.Data())); d != "" {
+		t.Errorf("unexpected resource from Resolve: %s", diff.PrintWantGot(d))
+	}
+}
+
+func TestResolveWithConfigMapURLs(t *testing.T) {
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"data":{"manifestRaw":"from configmap url"}}`)
+	}))
+	defer svr.Close()
+
+	config := map[string]string{
+		"default-tekton-hub-catalog":            "Tekton",
+		"default-artifact-hub-task-catalog":     "tekton-catalog-tasks",
+		"default-artifact-hub-pipeline-catalog": "tekton-catalog-pipelines",
+		"default-type":                          "artifact",
+		ConfigArtifactHubURLs:                   "- " + svr.URL,
+	}
+	ctx := resolutionframework.InjectResolverConfigToContext(context.Background(), config)
+
+	resolver := &Resolver{
+		ArtifactHubURL: "https://should-not-be-used.example.com",
+	}
+
+	params := map[string]string{
+		hubresolver.ParamKind:    "task",
+		hubresolver.ParamName:    "foo",
+		hubresolver.ParamVersion: "baz",
+		hubresolver.ParamCatalog: "Tekton",
+		hubresolver.ParamType:    ArtifactHubType,
+	}
+	req := v1beta1.ResolutionRequestSpec{
+		Params: toParams(params),
+	}
+
+	output, err := resolver.Resolve(ctx, &req)
+	if err != nil {
+		t.Fatalf("unexpected error resolving: %v", err)
+	}
+	if d := cmp.Diff([]byte("from configmap url"), output.Data()); d != "" {
+		t.Errorf("unexpected resource from Resolve: %s", diff.PrintWantGot(d))
+	}
+}
+
+func TestResolveSingleConfigMapURLErrorFormat(t *testing.T) {
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer svr.Close()
+
+	config := map[string]string{
+		"default-tekton-hub-catalog":            "Tekton",
+		"default-artifact-hub-task-catalog":     "tekton-catalog-tasks",
+		"default-artifact-hub-pipeline-catalog": "tekton-catalog-pipelines",
+		"default-type":                          "artifact",
+		ConfigArtifactHubURLs:                   "- " + svr.URL,
+	}
+	ctx := resolutionframework.InjectResolverConfigToContext(context.Background(), config)
+
+	resolver := &Resolver{}
+
+	params := map[string]string{
+		hubresolver.ParamKind:    "task",
+		hubresolver.ParamName:    "foo",
+		hubresolver.ParamVersion: "baz",
+		hubresolver.ParamCatalog: "Tekton",
+		hubresolver.ParamType:    ArtifactHubType,
+	}
+	req := v1beta1.ResolutionRequestSpec{
+		Params: toParams(params),
+	}
+
+	_, err := resolver.Resolve(ctx, &req)
+	if err == nil {
+		t.Fatal("expected error when single ConfigMap URL fails")
+	}
+	if strings.Contains(err.Error(), "failed to fetch resource from any configured hub URL") {
+		t.Errorf("single URL error should not be wrapped in aggregate message, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "fail to fetch Artifact Hub resource") {
+		t.Errorf("expected direct Artifact Hub error, got: %v", err)
+	}
+}
+
+func TestResolveURLParamOverridesConfigMapURLs(t *testing.T) {
+	configMapSvr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("ConfigMap URL server should not be called when url param is set")
+	}))
+	defer configMapSvr.Close()
+
+	overrideSvr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"data":{"manifestRaw":"from url param"}}`)
+	}))
+	defer overrideSvr.Close()
+
+	config := map[string]string{
+		"default-tekton-hub-catalog":            "Tekton",
+		"default-artifact-hub-task-catalog":     "tekton-catalog-tasks",
+		"default-artifact-hub-pipeline-catalog": "tekton-catalog-pipelines",
+		"default-type":                          "artifact",
+		ConfigArtifactHubURLs:                   "- " + configMapSvr.URL,
+	}
+	ctx := resolutionframework.InjectResolverConfigToContext(context.Background(), config)
+
+	resolver := &Resolver{}
+
+	params := map[string]string{
+		hubresolver.ParamKind:    "task",
+		hubresolver.ParamName:    "foo",
+		hubresolver.ParamVersion: "baz",
+		hubresolver.ParamCatalog: "Tekton",
+		hubresolver.ParamType:    ArtifactHubType,
+		ParamURL:                 overrideSvr.URL,
+	}
+	req := v1beta1.ResolutionRequestSpec{
+		Params: toParams(params),
+	}
+
+	output, err := resolver.Resolve(ctx, &req)
+	if err != nil {
+		t.Fatalf("unexpected error resolving: %v", err)
+	}
+	if d := cmp.Diff([]byte("from url param"), output.Data()); d != "" {
+		t.Errorf("unexpected resource from Resolve: %s", diff.PrintWantGot(d))
+	}
+}
+
+func TestValidateParamsTektonTypeWithConfigMapURLs(t *testing.T) {
+	config := map[string]string{
+		"default-tekton-hub-catalog":            "Tekton",
+		"default-artifact-hub-task-catalog":     "tekton-catalog-tasks",
+		"default-artifact-hub-pipeline-catalog": "tekton-catalog-pipelines",
+		"default-type":                          "artifact",
+		ConfigTektonHubURLs:                     "- https://tekton-hub.example.com",
+	}
+	ctx := resolutionframework.InjectResolverConfigToContext(context.Background(), config)
+
+	resolver := Resolver{TektonHubURL: ""}
+
+	params := map[string]string{
+		hubresolver.ParamKind:    "task",
+		hubresolver.ParamName:    "foo",
+		hubresolver.ParamVersion: "bar",
+		hubresolver.ParamCatalog: "baz",
+		hubresolver.ParamType:    TektonHubType,
+	}
+	req := v1beta1.ResolutionRequestSpec{
+		Params: toParams(params),
+	}
+
+	err := resolver.Validate(ctx, &req)
+	if err != nil {
+		t.Fatalf("expected no error when ConfigMap has tekton-hub-urls, got: %v", err)
 	}
 }

--- a/test/resolvers_test.go
+++ b/test/resolvers_test.go
@@ -197,6 +197,222 @@ spec:
 }
 
 // @test:execution=parallel
+func TestHubResolver_URLParam(t *testing.T) {
+	ctx := t.Context()
+	c, namespace := setup(ctx, t, hubFeatureFlags)
+
+	t.Parallel()
+
+	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
+	defer tearDown(ctx, t, c, namespace)
+
+	prName := helpers.ObjectNameForTest(t)
+
+	pipelineRun := parse.MustParseV1PipelineRun(t, fmt.Sprintf(`
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  workspaces:
+    - name: output
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi
+  pipelineSpec:
+    workspaces:
+      - name: output
+    tasks:
+      - name: task1
+        workspaces:
+          - name: output
+        taskRef:
+          resolver: hub
+          params:
+          - name: kind
+            value: task
+          - name: name
+            value: git-clone
+          - name: version
+            value: "0.10"
+          - name: url
+            value: https://artifacthub.io
+        params:
+          - name: url
+            value: https://github.com/tektoncd/pipeline
+          - name: deleteExisting
+            value: "true"
+`, prName, namespace))
+
+	_, err := c.V1PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create PipelineRun `%s`: %s", prName, err)
+	}
+
+	t.Logf("Waiting for PipelineRun %s in namespace %s to complete", prName, namespace)
+	if err := WaitForPipelineRunState(ctx, c, prName, timeout, PipelineRunSucceed(prName), "PipelineRunSuccess", v1Version); err != nil {
+		t.Fatalf("Error waiting for PipelineRun %s to finish: %s", prName, err)
+	}
+}
+
+// @test:execution=parallel
+func TestHubResolver_URLParam_Failure(t *testing.T) {
+	ctx := t.Context()
+	c, namespace := setup(ctx, t, hubFeatureFlags)
+
+	t.Parallel()
+
+	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
+	defer tearDown(ctx, t, c, namespace)
+
+	prName := helpers.ObjectNameForTest(t)
+
+	pipelineRun := parse.MustParseV1PipelineRun(t, fmt.Sprintf(`
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  pipelineSpec:
+    tasks:
+      - name: task1
+        taskRef:
+          resolver: hub
+          params:
+          - name: kind
+            value: task
+          - name: name
+            value: git-clone
+          - name: version
+            value: "0.10"
+          - name: url
+            value: https://bad-hub.invalid
+`, prName, namespace))
+
+	_, err := c.V1PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create PipelineRun `%s`: %s", prName, err)
+	}
+
+	t.Logf("Waiting for PipelineRun %s in namespace %s to complete", prName, namespace)
+	if err := WaitForPipelineRunState(ctx, c, prName, timeout,
+		Chain(
+			FailedWithReason(v1.PipelineRunReasonCouldntGetTask.String(), prName),
+			FailedWithMessage("fail to fetch Artifact Hub resource", prName),
+		), "PipelineRunFailed", v1Version); err != nil {
+		t.Fatalf("Error waiting for PipelineRun to finish with expected error: %s", err)
+	}
+}
+
+// @test:execution=parallel
+func TestHubResolver_VersionConstraint(t *testing.T) {
+	ctx := t.Context()
+	c, namespace := setup(ctx, t, hubFeatureFlags)
+
+	t.Parallel()
+
+	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
+	defer tearDown(ctx, t, c, namespace)
+
+	prName := helpers.ObjectNameForTest(t)
+
+	pipelineRun := parse.MustParseV1PipelineRun(t, fmt.Sprintf(`
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  workspaces:
+    - name: output
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi
+  pipelineSpec:
+    workspaces:
+      - name: output
+    tasks:
+      - name: task1
+        workspaces:
+          - name: output
+        taskRef:
+          resolver: hub
+          params:
+          - name: kind
+            value: task
+          - name: name
+            value: git-clone
+          - name: version
+            value: ">= 0.7.0"
+        params:
+          - name: url
+            value: https://github.com/tektoncd/pipeline
+          - name: deleteExisting
+            value: "true"
+`, prName, namespace))
+
+	_, err := c.V1PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create PipelineRun `%s`: %s", prName, err)
+	}
+
+	t.Logf("Waiting for PipelineRun %s in namespace %s to complete", prName, namespace)
+	if err := WaitForPipelineRunState(ctx, c, prName, timeout, PipelineRunSucceed(prName), "PipelineRunSuccess", v1Version); err != nil {
+		t.Fatalf("Error waiting for PipelineRun %s to finish: %s", prName, err)
+	}
+}
+
+// @test:execution=parallel
+func TestHubResolver_VersionConstraint_Failure(t *testing.T) {
+	ctx := t.Context()
+	c, namespace := setup(ctx, t, hubFeatureFlags)
+
+	t.Parallel()
+
+	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
+	defer tearDown(ctx, t, c, namespace)
+
+	prName := helpers.ObjectNameForTest(t)
+
+	pipelineRun := parse.MustParseV1PipelineRun(t, fmt.Sprintf(`
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  pipelineSpec:
+    tasks:
+      - name: task1
+        taskRef:
+          resolver: hub
+          params:
+          - name: kind
+            value: task
+          - name: name
+            value: git-clone
+          - name: version
+            value: ">= 999.0.0"
+`, prName, namespace))
+
+	_, err := c.V1PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create PipelineRun `%s`: %s", prName, err)
+	}
+
+	t.Logf("Waiting for PipelineRun %s in namespace %s to complete", prName, namespace)
+	if err := WaitForPipelineRunState(ctx, c, prName, timeout,
+		Chain(
+			FailedWithReason(v1.PipelineRunReasonCouldntGetTask.String(), prName),
+			FailedWithMessage("no version found for constraint", prName),
+		), "PipelineRunFailed", v1Version); err != nil {
+		t.Fatalf("Error waiting for PipelineRun to finish with expected error: %s", err)
+	}
+}
+
+// @test:execution=parallel
 func TestGitResolver_Clone(t *testing.T) {
 	ctx := t.Context()
 	c, namespace := setup(ctx, t, gitFeatureFlags)


### PR DESCRIPTION
- Adds a per-resolution `url` parameter to the Hub Resolver, allowing Pipeline authors to explicitly target a specific hub instance (Option A from #9353)
- Adds `artifact-hub-urls` / `tekton-hub-urls` ConfigMap keys for configuring multiple hub URLs with ordered fallback — first successful response
  wins (Option B from #9353)
- Implements URL precedence: `url` param > ConfigMap URL lists > env var > default
- Add unit tests for fallback, url override, error formatting
- Add e2e tests for url param and version constraint resolution
- Update docs with new param, ConfigMap options, and URL precedence

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Add multi-URL support and per-resolution url parameter to Hub Resolver, enabling ordered fallback across multiple hub instances and explicit URL targeting per resolution request.
```