### PR TITLE
Fix running_taskruns metric overcounting TaskRuns with no condition

### DIFF
--- a/pkg/pipelinerunmetrics/metrics.go
+++ b/pkg/pipelinerunmetrics/metrics.go
@@ -258,34 +258,36 @@ func (r *Recorder) observeRunningPipelineRuns(ctx context.Context, o metric.Obse
 
 	for _, pr := range prs {
 		succeedCondition := pr.Status.GetCondition(apis.ConditionSucceeded)
-		if succeedCondition.IsUnknown() {
-			// Handle waiting metrics (these are cluster-wide, no extra attributes).
-			switch succeedCondition.Reason {
-			case v1.PipelineRunReasonResolvingPipelineRef.String():
-				waitingOnPipelineCount++
-			case v1.TaskRunReasonResolvingTaskRef:
-				waitingOnTaskCount++
-			}
-
-			// Handle running_pipelineruns metric with per-level aggregation.
-			pipelineName := getPipelineTagName(pr)
-			var attrs []attribute.KeyValue
-
-			// Build attributes based on configured level.
-			switch cfg.RunningPipelinerunLevel {
-			case config.PipelinerunLevelAtPipelinerun:
-				attrs = append(attrs, attribute.String("pipelinerun", pr.Name))
-				fallthrough
-			case config.PipelinerunLevelAtPipeline:
-				attrs = append(attrs, attribute.String("pipeline", pipelineName))
-				fallthrough
-			case config.PipelinerunLevelAtNS:
-				attrs = append(attrs, attribute.String("namespace", pr.Namespace))
-			}
-
-			attrSet := attribute.NewSet(attrs...)
-			currentCounts[attrSet]++
+		if succeedCondition == nil || !succeedCondition.IsUnknown() {
+			continue
 		}
+
+		// Handle waiting metrics (these are cluster-wide, no extra attributes).
+		switch succeedCondition.Reason {
+		case v1.PipelineRunReasonResolvingPipelineRef.String():
+			waitingOnPipelineCount++
+		case v1.TaskRunReasonResolvingTaskRef:
+			waitingOnTaskCount++
+		}
+
+		// Handle running_pipelineruns metric with per-level aggregation.
+		pipelineName := getPipelineTagName(pr)
+		var attrs []attribute.KeyValue
+
+		// Build attributes based on configured level.
+		switch cfg.RunningPipelinerunLevel {
+		case config.PipelinerunLevelAtPipelinerun:
+			attrs = append(attrs, attribute.String("pipelinerun", pr.Name))
+			fallthrough
+		case config.PipelinerunLevelAtPipeline:
+			attrs = append(attrs, attribute.String("pipeline", pipelineName))
+			fallthrough
+		case config.PipelinerunLevelAtNS:
+			attrs = append(attrs, attribute.String("namespace", pr.Namespace))
+		}
+
+		attrSet := attribute.NewSet(attrs...)
+		currentCounts[attrSet]++
 	}
 
 	// Report running_pipelineruns.

--- a/pkg/pipelinerunmetrics/metrics_test.go
+++ b/pkg/pipelinerunmetrics/metrics_test.go
@@ -1075,6 +1075,53 @@ func TestRecordRunningPipelineRunsCountZeroing(t *testing.T) {
 	t.Error("running_pipelineruns metric not found")
 }
 
+func TestObserveRunningPipelineRunsNoSucceededCondition(t *testing.T) {
+	resetMetrics()
+	ctx := getConfigContext(false)
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	otel.SetMeterProvider(provider)
+
+	r, err := NewRecorder(ctx)
+	if err != nil {
+		t.Fatalf("NewRecorder: %v", err)
+	}
+
+	pr := &v1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "pipelinerun-no-condition", Namespace: "ns"},
+		Status:     v1.PipelineRunStatus{},
+	}
+	mockLister := &mockPipelineRunLister{prs: []*v1.PipelineRun{pr}}
+
+	_, err = r.meter.RegisterCallback(func(ctx context.Context, o metric.Observer) error {
+		return r.observeRunningPipelineRuns(ctx, o, mockLister)
+	}, r.runningPRsGauge, r.runningPRsWaitingOnPipelineResolutionGauge, r.runningPRsWaitingOnTaskResolutionGauge)
+	if err != nil {
+		t.Fatalf("RegisterCallback: %v", err)
+	}
+
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(ctx, &rm); err != nil {
+		t.Fatalf("Collect error: %v", err)
+	}
+
+	runningPRsMetric := getRunningPRsMetric(t, rm)
+	gauge, ok := runningPRsMetric.Data.(metricdata.Gauge[int64])
+	if !ok {
+		t.Fatalf("metric data is not a Gauge[int64]: %T", runningPRsMetric.Data)
+	}
+
+	if len(gauge.DataPoints) != 1 {
+		t.Fatalf("Expected 1 global data point, got %d", len(gauge.DataPoints))
+	}
+	if gauge.DataPoints[0].Attributes.Len() != 0 {
+		t.Errorf("Expected global data point with no attributes, got %v", gauge.DataPoints[0].Attributes)
+	}
+	if gauge.DataPoints[0].Value != 0 {
+		t.Errorf("PipelineRun with no Succeeded condition should not be counted as running, got %d", gauge.DataPoints[0].Value)
+	}
+}
+
 func TestObserveRunningPipelineRunsListerError(t *testing.T) {
 	resetMetrics()
 	ctx := getConfigContext(false)

--- a/pkg/taskrunmetrics/metrics.go
+++ b/pkg/taskrunmetrics/metrics.go
@@ -23,6 +23,11 @@ import (
 	"sync"
 	"time"
 
+	"github.com/tektoncd/pipeline/pkg/apis/config"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	listers "github.com/tektoncd/pipeline/pkg/client/listers/pipeline/v1"
+	"github.com/tektoncd/pipeline/pkg/pod"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
@@ -33,12 +38,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/logging"
-
-	"github.com/tektoncd/pipeline/pkg/apis/config"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
-	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
-	listers "github.com/tektoncd/pipeline/pkg/client/listers/pipeline/v1"
-	"github.com/tektoncd/pipeline/pkg/pod"
 )
 
 const anonymous = "anonymous"

--- a/pkg/taskrunmetrics/metrics.go
+++ b/pkg/taskrunmetrics/metrics.go
@@ -23,11 +23,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/tektoncd/pipeline/pkg/apis/config"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
-	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
-	listers "github.com/tektoncd/pipeline/pkg/client/listers/pipeline/v1"
-	"github.com/tektoncd/pipeline/pkg/pod"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
@@ -38,6 +33,12 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/logging"
+
+	"github.com/tektoncd/pipeline/pkg/apis/config"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	listers "github.com/tektoncd/pipeline/pkg/client/listers/pipeline/v1"
+	"github.com/tektoncd/pipeline/pkg/pod"
 )
 
 const anonymous = "anonymous"
@@ -326,25 +327,25 @@ func (r *Recorder) observeRunningTaskRuns(ctx context.Context, o metric.Observer
 	var trsWaitResolvingTaskRef int64
 
 	for _, tr := range trs {
-		if !tr.IsDone() {
-			runningTrs++
-			succeedCondition := tr.Status.GetCondition(apis.ConditionSucceeded)
-			if succeedCondition != nil && succeedCondition.Status == corev1.ConditionUnknown {
-				var attrs []attribute.KeyValue
-				if addNamespaceLabelToThrottleMetric {
-					attrs = append(attrs, attribute.String("namespace", tr.Namespace))
-				}
-				attrSet := attribute.NewSet(attrs...)
+		succeedCondition := tr.Status.GetCondition(apis.ConditionSucceeded)
+		if succeedCondition == nil || !succeedCondition.IsUnknown() {
+			continue
+		}
+		runningTrs++
 
-				switch succeedCondition.Reason {
-				case pod.ReasonExceededResourceQuota:
-					trsThrottledByQuota[attrSet]++
-				case pod.ReasonExceededNodeResources:
-					trsThrottledByNode[attrSet]++
-				case v1.TaskRunReasonResolvingTaskRef:
-					trsWaitResolvingTaskRef++
-				}
-			}
+		var attrs []attribute.KeyValue
+		if addNamespaceLabelToThrottleMetric {
+			attrs = append(attrs, attribute.String("namespace", tr.Namespace))
+		}
+		attrSet := attribute.NewSet(attrs...)
+
+		switch succeedCondition.Reason {
+		case pod.ReasonExceededResourceQuota:
+			trsThrottledByQuota[attrSet]++
+		case pod.ReasonExceededNodeResources:
+			trsThrottledByNode[attrSet]++
+		case v1.TaskRunReasonResolvingTaskRef:
+			trsWaitResolvingTaskRef++
 		}
 	}
 

--- a/pkg/taskrunmetrics/metrics_test.go
+++ b/pkg/taskrunmetrics/metrics_test.go
@@ -24,12 +24,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/tektoncd/pipeline/pkg/apis/config"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
-	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
-	listers "github.com/tektoncd/pipeline/pkg/client/listers/pipeline/v1"
-	"github.com/tektoncd/pipeline/pkg/names"
-	"github.com/tektoncd/pipeline/pkg/pod"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
@@ -41,6 +35,13 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
+
+	"github.com/tektoncd/pipeline/pkg/apis/config"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	listers "github.com/tektoncd/pipeline/pkg/client/listers/pipeline/v1"
+	"github.com/tektoncd/pipeline/pkg/names"
+	"github.com/tektoncd/pipeline/pkg/pod"
 )
 
 var (
@@ -1089,6 +1090,52 @@ func TestObserveRunningTaskRunsResolvingTaskRef(t *testing.T) {
 		}
 	}
 	t.Error("waiting_on_task_resolution metric not found")
+}
+
+func TestObserveRunningTaskRunsNoSucceededCondition(t *testing.T) {
+	resetMetrics()
+	ctx := getConfigContext(false, false)
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	otel.SetMeterProvider(provider)
+
+	r, err := NewRecorder(ctx)
+	if err != nil {
+		t.Fatalf("NewRecorder: %v", err)
+	}
+
+	tr := &v1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "taskrun-no-condition", Namespace: "ns"},
+		Status:     v1.TaskRunStatus{},
+	}
+	mockLister := &mockTaskRunLister{trs: []*v1.TaskRun{tr}}
+
+	_, err = r.meter.RegisterCallback(func(ctx context.Context, o metric.Observer) error {
+		return r.observeRunningTaskRuns(ctx, o, mockLister)
+	}, r.runningTRsGauge, r.runningTRsWaitingOnTaskResolutionGauge, r.runningTRsThrottledByQuotaGauge, r.runningTRsThrottledByNodeGauge)
+	if err != nil {
+		t.Fatalf("RegisterCallback: %v", err)
+	}
+
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(ctx, &rm); err != nil {
+		t.Fatalf("Collect error: %v", err)
+	}
+
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name == "tekton_pipelines_controller_running_taskruns" {
+				gauge, ok := m.Data.(metricdata.Gauge[int64])
+				if !ok {
+					t.Fatalf("Expected Gauge[int64], got %T", m.Data)
+				}
+				if len(gauge.DataPoints) > 0 && gauge.DataPoints[0].Value != 0 {
+					t.Errorf("TaskRun with no Succeeded condition should not be counted as running, got %d", gauge.DataPoints[0].Value)
+				}
+				return
+			}
+		}
+	}
 }
 
 func TestObserveRunningTaskRunsListerError(t *testing.T) {

--- a/pkg/taskrunmetrics/metrics_test.go
+++ b/pkg/taskrunmetrics/metrics_test.go
@@ -24,6 +24,12 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/pipeline/pkg/apis/config"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	listers "github.com/tektoncd/pipeline/pkg/client/listers/pipeline/v1"
+	"github.com/tektoncd/pipeline/pkg/names"
+	"github.com/tektoncd/pipeline/pkg/pod"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
@@ -35,13 +41,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
-
-	"github.com/tektoncd/pipeline/pkg/apis/config"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
-	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
-	listers "github.com/tektoncd/pipeline/pkg/client/listers/pipeline/v1"
-	"github.com/tektoncd/pipeline/pkg/names"
-	"github.com/tektoncd/pipeline/pkg/pod"
 )
 
 var (


### PR DESCRIPTION
Replace !tr.IsDone() with an explicit nil + ConditionUnknown check so that newly created TaskRuns (before their first reconcile) are no longer counted as running. This aligns with the pipelinerunmetrics behavior and eliminates the inconsistency where sub-metrics were gated on ConditionUnknown while the top-level count was not.

Fixes #9438

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Fixed overcounting in the `running_taskruns` metric for `TaskRun`s with no condition set yet.
```
