### PR TITLE
remove stale TODO/FIXME comments referencing closed issues

### DIFF
--- a/pkg/apis/pipeline/v1beta1/container_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/container_conversion.go
@@ -137,7 +137,6 @@ func (s StepTemplate) convertTo(ctx context.Context, sink *v1.StepTemplate) {
 	sink.VolumeDevices = s.VolumeDevices
 	sink.ImagePullPolicy = s.ImagePullPolicy
 	sink.SecurityContext = s.SecurityContext
-	// TODO(#4546): Handle deprecated fields
 	// Name, Ports, LivenessProbe, ReadinessProbe, StartupProbe, Lifecycle, TerminationMessagePath
 	// TerminationMessagePolicy, Stdin, StdinOnce, TTY
 }

--- a/pkg/internal/computeresources/transformer.go
+++ b/pkg/internal/computeresources/transformer.go
@@ -66,7 +66,6 @@ func transformPodBasedOnLimitRange(p *corev1.Pod, limitRange *corev1.LimitRange)
 		}
 	}
 
-	// FIXME(#4230) maxLimitRequestRatio to support later
 	defaultStepContainerRequests := getDefaultStepContainerRequest(limitRange, nbStepContainers)
 
 	for i, c := range p.Spec.Containers {

--- a/pkg/reconciler/pipelinerun/resources/pipelineref.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelineref.go
@@ -107,7 +107,6 @@ type LocalPipelineRefResolver struct {
 // return an error if it can't find an appropriate Pipeline for any reason.
 // TODO: if we want to set RefSource for in-cluster pipeline, set it here.
 // https://github.com/tektoncd/pipeline/issues/5522
-// TODO(#6666): Support local resources verification
 func (l *LocalPipelineRefResolver) GetPipeline(ctx context.Context, name string) (*v1.Pipeline, *v1.RefSource, *trustedresources.VerificationResult, error) {
 	// If we are going to resolve this reference locally, we need a namespace scope.
 	if l.Namespace == "" {
@@ -146,7 +145,6 @@ func resolvePipeline(ctx context.Context, resolver remote.Resolver, name string,
 // An error is returned if the given object is not a
 // PipelineObject or if there is an error validating or upgrading an
 // older PipelineObject into its v1beta1 equivalent.
-// TODO(#5541): convert v1beta1 obj to v1 once we use v1 as the stored version
 func readRuntimeObjectAsPipeline(ctx context.Context, namespace string, obj runtime.Object, k8s kubernetes.Interface, tekton clientset.Interface, refSource *v1.RefSource, verificationPolicies []*v1alpha1.VerificationPolicy) (*v1.Pipeline, *trustedresources.VerificationResult, error) {
 	switch obj := obj.(type) {
 	case *v1beta1.Pipeline:

--- a/pkg/reconciler/taskrun/resources/taskref.go
+++ b/pkg/reconciler/taskrun/resources/taskref.go
@@ -278,7 +278,6 @@ func resolveStepAction(ctx context.Context, resolver remote.Resolver, name, name
 // its v1beta1 equivalent.
 // A VerificationResult is returned if trusted resources is enabled, VerificationResult contains the result type and err.
 // v1beta1 task will be verified by trusted resources if the feature is enabled
-// TODO(#5541): convert v1beta1 obj to v1 once we use v1 as the stored version
 func readRuntimeObjectAsTask(ctx context.Context, namespace string, obj runtime.Object, k8s kubernetes.Interface, tekton clientset.Interface, refSource *v1.RefSource, verificationPolicies []*v1alpha1.VerificationPolicy) (*v1.Task, *trustedresources.VerificationResult, error) {
 	switch obj := obj.(type) {
 	case *v1beta1.Task:
@@ -338,7 +337,6 @@ type LocalTaskRefResolver struct {
 
 // GetTask will resolve a Task from the local cluster using a versioned Tekton client. It will
 // return an error if it can't find an appropriate Task for any reason.
-// TODO(#6666): support local task verification
 func (l *LocalTaskRefResolver) GetTask(ctx context.Context, name string) (*v1.Task, *v1.RefSource, *trustedresources.VerificationResult, error) {
 	// If we are going to resolve this reference locally, we need a namespace scope.
 	if l.Namespace == "" {

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -916,7 +916,6 @@ func terminateStepsInPod(tr *v1.TaskRun, taskRunReason v1.TaskRunReason) {
 				ExitCode:   1,
 				StartedAt:  step.Running.StartedAt,
 				FinishedAt: *tr.Status.CompletionTime,
-				// TODO(#7385): replace with more pod/container termination reason instead of overloading taskRunReason
 				Reason:  taskRunReason.String(),
 				Message: fmt.Sprintf("Step %s terminated as pod %s is terminated", step.Name, tr.Status.PodName),
 			}
@@ -930,7 +929,6 @@ func terminateStepsInPod(tr *v1.TaskRun, taskRunReason v1.TaskRunReason) {
 				ExitCode:   1,
 				StartedAt:  tr.CreationTimestamp, // startedAt cannot be null due to CRD schema validation
 				FinishedAt: *tr.Status.CompletionTime,
-				// TODO(#7385): replace with more pod/container termination reason instead of overloading taskRunReason
 				Reason:  taskRunReason.String(),
 				Message: fmt.Sprintf("Step %s terminated as pod %s is terminated", step.Name, tr.Status.PodName),
 			}

--- a/pkg/reconciler/taskrun/validate_taskrun.go
+++ b/pkg/reconciler/taskrun/validate_taskrun.go
@@ -79,7 +79,6 @@ func missingParamsNames(neededParams sets.String, providedParams sets.String, pa
 	return missingParamsNamesWithNoDefaults
 }
 func wrongTypeParamsNames(params []v1.Param, matrix v1.Params, neededParamsTypes map[string]v1.ParamType) []string {
-	// TODO(#4723): validate that $(task.taskname.result.resultname) is invalid for array and object type.
 	// It should be used to refer string and need to add [*] to refer to array or object.
 	var wrongTypeParamNames []string
 	for _, param := range params {
@@ -304,7 +303,6 @@ func mismatchedTypesResults(tr *v1.TaskRun, specResults []v1.TaskResult) map[str
 	}
 
 	// collect mismatched types for results, and correct results in filteredResults
-	// TODO(#6097): Validate if the emitted results are defined in taskspec
 	for _, trr := range tr.Status.Results {
 		needed, ok := neededTypes[trr.Name]
 		if ok && needed != string(trr.Type) {

--- a/pkg/trustedresources/verifier/verifier.go
+++ b/pkg/trustedresources/verifier/verifier.go
@@ -28,7 +28,6 @@ import (
 	"github.com/sigstore/sigstore/pkg/signature"
 	"github.com/sigstore/sigstore/pkg/signature/kms"
 
-	// TODO(#5976): consider move these registration to cmd/controller/main.go
 	_ "github.com/sigstore/sigstore/pkg/signature/kms/aws"        // imported to execute init function to register aws kms
 	_ "github.com/sigstore/sigstore/pkg/signature/kms/azure"      // imported to execute init function to register azure kms
 	_ "github.com/sigstore/sigstore/pkg/signature/kms/gcp"        // imported to execute init function to register gcp kms

--- a/pkg/trustedresources/verify.go
+++ b/pkg/trustedresources/verify.go
@@ -142,7 +142,6 @@ func getMatchedPolicies(resourceName string, source string, policies []*v1alpha1
 //     Alternatively, if the resource only matches policies in "warn" mode, it will still pass verification and only log a warning if these policies are not satisfied.
 //  2. To pass one policy, the resource can pass any public keys in the policy. We use OR logic on public keys of one policy.
 //
-// TODO(#6683): return all failed policies in error.
 func verifyResource(ctx context.Context, resource metav1.Object, k8s kubernetes.Interface, signature []byte, matchedPolicies []*v1alpha1.VerificationPolicy) VerificationResult {
 	logger := logging.FromContext(ctx)
 	var warnPolicies []*v1alpha1.VerificationPolicy


### PR DESCRIPTION
# Changes

Fixes #9492

Removed TODO/FIXME comments that reference closed GitHub issues. These comments were no longer relevant since the issues have been resolved.

# Submitter Checklist

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes
```release-note
NONE
```