### PR TITLE
docs(spire): mark SPIRE entry snippet as shell code

### DIFF
--- a/docs/spire.md
+++ b/docs/spire.md
@@ -73,7 +73,7 @@ To enable TaskRun attestations:
 1. Make sure `enforce-nonfalsifiability` is set to `"spire"`. See [`additional-configs.md`](./additional-configs.md#customizing-the-pipelines-controller-behavior) for details
 1. Create a SPIRE deployment containing a SPIRE server, SPIRE agents and the SPIRE CSI driver, for convenience, [this sample single cluster deployment](https://github.com/spiffe/spiffe-csi/tree/main/example/config) can be used.
 1. Register the SPIRE workload entry for Tekton with the "Admin" flag, which will allow the Tekton controller to communicate with the SPIRE server to manage the TaskRun identities dynamically.
-    ```
+    ```shell
 
     # This example is assuming use of the above SPIRE deployment
     # Example where trust domain is "example.org" and cluster name is "example-cluster"


### PR DESCRIPTION
## Summary\n- mark the TaskRun attestation command snippet as `shell` fenced code\n- prevent markdown emoji substitution from rendering `k8s:sa:` as 🈂️ in rendered docs\n\nFixes #6822\n\n## Testing\n- `git diff --check`