### PR TITLE
docs: fix broken internal markdown links

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -2000,7 +2000,7 @@ If the `taskSpec` is not supported, the custom task controller should produce pr
 
 Please take a look at the
 developer guide for custom controllers supporting `taskSpec`:
-- [guidance for `Run`](runs.md#developer-guide-for-custom-controllers-supporting-spec)
+- [guidance for `Run`](customruns.md#developer-guide-for-custom-controllers-supporting-customspec)
 - [guidance for `CustomRun`](customruns.md#developer-guide-for-custom-controllers-supporting-customspec)
 
 `taskSpec` support for `pipelineRun` was designed and discussed in
@@ -2106,7 +2106,7 @@ If the custom task produces results, you can reference them in a Pipeline using 
 ### Specifying `Timeout`
 
 #### `v1alpha1.Run`
-If the custom task supports it as [we recommended](runs.md#developer-guide-for-custom-controllers-supporting-timeout), you can provide `timeout` to specify the maximum running time of a `CustomRun` (including all retry attempts or other operations).
+If the custom task supports it as [we recommended](customruns.md#developer-guide-for-custom-controllers-supporting-timeout), you can provide `timeout` to specify the maximum running time of a `CustomRun` (including all retry attempts or other operations).
 
 #### `v1beta1.CustomRun`
 If the custom task supports it as [we recommended](customruns.md#developer-guide-for-custom-controllers-supporting-timeout), you can provide `timeout` to specify the maximum running time of one `CustomRun` execution.

--- a/docs/podtemplates.md
+++ b/docs/podtemplates.md
@@ -172,7 +172,7 @@ roleRef:
 # Affinity Assistant Pod templates
 
 The Pod templates specified in the `TaskRuns` and `PipelineRuns `also apply to
-the [affinity assistant Pods](#./workspaces.md#specifying-workspace-order-in-a-pipeline-and-affinity-assistants)
+the [affinity assistant Pods](workspaces.md#specifying-workspace-order-in-a-pipeline-and-affinity-assistants)
 that are created when using Workspaces, but only on selected fields.
 
 The supported fields for affinity assistant pods are: `tolerations`, `nodeSelector`, `securityContext`, 


### PR DESCRIPTION
Fix broken internal markdown links in documentation files:
- Replace references to non-existent runs.md with customruns.md in pipelines.md
- Fix malformed anchor link in podtemplates.md (#./workspaces.md -> workspaces.md)

Fixes #9498

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
