### PR TITLE
docs(examples): replace deleted v1beta1 paths with v1 examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -16,17 +16,17 @@ push to from inside your cluster. If you are following instructions
 `$KO_DOCKER_REPO` instead of `gcr.io/christiewilson-catfactory`.
 
 ```bash
-# To invoke the build-push Task only
-kubectl apply -f examples/v1beta1/taskruns/task-output-image.yaml
+# To invoke a TaskRun example
+kubectl apply -f examples/v1/taskruns/task-result.yaml
 
 # To invoke the simple Pipeline
-kubectl apply -f examples/v1beta1/pipelineruns/pipelinerun.yaml
+kubectl apply -f examples/v1/pipelineruns/pipelinerun.yaml
 
-# To invoke the Pipeline that links outputs
-kubectl apply -f examples/v1beta1/pipelineruns/output-pipelinerun.yaml
+# To invoke a PipelineRun example that uses task results
+kubectl apply -f examples/v1/pipelineruns/task_results_example.yaml
 
-# To invoke the TaskRun with embedded Resource spec and task Spec
-kubectl apply -f examples/v1beta1/taskruns/git-resource.yaml
+# To invoke a TaskRun example that authenticates Git commands
+kubectl apply -f examples/v1/taskruns/authenticating-git-commands.yaml
 ```
 
 ## Results


### PR DESCRIPTION
## Summary
- update `examples/README.md` commands to use existing `examples/v1/...` files
- remove stale references to deleted `examples/v1beta1/...` examples
- keep the quick-start snippet aligned with files currently in the repository

## Validation
- verified no remaining `v1beta1` reference in `examples/README.md`
- verified each referenced `examples/v1/...` YAML file exists

Fixes #9499