### PR TITLE
docs: replace 'coming soon' with tkn bundle link in taskruns.md

### DIFF
--- a/docs/taskruns.md
+++ b/docs/taskruns.md
@@ -173,8 +173,7 @@ will then run that `Task` without registering it in the cluster allowing multipl
 of the same named `Task` to be run at once.
 
 `Tekton Bundles` may be constructed with any toolsets that produces valid OCI image artifacts so long as
-the artifact adheres to the [contract](tekton-bundle-contracts.md). Additionally, you may also use the `tkn`
-cli *(coming soon)*.
+the artifact adheres to the [contract](tekton-bundle-contracts.md). Additionally, you may also use the [`tkn bundle`](https://github.com/tektoncd/cli/blob/main/docs/cmd/tkn_bundle.md) CLI command.
 
 #### Remote Tasks
 


### PR DESCRIPTION
# Changes

Remove the outdated "coming soon" placeholder for `tkn` CLI support in `docs/taskruns.md`.
`tkn bundle` has been available for a long time, so the two broken lines referencing it have
been replaced with a single sentence linking directly to the [`tkn bundle`](https://github.com/tektoncd/cli/blob/main/docs/cmd/tkn_bundle.md) documentation.

Fixes #9497

# Submitter Checklist

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes
```release-note
NONE
```