### PR TITLE
fix: lowercase error strings to follow Go conventions

### DIFF
--- a/docs/resolver-template/cmd/resolver/main.go
+++ b/docs/resolver-template/cmd/resolver/main.go
@@ -64,7 +64,7 @@ func (r *resolver) Validate(ctx context.Context, req *v1beta1.ResolutionRequestS
 		return err
 	}
 	if u.Scheme != "demoscheme" {
-		return fmt.Errorf("Invalid Scheme. Want %s, Got %s", "demoscheme", u.Scheme)
+		return fmt.Errorf("invalid scheme. Want %s, Got %s", "demoscheme", u.Scheme)
 	}
 	return nil
 }

--- a/pkg/apis/pipeline/v1/result_validation.go
+++ b/pkg/apis/pipeline/v1/result_validation.go
@@ -159,7 +159,7 @@ func ExtractStepResultName(value string) (string, string, error) {
 	re := regexp.MustCompile(`\$\(steps\.(.*?)\.results\.(.*?)\)`)
 	rs := re.FindStringSubmatch(value)
 	if len(rs) != 3 {
-		return "", "", fmt.Errorf("Could not extract step name and result name. Expected value to look like $(steps.<stepName>.results.<resultName>) but got \"%v\"", value)
+		return "", "", fmt.Errorf("could not extract step name and result name. Expected value to look like $(steps.<stepName>.results.<resultName>) but got \"%v\"", value)
 	}
 	return rs[1], rs[2], nil
 }

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -121,7 +121,7 @@ func (t *ResolvedPipelineTask) EvaluateCEL() error {
 				if ok {
 					t.EvaluatedCEL[we.CEL] = b
 				} else {
-					return fmt.Errorf("The CEL expression %s is not evaluated to a boolean", we.CEL)
+					return fmt.Errorf("the CEL expression %s is not evaluated to a boolean", we.CEL)
 				}
 			}
 		}
@@ -755,9 +755,9 @@ func (t *ResolvedPipelineTask) setChildPipelineRunsAndResolvedPipeline(
 	case pipelineTask.PipelineSpec != nil:
 		rp.PipelineSpec = pipelineTask.PipelineSpec
 	case pipelineTask.PipelineRef != nil:
-		return fmt.Errorf("PipelineRef for PipelineTask %q is not yet implemented", pipelineTask.Name)
+		return fmt.Errorf("pipelineRef for PipelineTask %q is not yet implemented", pipelineTask.Name)
 	default:
-		return fmt.Errorf("PipelineSpec in PipelineTask %q missing", pipelineTask.Name)
+		return fmt.Errorf("pipelineSpec in PipelineTask %q missing", pipelineTask.Name)
 	}
 
 	t.ResolvedPipeline = rp
@@ -993,11 +993,11 @@ func CheckMissingResultReferences(pipelineRunState PipelineRunState, target *Res
 	for _, resultRef := range v1.PipelineTaskResultRefs(target.PipelineTask) {
 		referencedPipelineTask, ok := pipelineRunState.ToMap()[resultRef.PipelineTask]
 		if !ok {
-			return fmt.Errorf("Result reference error: Could not find ref \"%s\" in internal pipelineRunState", resultRef.PipelineTask)
+			return fmt.Errorf("result reference error: could not find ref \"%s\" in internal pipelineRunState", resultRef.PipelineTask)
 		}
 		if referencedPipelineTask.IsCustomTask() {
 			if len(referencedPipelineTask.CustomRuns) == 0 {
-				return fmt.Errorf("Result reference error: Internal result ref \"%s\" has zero-length CustomRuns", resultRef.PipelineTask)
+				return fmt.Errorf("result reference error: internal result ref \"%s\" has zero-length CustomRuns", resultRef.PipelineTask)
 			}
 			customRun := referencedPipelineTask.CustomRuns[0]
 			_, err := findRunResultForParam(customRun, resultRef)
@@ -1006,7 +1006,7 @@ func CheckMissingResultReferences(pipelineRunState PipelineRunState, target *Res
 			}
 		} else {
 			if len(referencedPipelineTask.TaskRuns) == 0 {
-				return fmt.Errorf("Result reference error: Internal result ref \"%s\" has zero-length TaskRuns", resultRef.PipelineTask)
+				return fmt.Errorf("result reference error: internal result ref \"%s\" has zero-length TaskRuns", resultRef.PipelineTask)
 			}
 			taskRun := referencedPipelineTask.TaskRuns[0]
 			_, err := findTaskResultForParam(taskRun, resultRef)

--- a/pkg/reconciler/taskrun/validate_taskrun.go
+++ b/pkg/reconciler/taskrun/validate_taskrun.go
@@ -283,7 +283,7 @@ func validateTaskRunResults(tr *v1.TaskRun, resolvedTaskSpec *v1.TaskSpec) error
 			s = append(s, fmt.Sprintf(" \"%v\": %v", k, v))
 		}
 		sort.Strings(s)
-		return pipelineErrors.WrapUserError(fmt.Errorf("Provided results don't match declared results; may be invalid JSON or missing result declaration: %v", strings.Join(s, ",")))
+		return pipelineErrors.WrapUserError(fmt.Errorf("provided results don't match declared results; may be invalid JSON or missing result declaration: %v", strings.Join(s, ",")))
 	}
 
 	// When get the results, for object value need to check if they have missing keys.

--- a/pkg/remote/oci/resolver.go
+++ b/pkg/remote/oci/resolver.go
@@ -70,7 +70,7 @@ func (o *Resolver) List(ctx context.Context) ([]remote.ResolvedObject, error) {
 
 	manifest, err := img.Manifest()
 	if err != nil {
-		return nil, fmt.Errorf("Could not parse image manifest: %w", err)
+		return nil, fmt.Errorf("could not parse image manifest: %w", err)
 	}
 
 	if err := o.checkImageCompliance(manifest); err != nil {
@@ -181,7 +181,7 @@ func (o *Resolver) checkImageCompliance(manifest *v1.Manifest) error {
 func readTarLayer(layer v1.Layer) (runtime.Object, error) {
 	rc, err := layer.Uncompressed()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to read image layer: %w", err)
+		return nil, fmt.Errorf("failed to read image layer: %w", err)
 	}
 	defer rc.Close()
 

--- a/pkg/remoteresolution/resolver/framework/fakeresolver.go
+++ b/pkg/remoteresolution/resolver/framework/fakeresolver.go
@@ -63,7 +63,7 @@ func (r *FakeResolver) Validate(_ context.Context, req *v1beta1.ResolutionReques
 		return framework.ValidateParams(req.Params)
 	}
 	if req.URL != FakeUrl {
-		return fmt.Errorf("Wrong url. Expected: %s,  Got: %s", FakeUrl, req.URL)
+		return fmt.Errorf("wrong url. Expected: %s,  Got: %s", FakeUrl, req.URL)
 	}
 	return nil
 }

--- a/pkg/resolution/resolver/http/resolver.go
+++ b/pkg/resolution/resolver/http/resolver.go
@@ -226,7 +226,7 @@ func compareSHA(expectedSHA string, computedSHA []byte) error {
 
 	match := subtle.ConstantTimeCompare(expectedBytes, computedSHA)
 	if match != 1 {
-		return fmt.Errorf("SHA mismatch, expected %s, got %s", expectedSHA, hex.EncodeToString(computedSHA))
+		return fmt.Errorf("sha mismatch, expected %s, got %s", expectedSHA, hex.EncodeToString(computedSHA))
 	}
 
 	return nil

--- a/pkg/spire/test/pemutil/pem.go
+++ b/pkg/spire/test/pemutil/pem.go
@@ -128,7 +128,7 @@ func parseBlock(pemBytes []byte, pemType string) (interface{}, []byte, bool, err
 	case keyType:
 		object, err = x509.ParsePKCS8PrivateKey(pemBlock.Bytes)
 	default:
-		err = fmt.Errorf("PEM type not supported: %q", pemType)
+		err = fmt.Errorf("pem type not supported: %q", pemType)
 	}
 
 	if err != nil {

--- a/pkg/workspace/apply.go
+++ b/pkg/workspace/apply.go
@@ -307,7 +307,7 @@ func FindWorkspacesUsedByTask(ts v1.TaskSpec) (sets.String, error) {
 	for item := range locationsToCheck {
 		workspacesUsed, _, errString := substitution.ExtractVariablesFromString(item, "workspaces")
 		if errString != "" {
-			return workspacesUsedInSteps, fmt.Errorf("Error while extracting workspace: %s", errString)
+			return workspacesUsedInSteps, fmt.Errorf("error while extracting workspace: %s", errString)
 		}
 		workspacesUsedInSteps.Insert(workspacesUsed...)
 	}


### PR DESCRIPTION
## Summary
- lowercased fmt.Errorf messages in non-test, non-vendor code to align with Go error style
- kept scope to instances listed in issue #9500 and ran gofmt on touched files

## Rationale
- Go convention requires error strings to start lowercase; these messages violated that guideline.

## Changes
- pkg/workspace/apply.go: workspace extraction error lowercased
- pkg/remote/oci/resolver.go: manifest/layer errors lowercased
- pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go: cel eval, pipelineRef/spec, and result-ref errors lowercased
- pkg/reconciler/taskrun/validate_taskrun.go: results mismatch user error lowercased
- pkg/apis/pipeline/v1/result_validation.go: step/result name parse error lowercased
- pkg/resolution/resolver/http/resolver.go: SHA mismatch error lowercased
- pkg/remoteresolution/resolver/framework/fakeresolver.go: fake resolver URL validation error lowercased
- pkg/spire/test/pemutil/pem.go: unsupported PEM type error lowercased
- docs/resolver-template/cmd/resolver/main.go: demo resolver scheme validation error lowercased

## Tests
- Not run (string-only change).

Fixes #9500