### PR TITLE
docs: fix broken internal markdown links

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -2000,7 +2000,7 @@ If the `taskSpec` is not supported, the custom task controller should produce pr
 
 Please take a look at the
 developer guide for custom controllers supporting `taskSpec`:
-- [guidance for `Run`](runs.md#developer-guide-for-custom-controllers-supporting-spec)
+- [guidance for `Run`](customruns.md#developer-guide-for-custom-controllers-supporting-spec)
 - [guidance for `CustomRun`](customruns.md#developer-guide-for-custom-controllers-supporting-customspec)
 
 `taskSpec` support for `pipelineRun` was designed and discussed in
@@ -2106,7 +2106,7 @@ If the custom task produces results, you can reference them in a Pipeline using 
 ### Specifying `Timeout`
 
 #### `v1alpha1.Run`
-If the custom task supports it as [we recommended](runs.md#developer-guide-for-custom-controllers-supporting-timeout), you can provide `timeout` to specify the maximum running time of a `CustomRun` (including all retry attempts or other operations).
+If the custom task supports it as [we recommended](customruns.md#developer-guide-for-custom-controllers-supporting-timeout), you can provide `timeout` to specify the maximum running time of a `CustomRun` (including all retry attempts or other operations).
 
 #### `v1beta1.CustomRun`
 If the custom task supports it as [we recommended](customruns.md#developer-guide-for-custom-controllers-supporting-timeout), you can provide `timeout` to specify the maximum running time of one `CustomRun` execution.

--- a/docs/podtemplates.md
+++ b/docs/podtemplates.md
@@ -172,7 +172,7 @@ roleRef:
 # Affinity Assistant Pod templates
 
 The Pod templates specified in the `TaskRuns` and `PipelineRuns `also apply to
-the [affinity assistant Pods](#./workspaces.md#specifying-workspace-order-in-a-pipeline-and-affinity-assistants)
+the [affinity assistant Pods](workspaces.md#specifying-workspace-order-in-a-pipeline-and-affinity-assistants)
 that are created when using Workspaces, but only on selected fields.
 
 The supported fields for affinity assistant pods are: `tolerations`, `nodeSelector`, `securityContext`, 


### PR DESCRIPTION
Fixes #9498

## Summary
Fix broken internal markdown links in documentation files that were pointing to non-existent or renamed files.

## Changes

### docs/pipelines.md
- Line 2003: `runs.md#developer-guide-for-custom-controllers-supporting-spec` → `customruns.md#developer-guide-for-custom-controllers-supporting-spec`
- Line 2109: `runs.md#developer-guide-for-custom-controllers-supporting-timeout` → `customruns.md#developer-guide-for-custom-controllers-supporting-timeout`

**Reason:** `runs.md` no longer exists in the docs/ directory. It has been replaced by `customruns.md`.

### docs/podtemplates.md  
- Line 175: `#./workspaces.md#specifying-workspace-order...` → `workspaces.md#specifying-workspace-order...`

**Reason:** The link had a malformed `#.` prefix that caused it to be invalid.

## Verification

✅ All updated links point to existing files:
- `docs/customruns.md` — exists
- `docs/workspaces.md` — exists

✅ Verified with script:
```bash
cd docs
# Check that target files exist
[ -f customruns.md ] && echo "✓ customruns.md exists"
[ -f workspaces.md ] && echo "✓ workspaces.md exists"
```

## Note

The links to `../api_compatibility_policy.md` in `additional-configs.md` and `deprecations.md` mentioned in the issue are actually **correct** — the file exists in the repository root and the relative path is valid.