### PR TITLE
docs: add 4 undocumented metrics to docs/metrics.md

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -22,7 +22,10 @@ We expose several kinds of exporters, including Prometheus, Google Stackdriver, 
 | `tekton_pipelines_controller_running_taskruns` | Gauge |                                                 | experimental |
 | `tekton_pipelines_controller_running_taskruns_throttled_by_quota` | Gauge | <br> `namespace`=&lt;pipelinerun-namespace&gt; | experimental |
 | `tekton_pipelines_controller_running_taskruns_throttled_by_node`  | Gauge | <br> `namespace`=&lt;pipelinerun-namespace&gt; | experimental |
-| `tekton_pipelines_controller_taskruns_pod_latency_milliseconds_[bucket, sum, count]` | Histogram | `namespace`=&lt;taskrun-namespace&gt; <br> `*task`=&lt;task_name&gt; <br> `*taskrun`=&lt;taskrun_name&gt; | experimental |
+| `tekton_pipelines_controller_running_pipelineruns_waiting_on_pipeline_resolution` | Gauge | | experimental |
+| `tekton_pipelines_controller_running_pipelineruns_waiting_on_task_resolution` | Gauge | | experimental |
+| `tekton_pipelines_controller_running_taskruns_waiting_on_task_resolution_count` | Gauge | | experimental |
+| `tekton_pipelines_controller_taskruns_pod_latency_milliseconds` | Gauge | `namespace`=&lt;namespace&gt; `pod`=&lt;pod_name&gt; `*task`=&lt;task_name&gt; `*taskrun`=&lt;taskrun_name&gt; (unbounded cardinality, see [#9393](https://github.com/tektoncd/pipeline/issues/9393)) | experimental |
 | `tekton_pipelines_controller_client_latency_[bucket, sum, count]` | Histogram |                                                 | experimental |
 
 The Labels/Tag marked as "*" are optional. And there's a choice between Histogram and LastValue(Gauge) for pipelinerun and taskrun duration metrics.


### PR DESCRIPTION
# Changes

Add 4 metrics that are defined in the controller code but were missing from `docs/metrics.md`:

- `tekton_pipelines_controller_running_pipelineruns_waiting_on_pipeline_resolution`
- `tekton_pipelines_controller_running_pipelineruns_waiting_on_task_resolution`
- `tekton_pipelines_controller_running_taskruns_waiting_on_task_resolution_count`
- `tekton_pipelines_controller_taskruns_pod_latency_milliseconds` (includes note on unbounded cardinality via the `pod` label — see #9393)

All 4 are Gauge metrics at experimental status. New rows are inserted after `throttled_by_node` and before `client_latency`.

Fixes #9495

# Submitter Checklist

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes
```release-note
NONE
```