### PR TITLE
docs: fix broken internal markdown links

### DIFF
--- a/docs/additional-configs.md
+++ b/docs/additional-configs.md
@@ -398,7 +398,7 @@ Features currently in "alpha" are:
 
 ### Beta Features
 
-Beta features are fields of stable CRDs that follow our "beta" [compatibility policy](../api_compatibility_policy.md).
+Beta features are fields of stable CRDs that follow our "beta" [compatibility policy](https://github.com/tektoncd/pipeline/blob/main/api_compatibility_policy.md).
 To enable these features, set the `enable-api-fields` feature flag to `"beta"` in
 the `feature-flags` ConfigMap alongside your Tekton Pipelines deployment via
 `kubectl patch cm feature-flags -n tekton-pipelines -p '{"data":{"enable-api-fields":"beta"}}'`.

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -31,7 +31,7 @@ The following features are deprecated but have not yet been removed.
 ### v1beta1 deprecation
 
 The v1beta1 versions of Task, TaskRun, Pipeline, and PipelineRun are deprecated in favor of the v1 versions of these APIs,
-as of release v0.50.0. Following the [beta CRD compatibility policy](../api_compatibility_policy.md#beta-crds),
+as of release v0.50.0. Following the [beta CRD compatibility policy](https://github.com/tektoncd/pipeline/blob/main/api_compatibility_policy.md#beta-crds),
 the earliest release the v1beta1 versions of these CRDs may be removed is 1 year later, or v0.62.0 (LTS).
 The v1beta1 client libraries will be retained until v0.62.0 has reached its end of life, 1 year later.
 Therefore, the earliest release the client libraries may be removed is v0.74.0, 12 months after v0.62.0.

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -2000,7 +2000,7 @@ If the `taskSpec` is not supported, the custom task controller should produce pr
 
 Please take a look at the
 developer guide for custom controllers supporting `taskSpec`:
-- [guidance for `Run`](runs.md#developer-guide-for-custom-controllers-supporting-spec)
+- [guidance for `Run`](customruns.md#developer-guide-for-custom-controllers-supporting-customspec)
 - [guidance for `CustomRun`](customruns.md#developer-guide-for-custom-controllers-supporting-customspec)
 
 `taskSpec` support for `pipelineRun` was designed and discussed in
@@ -2106,7 +2106,7 @@ If the custom task produces results, you can reference them in a Pipeline using 
 ### Specifying `Timeout`
 
 #### `v1alpha1.Run`
-If the custom task supports it as [we recommended](runs.md#developer-guide-for-custom-controllers-supporting-timeout), you can provide `timeout` to specify the maximum running time of a `CustomRun` (including all retry attempts or other operations).
+If the custom task supports it as [we recommended](customruns.md#developer-guide-for-custom-controllers-supporting-timeout), you can provide `timeout` to specify the maximum running time of a `CustomRun` (including all retry attempts or other operations).
 
 #### `v1beta1.CustomRun`
 If the custom task supports it as [we recommended](customruns.md#developer-guide-for-custom-controllers-supporting-timeout), you can provide `timeout` to specify the maximum running time of one `CustomRun` execution.

--- a/docs/podtemplates.md
+++ b/docs/podtemplates.md
@@ -172,7 +172,7 @@ roleRef:
 # Affinity Assistant Pod templates
 
 The Pod templates specified in the `TaskRuns` and `PipelineRuns `also apply to
-the [affinity assistant Pods](#./workspaces.md#specifying-workspace-order-in-a-pipeline-and-affinity-assistants)
+the [affinity assistant Pods](./workspaces.md#specifying-workspace-order-in-a-pipeline-and-affinity-assistants)
 that are created when using Workspaces, but only on selected fields.
 
 The supported fields for affinity assistant pods are: `tolerations`, `nodeSelector`, `securityContext`, 


### PR DESCRIPTION
## Summary
- fix stale `runs.md` references in `docs/pipelines.md` by pointing to `customruns.md`
- fix malformed `#./workspaces.md` link in `docs/podtemplates.md`
- replace two compatibility policy relative links with stable GitHub blob links

## Validation
- `git diff --check`
- targeted check to ensure old broken link targets are removed and expected replacements are present

Closes #9498
