### PR TITLE
Move inactive approvers to alumni

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,15 +2,10 @@ aliases:
   pipeline-approvers:
   - afrittoli
   - dibyom
-  - ImJasonH
   - vdemeester
   - pritidesai
-  - jerop
   - abayer
   - wlynch
-  - yongxuanzhang
-  - chitrangpatel
-  - jeromeJu
   - waveywaves
   - twoGiants
 
@@ -19,7 +14,6 @@ aliases:
   - dibyom
   - vdemeester
   - pritidesai
-  - jerop
   - abayer
   - twoGiants
   - khrm
@@ -28,10 +22,8 @@ aliases:
   apis-approvers:
   - afrittoli
   - dibyom
-  - ImJasonH
   - vdemeester
   - pritidesai
-  - jerop
   - abayer
   - wlynch
 
@@ -48,3 +40,8 @@ aliases:
 # dlorenc
 # lbernick
 # bobcatfish
+# ImJasonH
+# jerop
+# yongxuanzhang
+# chitrangpatel
+# jeromeJu


### PR DESCRIPTION
# Changes

Move ImJasonH, jerop, yongxuanzhang, chitrangpatel, and jeromeJu to alumni status in OWNERS_ALIASES.

These maintainers have had zero contributions across all activity metrics (PRs authored, PR reviews, issue comments, issues created, commits) in the last 12 months, as confirmed by both GitHub API data and [Tekton DevStats](https://tekton.devstats.cd.foundation/d/9/developer-activity-counts-by-repository-group-table?orgId=1&var-period_name=Last%20year&var-metric=contributions&var-repogroup_name=All&var-country_name=All).

Several were previously very active contributors (e.g. jerop: 4,783 contributions in last 5 years, yongxuanzhang: 4,440, chitrangpatel: 1,073 in last 2 years). Per the [contributor ladder inactivity policy](https://github.com/tektoncd/community/blob/main/process/contributor-ladder.md#inactivity), >4 months of no contributions warrants moving to emeritus.

Full triage report: https://gist.github.com/vdemeester/c7ce8d4fea6f7a2f9b3f685558ce8ded

**Note:** Govboard members (dibyom, abayer, wlynch) are intentionally kept for now — they require separate discussion given their governance role grants maintainer privileges.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`.
- [x] Release notes block below has been updated with any user facing changes

# Release Notes

```release-note
NONE
```