### PR TITLE
Nominate khrm and aThorp96 as pipeline approvers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,7 +1,9 @@
 aliases:
   pipeline-approvers:
   - afrittoli
+  - aThorp96
   - dibyom
+  - khrm
   - vdemeester
   - pritidesai
   - abayer
@@ -11,6 +13,7 @@ aliases:
 
   pipeline-reviewers:
   - afrittoli
+  - aThorp96
   - dibyom
   - vdemeester
   - pritidesai


### PR DESCRIPTION
# Changes

Nominate **khrm** and **aThorp96** for promotion to pipeline approvers. Also adds aThorp96 to pipeline-reviewers.

Per the [contributor ladder](https://github.com/tektoncd/community/blob/main/process/contributor-ladder.md#maintainer), nominees must agree to all requirements by commenting on this PR.

## khrm — Activity (last 12 months)

| Metric | Pipeline | Org-wide |
|--------|----------|----------|
| DevStats contributions | 112 | 1,013 |
| PRs authored | 11 (9 merged) | 75 |
| PR reviews | 27 | 410 |
| Comments | 130 | 667 |
| Issues | 6 | 22 |

Already a pipeline reviewer. Lead maintainer of **triggers** (260 contributions) and **results** (534 contributions). Demonstrates broad cross-project knowledge and consistent high-quality reviews.

## aThorp96 — Activity (last 12 months)

| Metric | Pipeline | Org-wide |
|--------|----------|----------|
| DevStats contributions | 161 | 310 |
| PRs authored | 7 (all merged) | 22 |
| PR reviews | 13 | 230 |
| Comments | 83 | 174 |
| Issues | 11 | 12 |

Active across multiple repos: operator (42 devstats), results (57), chains (27). Strong reviewer presence and growing contributor.

## Maintainer Requirements Checklist

Both candidates meet the [maintainer requirements](https://github.com/tektoncd/community/blob/main/process/contributor-ladder.md#maintainer):
- [x] Active reviewing for 3+ months
- [x] 30+ PRs authored/reviewed
- [x] Primary reviewer for 10+ substantial PRs
- [x] Broad knowledge of the project across multiple areas
- [ ] **Nominees**: please comment confirming you agree to all maintainer responsibilities

Full triage report: https://gist.github.com/vdemeester/c7ce8d4fea6f7a2f9b3f685558ce8ded

# Submitter Checklist

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md)
- [x] Has a kind label.
- [x] Release notes block below has been updated

# Release Notes

```release-note
NONE
```