### PR TITLE
docs: add helper script for running examples with custom registry

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -11,9 +11,32 @@ can not be executed by `kubectl apply`.  Please use `kubectl create` instead.
 In few examples to demonstrate tasks that push image to registry, sample URL
 `gcr.io/christiewilson-catfactory` is used. To run these examples yourself, you
 will need to change the values of this sample registry URL to a registry you can
-push to from inside your cluster. If you are following instructions
-[here](../DEVELOPMENT.md#getting-started) to setup then use the value of
-`$KO_DOCKER_REPO` instead of `gcr.io/christiewilson-catfactory`.
+push to from inside your cluster.
+
+## Using the run-example.sh Helper Script
+
+We provide a helper script to automatically substitute the registry URL before
+applying examples. This is useful for:
+- Using local registries to avoid rate limiting
+- Testing in air-gapped environments
+- Speeding up development with cached images
+
+Set the `KO_DOCKER_REPO` environment variable to your registry and use the script:
+
+```bash
+# Set your registry
+export KO_DOCKER_REPO=kind.local
+# or: export KO_DOCKER_REPO=localhost:5000
+# or: export KO_DOCKER_REPO=your-registry.example.com
+
+# Run examples using the helper script
+./hack/run-example.sh examples/v1/pipelineruns/pipelinerun.yaml
+./hack/run-example.sh examples/v1beta1/taskruns/task-output-image.yaml
+```
+
+## Manual Application
+
+Alternatively, you can manually apply examples with `kubectl apply`:
 
 ```bash
 # To invoke the build-push Task only
@@ -28,6 +51,9 @@ kubectl apply -f examples/v1beta1/pipelineruns/output-pipelinerun.yaml
 # To invoke the TaskRun with embedded Resource spec and task Spec
 kubectl apply -f examples/v1beta1/taskruns/git-resource.yaml
 ```
+
+**Note:** When using manual application with examples that contain registry URLs,
+you'll need to edit the files or use `sed` to substitute the registry before applying.
 
 ## Results
 

--- a/hack/run-example.sh
+++ b/hack/run-example.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+# Copyright 2025 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script applies an example YAML file with registry substitution.
+# It replaces the hardcoded registry (gcr.io/christiewilson-catfactory)
+# with the value from KO_DOCKER_REPO environment variable.
+#
+# Usage:
+#   KO_DOCKER_REPO=kind.local ./hack/run-example.sh examples/v1/pipelineruns/pipelinerun.yaml
+#   KO_DOCKER_REPO=localhost:5000 ./hack/run-example.sh examples/v1/taskruns/task-output-image.yaml
+#
+# This allows you to use local registries and avoid rate limiting issues
+# with remote registries.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Print usage information
+function usage() {
+  echo "Usage: $0 <example-yaml-file>"
+  echo ""
+  echo "Applies a Tekton example YAML file with registry substitution."
+  echo ""
+  echo "The script replaces 'gcr.io/christiewilson-catfactory' with the value"
+  echo "from the KO_DOCKER_REPO environment variable, allowing you to use"
+  echo "local registries or different remote registries."
+  echo ""
+  echo "Environment Variables:"
+  echo "  KO_DOCKER_REPO  - The container registry to use (required)"
+  echo ""
+  echo "Examples:"
+  echo "  KO_DOCKER_REPO=kind.local $0 examples/v1/pipelineruns/pipelinerun.yaml"
+  echo "  KO_DOCKER_REPO=localhost:5000 $0 examples/v1/taskruns/task-output-image.yaml"
+  echo ""
+  echo "For setting up a local registry with kind, see:"
+  echo "  https://kind.sigs.k8s.io/docs/user/local-registry/"
+  exit 1
+}
+
+# Check if file argument is provided
+if [[ $# -ne 1 ]]; then
+  usage
+fi
+
+EXAMPLE_FILE="$1"
+
+# Check if the example file exists
+if [[ ! -f "${EXAMPLE_FILE}" ]]; then
+  echo "error: Example file not found: ${EXAMPLE_FILE}"
+  exit 1
+fi
+
+# Check if KO_DOCKER_REPO is set
+if [[ -z "${KO_DOCKER_REPO:-}" ]]; then
+  echo "error: KO_DOCKER_REPO environment variable is not set"
+  echo ""
+  echo "Please set KO_DOCKER_REPO to your container registry."
+  echo "For example:"
+  echo "  export KO_DOCKER_REPO=kind.local"
+  echo "  export KO_DOCKER_REPO=localhost:5000"
+  echo "  export KO_DOCKER_REPO=your-registry.example.com"
+  exit 1
+fi
+
+echo "Applying ${EXAMPLE_FILE} with registry: ${KO_DOCKER_REPO}"
+
+# Substitute the registry and apply
+# Using sed to replace the hardcoded registry with KO_DOCKER_REPO
+sed "s|gcr.io/christiewilson-catfactory|${KO_DOCKER_REPO}|g" "${EXAMPLE_FILE}" | kubectl apply -f -
+
+echo "Successfully applied ${EXAMPLE_FILE}"


### PR DESCRIPTION
Fixes #9191

## Summary

This PR adds a helper script (`hack/run-example.sh`) that makes it easy to configure and run Tekton Pipeline examples with a custom container registry. This addresses several issues:

- Avoid registry rate limiting during development/testing
- Faster test execution with local registries
- Better developer experience for running examples locally
- Support for air-gapped/restricted environments

## Changes

- Added `hack/run-example.sh` helper script that substitutes `gcr.io/christiewilson-catfactory` with `KO_DOCKER_REPO` environment variable
- Updated `examples/README.md` with documentation for the helper script

## Implementation Details

The helper script:
- Takes an example YAML file path as input
- Checks for `KO_DOCKER_REPO` environment variable
- Replaces `gcr.io/christiewilson-catfactory` with the registry value
- Applies the modified YAML to the cluster using `kubectl apply`
- Provides helpful usage examples and error messages

## Usage
```bash
# Set the container registry (required)
export KO_DOCKER_REPO=kind.local

# Run an example
./hack/run-example.sh examples/v1/pipelineruns/pipelinerun.yaml
./hack/run-example.sh examples/v1beta1/taskruns/task-output-image.yaml
```

### Benefits
- Developers can use local registries (kind.local, localhost:5000, registry.local:5000) to avoid Docker Hub rate limits
- Examples can be run offline or in air-gapped environments after pre-loading images to local registry
- Faster iteration during local development with cached images

## Testing
- Verified script syntax with `bash -n`
- Tested registry substitution with example files - correctly replaces hardcoded registry with custom value
- Tested error handling - shows usage when KO_DOCKER_REPO is not set
- Confirmed script is executable and has correct permissions

## Related
- Issue #9191
- `test/examples_test.go` - contains the existing `substituteEnv` function
- `examples/README.md` - documentation for running examples

## Diff Stats

 examples/README.md  | 32 ++++++++++++++++++---
 hack/run-example.sh | 85 +++++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 114 insertions(+), 3 deletions(-)