### PR TITLE
fix: use hashed volume names to prevent credential volume name collisions

### DIFF
--- a/pkg/pod/creds_init.go
+++ b/pkg/pod/creds_init.go
@@ -41,8 +41,8 @@ import (
 const (
 	credsInitHomeMountPrefix       = "tekton-creds-init-home" // #nosec
 	sshKnownHosts                  = "known_hosts"
-	credentialVolumeNamePrefix     = "tekton-internal-secret-volume" // #nosec G101 -- not a credential
-	credentialVolumeNameHashLength = 5
+	credentialVolumeNamePrefix     = "tekton-creds" // #nosec G101 -- not a credential
+	credentialVolumeNameHashLength = 8
 )
 
 // credsInit reads secrets available to the given service account and

--- a/pkg/pod/creds_init_test.go
+++ b/pkg/pod/creds_init_test.go
@@ -120,7 +120,7 @@ func TestCredsInit(t *testing.T) {
 			"-basic-git=my-creds=gitlab.com",
 		},
 		wantVolumeMounts: []corev1.VolumeMount{{
-			Name:      "tekton-internal-secret-volume-bb404",
+			Name:      "tekton-creds-bb4044db",
 			MountPath: "/tekton/creds-secrets/my-creds",
 		}},
 		ctx: t.Context(),
@@ -153,7 +153,7 @@ func TestCredsInit(t *testing.T) {
 			"-docker-config=my-docker-creds",
 		},
 		wantVolumeMounts: []corev1.VolumeMount{{
-			Name:      "tekton-internal-secret-volume-f2d45",
+			Name:      "tekton-creds-f2d456c2",
 			MountPath: "/tekton/creds-secrets/my-docker-creds",
 		}},
 		ctx: t.Context(),
@@ -192,7 +192,7 @@ func TestCredsInit(t *testing.T) {
 			"-basic-git=my-creds=gitlab.com",
 		},
 		wantVolumeMounts: []corev1.VolumeMount{{
-			Name:      "tekton-internal-secret-volume-bb404",
+			Name:      "tekton-creds-bb4044db",
 			MountPath: "/tekton/creds-secrets/my-creds",
 		}},
 		ctx: t.Context(),
@@ -256,7 +256,7 @@ func TestCredsInit(t *testing.T) {
 		envVars:  []corev1.EnvVar{},
 		wantArgs: []string{"-basic-docker=foo.bar.com=https://docker.io"},
 		wantVolumeMounts: []corev1.VolumeMount{{
-			Name:      "tekton-internal-secret-volume-b18d2",
+			Name:      "tekton-creds-b18d27f0",
 			MountPath: "/tekton/creds-secrets/foo.bar.com",
 		}},
 		ctx: t.Context(),
@@ -289,7 +289,7 @@ func TestCredsInit(t *testing.T) {
 			"-basic-git=my-creds=github.com",
 		},
 		wantVolumeMounts: []corev1.VolumeMount{{
-			Name:      "tekton-internal-secret-volume-bb404",
+			Name:      "tekton-creds-bb4044db",
 			MountPath: "/tekton/creds-secrets/my-creds",
 		}},
 		ctx: t.Context(),
@@ -324,7 +324,7 @@ func TestCredsInit(t *testing.T) {
 			"-basic-git=my-creds=github.com",
 		},
 		wantVolumeMounts: []corev1.VolumeMount{{
-			Name:      "tekton-internal-secret-volume-bb404",
+			Name:      "tekton-creds-bb4044db",
 			MountPath: "/tekton/creds-secrets/my-creds",
 		}},
 		events: []string{
@@ -363,7 +363,7 @@ func TestCredsInit(t *testing.T) {
 	}
 }
 
-// TestCredentialVolumeNameUniqueness is a regression test for SRVKP-6798: when a
+// TestCredentialVolumeNameUniqueness is a regression test: when a
 // namespace has 118+ annotated secrets with similar prefixes, the old random-suffix
 // naming scheme could produce volume name collisions. The hashed scheme using
 // names.GenerateHashedName (FNV-32a) produces unique names for each distinct input.

--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -80,7 +80,7 @@ func init() {
 
 func TestPodBuild(t *testing.T) {
 	secretsVolume := corev1.Volume{
-		Name:         "tekton-internal-secret-volume-8e736",
+		Name:         "tekton-creds-8e736f4e",
 		VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "multi-creds"}},
 	}
 	runtimeClassName := "gvisor"
@@ -285,7 +285,7 @@ func TestPodBuild(t *testing.T) {
 						Name:      "tekton-creds-init-home-0",
 						MountPath: "/tekton/creds",
 					}}, append(append([]corev1.VolumeMount{}, implicitVolumeMounts...), corev1.VolumeMount{
-						Name:      "tekton-internal-secret-volume-8e736",
+						Name:      "tekton-creds-8e736f4e",
 						MountPath: "/tekton/creds-secrets/multi-creds",
 					})...),
 					TerminationMessagePath: "/tekton/termination",


### PR DESCRIPTION
# Changes

When a namespace has many (118+) secrets annotated for Tekton credential
injection, the generated volume names could collide because the naming
scheme didn't guarantee uniqueness for secrets with similar prefixes.

The old scheme sanitized the secret name, prepended a fixed prefix, then
truncated to 57 characters before appending a random 5-char suffix.
Secrets sharing the first ~27 characters got identical bases.

This replaces the random-suffix approach with a deterministic SHA-256
hash of the full secret name:

```
tekton-internal-secret-volume-<8-hex-chars-of-sha256>
```

Always 39 characters, well within the 63-char k8s limit, deterministic
across reconciliation passes, and collision-free for any practical
number of secrets.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Fix credential volume name collisions when namespaces have many (118+)
annotated secrets. Volume names now use deterministic SHA-256 hashing
instead of truncation with random suffix.
```