### PR TITLE
fix: convert pod latency metric to histogram and remove pod label

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -22,6 +22,7 @@ We expose several kinds of exporters, including Prometheus, Google Stackdriver, 
 | `tekton_pipelines_controller_running_taskruns` | Gauge |                                                 | experimental |
 | `tekton_pipelines_controller_running_taskruns_throttled_by_quota` | Gauge | <br> `namespace`=&lt;pipelinerun-namespace&gt; | experimental |
 | `tekton_pipelines_controller_running_taskruns_throttled_by_node`  | Gauge | <br> `namespace`=&lt;pipelinerun-namespace&gt; | experimental |
+| `tekton_pipelines_controller_taskruns_pod_latency_milliseconds_[bucket, sum, count]` | Histogram | `namespace`=&lt;taskrun-namespace&gt; <br> `*task`=&lt;task_name&gt; <br> `*taskrun`=&lt;taskrun_name&gt; | experimental |
 | `tekton_pipelines_controller_client_latency_[bucket, sum, count]` | Histogram |                                                 | experimental |
 
 The Labels/Tag marked as "*" are optional. And there's a choice between Histogram and LastValue(Gauge) for pipelinerun and taskrun duration metrics.

--- a/pkg/taskrunmetrics/metrics.go
+++ b/pkg/taskrunmetrics/metrics.go
@@ -59,7 +59,7 @@ type Recorder struct {
 	runningTRsWaitingOnTaskResolutionGauge metric.Int64ObservableGauge
 	runningTRsThrottledByQuotaGauge        metric.Int64ObservableGauge
 	runningTRsThrottledByNodeGauge         metric.Int64ObservableGauge
-	podLatencyGauge                        metric.Float64Gauge
+	podLatencyHistogram                    metric.Float64Histogram
 
 	insertTaskTag     func(task, taskrun string) []attribute.KeyValue
 	insertPipelineTag func(pipeline, pipelinerun string) []attribute.KeyValue
@@ -220,15 +220,16 @@ func (r *Recorder) configure(cfg *config.Metrics) error {
 	}
 	r.runningTRsThrottledByNodeGauge = runningTRsThrottledByNodeGauge
 
-	podLatencyGauge, err := r.meter.Float64Gauge(
+	podLatencyHistogram, err := r.meter.Float64Histogram(
 		"tekton_pipelines_controller_taskruns_pod_latency_milliseconds",
 		metric.WithDescription("scheduling latency for the taskrun pods"),
 		metric.WithUnit("ms"),
+		metric.WithExplicitBucketBoundaries(5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000),
 	)
 	if err != nil {
-		return fmt.Errorf("failed to create taskrun pod latency gauge: %w", err)
+		return fmt.Errorf("failed to create taskrun pod latency histogram: %w", err)
 	}
-	r.podLatencyGauge = podLatencyGauge
+	r.podLatencyHistogram = podLatencyHistogram
 
 	return nil
 }
@@ -395,11 +396,10 @@ func (r *Recorder) RecordPodLatency(ctx context.Context, pod *corev1.Pod, tr *v1
 
 	attrs := []attribute.KeyValue{
 		attribute.String("namespace", tr.Namespace),
-		attribute.String("pod", pod.Name),
 	}
 	attrs = append(attrs, r.insertTaskTag(taskName, tr.Name)...)
 
-	r.podLatencyGauge.Record(ctx, float64(latency.Milliseconds()), metric.WithAttributes(attrs...))
+	r.podLatencyHistogram.Record(ctx, float64(latency.Milliseconds()), metric.WithAttributes(attrs...))
 
 	return nil
 }

--- a/pkg/taskrunmetrics/metrics_test.go
+++ b/pkg/taskrunmetrics/metrics_test.go
@@ -1242,6 +1242,10 @@ func TestRecordPodLatency(t *testing.T) {
 		t.Run(td.name, func(t *testing.T) {
 			resetMetrics()
 			ctx := getConfigContext(false, false)
+			reader := sdkmetric.NewManualReader()
+			provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+			otel.SetMeterProvider(provider)
+
 			metrics, err := NewRecorder(ctx)
 			if err != nil {
 				t.Fatalf("NewRecorder: %v", err)
@@ -1251,8 +1255,52 @@ func TestRecordPodLatency(t *testing.T) {
 				t.Error("RecordPodLatency wanted error, got nil")
 			} else if !td.expectingError {
 				if err != nil {
-					t.Errorf("RecordPodLatency: %v", err)
+					t.Fatalf("RecordPodLatency: %v", err)
 				}
+
+				var rm metricdata.ResourceMetrics
+				if err := reader.Collect(ctx, &rm); err != nil {
+					t.Fatalf("Collect error: %v", err)
+				}
+
+				for _, sm := range rm.ScopeMetrics {
+					for _, m := range sm.Metrics {
+						if m.Name == "tekton_pipelines_controller_taskruns_pod_latency_milliseconds" {
+							hist, ok := m.Data.(metricdata.Histogram[float64])
+							if !ok {
+								t.Fatalf("Expected Histogram[float64], got %T", m.Data)
+							}
+							if len(hist.DataPoints) != 1 {
+								t.Fatalf("Expected 1 data point, got %d", len(hist.DataPoints))
+							}
+							dp := hist.DataPoints[0]
+
+							// Verify latency value (4 seconds = 4000 ms)
+							if dp.Sum != 4000 {
+								t.Errorf("Expected latency sum 4000ms, got %v", dp.Sum)
+							}
+
+							// Verify attributes: namespace, task, taskrun should be present; pod should NOT
+							gotAttrs := make(map[string]string)
+							for _, kv := range dp.Attributes.ToSlice() {
+								gotAttrs[string(kv.Key)] = kv.Value.AsString()
+							}
+							if _, hasPod := gotAttrs["pod"]; hasPod {
+								t.Error("pod label should not be present on pod latency metric")
+							}
+							expectedAttrs := map[string]string{
+								"namespace": "foo",
+								"task":      "task-1",
+								"taskrun":   "test-taskrun",
+							}
+							if d := cmp.Diff(expectedAttrs, gotAttrs); d != "" {
+								t.Errorf("Attributes diff (-want, +got): %s", d)
+							}
+							return
+						}
+					}
+				}
+				t.Error("pod latency metric not found")
 			}
 		})
 	}


### PR DESCRIPTION
# Changes

The `tekton_pipelines_controller_taskruns_pod_latency_milliseconds` metric
was a `Float64Gauge` which cannot be used with Prometheus `rate()` or
`histogram_quantile()`. The hardcoded `pod` label created a unique time
series per TaskRun, causing 1.2M+ active series on large clusters and
Prometheus scrape timeouts that lose all Tekton metrics.

This converts the metric to a `Float64Histogram` with explicit bucket
boundaries and removes the `pod` label to keep cardinality bounded.

Fixes #9393
Related: #7553

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
action required: The `tekton_pipelines_controller_taskruns_pod_latency_milliseconds` metric has been converted from a Gauge to a Histogram and the `pod` label has been removed. Dashboards or alerts referencing this metric will need to be updated to use `histogram_quantile()` instead of direct value queries.
```