### PR TITLE
feat: add namespace label to pipelinerun and taskrun metrics

### DIFF
--- a/pkg/pipelinerunmetrics/metrics.go
+++ b/pkg/pipelinerunmetrics/metrics.go
@@ -228,7 +228,10 @@ func (r *Recorder) DurationAndCount(ctx context.Context, pr *v1.PipelineRun, bef
 	} else if r.prDurationHistogram != nil {
 		r.prDurationHistogram.Record(ctx, duration.Seconds(), metric.WithAttributes(attrs...))
 	}
-	r.prTotalCounter.Add(ctx, 1, metric.WithAttributes(attribute.String("status", status)))
+	r.prTotalCounter.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("namespace", pr.Namespace),
+		attribute.String("status", status),
+	))
 
 	return nil
 }

--- a/pkg/pipelinerunmetrics/metrics_test.go
+++ b/pkg/pipelinerunmetrics/metrics_test.go
@@ -655,7 +655,7 @@ func TestRecordPipelineRunDurationCount(t *testing.T) {
 						}
 
 						// Verify attributes for count (status only)
-						expectedCountTags := map[string]string{"status": test.expectedTags["status"]}
+						expectedCountTags := map[string]string{"namespace": test.expectedTags["namespace"], "status": test.expectedTags["status"]}
 						gotAttrs := make(map[string]string)
 						for _, kv := range dp.Attributes.ToSlice() {
 							gotAttrs[string(kv.Key)] = kv.Value.AsString()

--- a/pkg/taskrunmetrics/metrics.go
+++ b/pkg/taskrunmetrics/metrics.go
@@ -294,7 +294,10 @@ func (r *Recorder) DurationAndCount(ctx context.Context, tr *v1.TaskRun, beforeC
 		}
 	}
 
-	r.trTotalCounter.Add(ctx, 1, metric.WithAttributes(attribute.String("status", status)))
+	r.trTotalCounter.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("namespace", tr.Namespace),
+		attribute.String("status", status),
+	))
 
 	return nil
 }

--- a/pkg/taskrunmetrics/metrics_test.go
+++ b/pkg/taskrunmetrics/metrics_test.go
@@ -740,7 +740,7 @@ func TestRecordTaskRunDurationCount(t *testing.T) {
 						}
 
 						// Verify attributes for count (should only have status)
-						expectedCountTags := map[string]string{"status": c.expectedTags["status"]}
+						expectedCountTags := map[string]string{"namespace": c.expectedTags["namespace"], "status": c.expectedTags["status"]}
 						gotAttrs := make(map[string]string)
 						for _, kv := range dp.Attributes.ToSlice() {
 							gotAttrs[string(kv.Key)] = kv.Value.AsString()


### PR DESCRIPTION
Fixes #9544

## Changes

Added `namespace` label to `tekton_pipelines_controller_pipelinerun_total` and `tekton_pipelines_controller_taskrun_total` counters for consistency with `pipelinerun_duration_seconds` and `taskrun_duration_seconds` metrics.

This enables operators to query completed PipelineRun and TaskRun counts per namespace for chargeback, capacity planning, and usage reporting.

```release-note
Added namespace label to tekton_pipelines_controller_pipelinerun_total and tekton_pipelines_controller_taskrun_total metrics, enabling per-namespace usage reporting.
```
