### PR TITLE
Update tj-actions/changed-files version comment to v47.0.5

### DIFF
--- a/.github/workflows/woke.yml
+++ b/.github/workflows/woke.yml
@@ -19,7 +19,7 @@ jobs:
         
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323 # v45.0.7
+        uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323 # v47.0.5
         with:
           write_output_files: true
           files: |


### PR DESCRIPTION
<!-- 🎉 Thank you for the PR!!! 🎉 -->

# Changes

Updates the version comment on `tj-actions/changed-files` in `woke.yml` from `v45.0.7` to `v47.0.5`.

**The SHA pin itself is unchanged** — `22103cc46bda19c2b464ffe86db46df6922fd323` already points to the v47.0.5 commit. Only the trailing version comment was stale.

`v45.0.7` was the tag [compromised in CVE-2025-30066](https://github.com/advisories/ghsa-mrrh-fwg8-r2c3) (March 2025), where all tags v1–v45.0.7 were modified to point to malicious commit `0e58ed8`. The SHA pin protected this repository during the attack, but having `v45.0.7` in comments is misleading during security audits.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```