### PR TITLE
fix: surface runtime result reference validation errors in PipelineRun status

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -928,6 +928,12 @@ func (c *Reconciler) runNextSchedulableTask(ctx context.Context, pr *v1.Pipeline
 			nextRpts = nil
 			logger.Infof("Adding the task %q to the validation failed list", rpt.ResolvedTask)
 			pipelineRunFacts.ValidationFailedTask = append(pipelineRunFacts.ValidationFailedTask, rpt)
+			// Preserve the error details so they can be surfaced in the PipelineRun status condition.
+			// See https://github.com/tektoncd/pipeline/issues/9100
+			if pipelineRunFacts.ValidationFailedErrors == nil {
+				pipelineRunFacts.ValidationFailedErrors = make(map[string]string)
+			}
+			pipelineRunFacts.ValidationFailedErrors[rpt.PipelineTask.Name] = err.Error()
 		}
 	}
 	// GetFinalTasks only returns final tasks when a DAG is complete

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -928,11 +928,6 @@ func (c *Reconciler) runNextSchedulableTask(ctx context.Context, pr *v1.Pipeline
 			nextRpts = nil
 			logger.Infof("Adding the task %q to the validation failed list", rpt.ResolvedTask)
 			pipelineRunFacts.ValidationFailedTask = append(pipelineRunFacts.ValidationFailedTask, rpt)
-			// Preserve the error details so they can be surfaced in the PipelineRun status condition.
-			if pipelineRunFacts.ValidationFailedErrors == nil {
-				pipelineRunFacts.ValidationFailedErrors = make(map[string]string)
-			}
-			pipelineRunFacts.ValidationFailedErrors[rpt.PipelineTask.Name] = err.Error()
 		}
 	}
 	// GetFinalTasks only returns final tasks when a DAG is complete

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -929,7 +929,6 @@ func (c *Reconciler) runNextSchedulableTask(ctx context.Context, pr *v1.Pipeline
 			logger.Infof("Adding the task %q to the validation failed list", rpt.ResolvedTask)
 			pipelineRunFacts.ValidationFailedTask = append(pipelineRunFacts.ValidationFailedTask, rpt)
 			// Preserve the error details so they can be surfaced in the PipelineRun status condition.
-			
 			if pipelineRunFacts.ValidationFailedErrors == nil {
 				pipelineRunFacts.ValidationFailedErrors = make(map[string]string)
 			}

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -929,7 +929,7 @@ func (c *Reconciler) runNextSchedulableTask(ctx context.Context, pr *v1.Pipeline
 			logger.Infof("Adding the task %q to the validation failed list", rpt.ResolvedTask)
 			pipelineRunFacts.ValidationFailedTask = append(pipelineRunFacts.ValidationFailedTask, rpt)
 			// Preserve the error details so they can be surfaced in the PipelineRun status condition.
-			// See https://github.com/tektoncd/pipeline/issues/9100
+			
 			if pipelineRunFacts.ValidationFailedErrors == nil {
 				pipelineRunFacts.ValidationFailedErrors = make(map[string]string)
 			}

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -1308,7 +1308,7 @@ status:
           image: busybox
           script: 'exit 0'
   conditions:
-  - message: "Tasks Completed: 1 (Failed: 0, Cancelled 0), Skipped: 0, Failed Validation: 1"
+  - message: 'Tasks Completed: 1 (Failed: 0, Cancelled 0), Skipped: 0, Failed Validation: 1 (task "task2": Invalid task result reference: Could not find result with name result2 for pipeline task task1)'
     reason: PipelineValidationFailed
     status: "False"
     type: Succeeded

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
@@ -80,7 +80,7 @@ type PipelineRunFacts struct {
 	// ValidationFailedErrors stores the specific error messages for tasks that failed runtime
 	// result-reference validation, keyed by pipeline task name. This allows surfacing actionable
 	// error details in the PipelineRun status condition instead of only a generic count.
-	// See https://github.com/tektoncd/pipeline/issues/9100
+	
 	ValidationFailedErrors map[string]string
 }
 

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
@@ -80,7 +80,6 @@ type PipelineRunFacts struct {
 	// ValidationFailedErrors stores the specific error messages for tasks that failed runtime
 	// result-reference validation, keyed by pipeline task name. This allows surfacing actionable
 	// error details in the PipelineRun status condition instead of only a generic count.
-	
 	ValidationFailedErrors map[string]string
 }
 

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
@@ -76,11 +76,6 @@ type PipelineRunFacts struct {
 	// the case of failing at the validation is during CheckMissingResultReferences method
 	// Tasks in ValidationFailedTask is added in method runNextSchedulableTask
 	ValidationFailedTask []*ResolvedPipelineTask
-
-	// ValidationFailedErrors stores the specific error messages for tasks that failed runtime
-	// result-reference validation, keyed by pipeline task name. This allows surfacing actionable
-	// error details in the PipelineRun status condition instead of only a generic count.
-	ValidationFailedErrors map[string]string
 }
 
 // PipelineRunTimeoutsState records information about start times and timeouts for the PipelineRun, so that the PipelineRunFacts
@@ -586,8 +581,8 @@ func (facts *PipelineRunFacts) GetPipelineConditionStatus(ctx context.Context, p
 		if s.ValidationFailed > 0 {
 			var errDetails []string
 			for _, rpt := range facts.ValidationFailedTask {
-				if errMsg, ok := facts.ValidationFailedErrors[rpt.PipelineTask.Name]; ok {
-					errDetails = append(errDetails, fmt.Sprintf("task %q: %s", rpt.PipelineTask.Name, errMsg))
+				if err := CheckMissingResultReferences(facts.State, rpt); err != nil {
+					errDetails = append(errDetails, fmt.Sprintf("task %q: %s", rpt.PipelineTask.Name, err))
 				}
 			}
 			if len(errDetails) > 0 {

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
@@ -76,6 +76,12 @@ type PipelineRunFacts struct {
 	// the case of failing at the validation is during CheckMissingResultReferences method
 	// Tasks in ValidationFailedTask is added in method runNextSchedulableTask
 	ValidationFailedTask []*ResolvedPipelineTask
+
+	// ValidationFailedErrors stores the specific error messages for tasks that failed runtime
+	// result-reference validation, keyed by pipeline task name. This allows surfacing actionable
+	// error details in the PipelineRun status condition instead of only a generic count.
+	// See https://github.com/tektoncd/pipeline/issues/9100
+	ValidationFailedErrors map[string]string
 }
 
 // PipelineRunTimeoutsState records information about start times and timeouts for the PipelineRun, so that the PipelineRunFacts
@@ -577,9 +583,19 @@ func (facts *PipelineRunFacts) GetPipelineConditionStatus(ctx context.Context, p
 			message = fmt.Sprintf("Tasks Completed: %d (Failed: %d, Cancelled %d), Skipped: %d",
 				cmTasks, totalFailedTasks, s.Cancelled, s.Skipped)
 		}
-		// append validation failed count in the message
+		// append validation failed count and details in the message
 		if s.ValidationFailed > 0 {
-			message += fmt.Sprintf(", Failed Validation: %d", s.ValidationFailed)
+			var errDetails []string
+			for _, rpt := range facts.ValidationFailedTask {
+				if errMsg, ok := facts.ValidationFailedErrors[rpt.PipelineTask.Name]; ok {
+					errDetails = append(errDetails, fmt.Sprintf("task %q: %s", rpt.PipelineTask.Name, errMsg))
+				}
+			}
+			if len(errDetails) > 0 {
+				message += fmt.Sprintf(", Failed Validation: %d (%s)", s.ValidationFailed, strings.Join(errDetails, "; "))
+			} else {
+				message += fmt.Sprintf(", Failed Validation: %d", s.ValidationFailed)
+			}
 		}
 		// Set reason to ReasonCompleted - At least one is skipped
 		if s.Skipped > 0 {

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
@@ -18,6 +18,7 @@ package resources
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -2141,6 +2142,63 @@ func TestGetPipelineConditionStatus(t *testing.T) {
 				t.Fatalf("Mismatch in condition %s", diff.PrintWantGot(d))
 			}
 		})
+	}
+}
+
+func TestGetPipelineConditionStatus_WithValidationFailureDetails(t *testing.T) {
+	pr := &v1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "somepipelinerun",
+		},
+	}
+
+	validatedTask := &ResolvedPipelineTask{
+		PipelineTask: &pts[14],
+		ResolvedTask: &resources.ResolvedTask{TaskSpec: &task.Spec},
+	}
+
+	state := PipelineRunState{{
+		TaskRunNames: []string{"successfulTaskRun"},
+		PipelineTask: &pts[0],
+		TaskRuns:     []*v1.TaskRun{makeSucceeded(trs[0])},
+		ResolvedTask: &resources.ResolvedTask{TaskSpec: &task.Spec},
+	}, {
+		PipelineTask: validatedTask.PipelineTask,
+		ResolvedTask: validatedTask.ResolvedTask,
+	}}
+
+	d, err := dagFromState(state)
+	if err != nil {
+		t.Fatalf("Unexpected error while building DAG for state %v: %v", state, err)
+	}
+
+	facts := PipelineRunFacts{
+		State:                state,
+		TasksGraph:           d,
+		FinalTasksGraph:      &dag.Graph{},
+		ValidationFailedTask: []*ResolvedPipelineTask{validatedTask},
+		TimeoutsState: PipelineRunTimeoutsState{
+			Clock: testClock,
+		},
+	}
+
+	condition := facts.GetPipelineConditionStatus(t.Context(), pr, zap.NewNop().Sugar(), testClock)
+	if condition.Reason != v1.PipelineRunReasonFailedValidation.String() {
+		t.Fatalf("unexpected reason, got %q want %q", condition.Reason, v1.PipelineRunReasonFailedValidation.String())
+	}
+	if condition.Status != corev1.ConditionFalse {
+		t.Fatalf("unexpected status, got %q want %q", condition.Status, corev1.ConditionFalse)
+	}
+
+	wantParts := []string{
+		"Failed Validation: 1 (",
+		"task \"mytask15\": Invalid task result reference:",
+		"Could not find result with name result1 for pipeline task mytask1",
+	}
+	for _, want := range wantParts {
+		if !strings.Contains(condition.Message, want) {
+			t.Fatalf("expected condition message to contain %q, got %q", want, condition.Message)
+		}
 	}
 }
 


### PR DESCRIPTION
# Changes

Surface runtime task result reference validation errors in PipelineRun status.

Previously, when `CheckMissingResultReferences` failed for a pipeline task,
the error was silently stored in `ValidationFailedErrors` but no detail appeared
in the PipelineRun condition message. Now the condition message includes the
per-task error, e.g.:
`Failed Validation: 1 (task "task2": Invalid task result reference: Could not find result with name result2 for pipeline task task1)`

Fixes https://github.com/tektoncd/pipeline/issues/9100

# Submitter Checklist

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Surface runtime task result reference validation errors in PipelineRun status condition message.
```