### PR TITLE
fix(metrics): add namespace label to taskrun/pipelinerun totals

### DIFF
--- a/pkg/pipelinerunmetrics/metrics.go
+++ b/pkg/pipelinerunmetrics/metrics.go
@@ -228,7 +228,10 @@ func (r *Recorder) DurationAndCount(ctx context.Context, pr *v1.PipelineRun, bef
 	} else if r.prDurationHistogram != nil {
 		r.prDurationHistogram.Record(ctx, duration.Seconds(), metric.WithAttributes(attrs...))
 	}
-	r.prTotalCounter.Add(ctx, 1, metric.WithAttributes(attribute.String("status", status)))
+	r.prTotalCounter.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("namespace", pr.Namespace),
+		attribute.String("status", status),
+	))
 
 	return nil
 }

--- a/pkg/pipelinerunmetrics/metrics_test.go
+++ b/pkg/pipelinerunmetrics/metrics_test.go
@@ -655,7 +655,7 @@ func TestRecordPipelineRunDurationCount(t *testing.T) {
 						}
 
 						// Verify attributes for count (status only)
-						expectedCountTags := map[string]string{"status": test.expectedTags["status"]}
+						expectedCountTags := map[string]string{"namespace": test.expectedTags["namespace"], "status": test.expectedTags["status"]}
 						gotAttrs := make(map[string]string)
 						for _, kv := range dp.Attributes.ToSlice() {
 							gotAttrs[string(kv.Key)] = kv.Value.AsString()

--- a/pkg/taskrunmetrics/metrics.go
+++ b/pkg/taskrunmetrics/metrics.go
@@ -294,7 +294,10 @@ func (r *Recorder) DurationAndCount(ctx context.Context, tr *v1.TaskRun, beforeC
 		}
 	}
 
-	r.trTotalCounter.Add(ctx, 1, metric.WithAttributes(attribute.String("status", status)))
+	r.trTotalCounter.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("namespace", tr.Namespace),
+		attribute.String("status", status),
+	))
 
 	return nil
 }

--- a/pkg/taskrunmetrics/metrics_test.go
+++ b/pkg/taskrunmetrics/metrics_test.go
@@ -196,13 +196,20 @@ func TestDurationAndCountCancelledTaskRun(t *testing.T) {
 					t.Fatalf("Expected 1 total data point, got %d", len(sum.DataPoints))
 				}
 				gotStatus := ""
+				gotNamespace := ""
 				for _, kv := range sum.DataPoints[0].Attributes.ToSlice() {
 					if kv.Key == "status" {
 						gotStatus = kv.Value.AsString()
 					}
+					if kv.Key == "namespace" {
+						gotNamespace = kv.Value.AsString()
+					}
 				}
 				if gotStatus != "cancelled" {
 					t.Errorf("Expected status=cancelled, got %q", gotStatus)
+				}
+				if gotNamespace != "ns" {
+					t.Errorf("Expected namespace=ns, got %q", gotNamespace)
 				}
 				return
 			}
@@ -740,7 +747,7 @@ func TestRecordTaskRunDurationCount(t *testing.T) {
 						}
 
 						// Verify attributes for count (should only have status)
-						expectedCountTags := map[string]string{"status": c.expectedTags["status"]}
+						expectedCountTags := map[string]string{"namespace": c.expectedTags["namespace"], "status": c.expectedTags["status"]}
 						gotAttrs := make(map[string]string)
 						for _, kv := range dp.Attributes.ToSlice() {
 							gotAttrs[string(kv.Key)] = kv.Value.AsString()


### PR DESCRIPTION
## Summary
- add `namespace` attribute to `tekton_pipelines_controller_pipelinerun_total`
- add `namespace` attribute to `tekton_pipelines_controller_taskrun_total`
- update metrics tests to assert the new counter attributes

Fixes #9544

## Test Plan
- `go test ./pkg/pipelinerunmetrics ./pkg/taskrunmetrics`
