### PR TITLE
fix: name field to StepTemplate spec

### DIFF
--- a/config/300-crds/300-task.yaml
+++ b/config/300-crds/300-task.yaml
@@ -1510,8 +1510,6 @@ spec:
                 stepTemplate:
                   description: StepTemplate
                   type: object
-                  required:
-                    - name
                   properties:
                     args:
                       description: Args

--- a/docs/pipeline-api.md
+++ b/docs/pipeline-api.md
@@ -14742,6 +14742,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Default name for each Step specified as a DNS_LABEL.
 Each Step in a Task must have a unique name.
 Cannot be updated.</p>

--- a/pkg/apis/pipeline/v1beta1/container_types.go
+++ b/pkg/apis/pipeline/v1beta1/container_types.go
@@ -341,7 +341,7 @@ type StepTemplate struct {
 	//
 	// Deprecated: This field will be removed in a future release.
 	//
-	DeprecatedName string `json:"name" protobuf:"bytes,1,opt,name=name"`
+	DeprecatedName string `json:"name,omitempty" protobuf:"bytes,1,opt,name=name"`
 	// Default image name to use for each Step.
 	// More info: https://kubernetes.io/docs/concepts/containers/images
 	// This field is optional to allow higher level config management to default or override

--- a/pkg/apis/pipeline/v1beta1/container_types.go
+++ b/pkg/apis/pipeline/v1beta1/container_types.go
@@ -341,6 +341,7 @@ type StepTemplate struct {
 	//
 	// Deprecated: This field will be removed in a future release.
 	//
+	// +optional
 	DeprecatedName string `json:"name,omitempty" protobuf:"bytes,1,opt,name=name"`
 	// Default image name to use for each Step.
 	// More info: https://kubernetes.io/docs/concepts/containers/images

--- a/pkg/apis/pipeline/v1beta1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1beta1/openapi_generated.go
@@ -4386,7 +4386,6 @@ func schema_pkg_apis_pipeline_v1beta1_StepTemplate(ref common.ReferenceCallback)
 					"name": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Default name for each Step specified as a DNS_LABEL. Each Step in a Task must have a unique name. Cannot be updated.\n\nDeprecated: This field will be removed in a future release.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -4632,7 +4631,6 @@ func schema_pkg_apis_pipeline_v1beta1_StepTemplate(ref common.ReferenceCallback)
 						},
 					},
 				},
-				Required: []string{"name"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/apis/pipeline/v1beta1/swagger.json
+++ b/pkg/apis/pipeline/v1beta1/swagger.json
@@ -2435,9 +2435,6 @@
     "v1beta1.StepTemplate": {
       "description": "StepTemplate is a template for a Step",
       "type": "object",
-      "required": [
-        "name"
-      ],
       "properties": {
         "args": {
           "description": "Arguments to the entrypoint. The image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the Step's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
@@ -2495,8 +2492,7 @@
         },
         "name": {
           "description": "Default name for each Step specified as a DNS_LABEL. Each Step in a Task must have a unique name. Cannot be updated.\n\nDeprecated: This field will be removed in a future release.",
-          "type": "string",
-          "default": ""
+          "type": "string"
         },
         "ports": {
           "description": "List of ports to expose from the Step's container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Cannot be updated.\n\nDeprecated: This field will be removed in a future release.",

--- a/pkg/apis/pipeline/v1beta1/task_conversion_test.go
+++ b/pkg/apis/pipeline/v1beta1/task_conversion_test.go
@@ -366,7 +366,7 @@ spec:
 	taskWithDeprecatedFieldsV1.ObjectMeta.Annotations = map[string]string{
 		v1beta1.TaskDeprecationsAnnotationKey: `{"foo":{"deprecatedSteps":` +
 			`[{"name":"","ports":[{"name":"port","containerPort":0}],"resources":{},"livenessProbe":{"initialDelaySeconds":1},"readinessProbe":{"initialDelaySeconds":2},"startupProbe":{"initialDelaySeconds":3},"lifecycle":{"postStart":{"exec":{"command":["lifecycle command"]}}},"terminationMessagePath":"path","terminationMessagePolicy":"policy","stdin":true,"stdinOnce":true,"tty":true}],` +
-			`"deprecatedStepTemplate":{"name":"","ports":[{"name":"port","containerPort":0}],"resources":{},"livenessProbe":{"initialDelaySeconds":1},"readinessProbe":{"initialDelaySeconds":2},"startupProbe":{"initialDelaySeconds":3},"lifecycle":{"postStart":{"exec":{"command":["lifecycle command"]}}},"terminationMessagePath":"path","terminationMessagePolicy":"policy","stdin":true,"stdinOnce":true,"tty":true}}}`,
+			`"deprecatedStepTemplate":{"ports":[{"name":"port","containerPort":0}],"resources":{},"livenessProbe":{"initialDelaySeconds":1},"readinessProbe":{"initialDelaySeconds":2},"startupProbe":{"initialDelaySeconds":3},"lifecycle":{"postStart":{"exec":{"command":["lifecycle command"]}}},"terminationMessagePath":"path","terminationMessagePolicy":"policy","stdin":true,"stdinOnce":true,"tty":true}}}`,
 	}
 	taskWithoutStepTemplateYAMLV1beta1 := parse.MustParseV1beta1Task(t, taskWithoutStepTemplateYAML)
 	taskWithoutStepTemplateYAMLV1 := parse.MustParseV1Task(t, taskWithoutStepTemplateYAML)


### PR DESCRIPTION
# Changes

`spec.stepTemplate.name` was incorrectly marked as required in the CRD schema, causing a 422 rejection error when the field was set. Adds omitempty to the DeprecatedName JSON tag in StepTemplate and regenerates the CRD schemas to remove name from the required fields.

- config/300-crds/300-task.yaml - removed required field
- pkg/apis/pipeline/v1beta1/container_types.go - added omitempty tag

Fixes #9554

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
None
```
