### PR TITLE
Add explicit permissions blocks to workflows missing them

### DIFF
--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -3,6 +3,10 @@ name: Tekton Integration
 
 on: [workflow_call]
 
+permissions:
+  contents: read
+  checks: write
+
 defaults:
   run:
     shell: bash

--- a/.github/workflows/labels.yaml
+++ b/.github/workflows/labels.yaml
@@ -9,6 +9,10 @@ on:
       - labeled
       - unlabeled
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
 
   check_labels:

--- a/.github/workflows/slash.yml
+++ b/.github/workflows/slash.yml
@@ -24,6 +24,9 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  contents: read
+
 jobs:
   check_comments:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This PR adds explicit top-level permissions blocks to three GitHub Actions workflows that were missing them, so they follow the principle of least privilege and align with the repo’s security practices.

Fixes #9550

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
