### PR TITLE
fix: Upgrade Gitea test infrastructure from v1.17.1 to latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	cloud.google.com/go/kms v1.23.2 // indirect
 	cloud.google.com/go/longrunning v0.6.7 // indirect
 	fortio.org/safecast v1.2.0 // indirect
-	github.com/42wim/httpsig v1.2.2 // indirect
+	github.com/42wim/httpsig v1.2.3 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.20.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -59,8 +59,8 @@ code.gitea.io/sdk/gitea v0.21.0/go.mod h1:tnBjVhuKJCn8ibdyyhvUyxrR1Ca2KHEoTWoukN
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 fortio.org/safecast v1.2.0 h1:ckQJNenMJHycqPsi/QrzA4EUX5WQkyd+hGO4mxt/a8w=
 fortio.org/safecast v1.2.0/go.mod h1:xZmcPk3vi4kuUFf+tq4SvnlVdwViqf6ZSZl91Jr9Jdg=
-github.com/42wim/httpsig v1.2.2 h1:ofAYoHUNs/MJOLqQ8hIxeyz2QxOz8qdSVvp3PX/oPgA=
-github.com/42wim/httpsig v1.2.2/go.mod h1:P/UYo7ytNBFwc+dg35IubuAUIs8zj5zzFIgUCEl55WY=
+github.com/42wim/httpsig v1.2.3 h1:xb0YyWhkYj57SPtfSttIobJUPJZB9as1nsfo7KWVcEs=
+github.com/42wim/httpsig v1.2.3/go.mod h1:nZq9OlYKDrUBhptd77IHx4/sZZD+IxTBADvAPI9G/EM=
 github.com/Azure/azure-sdk-for-go v16.2.1+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-sdk-for-go v68.0.0+incompatible h1:fcYLmCpyNYRnvJbPerq7U0hS+6+I79yEDJBqVNcqUzU=
 github.com/Azure/azure-sdk-for-go v68.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=

--- a/test/git-resolver/gitea.yaml
+++ b/test/git-resolver/gitea.yaml
@@ -39,12 +39,12 @@ kind: Secret
 metadata:
   name: gitea-inline-config
   labels:
-    helm.sh/chart: gitea-6.0.0
+    helm.sh/chart: gitea-12.5.0
     app: gitea
     app.kubernetes.io/name: gitea
     app.kubernetes.io/instance: gitea
-    app.kubernetes.io/version: "1.17.1"
-    version: "1.17.1"
+    app.kubernetes.io/version: "1.25.4"
+    version: "1.25.4"
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 stringData:
@@ -79,12 +79,12 @@ kind: Secret
 metadata:
   name: gitea
   labels:
-    helm.sh/chart: gitea-6.0.0
+    helm.sh/chart: gitea-12.5.0
     app: gitea
     app.kubernetes.io/name: gitea
     app.kubernetes.io/instance: gitea
-    app.kubernetes.io/version: "1.17.1"
-    version: "1.17.1"
+    app.kubernetes.io/version: "1.25.4"
+    version: "1.25.4"
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 stringData:
@@ -125,14 +125,14 @@ stringData:
       env2ini::log "    + '${setting}'"
 
       if [[ -z "${section}" ]]; then
-        export "ENV_TO_INI____${setting^^}=${value}"                           # '^^' makes the variable content uppercase
+        export "GITEA____${setting^^}=${value}"                                 # '^^' makes the variable content uppercase
         return
       fi
 
       local masked_section="${section//./_0X2E_}"                            # '//' instructs to replace all matches
       masked_section="${masked_section//-/_0X2D_}"
 
-      export "ENV_TO_INI__${masked_section^^}__${setting^^}=${value}"        # '^^' makes the variable content uppercase
+      export "GITEA__${masked_section^^}__${setting^^}=${value}"             # '^^' makes the variable content uppercase
     }
 
     function env2ini::reload_preset_envs() {
@@ -206,15 +206,15 @@ stringData:
       #   - initially used to set up Gitea
       # Anyway, they won't harm existing app.ini files
 
-      export ENV_TO_INI__SECURITY__INTERNAL_TOKEN=$(gitea generate secret INTERNAL_TOKEN)
-      export ENV_TO_INI__SECURITY__SECRET_KEY=$(gitea generate secret SECRET_KEY)
-      export ENV_TO_INI__OAUTH2__JWT_SECRET=$(gitea generate secret JWT_SECRET)
-      export ENV_TO_INI__SERVER__LFS_JWT_SECRET=$(gitea generate secret LFS_JWT_SECRET)
+      export GITEA__SECURITY__INTERNAL_TOKEN=$(gitea generate secret INTERNAL_TOKEN)
+      export GITEA__SECURITY__SECRET_KEY=$(gitea generate secret SECRET_KEY)
+      export GITEA__OAUTH2__JWT_SECRET=$(gitea generate secret JWT_SECRET)
+      export GITEA__SERVER__LFS_JWT_SECRET=$(gitea generate secret LFS_JWT_SECRET)
 
       env2ini::log "...Initial secrets generated\n"
     }
 
-    env | (grep ENV_TO_INI || [[ $? == 1 ]]) > /tmp/existing-envs
+    env | (grep GITEA__ || [[ $? == 1 ]]) > /tmp/existing-envs
 
     # MUST BE CALLED BEFORE OTHER CONFIGURATION
     env2ini::generate_initial_secrets
@@ -235,13 +235,13 @@ stringData:
       env2ini::log '  - oauth2.JWT_SECRET'
       env2ini::log '  - server.LFS_JWT_SECRET'
 
-      unset ENV_TO_INI__SECURITY__INTERNAL_TOKEN
-      unset ENV_TO_INI__SECURITY__SECRET_KEY
-      unset ENV_TO_INI__OAUTH2__JWT_SECRET
-      unset ENV_TO_INI__SERVER__LFS_JWT_SECRET
+      unset GITEA__SECURITY__INTERNAL_TOKEN
+      unset GITEA__SECURITY__SECRET_KEY
+      unset GITEA__OAUTH2__JWT_SECRET
+      unset GITEA__SERVER__LFS_JWT_SECRET
     fi
 
-    environment-to-ini -o $GITEA_APP_INI -p ENV_TO_INI
+    environment-to-ini -o $GITEA_APP_INI
 ---
 # Source: gitea/templates/gitea/init.yaml
 apiVersion: v1
@@ -249,12 +249,12 @@ kind: Secret
 metadata:
   name: gitea-init
   labels:
-    helm.sh/chart: gitea-6.0.0
+    helm.sh/chart: gitea-12.5.0
     app: gitea
     app.kubernetes.io/name: gitea
     app.kubernetes.io/instance: gitea
-    app.kubernetes.io/version: "1.17.1"
-    version: "1.17.1"
+    app.kubernetes.io/version: "1.25.4"
+    version: "1.25.4"
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 stringData:
@@ -282,20 +282,20 @@ stringData:
     echo '==== BEGIN GITEA CONFIGURATION ===='
 
     { # try
-      gitea migrate
+      gitea migrate --config ${GITEA_APP_INI}
     } || { # catch
       echo "Gitea migrate might fail due to database connection...This init-container will try again in a few seconds"
       exit 1
     }
     function configure_admin_user() {
-      local ACCOUNT_ID=$(gitea admin user list --admin | grep -e "\s\+${GITEA_ADMIN_USERNAME}\s\+" | awk -F " " "{printf \$1}")
+      local ACCOUNT_ID=$(gitea admin user list --admin --config ${GITEA_APP_INI} | grep -e "\s\+${GITEA_ADMIN_USERNAME}\s\+" | awk -F " " "{printf \$1}")
       if [[ -z "${ACCOUNT_ID}" ]]; then
         echo "No admin user '${GITEA_ADMIN_USERNAME}' found. Creating now..."
-        gitea admin user create --admin --username "${GITEA_ADMIN_USERNAME}" --password "${GITEA_ADMIN_PASSWORD}" --email "gitea@local.domain" --must-change-password=false
+        gitea admin user create --admin --username "${GITEA_ADMIN_USERNAME}" --password "${GITEA_ADMIN_PASSWORD}" --email "gitea@local.domain" --must-change-password=false --config ${GITEA_APP_INI}
         echo '...created.'
       else
         echo "Admin account '${GITEA_ADMIN_USERNAME}' already exist. Running update to sync password..."
-        gitea admin user change-password --username "${GITEA_ADMIN_USERNAME}" --password "${GITEA_ADMIN_PASSWORD}"
+        gitea admin user change-password --username "${GITEA_ADMIN_USERNAME}" --password "${GITEA_ADMIN_PASSWORD}" --config ${GITEA_APP_INI}
         echo '...password sync done.'
       fi
     }
@@ -397,12 +397,12 @@ kind: Service
 metadata:
   name: gitea-http
   labels:
-    helm.sh/chart: gitea-6.0.0
+    helm.sh/chart: gitea-12.5.0
     app: gitea
     app.kubernetes.io/name: gitea
     app.kubernetes.io/instance: gitea
-    app.kubernetes.io/version: "1.17.1"
-    version: "1.17.1"
+    app.kubernetes.io/version: "1.25.4"
+    version: "1.25.4"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -422,12 +422,12 @@ kind: Service
 metadata:
   name: gitea-ssh
   labels:
-    helm.sh/chart: gitea-6.0.0
+    helm.sh/chart: gitea-12.5.0
     app: gitea
     app.kubernetes.io/name: gitea
     app.kubernetes.io/instance: gitea
-    app.kubernetes.io/version: "1.17.1"
-    version: "1.17.1"
+    app.kubernetes.io/version: "1.25.4"
+    version: "1.25.4"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -673,12 +673,12 @@ kind: StatefulSet
 metadata:
   name: gitea
   labels:
-    helm.sh/chart: gitea-6.0.0
+    helm.sh/chart: gitea-12.5.0
     app: gitea
     app.kubernetes.io/name: gitea
     app.kubernetes.io/instance: gitea
-    app.kubernetes.io/version: "1.17.1"
-    version: "1.17.1"
+    app.kubernetes.io/version: "1.25.4"
+    version: "1.25.4"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -692,21 +692,21 @@ spec:
       annotations:
         checksum/config: 209703c6b25e9ee0efedb8a8dc69015a7ab053bec72a36e5d881edb9b02ec6c7
       labels:
-        helm.sh/chart: gitea-6.0.0
+        helm.sh/chart: gitea-12.5.0
         app: gitea
         app.kubernetes.io/name: gitea
         app.kubernetes.io/instance: gitea
-        app.kubernetes.io/version: "1.17.1"
-        version: "1.17.1"
+        app.kubernetes.io/version: "1.25.4"
+        version: "1.25.4"
         app.kubernetes.io/managed-by: Helm
     spec:
       securityContext:
         fsGroup: 1000
       initContainers:
         - name: init-directories
-          image: "mirror.gcr.io/gitea/gitea:1.17.1"
+          image: "mirror.gcr.io/gitea/gitea:1.25.4"
           imagePullPolicy: Always
-          command: ["/usr/sbin/init_directory_structure.sh"]
+          command: ["/usr/sbinx/init_directory_structure.sh"]
           env:
             - name: GITEA_APP_INI
               value: /data/gitea/conf/app.ini
@@ -718,7 +718,7 @@ spec:
               value: /tmp/gitea
           volumeMounts:
             - name: init
-              mountPath: /usr/sbin
+              mountPath: /usr/sbinx
             - name: temp
               mountPath: /tmp
             - name: data
@@ -727,9 +727,9 @@ spec:
           securityContext:
             {}
         - name: init-app-ini
-          image: "mirror.gcr.io/gitea/gitea:1.17.1"
+          image: "mirror.gcr.io/gitea/gitea:1.25.4"
           imagePullPolicy: Always
-          command: ["/usr/sbin/config_environment.sh"]
+          command: ["/usr/sbinx/config_environment.sh"]
           env:
             - name: GITEA_APP_INI
               value: /data/gitea/conf/app.ini
@@ -739,9 +739,13 @@ spec:
               value: /data
             - name: GITEA_TEMP
               value: /tmp/gitea
+            - name: TMP_EXISTING_ENVS_FILE
+              value: /tmp/existing-envs
+            - name: ENV_TO_INI_MOUNT_POINT
+              value: /env-to-ini-mounts
           volumeMounts:
             - name: config
-              mountPath: /usr/sbin
+              mountPath: /usr/sbinx
             - name: temp
               mountPath: /tmp
             - name: data
@@ -752,8 +756,8 @@ spec:
           securityContext:
             {}
         - name: configure-gitea
-          image: "mirror.gcr.io/gitea/gitea:1.17.1"
-          command: ["/usr/sbin/configure_gitea.sh"]
+          image: "mirror.gcr.io/gitea/gitea:1.25.4"
+          command: ["/usr/sbinx/configure_gitea.sh"]
           imagePullPolicy: Always
           securityContext:
             runAsUser: 1000
@@ -772,7 +776,7 @@ spec:
               value: "giteaPassword1234"
           volumeMounts:
             - name: init
-              mountPath: /usr/sbin
+              mountPath: /usr/sbinx
             - name: temp
               mountPath: /tmp
             - name: data
@@ -781,7 +785,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
         - name: gitea
-          image: "mirror.gcr.io/gitea/gitea:1.17.1"
+          image: "mirror.gcr.io/gitea/gitea:1.25.4"
           imagePullPolicy: Always
           env:
             # SSH Port values have to be set here as well for openssh configuration

--- a/test/resolvers_gitea_test.go
+++ b/test/resolvers_gitea_test.go
@@ -283,7 +283,7 @@ spec:
         #!/bin/ash
         curl -X POST "http://gitea_admin:%s@%s:3000/api/v1/admin/users" -H "accept: application/json" -H "Content-Type: application/json" -d '%s'
         curl -X PATCH "http://gitea_admin:%s@%s:3000/api/v1/admin/users/tekton-bot" -H "accept: application/json" -H "Content-Type: application/json" -d '%s'
-        TOKEN=$(curl -X POST "http://%s:%s@%s:3000/api/v1/users/tekton-bot/tokens" -H "accept: application/json" -H "Content-Type: application/json" -d "{\"name\":\"bot_token_name\"}" | sed 's/.*"sha1":"\([^"]*\)".*/\1/')
+        TOKEN=$(curl -X POST "http://%s:%s@%s:3000/api/v1/users/tekton-bot/tokens" -H "accept: application/json" -H "Content-Type: application/json" -d "{\"name\":\"bot_token_name\",\"scopes\":[\"all\"]}" | sed 's/.*"sha1":"\([^"]*\)".*/\1/')
          # Make sure we don't add a trailing newline to the result!
          echo -n "$TOKEN" > $(results.token.path)
 `,

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -50,8 +50,8 @@ code.gitea.io/sdk/gitea
 # fortio.org/safecast v1.2.0
 ## explicit; go 1.20
 fortio.org/safecast
-# github.com/42wim/httpsig v1.2.2
-## explicit; go 1.18
+# github.com/42wim/httpsig v1.2.3
+## explicit; go 1.23.0
 github.com/42wim/httpsig
 # github.com/Azure/azure-sdk-for-go v68.0.0+incompatible
 ## explicit


### PR DESCRIPTION
# Changes

Upgrade Gitea from 1.17.1 to 1.25.4 and update the e2e test infrastructure to match upstream Helm chart v12.5.0 templates. Updates config_environment.sh to use the GITEA__ env prefix instead of the deprecated ENV_TO_INI__ and removes the deprecated -p flag from environment-to-ini. Adds "scopes":["all"] to the API token creation request and upgrades the Gitea Go SDK (code.gitea.io/sdk/gitea) to v0.21.0 for compatibility with Gitea 1.25.x API.

- test/git-resolver/gitea.yaml
- test/resolvers_gitea_test.go
- vendor/modules.txt
- go.mod
- go.sum

Fixes #9443 

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
None
```