### PR TITLE
cleanup: replace GCS release URLs with infra.tekton.dev

### DIFF
--- a/docs/additional-configs.md
+++ b/docs/additional-configs.md
@@ -632,7 +632,7 @@ which results in:
 Now, verify the digest in the `release.yaml` by matching it with the provenance, for example, the digest for the release `v0.28.1`:
 
 ```shell
-curl -s https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.28.1/release.yaml | grep github.com/tektoncd/pipeline/cmd/controller:v0.28.1 | awk -F"github.com/tektoncd/pipeline/cmd/controller:v0.28.1@" '{print $2}'
+curl -s https://infra.tekton.dev/tekton-releases/pipeline/previous/v0.28.1/release.yaml | grep github.com/tektoncd/pipeline/cmd/controller:v0.28.1 | awk -F"github.com/tektoncd/pipeline/cmd/controller:v0.28.1@" '{print $2}'
 ```
 
 which results in:

--- a/docs/install.md
+++ b/docs/install.md
@@ -44,7 +44,7 @@ To install Tekton Pipelines on a Kubernetes cluster:
    - **Latest official release:**
 
      ```bash
-     kubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml
+     kubectl apply --filename https://infra.tekton.dev/tekton-releases/pipeline/latest/release.yaml
      ```
      
       Note: These instructions are ideal as a quick start installation guide with Tekton Pipelines and not meant for the production use. Please refer to the [operator](https://github.com/tektoncd/operator) to install, upgrade and manage Tekton projects. 
@@ -52,13 +52,13 @@ To install Tekton Pipelines on a Kubernetes cluster:
    - **Nightly release:**
 
      ```bash
-     kubectl apply --filename https://storage.googleapis.com/tekton-releases-nightly/pipeline/latest/release.yaml
+     kubectl apply --filename https://infra.tekton.dev/tekton-releases-nightly/pipeline/latest/release.yaml
      ```
 
    - **Specific release:**
 
      ```bash
-      kubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/previous/<version_number>/release.yaml
+      kubectl apply --filename https://infra.tekton.dev/tekton-releases/pipeline/previous/<version_number>/release.yaml
      ```
 
      Replace `<version_number>` with the numbered version you want to install.
@@ -69,7 +69,7 @@ To install Tekton Pipelines on a Kubernetes cluster:
      If your container runtime does not support `image-reference:tag@digest`:
 
      ```bash
-     kubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/latest/release.notags.yaml
+     kubectl apply --filename https://infra.tekton.dev/tekton-releases/pipeline/latest/release.notags.yaml
      ```
 
 Multi-tenant installation is only partially supported today, read the [guide](./developers/multi-tenant-support.md)

--- a/docs/metrics-migration-otel.md
+++ b/docs/metrics-migration-otel.md
@@ -243,7 +243,7 @@ kubectl edit configmap config-observability -n tekton-pipelines
 
 ```bash
 # Apply the new version containing the OTel migration
-kubectl apply -f https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml
+kubectl apply -f https://infra.tekton.dev/tekton-releases/pipeline/latest/release.yaml
 
 # Wait for rollout
 kubectl rollout status deployment/tekton-pipelines-controller -n tekton-pipelines

--- a/tekton/README.md
+++ b/tekton/README.md
@@ -74,7 +74,7 @@ kubectl create clusterrolebinding cluster-admin-binding-someusername \
 
 # Example, Tekton v0.9.1
 export TEKTON_VERSION=0.9.1
-kubectl apply --filename  https://storage.googleapis.com/tekton-releases/pipeline/previous/v${TEKTON_VERSION}/release.yaml
+kubectl apply --filename  https://infra.tekton.dev/tekton-releases/pipeline/previous/v${TEKTON_VERSION}/release.yaml
 ```
 
 ### Install tasks and pipelines

--- a/tekton/bugfix-release.sh
+++ b/tekton/bugfix-release.sh
@@ -55,7 +55,7 @@ tkn pipeline start pipeline-release \
   --workspace name=release-images-secret,secret=ghcr-creds \
   --workspace name=workarea,volumeClaimTemplateFile=workspace-template.yaml --use-param-defaults --pipeline-timeout 3h --showlog
 
-RELEASE_FILE=https://storage.googleapis.com/tekton-releases/pipeline/previous/${TEKTON_VERSION}/release.yaml
+RELEASE_FILE=https://infra.tekton.dev/tekton-releases/pipeline/previous/${TEKTON_VERSION}/release.yaml
 CONTROLLER_IMAGE_SHA=$(curl $RELEASE_FILE | egrep 'ghcr.io.*controller' | cut -d'@' -f2)
 REKOR_UUID=$(rekor-cli search --sha $CONTROLLER_IMAGE_SHA | grep -v Found | head -1)
 echo -e "CONTROLLER_IMAGE_SHA: ${CONTROLLER_IMAGE_SHA}\nREKOR_UUID: ${REKOR_UUID}"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Replace legacy Google Cloud Storage release URLs (`storage.googleapis.com/tekton-releases`) with the current Tekton infrastructure domain (`infra.tekton.dev/tekton-releases`) across documentation and scripts.

This update ensures the repository reflects the current Tekton release distribution infrastructure and avoids confusion for users following installation instructions.

Updated locations include:

* `docs/install.md`
* `docs/additional-configs.md`
* `docs/metrics-migration-otel.md`
* `tekton/README.md`
* `tekton/bugfix-release.sh`

All references to:

```
https://storage.googleapis.com/tekton-releases
```

have been updated to:

```
https://infra.tekton.dev/tekton-releases
```

Repository-wide searches were performed to ensure no remaining references to the legacy GCS release URLs remain.

Fixes #9566

---

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

* [ ] Has [[Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs)](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
* [ ] Has [[Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests)](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed (not applicable – documentation/script URL updates only)
* [ ]  [[pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools)](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
* [x] Follows the [[commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)](https://github.com/tektoncd/community/blob/main/standards.md#commits)
* [x] Meets the [[Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md)](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
* [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind cleanup`
* [ ] Release notes block below has been updated with any user facing changes
* [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release (not applicable)

---

# Release Notes

```release-note
NONE
```

/kind cleanup