### PR TITLE
ci: add PR welcome comment with slash commands

### DIFF
--- a/.github/workflows/pr-welcome-comment.yaml
+++ b/.github/workflows/pr-welcome-comment.yaml
@@ -11,7 +11,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Post slash commands comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@v5
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |

--- a/.github/workflows/pr-welcome-comment.yaml
+++ b/.github/workflows/pr-welcome-comment.yaml
@@ -1,0 +1,31 @@
+name: PR Welcome Comment
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  welcome-comment:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Post slash commands comment
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            Thanks for opening a pull request!
+
+            The following slash commands are available for maintainers (requires write access):
+
+            | Command | Description |
+            |---|---|
+            | `/retest` | Re-trigger workflows that failed on this PR |
+            | `/e2e-extras` | Run extra e2e tests on this PR |
+            | `/cherry-pick <branch>` | Cherry-pick the merged PR to the specified branch |
+            | `/rebase` | Rebase the PR branch against its base branch |
+
+            Note: Slash commands must be placed at the very beginning of the first line of a comment.
+
+            For more details, see the [slash command docs](https://github.com/peter-evans/slash-command-dispatch/tree/main?tab=readme-ov-file#how-comments-are-parsed-for-slash-commands).

--- a/.github/workflows/pr-welcome-comment.yaml
+++ b/.github/workflows/pr-welcome-comment.yaml
@@ -33,7 +33,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0
+        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
         with:
           egress-policy: audit
 
@@ -51,7 +51,6 @@ jobs:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           edit-mode: replace
-
           body: |
             Thanks for opening a pull request!
 

--- a/.github/workflows/pr-welcome-comment.yaml
+++ b/.github/workflows/pr-welcome-comment.yaml
@@ -37,11 +37,21 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Find existing slash commands comment
+        id: find-comment
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: github-actions[bot]
+          body-includes: Thanks for opening a pull request!
+
       - name: Post slash commands comment
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
-          comment-tag: tekton-slash-commands
+          edit-mode: replace
+
           body: |
             Thanks for opening a pull request!
 

--- a/.github/workflows/pr-welcome-comment.yaml
+++ b/.github/workflows/pr-welcome-comment.yaml
@@ -1,8 +1,30 @@
+# This workflow posts a welcome comment on newly opened pull requests listing
+# all available slash commands for maintainers.
+#
+# SECURITY: This workflow uses pull_request_target to post comments on fork PRs.
+# It is safe because it does NOT checkout PR code and only posts a static comment.
+# Do NOT add actions/checkout or run untrusted code in this workflow.
+#
+# pull_request_target runs in the context of the base branch (not the PR branch),
+# so it has access to repository secrets and elevated permissions. Adding any step
+# that executes code from the PR would create a critical security vulnerability.
+#
+# Available slash commands posted in the welcome comment:
+# - /kind <type>: add a kind label to the PR
+# - /retest: re-trigger workflows that failed on a given PR
+# - /e2e-extras: run extra e2e tests on a given PR
+# - /cherry-pick <branch>: cherry-picks the merged PR to the specified branch
+# - /rebase: rebase a PR branch against its base branch
+#
+# Slash commands must be placed at the very beginning of the first line of a comment.
+
 name: PR Welcome Comment
 
 on:
   pull_request_target:
     types: [opened]
+
+permissions: {}
 
 jobs:
   welcome-comment:
@@ -10,10 +32,16 @@ jobs:
     permissions:
       pull-requests: write
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0
+        with:
+          egress-policy: audit
+
       - name: Post slash commands comment
-        uses: peter-evans/create-or-update-comment@v5
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           issue-number: ${{ github.event.pull_request.number }}
+          comment-tag: tekton-slash-commands
           body: |
             Thanks for opening a pull request!
 
@@ -21,6 +49,7 @@ jobs:
 
             | Command | Description |
             |---|---|
+            | `/kind <type>` | Add a kind label (bug, cleanup, design, documentation, feature, flake, misc, question, tep) |
             | `/retest` | Re-trigger workflows that failed on this PR |
             | `/e2e-extras` | Run extra e2e tests on this PR |
             | `/cherry-pick <branch>` | Cherry-pick the merged PR to the specified branch |


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

Closes #9148

## Changes
- Added `.github/workflows/pr-welcome-comment.yaml`
- Triggers on `pull_request_target` when a PR is opened
- Posts a comment listing all available slash commands with descriptions
- Uses `peter-evans/create-or-update-comment@v5`

## Testing
- Tested in fork - workflow triggered and posted comment successfully

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```