### PR TITLE
docs(resolver): add per-run cache override examples

### DIFF
--- a/docs/bundle-resolver.md
+++ b/docs/bundle-resolver.md
@@ -21,6 +21,56 @@ This Resolver responds to type `bundles`.
 | `kind`           | The resource kind to pull out of the bundle                                   | `task`                                                     |
 | `cache`          | Controls caching behavior for the resolved resource                           | `always`, `never`, `auto`                                  |
 
+### Per-run cache override
+
+To override cache behavior for a specific run, set `cache` under resolver parameters:
+- `spec.taskRef.params` for `TaskRun`
+- `spec.pipelineRef.params` for `PipelineRun`
+
+> `cache` under `spec.params` is a runtime parameter and is **not** passed to resolvers.
+
+TaskRun example (`cache: never`):
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: remote-task-reference-no-cache
+spec:
+  taskRef:
+    resolver: bundles
+    params:
+    - name: bundle
+      value: docker.io/ptasci67/example-oci@sha256:053a6cb9f3711d4527dd0d37ac610e8727ec0288a898d5dfbd79b25bcaa29828
+    - name: name
+      value: hello-world
+    - name: kind
+      value: task
+    - name: cache
+      value: never
+```
+
+PipelineRun example (`cache: never`):
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: bundle-demo-no-cache
+spec:
+  pipelineRef:
+    resolver: bundles
+    params:
+    - name: bundle
+      value: 10.96.190.208:5000/simple/pipeline:latest
+    - name: name
+      value: hello-pipeline
+    - name: kind
+      value: pipeline
+    - name: cache
+      value: never
+```
+
 ## Requirements
 
 - A cluster running Tekton Pipeline v0.41.0 or later.

--- a/docs/cluster-resolver.md
+++ b/docs/cluster-resolver.md
@@ -61,6 +61,33 @@ data:
   default-cache-mode: "never"  # Never cache by default (since cluster resources are mutable)
 ```
 
+### Per-run cache override for PipelineRun
+
+To override cache behavior for a specific pipeline run, set `cache` under `spec.pipelineRef.params`.
+
+> `cache` under `spec.params` is a runtime parameter and is **not** passed to resolvers.
+
+PipelineRun example (`cache: never`):
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: remote-pipeline-reference-no-cache
+spec:
+  pipelineRef:
+    resolver: cluster
+    params:
+    - name: kind
+      value: pipeline
+    - name: name
+      value: some-pipeline
+    - name: namespace
+      value: namespace-containing-pipeline
+    - name: cache
+      value: never
+```
+
 ## Requirements
 
 - A cluster running Tekton Pipeline v0.41.0 or later.

--- a/docs/git-resolver.md
+++ b/docs/git-resolver.md
@@ -28,6 +28,56 @@ This Resolver responds to type `git`.
 | `scmType`     | An optional SCM type to use for API operations                                                                                                                             | `github`, `gitlab`, `gitea`                                 |
 | `cache`       | Controls caching behavior for the resolved resource                                                                                                                         | `always`, `never`, `auto`                                   |
 
+### Per-run cache override
+
+To override cache behavior for a specific run, set `cache` under resolver parameters:
+- `spec.taskRef.params` for `TaskRun`
+- `spec.pipelineRef.params` for `PipelineRun`
+
+> `cache` under `spec.params` is a runtime parameter and is **not** passed to resolvers.
+
+TaskRun example (`cache: never`):
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: git-clone-demo-tr-no-cache
+spec:
+  taskRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/tektoncd/catalog.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: task/git-clone/0.6/git-clone.yaml
+    - name: cache
+      value: never
+```
+
+PipelineRun example (`cache: never`):
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: git-clone-demo-pr-no-cache
+spec:
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/tektoncd/catalog.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/simple/0.1/simple.yaml
+    - name: cache
+      value: never
+```
+
 ## Requirements
 
 - A cluster running Tekton Pipeline v0.41.0 or later.


### PR DESCRIPTION
## Summary
- add per-run cache override examples in bundle and git resolver docs (TaskRun + PipelineRun)
- add PipelineRun cache override example in cluster resolver docs
- clarify that `cache` under `spec.params` is not passed to resolvers

Fixes #9559

## Testing
- git diff --check