### PR TITLE
fix(resolvers): validate data is Tekton object in resolver framework

### DIFF
--- a/pkg/apis/pipeline/v1beta1/stepaction_types.go
+++ b/pkg/apis/pipeline/v1beta1/stepaction_types.go
@@ -23,6 +23,8 @@ import (
 	"knative.dev/pkg/kmeta"
 )
 
+const StepActionKind = "StepAction"
+
 // +genclient
 // +genclient:noStatus
 // +genreconciler:krshapedlogic=false
@@ -62,7 +64,7 @@ func (s *StepAction) Copy() StepActionObject {
 
 // GetGroupVersionKind implements kmeta.OwnerRefable.
 func (*StepAction) GetGroupVersionKind() schema.GroupVersionKind {
-	return SchemeGroupVersion.WithKind("StepAction")
+	return SchemeGroupVersion.WithKind(StepActionKind)
 }
 
 // Checksum computes the sha256 checksum of the stepaction object.

--- a/pkg/remoteresolution/resolver/framework/reconciler.go
+++ b/pkg/remoteresolution/resolver/framework/reconciler.go
@@ -167,6 +167,14 @@ func (r *Reconciler) resolve(ctx context.Context, key string, rr *v1beta1.Resolu
 			}
 			return
 		}
+		if err := framework.ValidateResolvedResource(resource); err != nil {
+			errChan <- &resolutioncommon.GetResourceError{
+				ResolverName: r.resolver.GetName(resolutionCtx),
+				Key:          key,
+				Original:     fmt.Errorf("resolved resource validation error: %w", err),
+			}
+			return
+		}
 		resourceChan <- resource
 	}()
 

--- a/pkg/remoteresolution/resolver/framework/reconciler_test.go
+++ b/pkg/remoteresolution/resolver/framework/reconciler_test.go
@@ -67,30 +67,6 @@ func TestReconcile(t *testing.T) {
 		transient         bool
 	}{
 		{
-			name: "unknown value",
-			inputRequest: &v1beta1.ResolutionRequest{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: "resolution.tekton.dev/v1beta1",
-					Kind:       "ResolutionRequest",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "rr",
-					Namespace:         "foo",
-					CreationTimestamp: metav1.Time{Time: time.Now()},
-					Labels: map[string]string{
-						resolutioncommon.LabelKeyResolverType: resolutionframework.LabelValueFakeResolverType,
-					},
-				},
-				Spec: v1beta1.ResolutionRequestSpec{
-					Params: []pipelinev1.Param{{
-						Name:  resolutionframework.FakeParamName,
-						Value: *pipelinev1.NewStructuredValues("bar"),
-					}},
-				},
-				Status: v1beta1.ResolutionRequestStatus{},
-			},
-			expectedErr: errors.New("error getting \"Fake\" \"foo/rr\": couldn't find resource for param value bar"),
-		}, {
 			name: "known value",
 			inputRequest: &v1beta1.ResolutionRequest{
 				TypeMeta: metav1.TypeMeta{
@@ -115,7 +91,7 @@ func TestReconcile(t *testing.T) {
 			},
 			paramMap: map[string]*resolutionframework.FakeResolvedResource{
 				"bar": {
-					Content:       "some content",
+					Content:       "{\"apiVersion\": \"tekton.dev/v1\", \"kind\": \"Pipeline\"}",
 					AnnotationMap: map[string]string{"foo": "bar"},
 					ContentSource: &pipelinev1.RefSource{
 						URI: "https://abc.com",
@@ -133,7 +109,7 @@ func TestReconcile(t *testing.T) {
 					},
 				},
 				ResolutionRequestStatusFields: v1beta1.ResolutionRequestStatusFields{
-					Data: base64.StdEncoding.Strict().EncodeToString([]byte("some content")),
+					Data: base64.StdEncoding.Strict().EncodeToString([]byte("{\"apiVersion\": \"tekton.dev/v1\", \"kind\": \"Pipeline\"}")),
 					RefSource: &pipelinev1.RefSource{
 						URI: "https://abc.com",
 						Digest: map[string]string{
@@ -150,6 +126,141 @@ func TestReconcile(t *testing.T) {
 					},
 				},
 			},
+		}, {
+			name: "known invalid value",
+			inputRequest: &v1beta1.ResolutionRequest{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "resolution.tekton.dev/v1beta1",
+					Kind:       "ResolutionRequest",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "rr",
+					Namespace:         "foo",
+					CreationTimestamp: metav1.Time{Time: time.Now()},
+					Labels: map[string]string{
+						resolutioncommon.LabelKeyResolverType: resolutionframework.LabelValueFakeResolverType,
+					},
+				},
+				Spec: v1beta1.ResolutionRequestSpec{
+					Params: []pipelinev1.Param{{
+						Name:  resolutionframework.FakeParamName,
+						Value: *pipelinev1.NewStructuredValues("bar"),
+					}},
+				},
+				Status: v1beta1.ResolutionRequestStatus{},
+			},
+			paramMap: map[string]*resolutionframework.FakeResolvedResource{
+				"bar": {
+					Content:       "foo: bar\nbax: baz",
+					AnnotationMap: map[string]string{"foo": "bar"},
+					ContentSource: &pipelinev1.RefSource{
+						URI: "https://abc.com",
+						Digest: map[string]string{
+							"sha1": "xyz",
+						},
+						EntryPoint: "foo/bar",
+					},
+				},
+			},
+			expectedErr: errors.New("error getting \"Fake\" \"foo/rr\": resolved resource validation error: resolved data is not of a supported type, must be of Group: tekton.dev, Kinds: [Pipeline Task StepAction]"),
+		}, {
+			name: "known value invalid type",
+			inputRequest: &v1beta1.ResolutionRequest{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "resolution.tekton.dev/v1beta1",
+					Kind:       "ResolutionRequest",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "rr",
+					Namespace:         "foo",
+					CreationTimestamp: metav1.Time{Time: time.Now()},
+					Labels: map[string]string{
+						resolutioncommon.LabelKeyResolverType: resolutionframework.LabelValueFakeResolverType,
+					},
+				},
+				Spec: v1beta1.ResolutionRequestSpec{
+					Params: []pipelinev1.Param{{
+						Name:  resolutionframework.FakeParamName,
+						Value: *pipelinev1.NewStructuredValues("bar"),
+					}},
+				},
+				Status: v1beta1.ResolutionRequestStatus{},
+			},
+			paramMap: map[string]*resolutionframework.FakeResolvedResource{
+				"bar": {
+					Content:       "{\"apiVersion\": \"tekton.dev/v1\", \"kind\": \"PipelineRun\"}",
+					AnnotationMap: map[string]string{"foo": "bar"},
+					ContentSource: &pipelinev1.RefSource{
+						URI: "https://abc.com",
+						Digest: map[string]string{
+							"sha1": "xyz",
+						},
+						EntryPoint: "foo/bar",
+					},
+				},
+			},
+			expectedErr: errors.New("error getting \"Fake\" \"foo/rr\": resolved resource validation error: resolved data is not of a supported type, must be of Group: tekton.dev, Kinds: [Pipeline Task StepAction]"),
+		}, {
+			name: "known value unknown type",
+			inputRequest: &v1beta1.ResolutionRequest{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "resolution.tekton.dev/v1beta1",
+					Kind:       "ResolutionRequest",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "rr",
+					Namespace:         "foo",
+					CreationTimestamp: metav1.Time{Time: time.Now()},
+					Labels: map[string]string{
+						resolutioncommon.LabelKeyResolverType: resolutionframework.LabelValueFakeResolverType,
+					},
+				},
+				Spec: v1beta1.ResolutionRequestSpec{
+					Params: []pipelinev1.Param{{
+						Name:  resolutionframework.FakeParamName,
+						Value: *pipelinev1.NewStructuredValues("bar"),
+					}},
+				},
+				Status: v1beta1.ResolutionRequestStatus{},
+			},
+			paramMap: map[string]*resolutionframework.FakeResolvedResource{
+				"bar": {
+					Content:       "{\"apiVersion\": \"other/type\", \"kind\": \"NonTekton\"}",
+					AnnotationMap: map[string]string{"foo": "bar"},
+					ContentSource: &pipelinev1.RefSource{
+						URI: "https://abc.com",
+						Digest: map[string]string{
+							"sha1": "xyz",
+						},
+						EntryPoint: "foo/bar",
+					},
+				},
+			},
+			expectedErr: errors.New("error getting \"Fake\" \"foo/rr\": resolved resource validation error: resolved data is not of a supported type, must be of Group: tekton.dev, Kinds: [Pipeline Task StepAction]"),
+		}, {
+			name: "unknown value",
+			inputRequest: &v1beta1.ResolutionRequest{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "resolution.tekton.dev/v1beta1",
+					Kind:       "ResolutionRequest",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "rr",
+					Namespace:         "foo",
+					CreationTimestamp: metav1.Time{Time: time.Now()},
+					Labels: map[string]string{
+						resolutioncommon.LabelKeyResolverType: resolutionframework.LabelValueFakeResolverType,
+					},
+				},
+				Spec: v1beta1.ResolutionRequestSpec{
+					Params: []pipelinev1.Param{{
+						Name:  resolutionframework.FakeParamName,
+						Value: *pipelinev1.NewStructuredValues("bar"),
+					}},
+				},
+				Status: v1beta1.ResolutionRequestStatus{},
+			},
+			expectedErr: errors.New("error getting \"Fake\" \"foo/rr\": couldn't find resource for param value bar"),
 		}, {
 			name: "unknown url",
 			inputRequest: &v1beta1.ResolutionRequest{
@@ -193,7 +304,7 @@ func TestReconcile(t *testing.T) {
 			},
 			paramMap: map[string]*resolutionframework.FakeResolvedResource{
 				framework.FakeUrl: {
-					Content:       "some content",
+					Content:       "{\"apiVersion\": \"tekton.dev/v1\", \"kind\": \"Pipeline\"}",
 					AnnotationMap: map[string]string{"foo": "bar"},
 					ContentSource: &pipelinev1.RefSource{
 						URI: "https://abc.com",
@@ -211,7 +322,7 @@ func TestReconcile(t *testing.T) {
 					},
 				},
 				ResolutionRequestStatusFields: v1beta1.ResolutionRequestStatusFields{
-					Data: base64.StdEncoding.Strict().EncodeToString([]byte("some content")),
+					Data: base64.StdEncoding.Strict().EncodeToString([]byte("{\"apiVersion\": \"tekton.dev/v1\", \"kind\": \"Pipeline\"}")),
 					RefSource: &pipelinev1.RefSource{
 						URI: "https://abc.com",
 						Digest: map[string]string{

--- a/pkg/remoteresolution/resolver/git/resolver_test.go
+++ b/pkg/remoteresolution/resolver/git/resolver_test.go
@@ -341,22 +341,26 @@ type params struct {
 }
 
 func TestResolve(t *testing.T) {
+	objTemplate := "{\"apiVersion\": \"tekton.dev/v1\", \"kind\": \"%s\", \"metadata\": {\"name\": \"%s\"}}"
+	mainContent := fmt.Sprintf(objTemplate, "Pipeline", "released content in main branch and in tag v1")
+	oldBranchContent := fmt.Sprintf(objTemplate, "Pipeline", "oldcontent in test branch")
+	newBranchContent := fmt.Sprintf(objTemplate, "Pipeline", "new content in test branch")
 	// local repo set up for anonymous cloning
 	// ----
 	commits := []commitForRepo{{
 		Dir:      "foo/",
 		Filename: "old",
-		Content:  "old content in test branch",
+		Content:  oldBranchContent,
 		Branch:   "test-branch",
 	}, {
 		Dir:      "foo/",
 		Filename: "new",
-		Content:  "new content in test branch",
+		Content:  newBranchContent,
 		Branch:   "test-branch",
 	}, {
 		Dir:      "./",
 		Filename: "released",
-		Content:  "released content in main branch and in tag v1",
+		Content:  mainContent,
 		Tag:      "v1",
 	}}
 
@@ -420,7 +424,7 @@ func TestResolve(t *testing.T) {
 			url:        anonFakeRepoURL,
 		},
 		expectedCommitSHA: commitSHAsInAnonRepo[2],
-		expectedStatus:    resolution.CreateResolutionRequestStatusWithData([]byte("released content in main branch and in tag v1")),
+		expectedStatus:    resolution.CreateResolutionRequestStatusWithData([]byte(mainContent)),
 	}, {
 		name: "clone: revision is tag name",
 		args: &params{
@@ -429,7 +433,7 @@ func TestResolve(t *testing.T) {
 			url:        anonFakeRepoURL,
 		},
 		expectedCommitSHA: commitSHAsInAnonRepo[2],
-		expectedStatus:    resolution.CreateResolutionRequestStatusWithData([]byte("released content in main branch and in tag v1")),
+		expectedStatus:    resolution.CreateResolutionRequestStatusWithData([]byte(mainContent)),
 	}, {
 		name: "clone: revision is the full tag name i.e. refs/tags/v1",
 		args: &params{
@@ -438,7 +442,7 @@ func TestResolve(t *testing.T) {
 			url:        anonFakeRepoURL,
 		},
 		expectedCommitSHA: commitSHAsInAnonRepo[2],
-		expectedStatus:    resolution.CreateResolutionRequestStatusWithData([]byte("released content in main branch and in tag v1")),
+		expectedStatus:    resolution.CreateResolutionRequestStatusWithData([]byte(mainContent)),
 	}, {
 		name: "clone: revision is a branch name",
 		args: &params{
@@ -447,7 +451,7 @@ func TestResolve(t *testing.T) {
 			url:        anonFakeRepoURL,
 		},
 		expectedCommitSHA: commitSHAsInAnonRepo[1],
-		expectedStatus:    resolution.CreateResolutionRequestStatusWithData([]byte("new content in test branch")),
+		expectedStatus:    resolution.CreateResolutionRequestStatusWithData([]byte(newBranchContent)),
 	}, {
 		name: "clone: revision is a specific commit sha",
 		args: &params{
@@ -456,7 +460,7 @@ func TestResolve(t *testing.T) {
 			url:        anonFakeRepoURL,
 		},
 		expectedCommitSHA: commitSHAsInAnonRepo[0],
-		expectedStatus:    resolution.CreateResolutionRequestStatusWithData([]byte("old content in test branch")),
+		expectedStatus:    resolution.CreateResolutionRequestStatusWithData([]byte(oldBranchContent)),
 	}, {
 		name: "clone: file does not exist",
 		args: &params{

--- a/pkg/resolution/resolver/framework/interface.go
+++ b/pkg/resolution/resolver/framework/interface.go
@@ -18,9 +18,14 @@ package framework
 
 import (
 	"context"
+	"fmt"
+	"slices"
 	"time"
 
+	pipelineapi "github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/yaml"
 )
 
 // Resolver is the interface to implement for type-specific resource
@@ -99,4 +104,24 @@ type ResolvedResource interface {
 	Data() []byte
 	Annotations() map[string]string
 	RefSource() *pipelinev1.RefSource
+}
+
+// ValidateResolvedResource validates that the ResolvedResource's data is a
+// kubernetes object and a Tekton kind. This ensures non-k8s data (e.g. tokens) or non-tekton
+// k8s objects (e.g. Secrets) are not written into the unprivileged ResolutionRequest objects.
+func ValidateResolvedResource(resource ResolvedResource) error {
+	var metadata struct {
+		APIVersion string
+		Kind       string
+	}
+	if err := yaml.Unmarshal(resource.Data(), &metadata); err != nil {
+		return fmt.Errorf("decoding error: %w", err)
+	}
+	// gv is not nil when there is an error
+	gv, _ := schema.ParseGroupVersion(metadata.APIVersion)
+
+	if gv.Group != pipelineapi.GroupName || !slices.Contains(allowedResourceKinds, metadata.Kind) {
+		return fmt.Errorf("resolved data is not of a supported type, must be of Group: %s, Kinds: %v", pipelineapi.GroupName, allowedResourceKinds)
+	}
+	return nil
 }

--- a/pkg/resolution/resolver/framework/reconciler.go
+++ b/pkg/resolution/resolver/framework/reconciler.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	pipelineapi "github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	pipelinev1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/apis/resolution/v1beta1"
@@ -70,6 +71,12 @@ var _ reconciler.LeaderAware = &Reconciler{}
 // Resolve() may take. It can be overridden by a resolver implementing
 // the framework.TimedResolution interface.
 const defaultMaximumResolutionDuration = time.Minute
+
+var allowedResourceKinds = []string{
+	pipelineapi.PipelineControllerName,
+	pipelineapi.TaskControllerName,
+	pipelinev1beta1.StepActionKind,
+}
 
 // Reconcile receives the string key of a ResolutionRequest object, looks
 // it up, checks it for common errors, and then delegates
@@ -144,6 +151,14 @@ func (r *Reconciler) resolve(ctx context.Context, key string, rr *v1beta1.Resolu
 				ResolverName: r.resolver.GetName(resolutionCtx),
 				Key:          key,
 				Original:     resolveErr,
+			}
+			return
+		}
+		if err := ValidateResolvedResource(resource); err != nil {
+			errChan <- &resolutioncommon.GetResourceError{
+				ResolverName: r.resolver.GetName(resolutionCtx),
+				Key:          key,
+				Original:     fmt.Errorf("resolved resource validation error: %w", err),
 			}
 			return
 		}

--- a/pkg/resolution/resolver/framework/reconciler_test.go
+++ b/pkg/resolution/resolver/framework/reconciler_test.go
@@ -112,7 +112,7 @@ func TestReconcile(t *testing.T) {
 			},
 			paramMap: map[string]*framework.FakeResolvedResource{
 				"bar": {
-					Content:       "some content",
+					Content:       "{\"apiVersion\": \"tekton.dev/v1\", \"kind\": \"Pipeline\"}",
 					AnnotationMap: map[string]string{"foo": "bar"},
 					ContentSource: &pipelinev1.RefSource{
 						URI: "https://abc.com",
@@ -130,7 +130,7 @@ func TestReconcile(t *testing.T) {
 					},
 				},
 				ResolutionRequestStatusFields: v1beta1.ResolutionRequestStatusFields{
-					Data: base64.StdEncoding.Strict().EncodeToString([]byte("some content")),
+					Data: base64.StdEncoding.Strict().EncodeToString([]byte("{\"apiVersion\": \"tekton.dev/v1\", \"kind\": \"Pipeline\"}")),
 					RefSource: &pipelinev1.RefSource{
 						URI: "https://abc.com",
 						Digest: map[string]string{

--- a/pkg/resolution/resolver/git/resolver_test.go
+++ b/pkg/resolution/resolver/git/resolver_test.go
@@ -293,22 +293,27 @@ type params struct {
 }
 
 func TestResolve(t *testing.T) {
+	objTemplate := "{\"apiVersion\": \"tekton.dev/v1\", \"kind\": \"%s\", \"metadata\": {\"name\": \"%s\"}}"
+	mainContent := fmt.Sprintf(objTemplate, "Pipeline", "released content in main branch and in tag v1")
+	oldBranchContent := fmt.Sprintf(objTemplate, "Pipeline", "oldcontent in test branch")
+	newBranchContent := fmt.Sprintf(objTemplate, "Pipeline", "new content in test branch")
+
 	// local repo set up for anonymous cloning
 	// ----
 	commits := []commitForRepo{{
 		Dir:      "foo/",
 		Filename: "old",
-		Content:  "old content in test branch",
+		Content:  oldBranchContent,
 		Branch:   "test-branch",
 	}, {
 		Dir:      "foo/",
 		Filename: "new",
-		Content:  "new content in test branch",
+		Content:  newBranchContent,
 		Branch:   "test-branch",
 	}, {
 		Dir:      "./",
 		Filename: "released",
-		Content:  "released content in main branch and in tag v1",
+		Content:  mainContent,
 		Tag:      "v1",
 	}}
 
@@ -372,7 +377,7 @@ func TestResolve(t *testing.T) {
 			url:        anonFakeRepoURL,
 		},
 		expectedCommitSHA: commitSHAsInAnonRepo[2],
-		expectedStatus:    resolution.CreateResolutionRequestStatusWithData([]byte("released content in main branch and in tag v1")),
+		expectedStatus:    resolution.CreateResolutionRequestStatusWithData([]byte(mainContent)),
 	}, {
 		name: "clone: revision is tag name",
 		args: &params{
@@ -381,7 +386,7 @@ func TestResolve(t *testing.T) {
 			url:        anonFakeRepoURL,
 		},
 		expectedCommitSHA: commitSHAsInAnonRepo[2],
-		expectedStatus:    resolution.CreateResolutionRequestStatusWithData([]byte("released content in main branch and in tag v1")),
+		expectedStatus:    resolution.CreateResolutionRequestStatusWithData([]byte(mainContent)),
 	}, {
 		name: "clone: revision is the full tag name i.e. refs/tags/v1",
 		args: &params{
@@ -390,7 +395,7 @@ func TestResolve(t *testing.T) {
 			url:        anonFakeRepoURL,
 		},
 		expectedCommitSHA: commitSHAsInAnonRepo[2],
-		expectedStatus:    resolution.CreateResolutionRequestStatusWithData([]byte("released content in main branch and in tag v1")),
+		expectedStatus:    resolution.CreateResolutionRequestStatusWithData([]byte(mainContent)),
 	}, {
 		name: "clone: revision is a branch name",
 		args: &params{
@@ -399,7 +404,7 @@ func TestResolve(t *testing.T) {
 			url:        anonFakeRepoURL,
 		},
 		expectedCommitSHA: commitSHAsInAnonRepo[1],
-		expectedStatus:    resolution.CreateResolutionRequestStatusWithData([]byte("new content in test branch")),
+		expectedStatus:    resolution.CreateResolutionRequestStatusWithData([]byte(newBranchContent)),
 	}, {
 		name: "clone: revision is a specific commit sha",
 		args: &params{
@@ -408,7 +413,7 @@ func TestResolve(t *testing.T) {
 			url:        anonFakeRepoURL,
 		},
 		expectedCommitSHA: commitSHAsInAnonRepo[0],
-		expectedStatus:    resolution.CreateResolutionRequestStatusWithData([]byte("old content in test branch")),
+		expectedStatus:    resolution.CreateResolutionRequestStatusWithData([]byte(oldBranchContent)),
 	}, {
 		name: "clone: file does not exist",
 		args: &params{
@@ -426,7 +431,7 @@ func TestResolve(t *testing.T) {
 			namespace:   "foo",
 		},
 		expectedCommitSHA: commitSHAsInAnonRepo[2],
-		expectedStatus:    resolution.CreateResolutionRequestStatusWithData([]byte("released content in main branch and in tag v1")),
+		expectedStatus:    resolution.CreateResolutionRequestStatusWithData([]byte(mainContent)),
 	}, {
 		name: "clone: secret for git clone does not exist",
 		args: &params{


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Validate that the data resolved by resolvers is a Pipeline, Task, or StepAction object before writing the data to the ResolutionRequest.

Fundamentally ResolutionRequests are only supposed to resolve Tekton types (specifically Pipelines, Tasks, and StepActions). However they may fetch any object or string and mark the ResolutionRequest as "successful". Currently the data validation is only done when the "successful" ResolutionRequest is being injected into the parent Run object.

Minimally validating the object before updating the ResolutionRequest takes some of the validation burden off of the Pipelines controller and may catch errors faster and ensure (potentially sensitive) non-tekton objects cannot be written into ResolutionRequests, which are considered less restricted.


<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Fixes a bug which lets Tekton Resolvers resolve non-tekton objects and arbitrary data. After this change, resolving a non-tekton object causes the ResolutionRequest to fail. 
Action Required: Tekton Resolvers are now only permitted to resolve StepActions, Tasks, and Pipelines. Custom resolvers or ResolutionRequest which use the Resolver API for other object types will no longer function. 
```
/kind bugfix