### PR TITLE
perf: strip ManagedFields from PipelineRun and TaskRun informer caches

### DIFF
--- a/pkg/reconciler/pipelinerun/controller.go
+++ b/pkg/reconciler/pipelinerun/controller.go
@@ -31,6 +31,7 @@ import (
 	resolutionclient "github.com/tektoncd/pipeline/pkg/client/resolution/injection/client"
 	resolutioninformer "github.com/tektoncd/pipeline/pkg/client/resolution/injection/informers/resolution/v1beta1/resolutionrequest"
 	"github.com/tektoncd/pipeline/pkg/pipelinerunmetrics"
+	"github.com/tektoncd/pipeline/pkg/reconciler"
 	cloudeventclient "github.com/tektoncd/pipeline/pkg/reconciler/events/cloudevent"
 	"github.com/tektoncd/pipeline/pkg/reconciler/volumeclaim"
 	resolution "github.com/tektoncd/pipeline/pkg/remoteresolution/resource"
@@ -104,6 +105,14 @@ func NewController(opts *pipeline.Options, clock clock.PassiveClock) func(contex
 				PromoteFilterFunc: pipelineRunFilterManagedBy,
 			}
 		})
+
+		if err := pipelineRunInformer.Informer().SetTransform(reconciler.StripManagedFields); err != nil {
+			logging.FromContext(ctx).Panicf("Failed to set PipelineRun informer transform: %v", err)
+		}
+
+		if err := taskRunInformer.Informer().SetTransform(reconciler.StripManagedFields); err != nil {
+			logging.FromContext(ctx).Panicf("Failed to set TaskRun informer transform: %v", err)
+		}
 
 		if _, err := secretinformer.Informer().AddEventHandler(controller.HandleAll(tracerProvider.Handler)); err != nil {
 			logging.FromContext(ctx).Panicf("Couldn't register Secret informer event handler: %w", err)

--- a/pkg/reconciler/taskrun/controller.go
+++ b/pkg/reconciler/taskrun/controller.go
@@ -29,6 +29,7 @@ import (
 	resolutionclient "github.com/tektoncd/pipeline/pkg/client/resolution/injection/client"
 	resolutioninformer "github.com/tektoncd/pipeline/pkg/client/resolution/injection/informers/resolution/v1beta1/resolutionrequest"
 	"github.com/tektoncd/pipeline/pkg/pod"
+	"github.com/tektoncd/pipeline/pkg/reconciler"
 	"github.com/tektoncd/pipeline/pkg/reconciler/volumeclaim"
 	resolution "github.com/tektoncd/pipeline/pkg/remoteresolution/resource"
 	"github.com/tektoncd/pipeline/pkg/spire"
@@ -113,6 +114,14 @@ func NewController(opts *pipeline.Options, clock clock.PassiveClock) func(contex
 				PromoteFilterFunc: taskRunFilterManagedBy,
 			}
 		})
+
+		if err := taskRunInformer.Informer().SetTransform(reconciler.StripManagedFields); err != nil {
+			logging.FromContext(ctx).Panicf("Failed to set TaskRun informer transform: %v", err)
+		}
+
+		if err := podInformer.Informer().SetTransform(reconciler.StripManagedFields); err != nil {
+			logging.FromContext(ctx).Panicf("Failed to set Pod informer transform: %v", err)
+		}
 
 		if _, err := secretinformer.Informer().AddEventHandler(controller.HandleAll(tracerProvider.Handler)); err != nil {
 			logging.FromContext(ctx).Panicf("Couldn't register Secret informer event handler: %w", err)

--- a/pkg/reconciler/transform.go
+++ b/pkg/reconciler/transform.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2025 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// StripManagedFields removes metadata.managedFields from objects on cache insertion.
+// ManagedFields can be 30-70% of an object's serialized size but are never read
+// by the controller, so stripping them reduces informer cache memory and DeepCopy cost.
+func StripManagedFields(obj interface{}) (interface{}, error) {
+	if accessor, ok := obj.(metav1.ObjectMetaAccessor); ok {
+		accessor.GetObjectMeta().SetManagedFields(nil)
+	}
+	return obj, nil
+}

--- a/pkg/reconciler/transform_test.go
+++ b/pkg/reconciler/transform_test.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2025 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler_test
+
+import (
+	"testing"
+
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	reconciler "github.com/tektoncd/pipeline/pkg/reconciler"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestStripManagedFields(t *testing.T) {
+	tests := []struct {
+		name string
+		obj  interface{}
+	}{
+		{
+			name: "strips managedFields from TaskRun",
+			obj: &v1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-taskrun",
+					Namespace: "default",
+					Labels:    map[string]string{"app": "test"},
+					ManagedFields: []metav1.ManagedFieldsEntry{
+						{Manager: "kubectl", Operation: metav1.ManagedFieldsOperationApply},
+					},
+				},
+			},
+		},
+		{
+			name: "strips managedFields from PipelineRun",
+			obj: &v1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-pipelinerun",
+					Namespace: "default",
+					ManagedFields: []metav1.ManagedFieldsEntry{
+						{Manager: "tekton-pipelines-controller", Operation: metav1.ManagedFieldsOperationUpdate},
+						{Manager: "kubectl", Operation: metav1.ManagedFieldsOperationApply},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := reconciler.StripManagedFields(tt.obj)
+			if err != nil {
+				t.Fatalf("StripManagedFields() returned error: %v", err)
+			}
+			accessor, ok := result.(metav1.ObjectMetaAccessor)
+			if !ok {
+				t.Fatal("result does not implement ObjectMetaAccessor")
+			}
+			if mf := accessor.GetObjectMeta().GetManagedFields(); mf != nil {
+				t.Errorf("ManagedFields = %v, want nil", mf)
+			}
+			// Verify other metadata is preserved.
+			meta := accessor.GetObjectMeta()
+			if meta.GetName() == "" {
+				t.Error("Name was cleared, expected it to be preserved")
+			}
+			if meta.GetNamespace() != "default" {
+				t.Errorf("Namespace = %q, want %q", meta.GetNamespace(), "default")
+			}
+		})
+	}
+}
+
+func TestStripManagedFields_NonAccessor(t *testing.T) {
+	// A plain string does not implement ObjectMetaAccessor; it should pass
+	// through unchanged without error.
+	obj := "not-a-k8s-object"
+	result, err := reconciler.StripManagedFields(obj)
+	if err != nil {
+		t.Fatalf("StripManagedFields() returned error: %v", err)
+	}
+	if result != obj {
+		t.Errorf("result = %v, want original object %v", result, obj)
+	}
+}


### PR DESCRIPTION
# Changes

Apply `SetTransform` on PipelineRun, TaskRun, and Pod informers to strip `metadata.managedFields` on cache insertion. The controller never reads these fields, but they can be 30-70% of serialized object size and are copied in full on every `DeepCopy` during reconciliation (3-4 per cycle via the Knative reconciler framework).

The transform function is defined once in `pkg/reconciler/transform.go` and shared by both controllers. Error handling uses `Panicf` to match all other informer initialization failures.

Pods are included because they carry 3-5 field managers (kubelet, scheduler, controller-manager, tekton) compared to 1-2 for TaskRuns/PipelineRuns, making them the largest source of unnecessary cached data.

This is an established pattern in the Kubernetes ecosystem (kube-controller-manager added ManagedFields stripping in k/k 1.27).

Fixes #9573

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```