### PR TITLE
fix: harden resolver secret namespace handling, prevent enumeration, and fix cache

### DIFF
--- a/pkg/remoteresolution/resolver/git/resolver_test.go
+++ b/pkg/remoteresolution/resolver/git/resolver_test.go
@@ -728,12 +728,12 @@ func TestResolve(t *testing.T) {
 		config: map[string]string{
 			gitresolution.ServerURLKey:          "fake",
 			gitresolution.SCMTypeKey:            "fake",
-			gitresolution.APISecretNameKey:      "token-secret",
+			gitresolution.APISecretNameKey:      "token-secret-nonexistent",
 			gitresolution.APISecretKeyKey:       "token",
 			gitresolution.APISecretNamespaceKey: system.Namespace(),
 		},
 		expectedStatus: resolution.CreateResolutionRequestFailureStatus(),
-		expectedErr:    createError("cannot get API token, secret token-secret not found in namespace " + system.Namespace()),
+		expectedErr:    createError("cannot get API token, secret token-secret-nonexistent not accessible in namespace " + system.Namespace()),
 	}, {
 		name: "api: token secret name not specified",
 		args: &params{

--- a/pkg/remoteresolution/resolver/git/resolver_test.go
+++ b/pkg/remoteresolution/resolver/git/resolver_test.go
@@ -733,7 +733,7 @@ func TestResolve(t *testing.T) {
 			gitresolution.APISecretNamespaceKey: system.Namespace(),
 		},
 		expectedStatus: resolution.CreateResolutionRequestFailureStatus(),
-		expectedErr:    createError("cannot get API token, secret token-secret-nonexistent not accessible in namespace " + system.Namespace()),
+		expectedErr:    createError("cannot get API token, secret not accessible in namespace " + system.Namespace()),
 	}, {
 		name: "api: token secret name not specified",
 		args: &params{

--- a/pkg/remoteresolution/resolver/http/resolver_test.go
+++ b/pkg/remoteresolution/resolver/http/resolver_test.go
@@ -296,7 +296,7 @@ func TestResolverReconcileBasicAuth(t *testing.T) {
 				authUsername: "user",
 				url:          "https://blah/blah.com",
 			},
-			expectedErr: errors.New(`error getting "Http" "foo/rr": cannot get API token, secret notcreate not found in namespace foo`),
+			expectedErr: errors.New(`error getting "Http" "foo/rr": cannot get API token, secret not accessible in namespace foo`),
 		},
 		{
 			name: "bad/no valid secret key",
@@ -306,7 +306,7 @@ func TestResolverReconcileBasicAuth(t *testing.T) {
 				authSecretKey: wrongSecretKey,
 				url:           "https://blah/blah",
 			},
-			expectedErr: errors.New(`error getting "Http" "foo/rr": cannot get API token, key wrongsecretk not found in secret shhhhh in namespace foo`),
+			expectedErr: errors.New(`error getting "Http" "foo/rr": cannot get API token, secret not accessible in namespace foo`),
 		},
 		{
 			name: "bad/missing username params for secret with params",

--- a/pkg/resolution/resolver/git/resolver.go
+++ b/pkg/resolution/resolver/git/resolver.go
@@ -536,8 +536,6 @@ func (g *GitResolver) getAPIToken(ctx context.Context, apiSecret *secretCacheKey
 		return nil, err
 	}
 
-	ok := false
-
 	// NOTE(chmouel): only cache secrets when user hasn't passed params in their resolver configuration
 	// Track whether the secret was user-specified (via resolver params) before
 	// the nil check mutates apiSecret. This determines whether namespace

--- a/pkg/resolution/resolver/git/resolver.go
+++ b/pkg/resolution/resolver/git/resolver.go
@@ -33,7 +33,6 @@ import (
 	common "github.com/tektoncd/pipeline/pkg/resolution/common"
 	"github.com/tektoncd/pipeline/pkg/resolution/resolver/framework"
 	"go.uber.org/zap"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/cache"
 	"k8s.io/client-go/kubernetes"
@@ -540,6 +539,10 @@ func (g *GitResolver) getAPIToken(ctx context.Context, apiSecret *secretCacheKey
 	ok := false
 
 	// NOTE(chmouel): only cache secrets when user hasn't passed params in their resolver configuration
+	// Track whether the secret was user-specified (via resolver params) before
+	// the nil check mutates apiSecret. This determines whether namespace
+	// fallback to config/system namespace is allowed.
+	userSpecified := apiSecret != nil
 	cacheSecret := false
 	if apiSecret == nil {
 		cacheSecret = true
@@ -563,6 +566,14 @@ func (g *GitResolver) getAPIToken(ctx context.Context, apiSecret *secretCacheKey
 		}
 	}
 	if apiSecret.ns == "" {
+		if userSpecified {
+			// User-specified secret: refuse to fall back to config or system
+			// namespace. This prevents silent privilege escalation from the
+			// user's namespace to the system namespace when RequestNamespace
+			// is not available in the context.
+			return nil, fmt.Errorf("cannot determine namespace for user-specified secret %q: request namespace not available in context", apiSecret.name)
+		}
+		// Config-sourced secret: admin controls all values, fallback is safe
 		apiSecret.ns = conf.APISecretNamespace
 		if apiSecret.ns == "" {
 			apiSecret.ns = os.Getenv("SYSTEM_NAMESPACE")
@@ -570,7 +581,7 @@ func (g *GitResolver) getAPIToken(ctx context.Context, apiSecret *secretCacheKey
 	}
 
 	if cacheSecret {
-		val, ok := g.Cache.Get(apiSecret)
+		val, ok := g.Cache.Get(*apiSecret)
 		if ok {
 			return val.([]byte), nil
 		}
@@ -578,24 +589,19 @@ func (g *GitResolver) getAPIToken(ctx context.Context, apiSecret *secretCacheKey
 
 	secret, err := g.KubeClient.CoreV1().Secrets(apiSecret.ns).Get(ctx, apiSecret.name, metav1.GetOptions{})
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			notFoundErr := fmt.Errorf("cannot get API token, secret %s not found in namespace %s", apiSecret.name, apiSecret.ns)
-			g.Logger.Info(notFoundErr)
-			return nil, notFoundErr
-		}
-		wrappedErr := fmt.Errorf("error reading API token from secret %s in namespace %s: %w", apiSecret.name, apiSecret.ns, err)
-		g.Logger.Info(wrappedErr)
-		return nil, wrappedErr
+		// Use a single generic error message for all secret access failures
+		// to prevent secret enumeration via distinct error strings.
+		g.Logger.Debugf("secret lookup failed: ns=%s name=%s err=%v", apiSecret.ns, apiSecret.name, err)
+		return nil, fmt.Errorf("cannot get API token, secret %s not accessible in namespace %s", apiSecret.name, apiSecret.ns)
 	}
 
 	secretVal, ok := secret.Data[apiSecret.key]
 	if !ok {
-		err := fmt.Errorf("cannot get API token, key %s not found in secret %s in namespace %s", apiSecret.key, apiSecret.name, apiSecret.ns)
-		g.Logger.Info(err)
-		return nil, err
+		g.Logger.Debugf("secret key not found: ns=%s name=%s key=%s", apiSecret.ns, apiSecret.name, apiSecret.key)
+		return nil, fmt.Errorf("cannot get API token, secret %s not accessible in namespace %s", apiSecret.name, apiSecret.ns)
 	}
 	if cacheSecret {
-		g.Cache.Add(apiSecret, secretVal, ttl)
+		g.Cache.Add(*apiSecret, secretVal, ttl)
 	}
 	return secretVal, nil
 }

--- a/pkg/resolution/resolver/git/resolver.go
+++ b/pkg/resolution/resolver/git/resolver.go
@@ -569,7 +569,7 @@ func (g *GitResolver) getAPIToken(ctx context.Context, apiSecret *secretCacheKey
 			// namespace. This prevents silent privilege escalation from the
 			// user's namespace to the system namespace when RequestNamespace
 			// is not available in the context.
-			return nil, fmt.Errorf("cannot get API token, secret not accessible: request namespace not available in context")
+			return nil, errors.New("cannot get API token, secret not accessible: request namespace not available in context")
 		}
 		// Config-sourced secret: admin controls all values, fallback is safe
 		apiSecret.ns = conf.APISecretNamespace

--- a/pkg/resolution/resolver/git/resolver.go
+++ b/pkg/resolution/resolver/git/resolver.go
@@ -571,7 +571,7 @@ func (g *GitResolver) getAPIToken(ctx context.Context, apiSecret *secretCacheKey
 			// namespace. This prevents silent privilege escalation from the
 			// user's namespace to the system namespace when RequestNamespace
 			// is not available in the context.
-			return nil, fmt.Errorf("cannot determine namespace for user-specified secret %q: request namespace not available in context", apiSecret.name)
+			return nil, fmt.Errorf("cannot get API token, secret not accessible: request namespace not available in context")
 		}
 		// Config-sourced secret: admin controls all values, fallback is safe
 		apiSecret.ns = conf.APISecretNamespace
@@ -592,13 +592,13 @@ func (g *GitResolver) getAPIToken(ctx context.Context, apiSecret *secretCacheKey
 		// Use a single generic error message for all secret access failures
 		// to prevent secret enumeration via distinct error strings.
 		g.Logger.Debugf("secret lookup failed: ns=%s name=%s err=%v", apiSecret.ns, apiSecret.name, err)
-		return nil, fmt.Errorf("cannot get API token, secret %s not accessible in namespace %s", apiSecret.name, apiSecret.ns)
+		return nil, fmt.Errorf("cannot get API token, secret not accessible in namespace %s", apiSecret.ns)
 	}
 
 	secretVal, ok := secret.Data[apiSecret.key]
 	if !ok {
 		g.Logger.Debugf("secret key not found in secret: ns=%s name=%s", apiSecret.ns, apiSecret.name)
-		return nil, fmt.Errorf("cannot get API token, secret %s not accessible in namespace %s", apiSecret.name, apiSecret.ns)
+		return nil, fmt.Errorf("cannot get API token, secret not accessible in namespace %s", apiSecret.ns)
 	}
 	if cacheSecret {
 		g.Cache.Add(*apiSecret, secretVal, ttl)

--- a/pkg/resolution/resolver/git/resolver.go
+++ b/pkg/resolution/resolver/git/resolver.go
@@ -597,7 +597,7 @@ func (g *GitResolver) getAPIToken(ctx context.Context, apiSecret *secretCacheKey
 
 	secretVal, ok := secret.Data[apiSecret.key]
 	if !ok {
-		g.Logger.Debugf("secret key not found: ns=%s name=%s key=%s", apiSecret.ns, apiSecret.name, apiSecret.key)
+		g.Logger.Debugf("secret key not found in secret: ns=%s name=%s", apiSecret.ns, apiSecret.name)
 		return nil, fmt.Errorf("cannot get API token, secret %s not accessible in namespace %s", apiSecret.name, apiSecret.ns)
 	}
 	if cacheSecret {

--- a/pkg/resolution/resolver/git/resolver_test.go
+++ b/pkg/resolution/resolver/git/resolver_test.go
@@ -23,10 +23,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"go.uber.org/zap"
 	"github.com/jenkins-x/go-scm/scm"
 	"github.com/jenkins-x/go-scm/scm/driver/fake"
 	"github.com/jenkins-x/go-scm/scm/factory"
@@ -42,6 +44,8 @@ import (
 	"github.com/tektoncd/pipeline/test/diff"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/cache"
+	fakekubeclient "k8s.io/client-go/kubernetes/fake"
 	"knative.dev/pkg/system"
 	_ "knative.dev/pkg/system/testing"
 )
@@ -542,7 +546,7 @@ func TestResolve(t *testing.T) {
 			gitToken:    "non-existent",
 			gitTokenKey: "token",
 		},
-		expectedErr: createError(`cannot get API token, secret non-existent not accessible in namespace foo`),
+		expectedErr: createError(`cannot get API token, secret not accessible in namespace foo`),
 	}, {
 		name: "clone: revision does not exist",
 		args: &params{
@@ -778,7 +782,7 @@ func TestResolve(t *testing.T) {
 			APISecretNamespaceKey: system.Namespace(),
 		},
 		expectedStatus: resolution.CreateResolutionRequestFailureStatus(),
-		expectedErr:    createError("cannot get API token, secret token-secret not accessible in namespace " + system.Namespace()),
+		expectedErr:    createError("cannot get API token, secret not accessible in namespace " + system.Namespace()),
 	}, {
 		name: "api: token secret name not specified",
 		args: &params{
@@ -1045,6 +1049,68 @@ func toParams(m map[string]string) []pipelinev1.Param {
 	}
 
 	return params
+}
+
+func TestGetAPITokenUserSpecifiedEmptyNamespace(t *testing.T) {
+	ctx := framework.InjectResolverConfigToContext(t.Context(), map[string]string{
+		ServerURLKey:     "fake",
+		SCMTypeKey:       "fake",
+		APISecretNameKey: "config-secret",
+		APISecretKeyKey:  "token",
+	})
+	resolver := &GitResolver{
+		Logger: zap.NewNop().Sugar(),
+		Cache:  cache.NewLRUExpireCache(10),
+		TTL:    1 * time.Minute,
+		Params: map[string]string{},
+	}
+	// User-specified secret with empty namespace — simulates RequestNamespace returning ""
+	apiSecret := &secretCacheKey{
+		name: "user-secret",
+		key:  "token",
+		ns:   "",
+	}
+	_, err := resolver.getAPIToken(ctx, apiSecret, "token")
+	if err == nil {
+		t.Fatal("expected error when user-specified secret has empty namespace, got nil")
+	}
+	expectedErr := "cannot get API token, secret not accessible: request namespace not available in context"
+	if err.Error() != expectedErr {
+		t.Errorf("expected error %q, got %q", expectedErr, err.Error())
+	}
+	if strings.Contains(err.Error(), "user-secret") {
+		t.Error("error message should not contain the secret name")
+	}
+}
+
+func TestGetAPITokenConfigSourcedFallback(t *testing.T) {
+	ctx := framework.InjectResolverConfigToContext(t.Context(), map[string]string{
+		ServerURLKey:          "fake",
+		SCMTypeKey:            "fake",
+		APISecretNameKey:      "config-secret",
+		APISecretKeyKey:       "token",
+		APISecretNamespaceKey: "config-ns",
+	})
+	resolver := &GitResolver{
+		Logger:     zap.NewNop().Sugar(),
+		Cache:      cache.NewLRUExpireCache(10),
+		TTL:        1 * time.Minute,
+		KubeClient: fakekubeclient.NewSimpleClientset(),
+		Params:     map[string]string{},
+	}
+	// Config-sourced secret (apiSecret == nil) — should fall back to config namespace
+	_, err := resolver.getAPIToken(ctx, nil, "token")
+	if err == nil {
+		t.Fatal("expected error (secret not found), got nil")
+	}
+	// Should use the config namespace, not error about missing namespace
+	expectedErr := "cannot get API token, secret not accessible in namespace config-ns"
+	if err.Error() != expectedErr {
+		t.Errorf("expected error %q, got %q", expectedErr, err.Error())
+	}
+	if strings.Contains(err.Error(), "config-secret") {
+		t.Error("error message should not contain the secret name")
+	}
 }
 
 func TestGetScmConfigForParamConfigKey(t *testing.T) {

--- a/pkg/resolution/resolver/git/resolver_test.go
+++ b/pkg/resolution/resolver/git/resolver_test.go
@@ -28,7 +28,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"go.uber.org/zap"
 	"github.com/jenkins-x/go-scm/scm"
 	"github.com/jenkins-x/go-scm/scm/driver/fake"
 	"github.com/jenkins-x/go-scm/scm/factory"
@@ -42,6 +41,7 @@ import (
 	frtesting "github.com/tektoncd/pipeline/pkg/resolution/resolver/framework/testing"
 	"github.com/tektoncd/pipeline/test"
 	"github.com/tektoncd/pipeline/test/diff"
+	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/cache"

--- a/pkg/resolution/resolver/git/resolver_test.go
+++ b/pkg/resolution/resolver/git/resolver_test.go
@@ -542,7 +542,7 @@ func TestResolve(t *testing.T) {
 			gitToken:    "non-existent",
 			gitTokenKey: "token",
 		},
-		expectedErr: createError(`cannot get API token, secret non-existent not found in namespace foo`),
+		expectedErr: createError(`cannot get API token, secret non-existent not accessible in namespace foo`),
 	}, {
 		name: "clone: revision does not exist",
 		args: &params{
@@ -778,7 +778,7 @@ func TestResolve(t *testing.T) {
 			APISecretNamespaceKey: system.Namespace(),
 		},
 		expectedStatus: resolution.CreateResolutionRequestFailureStatus(),
-		expectedErr:    createError("cannot get API token, secret token-secret not found in namespace " + system.Namespace()),
+		expectedErr:    createError("cannot get API token, secret token-secret not accessible in namespace " + system.Namespace()),
 	}, {
 		name: "api: token secret name not specified",
 		args: &params{

--- a/pkg/resolution/resolver/http/resolver.go
+++ b/pkg/resolution/resolver/http/resolver.go
@@ -33,7 +33,6 @@ import (
 	common "github.com/tektoncd/pipeline/pkg/resolution/common"
 	"github.com/tektoncd/pipeline/pkg/resolution/resolver/framework"
 	"go.uber.org/zap"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
@@ -334,22 +333,18 @@ func getBasicAuthSecret(ctx context.Context, params map[string]string, kubeclien
 		}
 	}
 	secretNS := common.RequestNamespace(ctx)
+	if secretNS == "" {
+		return "", fmt.Errorf("cannot get API token, secret not accessible: request namespace not available in context")
+	}
 	secret, err := kubeclient.CoreV1().Secrets(secretNS).Get(ctx, secretName, metav1.GetOptions{})
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			notFoundErr := fmt.Errorf("cannot get API token, secret %s not found in namespace %s", secretName, secretNS)
-			logger.Info(notFoundErr)
-			return "", notFoundErr
-		}
-		wrappedErr := fmt.Errorf("error reading API token from secret %s in namespace %s: %w", secretName, secretNS, err)
-		logger.Info(wrappedErr)
-		return "", wrappedErr
+		logger.Debugf("secret lookup failed: ns=%s name=%s err=%v", secretNS, secretName, err)
+		return "", fmt.Errorf("cannot get API token, secret not accessible in namespace %s", secretNS)
 	}
 	secretVal, ok := secret.Data[tokenSecretKey]
 	if !ok {
-		err := fmt.Errorf("cannot get API token, key %s not found in secret %s in namespace %s", tokenSecretKey, secretName, secretNS)
-		logger.Info(err)
-		return "", err
+		logger.Debugf("secret key not found in secret: ns=%s name=%s", secretNS, secretName)
+		return "", fmt.Errorf("cannot get API token, secret not accessible in namespace %s", secretNS)
 	}
 	return "Basic " + base64.StdEncoding.EncodeToString(
 		[]byte(fmt.Sprintf("%s:%s", userName, secretVal))), nil

--- a/pkg/resolution/resolver/http/resolver.go
+++ b/pkg/resolution/resolver/http/resolver.go
@@ -334,7 +334,7 @@ func getBasicAuthSecret(ctx context.Context, params map[string]string, kubeclien
 	}
 	secretNS := common.RequestNamespace(ctx)
 	if secretNS == "" {
-		return "", fmt.Errorf("cannot get API token, secret not accessible: request namespace not available in context")
+		return "", errors.New("cannot get API token, secret not accessible: request namespace not available in context")
 	}
 	secret, err := kubeclient.CoreV1().Secrets(secretNS).Get(ctx, secretName, metav1.GetOptions{})
 	if err != nil {

--- a/pkg/resolution/resolver/http/resolver_test.go
+++ b/pkg/resolution/resolver/http/resolver_test.go
@@ -46,6 +46,7 @@ import (
 	"github.com/tektoncd/pipeline/test/diff"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakekubeclient "k8s.io/client-go/kubernetes/fake"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/system"
 	_ "knative.dev/pkg/system/testing"
@@ -349,7 +350,7 @@ func TestResolverReconcileBasicAuth(t *testing.T) {
 				authUsername: "user",
 				url:          "https://blah/blah.com",
 			},
-			expectedErr: errors.New(`error getting "Http" "foo/rr": cannot get API token, secret notcreate not found in namespace foo`),
+			expectedErr: errors.New(`error getting "Http" "foo/rr": cannot get API token, secret not accessible in namespace foo`),
 		},
 		{
 			name: "bad/no valid secret key",
@@ -359,7 +360,7 @@ func TestResolverReconcileBasicAuth(t *testing.T) {
 				authSecretKey: wrongSecretKey,
 				url:           "https://blah/blah",
 			},
-			expectedErr: errors.New(`error getting "Http" "foo/rr": cannot get API token, key wrongsecretk not found in secret shhhhh in namespace foo`),
+			expectedErr: errors.New(`error getting "Http" "foo/rr": cannot get API token, secret not accessible in namespace foo`),
 		},
 		{
 			name: "bad/missing username params for secret with params",
@@ -493,6 +494,71 @@ func TestGetName(t *testing.T) {
 	}
 	if d := cmp.Diff(configMapName, resolver.GetConfigName(ctx)); d != "" {
 		t.Errorf("invalid config map name: %s", diff.PrintWantGot(d))
+	}
+}
+
+func TestGetBasicAuthSecretEmptyNamespace(t *testing.T) {
+	logger, _ := logging.NewLogger("", "")
+	params := map[string]string{
+		HttpBasicAuthSecret:   "my-secret",
+		HttpBasicAuthUsername: "user",
+	}
+	// Context without RequestNamespace injected — simulates missing namespace
+	ctx := context.Background()
+	_, err := getBasicAuthSecret(ctx, params, nil, logger)
+	if err == nil {
+		t.Fatal("expected error when namespace is empty, got nil")
+	}
+	expectedErr := "cannot get API token, secret not accessible: request namespace not available in context"
+	if err.Error() != expectedErr {
+		t.Errorf("expected error %q, got %q", expectedErr, err.Error())
+	}
+}
+
+func TestGetBasicAuthSecretNotFound(t *testing.T) {
+	logger, _ := logging.NewLogger("", "")
+	params := map[string]string{
+		HttpBasicAuthSecret:   "nonexistent-secret",
+		HttpBasicAuthUsername: "user",
+	}
+	ctx := common.InjectRequestNamespace(context.Background(), "test-ns")
+	kubeclient := fakekubeclient.NewSimpleClientset()
+	_, err := getBasicAuthSecret(ctx, params, kubeclient, logger)
+	if err == nil {
+		t.Fatal("expected error when secret not found, got nil")
+	}
+	expectedErr := "cannot get API token, secret not accessible in namespace test-ns"
+	if err.Error() != expectedErr {
+		t.Errorf("expected error %q, got %q", expectedErr, err.Error())
+	}
+	if strings.Contains(err.Error(), "nonexistent-secret") {
+		t.Error("error message should not contain the secret name")
+	}
+}
+
+func TestGetBasicAuthSecretWrongKey(t *testing.T) {
+	logger, _ := logging.NewLogger("", "")
+	params := map[string]string{
+		HttpBasicAuthSecret:    "real-secret",
+		HttpBasicAuthUsername:  "user",
+		HttpBasicAuthSecretKey: "wrong-key",
+	}
+	ctx := common.InjectRequestNamespace(context.Background(), "test-ns")
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "real-secret", Namespace: "test-ns"},
+		Data:       map[string][]byte{"correct-key": []byte("token-value")},
+	}
+	kubeclient := fakekubeclient.NewSimpleClientset(secret)
+	_, err := getBasicAuthSecret(ctx, params, kubeclient, logger)
+	if err == nil {
+		t.Fatal("expected error when secret key not found, got nil")
+	}
+	expectedErr := "cannot get API token, secret not accessible in namespace test-ns"
+	if err.Error() != expectedErr {
+		t.Errorf("expected error %q, got %q", expectedErr, err.Error())
+	}
+	if strings.Contains(err.Error(), "real-secret") || strings.Contains(err.Error(), "wrong-key") {
+		t.Error("error message should not contain secret name or key name")
 	}
 }
 

--- a/pkg/resolution/resolver/http/resolver_test.go
+++ b/pkg/resolution/resolver/http/resolver_test.go
@@ -527,12 +527,13 @@ func TestGetBasicAuthSecretNotFound(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error when secret not found, got nil")
 	}
-	expectedErr := "cannot get API token, secret not accessible in namespace test-ns"
-	if err.Error() != expectedErr {
-		t.Errorf("expected error %q, got %q", expectedErr, err.Error())
-	}
-	if strings.Contains(err.Error(), "nonexistent-secret") {
+	gotErr := err.Error()
+	if strings.Contains(gotErr, params[HttpBasicAuthSecret]) {
 		t.Error("error message should not contain the secret name")
+	}
+	expectedErr := "cannot get API token, secret not accessible in namespace test-ns"
+	if gotErr != expectedErr {
+		t.Errorf("expected error %q, got %q", expectedErr, gotErr)
 	}
 }
 
@@ -553,12 +554,13 @@ func TestGetBasicAuthSecretWrongKey(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error when secret key not found, got nil")
 	}
-	expectedErr := "cannot get API token, secret not accessible in namespace test-ns"
-	if err.Error() != expectedErr {
-		t.Errorf("expected error %q, got %q", expectedErr, err.Error())
-	}
-	if strings.Contains(err.Error(), "real-secret") || strings.Contains(err.Error(), "wrong-key") {
+	gotErr := err.Error()
+	if strings.Contains(gotErr, params[HttpBasicAuthSecret]) || strings.Contains(gotErr, params[HttpBasicAuthSecretKey]) {
 		t.Error("error message should not contain secret name or key name")
+	}
+	expectedErr := "cannot get API token, secret not accessible in namespace test-ns"
+	if gotErr != expectedErr {
+		t.Errorf("expected error %q, got %q", expectedErr, gotErr)
 	}
 }
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Harden the git resolver's secret namespace handling with three fixes:

1. **Prevent cross-namespace secret fallback for user-specified secrets**: When a user specifies a secret name via resolver params but `RequestNamespace(ctx)` returns empty, the code previously fell back to `conf.APISecretNamespace` then `os.Getenv("SYSTEM_NAMESPACE")` — silently escalating from user namespace to system namespace. Now returns an explicit error for user-specified secrets. Config-sourced secrets (admin-controlled) still use the fallback.

2. **Normalize error messages to prevent secret enumeration**: Three distinct error messages ("not found", "error reading", "key not found") revealed secret existence to callers. Replaced with a single generic message; detailed info logged at Debug level.

3. **Fix LRU cache key type**: The cache used `*secretCacheKey` (pointer) as map key. Pointer comparison uses address equality, so every allocation was unique — the cache never hit. Fixed to use struct value (`*apiSecret` dereference).

**Note**: This PR has a logical dependency on the context key collision fix (#9593). The `RequestNamespace(ctx)` returning empty is blocked by the reconciler always injecting a non-empty namespace, but this PR adds explicit validation as defense-in-depth.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md)
- [ ] Has a kind label.
- [ ] Release notes block below has been updated with any user facing changes.
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Harden git resolver secret handling: prevent cross-namespace secret fallback for user-specified secrets, normalize error messages to prevent secret enumeration, and fix LRU cache key type so caching actually works.
```