### PR TITLE
Extract memberOfLookup from createChildResourceLabels to reduce nested loop

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -1622,23 +1622,27 @@ func createChildResourceLabels(pr *v1.PipelineRun, pipelineTaskName string, incl
 	if pipelineTaskName != "" {
 		labels[pipeline.PipelineTaskLabelKey] = pipelineTaskName
 	}
-	if pr.Status.PipelineSpec != nil {
-		// check if a task is part of the "tasks" section, add a label to identify it during the runtime
-		for _, f := range pr.Status.PipelineSpec.Tasks {
-			if pipelineTaskName == f.Name {
-				labels[pipeline.MemberOfLabelKey] = v1.PipelineTasks
-				break
-			}
-		}
-		// check if a task is part of the "finally" section, add a label to identify it during the runtime
-		for _, f := range pr.Status.PipelineSpec.Finally {
-			if pipelineTaskName == f.Name {
-				labels[pipeline.MemberOfLabelKey] = v1.PipelineFinallyTasks
-				break
-			}
-		}
+	if memberOf := memberOfLookup(pr.Status.PipelineSpec, pipelineTaskName); memberOf != "" {
+		labels[pipeline.MemberOfLabelKey] = memberOf
 	}
 	return labels
+}
+
+func memberOfLookup(ps *v1.PipelineSpec, name string) string {
+	if ps == nil {
+		return ""
+	}
+	for _, t := range ps.Tasks {
+		if name == t.Name {
+			return v1.PipelineTasks
+		}
+	}
+	for _, t := range ps.Finally {
+		if name == t.Name {
+			return v1.PipelineFinallyTasks
+		}
+	}
+	return ""
 }
 
 func combineTaskRunAndTaskSpecLabels(pr *v1.PipelineRun, pipelineTask *v1.PipelineTask) map[string]string {

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -19027,3 +19027,60 @@ spec:
 		t.Errorf("Expected Tekton-managed PipelineRun to be running, but it was not")
 	}
 }
+
+func TestMemberOfLookup(t *testing.T) {
+	tcs := []struct {
+		name     string
+		spec     *v1.PipelineSpec
+		taskName string
+		expected string
+	}{
+		{
+			name: "task found in tasks list",
+			spec: &v1.PipelineSpec{
+				Tasks: []v1.PipelineTask{{Name: "my-task"}, {Name: "other-task"}},
+			},
+			taskName: "my-task",
+			expected: v1.PipelineTasks,
+		},
+		{
+			name: "task found in finally list",
+			spec: &v1.PipelineSpec{
+				Tasks:   []v1.PipelineTask{{Name: "my-task"}},
+				Finally: []v1.PipelineTask{{Name: "my-finally-task"}},
+			},
+			taskName: "my-finally-task",
+			expected: v1.PipelineFinallyTasks,
+		},
+		{
+			name: "task not found",
+			spec: &v1.PipelineSpec{
+				Tasks:   []v1.PipelineTask{{Name: "some-task"}},
+				Finally: []v1.PipelineTask{{Name: "some-finally-task"}},
+			},
+			taskName: "missing-task",
+			expected: "",
+		},
+		{
+			name:     "nil pipeline spec does not panic",
+			spec:     nil,
+			taskName: "any-task",
+			expected: "",
+		},
+		{
+			name:     "empty pipeline spec",
+			spec:     &v1.PipelineSpec{},
+			taskName: "any-task",
+			expected: "",
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := memberOfLookup(tc.spec, tc.taskName)
+			if actual != tc.expected {
+				t.Errorf("memberOfLookup() = %q, expected %q", actual, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR resolves [#9575](https://github.com/tektoncd/pipeline/issues/9575) by implementing the logic to propagate the tekton.dev/memberOf label from a PipelineRun to its child resources (TaskRun/CustomRun/PipelineRun).

It adds a helper function in `pkg/reconciler/pipelinerun/pipelinerun.go/createChildResourceLabels` to look up whether a given task is part of the tasks or finally list within the PipelineSpec, and applies the correct label (tasks or finally) to the child resource accordingly.
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
