### PR TITLE
fix: Pin Ubuntu container images to digests in examples/v1/taskruns

### DIFF
--- a/examples/v1/taskruns/configmap.yaml
+++ b/examples/v1/taskruns/configmap.yaml
@@ -13,7 +13,7 @@ spec:
   taskSpec:
     steps:
     - name: secret
-      image: mirror.gcr.io/ubuntu
+      image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
       script: |
         #!/usr/bin/env bash
         [[ $(cat /config/test.data) == $TEST_DATA ]]

--- a/examples/v1/taskruns/custom-env.yaml
+++ b/examples/v1/taskruns/custom-env.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   taskSpec:
     steps:
-    - image: mirror.gcr.io/ubuntu
+    - image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
       script: |
         #!/usr/bin/env bash
         [[ $MY_VAR1 == foo ]]

--- a/examples/v1/taskruns/custom-volume.yaml
+++ b/examples/v1/taskruns/custom-volume.yaml
@@ -6,7 +6,7 @@ spec:
   taskSpec:
     steps:
     - name: write
-      image: mirror.gcr.io/ubuntu
+      image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
       script: |
         #!/usr/bin/env bash
         echo some stuff > /im/a/custom/mount/path/file
@@ -14,7 +14,7 @@ spec:
       - name: custom
         mountPath: /im/a/custom/mount/path
     - name: read
-      image: mirror.gcr.io/ubuntu
+      image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
       script: |
         #!/usr/bin/env bash
         cat /short/and/stout/file | grep stuff

--- a/examples/v1/taskruns/default_task_params.yaml
+++ b/examples/v1/taskruns/default_task_params.yaml
@@ -10,7 +10,7 @@ spec:
       default: "No input provided, but that's okay!"
   steps:
     - name: echo-input
-      image: mirror.gcr.io/ubuntu
+      image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
       script: |
         echo "$(params.input)"
 ---

--- a/examples/v1/taskruns/entrypoint-resolution.yaml
+++ b/examples/v1/taskruns/entrypoint-resolution.yaml
@@ -13,16 +13,16 @@ spec:
     # Multi-arch image with no command defined, but with args. We'll look
     # up the commands and pass it to the entrypoint binary via env var, then
     # append the specified args.
-    - image: mirror.gcr.io/ubuntu
+    - image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
       args: ['-c', 'echo', 'hello']
 
     # Multi-arch image, but since we specify `script` we don't need to look it
     # up and pass it down.
-    - image: mirror.gcr.io/ubuntu
+    - image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
       script: echo hello
 
     # Multi-arch image, but since we specify `command` and `args` we don't
     # need to look it up and pass it down.
-    - image: mirror.gcr.io/ubuntu
+    - image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
       command: ['sh', '-c']
       args: ['echo hello']

--- a/examples/v1/taskruns/home-is-set.yaml
+++ b/examples/v1/taskruns/home-is-set.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   taskSpec:
     steps:
-    - image: mirror.gcr.io/ubuntu
+    - image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
       env:
       - name: HOME
         value: /tekton/home

--- a/examples/v1/taskruns/home-volume.yaml
+++ b/examples/v1/taskruns/home-volume.yaml
@@ -6,13 +6,13 @@ spec:
   taskSpec:
     steps:
     - name: write
-      image: mirror.gcr.io/ubuntu
+      image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
       script: echo some stuff > /tekton/home/stuff
     - name: read
-      image: mirror.gcr.io/ubuntu
+      image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
       script: cat /tekton/home/stuff
     - name: override-homevol
-      image: mirror.gcr.io/ubuntu
+      image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
       # /tekton/home/stuff *doesn't* exist, because the specified volumeMount
       # conflicts with it, and the user's explicit declaration wins the tie.
       script: |

--- a/examples/v1/taskruns/propagating_params_implicit.yaml
+++ b/examples/v1/taskruns/propagating_params_implicit.yaml
@@ -10,6 +10,6 @@ spec:
     # There are no explicit params defined here. They are derived from the TaskRun.
     steps:
     - name: default
-      image: mirror.gcr.io/ubuntu
+      image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
       script: |
         echo $(params.message)

--- a/examples/v1/taskruns/propagating_workspaces.yaml
+++ b/examples/v1/taskruns/propagating_workspaces.yaml
@@ -6,7 +6,7 @@ spec:
   taskSpec:
     steps:
       - name: simple-step
-        image: mirror.gcr.io/ubuntu
+        image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
         command:
           - echo
         args:

--- a/examples/v1/taskruns/readonly-internal-dir.yaml
+++ b/examples/v1/taskruns/readonly-internal-dir.yaml
@@ -7,9 +7,9 @@ metadata:
 spec:
   taskSpec:
     steps:
-    - image: mirror.gcr.io/ubuntu
+    - image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
       script: exit 0
-    - image: mirror.gcr.io/ubuntu
+    - image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
       script: |
         set +e # dont fail the script on error
 
@@ -19,7 +19,7 @@ spec:
           echo "able to write to run directory of non-current step"
           exit 1
         fi
-    - image: mirror.gcr.io/ubuntu
+    - image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
       script: |
         set +e # dont fail the script on error
 

--- a/examples/v1/taskruns/run-steps-as-non-root.yaml
+++ b/examples/v1/taskruns/run-steps-as-non-root.yaml
@@ -7,7 +7,7 @@ spec:
     # no securityContext specified so will use
     # securityContext from TaskRun podTemplate
     - name: show-user-1001
-      image: mirror.gcr.io/ubuntu
+      image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
       command:
         - ps
       args:
@@ -15,7 +15,7 @@ spec:
     # securityContext specified so will run as
     # user 2000 instead of 1001
     - name: show-user-2000
-      image: mirror.gcr.io/ubuntu
+      image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
       command:
         - ps
       args:

--- a/examples/v1/taskruns/secret-env.yaml
+++ b/examples/v1/taskruns/secret-env.yaml
@@ -13,7 +13,7 @@ spec:
   taskSpec:
     steps:
     - name: secret
-      image: mirror.gcr.io/ubuntu
+      image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
       script: |
         #!/usr/bin/env bash
         [[ $SECRET_PASSWORD == SECRET_PASSWORD ]]

--- a/examples/v1/taskruns/secret-volume-params.yaml
+++ b/examples/v1/taskruns/secret-volume-params.yaml
@@ -16,7 +16,7 @@ spec:
       description: Name of secret
       type: string
     steps:
-    - image: mirror.gcr.io/ubuntu
+    - image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
       script: |
         #!/usr/bin/env bash
         SECRET_PASSWORD=$(cat /var/secret/ninja)

--- a/examples/v1/taskruns/secret-volume.yaml
+++ b/examples/v1/taskruns/secret-volume.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   taskSpec:
     steps:
-    - image: mirror.gcr.io/ubuntu
+    - image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
       script: |
         #!/usr/bin/env bash
         SECRET_PASSWORD=$(cat /var/secret/ninja)

--- a/examples/v1/taskruns/sidecar-interp.yaml
+++ b/examples/v1/taskruns/sidecar-interp.yaml
@@ -12,7 +12,7 @@ spec:
         emptyDir: {}
     sidecars:
       - name: value-sidecar
-        image: mirror.gcr.io/ubuntu
+        image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
         command:
           - /bin/bash
         args:
@@ -23,7 +23,7 @@ spec:
             mountPath: /shared
     steps:
       - name: check-value
-        image: mirror.gcr.io/ubuntu
+        image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
         script: |
           #!/bin/bash
           VALUE=$(cat /shared/value)

--- a/examples/v1/taskruns/sidecar-ready-script.yaml
+++ b/examples/v1/taskruns/sidecar-ready-script.yaml
@@ -6,7 +6,7 @@ spec:
   taskSpec:
     sidecars:
     - name: slow-sidecar
-      image: mirror.gcr.io/ubuntu
+      image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
       script: |
         echo "hello from sidecar" > /shared/message
         sleep 2
@@ -16,7 +16,7 @@ spec:
 
     steps:
     - name: check-ready
-      image: mirror.gcr.io/ubuntu
+      image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
       script: cat /shared/message
       volumeMounts:
       - name: shared

--- a/examples/v1/taskruns/sidecar-ready.yaml
+++ b/examples/v1/taskruns/sidecar-ready.yaml
@@ -6,7 +6,7 @@ spec:
   taskSpec:
     sidecars:
     - name: slow-sidecar
-      image: mirror.gcr.io/ubuntu
+      image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
       command: ['sleep', 'infinity']
       # The sidecar takes 5s to report as Ready, even after it starts.  If the
       # step runs as soon as the sidecar starts, it will fail because
@@ -33,7 +33,7 @@ spec:
 
     steps:
     - name: check-ready
-      image: mirror.gcr.io/ubuntu
+      image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
       # The step will only succeed if the sidecar has written this file, which
       # it does 5s after it starts, before it reports Ready.
       script: cat /shared/ready

--- a/examples/v1/taskruns/stepaction-params.yaml
+++ b/examples/v1/taskruns/stepaction-params.yaml
@@ -59,7 +59,7 @@ spec:
       value: $(params.enum-param.v2)
     - name: enumparamkey3
       value: $(params.enum-param.v3)
-  image: mirror.gcr.io/ubuntu
+  image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
   script: |
     #!/bin/bash
     ARRAYVALUE=("${arrayparam0}" "${arrayparam1}" "${arrayparam2}" "${stringparam}" "${objectparamkey1}" "${objectparamkey2}" "${objectparamkey3}" "${enumparamkey1}" "${enumparamkey2}" "${enumparamkey3}")

--- a/examples/v1/taskruns/steptemplate-env-merge.yaml
+++ b/examples/v1/taskruns/steptemplate-env-merge.yaml
@@ -25,7 +25,7 @@ spec:
     steps:
       # Test the environment variables are set in the task
       - name: foo
-        image: mirror.gcr.io/ubuntu
+        image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
         script: |
           #!/usr/bin/env bash
           [[ $FOO == "foo" ]]
@@ -33,7 +33,7 @@ spec:
         - name: FOO
           value: $(params.FOO)
       - name: foobar
-        image: mirror.gcr.io/ubuntu
+        image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
         script: |
           #!/usr/bin/env bash
           [[ $FOOBAR == "foobar" ]]
@@ -41,7 +41,7 @@ spec:
         - name: FOOBAR
           value: $(params.FOOBAR)
       - name: bar
-        image: mirror.gcr.io/ubuntu
+        image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
         script: |
           #!/usr/bin/env bash
           [[ $BAR == "bar" ]]
@@ -50,13 +50,13 @@ spec:
           value: $(params.BAR)
       # Use the env var from the stepTemplate
       - name: qux-no-override
-        image: mirror.gcr.io/ubuntu
+        image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
         script: |
           #!/usr/bin/env bash
           [[ $QUX == "original" ]]
       # Override the env var in the stepTemplate
       - name: qux-override
-        image: mirror.gcr.io/ubuntu
+        image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
         script: |
           #!/usr/bin/env bash
           [[ $QUX == "override" ]]

--- a/examples/v1/taskruns/task-volume-args.yaml
+++ b/examples/v1/taskruns/task-volume-args.yaml
@@ -17,7 +17,7 @@ spec:
       type: string
     steps:
     - name: read
-      image: mirror.gcr.io/ubuntu
+      image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
       script: |
         #!/usr/bin/env bash
         cat /configmap/test.data

--- a/examples/v1/taskruns/template-volume.yaml
+++ b/examples/v1/taskruns/template-volume.yaml
@@ -6,7 +6,7 @@ spec:
   taskSpec:
     steps:
     - name: write
-      image: mirror.gcr.io/ubuntu
+      image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
       script: |
         #!/usr/bin/env bash
         echo some stuff > /im/a/custom/mount/path/file
@@ -14,7 +14,7 @@ spec:
       - name: custom
         mountPath: /im/a/custom/mount/path
     - name: read
-      image: mirror.gcr.io/ubuntu
+      image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
       script: |
         #!/usr/bin/env bash
         cat /short/and/stout/file

--- a/examples/v1/taskruns/unnamed-steps.yaml
+++ b/examples/v1/taskruns/unnamed-steps.yaml
@@ -5,9 +5,9 @@ metadata:
 spec:
   taskSpec:
     steps:
-    - image: mirror.gcr.io/ubuntu
+    - image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
       script: 'true'
-    - image: mirror.gcr.io/ubuntu
+    - image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
       script: 'true'
-    - image: mirror.gcr.io/ubuntu
+    - image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
       script: 'true'

--- a/examples/v1/taskruns/using_context_variables.yaml
+++ b/examples/v1/taskruns/using_context_variables.yaml
@@ -5,11 +5,11 @@ metadata:
 spec:
   taskSpec:
     steps:
-    - image: mirror.gcr.io/ubuntu
+    - image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
       name: print-uid
       script: |
         echo "TaskRunUID name: $(context.taskRun.uid)"
-    - image: mirror.gcr.io/ubuntu
+    - image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
       name: print-names
       script: |
         echo "Task name: $(context.task.name)"

--- a/examples/v1/taskruns/workingdir.yaml
+++ b/examples/v1/taskruns/workingdir.yaml
@@ -6,14 +6,14 @@ spec:
   taskSpec:
     steps:
     - name: default
-      image: mirror.gcr.io/ubuntu
+      image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
       workingDir: /workspace
       script: |
         #!/usr/bin/env bash
         [[ $PWD == /workspace ]]
 
     - name: override
-      image: mirror.gcr.io/ubuntu
+      image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
       workingDir: '/a/path/too/far'
       script: |
         #!/usr/bin/env bash

--- a/examples/v1/taskruns/workspace-readonly.yaml
+++ b/examples/v1/taskruns/workspace-readonly.yaml
@@ -29,19 +29,19 @@ spec:
       readOnly: true
     steps:
     - name: write-allowed
-      image: mirror.gcr.io/ubuntu
+      image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
       script: echo "hello" > $(workspaces.write-allowed.path)/foo
     - name: read-allowed
-      image: mirror.gcr.io/ubuntu
+      image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
       script: cat $(workspaces.write-allowed.path)/foo | grep "hello"
     - name: write-disallowed
-      image: mirror.gcr.io/ubuntu
+      image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
       script:
         echo "goodbye" > $(workspaces.write-disallowed.path)/foo || touch write-failed.txt
         test -f write-failed.txt
     - name: read-again
       # We should get "hello" when reading again because writing "goodbye" to
       # the file should have been disallowed.
-      image: mirror.gcr.io/ubuntu
+      image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
       script:
         cat $(workspaces.write-disallowed.path)/foo | grep "hello"

--- a/examples/v1/taskruns/workspace-volume.yaml
+++ b/examples/v1/taskruns/workspace-volume.yaml
@@ -6,14 +6,14 @@ spec:
   taskSpec:
     steps:
     - name: write
-      image: mirror.gcr.io/ubuntu
+      image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
       script: echo some stuff > /workspace/stuff
     - name: read
-      image: mirror.gcr.io/ubuntu
+      image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
       script: cat /workspace/stuff
 
     - name: override-workspace
-      image: mirror.gcr.io/ubuntu
+      image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
       # /workspace/stuff *doesn't* exist.
       script: |
         #!/usr/bin/env bash

--- a/examples/v1/taskruns/workspace-with-volumeClaimTemplate.yaml
+++ b/examples/v1/taskruns/workspace-with-volumeClaimTemplate.yaml
@@ -6,7 +6,7 @@ spec:
   taskSpec:
     steps:
       - name: list-files
-        image: mirror.gcr.io/ubuntu
+        image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
         script: ls $(workspaces.read-allowed.path)
     workspaces:
       - name: read-allowed

--- a/examples/v1/taskruns/workspace.yaml
+++ b/examples/v1/taskruns/workspace.yaml
@@ -55,28 +55,28 @@ spec:
   taskSpec:
     steps:
     - name: write
-      image: mirror.gcr.io/ubuntu
+      image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
       script: echo $(workspaces.custom.volume) > $(workspaces.custom.path)/foo
     - name: read
-      image: mirror.gcr.io/ubuntu
+      image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
       script: cat $(workspaces.custom.path)/foo | grep $(workspaces.custom.volume)
     - name: write2
-      image: mirror.gcr.io/ubuntu
+      image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
       script: echo $(workspaces.custom2.path) > $(workspaces.custom2.path)/foo
     - name: read2
-      image: mirror.gcr.io/ubuntu
+      image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
       script: cat $(workspaces.custom2.path)/foo | grep $(workspaces.custom2.path)
     - name: write3
-      image: mirror.gcr.io/ubuntu
+      image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
       script: echo $(workspaces.custom3.path) > $(workspaces.custom3.path)/foo
     - name: read3
-      image: mirror.gcr.io/ubuntu
+      image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
       script: cat $(workspaces.custom3.path)/foo | grep $(workspaces.custom3.path)
     - name: readconfigmap
-      image: mirror.gcr.io/ubuntu
+      image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
       script: cat $(workspaces.custom4.path)/my-message.txt | grep "hello world"
     - name: readsecret
-      image: mirror.gcr.io/ubuntu
+      image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
       script: |
         #!/usr/bin/env bash
         set -xe


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Pin **Ubuntu** container image references from tags to digests in the **`examples/v1/taskruns`** directory (excluding alpha/, beta/ and no-ci/) to mitigate registry rate limiting during e2e tests.

1. Discovered the affected files using the command `grep -rn "image:" examples/ | grep -v "@sha256:" | grep -v "\\$(" | grep -v "KO_DOCKER_REPO"`
2. Generated digest for `mirror.gcr.io/ubuntu`
```bash
crane digest mirror.gcr.io/ubuntu
sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932

```
3. Pin image references to digest
**Ubuntu**
```
OLD
image: mirror.gcr.io/ubuntu
NEW
image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
```
4. Files Updated:

- examples/v1/taskruns/configmap.yaml
- examples/v1/taskruns/custom-env.yaml
- examples/v1/taskruns/custom-volume.yaml
- examples/v1/taskruns/default_task_params.yaml
- examples/v1/taskruns/entrypoint-resolution.yaml
- examples/v1/taskruns/home-is-set.yaml
- examples/v1/taskruns/home-volume.yaml
- examples/v1/taskruns/propagating_params_implicit.yaml
- examples/v1/taskruns/propagating_workspaces.yaml
- examples/v1/taskruns/readonly-internal-dir.yaml
- examples/v1/taskruns/run-steps-as-non-root.yaml
- examples/v1/taskruns/secret-env.yaml
- examples/v1/taskruns/secret-volume-params.yaml
- examples/v1/taskruns/secret-volume.yaml
- examples/v1/taskruns/sidecar-interp.yaml
- examples/v1/taskruns/sidecar-ready-script.yaml
- examples/v1/taskruns/sidecar-ready.yaml
- examples/v1/taskruns/stepaction-params.yaml
- examples/v1/taskruns/steptemplate-env-merge.yaml
- examples/v1/taskruns/task-volume-args.yaml
- examples/v1/taskruns/template-volume.yaml
- examples/v1/taskruns/unnamed-steps.yaml
- examples/v1/taskruns/using_context_variables.yaml
- examples/v1/taskruns/workingdir.yaml
- examples/v1/taskruns/workspace-readonly.yaml
- examples/v1/taskruns/workspace-volume.yaml
- examples/v1/taskruns/workspace-with-volumeClaimTemplate.yaml
- examples/v1/taskruns/workspace.yaml


Fixes issue #9084 


# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
/kind flake