### PR TITLE
fix: Pin Ubuntu,Bash,Python, Node & Perl container images to digests in examples/v1/taskruns/step-script.yaml

### DIFF
--- a/examples/v1/taskruns/step-script.yaml
+++ b/examples/v1/taskruns/step-script.yaml
@@ -71,7 +71,7 @@ spec:
         print("Hello from Python!")
 
     - name: perl
-      image: mirror.gcr.io/perl:@sha256:e1ec4246c431a86d251de5b5966983d0782ba5a9be955c530d85cfc5ebec2ca2
+      image: mirror.gcr.io/perl@sha256:e1ec4246c431a86d251de5b5966983d0782ba5a9be955c530d85cfc5ebec2ca2
       script: |
         #!/usr/bin/perl
         print "Hello from Perl!"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

to mitigate registry rate limiting during e2e tests, below changes were done:

- Pin **Ubuntu** container image references from tags to digests in the file **`examples/v1/taskruns/step-script.yaml`**
- Pin **Python** container image references from tags to digests in the file **`examples/v1/taskruns/step-script.yaml`**
- Pin **Bash** container image references from tags to digests in the file **`examples/v1/taskruns/step-script.yaml`**
- Pin **Node** container image references from tags to digests in the file **`examples/v1/taskruns/step-script.yaml`**
- Pin **Perl** container image references from tags to digests in the file **`examples/v1/taskruns/step-script.yaml`**

1. Identified the affected file `examples/v1/taskruns/step-script.yaml` using the command `grep -rn "image:" examples/ | grep -v "@sha256:" | grep -v "\\$(" | grep -v "KO_DOCKER_REPO"`
2. Generated digest 
```bash
crane digest mirror.gcr.io/ubuntu
sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932

crane digest mirror.gcr.io/python:3.12.4
sha256:e8be0ea148390d08bc077840cf87ac6a538d80b0ea1e8752b3e3982987cd0a53

crane digest mirror.gcr.io/bash
sha256:e320b40b14abc61f053286705070342c46034a549a276b798e64541457c4af92

crane digest mirror.gcr.io/node:lts-alpine3.20
sha256:2289fb1fba0f4633b08ec47b94a89c7e20b829fc5679f9b7b298eaa2f1ed8b7e

crane digest mirror.gcr.io/perl:devel-bullseye
sha256:e1ec4246c431a86d251de5b5966983d0782ba5a9be955c530d85cfc5ebec2ca2
```


3. Pin image references to digest

**Ubuntu**
```
OLD
image: mirror.gcr.io/ubuntu
NEW
image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932

```


**Python**
```
OLD
image: mirror.gcr.io/python:3.12.4
NEW
image: mirror.gcr.io/python@sha256:e8be0ea148390d08bc077840cf87ac6a538d80b0ea1e8752b3e3982987cd0a53
```

**Bash**
```
OLD
image: mirror.gcr.io/bash

NEW
image: mirror.gcr.io/bash@sha256:e320b40b14abc61f053286705070342c46034a549a276b798e64541457c4af92

```

**Node**
```
OLD
image: mirror.gcr.io/node:lts-alpine3.20

NEW
image: mirror.gcr.io/node@sha256:2289fb1fba0f4633b08ec47b94a89c7e20b829fc5679f9b7b298eaa2f1ed8b7e

```

**Perl**

```
OLD
image: mirror.gcr.io/perl:devel-bullseye

NEW
image: mirror.gcr.io/perl@sha256:e1ec4246c431a86d251de5b5966983d0782ba5a9be955c530d85cfc5ebec2ca2

```
4. Files Updated:

- examples/v1/taskruns/step-script.yaml


Fixes issue #9084 


# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```

/kind flake