### PR TITLE
Re-enable pipeline-api.md generation

### DIFF
--- a/docs/pipeline-api.md
+++ b/docs/pipeline-api.md
@@ -857,6 +857,21 @@ with those declared in the pipeline.</p>
 <p>TaskRunSpecs holds a set of runtime specs</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>managedBy</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ManagedBy indicates which controller is responsible for reconciling
+this resource. If unset or set to &ldquo;tekton.dev/pipeline&rdquo;, the default
+Tekton controller will manage this resource.
+This field is immutable.</p>
+</td>
+</tr>
 </table>
 </td>
 </tr>
@@ -998,8 +1013,8 @@ source mounted into /workspace.</p>
 <td>
 <code>volumes</code><br/>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#volume-v1-core">
-[]Kubernetes core/v1.Volume
+<a href="#tekton.dev/v1.Volumes">
+Volumes
 </a>
 </em>
 </td>
@@ -1255,8 +1270,8 @@ Refer Go&rsquo;s ParseDuration documentation for expected format: <a href="https
 <td>
 <code>podTemplate</code><br/>
 <em>
-<a href="#tekton.dev/unversioned.Template">
-Template
+<a href="#tekton.dev/unversioned.PodTemplate">
+PodTemplate
 </a>
 </em>
 </td>
@@ -1325,6 +1340,21 @@ Kubernetes core/v1.ResourceRequirements
 <p>Compute resources to use for this TaskRun</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>managedBy</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ManagedBy indicates which controller is responsible for reconciling
+this resource. If unset or set to &ldquo;tekton.dev/pipeline&rdquo;, the default
+Tekton controller will manage this resource.
+This field is immutable.</p>
+</td>
+</tr>
 </table>
 </td>
 </tr>
@@ -1351,11 +1381,11 @@ TaskRunStatus
 <h3 id="tekton.dev/v1.Artifact">Artifact
 </h3>
 <p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.Artifacts">Artifacts</a>, <a href="#tekton.dev/v1.StepState">StepState</a>)
+(<em>Appears on:</em><a href="#tekton.dev/v1.Artifacts">Artifacts</a>)
 </p>
 <div>
-<p>TaskRunStepArtifact represents an artifact produced or used by a step within a task run.
-It directly uses the Artifact type for its structure.</p>
+<p>Artifact represents an artifact within a system, potentially containing multiple values
+associated with it.</p>
 </div>
 <table>
 <thead>
@@ -1581,7 +1611,9 @@ string
 <td>
 <code>spec</code><br/>
 <em>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime#RawExtension">
 k8s.io/apimachinery/pkg/runtime.RawExtension
+</a>
 </em>
 </td>
 <td>
@@ -1606,7 +1638,9 @@ k8s.io/apimachinery/pkg/runtime.RawExtension
 <td>
 <code>-</code><br/>
 <em>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime#Object">
 k8s.io/apimachinery/pkg/runtime.Object
+</a>
 </em>
 </td>
 <td>
@@ -1934,10 +1968,12 @@ Used to distinguish between a single string and an array of strings.</p>
 <h3 id="tekton.dev/v1.ParamValue">ParamValue
 </h3>
 <p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.Param">Param</a>, <a href="#tekton.dev/v1.ParamSpec">ParamSpec</a>, <a href="#tekton.dev/v1.PipelineResult">PipelineResult</a>, <a href="#tekton.dev/v1.PipelineRunResult">PipelineRunResult</a>, <a href="#tekton.dev/v1.TaskResult">TaskResult</a>, <a href="#tekton.dev/v1.TaskRunResult">TaskRunResult</a>)
+(<em>Appears on:</em><a href="#tekton.dev/v1.Param">Param</a>, <a href="#tekton.dev/v1.ParamSpec">ParamSpec</a>)
 </p>
 <div>
-<p>ResultValue is a type alias of ParamValue</p>
+<p>ParamValue is a type that can hold a single string, string array, or string map.
+Used in JSON unmarshalling so that a single JSON field can accept
+either an individual string or an array of strings.</p>
 </div>
 <table>
 <thead>
@@ -2115,8 +2151,8 @@ string
 <td>
 <code>value</code><br/>
 <em>
-<a href="#tekton.dev/v1.ParamValue">
-ParamValue
+<a href="#tekton.dev/v1.ResultValue">
+ResultValue
 </a>
 </em>
 </td>
@@ -2298,8 +2334,8 @@ string
 <td>
 <code>value</code><br/>
 <em>
-<a href="#tekton.dev/v1.ParamValue">
-ParamValue
+<a href="#tekton.dev/v1.ResultValue">
+ResultValue
 </a>
 </em>
 </td>
@@ -2493,6 +2529,21 @@ with those declared in the pipeline.</p>
 <td>
 <em>(Optional)</em>
 <p>TaskRunSpecs holds a set of runtime specs</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>managedBy</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ManagedBy indicates which controller is responsible for reconciling
+this resource. If unset or set to &ldquo;tekton.dev/pipeline&rdquo;, the default
+Tekton controller will manage this resource.
+This field is immutable.</p>
 </td>
 </tr>
 </tbody>
@@ -3044,7 +3095,7 @@ Kubernetes meta/v1.Duration
 </td>
 <td>
 <em>(Optional)</em>
-<p>Time after which the TaskRun times out. Defaults to 1 hour.
+<p>Duration after which the TaskRun times out. Defaults to 1 hour.
 Refer Go&rsquo;s ParseDuration documentation for expected format: <a href="https://golang.org/pkg/time/#ParseDuration">https://golang.org/pkg/time/#ParseDuration</a></p>
 </td>
 </tr>
@@ -3264,8 +3315,8 @@ string
 <td>
 <code>podTemplate</code><br/>
 <em>
-<a href="#tekton.dev/unversioned.Template">
-Template
+<a href="#tekton.dev/unversioned.PodTemplate">
+PodTemplate
 </a>
 </em>
 </td>
@@ -3333,7 +3384,9 @@ Kubernetes meta/v1.Duration
 </td>
 <td>
 <em>(Optional)</em>
-<p>Time after which the TaskRun times out.
+<p>Duration after which the TaskRun times out. Overrides the timeout specified
+on the Task&rsquo;s spec if specified. Takes lower precedence to PipelineRun&rsquo;s
+<code>spec.timeouts.tasks</code>
 Refer Go&rsquo;s ParseDuration documentation for expected format: <a href="https://golang.org/pkg/time/#ParseDuration">https://golang.org/pkg/time/#ParseDuration</a></p>
 </td>
 </tr>
@@ -3359,8 +3412,8 @@ Refer Go&rsquo;s ParseDuration documentation for expected format: <a href="https
 <td>
 <code>podTemplate</code><br/>
 <em>
-<a href="#tekton.dev/unversioned.Template">
-Template
+<a href="#tekton.dev/unversioned.PodTemplate">
+PodTemplate
 </a>
 </em>
 </td>
@@ -3387,9 +3440,8 @@ string
 (<em>Appears on:</em><a href="#tekton.dev/v1.PipelineSpec">PipelineSpec</a>)
 </p>
 <div>
-<p>WorkspacePipelineDeclaration creates a named slot in a Pipeline that a PipelineRun
+<p>PipelineWorkspaceDeclaration creates a named slot in a Pipeline that a PipelineRun
 is expected to populate with a workspace binding.</p>
-<p>Deprecated: use PipelineWorkspaceDeclaration type instead</p>
 </div>
 <table>
 <thead>
@@ -3609,7 +3661,7 @@ string
 <td>
 <p>EntryPoint identifies the entry point into the build. This is often a path to a
 build definition file and/or a target label within that file.
-Example: &ldquo;task/git-clone/0.8/git-clone.yaml&rdquo;</p>
+Example: &ldquo;task/git-clone/0.10/git-clone.yaml&rdquo;</p>
 </td>
 </tr>
 </tbody>
@@ -3730,6 +3782,14 @@ string
 </tr>
 </tbody>
 </table>
+<h3 id="tekton.dev/v1.ResultValue">ResultValue
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineResult">PipelineResult</a>, <a href="#tekton.dev/v1.PipelineRunResult">PipelineRunResult</a>, <a href="#tekton.dev/v1.TaskResult">TaskResult</a>, <a href="#tekton.dev/v1.TaskRunResult">TaskRunResult</a>)
+</p>
+<div>
+<p>ResultValue is a type alias of ParamValue</p>
+</div>
 <h3 id="tekton.dev/v1.ResultsType">ResultsType
 (<code>string</code> alias)</h3>
 <p>
@@ -3757,6 +3817,13 @@ this ResultsType.</p>
 <td></td>
 </tr></tbody>
 </table>
+<h3 id="tekton.dev/v1.RetriesStatus">RetriesStatus
+(<code>[]github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.TaskRunStatus</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.TaskRunStatusFields">TaskRunStatusFields</a>)
+</p>
+<div>
+</div>
 <h3 id="tekton.dev/v1.Sidecar">Sidecar
 </h3>
 <p>
@@ -4717,8 +4784,8 @@ The Results declared by the StepActions will be stored here instead.</p>
 <td>
 <code>when</code><br/>
 <em>
-<a href="#tekton.dev/v1.WhenExpressions">
-WhenExpressions
+<a href="#tekton.dev/v1.StepWhenExpressions">
+StepWhenExpressions
 </a>
 </em>
 </td>
@@ -4893,8 +4960,8 @@ string
 <td>
 <code>results</code><br/>
 <em>
-<a href="#tekton.dev/v1.TaskRunResult">
-[]TaskRunResult
+<a href="#tekton.dev/v1.TaskRunStepResult">
+[]TaskRunStepResult
 </a>
 </em>
 </td>
@@ -4927,8 +4994,8 @@ string
 <td>
 <code>inputs</code><br/>
 <em>
-<a href="#tekton.dev/v1.Artifact">
-[]Artifact
+<a href="#tekton.dev/v1.TaskRunStepArtifact">
+[]TaskRunStepArtifact
 </a>
 </em>
 </td>
@@ -4939,8 +5006,8 @@ string
 <td>
 <code>outputs</code><br/>
 <em>
-<a href="#tekton.dev/v1.Artifact">
-[]Artifact
+<a href="#tekton.dev/v1.TaskRunStepArtifact">
+[]TaskRunStepArtifact
 </a>
 </em>
 </td>
@@ -5146,6 +5213,13 @@ More info: <a href="https://kubernetes.io/docs/tasks/configure-pod-container/sec
 </tr>
 </tbody>
 </table>
+<h3 id="tekton.dev/v1.StepWhenExpressions">StepWhenExpressions
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.Step">Step</a>)
+</p>
+<div>
+</div>
 <h3 id="tekton.dev/v1.TaskBreakpoints">TaskBreakpoints
 </h3>
 <p>
@@ -5353,8 +5427,8 @@ string
 <td>
 <code>value</code><br/>
 <em>
-<a href="#tekton.dev/v1.ParamValue">
-ParamValue
+<a href="#tekton.dev/v1.ResultValue">
+ResultValue
 </a>
 </em>
 </td>
@@ -5441,6 +5515,9 @@ reasons that emerge from underlying resources are not included here</p>
 <tbody><tr><td><p>&#34;TaskRunCancelled&#34;</p></td>
 <td><p>TaskRunReasonCancelled is the reason set when the TaskRun is cancelled by the user</p>
 </td>
+</tr><tr><td><p>&#34;CreateContainerConfigError&#34;</p></td>
+<td><p>TaskRunReasonCreateContainerConfigError is the reason set when the step of a task fails due to config error (e.g., missing ConfigMap or Secret)</p>
+</td>
 </tr><tr><td><p>&#34;Failed&#34;</p></td>
 <td><p>TaskRunReasonFailed is the reason set when the TaskRun completed with a failure</p>
 </td>
@@ -5461,6 +5538,9 @@ TaskRuns failed due to reconciler/validation error should not use this reason.</
 </td>
 </tr><tr><td><p>&#34;InvalidParamValue&#34;</p></td>
 <td><p>TaskRunReasonInvalidParamValue indicates that the TaskRun Param input value is not allowed.</p>
+</td>
+</tr><tr><td><p>&#34;PodCreationFailed&#34;</p></td>
+<td><p>TaskRunReasonPodCreationFailed is the reason set when the pod backing the TaskRun fails to be created (e.g., CreateContainerError)</p>
 </td>
 </tr><tr><td><p>&#34;ResourceVerificationFailed&#34;</p></td>
 <td><p>TaskRunReasonResourceVerificationFailed indicates that the task fails the trusted resource verification,
@@ -5496,10 +5576,10 @@ that task failed runtime validation</p>
 <h3 id="tekton.dev/v1.TaskRunResult">TaskRunResult
 </h3>
 <p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.StepState">StepState</a>, <a href="#tekton.dev/v1.TaskRunStatusFields">TaskRunStatusFields</a>)
+(<em>Appears on:</em><a href="#tekton.dev/v1.TaskRunStatusFields">TaskRunStatusFields</a>)
 </p>
 <div>
-<p>TaskRunStepResult is a type alias of TaskRunResult</p>
+<p>TaskRunResult used to describe the results of a task</p>
 </div>
 <table>
 <thead>
@@ -5539,8 +5619,8 @@ is currently &ldquo;string&rdquo; and will support &ldquo;array&rdquo; in follow
 <td>
 <code>value</code><br/>
 <em>
-<a href="#tekton.dev/v1.ParamValue">
-ParamValue
+<a href="#tekton.dev/v1.ResultValue">
+ResultValue
 </a>
 </em>
 </td>
@@ -5734,8 +5814,8 @@ Refer Go&rsquo;s ParseDuration documentation for expected format: <a href="https
 <td>
 <code>podTemplate</code><br/>
 <em>
-<a href="#tekton.dev/unversioned.Template">
-Template
+<a href="#tekton.dev/unversioned.PodTemplate">
+PodTemplate
 </a>
 </em>
 </td>
@@ -5804,6 +5884,21 @@ Kubernetes core/v1.ResourceRequirements
 <p>Compute resources to use for this TaskRun</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>managedBy</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ManagedBy indicates which controller is responsible for reconciling
+this resource. If unset or set to &ldquo;tekton.dev/pipeline&rdquo;, the default
+Tekton controller will manage this resource.
+This field is immutable.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="tekton.dev/v1.TaskRunSpecStatus">TaskRunSpecStatus
@@ -5841,7 +5936,7 @@ TaskRun was a part of has been cancelled.</p>
 <h3 id="tekton.dev/v1.TaskRunStatus">TaskRunStatus
 </h3>
 <p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.TaskRun">TaskRun</a>, <a href="#tekton.dev/v1.PipelineRunTaskRunStatus">PipelineRunTaskRunStatus</a>, <a href="#tekton.dev/v1.TaskRunStatusFields">TaskRunStatusFields</a>)
+(<em>Appears on:</em><a href="#tekton.dev/v1.TaskRun">TaskRun</a>, <a href="#tekton.dev/v1.PipelineRunTaskRunStatus">PipelineRunTaskRunStatus</a>)
 </p>
 <div>
 <p>TaskRunStatus defines the observed state of TaskRun</p>
@@ -5960,8 +6055,8 @@ Kubernetes meta/v1.Time
 <td>
 <code>retriesStatus</code><br/>
 <em>
-<a href="#tekton.dev/v1.TaskRunStatus">
-[]TaskRunStatus
+<a href="#tekton.dev/v1.RetriesStatus">
+RetriesStatus
 </a>
 </em>
 </td>
@@ -6053,6 +6148,23 @@ map[string]string
 </tr>
 </tbody>
 </table>
+<h3 id="tekton.dev/v1.TaskRunStepArtifact">TaskRunStepArtifact
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.StepState">StepState</a>)
+</p>
+<div>
+<p>TaskRunStepArtifact represents an artifact produced or used by a step within a task run.
+It directly uses the Artifact type for its structure.</p>
+</div>
+<h3 id="tekton.dev/v1.TaskRunStepResult">TaskRunStepResult
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.StepState">StepState</a>)
+</p>
+<div>
+<p>TaskRunStepResult is a type alias of TaskRunResult</p>
+</div>
 <h3 id="tekton.dev/v1.TaskRunStepSpec">TaskRunStepSpec
 </h3>
 <p>
@@ -6171,8 +6283,8 @@ source mounted into /workspace.</p>
 <td>
 <code>volumes</code><br/>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#volume-v1-core">
-[]Kubernetes core/v1.Volume
+<a href="#tekton.dev/v1.Volumes">
+Volumes
 </a>
 </em>
 </td>
@@ -6295,6 +6407,13 @@ Kubernetes meta/v1.Duration
 </tr>
 </tbody>
 </table>
+<h3 id="tekton.dev/v1.Volumes">Volumes
+(<code>[]k8s.io/api/core/v1.Volume</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.TaskSpec">TaskSpec</a>)
+</p>
+<div>
+</div>
 <h3 id="tekton.dev/v1.WhenExpression">WhenExpression
 </h3>
 <p>
@@ -6327,7 +6446,9 @@ string
 <td>
 <code>operator</code><br/>
 <em>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/selection#Operator">
 k8s.io/apimachinery/pkg/selection.Operator
+</a>
 </em>
 </td>
 <td>
@@ -6365,7 +6486,7 @@ More info about CEL syntax: <a href="https://github.com/google/cel-spec/blob/mas
 <h3 id="tekton.dev/v1.WhenExpressions">WhenExpressions
 (<code>[]github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.WhenExpression</code> alias)</h3>
 <p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineTask">PipelineTask</a>, <a href="#tekton.dev/v1.Step">Step</a>)
+(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineTask">PipelineTask</a>)
 </p>
 <div>
 <p>WhenExpressions are used to specify whether a Task should be executed or skipped
@@ -6593,6 +6714,13 @@ this field is false and so declared workspaces are required.</p>
 </tr>
 </tbody>
 </table>
+<h3 id="tekton.dev/v1.WorkspacePipelineDeclaration">WorkspacePipelineDeclaration
+</h3>
+<div>
+<p>WorkspacePipelineDeclaration creates a named slot in a Pipeline that a PipelineRun
+is expected to populate with a workspace binding.</p>
+<p>Deprecated: use PipelineWorkspaceDeclaration type instead</p>
+</div>
 <h3 id="tekton.dev/v1.WorkspacePipelineTaskBinding">WorkspacePipelineTaskBinding
 </h3>
 <p>
@@ -6863,8 +6991,8 @@ string
 <td>
 <code>podTemplate</code><br/>
 <em>
-<a href="#tekton.dev/unversioned.Template">
-Template
+<a href="#tekton.dev/unversioned.PodTemplate">
+PodTemplate
 </a>
 </em>
 </td>
@@ -7343,7 +7471,9 @@ used to populate a UI.</p>
 <td>
 <code>type</code><br/>
 <em>
-string
+<a href="#tekton.dev/v1alpha1.PipelineResourceType">
+PipelineResourceType
+</a>
 </em>
 </td>
 <td>
@@ -7470,7 +7600,9 @@ PipelineTaskMetadata
 <td>
 <code>spec</code><br/>
 <em>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime#RawExtension">
 k8s.io/apimachinery/pkg/runtime.RawExtension
+</a>
 </em>
 </td>
 <td>
@@ -7495,7 +7627,9 @@ k8s.io/apimachinery/pkg/runtime.RawExtension
 <td>
 <code>-</code><br/>
 <em>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime#Object">
 k8s.io/apimachinery/pkg/runtime.Object
+</a>
 </em>
 </td>
 <td>
@@ -7637,6 +7771,11 @@ Hub resource: <a href="https://artifacthub.io/*">https://artifacthub.io/*</a>,</
 <div>
 <p>RunReason is an enum used to store all Run reason for the Succeeded condition that are controlled by the Run itself.</p>
 </div>
+<h3 id="tekton.dev/v1alpha1.RunResult">RunResult
+</h3>
+<div>
+<p>RunResult used to describe the results of a task</p>
+</div>
 <h3 id="tekton.dev/v1alpha1.RunSpec">RunSpec
 </h3>
 <p>
@@ -7752,8 +7891,8 @@ string
 <td>
 <code>podTemplate</code><br/>
 <em>
-<a href="#tekton.dev/unversioned.Template">
-Template
+<a href="#tekton.dev/unversioned.PodTemplate">
+PodTemplate
 </a>
 </em>
 </td>
@@ -7808,6 +7947,21 @@ Refer Go&rsquo;s ParseDuration documentation for expected format: <a href="https
 </p>
 <div>
 <p>RunSpecStatusMessage defines human readable status messages for the TaskRun.</p>
+</div>
+<h3 id="tekton.dev/v1alpha1.RunStatus">RunStatus
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1alpha1.Run">Run</a>)
+</p>
+<div>
+<p>RunStatus defines the observed state of Run.</p>
+</div>
+<h3 id="tekton.dev/v1alpha1.RunStatusFields">RunStatusFields
+</h3>
+<div>
+<p>RunStatusFields holds the fields of Run&rsquo;s status.  This is defined
+separately and inlined so that other types can readily consume these fields
+via duck typing.</p>
 </div>
 <h3 id="tekton.dev/v1alpha1.StepActionObject">StepActionObject
 </h3>
@@ -8097,7 +8251,9 @@ used to populate a UI.</p>
 <td>
 <code>type</code><br/>
 <em>
-string
+<a href="#tekton.dev/v1alpha1.PipelineResourceType">
+PipelineResourceType
+</a>
 </em>
 </td>
 <td>
@@ -8141,11 +8297,19 @@ string
 do not have a status</p>
 <p>Deprecated: Unused, preserved only for backwards compatibility</p>
 </div>
-<h3 id="tekton.dev/v1alpha1.ResourceDeclaration">ResourceDeclaration
+<h3 id="tekton.dev/v1alpha1.PipelineResourceType">PipelineResourceType
 </h3>
 <p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskResource">TaskResource</a>)
+(<em>Appears on:</em><a href="#tekton.dev/v1alpha1.PipelineResourceSpec">PipelineResourceSpec</a>, <a href="#tekton.dev/v1alpha1.ResourceDeclaration">ResourceDeclaration</a>)
 </p>
+<div>
+<p>PipelineResourceType represents the type of endpoint the pipelineResource is, so that the
+controller will know this pipelineResource shouldx be fetched and optionally what
+additional metatdata should be provided for it.</p>
+<p>Deprecated: Unused, preserved only for backwards compatibility</p>
+</div>
+<h3 id="tekton.dev/v1alpha1.ResourceDeclaration">ResourceDeclaration
+</h3>
 <div>
 <p>ResourceDeclaration defines an input or output PipelineResource declared as a requirement
 by another type such as a Task or Condition. The Name field will be used to refer to these
@@ -8179,7 +8343,9 @@ Task&rsquo;s steps.</p>
 <td>
 <code>type</code><br/>
 <em>
-string
+<a href="#tekton.dev/v1alpha1.PipelineResourceType">
+PipelineResourceType
+</a>
 </em>
 </td>
 <td>
@@ -8360,7 +8526,7 @@ string
 <h3 id="tekton.dev/v1alpha1.RunStatus">RunStatus
 </h3>
 <p>
-(<em>Appears on:</em><a href="#tekton.dev/v1alpha1.Run">Run</a>, <a href="#tekton.dev/v1alpha1.RunStatusFields">RunStatusFields</a>)
+(<em>Appears on:</em><a href="#tekton.dev/v1alpha1.RunStatusFields">RunStatusFields</a>)
 </p>
 <div>
 <p>RunStatus defines the observed state of Run</p>
@@ -8485,7 +8651,9 @@ tasks in a pipeline.</p>
 <td>
 <code>extraFields</code><br/>
 <em>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime#RawExtension">
 k8s.io/apimachinery/pkg/runtime.RawExtension
+</a>
 </em>
 </td>
 <td>
@@ -9073,8 +9241,8 @@ Refer to Go&rsquo;s ParseDuration documentation for expected format: <a href="ht
 <td>
 <code>podTemplate</code><br/>
 <em>
-<a href="#tekton.dev/unversioned.Template">
-Template
+<a href="#tekton.dev/unversioned.PodTemplate">
+PodTemplate
 </a>
 </em>
 </td>
@@ -9109,6 +9277,21 @@ with those declared in the pipeline.</p>
 <td>
 <em>(Optional)</em>
 <p>TaskRunSpecs holds a set of runtime specs</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>managedBy</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ManagedBy indicates which controller is responsible for reconciling
+this resource. If unset or set to &ldquo;tekton.dev/pipeline&rdquo;, the default
+Tekton controller will manage this resource.
+This field is immutable.</p>
 </td>
 </tr>
 </table>
@@ -9239,7 +9422,9 @@ More info: <a href="https://kubernetes.io/docs/tasks/inject-data-application/def
 <td>
 <code>args</code><br/>
 <em>
-[]string
+<a href="#tekton.dev/v1beta1.Args">
+Args
+</a>
 </em>
 </td>
 <td>
@@ -9504,8 +9689,8 @@ source mounted into /workspace.</p>
 <td>
 <code>volumes</code><br/>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#volume-v1-core">
-[]Kubernetes core/v1.Volume
+<a href="#tekton.dev/v1beta1.Volumes">
+Volumes
 </a>
 </em>
 </td>
@@ -9776,8 +9961,8 @@ Refer Go&rsquo;s ParseDuration documentation for expected format: <a href="https
 <td>
 <code>podTemplate</code><br/>
 <em>
-<a href="#tekton.dev/unversioned.Template">
-Template
+<a href="#tekton.dev/unversioned.PodTemplate">
+PodTemplate
 </a>
 </em>
 </td>
@@ -9846,6 +10031,21 @@ Kubernetes core/v1.ResourceRequirements
 <p>Compute resources to use for this TaskRun</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>managedBy</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ManagedBy indicates which controller is responsible for reconciling
+this resource. If unset or set to &ldquo;tekton.dev/pipeline&rdquo;, the default
+Tekton controller will manage this resource.
+This field is immutable.</p>
+</td>
+</tr>
 </table>
 </td>
 </tr>
@@ -9869,14 +10069,27 @@ TaskRunStatus
 <div>
 <p>Algorithm Standard cryptographic hash algorithm</p>
 </div>
+<h3 id="tekton.dev/v1beta1.Args">Args
+(<code>[]string</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.StepActionSpec">StepActionSpec</a>)
+</p>
+<div>
+</div>
+<h3 id="tekton.dev/v1beta1.ArrayOrString">ArrayOrString
+</h3>
+<div>
+<p>ArrayOrString is deprecated, this is to keep backward compatibility</p>
+<p>Deprecated: Use ParamValue instead.</p>
+</div>
 <h3 id="tekton.dev/v1beta1.Artifact">Artifact
 </h3>
 <p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.Artifacts">Artifacts</a>, <a href="#tekton.dev/v1beta1.StepState">StepState</a>)
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.Artifacts">Artifacts</a>)
 </p>
 <div>
-<p>TaskRunStepArtifact represents an artifact produced or used by a step within a task run.
-It directly uses the Artifact type for its structure.</p>
+<p>Artifact represents an artifact within a system, potentially containing multiple values
+associated with it.</p>
 </div>
 <table>
 <thead>
@@ -10248,7 +10461,7 @@ string
 <td>
 <p>EntryPoint identifies the entry point into the build. This is often a path to a
 build definition file and/or a target label within that file.
-Example: &ldquo;task/git-clone/0.8/git-clone.yaml&rdquo;</p>
+Example: &ldquo;task/git-clone/0.10/git-clone.yaml&rdquo;</p>
 </td>
 </tr>
 </tbody>
@@ -10257,6 +10470,11 @@ Example: &ldquo;task/git-clone/0.8/git-clone.yaml&rdquo;</p>
 (<code>string</code> alias)</h3>
 <div>
 <p>CustomRunReason is an enum used to store all Run reason for the Succeeded condition that are controlled by the CustomRun itself.</p>
+</div>
+<h3 id="tekton.dev/v1beta1.CustomRunResult">CustomRunResult
+</h3>
+<div>
+<p>CustomRunResult used to describe the results of a task</p>
 </div>
 <h3 id="tekton.dev/v1beta1.CustomRunSpec">CustomRunSpec
 </h3>
@@ -10412,6 +10630,21 @@ Refer Go&rsquo;s ParseDuration documentation for expected format: <a href="https
 <div>
 <p>CustomRunSpecStatusMessage defines human readable status messages for the TaskRun.</p>
 </div>
+<h3 id="tekton.dev/v1beta1.CustomRunStatus">CustomRunStatus
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.CustomRun">CustomRun</a>, <a href="#tekton.dev/v1beta1.PipelineRunRunStatus">PipelineRunRunStatus</a>)
+</p>
+<div>
+<p>CustomRunStatus defines the observed state of CustomRun.</p>
+</div>
+<h3 id="tekton.dev/v1beta1.CustomRunStatusFields">CustomRunStatusFields
+</h3>
+<div>
+<p>CustomRunStatusFields holds the fields of CustomRun&rsquo;s status.  This is defined
+separately and inlined so that other types can readily consume these fields
+via duck typing.</p>
+</div>
 <h3 id="tekton.dev/v1beta1.EmbeddedCustomRunSpec">EmbeddedCustomRunSpec
 </h3>
 <p>
@@ -10445,7 +10678,9 @@ PipelineTaskMetadata
 <td>
 <code>spec</code><br/>
 <em>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime#RawExtension">
 k8s.io/apimachinery/pkg/runtime.RawExtension
+</a>
 </em>
 </td>
 <td>
@@ -10470,7 +10705,9 @@ k8s.io/apimachinery/pkg/runtime.RawExtension
 <td>
 <code>-</code><br/>
 <em>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime#Object">
 k8s.io/apimachinery/pkg/runtime.Object
+</a>
 </em>
 </td>
 <td>
@@ -10503,7 +10740,9 @@ structs.</p>
 <td>
 <code>spec</code><br/>
 <em>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime#RawExtension">
 k8s.io/apimachinery/pkg/runtime.RawExtension
+</a>
 </em>
 </td>
 <td>
@@ -10528,7 +10767,9 @@ k8s.io/apimachinery/pkg/runtime.RawExtension
 <td>
 <code>-</code><br/>
 <em>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime#Object">
 k8s.io/apimachinery/pkg/runtime.Object
+</a>
 </em>
 </td>
 <td>
@@ -10878,10 +11119,12 @@ Used to distinguish between a single string and an array of strings.</p>
 <h3 id="tekton.dev/v1beta1.ParamValue">ParamValue
 </h3>
 <p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.Param">Param</a>, <a href="#tekton.dev/v1beta1.ParamSpec">ParamSpec</a>, <a href="#tekton.dev/v1beta1.PipelineResult">PipelineResult</a>, <a href="#tekton.dev/v1beta1.PipelineRunResult">PipelineRunResult</a>, <a href="#tekton.dev/v1beta1.TaskResult">TaskResult</a>, <a href="#tekton.dev/v1beta1.TaskRunResult">TaskRunResult</a>)
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.Param">Param</a>, <a href="#tekton.dev/v1beta1.ParamSpec">ParamSpec</a>)
 </p>
 <div>
-<p>ResultValue is a type alias of ParamValue</p>
+<p>ParamValue is a type that can hold a single string or string array.
+Used in JSON unmarshalling so that a single JSON field can accept
+either an individual string or an array of strings.</p>
 </div>
 <table>
 <thead>
@@ -10981,7 +11224,9 @@ PipelineResources that will be bound in the PipelineRun.</p>
 <td>
 <code>type</code><br/>
 <em>
-string
+<a href="#tekton.dev/v1beta1.PipelineResourceType">
+PipelineResourceType
+</a>
 </em>
 </td>
 <td>
@@ -11188,6 +11433,26 @@ string
 </tr>
 </tbody>
 </table>
+<h3 id="tekton.dev/v1beta1.PipelineResourceResult">PipelineResourceResult
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskRunStatusFields">TaskRunStatusFields</a>)
+</p>
+<div>
+<p>PipelineResourceResult has been deprecated with the migration of PipelineResources
+Deprecated: Use RunResult instead</p>
+</div>
+<h3 id="tekton.dev/v1beta1.PipelineResourceType">PipelineResourceType
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineDeclaredResource">PipelineDeclaredResource</a>)
+</p>
+<div>
+<p>PipelineResourceType represents the type of endpoint the pipelineResource is, so that the
+controller will know this pipelineResource should be fetched and optionally what
+additional metatdata should be provided for it.</p>
+<p>Deprecated: Unused, preserved only for backwards compatibility</p>
+</div>
 <h3 id="tekton.dev/v1beta1.PipelineResult">PipelineResult
 </h3>
 <p>
@@ -11246,8 +11511,8 @@ string
 <td>
 <code>value</code><br/>
 <em>
-<a href="#tekton.dev/v1beta1.ParamValue">
-ParamValue
+<a href="#tekton.dev/v1beta1.ResultValue">
+ResultValue
 </a>
 </em>
 </td>
@@ -11293,8 +11558,8 @@ string
 <td>
 <code>value</code><br/>
 <em>
-<a href="#tekton.dev/v1beta1.ParamValue">
-ParamValue
+<a href="#tekton.dev/v1beta1.ResultValue">
+ResultValue
 </a>
 </em>
 </td>
@@ -11498,8 +11763,8 @@ Refer to Go&rsquo;s ParseDuration documentation for expected format: <a href="ht
 <td>
 <code>podTemplate</code><br/>
 <em>
-<a href="#tekton.dev/unversioned.Template">
-Template
+<a href="#tekton.dev/unversioned.PodTemplate">
+PodTemplate
 </a>
 </em>
 </td>
@@ -11534,6 +11799,21 @@ with those declared in the pipeline.</p>
 <td>
 <em>(Optional)</em>
 <p>TaskRunSpecs holds a set of runtime specs</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>managedBy</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ManagedBy indicates which controller is responsible for reconciling
+this resource. If unset or set to &ldquo;tekton.dev/pipeline&rdquo;, the default
+Tekton controller will manage this resource.
+This field is immutable.</p>
 </td>
 </tr>
 </tbody>
@@ -12149,7 +12429,7 @@ Kubernetes meta/v1.Duration
 </td>
 <td>
 <em>(Optional)</em>
-<p>Time after which the TaskRun times out. Defaults to 1 hour.
+<p>Duration after which the TaskRun times out. Defaults to 1 hour.
 Refer Go&rsquo;s ParseDuration documentation for expected format: <a href="https://golang.org/pkg/time/#ParseDuration">https://golang.org/pkg/time/#ParseDuration</a></p>
 </td>
 </tr>
@@ -12501,8 +12781,8 @@ string
 <td>
 <code>taskPodTemplate</code><br/>
 <em>
-<a href="#tekton.dev/unversioned.Template">
-Template
+<a href="#tekton.dev/unversioned.PodTemplate">
+PodTemplate
 </a>
 </em>
 </td>
@@ -12559,6 +12839,21 @@ Kubernetes core/v1.ResourceRequirements
 <p>Compute resources to use for this TaskRun</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>timeout</code><br/>
+<em>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+Kubernetes meta/v1.Duration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Duration after which the TaskRun times out.
+Refer Go&rsquo;s ParseDuration documentation for expected format: <a href="https://golang.org/pkg/time/#ParseDuration">https://golang.org/pkg/time/#ParseDuration</a></p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="tekton.dev/v1beta1.PipelineWorkspaceDeclaration">PipelineWorkspaceDeclaration
@@ -12567,9 +12862,8 @@ Kubernetes core/v1.ResourceRequirements
 (<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineSpec">PipelineSpec</a>)
 </p>
 <div>
-<p>WorkspacePipelineDeclaration creates a named slot in a Pipeline that a PipelineRun
+<p>PipelineWorkspaceDeclaration creates a named slot in a Pipeline that a PipelineRun
 is expected to populate with a workspace binding.</p>
-<p>Deprecated: use PipelineWorkspaceDeclaration type instead</p>
 </div>
 <table>
 <thead>
@@ -12802,7 +13096,7 @@ string
 <td>
 <p>EntryPoint identifies the entry point into the build. This is often a path to a
 build definition file and/or a target label within that file.
-Example: &ldquo;task/git-clone/0.8/git-clone.yaml&rdquo;</p>
+Example: &ldquo;task/git-clone/0.10/git-clone.yaml&rdquo;</p>
 </td>
 </tr>
 </tbody>
@@ -12867,6 +13161,26 @@ the chosen resolver.</p>
 </tr>
 </tbody>
 </table>
+<h3 id="tekton.dev/v1beta1.ResourceDeclaration">ResourceDeclaration
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskResource">TaskResource</a>)
+</p>
+<div>
+<p>ResourceDeclaration defines an input or output PipelineResource declared as a requirement
+by another type such as a Task or Condition. The Name field will be used to refer to these
+PipelineResources within the type&rsquo;s definition, and when provided as an Input, the Name will be the
+path to the volume mounted containing this PipelineResource as an input (e.g.
+an input Resource named <code>workspace</code> will be mounted at <code>/workspace</code>).</p>
+<p>Deprecated: Unused, preserved only for backwards compatibility</p>
+</div>
+<h3 id="tekton.dev/v1beta1.ResourceParam">ResourceParam
+</h3>
+<div>
+<p>ResourceParam declares a string value to use for the parameter called Name, and is used in
+the specific context of PipelineResources.</p>
+<p>Deprecated: Unused, preserved only for backwards compatibility</p>
+</div>
 <h3 id="tekton.dev/v1beta1.ResultRef">ResultRef
 </h3>
 <div>
@@ -12922,6 +13236,20 @@ string
 </tr>
 </tbody>
 </table>
+<h3 id="tekton.dev/v1beta1.ResultType">ResultType
+</h3>
+<div>
+<p>ResultType of PipelineResourceResult has been deprecated with the migration of PipelineResources
+Deprecated: v1beta1.ResultType is only kept for backward compatibility</p>
+</div>
+<h3 id="tekton.dev/v1beta1.ResultValue">ResultValue
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineResult">PipelineResult</a>, <a href="#tekton.dev/v1beta1.PipelineRunResult">PipelineRunResult</a>, <a href="#tekton.dev/v1beta1.TaskResult">TaskResult</a>, <a href="#tekton.dev/v1beta1.TaskRunResult">TaskRunResult</a>)
+</p>
+<div>
+<p>ResultValue is a type alias of ParamValue</p>
+</div>
 <h3 id="tekton.dev/v1beta1.ResultsType">ResultsType
 (<code>string</code> alias)</h3>
 <p>
@@ -12934,10 +13262,23 @@ Note that there is ResultType used to find out whether a
 RunResult is from a task result or not, which is different from
 this ResultsType.</p>
 </div>
+<h3 id="tekton.dev/v1beta1.RetriesStatus">RetriesStatus
+(<code>[]github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskRunStatus</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskRunStatusFields">TaskRunStatusFields</a>)
+</p>
+<div>
+</div>
 <h3 id="tekton.dev/v1beta1.RunObject">RunObject
 </h3>
 <div>
 <p>RunObject is implemented by CustomRun and Run</p>
+</div>
+<h3 id="tekton.dev/v1beta1.RunResult">RunResult
+</h3>
+<div>
+<p>RunResult is used to write key/value pairs to TaskRun pod termination messages.
+It has been migrated to the result package and kept for backward compatibility</p>
 </div>
 <h3 id="tekton.dev/v1beta1.Sidecar">Sidecar
 </h3>
@@ -14025,8 +14366,8 @@ The Results declared by the StepActions will be stored here instead.</p>
 <td>
 <code>when</code><br/>
 <em>
-<a href="#tekton.dev/v1beta1.WhenExpressions">
-WhenExpressions
+<a href="#tekton.dev/v1beta1.StepWhenExpressions">
+StepWhenExpressions
 </a>
 </em>
 </td>
@@ -14105,7 +14446,9 @@ More info: <a href="https://kubernetes.io/docs/tasks/inject-data-application/def
 <td>
 <code>args</code><br/>
 <em>
-[]string
+<a href="#tekton.dev/v1beta1.Args">
+Args
+</a>
 </em>
 </td>
 <td>
@@ -14321,8 +14664,8 @@ string
 <td>
 <code>results</code><br/>
 <em>
-<a href="#tekton.dev/v1beta1.TaskRunResult">
-[]TaskRunResult
+<a href="#tekton.dev/v1beta1.TaskRunStepResult">
+[]TaskRunStepResult
 </a>
 </em>
 </td>
@@ -14345,8 +14688,8 @@ Provenance
 <td>
 <code>inputs</code><br/>
 <em>
-<a href="#tekton.dev/v1beta1.Artifact">
-[]Artifact
+<a href="#tekton.dev/v1beta1.TaskRunStepArtifact">
+[]TaskRunStepArtifact
 </a>
 </em>
 </td>
@@ -14357,8 +14700,8 @@ Provenance
 <td>
 <code>outputs</code><br/>
 <em>
-<a href="#tekton.dev/v1beta1.Artifact">
-[]Artifact
+<a href="#tekton.dev/v1beta1.TaskRunStepArtifact">
+[]TaskRunStepArtifact
 </a>
 </em>
 </td>
@@ -14748,6 +15091,13 @@ Default is false.</p>
 </tr>
 </tbody>
 </table>
+<h3 id="tekton.dev/v1beta1.StepWhenExpressions">StepWhenExpressions
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.Step">Step</a>)
+</p>
+<div>
+</div>
 <h3 id="tekton.dev/v1beta1.TaskBreakpoints">TaskBreakpoints
 </h3>
 <p>
@@ -14921,7 +15271,7 @@ an input Resource named <code>workspace</code> will be mounted at <code>/workspa
 <td>
 <code>ResourceDeclaration</code><br/>
 <em>
-<a href="#tekton.dev/v1alpha1.ResourceDeclaration">
+<a href="#tekton.dev/v1beta1.ResourceDeclaration">
 ResourceDeclaration
 </a>
 </em>
@@ -15103,8 +15453,8 @@ string
 <td>
 <code>value</code><br/>
 <em>
-<a href="#tekton.dev/v1beta1.ParamValue">
-ParamValue
+<a href="#tekton.dev/v1beta1.ResultValue">
+ResultValue
 </a>
 </em>
 </td>
@@ -15278,10 +15628,10 @@ reasons that emerge from underlying resources are not included here</p>
 <h3 id="tekton.dev/v1beta1.TaskRunResult">TaskRunResult
 </h3>
 <p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.StepState">StepState</a>, <a href="#tekton.dev/v1beta1.TaskRunStatusFields">TaskRunStatusFields</a>)
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskRunStatusFields">TaskRunStatusFields</a>)
 </p>
 <div>
-<p>TaskRunStepResult is a type alias of TaskRunResult</p>
+<p>TaskRunResult used to describe the results of a task</p>
 </div>
 <table>
 <thead>
@@ -15321,8 +15671,8 @@ is currently &ldquo;string&rdquo; and will support &ldquo;array&rdquo; in follow
 <td>
 <code>value</code><br/>
 <em>
-<a href="#tekton.dev/v1beta1.ParamValue">
-ParamValue
+<a href="#tekton.dev/v1beta1.ResultValue">
+ResultValue
 </a>
 </em>
 </td>
@@ -15530,8 +15880,8 @@ Refer Go&rsquo;s ParseDuration documentation for expected format: <a href="https
 <td>
 <code>podTemplate</code><br/>
 <em>
-<a href="#tekton.dev/unversioned.Template">
-Template
+<a href="#tekton.dev/unversioned.PodTemplate">
+PodTemplate
 </a>
 </em>
 </td>
@@ -15600,6 +15950,21 @@ Kubernetes core/v1.ResourceRequirements
 <p>Compute resources to use for this TaskRun</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>managedBy</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ManagedBy indicates which controller is responsible for reconciling
+this resource. If unset or set to &ldquo;tekton.dev/pipeline&rdquo;, the default
+Tekton controller will manage this resource.
+This field is immutable.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="tekton.dev/v1beta1.TaskRunSpecStatus">TaskRunSpecStatus
@@ -15621,7 +15986,7 @@ Kubernetes core/v1.ResourceRequirements
 <h3 id="tekton.dev/v1beta1.TaskRunStatus">TaskRunStatus
 </h3>
 <p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskRun">TaskRun</a>, <a href="#tekton.dev/v1beta1.PipelineRunTaskRunStatus">PipelineRunTaskRunStatus</a>, <a href="#tekton.dev/v1beta1.TaskRunStatusFields">TaskRunStatusFields</a>)
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskRun">TaskRun</a>, <a href="#tekton.dev/v1beta1.PipelineRunTaskRunStatus">PipelineRunTaskRunStatus</a>)
 </p>
 <div>
 <p>TaskRunStatus defines the observed state of TaskRun</p>
@@ -15756,8 +16121,8 @@ CloudEventResource.</p>
 <td>
 <code>retriesStatus</code><br/>
 <em>
-<a href="#tekton.dev/v1beta1.TaskRunStatus">
-[]TaskRunStatus
+<a href="#tekton.dev/v1beta1.RetriesStatus">
+RetriesStatus
 </a>
 </em>
 </td>
@@ -15772,7 +16137,9 @@ See TaskRun.status (API version: tekton.dev/v1beta1)</p>
 <td>
 <code>resourcesResult</code><br/>
 <em>
-[]github.com/tektoncd/pipeline/pkg/result.RunResult
+<a href="#tekton.dev/v1beta1.PipelineResourceResult">
+[]PipelineResourceResult
+</a>
 </em>
 </td>
 <td>
@@ -15851,6 +16218,15 @@ map[string]string
 </tr>
 </tbody>
 </table>
+<h3 id="tekton.dev/v1beta1.TaskRunStepArtifact">TaskRunStepArtifact
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.StepState">StepState</a>)
+</p>
+<div>
+<p>TaskRunStepArtifact represents an artifact produced or used by a step within a task run.
+It directly uses the Artifact type for its structure.</p>
+</div>
 <h3 id="tekton.dev/v1beta1.TaskRunStepOverride">TaskRunStepOverride
 </h3>
 <p>
@@ -15893,6 +16269,14 @@ Kubernetes core/v1.ResourceRequirements
 </tr>
 </tbody>
 </table>
+<h3 id="tekton.dev/v1beta1.TaskRunStepResult">TaskRunStepResult
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.StepState">StepState</a>)
+</p>
+<div>
+<p>TaskRunStepResult is a type alias of TaskRunResult</p>
+</div>
 <h3 id="tekton.dev/v1beta1.TaskSpec">TaskSpec
 </h3>
 <p>
@@ -15986,8 +16370,8 @@ source mounted into /workspace.</p>
 <td>
 <code>volumes</code><br/>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#volume-v1-core">
-[]Kubernetes core/v1.Volume
+<a href="#tekton.dev/v1beta1.Volumes">
+Volumes
 </a>
 </em>
 </td>
@@ -16110,6 +16494,13 @@ Kubernetes meta/v1.Duration
 </tr>
 </tbody>
 </table>
+<h3 id="tekton.dev/v1beta1.Volumes">Volumes
+(<code>[]k8s.io/api/core/v1.Volume</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskSpec">TaskSpec</a>)
+</p>
+<div>
+</div>
 <h3 id="tekton.dev/v1beta1.WhenExpression">WhenExpression
 </h3>
 <p>
@@ -16142,7 +16533,9 @@ string
 <td>
 <code>operator</code><br/>
 <em>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/selection#Operator">
 k8s.io/apimachinery/pkg/selection.Operator
+</a>
 </em>
 </td>
 <td>
@@ -16180,7 +16573,7 @@ More info about CEL syntax: <a href="https://github.com/google/cel-spec/blob/mas
 <h3 id="tekton.dev/v1beta1.WhenExpressions">WhenExpressions
 (<code>[]github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.WhenExpression</code> alias)</h3>
 <p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineTask">PipelineTask</a>, <a href="#tekton.dev/v1beta1.Step">Step</a>)
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineTask">PipelineTask</a>)
 </p>
 <div>
 <p>WhenExpressions are used to specify whether a Task should be executed or skipped
@@ -16408,6 +16801,13 @@ this field is false and so declared workspaces are required.</p>
 </tr>
 </tbody>
 </table>
+<h3 id="tekton.dev/v1beta1.WorkspacePipelineDeclaration">WorkspacePipelineDeclaration
+</h3>
+<div>
+<p>WorkspacePipelineDeclaration creates a named slot in a Pipeline that a PipelineRun
+is expected to populate with a workspace binding.</p>
+<p>Deprecated: use PipelineWorkspaceDeclaration type instead</p>
+</div>
 <h3 id="tekton.dev/v1beta1.WorkspacePipelineTaskBinding">WorkspacePipelineTaskBinding
 </h3>
 <p>
@@ -16548,7 +16948,7 @@ string
 <h3 id="tekton.dev/v1beta1.CustomRunStatus">CustomRunStatus
 </h3>
 <p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.CustomRun">CustomRun</a>, <a href="#tekton.dev/v1.PipelineRunRunStatus">PipelineRunRunStatus</a>, <a href="#tekton.dev/v1beta1.PipelineRunRunStatus">PipelineRunRunStatus</a>, <a href="#tekton.dev/v1beta1.CustomRunStatusFields">CustomRunStatusFields</a>)
+(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineRunRunStatus">PipelineRunRunStatus</a>, <a href="#tekton.dev/v1beta1.CustomRunStatusFields">CustomRunStatusFields</a>)
 </p>
 <div>
 <p>CustomRunStatus defines the observed state of CustomRun</p>
@@ -16674,7 +17074,9 @@ See CustomRun.status (API version: tekton.dev/v1beta1)</p>
 <td>
 <code>extraFields</code><br/>
 <em>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime#RawExtension">
 k8s.io/apimachinery/pkg/runtime.RawExtension
+</a>
 </em>
 </td>
 <td>

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.6
 
 require (
 	github.com/Microsoft/go-winio v0.6.2 // indirect
-	github.com/ahmetb/gen-crd-api-reference-docs v0.3.1-0.20220720053627-e327d0730470 // Waiting for https://github.com/ahmetb/gen-crd-api-reference-docs/pull/43/files to merge
+	github.com/ahmetb/gen-crd-api-reference-docs v0.3.1-0.20260316152250-6bbddc29119c // Waiting for https://github.com/ahmetb/gen-crd-api-reference-docs/pull/43/files to merge
 	github.com/cloudevents/sdk-go/v2 v2.16.2
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-containerregistry v0.21.1
@@ -236,4 +236,4 @@ require (
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
 )
 
-replace github.com/ahmetb/gen-crd-api-reference-docs => github.com/tektoncd/ahmetb-gen-crd-api-reference-docs v0.3.1-0.20220729140133-6ce2d5aafcb4 // Waiting for https://github.com/ahmetb/gen-crd-api-reference-docs/pull/43/files to merge
+replace github.com/ahmetb/gen-crd-api-reference-docs => github.com/tektoncd/ahmetb-gen-crd-api-reference-docs v0.3.1-0.20260316152250-6bbddc29119c // Waiting for https://github.com/ahmetb/gen-crd-api-reference-docs/pull/43/files to merge

--- a/go.sum
+++ b/go.sum
@@ -1031,8 +1031,8 @@ github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
-github.com/tektoncd/ahmetb-gen-crd-api-reference-docs v0.3.1-0.20220729140133-6ce2d5aafcb4 h1:E5MV/fepEo6WUfYi+rE5y4oL5BUncZmO7e1FJm7F+sI=
-github.com/tektoncd/ahmetb-gen-crd-api-reference-docs v0.3.1-0.20220729140133-6ce2d5aafcb4/go.mod h1:lQON0TD5PnAUl7Q6H5FNV+/AqCSeltYf72OGIkegB/o=
+github.com/tektoncd/ahmetb-gen-crd-api-reference-docs v0.3.1-0.20260316152250-6bbddc29119c h1:zhs32gUzwxtgNvKV29nQR2n+pfNM82kKLFd3AwIGUug=
+github.com/tektoncd/ahmetb-gen-crd-api-reference-docs v0.3.1-0.20260316152250-6bbddc29119c/go.mod h1:lQON0TD5PnAUl7Q6H5FNV+/AqCSeltYf72OGIkegB/o=
 github.com/tektoncd/plumbing v0.0.0-20220817140952-3da8ce01aeeb h1:LUUCR8pLF+MzdQ7kOQQrMzDahIPZLdPCzfnNow1Um3Y=
 github.com/tektoncd/plumbing v0.0.0-20220817140952-3da8ce01aeeb/go.mod h1:uJBaI0AL/kjPThiMYZcWRujEz7D401v643d6s/21GAg=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/hack/reference-docs-gen-config.json
+++ b/hack/reference-docs-gen-config.json
@@ -16,6 +16,14 @@
             "docsURLTemplate": "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
         },
         {
+            "typeMatchPrefix": "^k8s\\.io/apimachinery/pkg/runtime\\.",
+            "docsURLTemplate": "https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime#{{.TypeIdentifier}}"
+        },
+        {
+            "typeMatchPrefix": "^k8s\\.io/apimachinery/pkg/selection\\.",
+            "docsURLTemplate": "https://pkg.go.dev/k8s.io/apimachinery/pkg/selection#{{.TypeIdentifier}}"
+        },
+        {
             "typeMatchPrefix": "^knative\\.dev/pkg/apis/duck",
             "docsURLTemplate": "https://pkg.go.dev/knative.dev/pkg/apis/duck/{{arrIndex .PackageSegments -1}}#{{.TypeIdentifier}}"
         },

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -101,4 +101,4 @@ ${REPO_ROOT_DIR}/hack/update-schemas.sh
 ${REPO_ROOT_DIR}/hack/update-openapigen.sh
 
 # Make sure the generated API reference docs are up-to-date
-# ${REPO_ROOT_DIR}/hack/update-reference-docs.sh
+${REPO_ROOT_DIR}/hack/update-reference-docs.sh

--- a/vendor/github.com/ahmetb/gen-crd-api-reference-docs/main.go
+++ b/vendor/github.com/ahmetb/gen-crd-api-reference-docs/main.go
@@ -498,7 +498,8 @@ func typeDisplayName(t *types.Type, c generatorConfig, typePkgMap map[*types.Typ
 		types.Alias,
 		types.Pointer,
 		types.Slice,
-		types.Builtin:
+		types.Builtin,
+		types.Unsupported: // Go type aliases (type X = Y) are parsed as Unsupported by gengo
 		// noop
 	case types.Map:
 		// return original name

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -154,7 +154,7 @@ github.com/Microsoft/go-winio/internal/fs
 github.com/Microsoft/go-winio/internal/socket
 github.com/Microsoft/go-winio/internal/stringbuffer
 github.com/Microsoft/go-winio/pkg/guid
-# github.com/ahmetb/gen-crd-api-reference-docs v0.3.1-0.20220720053627-e327d0730470 => github.com/tektoncd/ahmetb-gen-crd-api-reference-docs v0.3.1-0.20220729140133-6ce2d5aafcb4
+# github.com/ahmetb/gen-crd-api-reference-docs v0.3.1-0.20260316152250-6bbddc29119c => github.com/tektoncd/ahmetb-gen-crd-api-reference-docs v0.3.1-0.20260316152250-6bbddc29119c
 ## explicit; go 1.17
 github.com/ahmetb/gen-crd-api-reference-docs
 # github.com/antlr4-go/antlr/v4 v4.13.1
@@ -1942,4 +1942,4 @@ sigs.k8s.io/structured-merge-diff/v6/value
 sigs.k8s.io/yaml
 # github.com/aws/aws-sdk-go-v2/service/ecr => github.com/aws/aws-sdk-go-v2/service/ecr v1.27.3
 # github.com/aws/aws-sdk-go-v2/service/ecrpublic => github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.23.3
-# github.com/ahmetb/gen-crd-api-reference-docs => github.com/tektoncd/ahmetb-gen-crd-api-reference-docs v0.3.1-0.20220729140133-6ce2d5aafcb4
+# github.com/ahmetb/gen-crd-api-reference-docs => github.com/tektoncd/ahmetb-gen-crd-api-reference-docs v0.3.1-0.20260316152250-6bbddc29119c


### PR DESCRIPTION
This picks up a fix in the forked/vendored tool that adds minimal support for aliased types. It also enhances the configuration to address some missing external URLs.

With the update in, the generation of docs/pipeline-api.md can be re-enabled.

Merging this might trigger rebase for other PRs, but it's best done sooner than later as the current docs we publish to tekton.dev is slightly out of date.

Cherry-pick of: https://github.com/tektoncd/pipeline/pull/9604

# Release Notes

```release-note
Update the pipeline API published at https://tekton.dev/docs/pipelines/pipeline-api/
```

/kind documentation